### PR TITLE
Fix test case failures after secondary subnet enabled

### DIFF
--- a/ansible/library/interface_facts.py
+++ b/ansible/library/interface_facts.py
@@ -210,6 +210,20 @@ def gather_ip_interface_info():
                                                          'broadcast': broadcast,
                                                          'netmask': netmask,
                                                          'network': network}
+                        else:
+                            if isinstance(interfaces[iface]['ipv4'], list):
+                                interfaces[iface]['ipv4'].append({'address': address,
+                                                                 'broadcast': broadcast,
+                                                                 'netmast': netmask,
+                                                                 'network': network})
+                            else:
+                                previous_address = interfaces[iface]['ipv4']
+                                interfaces[iface]['ipv4'] = []
+                                interfaces[iface]['ipv4'].append(previous_address)
+                                interfaces[iface]['ipv4'].append({'address': address,
+                                                                 'broadcast': broadcast,
+                                                                 'netmast': netmask,
+                                                                 'network': network})
                     else:
                         if 'ipv4_secondaries' not in interfaces[iface]:
                             interfaces[iface]['ipv4_secondaries'] = []

--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -1,4 +1,5 @@
 import logging
+import netaddr
 
 logger = logging.getLogger(__name__)
 
@@ -27,3 +28,137 @@ def get_duthost_with_name(duthosts, dut_name):
             return duthost
     logger.error("Can't find duthost with name {}.".format(dut_name))
     return
+
+
+def get_vlan_interfaces_dict(duthost, tbinfo):
+    """
+    Helper function to organize VLAN interface information from minigraph and config facts
+    into a structured dictionary separating IPv4 and IPv6 addresses per VLAN.
+
+    Args:
+        mg_facts (dict): Minigraph facts containing VLAN interface information
+        config_facts (dict): Config facts containing VLAN interface configuration
+
+    Returns:
+        dict: Structured dictionary with VLAN interfaces organized by IPv4/IPv6 addresses
+        {
+            "Vlan1000": {
+                "ipv4": [
+                {
+                    'addr': '192.168.0.1',
+                    'subnet': '192.168.0.0/25',
+                    'prefixlen': 25,
+                    'mask': '255.255.255.128',
+                    'peer_addr': '192.168.0.2'
+                },
+                {
+                    'addr': '192.169.0.1',
+                    'subnet': '192.169.0.0/22',
+                    'attachto': 'Vlan1000',
+                    'prefixlen': 22,
+                    'mask': '255.255.252.0',
+                    'peer_addr': '192.169.0.2',
+                    'secondary': True
+                }
+                ],
+                "ipv6": [
+                {
+                    'addr': 'fc02:1000::1',
+                    'subnet': 'fc02:1000::/64',
+                    'attachto': 'Vlan1000',
+                    'prefixlen': 64,
+                    'mask': '64',
+                    'peer_addr': 'fc02:1000::2'
+                }
+                ]
+            }
+        }
+    """
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    result = {}
+
+    # Group interfaces by VLAN
+    for interface in mg_facts['minigraph_vlan_interfaces']:
+        vlan = interface['attachto']
+        if vlan not in result:
+            result[vlan] = {'ipv4': [], 'ipv6': []}
+
+        # Create interface info dict
+        interface_info = {
+            'addr': interface['addr'],
+            'subnet': interface['subnet'],
+            'prefixlen': interface['prefixlen'],
+            'mask': interface['mask'],
+            'peer_addr': interface['peer_addr'],
+            'attachto': interface['attachto']
+        }
+
+        # Check if this is a secondary address from config facts
+        if vlan in config_facts['VLAN_INTERFACE']:
+            ip_with_prefix = f"{interface['addr']}/{interface['prefixlen']}"
+            if ip_with_prefix in config_facts['VLAN_INTERFACE'][vlan]:
+                config = config_facts['VLAN_INTERFACE'][vlan][ip_with_prefix]
+                if config.get('secondary') == 'true':
+                    interface_info['secondary'] = True
+
+        # Add to appropriate IP version list
+        ip_version = netaddr.IPAddress(str(interface['addr'])).version
+        if ip_version == 6:  # IPv6
+            result[vlan]['ipv6'].append(interface_info)
+        else:  # IPv4
+            result[vlan]['ipv4'].append(interface_info)
+    return result
+
+
+def get_vlan_interface_list(duthost):
+    """
+    Helper function to get list of VLANs configured on the device.
+
+    Args:
+        mg_facts (dict): Minigraph facts containing VLAN interface information
+
+    Returns:
+        list: List of VLAN names (e.g. ["Vlan1000"] or ["Vlan1000", "Vlan2000"])
+    """
+    vlans = set()
+    config_facts = duthost.config_facts(zsxhost=duthost.hostname, source="running")['ansible_facts']
+    for vlan_interface in config_facts['VLAN_INTERFACE']:
+        vlans.add(vlan_interface)
+    return sorted(list(vlans))
+
+
+def get_vlan_interface_info(duthost, tbinfo, vlan_name, ip_version="ipv4"):
+    """
+    Helper function to get non-secondary IP interface information for a specific VLAN and IP version.
+
+    Args:
+        vlan_interfaces_dict (dict): Dict containing VLAN interface information from get_vlan_interfaces_dict()
+        vlan_name (str): Name of VLAN interface (e.g. "Vlan1000")
+        ip_version (int): IP version to filter by (4 or 6)
+
+    Returns:
+        list: List of dicts containing interface info (addr, subnet, etc) for non-secondary IPs
+        {
+            'addr': '192.168.0.1',
+            'subnet': '192.168.0.0/25',
+            'prefixlen': 25,
+            'mask': '255.255.255.128',
+            'peer_addr': '192.168.0.2'
+        }
+    """
+    vlan_interfaces_dict = get_vlan_interfaces_dict(duthost, tbinfo)
+    if vlan_name not in vlan_interfaces_dict:
+        return {}
+
+    result = {}
+
+    for interface in vlan_interfaces_dict[vlan_name][ip_version]:
+        # Skip secondary addresses
+        if interface.get('secondary'):
+            continue
+
+        result = interface
+        break
+
+    return result

