### PR TITLE
T2-Snappi-Route-Conv: Initial DUT Config Automation, Remove T1 from DUTList

### DIFF
--- a/tests/snappi_tests/multidut/bgp/conftest.py
+++ b/tests/snappi_tests/multidut/bgp/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def initial_setup(duthosts):
+    """
+    Perform initial DUT configurations(T1, Fanout(if present)) for convergence tests. This runs once per test session.
+    """
+    logger.info("Starting initial DUT setup for T2 Convergence tests")
+
+    # PLACEHOLDER For T2 Convergence test setup
+    # Configure T1 DUT: Interface IP, BGP etc: Use Connectivity details/Interface IPs/BGP Neighborship
+    # details from variables.py
+    # Configure Fanout DUT(if Applicable): Use connectivity details from variables.py
+
+    logger.info("########IMP########: Please ensure the below configurations are done on DUTs before running the tests")
+    logger.info("1. Ensure T1 DUT is Configured")
+    logger.info("2. Ensure Fanout DUT is Configured if Applicable")
+
+    logger.info("T2 Convergence test setup complete")

--- a/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/multidut/bgp/files/bgp_outbound_helper.py
@@ -1,7 +1,6 @@
 import logging
 import random
 import paramiko
-import json
 import time
 import math
 import os
@@ -17,8 +16,7 @@ from tests.snappi_tests.variables import T1_SNAPPI_AS_NUM, T2_SNAPPI_AS_NUM, T1_
      t2_uplink_portchannel_members, t1_t2_dut_ipv4_list, v4_prefix_length, \
      t1_t2_dut_ipv6_list, t1_t2_snappi_ipv4_list, t1_t2_device_hostnames, portchannel_count, \
      t1_t2_snappi_ipv6_list, t2_dut_portchannel_ipv4_list, t2_dut_portchannel_ipv6_list, \
-     snappi_portchannel_ipv4_list, snappi_portchannel_ipv6_list, AS_PATHS, \
-     BGP_TYPE, t1_side_interconnected_port, t2_side_interconnected_port, router_ids, \
+     snappi_portchannel_ipv4_list, snappi_portchannel_ipv6_list, AS_PATHS, BGP_TYPE, router_ids, \
      snappi_community_for_t1, snappi_community_for_t1_drop, snappi_community_for_t2, num_regionalhubs,  \
      SNAPPI_TRIGGER, DUT_TRIGGER, DUT_TRIGGER_SHORT, fanout_presence, t2_uplink_fanout_info  # noqa: F401
 from tests.common.snappi_tests.variables import v6_prefix_length
