### PR TITLE
[Mx] Enable everflow testcases on Mx topo

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -15,7 +15,7 @@ from .everflow_test_utilities import setup_info      # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t2", "m0")
+    pytest.mark.topology("t0", "t1", "t2", "m0", "mx")
 ]
 
 EVERFLOW_V6_RULES = "ipv6_test_rules.yaml"

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -20,7 +20,7 @@ from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py           
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t2", "m0")
+    pytest.mark.topology("t0", "t1", "t2", "m0", "mx")
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -12,7 +12,7 @@ from tests.route.utils import generate_intf_neigh, generate_route_file, prepare_
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "m0"),
+    pytest.mark.topology("t0", "m0", "mx"),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enable 2 everflow testcases on Mx topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Enable everflow testcases on Mx topo.

#### How did you do it?
Update pytest mark.

#### How did you verify/test it?
Verified testcases on Arista-720DT Mx testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
