### PR TITLE
Fix test_dynamic_acl uncompatible issue on dualtor

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -218,8 +218,8 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
     config_facts = rand_selected_dut.config_facts(host=rand_selected_dut.hostname, source="running")['ansible_facts']
 
     vlan_ips = {}
-    for vlan_ip_address in config_facts['VLAN_INTERFACE'][vlan_name].keys():
-        if config_facts['VLAN_INTERFACE'][vlan_name][vlan_ip_address].get("secondary"):
+    for vlan_ip_address, value in config_facts['VLAN_INTERFACE'][vlan_name].items():
+        if isinstance(value, dict) and value.get("secondary"):
             continue
         ip_address = vlan_ip_address.split("/")[0]
         try:
@@ -380,7 +380,7 @@ def prepare_ptf_intf_and_ip(request, rand_selected_dut, config_facts, intfs_for_
     # Filter out addresses that have the "secondary" attribute set
     vlan_addrs = [
         addr for addr, attrs in vlan_interface.items()
-        if not attrs.get("secondary")  # Only include if "secondary" is not set (or is false)
+        if isinstance(attrs, dict) and not attrs.get("secondary", False)  # Check if attrs is a dictionary
     ]
 
     intf_ipv6_addr = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_dynamic_acl  failed on dualtor testbed due to:
```
28/02/2025 16:40:42 __init__._fixture_func_decorator         L0073 ERROR  |               
AttributeError("'AnsibleUnsafeText' object has no attribute 'get'")
Traceback (most recent call last):
  File "/data/tests/common/plugins/log_section_start/__init__.py", line 71, in _fixture_func_decorator
    return fixture_func(*args, **kargs)
  File "/data/tests/generic_config_updater/test_dynamic_acl.py", line 227, in setup  
    if config_facts['VLAN_INTERFACE'][vlan_name][vlan_ip_address].get("secondary"):
AttributeError: 'AnsibleUnsafeText' object has no attribute 'get'

```

It's because the VLAN_INTERFACE is like this on dualtor:
```
    "VLAN_INTERFACE": {
      "Vlan1000": {
        "grat_arp": "enabled",
        "proxy_arp": "enabled",
        "192.168.0.1/21": {
          
        },
        "fc02:1000::1/64": {
          
        }
      }
    },
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Avoid to get `secondary` key from a string object

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
