### PR TITLE
Fix for generic_config_updater/test_portchannel_interfaces.py on dualtor

### DIFF
--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -69,14 +69,14 @@ def check_portchannel_table(duthost, portchannel_table):
 
 
 @pytest.fixture(autouse=True)
-def setup_env(duthosts, rand_one_dut_front_end_hostname, portchannel_table):
+def setup_env(duthosts, rand_one_dut_hostname, portchannel_table):
     """
     Setup/teardown fixture for portchannel interface config
     Args:
         duthosts: list of DUTs.
-        rand_one_dut_front_end_hostname: The fixture returns a randomly selected frontend DuT.
+        rand_one_dut_hostname: The fixture returns a randomly selected DuT
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     create_checkpoint(duthost)
 
     yield
@@ -224,13 +224,14 @@ def portchannel_interface_tc1_add_and_rm(duthost, portchannel_table,
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc1_suite(rand_selected_front_end_dut, portchannel_table,
+def test_portchannel_interface_tc1_suite(duthosts, rand_one_dut_hostname, portchannel_table,
                                          enum_rand_one_frontend_asic_index, rand_portchannel_name):
-    portchannel_interface_tc1_add_duplicate(rand_selected_front_end_dut, portchannel_table,
+    duthost = duthosts[rand_one_dut_hostname]
+    portchannel_interface_tc1_add_duplicate(duthost, portchannel_table,
                                             enum_rand_one_frontend_asic_index, rand_portchannel_name)
-    portchannel_interface_tc1_xfail(rand_selected_front_end_dut,
+    portchannel_interface_tc1_xfail(duthost,
                                     enum_rand_one_frontend_asic_index, rand_portchannel_name)
-    portchannel_interface_tc1_add_and_rm(rand_selected_front_end_dut, portchannel_table,
+    portchannel_interface_tc1_add_and_rm(duthost, portchannel_table,
                                          enum_rand_one_frontend_asic_index, rand_portchannel_name)
 
 
@@ -339,12 +340,13 @@ def portchannel_interface_tc2_incremental(duthost,
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_portchannel_interface_tc2_attributes(rand_selected_front_end_dut,
+def test_portchannel_interface_tc2_attributes(duthosts, rand_one_dut_hostname,
                                               enum_rand_one_frontend_asic_index,
                                               rand_portchannel_name):
-    portchannel_interface_tc2_replace(rand_selected_front_end_dut,
+    duthost = duthosts[rand_one_dut_hostname]
+    portchannel_interface_tc2_replace(duthost,
                                       enum_rand_one_frontend_asic_index,
                                       rand_portchannel_name)
-    portchannel_interface_tc2_incremental(rand_selected_front_end_dut,
+    portchannel_interface_tc2_incremental(duthost,
                                           enum_rand_one_frontend_asic_index,
                                           rand_portchannel_name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # [438](https://github.com/aristanetworks/sonic-qual.msft/issues/438)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
- Fixes failures in generic_config_updater/test_portchannel_interfaces.py failure on dualtor
- In dualtor topologies, the test picks ToR-A to apply portchannel config changes but verifies their effect on ToR-B instead, leading to test failure 

#### How did you do it?
Use rand_one_dut_hostname to ensure the same ToR is picked throughout the test run 

#### How did you verify/test it?
Ran generic_config_updater/test_portchannel_interfaces.py on DCS-7260CX3 and DCS-7050CX3
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
