### PR TITLE
Add testcase to validate the decap rules are created as expected before and after warm-reboot

### DIFF
--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -1,6 +1,6 @@
 import pytest
 import logging
-from tests.common.helpers.upgrade_helpers import install_sonic, upgrade_test_helper, check_asic_and_db_consistency
+from tests.common.helpers.upgrade_helpers import install_sonic, upgrade_test_helper
 from tests.common.helpers.upgrade_helpers import restore_image            # noqa F401
 from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot   # noqa F401
@@ -151,8 +151,6 @@ def test_warm_upgrade_subnet_decap(localhost, duthosts, ptfhost, rand_one_dut_ho
         test_vlan_subnet_decap(request, rand_one_dut_hostname, ptfhost, tbinfo, ip_version, stage,  
                                prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
                                prepare_negative_ip_port_map, setup_arp_responder)
-        patch_rsyslog(duthost)
-        check_asic_and_db_consistency(request.config, duthost, consistency_checker_provider)
     
     upgrade_test_helper(duthost, localhost, ptfhost, from_image,
                         to_image, tbinfo, upgrade_type, get_advanced_reboot,

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -13,7 +13,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
 from tests.common.platform.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
-from test.decap.test_subnet_decap import test_vlan_subnet_decap
+from tests.decap.test_subnet_decap import test_vlan_subnet_decap
 
 
 pytestmark = [
@@ -145,13 +145,13 @@ def test_warm_upgrade_subnet_decap(localhost, duthosts, ptfhost, rand_one_dut_ho
         
         setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
                            upgrade_type)
-        
+
     def upgrade_path_postboot_setup():
         logger.info(f"Validating decap rules for {ip_version} {stage} after upgrade...")
         test_vlan_subnet_decap(request, rand_one_dut_hostname, ptfhost, tbinfo, ip_version, stage,  
                                prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
                                prepare_negative_ip_port_map, setup_arp_responder)
-    
+
     upgrade_test_helper(duthost, localhost, ptfhost, from_image,
                         to_image, tbinfo, upgrade_type, get_advanced_reboot,
                         advanceboot_loganalyzer=advanceboot_loganalyzer,

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -1,6 +1,6 @@
 import pytest
 import logging
-from tests.common.helpers.upgrade_helpers import install_sonic, upgrade_test_helper
+from tests.common.helpers.upgrade_helpers import install_sonic, upgrade_test_helper, check_asic_and_db_consistency
 from tests.common.helpers.upgrade_helpers import restore_image            # noqa F401
 from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot   # noqa F401
@@ -13,6 +13,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
 from tests.common.platform.warmboot_sad_cases import get_sad_case_list, SAD_CASE_LIST
+from test.decap.test_subnet_decap import test_vlan_subnet_decap
 
 
 pytestmark = [
@@ -124,3 +125,38 @@ def test_warm_upgrade_sad_path(localhost, duthosts, ptfhost, rand_one_dut_hostna
                         consistency_checker_provider=consistency_checker_provider,
                         sad_preboot_list=sad_preboot_list,
                         sad_inboot_list=sad_inboot_list, enable_cpa=enable_cpa)
+
+
+@pytest.mark.device_type('vs')
+@pytest.mark.parametrize("ip_version", ["IPv4", "IPv6"])
+@pytest.mark.parametrize("stage", ["positive", "negative"])
+def test_warm_upgrade_subnet_decap(localhost, duthosts, ptfhost, rand_one_dut_hostname,
+                      nbrhosts, fanouthosts, tbinfo, request, restore_image,            # noqa F811
+                      get_advanced_reboot, verify_dut_health, advanceboot_loganalyzer,  # noqa F811
+                      consistency_checker_provider, upgrade_path_lists):
+    duthost = duthosts[rand_one_dut_hostname]
+    upgrade_type, from_image, to_image, _, enable_cpa = upgrade_path_lists
+    logger.info("Test upgrade path from {} to {}".format(from_image, to_image))
+    def upgrade_path_preboot_setup():
+        logger.info(f"Validating decap rules for {ip_version} {stage} before upgrade...")
+        test_vlan_subnet_decap(request, rand_one_dut_hostname, ptfhost, tbinfo, ip_version, stage,  
+                               prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
+                               prepare_negative_ip_port_map, setup_arp_responder)
+        
+        setup_upgrade_test(duthost, localhost, from_image, to_image, tbinfo,
+                           upgrade_type)
+        
+    def upgrade_path_postboot_setup():
+        logger.info(f"Validating decap rules for {ip_version} {stage} after upgrade...")
+        test_vlan_subnet_decap(request, rand_one_dut_hostname, ptfhost, tbinfo, ip_version, stage,  
+                               prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
+                               prepare_negative_ip_port_map, setup_arp_responder)
+        patch_rsyslog(duthost)
+        check_asic_and_db_consistency(request.config, duthost, consistency_checker_provider)
+    
+    upgrade_test_helper(duthost, localhost, ptfhost, from_image,
+                        to_image, tbinfo, upgrade_type, get_advanced_reboot,
+                        advanceboot_loganalyzer=advanceboot_loganalyzer,
+                        preboot_setup=upgrade_path_preboot_setup,
+                        consistency_checker_provider=consistency_checker_provider,
+                        enable_cpa=enable_cpa)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Test Gap Description
No testcase to validate the decap rules are created/working as expected after warm-reboot.

Note: This particular test case can be covered in dedicated upgrade path test.
Test Plan
verify the decap rules are present and IPinIP traffic could be decapsulated before warm reboot
warm reboot to a newer version
verify the decap rules are present and IPinIP traffic could be decapsulated after warm reboot

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
No testcase to validate the decap rules are created/working as expected after warm-reboot.
#### How did you do it?
Add dedicated upgrade path test to validate the decap rules are created as expected before and after warm-reboot
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
