### PR TITLE
Improve arp_responder.py performance

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -732,6 +732,11 @@ class ReloadTest(BaseTest):
         self.log("Enabling arp_responder")
         self.cmd(["supervisorctl", "restart", "arp_responder"])
 
+        # Give arp_responder 15 seconds to start up, because with the libpcap backend, scapy will first get information
+        # about all of the interfaces on the system (which takes a bit of time) and then proceeds.
+        self.log("Waiting 15 seconds for ARP responder to complete initialization")
+        time.sleep(15)
+
         return
 
     def setup_fdb(self):

--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -5,6 +5,9 @@ import os.path
 from collections import defaultdict
 import logging
 import scapy.all as scapy
+scapy.MTU = 1280
+scapy.conf.use_pcap = True
+# Callers: Expect to wait 10-15 seconds here, as scapy reinitializes everything to use libpcap
 logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Improve the overall performance of arp_responder.py.

#### How did you do it?

1. Reuse the socket that is receiving ARP/NDP requests for sending ARP/NDP responses. This avoids opening a socket, binding it to an interface, sending the packet, and closing it everytime, and just requires one syscall to send the packet.
2. Use the libpcap socket backend in scapy. With libpcap, instead of needing to use `recvmsg` syscalls to get packets one at a time, a RX ring buffer is set up as shared memory between userspace and kernel space. The kernel then writes incoming packets into that ring buffer, and then userspace reads it from there. All this happens with only one syscall to `select` (or equivalent) to know when data (one or more packets) is available, instead of 2 syscalls per packet. The downside is that this does increase memory usage, for the ring buffer to be created. A similar thing can be done for TX, but is a bit harder and is currently not supported by libpcap (so packets being sent out will still use the regular `sendmsg` syscall.
3. Enhance the BPF filter created for each socket by specifying which IPv4/IPv6 addresses we care about. That way, the kernel can do some filtering of packets within kernel space, and not need to signal us saying there's a packet available, only for us to get it and discard it. In the case of large VLANs and many hosts per port, this helps significantly.

#### How did you verify/test it?

Tested with multiple advanced reboot warm upgrade runs.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
