### PR TITLE
adding eos neighbor support for bgp passive peering

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -44,6 +44,7 @@ class EosHost(AnsibleHostBase):
         self.eos_passwd = eos_passwd
         self.shell_user = shell_user
         self.shell_passwd = shell_passwd
+        self.is_multi_asic = False
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
         self.localhost = ansible_adhoc(inventory='localhost', connection='local',
                                        host_pattern="localhost")["localhost"]


### PR DESCRIPTION
chore: update test for t2

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Previously this test skipped for eos neighbor due to legacy. Now we should be able to enable this. This PR added the necessary changes to make this compatible

Fixes # (issue) 28839241

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Described above

#### How did you do it?
Adjust the relevant code to be compatible with eos neighbor. 

#### How did you verify/test it?
Verified on T2 testbed compatibility.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
