### PR TITLE
Enhance test_show_chassis_modules_status to check expected physical s…

### DIFF
--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -12,6 +12,7 @@ pytestmark = [
 
 CMD_SHOW_CHASSIS_MODULE = "show chassis modules"
 
+
 @pytest.fixture(scope='module')
 def dut_vars(duthosts, enum_rand_one_per_hwsku_hostname, request):
     inv_files = get_inventory_files(request)
@@ -91,12 +92,11 @@ def test_show_chassis_module_status(duthosts, enum_rand_one_per_hwsku_hostname, 
             # If inventory contains physical slot info, perform expected slot number check
             if exp_module_slot_info:
                 pytest_assert(mod_idx in exp_module_slot_info,
-                          "Module {} is expected to be present but it is missing".format(
-                              mod_idx))
+                              "Module {} is expected to be present but it is missing".format(
+                                  mod_idx))
                 pytest_assert(res[mod_idx]['Physical-Slot'] == exp_module_slot_info[mod_idx],
-                          "Module {} expected slot {} not matching show output {}".format(
-                              mod_idx, exp_module_slot_info[mod_idx],
-                              res[mod_idx]['Physical-Slot']))
+                              "Module {} expected slot {} not matching show output {}".format(
+                                  mod_idx, exp_module_slot_info[mod_idx], res[mod_idx]['Physical-Slot']))
             else:
                 # In case Inventory file does not have the slot info, just log it but no need to fail the test
                 logger.info("Inventory file has no record of module_slot_info")

--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -64,7 +64,7 @@ def test_show_chassis_module_status(duthosts, enum_rand_one_per_hwsku_hostname, 
             "LINE-CARD3": "4"
             "SUPERVISOR0": "Y"
     """
-    exp_module_slot_info = {} 
+    exp_module_slot_info = {}
     if 'module_slot_info' in dut_vars:
         exp_module_slot_info = dut_vars['module_slot_info']
 

--- a/tests/platform_tests/cli/test_show_chassis_module.py
+++ b/tests/platform_tests/cli/test_show_chassis_module.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import get_inventory_files, get_host_visible_vars
 from .util import get_field_range, get_fields, get_skip_mod_list, get_skip_logical_module_list
 
 logger = logging.getLogger('__name__')
@@ -10,6 +11,12 @@ pytestmark = [
 ]
 
 CMD_SHOW_CHASSIS_MODULE = "show chassis modules"
+
+@pytest.fixture(scope='module')
+def dut_vars(duthosts, enum_rand_one_per_hwsku_hostname, request):
+    inv_files = get_inventory_files(request)
+    dut_vars = get_host_visible_vars(inv_files, enum_rand_one_per_hwsku_hostname)
+    yield dut_vars
 
 
 def parse_chassis_module(output, expected_headers):
@@ -33,13 +40,32 @@ def parse_chassis_module(output, expected_headers):
     return result
 
 
-def test_show_chassis_module_status(duthosts, enum_rand_one_per_hwsku_hostname):
+def test_show_chassis_module_status(duthosts, enum_rand_one_per_hwsku_hostname, dut_vars):
     cmd = " ".join([CMD_SHOW_CHASSIS_MODULE, "status"])
     logger.info("verifying output of cli command {}".format(cmd))
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     exp_headers = ["Name", "Description", "Physical-Slot", "Oper-Status", "Admin-Status"]
     skip_mod_list = get_skip_mod_list(duthost)
     skip_logical_lc_list = get_skip_logical_module_list(duthost)
+    """
+    Gather expected module slot data from a inventory file if 'module_slot_info' is defined in the inventory
+    # Sample inventory with module_slot_info:
+    str-sonic-chassis-01-sup:
+        ansible_host: 10.251.0.188
+        model: SOME-VENDOR-MODEL
+        serial: BADC0FFEE123
+        base_mac: 38:8a:29:13:45:67
+        module_slot_info:
+            "FABRIC-CARD0": "1"
+            "FABRIC-CARD3": "3"
+            "FABRIC-CARD4": "4"
+            "LINE-CARD1": "2"
+            "LINE-CARD3": "4"
+            "SUPERVISOR0": "Y"
+    """
+    exp_module_slot_info = {} 
+    if 'module_slot_info' in dut_vars:
+        exp_module_slot_info = dut_vars['module_slot_info']
 
     output = duthost.command(cmd)
     res = parse_chassis_module(output['stdout_lines'], exp_headers)
@@ -62,6 +88,18 @@ def test_show_chassis_module_status(duthosts, enum_rand_one_per_hwsku_hostname):
             pytest_assert(res[mod_idx]['Oper-Status'] == 'Online',
                           "Oper-status for slot {} should be Online but it is {}".format(
                               mod_idx, res[mod_idx]['Oper-Status']))
+            # If inventory contains physical slot info, perform expected slot number check
+            if exp_module_slot_info:
+                pytest_assert(mod_idx in exp_module_slot_info,
+                          "Module {} is expected to be present but it is missing".format(
+                              mod_idx))
+                pytest_assert(res[mod_idx]['Physical-Slot'] == exp_module_slot_info[mod_idx],
+                          "Module {} expected slot {} not matching show output {}".format(
+                              mod_idx, exp_module_slot_info[mod_idx],
+                              res[mod_idx]['Physical-Slot']))
+            else:
+                # In case Inventory file does not have the slot info, just log it but no need to fail the test
+                logger.info("Inventory file has no record of module_slot_info")
 
 
 def test_show_chassis_module_midplane_status(duthosts, enum_rand_one_per_hwsku_hostname):


### PR DESCRIPTION
…lot numbers based on Inventory Truth

### Description of PR
This PR is to add additional test in the "show chassis modules status" output to ensure that the expected modules such as FC, LC, or SUP that are present in the inventory truth are also present in the output of the show command and matching.
This will allow us to catch any discrepancies between the inventory truth and the actual output of the show command due to image change (regression) which changed the physical slot information.  It is expected that these physical slot information should never be changing as they are physical markings of the module location within the chassis.

We have seen HWSKU that miss-behaved which produced unexpected physical slot values compare to what the chassis slot labeling has on the actual chassis and this test should be able to catch it.

Please note that the inventory file new field "**module_slot_info**" is provided in the code change and demonstrated here as well:

    Sample inventory changes with module_slot_info:
    str-sonic-chassis-01-sup:
        ansible_host: 10.251.0.188
        model: SOME-VENDOR-MODEL
        serial: BADC0FFEE123
        base_mac: 38:8a:29:13:45:67
        module_slot_info:
            "FABRIC-CARD0": "1"
            "FABRIC-CARD3": "3"
            "FABRIC-CARD4": "4"
            "LINE-CARD1": "2"
            "LINE-CARD3": "4"
            "SUPERVISOR0": "Y"

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
To catch potential regression on Physical slot reporting.
This change is backward compatible and will not affect test results if user choose not to include the "new" inventory definition.

#### How did you do it?
Tested this change against various lab chassis devices with or without the new inventory definition.

#### How did you verify/test it?
Tested with following cases:
1. without the new inventory definition.
2. With the new inventory definition with correct module slot information.
3. With the new inventory definition with incorrect module slot information (simulate show output being incorrect).

#### Any platform specific information?
This enhancement is applicable for T2 Chassis only.

#### Supported testbed topology if it's a new test case?
N.A.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
