### PR TITLE
Initialize neighbor_ip before use to avoid UnboundLocalError

### DIFF
--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -88,12 +88,13 @@ def setup_uN(duthosts, enum_frontend_dut_hostname, enum_frontend_asic_index, tbi
 
     logger.info("Doing test on DUT port {} | PTF port {}".format(dut_port, ptf_src_port))
 
+    neighbor_ip = None
     # get neighbor IP
     lines = duthost.command("show ipv6 bgp sum")['stdout'].split("\n")
     for line in lines:
         if neighbor in line:
             neighbor_ip = line.split()[0]
-    assert neighbor_ip
+    assert neighbor_ip, "Unable to find neighbor {} IP".format(neighbor)
 
     # use DUT portchannel if applicable
     pc_info = duthost.command("show int portchannel")['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Previously, the `neighbor_ip` variable was not initialized before being assigned inside the loop. If the loop did not find a match, `neighbor_ip` remained undefined, leading to an `UnboundLocalError` when accessed later.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202412

### Approach
#### What is the motivation for this PR?
Initialize neighbor_ip before use to avoid UnboundLocalError

#### How did you do it?
Initialized `neighbor_ip` to None before the loop.

#### How did you verify/test it?

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