@@ -39,7 +37,8 @@ def get_hw_platform(hostnames):
         hw_platform (str): Hardware platform of the T2 DUT from the variables file
     """
     hw_platform = None
-    t2_dut = hostnames[1]
+    logger.info("T2 Hostnames: {}".format(hostnames))
+    t2_dut = hostnames[0]
     for hw_pltfm in t1_t2_device_hostnames:
         devices = t1_t2_device_hostnames[hw_pltfm]
         if t2_dut in devices:
@@ -47,26 +46,6 @@ def get_hw_platform(hostnames):
             break
 
     return hw_platform
-
-
-def run_dut_configuration(snappi_extra_params):
-    """
-    Configures the dut for the test
-
-        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
-    """
-    duthost1 = snappi_extra_params.multi_dut_params.duthost1
-    duthost2 = snappi_extra_params.multi_dut_params.duthost2
-    duthost3 = snappi_extra_params.multi_dut_params.duthost3
-    duthosts = [duthost1, duthost2, duthost3]
-    hw_platform = snappi_extra_params.multi_dut_params.hw_platform
-    test_name = snappi_extra_params.test_name
-    snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
-
-    duthost_bgp_config(duthosts,
-                       hw_platform,
-                       snappi_ports,
-                       test_name)
 
 
 def run_bgp_outbound_uplink_blackout_test(api,
@@ -85,8 +64,8 @@ def run_bgp_outbound_uplink_blackout_test(api,
 
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
-    duthost3 = snappi_extra_params.multi_dut_params.duthost3
-    duthosts = [duthost1, duthost2, duthost3]
+    duthosts = [duthost1, duthost2]
+    t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -100,6 +79,7 @@ def run_bgp_outbound_uplink_blackout_test(api,
         for key, value in route_range.items():
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
+                                                t1_hostname,
                                                 duthosts,
                                                 hw_platform,
                                                 snappi_ports,
@@ -135,8 +115,8 @@ def run_bgp_outbound_tsa_tsb_test(api,
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
-    duthost4 = snappi_extra_params.multi_dut_params.duthost4
-    duthosts = [duthost1, duthost2, duthost3, duthost4]
+    duthosts = [duthost1, duthost2, duthost3]
+    t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -150,6 +130,7 @@ def run_bgp_outbound_tsa_tsb_test(api,
         for key, value in route_range.items():
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
+                                                t1_hostname,
                                                 duthosts,
                                                 hw_platform,
                                                 snappi_ports,
@@ -184,8 +165,8 @@ def run_bgp_outbound_ungraceful_restart(api,
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
     duthost3 = snappi_extra_params.multi_dut_params.duthost3
-    duthost4 = snappi_extra_params.multi_dut_params.duthost4
-    duthosts = [duthost1, duthost2, duthost3, duthost4]
+    duthosts = [duthost1, duthost2, duthost3]
+    t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -199,6 +180,7 @@ def run_bgp_outbound_ungraceful_restart(api,
         for key, value in route_range.items():
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
+                                                t1_hostname,
                                                 duthosts,
                                                 hw_platform,
                                                 snappi_ports,
@@ -234,8 +216,8 @@ def run_bgp_outbound_process_restart_test(api,
 
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
-    duthost3 = snappi_extra_params.multi_dut_params.duthost3
-    duthosts = [duthost1, duthost2, duthost3]
+    duthosts = [duthost1, duthost2]
+    t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -244,18 +226,13 @@ def run_bgp_outbound_process_restart_test(api,
     iteration = snappi_extra_params.iteration
     test_name = snappi_extra_params.test_name
 
-    """ Create bgp config on dut """
-    duthost_bgp_config(duthosts,
-                       hw_platform,
-                       snappi_ports,
-                       test_name)
-
     """ Create snappi config """
     for route_range in route_ranges:
         traffic_type = []
         for key, value in route_range.items():
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
+                                                t1_hostname,
                                                 duthosts,
                                                 hw_platform,
                                                 snappi_ports,
@@ -290,8 +267,8 @@ def run_bgp_outbound_link_flap_test(api,
 
     duthost1 = snappi_extra_params.multi_dut_params.duthost1
     duthost2 = snappi_extra_params.multi_dut_params.duthost2
-    duthost3 = snappi_extra_params.multi_dut_params.duthost3
-    duthosts = [duthost1, duthost2, duthost3]
+    duthosts = [duthost1, duthost2]
+    t1_hostname = snappi_extra_params.multi_dut_params.t1_hostname
     hw_platform = snappi_extra_params.multi_dut_params.hw_platform
     route_ranges = snappi_extra_params.ROUTE_RANGES
     snappi_ports = snappi_extra_params.multi_dut_params.multi_dut_ports
@@ -299,18 +276,13 @@ def run_bgp_outbound_link_flap_test(api,
     flap_details = snappi_extra_params.multi_dut_params.flap_details
     test_name = snappi_extra_params.test_name
 
-    """ Create bgp config on dut """
-    duthost_bgp_config(duthosts,
-                       hw_platform,
-                       snappi_ports,
-                       test_name)
-
     """ Create snappi config """
     for route_range in route_ranges:
         traffic_type = []
         for key, value in route_range.items():
             traffic_type.append(key)
         snappi_bgp_config = __snappi_bgp_config(api,
+                                                t1_hostname,
                                                 duthosts,
                                                 hw_platform,
                                                 snappi_ports,
@@ -318,6 +290,7 @@ def run_bgp_outbound_link_flap_test(api,
                                                 route_range)
 
         get_convergence_for_link_flap(duthosts,
+                                      t1_hostname,
                                       hw_platform,
                                       api,
                                       snappi_bgp_config,
@@ -329,446 +302,13 @@ def run_bgp_outbound_link_flap_test(api,
                                       creds)
 
 
-def duthost_bgp_config(duthosts,
-                       hw_platform,
-                       snappi_ports,
-                       test_name):
-    """
-    Configures BGP on the DUT with N-1 ecmp
-
-    Args:
-        duthosts (pytest fixture): duthosts fixture
-        snappi_ports (pytest fixture): Ports mapping info of T0 testbed
-        test_name: Name of the test
-    """
-    logger.info('\n')
-    logger.info('--------------- T1 Snappi Section --------------------')
-    logger.info('\n')
-    t1_config_db = json.loads(duthosts[0].shell("sonic-cfggen -d --print-data")['stdout'])
-    interfaces = dict()
-    loopback_interfaces = dict()
-    loopback_interfaces.update({"Loopback0": {}})
-    loopback_interfaces.update({"Loopback0|1.1.1.1/32": {}})
-    loopback_interfaces.update({"Loopback0|1::1/128": {}})
-    for index, custom_port in enumerate(t1_ports[hw_platform][duthosts[0].hostname]):
-        interface_name = {custom_port: {}}
-        v4_interface = {f"{custom_port}|{t1_t2_dut_ipv4_list[index]}/{v4_prefix_length}": {}}
-        v6_interface = {f"{custom_port}|{t1_t2_dut_ipv6_list[index]}/{v6_prefix_length}": {}}
-        interfaces.update(interface_name)
-        interfaces.update(v4_interface)
-        interfaces.update(v6_interface)
-        logger.info('Configuring IPs {}/{} , {}/{} on {} in {}'.
-                    format(t1_t2_dut_ipv4_list[index], v4_prefix_length,
-                           t1_t2_dut_ipv6_list[index], v6_prefix_length, custom_port, duthosts[0].hostname))
-
-    bgp_neighbors = dict()
-    device_neighbors = dict()
-    device_neighbor_metadatas = dict()
-    for index, custom_port in enumerate(t1_ports[hw_platform][duthosts[0].hostname]):
-        for snappi_port in snappi_ports:
-            if custom_port == snappi_port['peer_port'] and snappi_port['peer_device'] == duthosts[0].hostname:
-                bgp_neighbor = \
-                        {
-                            t1_t2_snappi_ipv4_list[index]:
-                            {
-                                "admin_status": "up",
-                                "asn": T1_SNAPPI_AS_NUM,
-                                "holdtime": "10",
-                                "keepalive": "3",
-                                "local_addr": t1_t2_dut_ipv4_list[index],
-                                "name": "snappi-sonic"+str(index),
-                                "nhopself": "0",
-                                "rrclient": "0"
-                            },
-                            t1_t2_snappi_ipv6_list[index]:
-                            {
-                                "admin_status": "up",
-                                "asn": T1_SNAPPI_AS_NUM,
-                                "holdtime": "10",
-                                "keepalive": "3",
-                                "local_addr": t1_t2_dut_ipv6_list[index],
-                                "name": "snappi-sonic"+str(index),
-                                "nhopself": "0",
-                                "rrclient": "0"
-                            },
-                        }
-                bgp_neighbors.update(bgp_neighbor)
-                device_neighbor = {
-                                            custom_port:
-                                            {
-                                                "name": "snappi-sonic"+str(index),
-                                                "port": "Ethernet1"
-                                            }
-                                        }
-                device_neighbors.update(device_neighbor)
-                device_neighbor_metadata = {
-                                                "snappi-sonic"+str(index):
-                                                {
-                                                    "hwsku": "Snappi",
-                                                    "mgmt_addr": "172.16.149.206",
-                                                    "type": "SpineRouter"
-                                                }
-                                            }
-                device_neighbor_metadatas.update(device_neighbor_metadata)
-    logger.info('T1 Dut AS Number: {}'.format(T1_DUT_AS_NUM))
-    logger.info('T1 side Snappi AS Number: {}'.format(T1_SNAPPI_AS_NUM))
-    logger.info('\n')
-    logger.info('---------------T1 Inter-Connectivity Section --------------------')
-    logger.info('\n')
-    index = len(t1_ports[hw_platform][duthosts[0].hostname])
-    interface_name = {t1_side_interconnected_port[hw_platform]: {}}
-    v4_interface = {f"{t1_side_interconnected_port[hw_platform]}|{t1_t2_dut_ipv4_list[index]}/{v4_prefix_length}": {}}
-    v6_interface = {f"{t1_side_interconnected_port[hw_platform]}|{t1_t2_dut_ipv6_list[index]}/{v6_prefix_length}": {}}
-    interfaces.update(interface_name)
-    interfaces.update(v4_interface)
-    interfaces.update(v6_interface)
-    logger.info('Configuring IP {}/{} , {}/{} on {} in {} for the T1 interconnectivity'.
-                format(t1_t2_dut_ipv4_list[index], v4_prefix_length,
-                       t1_t2_dut_ipv6_list[index], v6_prefix_length, t1_side_interconnected_port[hw_platform],
-                       duthosts[0].hostname))
-
-    logger.info('Configuring BGP in T1 by writing into config_db')
-    bgp_neighbor = {
-                        t1_t2_snappi_ipv4_list[index]:
-                        {
-                            "admin_status": "up",
-                            "asn": T2_DUT_AS_NUM,
-                            "holdtime": "10",
-                            "keepalive": "3",
-                            "local_addr": t1_t2_dut_ipv4_list[index],
-                            "name": "T2",
-                            "nhopself": "0",
-                            "rrclient": "0"
-                        },
-                        t1_t2_snappi_ipv6_list[index]:
-                        {
-                            "admin_status": "up",
-                            "asn": T2_DUT_AS_NUM,
-                            "holdtime": "10",
-                            "keepalive": "3",
-                            "local_addr": t1_t2_dut_ipv6_list[index],
-                            "name": "T2",
-                            "nhopself": "0",
-                            "rrclient": "0"
-                        },
-                    }
-    bgp_neighbors.update(bgp_neighbor)
-    device_neighbor = {
-                                t1_side_interconnected_port[hw_platform]:
-                                {
-                                    "name": "T2",
-                                    "port": "Ethernet1"
-                                }
-                            }
-    device_neighbors.update(device_neighbor)
-    device_neighbor_metadata = {
-                                    "T2":
-                                    {
-                                        "hwsku": "Sonic-Dut",
-                                        "mgmt_addr": "172.16.149.206",
-                                        "type": "SpineRouter"
-                                    }
-                                }
-    device_neighbor_metadatas.update(device_neighbor_metadata)
-    if "INTERFACE" not in t1_config_db.keys():
-        t1_config_db["INTERFACE"] = interfaces
-    else:
-        t1_config_db["INTERFACE"].update(interfaces)
-
-    if "LOOPBACK_INTERFACE" not in t1_config_db.keys():
-        t1_config_db["LOOPBACK_INTERFACE"] = loopback_interfaces
-    else:
-        t1_config_db["LOOPBACK_INTERFACE"].update(loopback_interfaces)
-
-    if "BGP_NEIGHBOR" not in t1_config_db.keys():
-        t1_config_db["BGP_NEIGHBOR"] = bgp_neighbors
-    else:
-        t1_config_db["BGP_NEIGHBOR"].update(bgp_neighbors)
-
-    if "DEVICE_NEIGHBOR" not in t1_config_db.keys():
-        t1_config_db["DEVICE_NEIGHBOR"] = device_neighbors
-    else:
-        t1_config_db["DEVICE_NEIGHBOR"].update(device_neighbors)
-
-    if 'DEVICE_NEIGHBOR_METADATA' not in t1_config_db.keys():
-        t1_config_db["DEVICE_NEIGHBOR_METADATA"] = device_neighbor_metadatas
-    else:
-        t1_config_db["DEVICE_NEIGHBOR_METADATA"].update(device_neighbor_metadatas)
-
-    with open("/tmp/temp_config.json", 'w') as fp:
-        json.dump(t1_config_db, fp, indent=4)
-    duthosts[0].copy(src="/tmp/temp_config.json", dest="/etc/sonic/config_db.json")
-
-    logger.info('Reloading config_db.json to apply IP and BGP configuration on {}'.format(duthosts[0].hostname))
-    pytest_assert('Error' not in duthosts[0].shell("sudo config reload -f -y \n")['stderr'],
-                  'Error while reloading config in {} !!!!!'.format(duthosts[0].hostname))
-    logger.info('Config Reload Successful in {} !!!'.format(duthosts[0].hostname))
-
-    logger.info('\n')
-    logger.info('---------------T2 Downlink Inter-Connectivity Section --------------------')
-    logger.info('\n')
-    logger.info('T1 Dut AS Number: {}'.format(T1_DUT_AS_NUM))
-    logger.info('T2 Dut AS Number: {}'.format(T2_DUT_AS_NUM))
-
-    interfaces = dict()
-    loopback_interfaces = dict()
-    loopback_interfaces.update({"Loopback0": {}})
-    loopback_interfaces.update({"Loopback0|2.2.2.2/32": {}})
-    loopback_interfaces.update({"Loopback0|2::2/128": {}})
-    index = len(t1_ports[hw_platform][duthosts[0].hostname])
-    interface_name = {t2_side_interconnected_port[hw_platform]['port_name']: {}}
-    v4_interface = {
-                    f"{t2_side_interconnected_port[hw_platform]['port_name']}|"
-                    f"{t1_t2_snappi_ipv4_list[index]}/{v4_prefix_length}": {}
-                }
-    v6_interface = {
-                    f"{t2_side_interconnected_port[hw_platform]['port_name']}|"
-                    f"{t1_t2_snappi_ipv6_list[index]}/{v6_prefix_length}": {}
-                }
-    interfaces.update(interface_name)
-    interfaces.update(v4_interface)
-    interfaces.update(v6_interface)
-    device_neighbor = {
-                            t2_side_interconnected_port[hw_platform]['port_name']:
-                            {
-                                "name": "T1",
-                                "port": "Ethernet1"
-                            }
-                        }
-
-    device_neighbor_metadata = {
-                                    "T1":
-                                    {
-                                        "hwsku": "Sonic-Dut",
-                                        "mgmt_addr": t1_t2_dut_ipv4_list[index],
-                                        "type": "LeafRouter"
-                                    }
-                                }
-    bgp_neighbor = {
-                        t1_t2_dut_ipv4_list[index]:
-                        {
-                            "admin_status": "up",
-                            "asn": T1_DUT_AS_NUM,
-                            "holdtime": "10",
-                            "keepalive": "3",
-                            "local_addr": t1_t2_snappi_ipv4_list[index],
-                            "name": "T1",
-                            "nhopself": "0",
-                            "rrclient": "0"
-                        },
-                        t1_t2_dut_ipv6_list[index]:
-                        {
-                            "admin_status": "up",
-                            "asn": T1_DUT_AS_NUM,
-                            "holdtime": "10",
-                            "keepalive": "3",
-                            "local_addr": t1_t2_snappi_ipv6_list[index],
-                            "name": "T1",
-                            "nhopself": "0",
-                            "rrclient": "0"
-                        },
-                    }
-
-    if t2_side_interconnected_port[hw_platform]['asic_value'] is not None:
-        config_db = 'config_db'+list(t2_side_interconnected_port[hw_platform]['asic_value'])[-1]+'.json'
-        t2_config_db = json.loads(duthosts[2].shell("sonic-cfggen -d -n {} --print-data".
-                                  format(t2_side_interconnected_port[hw_platform]['asic_value']))['stdout'])
-    else:
-        config_db = 'config_db.json'
-        t2_config_db = json.loads(duthosts[2].shell("sonic-cfggen -d --print-data")['stdout'])
-
-    if "INTERFACE" not in t2_config_db.keys():
-        t2_config_db["INTERFACE"] = interfaces
-    else:
-        t2_config_db["INTERFACE"].update(interfaces)
-    logger.info('Configuring IP {}/{} , {}/{} on {} in {} for the T1 interconnectivity'.
-                format(t1_t2_snappi_ipv4_list[index], v4_prefix_length,
-                       t1_t2_snappi_ipv6_list[index], v6_prefix_length,
-                       t2_side_interconnected_port[hw_platform]['port_name'], duthosts[2].hostname))
-    if "LOOPBACK_INTERFACE" not in t2_config_db.keys():
-        t2_config_db["LOOPBACK_INTERFACE"] = loopback_interfaces
-    else:
-        t2_config_db["LOOPBACK_INTERFACE"].update(loopback_interfaces)
-
-    if "DEVICE_NEIGHBOR" not in t2_config_db.keys():
-        t2_config_db["DEVICE_NEIGHBOR"] = device_neighbor
-    else:
-        t2_config_db["DEVICE_NEIGHBOR"].update(device_neighbor)
-
-    if 'DEVICE_NEIGHBOR_METADATA' not in t2_config_db.keys():
-        t2_config_db["DEVICE_NEIGHBOR_METADATA"] = device_neighbor_metadata
-    else:
-        t2_config_db["DEVICE_NEIGHBOR_METADATA"].update(device_neighbor_metadata)
-
-    if "BGP_NEIGHBOR" not in t2_config_db.keys():
-        t2_config_db["BGP_NEIGHBOR"] = bgp_neighbor
-    else:
-        t2_config_db["BGP_NEIGHBOR"].update(bgp_neighbor)
-
-    with open("/tmp/temp_config.json", 'w') as fp:
-        json.dump(t2_config_db, fp, indent=4)
-    duthosts[2].copy(src="/tmp/temp_config.json", dest="/etc/sonic/%s" % config_db)
-
-    logger.info('Reloading config_db.json to apply IP and BGP configuration on {}'.format(duthosts[2].hostname))
-
-    pytest_assert('Error' not in duthosts[2].shell("sudo config reload -f -y \n")['stderr'],
-                  'Error while reloading config in {} !!!!!'.format(duthosts[2].hostname))
-    logger.info('Config Reload Successful in {} !!!'.format(duthosts[2].hostname))
-    logger.info('\n')
-    logger.info('--------------- T2 Uplink - Tgen Section --------------------')
-    logger.info('\n')
-    logger.info('T2 Dut AS Number: {}'.format(T2_DUT_AS_NUM))
-    logger.info('T2 side Snappi AS Number: {}'.format(T2_SNAPPI_AS_NUM))
-    loopback_interfaces = dict()
-    loopback_interfaces.update({"Loopback0": {}})
-    loopback_interfaces.update({"Loopback0|3.3.3.3/32": {}})
-    loopback_interfaces.update({"Loopback0|3::3/128": {}})
-    index = 0
-    index_2 = 0
-    for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
-        bgp_neighbors = dict()
-        device_neighbors = dict()
-        device_neighbor_metadatas = dict()
-        PORTCHANNELS = dict()
-        PORTCHANNEL_INTERFACES = dict()
-        PORTCHANNEL_MEMBERS = dict()
-        if asic_value is not None:
-            config_db = 'config_db'+list(asic_value)[-1]+'.json'
-            t2_config_db = json.loads(duthosts[1].shell("sonic-cfggen -d -n {} --print-data".
-                                      format(asic_value))['stdout'])
-        else:
-            config_db = 'config_db.json'
-            t2_config_db = json.loads(duthosts[1].shell("sonic-cfggen -d --print-data")['stdout'])
-        for portchannel, port_set in portchannel_info.items():
-            for port in port_set:
-                device_neighbor = {
-                    port: {
-                        "name": "snappi_"+portchannel,
-                        "port": "snappi_"+port,
-                    }
-                }
-                device_neighbors.update(device_neighbor)
-                MEMBER = {f"{portchannel}|{port}": {}}
-                PORTCHANNEL_MEMBERS.update(MEMBER)
-            if 'Portchannel Flap' in test_name:
-                min_link = len(port_set)
-            else:
-                min_link = 1
-            PORTCHANNEL = {
-                                portchannel:
-                                {
-                                    "admin_status": "up",
-                                    "lacp_key": "auto",
-                                    "min_links": str(min_link),
-                                    "mtu": "9100"
-                                }
-                          }
-            PORTCHANNELS.update(PORTCHANNEL)
-            logger.info('\n')
-            logger.info('Creating {} in {}'.format(portchannel, duthosts[1].hostname))
-            logger.info('Setting min_links to {} for {}'.format(min_link, portchannel))
-            interface_name = {portchannel: {}}
-            v4_interface = {f"{portchannel}|{t2_dut_portchannel_ipv4_list[index_2]}/{v4_prefix_length}": {}}
-            v6_interface = {f"{portchannel}|{t2_dut_portchannel_ipv6_list[index_2]}/{v6_prefix_length}": {}}
-            PORTCHANNEL_INTERFACES.update(interface_name)
-            PORTCHANNEL_INTERFACES.update(v4_interface)
-            PORTCHANNEL_INTERFACES.update(v6_interface)
-            logger.info('Configuring IPs {}/{} , {}/{} on {} in {}'.
-                        format(t2_dut_portchannel_ipv4_list[index_2], v4_prefix_length,
-                               t2_dut_portchannel_ipv6_list[index_2], v6_prefix_length,
-                               portchannel, duthosts[1].hostname))
-            index_2 = index_2 + 1
-
-        rh_portchannels = [f"PortChannel{i}" for i in range(num_regionalhubs)]
-        logger.info('RH PortChannels list: {}'.format(rh_portchannels))
-        for portchannel in portchannel_info:
-            upstream_type = "RegionalHub" if portchannel in rh_portchannels else "AZNGHub"
-            device_neighbor_metadata = {
-                                            "snappi_"+portchannel:
-                                            {
-                                                "hwsku": "Ixia",
-                                                "mgmt_addr": snappi_portchannel_ipv4_list[index],
-                                                "type": upstream_type
-                                            },
-                                        }
-            bgp_neighbor = {
-                                snappi_portchannel_ipv4_list[index]:
-                                {
-                                    "admin_status": "up",
-                                    "asn": T2_SNAPPI_AS_NUM,
-                                    "holdtime": "10",
-                                    "keepalive": "3",
-                                    "local_addr": t2_dut_portchannel_ipv4_list[index],
-                                    "name": "snappi_"+portchannel,
-                                    "nhopself": "0",
-                                    "rrclient": "0"
-                                },
-                                snappi_portchannel_ipv6_list[index]:
-                                {
-                                    "admin_status": "up",
-                                    "asn": T2_SNAPPI_AS_NUM,
-                                    "holdtime": "10",
-                                    "keepalive": "3",
-                                    "local_addr": t2_dut_portchannel_ipv6_list[index],
-                                    "name": "snappi_"+portchannel,
-                                    "nhopself": "0",
-                                    "rrclient": "0"
-                                },
-                            }
-            bgp_neighbors.update(bgp_neighbor)
-            device_neighbor_metadatas.update(device_neighbor_metadata)
-            index = index + 1
-        if "LOOPBACK_INTERFACE" not in t2_config_db.keys():
-            t2_config_db["LOOPBACK_INTERFACE"] = loopback_interfaces
-        else:
-            t2_config_db["LOOPBACK_INTERFACE"].update(loopback_interfaces)
-
-        if "PORTCHANNEL_INTERFACE" not in t2_config_db.keys():
-            t2_config_db["PORTCHANNEL_INTERFACE"] = PORTCHANNEL_INTERFACES
-        else:
-            t2_config_db["PORTCHANNEL_INTERFACE"].update(PORTCHANNEL_INTERFACES)
-
-        if "PORTCHANNEL" not in t2_config_db.keys():
-            t2_config_db["PORTCHANNEL"] = PORTCHANNELS
-        else:
-            t2_config_db["PORTCHANNEL"].update(PORTCHANNELS)
-
-        if "PORTCHANNEL_MEMBER" not in t2_config_db.keys():
-            t2_config_db["PORTCHANNEL_MEMBER"] = PORTCHANNEL_MEMBERS
-        else:
-            t2_config_db["PORTCHANNEL_MEMBER"].update(PORTCHANNEL_MEMBERS)
-
-        if "DEVICE_NEIGHBOR" not in t2_config_db.keys():
-            t2_config_db["DEVICE_NEIGHBOR"] = device_neighbors
-        else:
-            t2_config_db["DEVICE_NEIGHBOR"].update(device_neighbors)
-
-        if 'DEVICE_NEIGHBOR_METADATA' not in t2_config_db.keys():
-            t2_config_db["DEVICE_NEIGHBOR_METADATA"] = device_neighbor_metadatas
-        else:
-            t2_config_db["DEVICE_NEIGHBOR_METADATA"].update(device_neighbor_metadatas)
-
-        if "BGP_NEIGHBOR" not in t2_config_db.keys():
-            t2_config_db["BGP_NEIGHBOR"] = bgp_neighbors
-        else:
-            t2_config_db["BGP_NEIGHBOR"].update(bgp_neighbors)
-        with open("/tmp/temp_config.json", 'w') as fp:
-            json.dump(t2_config_db, fp, indent=4)
-        duthosts[1].copy(src="/tmp/temp_config.json", dest="/etc/sonic/%s" % config_db)
-
-    logger.info('Reloading config to apply IP and BGP configuration on {}'.format(duthosts[1].hostname))
-    pytest_assert('Error' not in duthosts[1].shell("sudo config reload -f -y \n")['stderr'],
-                  'Error while reloading config in {} !!!!!'.format(duthosts[1].hostname))
-    logger.info('Config Reload Successful in {} !!!'.format(duthosts[1].hostname))
-    wait(DUT_TRIGGER, "For configs to be loaded on the duts")
-
-
 def generate_mac_address():
     mac = [random.randint(0x00, 0xff) for _ in range(6)]
     return ':'.join(map(lambda x: "%02x" % x, mac))
 
 
 def __snappi_bgp_config(api,
+                        t1_hostname,
                         duthosts,
                         hw_platform,
                         snappi_ports,
@@ -791,26 +331,26 @@ def __snappi_bgp_config(api,
     total_routes = 0
     config = api.config()
     # get all the t1 and uplink ports from variables
-    t1_variable_ports = t1_ports[hw_platform][duthosts[0].hostname]
+    t1_variable_ports = t1_ports[hw_platform][t1_hostname]
     t2_variable_ports = []
     port_tuple = []
     rh_portchannels = [f"PortChannel{i}" for i in range(num_regionalhubs)]
 
-    for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
+    for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[0].hostname].items():
         for portchannel, ports in portchannel_info.items():
             port_tuple.append((portchannel, ports))
             for port in ports:
                 t2_variable_ports.append(port)
-
     snappi_t1_ports = []
     snappi_t2_ports = []
     for snappi_port in snappi_ports:
         for port in t1_variable_ports:
-            if snappi_port['peer_device'] == duthosts[0].hostname and snappi_port['peer_port'] == port:
+            if snappi_port['peer_device'] == t1_hostname and snappi_port['peer_port'] == port:
                 snappi_t1_ports.append(snappi_port)
         for port in t2_variable_ports:
-            if snappi_port['peer_device'] == duthosts[1].hostname and snappi_port['peer_port'] == port:
+            if snappi_port['peer_device'] == duthosts[0].hostname and snappi_port['peer_port'] == port:
                 snappi_t2_ports.append(snappi_port)
+
     # Adding Ports
     for index, snappi_test_port in enumerate(snappi_t1_ports):
         if index == 0:
@@ -818,14 +358,13 @@ def __snappi_bgp_config(api,
         else:
             snappi_test_port['name'] = 'Snappi_Backup_T2_%d' % index
         config.ports.port(name=snappi_test_port['name'], location=snappi_test_port['location'])
-
     for _, snappi_test_port in enumerate(snappi_t2_ports):
         po = 1
-        for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
+        for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[0].hostname].items():
             for portchannel, portchannel_members in portchannel_info.items():
                 for index, mem_port in enumerate(portchannel_members, 1):
                     if snappi_test_port['peer_port'] == mem_port and \
-                       snappi_test_port['peer_device'] == duthosts[1].hostname:
+                       snappi_test_port['peer_device'] == duthosts[0].hostname:
                         snappi_test_port['name'] = 'Snappi_Uplink_PO_{}_Link_{}'.format(po, index)
                         fanout_uplink_snappi_info.append(snappi_test_port)
                         config.ports.port(name=snappi_test_port['name'], location=snappi_test_port['location'])
@@ -1107,27 +646,54 @@ def get_port_stats(api):
     return api.get_metrics(request).port_metrics
 
 
-def flap_single_fanout_port(fanout_ip, creds, port_name, state):
+def flap_dut_port(creds, dut_ip, dut_port, state):
     """
