### PR TITLE
Skip linkdown_on_sup_reboot on topologies that don't use modular switches

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1106,6 +1106,15 @@ platform_tests/test_kdump.py:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 #######################################
+########   test_link_down.py   ########
+#######################################
+platform_tests/test_link_down.py::test_link_down_on_sup_reboot:
+  skip:
+    reason: "Skip for non T2"
+    conditions:
+      - "topo_type not in ['t2']"
+
+#######################################
 ####  test_memory_exhaustion.py   #####
 #######################################
 platform_tests/test_memory_exhaustion.py:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip `link_down_on_sup_reboot` on topologies that don't use modular switches
Fixes # [464](https://github.com/aristanetworks/sonic-qual.msft/issues/464)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
test_linkdown_on_sup_reboot() testcase should be  skipped for non-T2 topologies 

#### What is the motivation for this PR?
All testcases in this module were recently enabled for non-T2 topologies in https://github.com/sonic-net/sonic-mgmt/pull/13582

platform_tests/test_link_down.py::test_link_down_on_sup_reboot is still meant to be run on a modular chassis which reboots supervisor and then checks the port status on all linecards. However this ends up running on all multidut topologies due to this
check: https://github.com/sonic-net/sonic-mgmt/blob/202411/tests/platform_tests/test_link_down.py#L152-L153 which includes dualTor where every duthost is a standalone device as compared to being a unit in chassis.


#### How did you do it?
test_linkdown_on_sup_reboot() testcase is skipped for non-T2 topologies using a conditional marker

#### How did you verify/test it?
Tested on sonic dualtor fixed-testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