--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -122,7 +122,7 @@ def get_vlan_interface_list(duthost):
         list: List of VLAN names (e.g. ["Vlan1000"] or ["Vlan1000", "Vlan2000"])
     """
     vlans = set()
-    config_facts = duthost.config_facts(zsxhost=duthost.hostname, source="running")['ansible_facts']
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     for vlan_interface in config_facts['VLAN_INTERFACE']:
         vlans.add(vlan_interface)
     return sorted(list(vlans))

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -24,6 +24,7 @@ import ptf.mask as mask
 import ptf.packet as packet
 from tests.common import constants
 from tests.common.flow_counter.flow_counter_utils import RouteFlowCounterTestContext, is_route_flow_counter_supported # noqa F811
+from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 
 pytestmark = [
@@ -319,7 +320,13 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
     if expected_vlan_ifaces:
         mg_facts['minigraph_vlan_interfaces'] = expected_vlan_ifaces
 
-    vlan_intf = mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]
+    vlan_interfaces = get_vlan_interface_list(duthost)
+    # pick up the first vlan to test
+    vlan_if_name = vlan_interfaces[0]
+    if ipv6:
+        vlan_intf = get_vlan_interface_info(duthost, tbinfo, vlan_if_name, "ipv6")
+    else:
+        vlan_intf = get_vlan_interface_info(duthost, tbinfo, vlan_if_name, "ipv4")
     prefix_len = vlan_intf['prefixlen']
 
     is_backend_topology = mg_facts.get(constants.IS_BACKEND_TOPOLOGY_KEY, False)
@@ -332,7 +339,7 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
         nexthop_interfaces = nexthop_devs
     else:
         vlan_subnet = ipaddress.ip_network(vlan_intf['subnet'])
-        vlan = mg_facts['minigraph_vlans'][mg_facts['minigraph_vlan_interfaces'][1 if ipv6 else 0]['attachto']]
+        vlan = mg_facts['minigraph_vlans'][vlan_if_name]
         vlan_ports = vlan['members']
         vlan_id = vlan['vlanid']
         vlan_ptf_ports = [mg_facts['minigraph_ptf_indices'][port] for port in vlan_ports if 'PortChannel' not in port]

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -73,7 +73,11 @@ def verify_ip_address(host_facts, intfs):
         ip = IPAddress(intf['addr'])
         if ip.version == 4:
             addrs = []
-            addrs.append(host_facts[ifname]['ipv4'])
+            if isinstance(host_facts[ifname]['ipv4'], list):
+                for addr in host_facts[ifname]['ipv4']:
+                    addrs.append(addr)
+            else:
+                addrs.append(host_facts[ifname]['ipv4'])
             if 'ipv4_secondaries' in host_facts[ifname]:
                 for addr in host_facts[ifname]['ipv4_secondaries']:
                     addrs.append(addr)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix those failures on secondary subnet enabled testbed:
`test_interfaces.py` failed 
```
>           pytest_assert(found, "{} not found in the list {}".format(ip, ips_found))
E           Failed: 192.169.0.1 not found in the list ['192.168.0.1']

```
`bgp/test_bgp_speaker.py` failed:

```
stderr =
Error: inet6 prefix is expected rather than "192.169.0.2/22".
```
`route/test_static_route.py` failed:
```
AssertionError: config static route: 2000:1::/64 nexthop 192.169.0.26
real:
['']
```


`bgp/test_bgp_dual_asn.py` failed:
```
  File "/usr/lib/python3.8/ipaddress.py", line 1844, in __init__
    self._ip = self._ip_int_from_string(addr_str)
  File "/usr/lib/python3.8/ipaddress.py", line 1581, in _ip_int_from_string
    raise AddressValueError(msg)
ipaddress.AddressValueError: At least 3 parts expected in '192.169.0.1'

```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
These cases do not consider the secondary subnet scenario.

#### How did you do it?
Add several common helper functions t get vlan interface information.
```
get_vlan_interfaces_dict
get_vlan_interface_list
get_vlan_interface_info
```

#### How did you verify/test it?
Run bgp/test_bgp_speaker.py and test_interfaces.py on single vlan testbed and secondary subnet enabled testbed.

Test evidence for `test_interface.py` on secondary subnet testbed:
```
python3 -m pytest test_interfaces.py --inventory ../ansible/bjw2,../ansible/veos --host-pattern bjw2-can-7260-11 --testbed testbed-bjw2-can-t1-7260-11 --testbed_file ../ansible/testbed.yaml --skip_sanity  --disable_loganalyzer  --log-file /data/logs/testbed-bjw2-can-t1-7260-11_test_interfaces.py_2025-02-24_07:16:37.log
=========================================================================================================================================================== test session starts ============================================================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.3.0
ansible: 2.13.13
rootdir: /data/sonic-mgmt-int/tests
configfile: pytest.ini
plugins: repeat-0.9.3, forked-1.6.0, xdist-1.28.0, allure-pytest-2.8.22, html-4.1.1, ansible-4.0.0, metadata-3.0.0
collected 1 item                                                                                                                                                                                                                                                                                                                           

test_interfaces.py .                                                                                                                                                                                                                                                                                                                 [100%]

============================================================================================================================================================= warnings summary =============================================================================================================================================================
.
```

Test evidence for test_interface.py on single vlan testbed:
```
python3 -m pytest test_interfaces.py --inventory ../ansible/bjw,../ansible/veos --host-pattern bjw-can-7260-11 --testbed testbed-bjw-can-t0-7260-11 --testbed_file ../ansible/testbed.yaml --skip_sanity  --disable_loganalyzer  --log-file /data/logs/testbed-bjw-can-t0-7260-11_test_interfaces.py_2025-02-24_07:20:11.log
=========================================================================================================================================================== test session starts ============================================================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.3.0
ansible: 2.13.13
rootdir: /data/sonic-mgmt-int/tests
configfile: pytest.ini
plugins: repeat-0.9.3, forked-1.6.0, xdist-1.28.0, allure-pytest-2.8.22, html-4.1.1, ansible-4.0.0, metadata-3.0.0
collecting ... /usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collected 1 item                                                                                                                                                                                                                                                                                                                           

test_interfaces.py .                                                                                                                                                                                                                                                                                                                 [100%]

============================================================================================================================================================= warnings summary =============================================================================================================================================================
../
```

`bgp/test_bgp_speaker.py` passed on dualtor.
```
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
06:40:36 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================================================= 3 skipped, 6 warnings in 126.44s (0:02:06) =========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_bgp_speaker_announce_routes_v6[str3-msn4700-12-False-True-9114]>
INFO:root:Can not get Allure report URL. Please check logs
```

`tests/bgp/test_bgp_dual_asn.py` passed on dualtor
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
06:48:24 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================================================= 1 passed, 6 warnings in 335.57s (0:05:35) ==========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_bgp_dual_asn_v4>
INFO:root:Can not get Allure report URL. Please check logs
```

Verified on the 202405 branch across these testbeds:
testbed-bjw-can-4600c-1
run -t testbed-bjw-can-4600c-1 -c test_interfaces.py **checked**
run -t testbed-bjw-can-4600c-1 -c bgp/test_bgp_speaker.py **checked**
run -t testbed-bjw-can-4600c-1 -c tests/bgp/test_bgp_dual_asn.py  **checked**
run -t testbed-bjw-can-4600c-1 -c tests/route/test_static_route.py **checked**


testbed-bjw2-can-t0-7260-9
run -t testbed-bjw2-can-t0-7260-9 -c test_interfaces.py **checked**
run -t testbed-bjw2-can-t0-7260-9 -c bgp/test_bgp_speaker.py **checked**
run -t testbed-bjw2-can-t0-7260-9 -c tests/bgp/test_bgp_dual_asn.py **checked**
run -t testbed-bjw2-can-t0-7260-9 -c tests/route/test_static_route.py **checked**

vms68-dual-t0-4700-8
run -t vms68-dual-t0-4700-8 -c test_interfaces.py **checked**
run -t vms68-dual-t0-4700-8 -c bgp/test_bgp_speaker.py **checked**
run -t vms68-dual-t0-4700-8 -c tests/bgp/test_bgp_dual_asn.py **checked**
run -t vms68-dual-t0-4700-8 -c tests/route/test_static_route.py **checked**


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
