### PR TITLE
[ansible] Correct the formatting for linkmetadata minigraph generation for autonegotiation

### DIFF
--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,98 +1,90 @@
-{% set link_metadata_defined = False %}
+{% set ns = namespace(link_metadata_defined=False) -%}
 
-{% if 'dualtor' in topo or
-      (macsec_card is defined and macsec_card == True and 't2' in topo) %}
-    {% set link_metadata_defined = True %}
-{% endif %}
+{%- if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) -%}
+    {% set ns.link_metadata_defined = True %}
+{%- endif -%}
 
-{% if device_conn is defined and inventory_hostname in device_conn %}
-    {% for iface in device_conn[inventory_hostname] %}
-        {% if 'autoneg' in device_conn[inventory_hostname][iface] and
-           'on' in device_conn[inventory_hostname][iface]['autoneg'] %}
-            {% set link_metadata_defined = True %}
-        {% endif %}
-    {% endfor %}
-{% endif %}
+{%- if device_conn is defined and inventory_hostname in device_conn and
+      device_conn[inventory_hostname].values() | selectattr('autoneg', 'defined') | selectattr('autoneg', 'equalto', 'on') | list | length > 0 -%}
+    {% set ns.link_metadata_defined = True %}
+{%- endif -%}
 
-{% if link_metadata_defined %}
+{% if ns.link_metadata_defined %}
+
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 {% endif %}
-
 {% if 'dualtor' in topo %}
 {% for tunnel in tunnel_configs %}
