### PR TITLE
[radv_ipv6_ra]: Fix the hardcode interface for IPv6 advertisement interface

### DIFF
--- a/ansible/roles/test/files/ptftests/router_adv_mflag_test.py
+++ b/ansible/roles/test/files/ptftests/router_adv_mflag_test.py
@@ -53,15 +53,15 @@ class DataplaneBaseTest(BaseTest):
 
     """
 
-    def create_icmpv6_router_advertisement_packet_send(self, dst_mac, dst_ip, src_mac, src_ip):
+    def create_icmpv6_router_advertisement_packet_send(self, dst_mac, dst_ip, src_mac, src_ip, adv_iface):
         ether = Ether(dst=dst_mac, src=src_mac)
         ip6 = IPv6(src=src_ip, dst=dst_ip, fl=0, tc=0, hlim=255)
         icmp6 = RA(code=0, M=1, O=0)
         # NOTE: Test expects RA packet to contain route prefix as the first option
         icmp6 /= PrefixInfo(type=3, len=4)
         rapkt = ether / ip6 / icmp6
-        scapy2.sendp(rapkt, iface="eth1")
-        logging.info(scapy2.sniff(iface='eth1', timeout=10))
+        scapy2.sendp(rapkt, iface="eth{}".format(adv_iface))
+        logging.info(scapy2.sniff(iface='eth{}'.format(adv_iface), timeout=10))
         return rapkt
 
     """
@@ -136,7 +136,8 @@ class RadvUnSolicitedRATest(DataplaneBaseTest):
             src_mac=self.downlink_vlan_mac,
             dst_mac=ALL_NODES_MULTICAST_MAC_ADDRESS,
             src_ip=self.downlink_vlan_ip6,
-            dst_ip=ALL_NODES_IPV6_MULTICAST_ADDRESS)
+            dst_ip=ALL_NODES_IPV6_MULTICAST_ADDRESS,
+            adv_iface=self.ptf_port_index)
         self.masked_rapkt = self.mask_off_dont_care_ra_packet_fields(rapkt)
 
     def tearDown(self):
@@ -188,7 +189,8 @@ class RadvSolicitedRATest(DataplaneBaseTest):
             src_mac=self.downlink_vlan_mac,
             dst_mac=self.ptf_port_mac,
             src_ip=self.downlink_vlan_ip6,
-            dst_ip=self.ptf_port_ip6)
+            dst_ip=self.ptf_port_ip6,
+            adv_iface=self.ptf_port_index)
 
         self.masked_rapkt = self.mask_off_dont_care_ra_packet_fields(rapkt)
         self.rs_packet = self.create_icmpv6_router_solicitation_packet()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In some testbeds, `eth1` isn't always present. This PR is to enhance the test case to support the testbed without `eth1`.
#### How did you do it?
Replace the `ptf_port_index` as IPv6 advertisement interface which will be always present in the testbed.

#### How did you verify/test it?

```
radv/test_radv_ipv6_ra.py::test_radv_router_advertisement PASSED                                      [ 25%]
radv/test_radv_ipv6_ra.py::test_solicited_router_advertisement PASSED                                [ 50%]
radv/test_radv_ipv6_ra.py::test_unsolicited_router_advertisement_with_m_flag PASSED       [ 75%]
radv/test_radv_ipv6_ra.py::test_solicited_router_advertisement_with_m_flag PASSED           [ 100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
