### PR TITLE
[test gap] Add test script to cover secondary subnet data consistency

### DIFF
--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -163,30 +163,29 @@ def get_vlan_interface_info(duthost, tbinfo, vlan_name, ip_version="ipv4"):
 
     return result
 
+
 def get_secondary_subnet(duthost, tbinfo):
-        """
-        Check if any VLAN interface on the DUT has a secondary subnet configured.
+    """
+    Check if any VLAN interface has a secondary subnet configured.
 
-        This function examines all VLAN interfaces present on the device and
-        determines if any of them have a secondary IP configuration for either
-        IPv4 or IPv6.
+    Args:
+        tbinfo: Testbed information dictionary
 
-            tbinfo: Testbed information dictionary
+    Returns:
+        tuple: (has_secondary, vlan_name, ip_version, interface_info)
+        - has_secondary: True if a secondary subnet exists
+        - vlan_name: VLAN interface name with secondary subnet
+        - ip_version: IP version ("ipv4" or "ipv6") of the secondary subnet
+        - interface_info: Configuration dict for the secondary subnet
+    """
+    vlan_interfaces_dict = get_vlan_interfaces_dict(duthost, tbinfo)
 
-            tuple: (has_secondary, vlan_name, ip_version, interface_info)
-                - has_secondary (bool): True if a secondary subnet exists on any VLAN
-                - vlan_name (str or None): Name of VLAN interface with secondary subnet, or None if none found
-                - ip_version (str or None): The IP version ("ipv4" or "ipv6") of the secondary subnet, or None if none found
-                - interface_info (dict or None): Interface configuration dict for the secondary subnet, or None if none found
-        """
-        vlan_interfaces_dict = get_vlan_interfaces_dict(duthost, tbinfo)
+    # Initialize return values
+    for vlan_name, ip_versions in vlan_interfaces_dict.items():
+        for ip_version, interfaces in ip_versions.items():
+            for interface in interfaces:
+                if interface.get('secondary'):
+                    return True, vlan_name, ip_version, interface
 
-        # Initialize return values
-        for vlan_name, ip_versions in vlan_interfaces_dict.items():
-            for ip_version, interfaces in ip_versions.items():
-                for interface in interfaces:
-                    if interface.get('secondary'):
-                        return True, vlan_name, ip_version, interface
-
-        # No secondary subnet found
-        return False, None, None, None
+    # No secondary subnet found
+    return False, None, None, None

--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -162,3 +162,31 @@ def get_vlan_interface_info(duthost, tbinfo, vlan_name, ip_version="ipv4"):
         break
 
     return result
+
+def get_secondary_subnet(duthost, tbinfo):
+        """
+        Check if any VLAN interface on the DUT has a secondary subnet configured.
+
+        This function examines all VLAN interfaces present on the device and
+        determines if any of them have a secondary IP configuration for either
+        IPv4 or IPv6.
+
+            tbinfo: Testbed information dictionary
+
+            tuple: (has_secondary, vlan_name, ip_version, interface_info)
+                - has_secondary (bool): True if a secondary subnet exists on any VLAN
+                - vlan_name (str or None): Name of VLAN interface with secondary subnet, or None if none found
+                - ip_version (str or None): The IP version ("ipv4" or "ipv6") of the secondary subnet, or None if none found
+                - interface_info (dict or None): Interface configuration dict for the secondary subnet, or None if none found
+        """
+        vlan_interfaces_dict = get_vlan_interfaces_dict(duthost, tbinfo)
+
+        # Initialize return values
+        for vlan_name, ip_versions in vlan_interfaces_dict.items():
+            for ip_version, interfaces in ip_versions.items():
+                for interface in interfaces:
+                    if interface.get('secondary'):
+                        return True, vlan_name, ip_version, interface
+
+        # No secondary subnet found
+        return False, None, None, None

