### PR TITLE
Prting 16315 to 202411: qos-sai:dwrr:cisco-8000:Handle non-multiasic part as well for the dshell-script change.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2662,7 +2662,7 @@ class QosSaiBase(QosBase):
                         "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, peer_device))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
-    def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
+    def copy_and_run_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         if dut.facts['asic_type'] != "cisco-8000":
             raise RuntimeError("This function should have been called only for cisco-8000.")
         dshell_script = '''
@@ -2682,12 +2682,8 @@ def set_port_cir(interface, rate):
 
         script_path = "/tmp/set_scheduler.py"
         dut.copy(content=dshell_script, dest=script_path)
-        if dut.sonichost.is_multi_asic:
-            dest = f"syncd{asic}"
-        else:
-            dest = "syncd"
         dut.docker_copy_to_all_asics(
-            container_name=dest,
+            container_name=f"syncd{asic}",
             src=script_path,
             dst="/")
 
@@ -2714,7 +2710,7 @@ def set_port_cir(interface, rate):
             interfaces = match.group(1).split(' ')
 
         # Set scheduler to 5 Gbps.
-        self.copy_set_cir_script_cisco_8000(
+        self.copy_and_run_set_cir_script_cisco_8000(
             dut=dst_dut,
             ports=interfaces,
             asic=dst_index,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2662,7 +2662,7 @@ class QosSaiBase(QosBase):
                         "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, peer_device))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
-    def copy_and_run_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
+    def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         if dut.facts['asic_type'] != "cisco-8000":
             raise RuntimeError("This function should have been called only for cisco-8000.")
         dshell_script = '''
@@ -2682,8 +2682,12 @@ def set_port_cir(interface, rate):
 
         script_path = "/tmp/set_scheduler.py"
         dut.copy(content=dshell_script, dest=script_path)
+        if dut.sonichost.is_multi_asic:
+            dest = f"syncd{asic}"
+        else:
+            dest = "syncd"
         dut.docker_copy_to_all_asics(
-            container_name=f"syncd{asic}",
+            container_name=dest,
             src=script_path,
             dst="/")
 
@@ -2710,7 +2714,7 @@ def set_port_cir(interface, rate):
             interfaces = match.group(1).split(' ')
 
         # Set scheduler to 5 Gbps.
-        self.copy_and_run_set_cir_script_cisco_8000(
+        self.copy_set_cir_script_cisco_8000(
             dut=dst_dut,
             ports=interfaces,
             asic=dst_index,

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3847,17 +3847,24 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 recv_pkt = scapy.Ether(received.packet)
 
         if asic_type == 'cisco-8000':
-            cmd_opt = ""
-            if 'dst_asic_index' in self.test_params:
-                cmd_opt = "-n asic{}".format(self.test_params['dst_asic_index'])
+            out, err, ret = self.exec_cmd_on_dut(
+                self.dst_server_ip,
+                self.test_params['dut_username'],
+                self.test_params['dut_password'],
+                "show platform summary | egrep 'ASIC Count' | awk -F: '{print $2}'")
+            cmd_opt = "-n asic{}".format(self.test_params['dst_asic_index'])
+            if out[0].strip() == "1":
+                cmd_opt = ""
             cmd = "sudo show platform npu script {} -s set_scheduler.py".format(cmd_opt)
             out, err, ret = self.exec_cmd_on_dut(
                 self.dst_server_ip,
                 self.test_params['dut_username'],
                 self.test_params['dut_password'],
                 cmd)
-            if err != "" and out == "":
+            if err and out == []:
                 raise RuntimeError("cmd({}) might have failed in the DUT. Error:{}".format(cmd, err))
+            else:
+                print("Success in setting scheduler in DUT.", file=sys.stderr)
         else:
             # Release port
             self.sai_thrift_port_tx_enable(

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3847,24 +3847,17 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                 recv_pkt = scapy.Ether(received.packet)
 
         if asic_type == 'cisco-8000':
-            out, err, ret = self.exec_cmd_on_dut(
-                self.dst_server_ip,
-                self.test_params['dut_username'],
-                self.test_params['dut_password'],
-                "show platform summary | egrep 'ASIC Count' | awk -F: '{print $2}'")
-            cmd_opt = "-n asic{}".format(self.test_params['dst_asic_index'])
-            if out[0].strip() == "1":
-                cmd_opt = ""
+            cmd_opt = ""
+            if 'dst_asic_index' in self.test_params:
+                cmd_opt = "-n asic{}".format(self.test_params['dst_asic_index'])
             cmd = "sudo show platform npu script {} -s set_scheduler.py".format(cmd_opt)
             out, err, ret = self.exec_cmd_on_dut(
                 self.dst_server_ip,
                 self.test_params['dut_username'],
                 self.test_params['dut_password'],
                 cmd)
-            if err and out == []:
+            if err != "" and out == "":
                 raise RuntimeError("cmd({}) might have failed in the DUT. Error:{}".format(cmd, err))
-            else:
-                print("Success in setting scheduler in DUT.", file=sys.stderr)
         else:
             # Release port
             self.sai_thrift_port_tx_enable(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 16314

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
The recent commit for dwrr works for multi-asic only. This PR handles the single asic platforms.

#### How did you do it?
Making sure to use the correct container to use for single asic tests.

#### How did you verify/test it?
Not done yet. @kevinskwang , @yejianquan : Can you pls try this out ? I will try it when I get the testbed access.

#### Any platform specific information?
For cisco-8000 only.
