### PR TITLE
[dualtor-io] Update the ignored kill-bgp errors

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -67,7 +67,10 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
         r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_tnl_route_event_add:\d+ ecmp table entry lookup "
         "failed with error.*",
         r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_process_route_add_mode_default_and_host:\d+ "
-        "_brcm_sai_mptnl_tnl_route_event_add failed with error.*"
+        "_brcm_sai_mptnl_tnl_route_event_add failed with error.*",
+        r".* ERR bgp#mgmtd\[33\]: \[X3G8F-PM93W\] BE-adapter: mgmt_msg_read: got EOF/disconnect",
+        r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: "
+        r"\['vtysh', '-H', '/dev/null', '-c', 'show bgp summary json'\]"
     ]
 
     if loganalyzer:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The following errors should be ignored as bgpd is killed:
```
E               Match Messages:
E               2025 Feb  5 23:19:11.881870 str2-7050cx3-acs-07 ERR bgp#bgpmon: *ERROR* Failed with rc:1 when execute: ['vtysh', '-H', '/dev/null', '-c', 'show bgp summary json']
E               
E               2025 Feb  5 23:19:25.232074 str2-7050cx3-acs-07 ERR bgp#mgmtd[33]: [X3G8F-PM93W] BE-adapter: mgmt_msg_read: got EOF/disconnect
E               
E               2025 Feb  5 23:19:25.565904 str2-7050cx3-acs-07 ERR bgp#mgmtd[33]: [X3G8F-PM93W] BE-adapter: mgmt_msg_read: got EOF/disconnect
```

Signed-off-by: Longxiang <lolv@microsoft.com>


#### How did you do it?
Add regex strings to the ignore list.

#### How did you verify/test it?
```
dualtor_io/test_tor_bgp_failure.py::test_standby_tor_kill_bgpd_downstream_active[active-standby] PASSED                                                                                        [100%]

============================================================================= 1 passed, 14 warnings in 615.54s (0:10:15) =============================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
