### PR TITLE
Adding nvidia smartswitch support for MSN4280

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -471,6 +471,9 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             port_alias_to_name_map['etp65'] = "Ethernet512"
             if hwsku == "Mellanox-SN5610N-C224O8":
                 port_alias_to_name_map['etp66'] = "Ethernet520"
+        elif hwsku == "ACS-SN4280":
+            for i in range(0, 256, 8):
+                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Arista-7060DX5-32":
             for i in range(1, 33):
                 port_alias_to_name_map["Ethernet%d/1" % i] = "Ethernet%d" % ((i - 1) * 8)


### PR DESCRIPTION
Add port interface support for MSM4280, HwSKU = ACS-SN4280

### Description of PR
This PR is to add support for Nvidia smartswitch when creating ports.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to add support for nvidia smartswitch when creating ports.

#### How did you do it?
Local dev container within my own test environment

#### How did you verify/test it?
Added new lines to existing script and ran it within my own container.

#### Any platform specific information?
Mellanox Nvidia MSN4280-WS2RXOS

#### Supported testbed topology if it's a new test case?

### Documentation
