### PR TITLE
Align the test_bgp_suppress_fib for the topo which does not have port channel

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -324,6 +324,10 @@ def setup_vrf_cfg(duthost, cfg_facts, nbrhosts, tbinfo):
     vm_list = nbrhosts.keys()
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_channel_list = mg_facts['minigraph_portchannels'].keys()
+    if len(port_channel_list) == 0:
+        upstream_port_list = get_port_connected_with_vm(duthost, nbrhosts, vm_type="T2")
+        port_list.extend(upstream_port_list)
+
     extra_vars = {'cfg_t1': cfg_t1, 'port_list': port_list, 'vm_list': vm_list, 'pc_list': port_channel_list}
 
     duthost.host.options['variable_manager'].extra_vars.update(extra_vars)

--- a/tests/bgp/vrf_config_db.j2
+++ b/tests/bgp/vrf_config_db.j2
@@ -4,17 +4,12 @@
     "BGP_NEIGHBOR": {
 {%         for neigh in cfg_t1['BGP_NEIGHBOR'] | sort %}
 {#     to detect number of pcs, used multiplier 2, because each neigh have ipv4 and ipv6 key #}
-{%             if cfg_t1['BGP_NEIGHBOR'] | length == 48  %}
-{%                 if cfg_t1['BGP_NEIGHBOR'][neigh]['name'] in vm_list %}
+{%       if cfg_t1['BGP_NEIGHBOR'][neigh]['name'] in vm_list %}
         "Vrf1|{{ neigh }}": {{ cfg_t1['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
 {%-                else %}
         "{{ neigh }}": {{ cfg_t1['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
 {%-                endif %}
-{%-            else %}
-        "{{ neigh }}": {{ cfg_t1['BGP_NEIGHBOR'][neigh] | to_nice_json | indent(width=8) }}
-{%-            endif %}
 {%-            if not loop.last %},{%endif %}
-
 {%         endfor %}
     },
 {%     elif k == 'PORTCHANNEL_INTERFACE' %}


### PR DESCRIPTION
Align the test_bgp_suppress_fib for the topo which does not have port channel

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 1. Previously, the vrf_config in the test_bgp_suppress_fib test could only apply for the topology which has only 24 VMs, actually, no need to to check the number of the BGP_NEIGHBOR in the topology, then it could apply to any t1 topology.
2. For the topology which does not have the portchannel, the upstream port also need to be added to the vrf, else the vrf route could not be learned on the T2 VM.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Make sure the test_bgp_suppress_fib  could pass on t1 topo which does not have portchannel.
#### How did you do it?

#### How did you verify/test it?
Run the test_bgp_suppress_fib on the t1-isolated-d28u1, and it pass.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
