### PR TITLE
Fix fixture invocation order in qos_sai_base.py to prevent teardown failure.

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -567,7 +567,8 @@ class QosSaiBase(QosBase):
         return dutPortIps
 
     @pytest.fixture(scope='module')
-    def swapSyncd_on_selected_duts(self, request, duthosts, creds, tbinfo, lower_tor_host): # noqa F811
+    def swapSyncd_on_selected_duts(self, request, duthosts, creds, tbinfo, lower_tor_host, # noqa F811
+                                   core_dump_and_config_check): # noqa F811
         """
             Swap syncd on DUT host
 


### PR DESCRIPTION
…ailure.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#460](https://github.com/aristanetworks/sonic-qual.msft/issues/460)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

1. Regression due to: https://github.com/sonic-net/sonic-mgmt/pull/15938

2. This PR changes the scope of swapSyncd_on_selected_duts and dut_disable_ipv6 from class to module.  This was to reduce execution time in T2. The fixtures used to fire multiple times for chassis.

3. There is a fixture in global conftest, `core_dump_and_config_check` which in its teardown restores DUT config to the state as it was prior to the test. https://github.com/sonic-net/sonic-mgmt/blob/202411/tests/conftest.py#L2542

4. All the three fixtures are currently autouse and module scoped and core_dump_and_config_check and dut_disable_ipv6 share no explicit dependencies hence they will fire in any order.

5. If the teardown of core_dump_and_config_check happens before dut_disable_ipv6 has restored ipv6 on the DUT, this failure will be seen.


#### How did you do it?

The proposed fix will be to make [swapSyncd_on_selected_duts](https://github.com/sonic-net/sonic-mgmt/blob/202411/tests/qos/qos_sai_base.py#L567-L568) request [core_dump_and_config_check](https://github.com/sonic-net/sonic-mgmt/blob/202411/tests/conftest.py#L2273C5-L2273C31). This way setup of [core_dump_and_config_check](https://github.com/sonic-net/sonic-mgmt/blob/202411/tests/conftest.py#L2273C5-L2273C31) will happen before qos_sai_base fixtures and its teardown will happen after the teardown of qos_sai_base fixtures.

#### How did you verify/test it?
Ran `qos/test_qos_sai.py` with dualtor topology on Arista-7050CX3 and no error was seen.

```
SKIPPED [3] qos/test_qos_sai.py:1559: multi-dut is not supported on T0 topologies
SKIPPED [6] qos/test_qos_sai.py:1635: multi-dut is not supported on T0 topologies
SKIPPED [3] qos/test_qos_sai.py:1742: multi-dut is not supported on T0 topologies
SKIPPED [6] qos/test_qos_sai.py:1851: multi-dut is not supported on T0 topologies
SKIPPED [3] qos/test_qos_sai.py:1935: multi-dut is not supported on T0 topologies
SKIPPED [6] qos/test_qos_sai.py:2059: multi-dut is not supported on T0 topologies
SKIPPED [3] qos/test_qos_sai.py:2120: multi-dut is not supported on T0 topologies
============================= 15 passed, 220 skipped, 1 warning in 4656.78s (1:17:36) ==============================

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
