### PR TITLE
[sonic-mgmt][dualtor] Fix neighbor address slection logic for everflow tests

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -98,7 +98,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
         cmd = 'show ipv6 bgp summary'
         parse_result = everflow_dut.show_and_parse(cmd)
-        neigh_ipv6 = {entry['neighborname']: entry['neighbhor'] for entry in parse_result}
+        neigh_ipv6 = {entry['neighborname']: entry['neighbhor'].lower() for entry in parse_result}
 
         if len(neigh_ipv6) > 1:
             def background_traffic(run_count=None):

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -93,13 +93,14 @@ class EverflowIPv6Tests(BaseEverflowTest):
         yield direction
 
     @pytest.fixture(scope='function', autouse=True)
-    def background_traffic(self, ptfadapter, everflow_direction, setup_info):  # noqa F811
+    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut):  # noqa F811
         stop_thread = threading.Event()
         src_port = EverflowIPv6Tests.rx_port_ptf_id
 
-        neigh_ipv6 = {entry['name']: entry['addr'].lower() for entry in ptfadapter.mg_facts['minigraph_bgp'] if
-                      'ASIC' not in entry['name'] and isinstance(ipaddress.ip_address(entry['addr']),
-                                                                 ipaddress.IPv6Address)}
+        cmd = 'show ipv6 bgp summary'
+        parse_result = everflow_dut.show_and_parse(cmd)
+        neigh_ipv6 = {entry['neighborname']: entry['neighbhor'] for entry in parse_result}
+
         if len(neigh_ipv6) > 1:
             def background_traffic(run_count=None):
                 selected_addrs1 = random.sample(list(neigh_ipv6.values()), 2)

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -3,7 +3,6 @@ import threading
 import time
 import pytest
 import ptf.testutils as testutils
-import ipaddress
 from ptf import packet
 from ptf.mask import Mask
 import ptf.packet as scapy

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -3,7 +3,6 @@ import logging
 import random
 import time
 import pytest
-import ipaddress
 import threading
 import ptf.testutils as testutils
 from ptf.mask import Mask

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -694,9 +694,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
         # Events to control the thread
         stop_thread = threading.Event()
-        neigh_ipv4 = {entry['name']: entry['addr'].lower() for entry in ptfadapter.mg_facts['minigraph_bgp'] if
-                      'ASIC' not in entry['name'] and isinstance(ipaddress.ip_address(entry['addr']),
-                                                                 ipaddress.IPv4Address)}
+        cmd = 'show ip bgp summary'
+        parse_result = everflow_dut.show_and_parse(cmd)
+        neigh_ipv4 = {entry['neighborname']: entry['neighbhor'] for entry in parse_result}
         if len(neigh_ipv4) < 2:
             pytest.skip("Skipping as Less than 2 Neigbhour")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [dualtor] Fix neighbor address slection logic for everflow tests
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/463

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Everflow tests `test_everflow_ipv6.py` and `test_everflow_testbed.py::test_everflow_frwd_with_bkg_trf` are starting background traffic before verifying actual test traffic. Background traffic verification is failing in dualtor if rand selected dut (`everflow_dut`) is lower ToR (i.e second dut). Reason being `neigh_ipv[4|6]` collection is relying on `ptfadapter.mg_facts['minigraph_bgp']` which is having neighbours (T1) addresses corresponding to upper ToR only. Thus background traffic send to lower ToR with destination address corresponding to upper ToR's neighbor address will not reach any server ports and thus causing test failures with symptom ```"message": "AssertionError: Did not receive expected packet on any of ports ...```

#### How did you do it?
Fix is to get the correct neighbour addresses from selected dut (`everflow_dut`) using show command `show ip[v6] bgp summary`.


#### How did you verify/test it?
Stressed the test on sku `Arista-7050CX3-32S-C32` and verified that test is passing on dualtor topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
