### PR TITLE
[test_dynamic_acl]: Enhance test to support non-portchannel testbed

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -169,13 +169,13 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
                 upstream_port_ids.append(port_id)
     else:
         downstream_ports = list(mg_facts["minigraph_vlans"][vlan_name]["members"])
-        # Put all portchannel members into dst_ports
+        # Put all upstream ports into dst_ports
         upstream_port_ids = []
         upstream_ports = []
-        for _, v in mg_facts['minigraph_portchannels'].items():
-            for member in v['members']:
-                upstream_port_ids.append(mg_facts['minigraph_ptf_indices'][member])
-                upstream_ports.append(member)
+        for port in mg_facts['minigraph_ports']:
+            if port not in downstream_ports and port in mg_facts['minigraph_ptf_indices']:
+                upstream_port_ids.append(mg_facts['minigraph_ptf_indices'][port])
+                upstream_ports.append(port)
 
     for port in downstream_ports:
         if port in mg_facts['minigraph_port_name_to_alias_map']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The test_dynamic_acl testcases cannot be supported in some testbeds without port-channel

#### How did you do it?

Adapting the test parameters on both portchannel and non-portchannel scenarioes.

#### How did you verify/test it?

Run it on non-portchannel platform:
```
==================================================================================================================================== test session starts =====================================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /data/sonic-mgmt/tests
configfile: pytest.ini
plugins: ansible-4.0.0, metadata-3.1.1, stress-1.0.1, html-4.1.1, xdist-1.28.0, forked-1.6.0, repeat-0.9.3, allure-pytest-2.8.22
collecting ...
------------------------------------------------------------------------------------------------------------------------------------ live log collection -------------------------------------------------------------------------------------------------------------------------------------
11:12:47 testbed.get_testbed_type                 L0263 WARNING| Unsupported testbed type - force10-7nodes
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collecting 0 items                                                                                                                                                                                                                                                                           11:12:53 testbed.get_testbed_type                 L0263 WARNING| Unsupported testbed type - force10-7nodes
collected 12 items

generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV4-vlab-01-None-default-Vlan1000] PASSED                                                                                                                                                                  [  8%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV6-vlab-01-None-default-Vlan1000] PASSED                                                                                                                                                                  [ 16%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_removal[default-Vlan1000-IPV6] PASSED                                                                                                                                                                            [ 25%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_dhcp_rule_creation[default-Vlan1000] PASSED                                                                                                                                                                                   [ 33%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_drop_rule_creation[default-Vlan1000] PASSED                                                                                                                                                                                   [ 41%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_drop_rule_removal[default-Vlan1000] PASSED                                                                                                                                                                                    [ 50%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_priority_respected[default-Vlan1000] PASSED                                                                                                                                                                      [ 58%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_replacement[default-Vlan1000] PASSED                                                                                                                                                                             [ 66%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_removal[default-Vlan1000-IPV4] PASSED                                                                                                                                                                            [ 75%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_scale_rules[default-Vlan1000] PASSED                                                                                                                                                                                          [ 83%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_nonexistent_rule_replacement[default-Vlan1000] PASSED                                                                                                                                                                         [ 91%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_nonexistent_table_removal[default-Vlan1000] PASSED                                                                                                                                                                            [100%]

====================================================================================================================================== warnings summary ======================================================================================================================================
../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

generic_config_updater/test_dynamic_acl.py: 114 warnings
  /usr/local/lib/python3.8/dist-packages/ptf/mask.py:69: DeprecationWarning: "set_do_not_care_scapy" is going to be deprecated, please switch to the new one: "set_do_not_care_packet"
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------------------------ generated xml file: /data/sonic-mgmt/tests/logs/generic_config_updater/test_dynamic_acl.xml -------------------------------------------------------------------------------------------------
======================================================================================================================== 12 passed, 115 warnings in 508.66s (0:08:28) ========================================================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_gcu_acl_nonexistent_table_removal[default-Vlan1000]>

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
