### PR TITLE
[multi_passwd_ssh] switch ipv6 back to ipv4 when failed

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -80,12 +80,28 @@ def _password_retry(func):
             # This is a retry, so the fd/pipe for sshpass is closed, and we need a new one
             self.sshpass_pipe = os.pipe()
 
+    def _change_host(self, new_host, *args):
+        # This is a retry, so the fd/pipe for sshpass is closed, and we need a new one
+        self.sshpass_pipe = os.pipe()
+        self._play_context.remote_addr = new_host
+        # args sample:
+        # ( [b'sshpass', b'-d18', b'ssh', b'-o', b'ControlMaster=auto', b'-o', b'ControlPersist=120s', b'-o', b'UserKnownHostsFile=/dev/null', b'-o', b'StrictHostKeyChecking=no', b'-o', b'StrictHostKeyChecking=no', b'-o', b'User="admin"', b'-o', b'ConnectTimeout=60', b'-o', b'ControlPath="/home/user/.ansible/cp/376bdcc730"', 'fc00:1234:5678:abcd::2', b'/bin/sh -c \'echo PLATFORM; uname; echo FOUND; command -v \'"\'"\'python3.10\'"\'"\'; command -v \'"\'"\'python3.9\'"\'"\'; command -v \'"\'"\'python3.8\'"\'"\'; command -v \'"\'"\'python3.7\'"\'"\'; command -v \'"\'"\'python3.6\'"\'"\'; command -v \'"\'"\'python3.5\'"\'"\'; command -v \'"\'"\'/usr/bin/python3\'"\'"\'; command -v \'"\'"\'/usr/libexec/platform-python\'"\'"\'; command -v \'"\'"\'python2.7\'"\'"\'; command -v \'"\'"\'/usr/bin/python\'"\'"\'; command -v \'"\'"\'python\'"\'"\'; echo ENDFOUND && sleep 0\''], None) # noqa: E501
+        # args[0] are the parameters of ssh connection
+        ssh_args = args[0]
+        # Change the IPv4 host in the ssh_args to IPv6
+        for idx in range(len(ssh_args)):
+            if type(ssh_args[idx]) == bytes and ssh_args[idx].decode() == self.host:
+                ssh_args[idx] = new_host
+        self.host = new_host
+        self.set_option("host", new_host)
+
     @wraps(func)
     def wrapped(self, *args, **kwargs):
         try:
             # First, try with original host(generally IPv4) with multi-password
             return _conn_with_multi_pwd(self, *args, **kwargs)
         except AnsibleConnectionFailure as e:
+            orig_host = self._play_context.remote_addr
             # If a non-authentication related exception is raised and IPv6 host is set,
             # Retry with IPv6 host with multi-password
             try:
@@ -96,23 +112,15 @@ def _password_retry(func):
             ipv4_addr_unavailable = (CONNECTION_TIMEOUT_ERR_FLAG1 in e.message) or \
                                     (CONNECTION_TIMEOUT_ERR_FLAG2 in e.message)
 
-            try_ipv6_addr = (type(e) != AnsibleAuthenticationFailure) and ipv4_addr_unavailable and hostv6
-            if try_ipv6_addr:
-                # This is a retry, so the fd/pipe for sshpass is closed, and we need a new one
-                self.sshpass_pipe = os.pipe()
-                self._play_context.remote_addr = hostv6
-                # args sample:
-                # ( [b'sshpass', b'-d18', b'ssh', b'-o', b'ControlMaster=auto', b'-o', b'ControlPersist=120s', b'-o', b'UserKnownHostsFile=/dev/null', b'-o', b'StrictHostKeyChecking=no', b'-o', b'StrictHostKeyChecking=no', b'-o', b'User="admin"', b'-o', b'ConnectTimeout=60', b'-o', b'ControlPath="/home/user/.ansible/cp/376bdcc730"', 'fc00:1234:5678:abcd::2', b'/bin/sh -c \'echo PLATFORM; uname; echo FOUND; command -v \'"\'"\'python3.10\'"\'"\'; command -v \'"\'"\'python3.9\'"\'"\'; command -v \'"\'"\'python3.8\'"\'"\'; command -v \'"\'"\'python3.7\'"\'"\'; command -v \'"\'"\'python3.6\'"\'"\'; command -v \'"\'"\'python3.5\'"\'"\'; command -v \'"\'"\'/usr/bin/python3\'"\'"\'; command -v \'"\'"\'/usr/libexec/platform-python\'"\'"\'; command -v \'"\'"\'python2.7\'"\'"\'; command -v \'"\'"\'/usr/bin/python\'"\'"\'; command -v \'"\'"\'python\'"\'"\'; echo ENDFOUND && sleep 0\''], None) # noqa: E501
-                # args[0] are the parameters of ssh connection
-                ssh_args = args[0]
-                # Change the IPv4 host in the ssh_args to IPv6
-                for idx in range(len(ssh_args)):
-                    if type(ssh_args[idx]) == bytes and ssh_args[idx].decode() == self.host:
-                        ssh_args[idx] = hostv6
-                self.host = hostv6
-                self.set_option("host", hostv6)
+            try_ipv6_addr = orig_host != hostv6 and (type(e) != AnsibleAuthenticationFailure) and \
+                ipv4_addr_unavailable and hostv6
+            if not try_ipv6_addr:
+                raise e
+            self._change_host(hostv6, *args)
+            try:
                 return _conn_with_multi_pwd(self, *args, **kwargs)
-            else:
+            except AnsibleConnectionFailure as e:
+                self._change_host(orig_host, *args)
                 raise e
 
     return wrapped

--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -116,11 +116,11 @@ def _password_retry(func):
                 ipv4_addr_unavailable and hostv6
             if not try_ipv6_addr:
                 raise e
-            self._change_host(hostv6, *args)
+            _change_host(self, hostv6, *args)
             try:
                 return _conn_with_multi_pwd(self, *args, **kwargs)
             except AnsibleConnectionFailure as e:
-                self._change_host(orig_host, *args)
+                _change_host(self, orig_host, *args)
                 raise e
 
     return wrapped


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When running a command through the plugin multi_passwd_ssh, it will try every password, and at the end, the password will be reset to the original password. If ipv4 fails, the connection error will be caught, and switch to using ipv6, and it will stick to using ipv6 for all future connections. This change will switch back to trying ipv4, if ipv6 fails. Sometimes we have ipv4 and ipv6 recorded in inventory for a device but only one of them (typically ipv4) is configured (like when the mgmt interface is configured manually), the previous behavior is multi_passwd_ssh will always fail if an ipv4 connection ever fails, like during a reboot, or waiting for some breaking network changes.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When ipv4 fails, the multi_passwd_ssh switches to using ipv6. We would want it to continue trying both ipv4 and ipv6, and not just one.

#### How did you do it?

#### How did you verify/test it?
Run some ansible playbooks

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