--- a/tests/vlan/test_secondary_subnet.py
+++ b/tests/vlan/test_secondary_subnet.py
@@ -1,0 +1,181 @@
+import logging
+import pytest
+import re
+import time
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_ports import get_secondary_subnet
+from tests.common.helpers.dut_ports import get_vlan_interface_list
+
+
+pytestmark = [pytest.mark.topology("t0", "m0")]
+
+logger = logging.getLogger(__name__)
+
+SECONDARY_IP = "66.66.66.66/23"
+
+
+def check_secondary_ip_interface(duthost, vlan_interface, secondary_ip):
+    ip_interfaces_list = duthost.show_and_parse("show ip interface")
+
+    # Convert the list to a more usable format
+    ip_interface_dict = {}
+    last_interface = None
+
+    # Process the list to handle empty interface names
+    for item in ip_interfaces_list:
+        interface_name = item.get("interface", "")
+        if not interface_name and last_interface:
+            interface_name = last_interface
+        else:
+            last_interface = interface_name
+
+        # If this is the first time we're seeing this interface, create a list for it
+        if interface_name not in ip_interface_dict:
+            ip_interface_dict[interface_name] = []
+
+        # Add the ip address details
+        ip_interface_dict[interface_name].append(item)
+
+    # Check if vlan_interface exists in the processed data
+    found_secondary_ip = False
+    if vlan_interface in ip_interface_dict:
+        for item in ip_interface_dict[vlan_interface]:
+            if item["ipv4 address/mask"] == secondary_ip:
+                found_secondary_ip = True
+                logger.info(f"Found {secondary_ip} on {vlan_interface}")
+                break
+    return found_secondary_ip, ip_interface_dict
+
+
+def check_secondary_subnet_exist(duthost, vlan_interface, ip_address):
+    """
+    Verify that a secondary IP subnet exists and is properly configured.
+    This function performs multiple checks to verify that a secondary IP address is properly
+    configured on a VLAN interface:
+    1. Checks that the secondary IP appears in the "show ip interface" command output
+    2. Verifies that the secondary IP is stored correctly in Redis database
+    3. Confirms that the "secondary" property is set to "true" in Redis
+    Args:
+        duthost: DUT (Device Under Test) host object that provides the SSH connection
+        vlan_interface (str): The name of the VLAN interface (e.g., "Vlan1000")
+        ip_address (str): The secondary IP address to check for
+    Raises:
+        AssertionError: If any verification step fails
+    """
+    # Step 1: Verify secondary IP appears in "show ip interface" output
+    found_secondary_ip, ip_interfaces_dict = check_secondary_ip_interface(
+        duthost, vlan_interface, ip_address
+    )
+    pytest_assert(
+        found_secondary_ip,
+        f"Secondary IP {ip_address} not found for {vlan_interface} in IP interface list",
+    )
+    pytest_assert(
+        vlan_interface in ip_interfaces_dict,
+        f"Interface {vlan_interface} not found in structured output",
+    )
+
+    # Step 2: Verify secondary IP is stored in Redis
+    redis_key = f"VLAN_INTERFACE|{vlan_interface}|{ip_address}"
+    redis_output = duthost.command(f'sudo redis-cli -n 4 KEYS "{redis_key}"')
+    pytest_assert(
+        redis_key in redis_output["stdout"],
+        f"Secondary IP {ip_address} not found in Redis database",
+    )
+
+    # Step 5: Verify "secondary" property is set to "true" in Redis
+    redis_value = duthost.command(f'sudo redis-cli -n 4 HGETALL "{redis_key}"')
+    pytest_assert(
+        "secondary" in redis_value["stdout"],
+        f"'secondary' field not found for {redis_key} in Redis",
+    )
+    pytest_assert(
+        "true" in redis_value["stdout"],
+        f"'secondary' field not set to 'true' for {redis_key} in Redis",
+    )
+
+
+def check_secondary_subnet_not_exist(duthost, vlan_interface, ip_address):
+    """
+    Verify that a secondary IP subnet does not exist on a VLAN interface.
+    This function performs multiple checks to ensure that a secondary IP address is not
+    configured on a VLAN interface:
+    1. Checks that the secondary IP does not appear in the "show ip interface" command output
+    2. Verifies that the secondary IP is not stored in Redis database
+    Args:
+        duthost: DUT (Device Under Test) host object that provides the SSH connection
+        vlan_interface (str): The name of the VLAN interface (e.g., "Vlan1000")
+        ip_address (str): The secondary IP address to check for
+    Raises:
+        AssertionError: If any verification step fails
+    """
+    # Step 1: Verify secondary IP is removed from show output
+    found_secondary_ip, ip_interfaces_dict = check_secondary_ip_interface(
+        duthost, vlan_interface, ip_address
+    )
+    pytest_assert(
+        not found_secondary_ip,
+        f"Secondary IP {ip_address} found for {vlan_interface} after removal",
+    )
+
+    # Step 2: Verify secondary IP is removed from Redis
+    redis_key = f"VLAN_INTERFACE|{vlan_interface}|{ip_address}"
+    redis_output = duthost.command(f'sudo redis-cli -n 4 KEYS "{redis_key}"')
+    pytest_assert(
+        redis_key not in redis_output["stdout"],
+        f"Secondary IP {SECONDARY_IP} still found in Redis db after removal",
+    )
+
+
+def test_existing_secondary_subnet(duthost, tbinfo):
+    """
+    Test to verify existing secondary subnets on VLAN interfaces.
+
+    1. Check if the DUT already has a secondary subnet
+    2. If found, verify secondary ip address info is correct
+    """
+    # Step 1: Check if DUT has any secondary subnet configured
+    exist_flag, vlan_interface, ip_version, int_dict = get_secondary_subnet(
+        duthost, tbinfo
+    )
+
+    if not exist_flag:
+        pytest.skip("No secondary subnet found on DUT, skipping test")
+    if ip_version == "ipv6":
+        pytest.fail(
+            "Secondary subnet is IPv6, vlan interface information is not correct"
+        )
+
+    secondary_ip = int_dict["addr"] + "/" + str(int_dict["prefixlen"])
+
+    check_secondary_subnet_exist(duthost, vlan_interface, secondary_ip)
+
+
+def test_secondary_subnet(duthost):
+    """
+    Test secondary subnet functionality on a VLAN interface.
+
+    1. Add a secondary IP to a VLAN interface
+    2. Verify it appears in "show ip interface" output
+    3. Verify it's stored in Redis
+    4. Remove the secondary IP
+    5. Verify it's removed from both CLI output and Redis
+    """
+    # Step 1: Add secondary IP to VLAN interface
+    vlan_interfaces = get_vlan_interface_list(duthost)
+    # pick up the first vlan to test
+    vlan_interface = vlan_interfaces[0]
+
+    duthost.command(
+        f"sudo config interface ip add {vlan_interface} {SECONDARY_IP} --secondary"
+    )
+    time.sleep(2)
+    # Step 2: Verify secondary subnet info is added
+    check_secondary_subnet_exist(duthost, vlan_interface, SECONDARY_IP)
+
+    # Step 5: Remove the secondary IP
+    duthost.command(f"sudo config interface ip remove {vlan_interface} {SECONDARY_IP}")
+    time.sleep(2)
+
+    # Step 6: Verify secondary subnet info is removed
+    check_secondary_subnet_not_exist(duthost, vlan_interface, SECONDARY_IP)

