### PR TITLE
Update regexes used for calculating timings when upgrading to 202405

### DIFF
--- a/tests/common/platform/templates/expect_boot_messages
+++ b/tests/common/platform/templates/expect_boot_messages
@@ -1,9 +1,8 @@
 r, ".* NOTICE (?:admin|root): Rebooting with /sbin/kexec -e to.*..."
 
-r, ".* systemd.* (Stopping|Stopped|Starting|Started).* Database container.*"
-r, ".* NOTICE admin: (Stopping|Stopped|Starting|Started).* (?!syncd|swss|gbsyncd).* service.*"
-r, ".* NOTICE admin: Stopped.* swss.* service.*"
-r, ".* NOTICE root: (Stopping|Stopped|Starting|Started).* (swss|syncd|gbsyncd).* service.*"
+r, ".* admin: (Stopping|Stopped|Starting|Started).* (?!syncd|swss|gbsyncd|database).* service.*"
+r, ".* admin: Stopped.* swss.* service.*"
+r, ".* root: (Stopping|Stopped|Starting|Started).* (swss|syncd|gbsyncd|database).* service.*"
 r, ".* root: WARMBOOT_FINALIZER : Wait for database to become ready.*"
 r, ".* NOTICE root: WARMBOOT_FINALIZER : Finalizing warmboot.*"
 r, ".* NOTICE root: WARMBOOT_FINALIZER : warmboot is not enabled.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

On 202405 images and newer, primarily because of the upgrade to Debian Bookworm, the syslog regexes to search for have changed. Because of this, timing information cannot be correctly calculated.

#### How did you do it?

Update these regexes to make it work for 202405 images. They should still work for upgrades to older images.

#### How did you verify/test it?

Verified that on an upgrade path test, timing information is more fully populated:

```
    "time_span": {
        "radv": "96.507709",
        "bgp": "81.059592",
        "syncd": "65.405027",
        "swss": "",
        "teamd": "78.26226",
        "database": "",
        "syncd_create_switch": "8.901015",
        "sai_create_switch": "0.003605",
        "apply_view": "10.918213",
        "init_view": "11.141743",
        "neighbor_entry": "0.988314",
        "port_init": "0.849263",
        "port_ready": "",
        "finalizer": "0.0",
        "lag_ready": "0.005578",
        "fpmsyncd_reconciliation": "",
        "route_deferral_timer": "0.988564",
        "fdb_restore": "0.79146"
    },
    "offset_from_kexec": {
        "database": "23.761875",
        "finalizer": "23.880369",
        "init_view": "65.679794",
        "syncd_create_switch": "67.375081",
        "fpmsyncd_reconciliation": "69.663904",
        "port_init": "79.587944",
        "port_ready": "",
        "sai_create_switch": "76.837417",
        "neighbor_entry": "80.946173",
        "default_route_set": "83.321276",
        "apply_view": "95.486606",
        "lag_ready": "131.008816",
        "fdb_restore": "88.192801",
        "route_deferral_timer": "132.059586"
    }
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
