### PR TITLE
[WoL] Enable WoL test on M0 topo

### DIFF
--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -10,7 +10,7 @@ import ptf.testutils as testutils
 from ptf.dataplane import match_exp_pkt
 
 pytestmark = [
-    pytest.mark.topology('mx'),
+    pytest.mark.topology('mx', 'm0'),
 ]
 
 TARGET_MAC = "1a:2b:3c:d1:e2:f0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable WoL test on M0 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Enable WoL test on M0 topo.

#### How did you do it?
Add `m0` to pytest mark.

#### How did you verify/test it?
Verified on Arista-720DT M0 testbed.


```
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-None-None] PASSED                                                          [  1%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-None-3-1000] PASSED                                                             [  3%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-11:22:33:44:55:66-None-None] PASSED                                             [  5%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-11:22:33:44:55:66-3-1000] PASSED                                                [  7%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-192.168.0.1-None-None] PASSED                                                   [  9%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[False-192.168.0.1-3-1000] PASSED                                                      [ 11%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[True-None-None-None] PASSED                                                           [ 12%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[True-None-3-1000] PASSED                                                              [ 14%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[True-11:22:33:44:55:66-None-None] PASSED                                              [ 16%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[True-11:22:33:44:55:66-3-1000] PASSED                                                 [ 18%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[True-192.168.0.1-None-None] PASSED                                                    [ 20%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface[True-192.168.0.1-3-1000] PASSED                                                       [ 22%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp_no_ip PASSED                                                                      [ 24%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv4-5678-11:22:33:44:55:66-None-None] PASSED                                     [ 25%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv4-5678-11:22:33:44:55:66-3-1000] PASSED                                        [ 27%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv4-5678-192.168.0.1-None-None] PASSED                                           [ 29%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv4-5678-192.168.0.1-3-1000] PASSED                                              [ 31%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-11:22:33:44:55:66-None-None] PASSED                                     [ 33%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-11:22:33:44:55:66-3-1000] PASSED                                        [ 35%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-192.168.0.1-None-None] PASSED                                           [ 37%]
wol/test_wol.py::TestWOLSendFromInterface::test_wol_send_from_interface_udp[ipv6-5678-192.168.0.1-3-1000] PASSED                                              [ 38%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan[None-None-None] PASSED                                                                          [ 40%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan[None-3-1000] PASSED                                                                             [ 42%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan[11:22:33:44:55:66-None-None] PASSED                                                             [ 44%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan[11:22:33:44:55:66-3-1000] PASSED                                                                [ 46%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan[192.168.0.1-None-None] PASSED                                                                   [ 48%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan[192.168.0.1-3-1000] PASSED                                                                      [ 50%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp_no_ip PASSED                                                                                [ 51%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv4-5678-11:22:33:44:55:66-None-None] PASSED                                               [ 53%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv4-5678-11:22:33:44:55:66-3-1000] PASSED                                                  [ 55%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv4-5678-192.168.0.1-None-None] PASSED                                                     [ 57%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv4-5678-192.168.0.1-3-1000] PASSED                                                        [ 59%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv6-5678-11:22:33:44:55:66-None-None] PASSED                                               [ 61%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv6-5678-11:22:33:44:55:66-3-1000] PASSED                                                  [ 62%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv6-5678-192.168.0.1-None-None] PASSED                                                     [ 64%]
wol/test_wol.py::TestWOLSendFromVlan::test_wol_send_from_vlan_udp[ipv6-5678-192.168.0.1-3-1000] PASSED                                                        [ 66%]
wol/test_wol.py::test_wol_invalid_interface PASSED                                                                                                            [ 68%]
wol/test_wol.py::test_wol_down_interface PASSED                                                                                                               [ 70%]
wol/test_wol.py::test_wol_parameter_invalid_password[192.168.0.256] PASSED                                                                                    [ 72%]
wol/test_wol.py::test_wol_parameter_invalid_password[q1:11:22:33:44:55] PASSED                                                                                [ 74%]
wol/test_wol.py::test_wol_parameter_invalid_mac PASSED                                                                                                        [ 75%]
wol/test_wol.py::test_wol_parameter_invalid_interval PASSED                                                                                                   [ 77%]
wol/test_wol.py::test_wol_parameter_invalid_count PASSED                                                                                                      [ 79%]
wol/test_wol.py::test_wol_parameter_constraint_of_count_and_interval PASSED                                                                                   [ 81%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_constraint_of_udp[None-None] PASSED                                                                     [ 83%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_constraint_of_udp[None-5678] PASSED                                                                     [ 85%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_udp_with_broadcast[ipv4-None] PASSED                                                                    [ 87%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_udp_with_broadcast[ipv4-5678] PASSED                                                                    [ 88%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_constraint_of_udp[ipv4-None] PASSED                                                                     [ 90%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_constraint_of_udp[ipv4-5678] PASSED                                                                     [ 92%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_udp_with_broadcast[ipv6-None] PASSED                                                                    [ 94%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_udp_with_broadcast[ipv6-5678] PASSED                                                                    [ 96%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_constraint_of_udp[ipv6-None] PASSED                                                                     [ 98%]
wol/test_wol.py::TestWOLParameter::test_wol_parameter_constraint_of_udp[ipv6-5678] PASSED                                                                     [100%]
============================================================ 54 passed, 1 warning in 1358.23s (0:22:38) =============================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
