### PR TITLE
[platform_tests/sensord]: add sensord platform daemon test

### DIFF
--- a/tests/platform_tests/daemon/test_sensord.py
+++ b/tests/platform_tests/daemon/test_sensord.py
@@ -1,0 +1,105 @@
+import logging
+import time
+
+import pytest
+
+from tests.platform_tests.test_platform_info import check_sensord_status, start_pmon_sensord_task
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.sanity_check(skip_sanity=True),
+    pytest.mark.disable_loganalyzer
+]
+
+SIG_KILL = "-9"
+SIG_TERM = "-15"
+SIG_HUP = "-1"
+
+
+@pytest.fixture(scope="module")
+def check_sensord_supported(duthosts, rand_one_dut_hostname):
+    """
+    @summary: Check that sensord is enabled / supported by the SKU
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    cmd = "docker exec pmon ls /etc/sensors.d/sensors.conf"
+    no_sensors_config = duthost.shell(cmd, module_ignore_errors=True)['failed']
+    if no_sensors_config:
+        pytest.skip(f"No sensors.conf for this SKU {duthost.facts['platform']}")
+
+
+@pytest.fixture(scope="function")
+def sensord_start_and_get_pid(duthosts, rand_one_dut_hostname, check_sensord_supported):
+    """
+    @summary: Ensure sensord is running, and provide the PID to the testcase
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    daemon_status, pid = check_sensord_status(duthost)
+    if daemon_status is False:
+        start_pmon_sensord_task(duthost)
+
+    yield pid
+
+    start_pmon_sensord_task(duthost)
+
+
+def assert_expected_daemon_status(duthost, expected_daemon_status):
+    daemon_status, _ = check_sensord_status(duthost)
+    assert daemon_status == expected_daemon_status
+
+
+def test_pmon_sensord_sigterm(sensord_start_and_get_pid, duthosts, rand_one_dut_hostname):
+    """
+    @summary: Assert that sensord stops after sigterm
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    sensord_pid = sensord_start_and_get_pid
+
+    duthost.kill_pmon_daemon_pid_w_sig(sensord_pid, SIG_TERM)
+    time.sleep(2)
+
+    assert_expected_daemon_status(duthost, False)
+
+    start_pmon_sensord_task(duthost)
+    time.sleep(10)
+
+    assert_expected_daemon_status(duthost, True)
+
+
+def test_pmon_sensord_sigkill(sensord_start_and_get_pid, duthosts, rand_one_dut_hostname):
+    """
+    @summary: Assert that sensord stops after sigkill
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    sensord_pid = sensord_start_and_get_pid
+
+    duthost.kill_pmon_daemon_pid_w_sig(sensord_pid, SIG_KILL)
+    time.sleep(2)
+
+    assert_expected_daemon_status(duthost, False)
+
+    start_pmon_sensord_task(duthost)
+    time.sleep(10)
+
+    assert_expected_daemon_status(duthost, True)
+
+
+def test_pmon_sensord_sighup(sensord_start_and_get_pid, duthosts, rand_one_dut_hostname):
+    """
+    @summary: Assert that sensord remains running after receiving a sighup
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    sensord_pid = sensord_start_and_get_pid
+
+    duthost.kill_pmon_daemon_pid_w_sig(sensord_pid, SIG_HUP)
+    time.sleep(2)
+
+    # daemon should still be running
+    assert_expected_daemon_status(duthost, True)

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -114,6 +114,20 @@ def stop_pmon_sensord_task(ans_host):
         logging.info("sensord stopped successfully")
 
 
+def start_pmon_sensord_task(duthost):
+    sensord_running_status, sensord_pid = check_sensord_status(duthost)
+    if not sensord_running_status:
+        duthost.command("docker exec pmon supervisorctl restart lm-sensors")
+        time.sleep(3)
+        sensord_running_status, sensord_pid = check_sensord_status(duthost)
+        if sensord_running_status:
+            logging.info("sensord task restarted, pid = {}".format(sensord_pid))
+        else:
+            pytest_assert(False, "Failed to restart sensord task after test.")
+    else:
+        logging.info("sensord is running, pid = {}".format(sensord_pid))
+
+
 @pytest.fixture(scope="module")
 def psu_test_setup_teardown(duthosts, enum_rand_one_per_hwsku_hostname):
     """

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -121,11 +121,12 @@ def start_pmon_sensord_task(duthost):
         time.sleep(3)
         sensord_running_status, sensord_pid = check_sensord_status(duthost)
         if sensord_running_status:
-            logging.info("sensord task restarted, pid = {}".format(sensord_pid))
+            logging.info("sensord task started, pid = {}".format(sensord_pid))
         else:
-            pytest_assert(False, "Failed to restart sensord task after test.")
+            logging.error("Failed to start sensord task.")
     else:
         logging.info("sensord is running, pid = {}".format(sensord_pid))
+    return sensord_running_status, sensord_pid
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add a test to validate sensord is running if the sku supports it

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/10505

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fill test gap by adding a test for sensord daemon

#### How did you do it?
validate its running, and responds correctly when sent supported signals

#### How did you verify/test it?
Ran locally on t2 arista testbeds - passes

#### Any platform specific information?
Nokia does not support sensord, so the test will be skipped in nokias cases.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
