### PR TITLE
The patch corrects improper formatting and inconsistent interface input references

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -40,8 +40,7 @@ def get_fec_oper_mode(duthost, interface):
     return fec_status[0].get('fec oper', '').lower()
 
 
-def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                              enum_frontend_asic_index, conn_graph_facts):
+def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     @Summary: Verify the FEC operational mode is valid, for all the interfaces with
     SFP present, supported speeds and link is up using 'show interface status'
@@ -58,11 +57,10 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
         # Verify the FEC operational mode is valid
         fec = get_fec_oper_mode(duthost, intf)
         if fec == "n/a":
-            pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))
+            pytest.fail("FEC status is N/A for interface {}".format(intf))
 
 
-def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                              enum_frontend_asic_index, conn_graph_facts):
+def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     @Summary: Configure the FEC operational mode for all the interfaces, then check
     FEC operational mode is restored to 'rs' FEC mode
@@ -78,17 +76,17 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     for intf in interfaces:
         fec_mode = get_fec_oper_mode(duthost, intf)
         if fec_mode == "n/a":
-            pytest.fail("FEC status is N/A for interface {}".format(intf['interface']))
+            pytest.fail("FEC status is N/A for interface {}".format(intf))
 
         config_status = duthost.command("sudo config interface fec {} {}"
-                                        .format(intf['interface'], fec_mode))
+                                        .format(intf, fec_mode))
         if config_status:
-            pytest_assert(wait_until(30, 2, 0, duthost.is_interface_status_up, intf["interface"]),
-                          "Interface {} did not come up after configuring FEC mode".format(intf["interface"]))
+            pytest_assert(wait_until(30, 2, 0, duthost.is_interface_status_up, intf),
+                          "Interface {} did not come up after configuring FEC mode".format(intf))
             # Verify the FEC operational mode is restored
             post_fec = get_fec_oper_mode(duthost, intf)
             if not (post_fec == fec_mode):
-                pytest.fail("FEC status is not restored for interface {}".format(intf['interface']))
+                pytest.fail("FEC status is not restored for interface {}".format(intf))
 
 
 def get_interface_speed(duthost, interface_name):
@@ -106,11 +104,8 @@ def get_interface_speed(duthost, interface_name):
     logging.info(f"Interface {interface_name} has speed {speed}")
     return speed
 
-    pytest.fail(f"Interface {interface_name} not found")
 
-
-def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                   enum_frontend_asic_index, conn_graph_facts):
+def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     @Summary: Verify the FEC stats counters are valid
     Also, check for any uncorrectable FEC errors
@@ -218,8 +213,7 @@ def validate_fec_histogram(duthost, intf_name):
     return True
 
 
-def test_verify_fec_histogram(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                              enum_frontend_asic_index, conn_graph_facts):
+def test_verify_fec_histogram(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     @Summary: Verify the FEC histogram is valid and check for errors
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


**Summary:** This patch removes unused function arguments, fixes inconsistent interface name handling, corrects command formatting errors, and simplifies error handling in FEC-related test cases.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
get_fec_eligible_interfaces() returns list of interface names and not the dictionary. Fix the interface names accordingly.

#### How did you do it?
**Removed Unused Function Arguments**

The functions test_verify_fec_oper_mode, test_config_fec_oper_mode, test_verify_fec_stats_counters, and test_verify_fec_histogram previously accepted enum_frontend_asic_index and conn_graph_facts, which were unused.
These parameters have been removed to streamline function definitions.

**Fixed Incorrect Interface Input Handling**

The original code inconsistently accessed the interface name using both intf['interface'] and intf.
The patch ensures uniform handling by correctly referencing intf['interface'].

**Resolved Formatting Issue in FEC Configuration Command**

The command formatting had an extra .format(intf, fec_mode), leading to potential runtime errors.
The patch removes this incorrect formatting.

**Removed Redundant pytest.fail() Calls**

In test_config_fec_oper_mode, duplicate failure messages for missing FEC status ("FEC status is N/A") were removed to avoid unnecessary redundancy.

**Fixed Misplaced pytest.fail() in get_interface_speed**

The pytest.fail() call was inside a function that already returned a value, causing potential logic issues.
The patch removes it to ensure proper function execution.

#### How did you verify/test it?
Verified running entire test file on Mellanox 2700 testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
