### PR TITLE
Refine PR test job name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,7 +132,7 @@ stages:
           MGMT_BRANCH: "master"
 
   - job: impacted_area_t0_2vlans_elastictest
-    displayName: "impacted-area-kvmtest-t0_2vlans by Elastictest"
+    displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
     dependsOn:
     - get_impacted_area
     - choose_between_mixed_and_py3_ptf_image
@@ -222,7 +222,7 @@ stages:
           MGMT_BRANCH: "master"
 
   - job: impacted_area_multi_asic_elastictest
-    displayName: "impacted-area-kvmtest-multi_asic by Elastictest"
+    displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
     dependsOn:
     - get_impacted_area
     - choose_between_mixed_and_py3_ptf_image
@@ -250,8 +250,8 @@ stages:
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: "master"
 
-  - job: impacted_area_sonic_t0_elastictest
-    displayName: "impacted-area-kvmtest-sonic_t0 by Elastictest"
+  - job: impacted_area_t0_sonic_elastictest
+    displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
     dependsOn:
     - get_impacted_area
     - choose_between_mixed_and_py3_ptf_image
@@ -311,7 +311,7 @@ stages:
 
   # This PR checker aims to run all t1 test scripts on multi-asic topology.
   - job: impacted_area_multi_asic_t1_elastictest
-    displayName: "impacted-area-kvmtest-multi_asic_t1 by Elastictest - optional"
+    displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest - optional"
     dependsOn:
     - get_impacted_area
     - choose_between_mixed_and_py3_ptf_image


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Baseline test will use test plan name to distinguish different test platforms, and test plan name determined by pipeline job name, so job name should have a unified standard and be easy to distinguish.
#### How did you do it?
1. Replace `_` in job name with `-`, for example, in baseline test, once we create multiple test plans for t0, the test plan name will be `xxx_impacted-area-kvmtest-t0_number`, difficult to distinguish with t0_2vlans test job `xxx_impacted-area-kvmtest-t0_2vlans_number`, so use `-` in job name.
2. Use t0-sonic not sonic-t0, because in all other places, we are using t0-sonic.
3. Change `multi-asic` to `multi-asic-t1` to show the topo type.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
