### PR TITLE
Fix PCBB watermark test flaky issue

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -599,8 +599,6 @@ def test_pfc_watermark_extra_lossless_standby(ptfhost, fanouthosts, rand_selecte
             testutils.send(ptfadapter, src_port, pkt, num_storm_pkts)
         finally:
             stop_pfc_storm(storm_handler)
-        # Clear out packets for futher verification
-        testutils.count_matched_packets_all_ports(ptfadapter, exp_pkt, dst_ports, timeout=0.5)
         # Record new watermark after congestion and clear
         queue_wmk = get_queue_watermark(rand_selected_dut, actual_port_name, wmk_stat_queue, True)
         # Expect the watermark to have increased by a small proportion of the traffic
@@ -691,8 +689,6 @@ def test_pfc_watermark_extra_lossless_active(ptfhost, fanouthosts, rand_selected
             testutils.send_packet(ptfadapter, src_port, tunnel_pkt.exp_pkt, num_storm_pkts)
         finally:
             stop_pfc_storm(storm_handler)
-        # Clear out packets for futher verification
-        testutils.count_matched_packets(ptfadapter, exp_pkt, dualtor_meta['target_server_port'], timeout=0.5)
         # Record new watermark after congestion and clear
         queue_wmk = get_queue_watermark(rand_selected_dut, dualtor_meta['selected_port'], queue, True)
         # Expect the watermark to have increased by a small proportion of the traffic


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes an issue where sometimes the test framework would lockup due to trying to clear out packets from the PTF buffer, but failing to ever do so due to endless ICMP responder packets. 
The "clear out packets" operation is actually unnecessary due to the following loop iteration using a different DSCP, which will cause the extra packets from the prior loop to not match the next loop's packet verification mask. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix a flaky issue. 

#### How did you do it?

#### How did you verify/test it?
Verified 2 tests pass. 

#### Any platform specific information?
Cisco-8000 test. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
