### PR TITLE
Reset lpmode to off after sfp-reset on arista platforms

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -718,6 +718,11 @@ class TestSfpApi(PlatformApiTestBase):
                 continue
             info_dict = port_index_to_info_dict[sfp_port_idx]
 
+            # when an optic XCVR goes through sfp reset on an Arista platform it goes into lpmode
+            # https://github.com/aristanetworks/sonic/issues/121
+            if 'arista' in duthost.facts['platform'].lower() and self.is_xcvr_support_lpmode(info_dict):
+                sfp.set_lpmode(platform_api_conn, sfp_port_idx, False)
+
             # only flap interfaces where are CMIS optics,
             # non-CMIS optics should stay up after sfp_reset(), no need to flap.
             if "cmis_rev" in info_dict:


### PR DESCRIPTION
On Arista platforms when optic ports go through sfp-reset they go into low-power mode.
This change will bring those ports out of low-power mode after the sfp-reset to avoid ports remaining down and the test failing.

https://github.com/aristanetworks/sonic/issues/121

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411