### PR TITLE
Ignore the `handlePortStatusChangeNotification` log

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -328,3 +328,6 @@ r, ".* ERR kernel:.*sxd_kernel: \[error\] Health-Check: device=1, cause=10 \['SD
 # Ignore gbsynd error for 720DT
 r, ".*ERR gbsyncd#syncd: :- collectData: Failed to get stats of Port Counter.*"
 r, ".*ERR gbsyncd#syncd: :- diagShellThreadProc: Failed to enable switch shell: SAI_STATUS_NOT_SUPPORTED.*"
+
+# Ignore notifications about fabric port status changes on LCs
+r, ".*ERR swss\d*#orchagent:.*handlePortStatusChangeNotification: Failed to get port object for port id.*"


### PR DESCRIPTION
ERR swss1#orchagent: :- handlePortStatusChangeNotification: Failed to get port object for port id 0x1010000000000df

This log is discussed here: https://github.com/sonic-net/sonic-buildimage/issues/16489
It's been ignored for specific tests here: https://github.com/Azure/sonic-mgmt.msft/commit/8e128b911b5464f361b505ee3c04d80d2a414fae

This is ignoring it in general as we've seen it in other tests:
```
   -snmp/test_snmp_loopback.py::test_snmp_loopback::test_snmp_loopback
   -voq/test_fabric_reach.py voq.test_fabric_reach test_fabric_reach_supervisor
   -fib/test_fib.py::test_fib::test_basic_fib
   -qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue
```

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411