+    Flaps the specified DUT port by bringing it up or down.
+
     Args:
-        fanout_ip (pytest fixture): IP of the fanout device
-        creds (dict): DUT credentials
-        port_name: Name of the fanout port to be flapped
-        state: State of the interface to be up/down
+        creds (dict): DUT credentials'.
+        dut_ip (str): IP address of the DUT.
+        dut_port (str): Name of the port to be flapped.
+        state (str): Desired state of the port ('up' or 'down').
+
+    Returns:
+        bool: True if the command executed successfully, False otherwise.
     """
     username = creds.get('sonicadmin_user')
     password = creds.get('sonicadmin_password')
+
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh.connect(fanout_ip, port=22, username=username, password=password)
-    if state == 'up':
-        command = f'sudo config interface startup {port_name}'
-    elif state == 'down':
-        command = f'sudo config interface shutdown {port_name}'
-    stdin, stdout, stderr = ssh.exec_command(command)
+
+    try:
+        ssh.connect(dut_ip, port=22, username=username, password=password, timeout=10)
+        command = f'sudo config interface {"startup" if state == "up" else "shutdown"} {dut_port}'
+
+        stdin, stdout, stderr = ssh.exec_command(command)
+        stdout_output = stdout.read().decode().strip()
+        stderr_output = stderr.read().decode().strip()
+
+        if stderr_output:
+            logger.error(f"Error executing command on {dut_ip}: {stderr_output}")
+            return False
+
+        logger.info(f"Command executed successfully: {stdout_output}")
+        return True
+
+    except paramiko.SSHException as e:
+        logger.error(f"SSH connection error: {e}")
+        return False
+
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        return False
+
+    finally:
+        ssh.close()
 
 
 def get_convergence_for_link_flap(duthosts,
+                                  t1_hostname,
                                   hw_platform,
                                   api,
                                   bgp_config,
@@ -1203,11 +769,10 @@ def get_convergence_for_link_flap(duthosts,
             if 'Snappi_Uplink' in port_stat.name:
                 sum_t2_rx_frame_rate = sum_t2_rx_frame_rate + int(port_stat.frames_rx_rate)
         # Flap the required test port
-        if duthosts[0].hostname == flap_details['device_name']:
-            logger.info(' Shutting down {} port of {} dut !!'.
-                        format(flap_details['port_name'], flap_details['device_name']))
-            duthosts[0].command('sudo config interface shutdown {} \n'.
-                                format(flap_details['port_name']))
+        if t1_hostname == flap_details['device_name']:
+            logger.info(' Shutting down {} port of {} dut({}) !!'.
+                        format(flap_details['port_name'], flap_details['device_name'], flap_details['device_ip']))
+            flap_dut_port(creds, flap_details['device_ip'], flap_details['port_name'], state='down')
             wait(DUT_TRIGGER, "For link to shutdown")
         elif 'Ixia' == flap_details['device_name']:
             if fanout_presence is False:
@@ -1228,7 +793,7 @@ def get_convergence_for_link_flap(duthosts,
                         break
 
                 pytest_assert(fanout_port is not None, 'Unable to get fanout port info')
-                flap_single_fanout_port(fanout_ip, creds, fanout_port, state='down')
+                flap_dut_port(creds, fanout_ip, fanout_port, state='down')
                 logger.info(' Shutting down {} from {}'.format(fanout_port, fanout_ip))
                 wait(DUT_TRIGGER, "For link to shutdown")
         flow_stats = get_flow_stats(api)
@@ -1248,11 +813,10 @@ def get_convergence_for_link_flap(duthosts,
 
         logger.info('Performing Clear Stats')
         ixnetwork.ClearStats()
-        if duthosts[0].hostname == flap_details['device_name']:
-            logger.info(' Starting up {} port of {} dut !!'.
-                        format(flap_details['port_name'], flap_details['device_name']))
-            duthosts[0].command('sudo config interface startup {} \n'.
-                                format(flap_details['port_name']))
+        if t1_hostname == flap_details['device_name']:
+            logger.info(' Starting up {} port of {} dut({}) !!'.
+                        format(flap_details['port_name'], flap_details['device_name'], flap_details['device_ip']))
+            flap_dut_port(creds, flap_details['device_ip'], flap_details['port_name'], state='up')
             wait(DUT_TRIGGER, "For link to startup")
         elif 'Ixia' == flap_details['device_name']:
             if fanout_presence is False:
@@ -1261,7 +825,7 @@ def get_convergence_for_link_flap(duthosts,
                 logger.info('Starting up snappi port : {}'.format(flap_details['port_name']))
                 wait(SNAPPI_TRIGGER, "For link to startup")
             else:
-                flap_single_fanout_port(fanout_ip, creds, fanout_port, state='up')
+                flap_dut_port(creds, fanout_ip, fanout_port, state='up')
                 logger.info('Starting up {} from {}'.format(fanout_port, fanout_ip))
                 wait(DUT_TRIGGER, "For link to startup")
         logger.info('\n')
@@ -1789,7 +1353,7 @@ def get_convergence_for_blackout(duthosts,
 
         # Link Down
         portchannel_dict = {}
-        for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[1].hostname].items():
+        for asic_value, portchannel_info in t2_uplink_portchannel_members[hw_platform][duthosts[0].hostname].items():
             portchannel_dict.update(portchannel_info)
         number_of_po = math.ceil(blackout_percentage * len(portchannel_dict)/100)
         snappi_port_names = []

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_port_flap.py
@@ -1,11 +1,11 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                        # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                   # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     snappi_api, multidut_snappi_ports_for_bgp                                                     # noqa: F401
-from tests.snappi_tests.variables import t1_side_interconnected_port, t1_t2_device_hostnames       # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api, multidut_snappi_ports_for_bgp    # noqa: F401
+from tests.snappi_tests.variables import t1_side_interconnected_port, t1_t2_device_hostnames, \
+     t1_dut_info, t1_snappi_ports                                                                   # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
      get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
@@ -71,28 +71,22 @@ def test_bgp_outbound_downlink_port_flap(snappi_api,                            
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
 
     snappi_extra_params.multi_dut_params.flap_details = {
         'device_name': t1_t2_device_hostnames[hw_platform][0],
+        'device_ip': t1_dut_info[hw_platform]['dut_ip'],
         'port_name': t1_side_interconnected_port[hw_platform]
     }
-
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_link_flap_test(api=snappi_api,
                                     creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_downlink_process_crash.py
@@ -1,11 +1,11 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                          # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                    # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                      # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t1_snappi_ports                    # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
      get_hw_platform, run_bgp_outbound_process_restart_test)                                        # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
@@ -73,24 +73,17 @@ def test_bgp_outbound_downlink_process_crash(snappi_api,                        
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
-
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[hw_platform][2]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_process_restart_test(api=snappi_api,
                                           creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_tsa.py
@@ -1,13 +1,13 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                         # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t1_snappi_ports                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     get_hw_platform, run_bgp_outbound_tsa_tsb_test, run_dut_configuration)                         # noqa: F401
+     get_hw_platform, run_bgp_outbound_tsa_tsb_test)                                                # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -35,53 +35,6 @@ ROUTE_RANGES = [{
                         ['4000::1', 64, 2500]
                     ],
             }]
-
-
-def test_dut_configuration(multidut_snappi_ports_for_bgp,                # noqa: F811
-                           conn_graph_facts,                             # noqa: F811
-                           fanout_graph_facts_multidut,                  # noqa: F811
-                           duthosts):                                    # noqa: F811
-    """
-    Configures BGP in T1, T2 Uplink and T2 Downlink
-
-    Args:
-        multidut_snappi_ports_for_bgp (pytest fixture):  Port mapping info on multidut testbed
-        conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts_multidut (pytest fixture): fanout graph
-        duthosts (pytest fixture): list of DUTs
-    Returns:
-        N/A
-    """
-    snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.test_name = "Dut Configuration"
-
-    ansible_dut_hostnames = []
-    for duthost in duthosts:
-        ansible_dut_hostnames.append(duthost.hostname)
-
-    hw_platform = get_hw_platform(ansible_dut_hostnames)
-    if hw_platform is None:
-        pytest_require(False, "Unable to get the hardware platform")
-    logger.info("hw_platform: {}".format(hw_platform))
-
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
-    for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
-        else:
-            continue
-    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
-    snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
-    run_dut_configuration(snappi_extra_params)
 
 
 def test_bgp_outbound_uplink_tsa(snappi_api,                                     # noqa: F811
@@ -117,27 +70,21 @@ def test_bgp_outbound_uplink_tsa(snappi_api,                                    
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][3] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost4 = duthost
+            snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.device_name = t1_t2_device_hostnames[hw_platform][1]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
 
     run_bgp_outbound_tsa_tsb_test(api=snappi_api,
                                   snappi_extra_params=snappi_extra_params,
@@ -178,27 +125,21 @@ def test_bgp_outbound_downlink_tsa(snappi_api,                                  
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][3] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost4 = duthost
+            snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.device_name = t1_t2_device_hostnames[hw_platform][2]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     run_bgp_outbound_tsa_tsb_test(api=snappi_api,
                                   snappi_extra_params=snappi_extra_params,
                                   creds=creds,
@@ -237,27 +178,21 @@ def test_bgp_outbound_supervisor_tsa(snappi_api,                                
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][3] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost4 = duthost
+            snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.device_name = t1_t2_device_hostnames[hw_platform][3]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     run_bgp_outbound_tsa_tsb_test(api=snappi_api,
                                   snappi_extra_params=snappi_extra_params,
                                   creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_ungraceful_restart.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_ungraceful_restart.py
@@ -1,13 +1,13 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                          # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t1_snappi_ports                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     get_hw_platform, run_bgp_outbound_ungraceful_restart, run_dut_configuration)                   # noqa: F401
+     get_hw_platform, run_bgp_outbound_ungraceful_restart)                                          # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -25,53 +25,6 @@ ROUTE_RANGES = [{
                         ['4000::1', 64, 15000]
                     ],
                 }]
-
-
-def test_dut_configuration(multidut_snappi_ports_for_bgp,                  # noqa: F811
-                           conn_graph_facts,                             # noqa: F811
-                           fanout_graph_facts_multidut,                  # noqa: F811
-                           duthosts):                                       # noqa: F811
-    """
-    Configures BGP in T1, T2 Uplink and T2 Downlink
-
-    Args:
-        multidut_snappi_ports_for_bgp (pytest fixture):  Port mapping info on multidut testbed
-        conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts_multidut (pytest fixture): fanout graph
-        duthosts (pytest fixture): list of DUTs
-    Returns:
-        N/A
-    """
-    snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.test_name = "Dut Configuration"
-
-    ansible_dut_hostnames = []
-    for duthost in duthosts:
-        ansible_dut_hostnames.append(duthost.hostname)
-
-    hw_platform = get_hw_platform(ansible_dut_hostnames)
-    if hw_platform is None:
-        pytest_require(False, "Unable to get the hardware platform")
-
-    logger.info("hw_platform: {}".format(hw_platform))
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
-    for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
-        else:
-            continue
-    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
-    snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
-    run_dut_configuration(snappi_extra_params)
 
 
 def test_bgp_outbound_uplink_ungraceful_restart(snappi_api,                                     # noqa: F811
@@ -107,27 +60,20 @@ def test_bgp_outbound_uplink_ungraceful_restart(snappi_api,                     
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][3] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost4 = duthost
+            snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
-
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.device_name = t1_t2_device_hostnames[hw_platform][1]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
 
     run_bgp_outbound_ungraceful_restart(api=snappi_api,
                                         creds=creds,
@@ -168,27 +114,21 @@ def test_bgp_outbound_downlink_ungraceful_restart(snappi_api,                   
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][3] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost4 = duthost
+            snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.device_name = t1_t2_device_hostnames[hw_platform][2]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
 
     run_bgp_outbound_ungraceful_restart(api=snappi_api,
                                         creds=creds,
@@ -229,27 +169,21 @@ def test_bgp_outbound_supervisor_ungraceful_restart(snappi_api,                 
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_assert(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][3] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost4 = duthost
+            snappi_extra_params.multi_dut_params.duthost3 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.device_name = t1_t2_device_hostnames[hw_platform][3]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
 
     run_bgp_outbound_ungraceful_restart(api=snappi_api,
                                         creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_multi_po_flap.py
@@ -1,13 +1,13 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                          # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
      snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t1_snappi_ports                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
-     run_bgp_outbound_uplink_blackout_test, run_dut_configuration, get_hw_platform)                 # noqa: F401
+     run_bgp_outbound_uplink_blackout_test, get_hw_platform)                                        # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -35,54 +35,6 @@ ROUTE_RANGES = [{
                         ['4000::1', 64, 2500]
                     ],
             }]
-
-
-def test_dut_configuration(multidut_snappi_ports_for_bgp,                  # noqa: F811
-                           conn_graph_facts,                             # noqa: F811
-                           fanout_graph_facts_multidut,                  # noqa: F811
-                           duthosts):                                       # noqa: F811
-    """
-    Configures BGP in T1, T2 Uplink and T2 Downlink
-
-    Args:
-        multidut_snappi_ports_for_bgp (pytest fixture):  Port mapping info on multidut testbed
-        conn_graph_facts (pytest fixture): connection graph
-        fanout_graph_facts_multidut (pytest fixture): fanout graph
-        duthosts (pytest fixture): list of DUTs
-    Returns:
-        N/A
-    """
-    snappi_extra_params = SnappiTestParams()
-    snappi_extra_params.test_name = "Dut Configuration"
-
-    ansible_dut_hostnames = []
-    for duthost in duthosts:
-        ansible_dut_hostnames.append(duthost.hostname)
-
-    hw_platform = get_hw_platform(ansible_dut_hostnames)
-    if hw_platform is None:
-        pytest_require(False, "Unknown HW Platform")
-    logger.info("HW Platform: {}".format(hw_platform))
-
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
-    for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
-        elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
-        else:
-            continue
-
-    snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
-    snappi_extra_params.multi_dut_params.hw_platform = hw_platform
-    run_dut_configuration(snappi_extra_params)
 
 
 def test_bgp_outbound_uplink_complete_blackout(snappi_api,                                     # noqa: F811
@@ -119,24 +71,18 @@ def test_bgp_outbound_uplink_complete_blackout(snappi_api,                      
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     run_bgp_outbound_uplink_blackout_test(api=snappi_api,
                                           creds=creds,
                                           snappi_extra_params=snappi_extra_params)
@@ -176,24 +122,17 @@ def test_bgp_outbound_uplink_partial_blackout(snappi_api,                       
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
-
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     run_bgp_outbound_uplink_blackout_test(api=snappi_api,
                                           creds=creds,
                                           snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_flap.py
@@ -1,11 +1,10 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                           # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                        # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api, multidut_snappi_ports_for_bgp      # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t1_dut_info, t1_snappi_ports        # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
      get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
@@ -76,23 +75,16 @@ def test_bgp_outbound_uplink_po_flap(snappi_api,                                
         pytest_require(False, "Unknown HW Platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
-
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_link_flap_test(api=snappi_api,
                                     creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_po_member_flap.py
@@ -1,11 +1,11 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                          # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
      fanout_graph_facts_multidut                                                                     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames, t2_uplink_portchannel_members       # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api, multidut_snappi_ports_for_bgp      # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t2_uplink_portchannel_members, \
+     t1_snappi_ports                                                                                # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
      get_hw_platform, run_bgp_outbound_link_flap_test)                                              # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
@@ -76,12 +76,6 @@ def test_bgp_outbound_uplink_po_member_flap(snappi_api,                         
         pytest_require(False, "Failed to get the hardware platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     # Skip the test if the uplink_portchannels has less than 2 members
     uplink_lc = t1_t2_device_hostnames[hw_platform][1]
     portchannel_data = t2_uplink_portchannel_members[hw_platform][uplink_lc]
@@ -95,15 +89,15 @@ def test_bgp_outbound_uplink_po_member_flap(snappi_api,                         
     pytest_require(len(po0_list) >= 2, "Portchannel has less than 2 members")
 
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_link_flap_test(api=snappi_api,
                                     creds=creds,

--- a/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
+++ b/tests/snappi_tests/multidut/bgp/test_bgp_outbound_uplink_process_crash.py
@@ -1,11 +1,9 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
-     fanout_graph_facts_multidut                                                                     # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-     snappi_api, multidut_snappi_ports_for_bgp                                                       # noqa: F401
-from tests.snappi_tests.variables import t1_t2_device_hostnames                                     # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                          # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut    # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api, multidut_snappi_ports_for_bgp      # noqa: F401
+from tests.snappi_tests.variables import t1_t2_device_hostnames, t1_snappi_ports                     # noqa: F401
 from tests.snappi_tests.multidut.bgp.files.bgp_outbound_helper import (
      get_hw_platform, run_bgp_outbound_process_restart_test)                                        # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams                           # noqa: F401
@@ -74,24 +72,18 @@ def test_bgp_outbound_uplink_process_crash(snappi_api,                          
         pytest_require(False, "Unable to get the hardware platform")
     logger.info("HW Platform: {}".format(hw_platform))
 
-    for device_hostname in t1_t2_device_hostnames[hw_platform]:
-        if device_hostname not in ansible_dut_hostnames:
-            logger.info('!!!!! Attention: {} not in : {} derived from ansible dut hostnames'.
-                        format(device_hostname, ansible_dut_hostnames))
-            pytest_require(False, "Mismatch between the dut hostnames in ansible and in variables.py files")
-
     for duthost in duthosts:
-        if t1_t2_device_hostnames[hw_platform][0] in duthost.hostname:
+        if t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
             snappi_extra_params.multi_dut_params.duthost1 = duthost
-        elif t1_t2_device_hostnames[hw_platform][1] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost2 = duthost
         elif t1_t2_device_hostnames[hw_platform][2] in duthost.hostname:
-            snappi_extra_params.multi_dut_params.duthost3 = duthost
+            snappi_extra_params.multi_dut_params.duthost2 = duthost
         else:
             continue
 
+    snappi_extra_params.multi_dut_params.t1_hostname = t1_t2_device_hostnames[hw_platform][0]
     snappi_extra_params.multi_dut_params.host_name = t1_t2_device_hostnames[hw_platform][1]
     snappi_extra_params.multi_dut_params.multi_dut_ports = multidut_snappi_ports_for_bgp
+    snappi_extra_params.multi_dut_params.multi_dut_ports.extend(t1_snappi_ports[hw_platform])
     snappi_extra_params.multi_dut_params.hw_platform = hw_platform
     run_bgp_outbound_process_restart_test(api=snappi_api,
                                           creds=creds,

--- a/tests/snappi_tests/variables.py
+++ b/tests/snappi_tests/variables.py
@@ -142,7 +142,16 @@ ipv6 = []
 peer_ipv6 = []
 # START ---------------------   T2 BGP Case -------------------
 '''
-    PRE-REQUISITE : The DUT ports must be Administratively Up and configured as Routed ports before starting the test
+    PRE-REQUISITE :
+    DUT Configs:
+        For the T2 DUT configuration, use the following topo file:
+            For multi-asic:  topo_tgen_t2_2lc_masic_route_conv.yml (or define one if topology is different)
+            For single-asic: topo_tgen_t2_2lc_route_conv.yml (or define one if topology is different)
+        For the T1 DUT configuration: Please ensure to configure the DUT using the initial_setup() fixture
+            in the tests/snappi_tests/multidut/bgp/conftest.py
+        For Fanout(if Applicable): Please ensure to configure the DUT using the initial_setup() fixture in the
+            tests/snappi_tests/multidut/bgp/conftest.py
+
 '''
 # *********** Common variables for Performance and Outbound ****************
 T2_SNAPPI_AS_NUM = 65400
@@ -201,6 +210,25 @@ t1_ports = {
      },
      'HW_PLATFORM2': {
      }
+}
+
+t1_dut_info = {
+    'HW_PLATFORM1': {
+        'dut_ip': '10.64.246.10',
+    },
+    'HW_PLATFORM2': {
+        'dut_ip': '10.64.246.10',
+    }
+}
+
+t1_snappi_ports = {
+    'HW_PLATFORM1': [
+        {'ip': '10.1.1.1', 'port_id': '11.3', 'peer_port': 'Ethernet24', 'peer_device': 'sonic-t1',
+         'speed': 'speed_100_gbps', 'location': '10.1.1.1/11.3', 'api_server_ip': '10.2.2.2'},
+        {'ip': '10.1.1.1', 'port_id': '11.4', 'peer_port': 'Ethernet28', 'peer_device': 'sonic-t1',
+         'speed': 'speed_100_gbps', 'location': '10.1.1.1/11.4', 'api_server_ip': '10.2.2.2'},
+    ],
+    'HW_PLATFORM2': []
 }
 
 # asic_value is None if it's non-chassis based or single line card


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. Infra changes to support automation of T2 DUT config using new tgen topo file using deploy-mg
2. Infra changes to support automation of T1 and Fanout config at runtime

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
For T2 Snappi based route convergence tests to be run through our Nightly pipeline, We need to be able to achieve T2 DUT initial config via deploy-mg
Also, T1 Config and fanout config needed to be automated(to avoid manual steps)

For the currently Nightly pipeline, infrastructure doesnt support multiple DUT type(t2, t1) in the testbed. As we can only provide single image path during the pipeline run.
#### How did you do it?
To Achieve T2 DUT config automation: New topo files were checked in earlier via PR: https://github.com/sonic-net/sonic-mgmt/pull/16957

To achieve T1 and fanout initial config: wrote a placeholder initial_setup() function in the conftest. Which will be invoked once (session scope).
For consumers of this: Please fill this placeholder function with the T1 and fanout config as you see fit in your environment.

To achieve Nightly piepleine: Remove T1 DUT from route_convergence testbed file. Made changes in test functions to incorporate this infra change. Now, only T2 DUT is part of route_conv testbed, which can easily be integrated in Nightly piepleine.
#### How did you verify/test it?
Ran the deploy-mg using the new topo file for route_conv testbed.
Ran the route-conv tests on this testbed.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
