### PR TITLE
[test gap] Add a new case to check caclmgrd syslog

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -2,7 +2,6 @@ import ipaddress
 import json
 import logging
 import pytest
-import time
 
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
@@ -1295,8 +1294,8 @@ def test_caclmgrd_syslog(duthosts, enum_rand_one_per_hwsku_hostname,):
     # Restart caclmgrd service
     duthost.command("sudo systemctl restart caclmgrd")
 
-    # Wait for a few seconds to allow caclmgrd to start and log messages
-    time.sleep(10)
+    # Wait for caclmgrd to be active
+    wait_until(30, 5, 0, lambda: "active (running)" in duthost.command("sudo systemctl status caclmgrd")["stdout"])
 
     # Check the syslog for the presence of "iptables"
     syslog_output = duthost.command("sudo grep 'Issuing the following iptables commands:' /var/log/syslog")["stdout"]
@@ -1308,7 +1307,5 @@ def test_caclmgrd_syslog(duthosts, enum_rand_one_per_hwsku_hostname,):
     pytest_assert("iptables -P INPUT ACCEPT" in syslog_output,
                   "Syslog does not contain 'iptables -P INPUT ACCEPT' after restarting caclmgrd")
     systemctl_output = duthost.command("sudo systemctl status caclmgrd")["stdout"]
-    pytest_assert("active (running)" in systemctl_output,
-                  "caclmgrd service is not running after restart")
     pytest_assert("iptables -A INPUT" in systemctl_output,
                   "iptables rules are not applied after restarting caclmgrd")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
To address https://github.com/sonic-net/sonic-mgmt/issues/16548.
The issue https://github.com/sonic-net/sonic-buildimage/issues/21290, the issue of INFO level logs disappear in caclmgrd was reported after the commit got merged months later.
We need a test case to help us report this kind of issue earlier.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
A new test case to check if INFO logs of caclmgrd was printed into syslog successfully.

#### How did you do it?
1. rotate syslog
2. restart caclmgrd
3. check if iptables syslog existing in syslog file
4. Check if iptables rules are applied successfully in the output of systemctl status caclmgrd

#### How did you verify/test it?
Run the new test case on the testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