-      <a:LinkMetadata>
-          <a:Name i:nil="true" />
-          <a:Properties>
-            <a:DeviceProperty>
-              <a:Name>GeminiPeeringLink</a:Name>
-              <a:Reference i:nil="true" />
-              <a:Value>True</a:Value>
-            </a:DeviceProperty>
-            <a:DeviceProperty>
-              <a:Name>UpperTOR</a:Name>
-              <a:Reference i:nil="true" />
-              <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
-            </a:DeviceProperty>
-            <a:DeviceProperty>
-              <a:Name>LowerTOR</a:Name>
-              <a:Reference i:nil="true" />
-              <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
-            </a:DeviceProperty>
-          </a:Properties>
-        <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
-      </a:LinkMetadata>
-{% endfor %}
-{% endif %}
-
-{% if macsec_card is defined and macsec_card == True and 't2' in topo %}
-{% for index in range(vms_number) %}
-{% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
-{% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
-{% for if_index in range(vm_intfs | length) %}
-{% if 'IB' not in port_alias[dut_intfs[if_index]] %}
-        <a:LinkMetadata>
-            <a:Name i:nil="true"/>
-            <a:Properties>
-            <a:DeviceProperty>
-                <a:Name>MacSecEnabled</a:Name>
-                <a:Value>True</a:Value>
-            </a:DeviceProperty>
-            </a:Properties>
-            <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
-        </a:LinkMetadata>
-{% endif %}
-{% endfor %}
-{% endfor %}
-{% endif %}
-
-{% if device_conn is defined and inventory_hostname in device_conn %}
-{% for iface_name in device_conn[inventory_hostname].keys() %}
-    {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
-        {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>
                 <a:DeviceProperty>
-                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Name>GeminiPeeringLink</a:Name>
+                    <a:Reference i:nil="true"/>
                     <a:Value>True</a:Value>
-                    </a:DeviceProperty>
-            {% if msft_an_enabled is defined %}
-                 <a:DeviceProperty>
-                     <a:Name>FECDisabled</a:Name>
-                     <a:Reference i:nil="true"/>
-                     <a:Value>True</a:Value>
-                 </a:DeviceProperty>
-            {% endif %}
+                </a:DeviceProperty>
+                <a:DeviceProperty>
+                    <a:Name>UpperTOR</a:Name>
+                    <a:Reference i:nil="true"/>
+                    <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
+                </a:DeviceProperty>
+                <a:DeviceProperty>
+                    <a:Name>LowerTOR</a:Name>
+                    <a:Reference i:nil="true"/>
+                    <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
+                </a:DeviceProperty>
             </a:Properties>
-            <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
-            </a:LinkMetadata>
-        {% endif %}
-    {% endif %}
+            <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
+        </a:LinkMetadata>
 {% endfor %}
 {% endif %}
-
-{% if link_metadata_defined %}
-    </Link>
-  </LinkMetadataDeclaration>
+{% if macsec_card is defined and macsec_card == True and 't2' in topo %}
+{% for index in range(vms_number) %}
+{% set vm_intfs = vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
+{% set dut_intfs = vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
+{% for if_index in range(vm_intfs | length) %}
+{% if 'IB' not in port_alias[dut_intfs[if_index]] %}
+                <a:LinkMetadata>
+                    <a:Name i:nil="true"/>
+                    <a:Properties>
+                        <a:DeviceProperty>
+                            <a:Name>MacSecEnabled</a:Name>
+                            <a:Value>True</a:Value>
+                        </a:DeviceProperty>
+                    </a:Properties>
+                    <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
+                </a:LinkMetadata>
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% if device_conn is defined and inventory_hostname in device_conn %}
+{% for iface_name in device_conn[inventory_hostname].keys() %}
+{% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
+{% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
+                <a:LinkMetadata>
+                    <a:Name i:nil="true"/>
+                    <a:Properties>
+                        <a:DeviceProperty>
+                            <a:Name>AutoNegotiation</a:Name>
+                            <a:Value>True</a:Value>
+                        </a:DeviceProperty>
+{% if msft_an_enabled is defined %}
+                        <a:DeviceProperty>
+                            <a:Name>FECDisabled</a:Name>
+                            <a:Reference i:nil="true"/>
+                            <a:Value>True</a:Value>
+                        </a:DeviceProperty>
+{% endif %}
+                    </a:Properties>
+                    <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+                </a:LinkMetadata>
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if ns.link_metadata_defined %}
+  </Link>
+</LinkMetadataDeclaration>
 {% endif %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -8,7 +8,6 @@
       device_conn[inventory_hostname].values() | selectattr('autoneg', 'defined') | selectattr('autoneg', 'equalto', 'on') | list | length > 0 -%}
     {% set ns.link_metadata_defined = True %}
 {%- endif -%}
-
 {% if ns.link_metadata_defined %}
 
   <LinkMetadataDeclaration>

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -40,8 +40,8 @@
 {% endif %}
 {% if macsec_card is defined and macsec_card == True and 't2' in topo %}
 {% for index in range(vms_number) %}
-{% set vm_intfs = vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
-{% set dut_intfs = vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
+{% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
+{% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
 {% for if_index in range(vm_intfs | length) %}
 {% if 'IB' not in port_alias[dut_intfs[if_index]] %}
         <a:LinkMetadata>
@@ -62,23 +62,23 @@
 {% for iface_name in device_conn[inventory_hostname].keys() %}
 {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
 {% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
-                <a:LinkMetadata>
-                    <a:Name i:nil="true"/>
-                    <a:Properties>
-                        <a:DeviceProperty>
-                            <a:Name>AutoNegotiation</a:Name>
-                            <a:Value>True</a:Value>
-                        </a:DeviceProperty>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+                <a:DeviceProperty>
+                    <a:Name>AutoNegotiation</a:Name>
+                    <a:Value>True</a:Value>
+                    </a:DeviceProperty>
 {% if msft_an_enabled is defined %}
-                        <a:DeviceProperty>
-                            <a:Name>FECDisabled</a:Name>
-                            <a:Reference i:nil="true"/>
-                            <a:Value>True</a:Value>
-                        </a:DeviceProperty>
+                 <a:DeviceProperty>
+                     <a:Name>FECDisabled</a:Name>
+                     <a:Reference i:nil="true"/>
+                     <a:Value>True</a:Value>
+                 </a:DeviceProperty>
 {% endif %}
-                    </a:Properties>
-                    <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
-                </a:LinkMetadata>
+            </a:Properties>
+            <a:Key>{{ device_conn[inventory_hostname][iface_name]['peerdevice'] }}:{{ device_conn[inventory_hostname][iface_name]['peerport'] }};{{ inventory_hostname }}:{{ port_name_map[iface_name] }}</a:Key>
+            </a:LinkMetadata>
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,4 +1,4 @@
-{% set ns = namespace(link_metadata_defined=False) -%}
+{%- set ns = namespace(link_metadata_defined=False) -%}
 
 {%- if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) -%}
     {% set ns.link_metadata_defined = True %}
@@ -15,27 +15,27 @@
 {% endif %}
 {% if 'dualtor' in topo %}
 {% for tunnel in tunnel_configs %}
-        <a:LinkMetadata>
-            <a:Name i:nil="true"/>
-            <a:Properties>
-                <a:DeviceProperty>
-                    <a:Name>GeminiPeeringLink</a:Name>
-                    <a:Reference i:nil="true"/>
-                    <a:Value>True</a:Value>
-                </a:DeviceProperty>
-                <a:DeviceProperty>
-                    <a:Name>UpperTOR</a:Name>
-                    <a:Reference i:nil="true"/>
-                    <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
-                </a:DeviceProperty>
-                <a:DeviceProperty>
-                    <a:Name>LowerTOR</a:Name>
-                    <a:Reference i:nil="true"/>
-                    <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
-                </a:DeviceProperty>
-            </a:Properties>
-            <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
-        </a:LinkMetadata>
+      <a:LinkMetadata>
+          <a:Name i:nil="true" />
+          <a:Properties>
+            <a:DeviceProperty>
+              <a:Name>GeminiPeeringLink</a:Name>
+              <a:Reference i:nil="true" />
+              <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            <a:DeviceProperty>
+              <a:Name>UpperTOR</a:Name>
+              <a:Reference i:nil="true" />
+              <a:Value>{{ dual_tor_facts['positions']['upper'] }}</a:Value>
+            </a:DeviceProperty>
+            <a:DeviceProperty>
+              <a:Name>LowerTOR</a:Name>
+              <a:Reference i:nil="true" />
+              <a:Value>{{ dual_tor_facts['positions']['lower'] }}</a:Value>
+            </a:DeviceProperty>
+          </a:Properties>
+        <a:Key>{{ dual_tor_facts['positions']['lower'] }}:{{ tunnel }};{{ dual_tor_facts['positions']['upper'] }}:{{ tunnel }}</a:Key>
+      </a:LinkMetadata>
 {% endfor %}
 {% endif %}
 {% if macsec_card is defined and macsec_card == True and 't2' in topo %}
@@ -44,16 +44,16 @@
 {% set dut_intfs = vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
 {% for if_index in range(vm_intfs | length) %}
 {% if 'IB' not in port_alias[dut_intfs[if_index]] %}
-                <a:LinkMetadata>
-                    <a:Name i:nil="true"/>
-                    <a:Properties>
-                        <a:DeviceProperty>
-                            <a:Name>MacSecEnabled</a:Name>
-                            <a:Value>True</a:Value>
-                        </a:DeviceProperty>
-                    </a:Properties>
-                    <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
-                </a:LinkMetadata>
+        <a:LinkMetadata>
+            <a:Name i:nil="true"/>
+            <a:Properties>
+            <a:DeviceProperty>
+                <a:Name>MacSecEnabled</a:Name>
+                <a:Value>True</a:Value>
+            </a:DeviceProperty>
+            </a:Properties>
+            <a:Key>{{ vms[index] }}:{{ vm_intfs[if_index] }};{{ inventory_hostname }}:{{ port_alias[dut_intfs[if_index]] }}</a:Key>
+        </a:LinkMetadata>
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

This PR refactors minigraph_link_meta.j2 by:

- Replacing link_metadata_defined with Jinja2 namespace (ns) for better variable scoping.
- Optimizing auto-negotiation detection using selectattr() to reduce looping.
- Improving code readability with structured formatting and consistent indentation.
These changes enhance efficiency and maintainability without altering functionality.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Correct the minigraph generation For autoneg in SONiC
#### How did you do it?

#### How did you verify/test it?
This minigraph is generated


```
<LinkMetadataDeclaration>
    <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
                <a:LinkMetadata>
                    <a:Name i:nil="true"/>
                    <a:Properties>
                        <a:DeviceProperty>
                            <a:Name>AutoNegotiation</a:Name>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                        <a:DeviceProperty>
                            <a:Name>FECDisabled</a:Name>
                            <a:Reference i:nil="true"/>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                    </a:Properties>
                    <a:Key>fanout1:Ethernet39/1;sonic1:Ethernet7/1</a:Key>
                </a:LinkMetadata>
                <a:LinkMetadata>
                    <a:Name i:nil="true"/>
                    <a:Properties>
                        <a:DeviceProperty>
                            <a:Name>AutoNegotiation</a:Name>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                        <a:DeviceProperty>
                            <a:Name>FECDisabled</a:Name>
                            <a:Reference i:nil="true"/>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                    </a:Properties>
                    <a:Key>fanout1:Ethernet40/1;sonic1:Ethernet8/1</a:Key>
                </a:LinkMetadata>
                <a:LinkMetadata>
                    <a:Name i:nil="true"/>
                    <a:Properties>
                        <a:DeviceProperty>
                            <a:Name>AutoNegotiation</a:Name>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                        <a:DeviceProperty>
                            <a:Name>FECDisabled</a:Name>
                            <a:Reference i:nil="true"/>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                    </a:Properties>
                    <a:Key>fanout1:Ethernet41/1;sonic1:Ethernet9/1</a:Key>
                </a:LinkMetadata>
                <a:LinkMetadata>
                    <a:Name i:nil="true"/>
                    <a:Properties>
                        <a:DeviceProperty>
                            <a:Name>AutoNegotiation</a:Name>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                        <a:DeviceProperty>
                            <a:Name>FECDisabled</a:Name>
                            <a:Reference i:nil="true"/>
                            <a:Value>True</a:Value>
                        </a:DeviceProperty>
                    </a:Properties>
                    <a:Key>fanout1:Ethernet42/1;sonic1:Ethernet10/1</a:Key>
                </a:LinkMetadata>
  </Link>
</LinkMetadataDeclaration>
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
