### PR TITLE
Fixing `PR16687` to work for chassis and non-chassis

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -126,7 +126,7 @@ def test_snmp_queue_counters(duthosts,
 
     # Get appropriate buffer queue value to delete
     buffer_queues = list(data['BUFFER_QUEUE'].keys())
-    iface_buffer_queues = [bq for bq in buffer_queues if bq.split('|')[0] == interface]
+    iface_buffer_queues = [bq for bq in buffer_queues if any(val == interface for val in bq.split('|'))]
     if iface_buffer_queues:
         buffer_queue_to_del = iface_buffer_queues[0]
     else:


### PR DESCRIPTION
https://github.com/sonic-net/sonic-mgmt/pull/16687 recently merged to fix an issue on non-chassis systems but it broke chassis systems as described in https://github.com/sonic-net/sonic-mgmt/issues/17131

This change will solve the issue originally targeted by https://github.com/sonic-net/sonic-mgmt/pull/16687
Where 'Ethernet112|6' when split with delimiter "|" the string in 1st index "6" is a substring of "Ethernet68"

By using `val == interface` it no longer matters if the buffer queue matches up a substring of the interface.

Summary:
Fixes #17131 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
