### PR TITLE
[BGP Testgap] Add BGP Update Replication

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -222,6 +222,22 @@ def restore_bgp_neighbors(duthost, asic_index, bgp_neighbors):
     pytest_assert(wait_until(100, 10, 0, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
 
 
+def is_neighbor_sessions_established(duthost, neighbors):
+    is_established = True
+
+    # handle both multi-asic and single-asic
+    bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())[
+        "ansible_facts"
+    ]
+    for neighbor in neighbors:
+        is_established &= (
+            neighbor.ip in bgp_facts["bgp_neighbors"]
+            and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
+        )
+
+    return is_established
+
+
 @pytest.fixture(scope='module')
 def bgp_allow_list_setup(tbinfo, nbrhosts, duthosts, rand_one_dut_hostname):
     """

--- a/tests/bgp/templates/bgp_summary_extended.textfsm
+++ b/tests/bgp/templates/bgp_summary_extended.textfsm
@@ -1,0 +1,11 @@
+Value num_rib (\d+)
+Value mem_rib (\d+)
+Value num_peers (\d+)
+Value mem_peers (\d+)
+Value num_group (\d+)
+Value mem_group (\d+)
+
+Start
+^RIB entries ${rib_entries}, using ${rib_memory} bytes of memory
+^Peers ${num_peers}, using ${mem_peers} KiB of memory
+^Peer groups ${num_group}, using ${mem_group} bytes of memory

--- a/tests/bgp/templates/bgp_summary_extended.textfsm
+++ b/tests/bgp/templates/bgp_summary_extended.textfsm
@@ -6,6 +6,6 @@ Value num_group (\d+)
 Value mem_group (\d+)
 
 Start
-^RIB entries ${rib_entries}, using ${rib_memory} bytes of memory
-^Peers ${num_peers}, using ${mem_peers} KiB of memory
-^Peer groups ${num_group}, using ${mem_group} bytes of memory
+    ^RIB entries ${rib_entries}, using ${rib_memory} bytes of memory
+    ^Peers ${num_peers}, using ${mem_peers} KiB of memory
+    ^Peer groups ${num_group}, using ${mem_group} bytes of memory

--- a/tests/bgp/templates/bgp_summary_extended.textfsm
+++ b/tests/bgp/templates/bgp_summary_extended.textfsm
@@ -6,6 +6,6 @@ Value num_group (\d+)
 Value mem_group (\d+)
 
 Start
-    ^RIB entries ${rib_entries}, using ${rib_memory} bytes of memory
-    ^Peers ${num_peers}, using ${mem_peers} KiB of memory
-    ^Peer groups ${num_group}, using ${mem_group} bytes of memory
+ ^RIB entries ${rib_entries}, using ${rib_memory} bytes of memory
+ ^Peers ${num_peers}, using ${mem_peers} KiB of memory
+ ^Peer groups ${num_group}, using ${mem_group} bytes of memory

--- a/tests/bgp/templates/bgp_summary_extended.textfsm
+++ b/tests/bgp/templates/bgp_summary_extended.textfsm
@@ -6,6 +6,6 @@ Value num_group (\d+)
 Value mem_group (\d+)
 
 Start
- ^RIB entries ${rib_entries}, using ${rib_memory} bytes of memory
+ ^RIB entries ${num_rib}, using ${mem_rib} bytes of memory
  ^Peers ${num_peers}, using ${mem_peers} KiB of memory
  ^Peer groups ${num_group}, using ${mem_group} bytes of memory

--- a/tests/bgp/templates/show_proc_extended.textfsm
+++ b/tests/bgp/templates/show_proc_extended.textfsm
@@ -1,0 +1,19 @@
+Value av1 (\d+\.\d+)
+Value av2 (\d+\.\d+)
+Value av3 (\d+\.\d+)
+Value cpu_usage (\d+\.\d+)
+Value cpu_system (\d+\.\d+)
+Value mem_total (\d+\.\d+)
+Value mem_free (\d+\.\d+)
+Value mem_used (\d+\.\d+)
+Value mem_cache (\d+\.\d+)
+Value mem_swap_total (\d+\.\d+)
+Value mem_swap_free (\d+\.\d+)
+Value mem_swap_used (\d+\.\d+)
+Value mem_swap_avail (\d+\.\d+)
+
+Start:
+    ^.*load average: ${av1}, ${av2}, ${av3}
+    ^%Cpu\(s\):\s+${cpu_usage}\s+us,\s+${cpu_system}\s+sy,
+    ^MiB Mem :\s+${mem_total} total,\s+${mem_free} free,\s+${mem_used} used,\s+${mem_cache} buff/cache
+    ^MiB Swap:\s+${mem_swap_total} total,\s+${mem_swap_free} free,\s+${mem_swap_used} used.\s+${mem_swap_avail} avail Mem

--- a/tests/bgp/templates/show_proc_extended.textfsm
+++ b/tests/bgp/templates/show_proc_extended.textfsm
@@ -12,7 +12,7 @@ Value mem_swap_free (\d+\.\d+)
 Value mem_swap_used (\d+\.\d+)
 Value mem_swap_avail (\d+\.\d+)
 
-Start:
+Start
     ^.*load average: ${av1}, ${av2}, ${av3}
     ^%Cpu\(s\):\s+${cpu_usage}\s+us,\s+${cpu_system}\s+sy,
     ^MiB Mem :\s+${mem_total} total,\s+${mem_free} free,\s+${mem_used} used,\s+${mem_cache} buff/cache

--- a/tests/bgp/templates/show_proc_extended.textfsm
+++ b/tests/bgp/templates/show_proc_extended.textfsm
@@ -13,7 +13,7 @@ Value mem_swap_used (\d+\.\d+)
 Value mem_swap_avail (\d+\.\d+)
 
 Start
-    ^.*load average: ${av1}, ${av2}, ${av3}
-    ^%Cpu\(s\):\s+${cpu_usage}\s+us,\s+${cpu_system}\s+sy,
-    ^MiB Mem :\s+${mem_total} total,\s+${mem_free} free,\s+${mem_used} used,\s+${mem_cache} buff/cache
-    ^MiB Swap:\s+${mem_swap_total} total,\s+${mem_swap_free} free,\s+${mem_swap_used} used.\s+${mem_swap_avail} avail Mem
+ ^.*load average: ${av1}, ${av2}, ${av3}
+ ^%Cpu\(s\):\s+${cpu_usage}\s+us,\s+${cpu_system}\s+sy,
+ ^MiB Mem :\s+${mem_total} total,\s+${mem_free} free,\s+${mem_used} used,\s+${mem_cache} buff/cache
+ ^MiB Swap:\s+${mem_swap_total} total,\s+${mem_swap_free} free,\s+${mem_swap_used} used.\s+${mem_swap_avail} avail Mem

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -12,7 +12,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 # Fixture params
-PEER_COUNT = 33
+PEER_COUNT = 16
 WAIT_TIMEOUT = 120
 
 # General constants

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -35,7 +35,7 @@ def stop_bgp_session(peer: BGPNeighbor):
 
 def run_functions_in_parallel(function, arg_list):
     results = []
-    with ThreadPoolExecutor(max_workers=33) as executor:
+    with ThreadPoolExecutor() as executor:
         futures = [executor.submit(function, argument) for argument in arg_list]
         for future in as_completed(futures):
             result = future.result()

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -101,9 +101,8 @@ def setup_bgp_peers(
         bgp_peers.append(peer)
 
     # Start sessions
-    # for peer in bgp_peers:
-        # peer.start_session()
-    run_functions_in_parallel(start_bgp_session, bgp_peers)
+    for peer in bgp_peers:
+        peer.start_session()
 
     yield bgp_peers
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -221,8 +221,8 @@ def test_bgp_update_replication(
 
     # Inject and withdraw routes with a specified interval in between iterations
     for interval in [3.0, 1.0, 0.5]:
-        # Repeat 100 times
-        for _ in range(100):
+        # Repeat 20 times
+        for _ in range(20):
             # Inject 10000 routes
             num_routes = 10_000
             route_injector.announce_routes_batch(generate_routes(num_routes=num_routes, nexthop=route_injector.ip))

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -47,7 +47,7 @@ def setup_bgp_peers(
 
     # Validate that the expected number of connections were established
     pytest_assert(
-        len(bgp_peers) == PEER_COUNT,
+        len(connections) == PEER_COUNT,
         f"Incorrect number of bgp peers established: {len(bgp_peers)} exist, {PEER_COUNT} expected"
     )
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -24,7 +24,7 @@ WAIT_TIMEOUT = 120
 # General constants
 ASN_BASE = 61000
 PORT_BASE = 11000
-SUBNET_TMPL = "10.{second_iter}.{first_iter}.0/24"
+SUBNET_TMPL = "10.{first_iter}.{second_iter}.0/24"
 
 
 '''

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
@@ -22,6 +23,25 @@ PORT_BASE = 11000
 '''
     Helper functions
 '''
+
+
+def start_bgp_session(peer: BGPNeighbor):
+    peer.start_session()
+
+
+def stop_bgp_session(peer: BGPNeighbor):
+    peer.stop_session()
+
+
+def run_functions_in_parallel(function, arg_list):
+    results = []
+    with ThreadPoolExecutor(max_workers=33) as executor:
+        futures = [executor.submit(function, argument) for argument in arg_list]
+        for future in as_completed(futures):
+            result = future.result()
+            results.append(result)
+
+    return results
 
 
 @pytest.fixture
@@ -81,8 +101,9 @@ def setup_bgp_peers(
         bgp_peers.append(peer)
 
     # Start sessions
-    for peer in bgp_peers:
-        peer.start_session()
+    # for peer in bgp_peers:
+        # peer.start_session()
+    run_functions_in_parallel(start_bgp_session, bgp_peers)
 
     yield bgp_peers
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -1,3 +1,4 @@
+import time
 import math
 import datetime
 import pytest
@@ -56,16 +57,11 @@ def measure_stats(dut):
         fsm = textfsm.TextFSM(template)
         parsed_bgp_sum = fsm.ParseTextToDicts(bgp_sum)
 
-    logger.debug(parsed_proc)
-    logger.debug(parsed_bgp_sum)
+    stats = {"timestamp": datetime.datetime.now().time()}
+    stats.update(parsed_proc[0])
+    stats.update(parsed_bgp_sum[0])
 
-    return (
-        datetime.datetime.now().time(),
-        'cpu_placeholder',
-        'memory_placeholder',
-        'route_placeholder',
-        'space_placeholder',
-    )
+    return stats
 
 
 @pytest.fixture
@@ -85,7 +81,7 @@ def setup_bgp_peers(
     dut_type = mg_facts["minigraph_devices"][duthost.hostname]["type"]
     neigh_type = "LeafRouter" if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"] else "ToRRouter"
 
-    # Establish 33 peers - 1 route injector, 32 receivers
+    # Establish peers - 1 route injector, the rest receivers
     connections = setup_interfaces
     bgp_peers: list[BGPNeighbor] = []
 
@@ -163,11 +159,8 @@ def test_bgp_update_replication(
 
     logger.info(f"Route injector: '{route_injector}', route receivers: '{route_receivers}'")
 
-    # results = [measure_stats(duthost)]
-    measure_stats(duthost)
+    results = [measure_stats(duthost)]
 
-
-'''
     # Inject routes
     for interval in [3.0, 1.0, 0.5]:
         # Repeat 1000 times
@@ -190,6 +183,3 @@ def test_bgp_update_replication(
     results.append(measure_stats(duthost))
 
     logger.debug(results)
-
-    logger.debug(get_cpu_stats(duthost))
-'''

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -16,7 +16,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 # Fixture params
-PEER_COUNT = 16
+PEER_COUNT = 1  # 6
 WAIT_TIMEOUT = 120
 
 # General constants
@@ -164,6 +164,7 @@ def test_bgp_update_replication(
     logger.info(f"Route injector: '{route_injector}', route receivers: '{route_receivers}'")
 
     # results = [measure_stats(duthost)]
+    measure_stats(duthost)
 
 
 '''

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -6,7 +6,6 @@ from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.bgp.test_bgp_update_timer import is_neighbor_sessions_established
 
 from tests.common.helpers.assertions import pytest_assert
-
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
@@ -46,11 +45,17 @@ def setup_bgp_peers(
     connections = setup_interfaces
     bgp_peers: list[BGPNeighbor] = []
 
+    # Validate that the expected number of connections were established
+    pytest_assert(
+        len(bgp_peers) == PEER_COUNT,
+        f"Incorrect number of bgp peers established: {len(bgp_peers)} exist, {PEER_COUNT} expected"
+    )
+
     # Validate that all connection namespaces are the same
     connection_ns_set = {connection.get("namespace") for connection in connections}
     pytest_assert(
         len(connection_ns_set) == 1,
-        "Multiple namespaces present: {}".format(connection_ns_set)
+        f"Multiple namespaces present: {connection_ns_set}"
     )
 
     for i, connection in enumerate(connections):

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -68,7 +68,10 @@ def measure_stats(dut):
     time_second_cmd = time.process_time()
 
     # Check that DUT remains responsive - average the response time for each command
-    average_response_time = ((time_second_cmd + time_first_cmd) - (2 * time_before_cmd)) / 2
+    first_response_time = time_first_cmd - time_before_cmd
+    second_response_time = time_second_cmd - time_first_cmd
+    average_response_time = (first_response_time + second_response_time) / 2
+
     pytest_assert(
         responsive_threshold > average_response_time,
         f"SSH session took longer than average of {responsive_threshold} sec to respond"

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -216,8 +216,11 @@ def test_bgp_update_replication(
         for _ in range(3):
             # Inject 10000 routes
             num_routes = 10_000
+            route_injector.announce_routes_batch(next_route(num_routes=num_routes, nexthop=route_injector.ip))
+            '''
             for route in next_route(num_routes=num_routes, nexthop=route_injector.ip):
                 route_injector.announce_route(route)
+            '''
 
             # Measure after injection
             results.append(measure_stats(duthost))
@@ -232,8 +235,11 @@ def test_bgp_update_replication(
             prev_num_rib = curr_num_rib
 
             # Remove routes
+            route_injector.withdraw_routes_batch(next_route(num_routes=num_routes, nexthop=route_injector.ip))
+            '''
             for route in next_route(num_routes=num_routes, nexthop=route_injector.ip):
                 route_injector.withdraw_route(route)
+            '''
 
             # Measure after removal
             results.append(measure_stats(duthost))

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -62,16 +62,20 @@ def measure_stats(dut):
     time_before_cmd = time.process_time()
 
     proc_cpu = dut.shell("show processes cpu | head -n 10", module_ignore_errors=True)['stdout']
-    time_first_cmd = time.process_time() - time_before_cmd
+    time_first_cmd = time.process_time()
 
     bgp_sum = dut.shell("show ip bgp summary | grep memory", module_ignore_errors=True)['stdout']
-    time_second_cmd = time.process_time() - time_first_cmd
+    time_second_cmd = time.process_time()
 
     num_cores = dut.shell('cat /proc/cpuinfo | grep "cpu cores" | uniq', module_ignore_errors=True)['stdout']
-    time_third_cmd = time.process_time() - time_second_cmd
+    time_third_cmd = time.process_time()
 
     # Check that DUT remains responsive - average the response time for each command
-    response_times = [time_first_cmd, time_second_cmd, time_third_cmd]
+    response_times = [
+        time_first_cmd - time_before_cmd,
+        time_second_cmd - time_first_cmd,
+        time_third_cmd - time_second_cmd
+    ]
     average_response_time = sum(response_times) / len(response_times)
 
     pytest_assert(

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -17,7 +17,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 # Fixture params
-PEER_COUNT = 1  # 6
+PEER_COUNT = 16
 WAIT_TIMEOUT = 120
 
 # General constants

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -217,10 +217,8 @@ def test_bgp_update_replication(
             # Inject 10000 routes
             num_routes = 10_000
             route_injector.announce_routes_batch(next_route(num_routes=num_routes, nexthop=route_injector.ip))
-            '''
-            for route in next_route(num_routes=num_routes, nexthop=route_injector.ip):
-                route_injector.announce_route(route)
-            '''
+
+            time.sleep(interval)
 
             # Measure after injection
             results.append(measure_stats(duthost))
@@ -236,10 +234,8 @@ def test_bgp_update_replication(
 
             # Remove routes
             route_injector.withdraw_routes_batch(next_route(num_routes=num_routes, nexthop=route_injector.ip))
-            '''
-            for route in next_route(num_routes=num_routes, nexthop=route_injector.ip):
-                route_injector.withdraw_route(route)
-            '''
+
+            time.sleep(interval)
 
             # Measure after removal
             results.append(measure_stats(duthost))
@@ -252,8 +248,6 @@ def test_bgp_update_replication(
                 f"All routes have not been withdrawn: current '{curr_num_rib}', expected: '{expected}'"
             )
             prev_num_rib = curr_num_rib
-
-        time.sleep(interval)
 
     results.append(measure_stats(duthost))
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -8,9 +8,7 @@ from tabulate import tabulate
 
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
-# TODO: move to helpers?
-from tests.bgp.test_bgp_update_timer import is_neighbor_sessions_established
-# END TODO
+from tests.bgp.bgp_helpers import is_neighbor_sessions_established
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -253,6 +251,11 @@ def test_bgp_update_replication(
 
     results.append(measure_stats(duthost))
 
+    # Output results as TSV for analysis in other programs
+    results_tsv = tabulate(results, headers="keys", tablefmt="tsv")
+
+    # Output results in human-readable format as well
     results_table = tabulate(results, headers="keys")
 
+    logger.info('TSV: \n' + results_tsv)
     logger.info('Results: \n' + results_table)

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -4,6 +4,7 @@ import datetime
 import pytest
 import logging
 import textfsm
+from tabulate import tabulate
 
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
@@ -169,17 +170,18 @@ def test_bgp_update_replication(
             for route in next_route(num_routes=10_000, nexthop=route_injector.ip):
                 route_injector.announce_route(route)
 
-            # Measure
+            # Measure after injection
             results.append(measure_stats(duthost))
 
             # Remove routes
             for route in next_route(num_routes=10_000, nexthop=route_injector.ip):
                 route_injector.withdraw_route(route)
 
+            # Measure after removal
             results.append(measure_stats(duthost))
 
         time.sleep(interval)
 
     results.append(measure_stats(duthost))
 
-    logger.debug(results)
+    logger.info(tabulate(results, headers="keys"))

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -88,7 +88,7 @@ def measure_stats(dut):
     )
 
     # Check that memory usage isn't excessive
-    total_mem = (float(stats["mem_total"]) - float(stats["mem_free"])) / float(stats["mem_total"])
+    total_mem = (float(stats["mem_total"]) - float(stats["mem_free"])) * 100 / float(stats["mem_total"])
     pytest_assert(
         mem_threshold > total_mem,
         f"Memory utilisation has reached {total_mem}, which is above threshold of {mem_threshold}"

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -1,0 +1,116 @@
+import pytest
+import logging
+
+from tests.common.helpers.bgp import BGPNeighbor
+from tests.common.helpers.constants import DEFAULT_NAMESPACE
+from tests.bgp.test_bgp_update_timer import is_neighbor_sessions_established
+
+from tests.common.helpers.assertions import pytest_assert
+
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+# Fixture params
+PEER_COUNT = 33
+WAIT_TIMEOUT = 120
+
+# General constants
+ASN_BASE = 61000
+PORT_BASE = 11000
+
+
+'''
+    Helper functions
+'''
+
+
+@pytest.fixture
+def setup_bgp_peers(
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
+    tbinfo,
+    ptfhost,
+    setup_interfaces,
+    is_dualtor,
+    is_quagga
+):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+    dut_asn = mg_facts["minigraph_bgp_asn"]
+    dut_type = mg_facts["minigraph_devices"][duthost.hostname]["type"]
+    neigh_type = "LeafRouter" if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"] else "ToRRouter"
+
+    # Establish 33 peers - 1 route injector, 32 receivers
+    connections = setup_interfaces
+    bgp_peers: list[BGPNeighbor] = []
+
+    # Validate that all connection namespaces are the same
+    connection_ns_set = {connection.get("namespace") for connection in connections}
+    pytest_assert(
+        len(connection_ns_set) == 1,
+        "Multiple namespaces present: {}".format(connection_ns_set)
+    )
+
+    for i, connection in enumerate(connections):
+        peer_asn = ASN_BASE + i
+        peer_port = PORT_BASE + i
+        connection_namespace = connection.get("namespace", DEFAULT_NAMESPACE)
+
+        peer = BGPNeighbor(
+            duthost=duthost,
+            ptfhost=ptfhost,
+            name=f"peer{i}",
+            neighbor_ip=connection["neighbor_addr"].split("/")[0],
+            neighbor_asn=peer_asn,
+            dut_ip=connection["local_addr"].split("/")[0],
+            dut_asn=dut_asn,
+            port=peer_port,
+            neigh_type=neigh_type,
+            namespace=connection_namespace,
+            is_multihop=is_quagga or is_dualtor,
+            is_passive=False
+        )
+
+        bgp_peers.append(peer)
+
+    # Start sessions
+    for peer in bgp_peers:
+        peer.start_session()
+
+    yield bgp_peers
+
+    # TODO: Finish teardown
+    # End sessions
+    for peer in bgp_peers:
+        peer.stop_session()
+
+
+'''
+    Tests
+'''
+
+
+def test_bgp_update_replication(
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
+    setup_bgp_peers,
+):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    bgp_peers: list[BGPNeighbor] = setup_bgp_peers
+
+    # Ensure new sessions are ready
+    if not wait_until(
+        WAIT_TIMEOUT,
+        5,
+        20,
+        lambda: is_neighbor_sessions_established(duthost, bgp_peers),
+    ):
+        pytest.fail(f"Could not establish the following bgp sessions: {bgp_peers}")
+
+    # Extract injector and receivers
+    # route_injector = bgp_peers[0]
+    # route_receivers = bgp_peers[1:PEER_COUNT]
+
+    pass

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -55,7 +55,7 @@ def measure_stats(dut):
     '''
     proc_template = "./bgp/templates/show_proc_extended.textfsm"
     bgp_sum_template = "./bgp/templates/bgp_summary_extended.textfsm"
-    responsive_timeout = 1
+    responsive_timeout = 2
     cpu_threshold = 90.0
     mem_threshold = 90.0
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -1,6 +1,7 @@
 import time
 import math
 import datetime
+from typing import Any
 import pytest
 import logging
 import textfsm
@@ -91,7 +92,7 @@ def measure_stats(dut):
         fsm = textfsm.TextFSM(template)
         parsed_bgp_sum = fsm.ParseTextToDicts(bgp_sum)
 
-    stats = {"timestamp": datetime.datetime.now().time()}
+    stats: dict[str, Any] = {"timestamp": datetime.datetime.now().time()}
     stats.update(parsed_proc[0])
     stats.update(parsed_bgp_sum[0])
 
@@ -220,8 +221,8 @@ def test_bgp_update_replication(
 
     # Inject and withdraw routes with a specified interval in between iterations
     for interval in [3.0, 1.0, 0.5]:
-        # Repeat 3 times
-        for _ in range(3):
+        # Repeat 100 times
+        for _ in range(100):
             # Inject 10000 routes
             num_routes = 10_000
             route_injector.announce_routes_batch(generate_routes(num_routes=num_routes, nexthop=route_injector.ip))

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -115,7 +115,7 @@ def test_bgp_update_replication(
         pytest.fail(f"Could not establish the following bgp sessions: {bgp_peers}")
 
     # Extract injector and receivers
-    # route_injector = bgp_peers[0]
-    # route_receivers = bgp_peers[1:PEER_COUNT]
+    route_injector = bgp_peers[0]
+    route_receivers = bgp_peers[1:PEER_COUNT]
 
-    pass
+    logger.info(f"Route injector: '{route_injector}', route receivers: '{route_receivers}'")

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -11,7 +11,11 @@ from datetime import datetime
 from scapy.all import sniff, IP
 from scapy.contrib import bgp
 
-from tests.bgp.bgp_helpers import capture_bgp_packages_to_file, fetch_and_delete_pcap_file
+from tests.bgp.bgp_helpers import (
+        capture_bgp_packages_to_file,
+        fetch_and_delete_pcap_file,
+        is_neighbor_sessions_established
+)
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until, delete_running_config
 
@@ -242,22 +246,6 @@ def match_bgp_update(packet, src_ip, dst_ip, action, route):
         return withdrawn_len_valid and withdrawn_route_valid
     else:
         return False
-
-
-def is_neighbor_sessions_established(duthost, neighbors):
-    is_established = True
-
-    # handle both multi-asic and single-asic
-    bgp_facts = duthost.bgp_facts(num_npus=duthost.sonichost.num_asics())[
-        "ansible_facts"
-    ]
-    for neighbor in neighbors:
-        is_established &= (
-            neighbor.ip in bgp_facts["bgp_neighbors"]
-            and bgp_facts["bgp_neighbors"][neighbor.ip]["state"] == "established"
-        )
-
-    return is_established
 
 
 def test_bgp_update_timer_single_route(

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -177,3 +177,47 @@ class BGPNeighbor(object):
         resp = requests.post(url, data={"commands": msg}, proxies={"http": None, "https": None})
         logging.debug("withdraw return: %s", resp)
         assert resp.status_code == 200
+
+    def announce_routes_batch(self, routes):
+        commands = []
+        for route in routes:
+            cmd = "announce route {prefix} next-hop {nexthop}".format(
+                prefix=route["prefix"],
+                nexthop=route["nexthop"]
+            )
+            if "aspath" in route:
+                cmd += " as-path [ {aspath} ]".format(
+                    aspath=route["aspath"]
+                )
+
+            logging.debug(f"Queueing {cmd} for batch announcement")
+            commands.append(cmd)
+
+        full_cmd = ";".join(commands)
+
+        url = "http://%s:%d" % (self.ptfip, self.port)
+        resp = requests.post(url, data={"commands": full_cmd}, proxies={"http": None, "https": None})
+        logging.debug("announce return: %s", resp)
+        assert resp.status_code == 200
+
+    def withdraw_routes_batch(self, routes):
+        commands = []
+        for route in routes:
+            cmd = "withdraw route {prefix} next-hop {nexthop}".format(
+                prefix=route["prefix"],
+                nexthop=route["nexthop"]
+            )
+            if "aspath" in route:
+                cmd += " as-path [ {aspath} ]".format(
+                    aspath=route["aspath"]
+                )
+
+            logging.debug(f"Queueing {cmd} for batch withdraw")
+            commands.append(cmd)
+
+        full_cmd = ";".join(commands)
+
+        url = "http://%s:%d" % (self.ptfip, self.port)
+        resp = requests.post(url, data={"commands": full_cmd}, proxies={"http": None, "https": None})
+        logging.debug("announce return: %s", resp)
+        assert resp.status_code == 200

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -190,7 +190,7 @@ class BGPNeighbor(object):
                     aspath=route["aspath"]
                 )
 
-            logging.debug(f"Queueing {cmd} for batch announcement")
+            logging.debug(f"Queueing cmd '{cmd}' for batch announcement")
             commands.append(cmd)
 
         full_cmd = ";".join(commands)
@@ -212,7 +212,7 @@ class BGPNeighbor(object):
                     aspath=route["aspath"]
                 )
 
-            logging.debug(f"Queueing {cmd} for batch withdraw")
+            logging.debug(f"Queueing cmd '{cmd}' for batch withdraw")
             commands.append(cmd)
 
         full_cmd = ";".join(commands)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #3612 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Focuses on addressing the BGP update replication testgap.

#### How did you do it?
##### Setup
1. Sets up 16 connections (using the DUT's physical interfaces)
    * Issue recommends using 33, but I found that 16 allows for a much greater proportion of testbeds to be able to run the test (as it is skipped on devices with not enough physical interfaces)
2. Uses connections to create BGP neighbours (1 for route injection, 15 for route receiving)

##### Test
1. Three nested loops are run (totalling 90000 announcements and 90000 withdrawals):
  a. Outer loop: Intervals (3 sec, 1 sec, 0.5 sec)
  b. First inner loop: 20 iterations (instead of 1000 suggested in the testgap issue, primarily for performance reasons)
  c. Second inner loops: 10000 route announcements + withdrawals (between each announcement loop, measurements are taken)
2. When measurements are taken, the following is checked:
  a. Session responsiveness (if command timeout is exceeded, fail)
  b. CPU utilisation (if total CPU usage is above 90%, fail)
  c. Memory utilisation (if total memory usage is above 90%, fail)
  d. RIB entry validation (expected number of routes should match routes present on the DUT exactly, after each loop of announcements, and each loop of withdrawals)
  e. Following these validations, a row of device statistics is appended to the results list
4. Results list is collated into a table at the end of the test, allowing for trends to be investigated if need be

#### How did you verify/test it?
Running on multiple DUTs (primarily T0 and T1), we can observe passing tests taking roughly 30 minutes:
<img width="860" alt="image" src="https://github.com/user-attachments/assets/cdd5e9ab-7a49-4b8d-b8b8-d034eaaa88e9" />
And the table produced by a successful run is as follows:
```
05:03:41 test_bgp_update_replication.test_bgp_upd L0257 INFO   | Results:
timestamp          av1    av2    av3    cpu_usage    cpu_system    mem_total    mem_free    mem_used    mem_cache    mem_swap_total    mem_swap_free    mem_swap_used    mem_swap_avail    num_rib    mem_rib    num_peers    mem_peers    num_group    mem_group    cpu_usage         mem_usage
---------------  -----  -----  -----  -----------  ------------  -----------  ----------  ----------  -----------  ----------------  ---------------  ---------------  ----------------  ---------  ---------  -----------  -----------  -----------  -----------  -----------------  -----------------
04:50:13.332508   1.51   1.43   1.56         11.1           0        15152.9      3720.1      4988.7       6949.4                 0                0                0           10164.2      12851    1644928           40       823680            4          256               11.1            75.4496
04:50:56.914403   1.92   1.52   1.58         12.5          12.5      15152.9      3697.9      5005.8       6954.4                 0                0                0           10147        32851    4204928           40       823680            4          256               25              75.5961
04:51:40.008111   1.48   1.47   1.56         12.5          12.5      15152.9      3679.4      5021.4       6957.3                 0                0                0           10131.4      12851    1644928           40       823680            4          256               25              75.7182
04:52:23.833455   1.47   1.47   1.55         30             0        15152.9      3638        5057.6       6962.5                 0                0                0           10095.2      32851    4204928           40       823680            4          256               30              75.9914
04:53:06.588974   1.26   1.4    1.53          0            22.2      15152.9      3696.4      4997.3       6964.5                 0                0                0           10155.5      12851    1644928           40       823680            4          256               22.2            75.606
04:53:49.867207   1.36   1.43   1.53         12.5          12.5      15152.9      3676.9      5011.2       6970.1                 0                0                0           10141.6      32851    4204928           40       823680            4          256               25              75.7347
04:54:33.301012   1.74   1.53   1.56         12.5          12.5      15152.9      3691.5      4993.9       6972.8                 0                0                0           10159        12851    1644928           40       823680            4          256               25              75.6383
04:55:27.307567   2.03   1.66   1.6          11.1          11.1      15152.9      3677.5      5002.4       6978.2                 0                0                0           10150.4      32851    4204928           40       823680            4          256               22.2            75.7307
04:56:10.932148   2.56   1.82   1.66         22.2          11.1      15152.9      3688.2      4989.3       6980.7                 0                0                0           10163.6      12851    1644928           40       823680            4          256               33.3            75.6601
04:56:52.818253   2.14   1.8    1.66         10            10        15152.9      3663.2      5008.8       6986.3                 0                0                0           10144.1      32851    4204928           40       823680            4          256               20              75.8251
04:57:37.581059   2.33   1.9    1.7          10            20        15152.9      3656.9      5012.4       6989                   0                0                0           10140.5      12851    1644928           40       823680            4          256               30              75.8667
04:58:19.933808   2.56   2.03   1.75         20            10        15152.9      3613.1      5050.4       6994.7                 0                0                0           10102.4      32851    4204928           40       823680            4          256               30              76.1557
04:59:05.093317   2.95   2.2    1.83         11.1          11.1      15152.9      3660.7      4999.7       6997.8                 0                0                0           10153.1      12851    1644928           40       823680            4          256               22.2            75.8416
04:59:50.087672   2.69   2.24   1.86         11.1          11.1      15152.9      3650        5005.3       7002.9                 0                0                0           10147.5      32851    4204928           40       823680            4          256               22.2            75.9122
05:00:33.762000   2.43   2.25   1.88         11.1          11.1      15152.9      3692.1      4998.6       6967.6                 0                0                0           10154.2      12851    1644928           40       823680            4          256               22.2            75.6344
05:01:21.439855   2.52   2.3    1.92         20            10        15152.9      3692.3      4993.6       6972.4                 0                0                0           10159.3      32851    4204928           40       823680            4          256               30              75.633
05:02:04.269988   2.5    2.31   1.94         10            10        15152.9      3681.6      5001.5       6975.2                 0                0                0           10151.4      12851    1644928           40       823680            4          256               20              75.7037
05:02:47.380161   2.75   2.41   2             0            14.3      15152.9      3670.1      5009.2       6978.9                 0                0                0           10143.7      32851    4204928           40       823680            4          256               14.3            75.7796
05:03:35.979800   2.3    2.35   2            12.5           0        15152.9      3683.6      4991.8       6982.9                 0                0                0           10161.1      12851    1644928           40       823680            4          256               12.5            75.6905
05:03:41.378287   2.28   2.34   2            12.5          12.5      15152.9      3655.1      5020         6983.2                 0                0                0           10132.9      12851    1644928           40       823680            4          256               25              75.8785
```
As the management container doesn't contain the necessary packages for charting via the command line output, this tabulated set of timeseries results allow for further investigation and external visual charting, for a given testbed/hwsku.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
T0 and T1 support confirmed, others likely

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
