### PR TITLE
Update `test_reset` to flap non-CMIS XCVRs too

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -718,9 +718,9 @@ class TestSfpApi(PlatformApiTestBase):
                 continue
             info_dict = port_index_to_info_dict[sfp_port_idx]
 
-            # only flap interfaces where are CMIS optics,
-            # non-CMIS optics should stay up after sfp_reset(), no need to flap.
-            if "cmis_rev" in info_dict:
+            # If the xcvr supports low-power mode then it needs to be flapped to come
+            # out of low-power mode after sfp_reset()
+            if self.is_xcvr_support_lpmode(info_dict):
                 duthost.shutdown_interface(intf)
                 intfs_changed.append(intf)
 


### PR DESCRIPTION
We see that non-CMIS optic XCVRs are still in low-power mode after sfp_reset and therefor down.
Update the test to flap all ports that support low-power mode instead of just CMIS XCVRs.

Note that this change along won't result in `platform_tests/api/test_sfp.py::TestSfpApi::test_reset` passing, it also needs https://github.com/sonic-net/sonic-platform-daemons/pull/592 to pull ports out of low-power mode on `admin_status=up`

https://github.com/aristanetworks/sonic/issues/121

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411