--- a/tests/vlan/test_secondary_subnet.py
+++ b/tests/vlan/test_secondary_subnet.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import re
 import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.dut_ports import get_secondary_subnet
@@ -173,9 +172,9 @@ def test_secondary_subnet(duthost):
     # Step 2: Verify secondary subnet info is added
     check_secondary_subnet_exist(duthost, vlan_interface, SECONDARY_IP)
 
-    # Step 5: Remove the secondary IP
+    # Step 3: Remove the secondary IP
     duthost.command(f"sudo config interface ip remove {vlan_interface} {SECONDARY_IP}")
     time.sleep(2)
 
-    # Step 6: Verify secondary subnet info is removed
+    # Step 4: Verify secondary subnet info is removed
     check_secondary_subnet_not_exist(duthost, vlan_interface, SECONDARY_IP)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Address test gap https://github.com/sonic-net/sonic-mgmt/issues/17145.
Need to wait for https://github.com/sonic-net/sonic-mgmt/pull/17153/ being merged.


This PR introduces a test suite to verify secondary IP subnet management on VLAN interfaces. 
It includes:

- Functions to validate the presence or absence of secondary IP addresses via CLI (show ip interface) and Redis database.
- Tests to confirm correct addition, verification, and removal of secondary IP subnets on VLAN interfaces.

These tests ensure reliable secondary subnet configuration and cleanup on the DUT.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add a new test script to cover the data consistency check for secondary subnet.

#### How did you do it?
- Add a new function to get secondary ip in `dut_port.py`
- Functions to validate the presence or absence of secondary IP addresses via CLI (show ip interface) and Redis database.
- Tests to confirm correct addition, verification, and removal of secondary IP subnets on VLAN interfaces.

#### How did you verify/test it?
Run `test_secondary_subnet.py` on T0/M0 testbed.

#### Any platform specific information?
Any T0/M0 platforms.

#### Supported testbed topology if it's a new test case?
Any T0/M0 testbeds.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
