### PR TITLE
feat: enable forced mgmt route test on T2

### DIFF
--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -11,7 +11,7 @@ from tests.common.utilities import wait_until, wait_for_file_changed, backup_con
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0'),
+    pytest.mark.topology('t0', 't2'),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable `route/test_forced_mgmt_route.py::test_update_forced_mgmt` test case on T2 topo to resolve the T2 test gap.

Summary:
Fixes # (issue) Microsoft ADO 28837282

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We want to run more tests on T2 topo to increase the test coverage. In this PR, we enabled `route/test_forced_mgmt_route.py::test_update_forced_mgmt` on T2 topo.

The other test case `test_forced_mgmt_route_add_and_remove_by_mgmt_port_status()` will still be skipped for multi-asic devices (for example, T2 devices) as I couldn't find a device with `eth1` port available, so I never got the chance to verify it. I have created a GitHub issue here to track this: #17250 

#### How did you do it?

#### How did you verify/test it?
Elastictest link: https://elastictest.org/scheduler/testplan/67bf90c1fdc60a30648c223b?testcase=route%2Ftest_forced_mgmt_route.py&type=console&leftSideViewMode=detail

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
