### PR TITLE
[test_switchover_faulty_ycable] Ignore pmon errors on the correct ToR

### DIFF
--- a/tests/dualtor/test_switchover_faulty_ycable.py
+++ b/tests/dualtor/test_switchover_faulty_ycable.py
@@ -22,15 +22,13 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
-def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
-    # Ignore in KVM test
-    KVMIgnoreRegex = [
-        ".*Could not establish the active side for Y cable port.*",
+def ignore_expected_loganalyzer_exceptions(simulated_faulty_side, loganalyzer):
+    """Ignore the pmon error."""
+    error_str = [
+        ".*Could not establish the active side for Y cable port.*"
     ]
-    duthost = duthosts[rand_one_dut_hostname]
     if loganalyzer:  # Skip if loganalyzer is disabled
-        if duthost.facts["asic_type"] == "vs":
-            loganalyzer[duthost.hostname].ignore_regex.extend(KVMIgnoreRegex)
+        loganalyzer[simulated_faulty_side.hostname].ignore_regex.extend(error_str)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
`test_switchover_faulty_ycable` uses faulty ycable driver, which will trigger the following errors that need to be ignored:

```
E               Match Messages:
E               2025 Feb 26 06:30:44.358985 bjw2-can-7260-4 ERR pmon#CCmisApi: Error: Could not establish the active side for Y cable port Ethernet0 to perform read_y_cable update state db
E
E               2025 Feb 26 06:30:44.406811 bjw2-can-7260-4 ERR pmon#CCmisApi: Error: Could not establish the active side for Y cable port Ethernet4 to perform read_y_cable update state db
E
E               2025 Feb 26 06:30:44.452066 bjw2-can-7260-4 ERR pmon#CCmisApi: Error: Could not establish the active side for Y cable port Ethernet8 to perform read_y_cable update state db
E
E               2025 Feb 26 06:30:44.493998 bjw2-can-7260-4 ERR pmon#CCmisApi: Error: Could not establish the active side for Y cable port Ethernet12 to perform read_y_cable update state db
```

Signed-off-by: Longxiang <lolv@microsoft.com>

#### How did you do it?
Add the error regex to the ignore list.

#### How did you verify/test it?
```
dualtor/test_switchover_faulty_ycable.py::test_switchover_probe_unknown PASSED                                                                                                                 [ 50%]
dualtor/test_switchover_faulty_ycable.py::test_switchover_peer_link_down PASSED                                                                                                                [100%]

============================================================================= 2 passed, 2 warnings in 522.37s (0:08:42) ==============================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
