### PR TITLE
Ignore DHCP relay related testcases for testbed with DHCP relay feature disabled

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -970,7 +970,7 @@ generic_config_updater/test_dhcp_relay.py:
       - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "'backend' in topo_name"
       - "'t2' in topo_name"
-      - "topo_name in ['t0-isolated-d16u16s1']"
+      - "'t0-isolated' in topo_name"
 
 generic_config_updater/test_dynamic_acl.py:
   skip:
@@ -1096,7 +1096,7 @@ gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[dhcp_relay-Tru
   skip:
     reason: "DHCP relay is not enabled on BT0"
     conditions:
-      - "topo_name in ['t0-isolated-d16u16s1']"
+      - "'t0-isolated' in topo_name"
 
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[pmon-True-]:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -970,6 +970,7 @@ generic_config_updater/test_dhcp_relay.py:
       - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "'backend' in topo_name"
       - "'t2' in topo_name"
+      - "topo_name in ['t0-isolated-d16u16s1']"
 
 generic_config_updater/test_dynamic_acl.py:
   skip:
@@ -1102,6 +1103,12 @@ gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[snmp-True-]:
     reason: "Not supported on KVM due to missing system EEPROM."
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16615"
+
+gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[dhcp_relay-True-]:
+  skip:
+    reason: "DHCP relay is not enabled on BT0"
+    conditions:
+      - "topo_name in ['t0-isolated-d16u16s1']"
 
 #######################################
 #####           hash              #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1094,9 +1094,9 @@ gnmi/test_gnmi_configdb.py:
 
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[dhcp_relay-True-]:
   skip:
-    reason: "DHCP relay is not enabled on BT0"
+    reason: "DHCP relay is disabled on T0 using isolated topo"
     conditions:
-      - "'t0-isolated' in topo_name"
+      - "feature_status['dhcp_relay'] == 'disabled'"
 
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[pmon-True-]:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1092,6 +1092,12 @@ gnmi/test_gnmi_configdb.py:
       - "'t2' in topo_name"
       - "is_multi_asic==True"
 
+gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[dhcp_relay-True-]:
+  skip:
+    reason: "DHCP relay is not enabled on BT0"
+    conditions:
+      - "topo_name in ['t0-isolated-d16u16s1']"
+
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[pmon-True-]:
   skip:
     reason: "Not supported on KVM due to missing system EEPROM."
@@ -1103,12 +1109,6 @@ gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[snmp-True-]:
     reason: "Not supported on KVM due to missing system EEPROM."
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16615"
-
-gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart[dhcp_relay-True-]:
-  skip:
-    reason: "DHCP relay is not enabled on BT0"
-    conditions:
-      - "topo_name in ['t0-isolated-d16u16s1']"
 
 #######################################
 #####           hash              #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Ignore DHCP relay related failed testcases (GCU, gNOI) as DHCP relay is not enabled for T0 using isolated topology.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Ignore DHCP relay related failed testcases (GCU, gNOI) as DHCP relay is not enabled on BT0.

#### How did you do it?

#### How did you verify/test it?
```
SKIPPED [1] gnmi/test_gnoi_killprocess.py:14: DHCP relay is disabled on T0 using isolated topo
```

#### Any platform specific information?
str4-sn5600-1

#### Supported testbed topology if it's a new test case?
t0-isolated-u16d16s1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
