### PR TITLE
[dhcp_relay] Skip test_dhcp_relay in t0-2vlan vs type

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -405,8 +405,10 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 dhcp_relay/test_dhcp_relay.py:
   skip:
     reason: "Need to skip for Cisco backend platform"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17205 and 't0-2vlans' in topo_name and asic_type in ['vs']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap:
   skip:
@@ -415,6 +417,7 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap:
     conditions:
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17205 and 't0-2vlans' in topo_name and asic_type in ['vs']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
@@ -423,6 +426,7 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17205 and 't0-2vlans' in topo_name and asic_type in ['vs']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
@@ -431,6 +435,7 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down:
     conditions:
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17205 and 't0-2vlans' in topo_name and asic_type in ['vs']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
   skip:
@@ -439,6 +444,7 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17205 and 't0-2vlans' in topo_name and asic_type in ['vs']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Skip test_dhcp_relay in vs with t0-2vlans topo due to flaky to unblock pr check

#### How did you do it?
Skip test_dhcp_relay in vs with t0-2vlans topo due to flaky to unblock pr check

#### How did you verify/test it?
RP check no run the case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
