### PR TITLE
Add the timeout value for check_bgp_session_state

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -204,5 +204,5 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     pytest_assert(wait_until(120, 10, 30, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")
-    pytest_assert(wait_until(60, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
+    pytest_assert(wait_until(120, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
                   "Not all BGP sessions are established on DUT")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add the timeout value for check_bgp_session_state
Fixes # 
Test case `test_bgp_session_interface_down[interface-swss_docker]` failed due to BGP session not UP
Check the syslog, all BGP session are UP but takes more time. This is the time line
1. Execute command `docker restart swss` at `2025-02-28 23:33:09.621050`
2. All critical processes are UP at `2025-02-28 23:35:53.413089` and then start to check BGP session status. Timeout value is 60s 
3. The first BGP session in Established status at `23:36:55.120466` and the last BGP session in Established status at `23:37:06.034725`. So needs more time to check if All BGP sessions are UP
```
2025 Feb 28 23:36:55.120466 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.61(Unknown) in vrf default Up
2025 Feb 28 23:36:55.121168 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::7a(Unknown) in vrf default Up
2025 Feb 28 23:37:02.282313 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.71(Unknown) in vrf default Up
2025 Feb 28 23:37:03.873604 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::8e(Unknown) in vrf default Up
2025 Feb 28 23:37:03.974046 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.69(Unknown) in vrf default Up
2025 Feb 28 23:37:03.978547 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::8a(Unknown) in vrf default Up
2025 Feb 28 23:37:04.388032 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.63(Unknown) in vrf default Up
2025 Feb 28 23:37:04.393283 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.57(Unknown) in vrf default Up
2025 Feb 28 23:37:04.404789 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.59(Unknown) in vrf default Up
2025 Feb 28 23:37:04.474376 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.67(Unknown) in vrf default Up
2025 Feb 28 23:37:04.576819 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor 10.0.0.65(Unknown) in vrf default Up
2025 Feb 28 23:37:04.617386 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::76(Unknown) in vrf default Up
2025 Feb 28 23:37:05.007761 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::72(Unknown) in vrf default Up
2025 Feb 28 23:37:05.243813 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::82(Unknown) in vrf default Up
2025 Feb 28 23:37:06.027792 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::86(Unknown) in vrf default Up
2025 Feb 28 23:37:06.034725 r-panther-23 INFO bgp#bgpd[48]: [N9HHH-F8H1M] %ADJCHANGE: neighbor fc00::7e(Unknown) in vrf default Up
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
