### PR TITLE
Fix missing `console_device` parameter in ConsoleHost during testbed auto-recovery

### DIFF
--- a/.azure-pipelines/recover_testbed/dut_connection.py
+++ b/.azure-pipelines/recover_testbed/dut_connection.py
@@ -88,8 +88,9 @@ def get_console_info(sonichost, conn_graph_facts):
     console_host = conn_graph_facts['device_console_info'][sonichost.hostname]['ManagementIp']
     console_port = conn_graph_facts['device_console_link'][sonichost.hostname]['ConsolePort']['peerport']
     console_type = conn_graph_facts['device_console_link'][sonichost.hostname]['ConsolePort']['type']
+    console_device = conn_graph_facts['device_console_link'][sonichost.hostname]['ConsolePort']['peerdevice']
 
-    return console_host, console_port, console_type
+    return console_host, console_port, console_type, console_device
 
 
 def get_ssh_info(sonichost):
@@ -103,7 +104,7 @@ def get_ssh_info(sonichost):
 
 
 def duthost_console(sonichost, conn_graph_facts):
-    console_host, console_port, console_type = get_console_info(sonichost, conn_graph_facts)
+    console_host, console_port, console_type, console_device = get_console_info(sonichost, conn_graph_facts)
     console_type = "console_" + console_type
     if "/" in console_host:
         console_host = console_host.split("/")[0]
@@ -119,7 +120,8 @@ def duthost_console(sonichost, conn_graph_facts):
                        sonic_username=creds['sonicadmin_user'],
                        sonic_password=[creds['sonicadmin_password'], sonicadmin_alt_password],
                        console_username=creds['console_user'][console_type],
-                       console_password=creds['console_password'][console_type])
+                       console_password=creds['console_password'][console_type],
+                       console_device=console_device)
 
     return host
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR #16686 introduced the `console_device` parameter in the `ConsoleHost` function. However, if this parameter is not passed during auto-recovery of the testbed, it results in the error `__init__() got an unexpected keyword argument 'console_device'`. This PR resolves the issue by ensuring that `console_device` is properly included when calling `ConsoleHost`

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
PR #16686 introduced the `console_device` parameter in the `ConsoleHost` function. However, if this parameter is not passed during auto-recovery of the testbed, it results in the error `__init__() got an unexpected keyword argument 'console_device'`. This PR resolves the issue by ensuring that `console_device` is properly included when calling `ConsoleHost`

#### How did you do it?
This PR resolves the issue by ensuring that `console_device` is properly included when calling `ConsoleHost`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
