### PR TITLE
[sdn_tests] updating patches to pins-ondatra.

### DIFF
--- a/sdn_tests/pins_ondatra/WORKSPACE.bazel
+++ b/sdn_tests/pins_ondatra/WORKSPACE.bazel
@@ -16,49 +16,31 @@ workspace(name = "com_github_sonic_net_sonic_mgmt_sdn_tests_pins_ondatra")
 
 # -- Load buildifier -----------------------------------------------------------
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-# Bazel toolchain to build go-lang.
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
-    ],
-)
-
-# Gazelle to auto generate go-lang BUILD rules.
-http_archive(
-    name = "bazel_gazelle",
-    sha256 = "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
-    ],
-)
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 load("pins_deps.bzl", "pins_deps")
-
 pins_deps()
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
+load("@com_github_google_pins_infra//:pins_infra_deps.bzl", "pins_infra_deps")
+pins_infra_deps()
 
 # -- Load Rules Foreign CC -----------------------------------------------------
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-
 rules_foreign_cc_dependencies()
 
 # -- Load GoLang Rules -----------------------------------------------------
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("//:infra_deps.bzl", "binding_deps")
-
 binding_deps()
 
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 go_rules_dependencies()
-
 go_register_toolchains(version = "1.21.1")
-
 gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 
 # -- Load GRPC -------------------------------------------------------------
@@ -76,10 +58,6 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
-
-grpc_extra_deps()
-
 # -- Load Protobuf -------------------------------------------------------------
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -92,43 +70,17 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
-### Bazel rules for many languages to compile PROTO into gRPC libraries
-http_archive(
-    name = "rules_proto_grpc",
-    sha256 = "f87d885ebfd6a1bdf02b4c4ba5bf6fb333f90d54561e4d520a8413c8d1fb7beb",
-    strip_prefix = "rules_proto_grpc-4.5.0",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.5.0.tar.gz"],
-    patch_args = ["-p1"],
-    patches = [
-        "//:bazel/patches/rules_proto_grpc.patch",
-    ],
-)
-
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
 
 rules_proto_grpc_toolchains()
 
 rules_proto_grpc_repos()
 
-# -- Load P4Runtime ------------------------------------------------------------
-
-load("@com_github_p4lang_p4runtime//:p4runtime_deps.bzl", "p4runtime_deps")
-
-p4runtime_deps()
-
 # -- Load packaging rules ------------------------------------------------------
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
-
-# == Dependencies needed for testing and formatting only =======================
-
-# -- Load p4c ------------------------------------------------------------------
-
-load("@com_github_p4lang_p4c//:bazel/p4c_deps.bzl", "p4c_deps")
-
-p4c_deps()
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 

--- a/sdn_tests/pins_ondatra/bazel/patches/com_github_google_pins_infra_deps_fix.patch
+++ b/sdn_tests/pins_ondatra/bazel/patches/com_github_google_pins_infra_deps_fix.patch
@@ -1,0 +1,40 @@
+diff --git a/pins_infra_deps.bzl b/pins_infra_deps.bzl
+index 3c9cb04..7cd49f0 100644
+--- a/pins_infra_deps.bzl
++++ b/pins_infra_deps.bzl
+@@ -87,7 +87,7 @@ def pins_infra_deps():
+             name = "com_github_otg_models",
+             url = "https://github.com/open-traffic-generator/models/archive/refs/tags/v0.12.5.zip",
+             strip_prefix = "models-0.12.5",
+-            build_file = "@//:bazel/BUILD.otg-models.bazel",
++            build_file = "@com_github_google_pins_infra//:bazel/BUILD.otg-models.bazel",
+             sha256 = "1a63e769f1d7f42c79bc1115babf54acbc44761849a77ac28f47a74567f10090",
+         )
+     if not native.existing_rule("com_github_gnmi"):
+@@ -155,7 +155,7 @@ def pins_infra_deps():
+             name = "com_jsoncpp",
+             url = "https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.zip",
+             strip_prefix = "jsoncpp-1.9.4",
+-            build_file = "@//:bazel/BUILD.jsoncpp.bazel",
++            build_file = "@com_github_google_pins_infra//:bazel/BUILD.jsoncpp.bazel",
+             sha256 = "6da6cdc026fe042599d9fce7b06ff2c128e8dd6b8b751fca91eb022bce310880",
+         )
+     if not native.existing_rule("com_gnu_gmp"):
+@@ -167,7 +167,7 @@ def pins_infra_deps():
+             ],
+             strip_prefix = "gmp-6.2.1",
+             sha256 = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2",
+-            build_file = "@//:bazel/BUILD.gmp.bazel",
++            build_file = "@com_github_google_pins_infra//:bazel/BUILD.gmp.bazel",
+         )
+     if not native.existing_rule("com_github_z3prover_z3"):
+         http_archive(
+@@ -175,7 +175,7 @@ def pins_infra_deps():
+             url = "https://github.com/Z3Prover/z3/archive/z3-4.8.12.tar.gz",
+             strip_prefix = "z3-z3-4.8.12",
+             sha256 = "e3aaefde68b839299cbc988178529535e66048398f7d083b40c69fe0da55f8b7",
+-            build_file = "@//:bazel/BUILD.z3.bazel",
++            build_file = "@com_github_google_pins_infra//:bazel/BUILD.z3.bazel",
+         )
+     if not native.existing_rule("rules_foreign_cc"):
+         http_archive(

--- a/sdn_tests/pins_ondatra/bazel/patches/com_github_sonic_net_sonic_pins.patch
+++ b/sdn_tests/pins_ondatra/bazel/patches/com_github_sonic_net_sonic_pins.patch
@@ -1,0 +1,80 @@
+diff --git a/WORKSPACE.bazel b/WORKSPACE.bazel
+index 10ddb1e..f90ff42 100644
+--- a/WORKSPACE.bazel
++++ b/WORKSPACE.bazel
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-workspace(name = "com_github_google_pins_infra")
++workspace(name = "com_github_sonic_net_sonic_pins")
+ 
+ load("pins_infra_deps.bzl", "pins_infra_deps")
+ 
+diff --git a/pins_infra_deps.bzl b/pins_infra_deps.bzl
+index d7afdb9..72f9e03 100644
+--- a/pins_infra_deps.bzl
++++ b/pins_infra_deps.bzl
+@@ -41,8 +41,8 @@ def pins_infra_deps():
+             sha256 = "04a52a313926f0f6ec2ed489ac7552aa5949693b071eaf45ae13b66e5910c32f",
+             patch_args = ["-p1"],
+             patches = [
+-                "//:bazel/patches/grpc-001-fix_file_watcher_race_condition.patch",
+-                "//:bazel/patches/grpc-002-change_authz_log_level.patch",
++                "@com_github_sonic_net_sonic_pins//:bazel/patches/grpc-001-fix_file_watcher_race_condition.patch",
++                "@com_github_sonic_net_sonic_pins//:bazel/patches/grpc-002-change_authz_log_level.patch",
+             ],
+         )
+     if not native.existing_rule("com_google_absl"):
+@@ -107,7 +107,7 @@ def pins_infra_deps():
+             name = "com_github_otg_models",
+             url = "https://github.com/open-traffic-generator/models/archive/v0.11.8.zip",
+             strip_prefix = "models-0.11.8",
+-            build_file = "@//:bazel/BUILD.otg-models.bazel",
++            build_file = "@com_github_sonic_net_sonic_pins//:bazel/BUILD.otg-models.bazel",
+             sha256 = "caf3a9c9cdf8f9f4fb16da2cc9123823af6446f40dff71a1f2c1b35e76ae36f5",
+         )
+ 
+@@ -128,7 +128,7 @@ def pins_infra_deps():
+             strip_prefix = "gnmi-0.10.0",
+             patch_args = ["-p1"],
+             patches = [
+-                "@com_github_google_pins_infra//:bazel/patches/gnmi-001-fix_virtual_proto_import.patch",
++                "@com_github_sonic_net_sonic_pins//:bazel/patches/gnmi-001-fix_virtual_proto_import.patch",
+             ],
+             sha256 = "2231e1cc398a523fa840810fa6fdb8960639f7b91b57bb8f12ed8681e0142a67",
+         )
+@@ -188,13 +188,13 @@ def pins_infra_deps():
+             name = "com_jsoncpp",
+             url = "https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.zip",
+             strip_prefix = "jsoncpp-1.9.4",
+-            build_file = "@//:bazel/BUILD.jsoncpp.bazel",
++            build_file = "@com_github_sonic_net_sonic_pins//:bazel/BUILD.jsoncpp.bazel",
+             sha256 = "6da6cdc026fe042599d9fce7b06ff2c128e8dd6b8b751fca91eb022bce310880",
+         )
+     if not native.existing_rule("com_github_ivmai_cudd"):
+         http_archive(
+             name = "com_github_ivmai_cudd",
+-            build_file = "@//:bazel/BUILD.cudd.bazel",
++            build_file = "@com_github_sonic_net_sonic_pins//:bazel/BUILD.cudd.bazel",
+             strip_prefix = "cudd-cudd-3.0.0",
+             sha256 = "5fe145041c594689e6e7cf4cd623d5f2b7c36261708be8c9a72aed72cf67acce",
+             urls = ["https://github.com/ivmai/cudd/archive/cudd-3.0.0.tar.gz"],
+@@ -208,7 +208,7 @@ def pins_infra_deps():
+             ],
+             strip_prefix = "gmp-6.2.1",
+             sha256 = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2",
+-            build_file = "@//:bazel/BUILD.gmp.bazel",
++            build_file = "@com_github_sonic_net_sonic_pins//:bazel/BUILD.gmp.bazel",
+         )
+     if not native.existing_rule("com_github_z3prover_z3"):
+         http_archive(
+@@ -216,7 +216,7 @@ def pins_infra_deps():
+             url = "https://github.com/Z3Prover/z3/archive/z3-4.8.12.tar.gz",
+             strip_prefix = "z3-z3-4.8.12",
+             sha256 = "e3aaefde68b839299cbc988178529535e66048398f7d083b40c69fe0da55f8b7",
+-            build_file = "@//:bazel/BUILD.z3.bazel",
++            build_file = "@com_github_sonic_net_sonic_pins//:bazel/BUILD.z3.bazel",
+         )
+     if not native.existing_rule("rules_foreign_cc"):
+         http_archive(

--- a/sdn_tests/pins_ondatra/bazel/patches/gnmi.patch
+++ b/sdn_tests/pins_ondatra/bazel/patches/gnmi.patch
@@ -68,34 +68,6 @@ index 2f385f7..0000000
 -load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 -
 -grpc_extra_deps()
-diff --git a/proto/gnmi/BUILD.bazel b/proto/gnmi/BUILD.bazel
-index f471488..f6bd3bd 100644
---- a/proto/gnmi/BUILD.bazel
-+++ b/proto/gnmi/BUILD.bazel
-@@ -16,6 +16,9 @@
- #
- 
- load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-+load("@rules_proto//proto:defs.bzl", "proto_library")
- 
- package(
-     default_visibility = ["//visibility:public"],
-@@ -45,3 +48,13 @@ cc_grpc_library(
-     grpc_only = True,
-     deps = [":gnmi_cc_proto"],
- )
-+
-+go_proto_library(
-+    name = "gnmi_go_proto",
-+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-+    importpath = "github.com/openconfig/gnmi/proto/gnmi",
-+    proto = ":gnmi_proto",
-+    deps = [
-+        "//proto/gnmi_ext:gnmi_ext_go_proto",
-+    ],
-+)
 diff --git a/proto/gnmi_ext/BUILD.bazel b/proto/gnmi_ext/BUILD.bazel
 index 2e0e9b4..5dcf6fb 100644
 --- a/proto/gnmi_ext/BUILD.bazel
@@ -389,4 +361,62 @@ index 0000000..b09b9f3
 +    name = "go_default_library",
 +    actual = ":match",
 +    visibility = ["//visibility:public"],
++)
+
+diff --git a/proto/gnmi/BUILD.bazel b/proto/gnmi/BUILD.bazel
+index f471488..8be3fdf 100644
+--- a/proto/gnmi/BUILD.bazel
++++ b/proto/gnmi/BUILD.bazel
+@@ -16,12 +16,26 @@
+ #
+ 
+ load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
++load("@rules_proto//proto:defs.bzl", "proto_library")
+ 
+ package(
+     default_visibility = ["//visibility:public"],
+     licenses = ["notice"],
+ )
+ 
++proto_library(
++    name = "gnmi_internal_proto",
++    srcs = ["gnmi.proto"],
++    deps = [
++        "//proto/gnmi_ext:gnmi_ext_proto",
++        "@com_google_protobuf//:any_proto",
++        "@com_google_protobuf//:descriptor_proto",
++    ],
++    visibility = ["//visibility:private"],
++)
++
+ proto_library(
+     name = "gnmi_proto",
+     srcs = ["gnmi.proto"],
+@@ -35,13 +49,23 @@ proto_library(
+ 
+ cc_proto_library(
+     name = "gnmi_cc_proto",
+-    deps = [":gnmi_proto"],
++    deps = [":gnmi_internal_proto"],
+ )
+ 
+ cc_grpc_library(
+     name = "gnmi_cc_grpc_proto",
+-    srcs = [":gnmi_proto"],
++    srcs = [":gnmi_internal_proto"],
+     generate_mocks = True,
+     grpc_only = True,
+     deps = [":gnmi_cc_proto"],
+ )
++
++go_proto_library(
++    name = "gnmi_go_proto",
++    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
++    importpath = "github.com/openconfig/gnmi/proto/gnmi",
++    proto = ":gnmi_proto",
++    deps = [
++        "//proto/gnmi_ext:gnmi_ext_go_proto",
++    ],
 +)

--- a/sdn_tests/pins_ondatra/bazel/patches/nelhage_fix_bazel_platforms.patch
+++ b/sdn_tests/pins_ondatra/bazel/patches/nelhage_fix_bazel_platforms.patch
@@ -1,0 +1,218 @@
+diff --git a/BUILD.boost b/BUILD.boost
+index d952c3b..f4718d0 100644
+--- a/BUILD.boost
++++ b/BUILD.boost
+@@ -12,7 +12,7 @@ _w_no_deprecated = selects.with_or({
+ config_setting(
+     name = "linux",
+     constraint_values = [
+-        "@bazel_tools//platforms:linux",
++        "@platforms//os:linux",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -20,7 +20,7 @@ config_setting(
+ config_setting(
+     name = "android",
+     constraint_values = [
+-        "@bazel_tools//platforms:android",
++        "@platforms//os:android",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -28,7 +28,7 @@ config_setting(
+ config_setting(
+     name = "osx",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
++        "@platforms//os:osx",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -36,7 +36,7 @@ config_setting(
+ config_setting(
+     name = "windows",
+     constraint_values = [
+-        "@bazel_tools//platforms:windows",
++        "@platforms//os:windows",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -44,8 +44,8 @@ config_setting(
+ config_setting(
+     name = "linux_arm",
+     constraint_values = [
+-        "@bazel_tools//platforms:linux",
+-        "@bazel_tools//platforms:arm",
++        "@platforms//os:linux",
++        "@platforms//cpu:arm",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -53,8 +53,8 @@ config_setting(
+ config_setting(
+     name = "linux_ppc",
+     constraint_values = [
+-        "@bazel_tools//platforms:linux",
+-        "@bazel_tools//platforms:ppc",
++        "@platforms//os:linux",
++        "@platforms//cpu:ppc",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -62,8 +62,8 @@ config_setting(
+ config_setting(
+     name = "linux_aarch64",
+     constraint_values = [
+-        "@bazel_tools//platforms:linux",
+-        "@bazel_tools//platforms:aarch64",
++        "@platforms//os:linux",
++        "@platforms//cpu:aarch64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -71,8 +71,8 @@ config_setting(
+ config_setting(
+     name = "linux_x86_64",
+     constraint_values = [
+-        "@bazel_tools//platforms:linux",
+-        "@bazel_tools//platforms:x86_64",
++        "@platforms//os:linux",
++        "@platforms//cpu:x86_64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -80,8 +80,8 @@ config_setting(
+ config_setting(
+     name = "osx_arm64",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
+-        "@bazel_tools//platforms:aarch64",
++        "@platforms//os:osx",
++        "@platforms//cpu:aarch64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -89,8 +89,8 @@ config_setting(
+ config_setting(
+     name = "osx_x86_64",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
+-        "@bazel_tools//platforms:x86_64",
++        "@platforms//os:osx",
++        "@platforms//cpu:x86_64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -98,8 +98,8 @@ config_setting(
+ config_setting(
+     name = "windows_x86_64",
+     constraint_values = [
+-        "@bazel_tools//platforms:windows",
+-        "@bazel_tools//platforms:x86_64",
++        "@platforms//os:windows",
++        "@platforms//cpu:x86_64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -107,7 +107,7 @@ config_setting(
+ config_setting(
+     name = "x86_64",
+     constraint_values = [
+-        "@bazel_tools//platforms:x86_64",
++        "@platforms//cpu:x86_64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -115,8 +115,8 @@ config_setting(
+ config_setting(
+     name = "android_arm",
+     constraint_values = [
+-        "@bazel_tools//platforms:android",
+-        "@bazel_tools//platforms:arm",
++        "@platforms//os:android",
++        "@platforms//cpu:arm",
+     ],
+     visibility = ["//visibility:public"],
+ )
+@@ -124,8 +124,8 @@ config_setting(
+ config_setting(
+     name = "android_aarch64",
+     constraint_values = [
+-        "@bazel_tools//platforms:android",
+-        "@bazel_tools//platforms:aarch64",
++        "@platforms//os:android",
++        "@platforms//cpu:aarch64",
+     ],
+     visibility = ["//visibility:public"],
+ )
+diff --git a/BUILD.lzma b/BUILD.lzma
+index 55a1d0e..448800c 100644
+--- a/BUILD.lzma
++++ b/BUILD.lzma
+@@ -6,33 +6,33 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+ 
+ config_setting(
+     name = "linux",
+-    constraint_values = ["@bazel_tools//platforms:linux"],
++    constraint_values = ["@platforms//os:linux"],
+ )
+ 
+ config_setting(
+     name = "osx_arm64",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
+-        "@bazel_tools//platforms:aarch64",
++        "@platforms//os:osx",
++        "@platforms//cpu:aarch64",
+     ],
+ )
+ 
+ config_setting(
+     name = "osx_x86_64",
+     constraint_values = [
+-        "@bazel_tools//platforms:osx",
+-        "@bazel_tools//platforms:x86_64",
++        "@platforms//os:osx",
++        "@platforms//cpu:x86_64",
+     ],
+ )
+ 
+ config_setting(
+     name = "windows",
+-    constraint_values = ["@bazel_tools//platforms:windows"],
++    constraint_values = ["@platforms//os:windows"],
+ )
+ 
+ config_setting(
+     name = "android",
+-    constraint_values = ["@bazel_tools//platforms:android"],
++    constraint_values = ["@platforms//os:android"],
+ )
+ 
+ copy_file(
+diff --git a/BUILD.zstd b/BUILD.zstd
+index 3112574..d47aec6 100644
+--- a/BUILD.zstd
++++ b/BUILD.zstd
+@@ -233,6 +233,6 @@ cc_library(
+ config_setting(
+     name = "windows",
+     constraint_values = [
+-        "@bazel_tools//platforms:windows",
++        "@platforms//os:windows",
+     ],
+ )
+diff --git a/test/BUILD b/test/BUILD
+index f60707f..d185a15 100644
+--- a/test/BUILD
++++ b/test/BUILD
+@@ -566,7 +566,7 @@ cc_test(
+ config_setting(
+     name = "windows",
+     constraint_values = [
+-        "@bazel_tools//platforms:windows",
++        "@platforms//os:windows",
+     ],
+     visibility = ["//visibility:public"],
+ )

--- a/sdn_tests/pins_ondatra/bazel/patches/ondatra.patch
+++ b/sdn_tests/pins_ondatra/bazel/patches/ondatra.patch
@@ -1,8 +1,8 @@
 diff --git a/binding/abstract.go b/binding/abstract.go
-index 4d431d1..0ff43a4 100644
+index ce1bdc3..b80dd84 100644
 --- a/binding/abstract.go
 +++ b/binding/abstract.go
-@@ -33,7 +33,7 @@ import (
+@@ -35,7 +35,7 @@ import (
  	credzpb "github.com/openconfig/gnsi/credentialz"
  	pathzpb "github.com/openconfig/gnsi/pathz"
  
@@ -12,10 +12,10 @@ index 4d431d1..0ff43a4 100644
  	p4pb "github.com/p4lang/p4runtime/go/p4/v1"
  )
 diff --git a/binding/binding.go b/binding/binding.go
-index 2a4d7ae..96229b5 100644
+index 25b6768..742250b 100644
 --- a/binding/binding.go
 +++ b/binding/binding.go
-@@ -33,7 +33,7 @@ import (
+@@ -35,7 +35,7 @@ import (
  	certzpb "github.com/openconfig/gnsi/certz"
  	credzpb "github.com/openconfig/gnsi/credentialz"
  	pathzpb "github.com/openconfig/gnsi/pathz"
@@ -25,7 +25,7 @@ index 2a4d7ae..96229b5 100644
  	p4pb "github.com/p4lang/p4runtime/go/p4/v1"
  )
 diff --git a/internal/rawapis/rawapis.go b/internal/rawapis/rawapis.go
-index bef545c..98df921 100644
+index 8ef57b5..ef702f2 100644
 --- a/internal/rawapis/rawapis.go
 +++ b/internal/rawapis/rawapis.go
 @@ -34,7 +34,7 @@ import (
@@ -37,11 +37,51 @@ index bef545c..98df921 100644
  	p4pb "github.com/p4lang/p4runtime/go/p4/v1"
  )
  
+diff --git a/proxy/proto/BUILD.bazel b/proxy/proto/BUILD.bazel
+new file mode 100644
+index 0000000..9d6160a
+--- /dev/null
++++ b/proxy/proto/BUILD.bazel
+@@ -0,0 +1,21 @@
++package(
++    default_visibility = ["//visibility:public"],
++    licenses = ["notice"],
++)
++
++proto_library(
++    name = "reservation_proto",
++    srcs = [
++        "reservation.proto",
++    ],
++    import_prefix = "github.com/openconfig/ondatra",
++    deps = [
++        "@com_github_openconfig_ondatra//proto:ondatra_proto"
++    ],
++)
++
++cc_proto_library(
++    name = "reservation_cc_proto",
++    deps = [":reservation_proto"],
++)
++
+diff --git a/proxy/proto/reservation.proto b/proxy/proto/reservation.proto
+index 7145250..85cb489 100644
+--- a/proxy/proto/reservation.proto
++++ b/proxy/proto/reservation.proto
+@@ -15,7 +15,7 @@ syntax = "proto3";
+ 
+ package reservation;
+ 
+-import "proto/testbed.proto";
++import "github.com/openconfig/ondatra/proto/testbed.proto";
+ 
+ option go_package = "github.com/openconfig/ondatra/proto/reservation";
+ 
 diff --git a/raw/raw.go b/raw/raw.go
-index 780e978..1821141 100644
+index f9b9640..d8a7713 100644
 --- a/raw/raw.go
 +++ b/raw/raw.go
-@@ -89,7 +89,7 @@ import (
+@@ -90,7 +90,7 @@ import (
  	"github.com/openconfig/ondatra/internal/rawapis"
  
  	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -49,4 +89,49 @@ index 780e978..1821141 100644
 +	grpb "github.com/openconfig/gribi/proto/service"
  	p4pb "github.com/p4lang/p4runtime/go/p4/v1"
  )
+ 
+
+diff --git a/proto/BUILD.bazel b/proto/BUILD.bazel
+index 8302111..e72ab58 100644
+--- a/proto/BUILD.bazel
++++ b/proto/BUILD.bazel
+@@ -1,5 +1,10 @@
+ load("@io_bazel_rules_go//go:def.bzl", "go_library")
+ 
++package(
++    default_visibility = ["//visibility:public"],
++    licenses = ["notice"],
++)
++
+ go_library(
+     name = "proto",
+     srcs = [
+@@ -16,6 +21,27 @@ go_library(
+     ],
+ )
+ 
++proto_library(
++    name = "ondatra_proto",
++    srcs = [
++        "ate.proto",
++        "testbed.proto",
++    ],
++    import_prefix = "github.com/openconfig/ondatra",
++    deps = [
++        "@com_google_protobuf//:any_proto",
++        "@com_google_protobuf//:duration_proto",
++        "@com_google_protobuf//:empty_proto",
++        "@com_google_protobuf//:descriptor_proto",
++    ],
++)
++
++cc_proto_library(
++    name = "ondatra_cc_proto",
++    deps = [":ondatra_proto"],
++)
++
++
+ alias(
+     name = "go_default_library",
+     actual = ":proto",
  

--- a/sdn_tests/pins_ondatra/infra_deps.bzl
+++ b/sdn_tests/pins_ondatra/infra_deps.bzl
@@ -1,3 +1,13 @@
+"""Third party dependencies.
+
+Please read carefully before adding new dependencies:
+- Any dependency can break all of pins-infra. Please be mindful of that before
+  adding new dependencies. Try to stick to stable versions of widely used libraries.
+  Do not depend on private repositories and forks.
+- Fix dependencies to a specific version or commit, so upstream changes cannot break
+  pins-infra. Prefer releases over arbitrary commits when both are available.
+"""
+
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
@@ -36,6 +46,8 @@ def binding_deps():
         "gazelle:resolve go github.com/open-traffic-generator/snappi/gosnappi @com_github_open_traffic_generator_snappi//gosnappi:go_default_library",
         "gazelle:resolve go github.com/openconfig/gnoi/types @com_github_openconfig_gnoi//types:types_go_proto",
         "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @org_golang_google_genproto//googleapis/rpc/status:status",
+        "gazelle:resolve go github.com/openconfig/attestz/proto/tpm_attestz @com_github_openconfig_attestz//proto:tpm_attestz_go",
+        "gazelle:resolve go github.com/openconfig/attestz/proto/tpm_enrollz @com_github_openconfig_attestz//proto:tpm_enrollz_go",
     ]
 
     go_repository(
@@ -52,8 +64,7 @@ def binding_deps():
         name = "com_github_golang_glog",
         importpath = "github.com/golang/glog",
         repo_mapping = repo_map,
-        sum = "h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=",
-        version = "v1.0.0",
+        commit = "97303146a4ffecf364d4300e07fca855d0062c43" # release v1.2.2
     )
 
     go_repository(
@@ -111,14 +122,24 @@ def binding_deps():
         build_directives = build_directives,
         patches = ["//:bazel/patches/ondatra.patch"],
         patch_args = ["-p1"],
-        commit = "c22622bbf6da04c44fe4bdc77c31c0001b8a5593",  #main as of 12/18/2023
+        commit = "203b379e0e361cb90282521b688ee6e1c65f9e93",  #main as of 28/05/2024
+    )
+
+
+    go_repository(
+        name = "com_github_openconfig_attestz",
+        importpath = "github.com/openconfig/attestz",
+        repo_mapping = repo_map,
+        build_file_proto_mode = "disable",
+        build_directives = build_directives,
+        commit = "59dbe650c5e7ad6234d2aa99ab856b0213324589",  #main as of 28/05/2024
     )
 
     go_repository(
         name = "com_github_open_traffic_generator_snappi",
         importpath = "github.com/open-traffic-generator/snappi",
         repo_mapping = repo_map,
-        commit = "c39ebe4b4cc4a0f63f2ed14b27e14ac51ec32b5d",  # v0.13.3
+        commit = "e177fe7270d4f1bdab34ced976d9b95b344e2694",  #main as of 28/05/2024
         patches = ["//:bazel/patches/snappi.patch"],
         patch_args = ["-p1"],
     )
@@ -300,6 +321,13 @@ def binding_deps():
         version = "v0.9.0",
     )
 
+    go_repository(
+        name = "org_golang_x_crypto",
+        importpath = "golang.org/x/crypto",
+        repo_mapping = repo_map,
+        sum = "h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=",
+        version = "v0.24.0",
+    )
 
     git_repository(
         name = "com_google_googleapis",
@@ -307,7 +335,6 @@ def binding_deps():
         commit = "c4915db59896a1da45b55507ece2ebc1d53ef6f5",
         shallow_since = "1642638275 -0800",
     )
-
 
     go_repository(
         name = "com_github_jstemmer_go_junit_report_v2",
@@ -335,4 +362,11 @@ def binding_deps():
         importpath = "github.com/pkg/sftp",
         sum = "h1:I2qBYMChEhIjOgazfJmV3/mZM256btk6wkCDRmW7JYs=",
         version = "v1.13.1",
+    )
+
+    go_repository(
+        name = "com_github_kr_fs",
+        importpath = "github.com/kr/fs",
+        sum = "h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=",
+        version = "v0.1.0",
     )

--- a/sdn_tests/pins_ondatra/pins_deps.bzl
+++ b/sdn_tests/pins_ondatra/pins_deps.bzl
@@ -1,203 +1,98 @@
+
+"""Third party dependencies.
+
+Please read carefully before adding new dependencies:
+- Any dependency can break all of pins-infra. Please be mindful of that before
+  adding new dependencies. Try to stick to stable versions of widely used libraries.
+  Do not depend on private repositories and forks.
+- Fix dependencies to a specific version or commit, so upstream changes cannot break
+  pins-infra. Prefer releases over arbitrary commits when both are available.
+"""
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def pins_deps():
-    if not native.existing_rule("com_github_grpc_grpc"):
-        http_archive(
-            name = "com_github_grpc_grpc",
-            url = "https://github.com/grpc/grpc/archive/v1.58.0.zip",
-            strip_prefix = "grpc-1.58.0",
-            sha256 = "aa329c7de707a03511c88206ef4483e9346ab6336b6be4378d294060aa7400b3",
-            patch_args = ["-p1"],
-            patches = [
-                "//:bazel/patches/grpc-001-fix_file_watcher_race_condition.patch",
-                "//:bazel/patches/grpc-003-fix_go_gazelle_register_toolchain.patch",
-            ],
-        )
-    if not native.existing_rule("com_google_absl"):
-        http_archive(
-            name = "com_google_absl",
-            url = "https://github.com/abseil/abseil-cpp/archive/20230802.0.tar.gz",
-            strip_prefix = "abseil-cpp-20230802.0",
-            sha256 = "59d2976af9d6ecf001a81a35749a6e551a335b949d34918cfade07737b9d93c5",
-        )
-    if not native.existing_rule("com_google_googletest"):
-        http_archive(
-            name = "com_google_googletest",
-            urls = ["https://github.com/google/googletest/archive/release-1.11.0.tar.gz"],
-            strip_prefix = "googletest-release-1.11.0",
-            sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
-        )
-    if not native.existing_rule("com_google_benchmark"):
-        http_archive(
-            name = "com_google_benchmark",
-            urls = ["https://github.com/google/benchmark/archive/v1.5.4.tar.gz"],
-            strip_prefix = "benchmark-1.5.4",
-            sha256 = "e3adf8c98bb38a198822725c0fc6c0ae4711f16fbbf6aeb311d5ad11e5a081b5",
-        )
-    if not native.existing_rule("com_google_protobuf"):
-        http_archive(
-            name = "com_google_protobuf",
-            url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v25.1.zip",
-            strip_prefix = "protobuf-25.1",
-            sha256 = "eaafa4e19a6619c15df4c30d7213efbfd0f33ad16021cc5f72bbc5d0877346b5",
-        )
-    if not native.existing_rule("com_googlesource_code_re2"):
-        http_archive(
-            name = "com_googlesource_code_re2",
-            url = "https://github.com/google/re2/archive/refs/tags/2023-06-01.tar.gz",
-            strip_prefix = "re2-2023-06-01",
-            sha256 = "8b4a8175da7205df2ad02e405a950a02eaa3e3e0840947cd598e92dca453199b",
-        )
-    if not native.existing_rule("com_google_googleapis"):
-        http_archive(
-            name = "com_google_googleapis",
-            url = "https://github.com/googleapis/googleapis/archive/f405c718d60484124808adb7fb5963974d654bb4.zip",
-            strip_prefix = "googleapis-f405c718d60484124808adb7fb5963974d654bb4",
-            sha256 = "406b64643eede84ce3e0821a1d01f66eaf6254e79cb9c4f53be9054551935e79",
-        )
-    if not native.existing_rule("com_github_google_glog"):
-        http_archive(
-            name = "com_github_google_glog",
-            url = "https://github.com/google/glog/archive/v0.6.0.tar.gz",
-            strip_prefix = "glog-0.6.0",
-            sha256 = "8a83bf982f37bb70825df71a9709fa90ea9f4447fb3c099e1d720a439d88bad6",
-        )
-    if not native.existing_rule("com_github_otg_models"):
-        http_archive(
-            name = "com_github_otg_models",
-            url = "https://github.com/open-traffic-generator/models/archive/refs/tags/v0.12.5.zip",
-            strip_prefix = "models-0.12.5",
-            build_file = "@//:bazel/BUILD.otg-models.bazel",
-            sha256 = "1a63e769f1d7f42c79bc1115babf54acbc44761849a77ac28f47a74567f10090",
-        )
+    """Sets up 3rd party workspaces needed to build PINS infrastructure."""
+    if not native.existing_rule("io_bazel_rules_go"):
+      http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+        ],
+      )
 
-    # Needed to make glog happy.
-    if not native.existing_rule("com_github_gflags_gflags"):
-        http_archive(
-            name = "com_github_gflags_gflags",
-            url = "https://github.com/gflags/gflags/archive/v2.2.2.tar.gz",
-            strip_prefix = "gflags-2.2.2",
-            sha256 = "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf",
-        )
-    if not native.existing_rule("com_github_gnmi"):
-        http_archive(
-            name = "com_github_gnmi",
-            # v0.10.0 release; commit-hash:5473f2ef722ee45c3f26eee3f4a44a7d827e3575.
-            url = "https://github.com/openconfig/gnmi/archive/refs/tags/v0.10.0.zip",
-            strip_prefix = "gnmi-0.10.0",
-            patch_args = ["-p1"],
-            patches = [
-                "//:bazel/patches/gnmi-001-fix_virtual_proto_import.patch",
-            ],
-            sha256 = "2231e1cc398a523fa840810fa6fdb8960639f7b91b57bb8f12ed8681e0142a67",
-        )
-    if not native.existing_rule("com_github_gnoi"):
-        http_archive(
-            name = "com_github_gnoi",
-            # Newest commit on main on 2021-11-08.
-            url = "https://github.com/openconfig/gnoi/archive/1ece8ed91a0d5d283219a99eb4dc6c7eadb8f287.zip",
-            strip_prefix = "gnoi-1ece8ed91a0d5d283219a99eb4dc6c7eadb8f287",
-            sha256 = "991ff13a0b28f2cdc2ccb123261e7554d9bcd95c00a127411939a3a8c8a9cc62",
-        )
-    if not native.existing_rule("com_github_p4lang_p4c"):
-        http_archive(
-            name = "com_github_p4lang_p4c",
-            # Newest commit on main on 2023-10-09.
-            url = "https://github.com/p4lang/p4c/archive/d79e2e8bfa07c7797891d44b7d084910947bf0a7.zip",
-            strip_prefix = "p4c-d79e2e8bfa07c7797891d44b7d084910947bf0a7",
-            sha256 = "1fad9b8e96988da76e3ad01c90e99d70fe7db90b3acb7bddf78b603117e857f9",
-        )
-    if not native.existing_rule("com_github_p4lang_p4runtime"):
-        # We frequently need bleeding-edge, unreleased version of P4Runtime, so we use a commit
-        # rather than a release.
-        http_archive(
-            name = "com_github_p4lang_p4runtime",
-            # 90553b9 is the newest commit on main as of 2023-10-09.
-            urls = ["https://github.com/p4lang/p4runtime/archive/f0e9f33818b74f0009daa44160926e568f1eaa4d.zip"],
-            strip_prefix = "p4runtime-f0e9f33818b74f0009daa44160926e568f1eaa4d/proto",
-            sha256 = "97b43996ada83484bfa3f9be205d6b6fd75b9ed6985839414ee72110d369cd53",
-        )
-    if not native.existing_rule("com_github_p4lang_p4_constraints"):
-        http_archive(
-            name = "com_github_p4lang_p4_constraints",
-            urls = ["https://github.com/p4lang/p4-constraints/archive/3d5196a793f375ccbe1bf38ae6c49e2e65604f4b.zip"],
-            strip_prefix = "p4-constraints-3d5196a793f375ccbe1bf38ae6c49e2e65604f4b",
-            sha256 = "f87d885ebfd6a1bdf02b4c4ba5bf6fb333f90d54561e4d520a8413c8d1fb7beb",
-        )
-    if not native.existing_rule("com_github_nlohmann_json"):
-        http_archive(
-            name = "com_github_nlohmann_json",
-            # JSON for Modern C++
-            url = "https://github.com/nlohmann/json/archive/v3.7.3.zip",
-            strip_prefix = "json-3.7.3",
-            sha256 = "e109cd4a9d1d463a62f0a81d7c6719ecd780a52fb80a22b901ed5b6fe43fb45b",
-            build_file_content = """cc_library(name = "nlohmann_json",
-                                               visibility = ["//visibility:public"],
-                                               hdrs = glob([
-                                                   "include/nlohmann/*.hpp",
-                                                   "include/nlohmann/**/*.hpp",
-                                                   ]),
-                                               includes = ["include"],
-                                              )""",
-        )
-    if not native.existing_rule("com_jsoncpp"):
-        http_archive(
-            name = "com_jsoncpp",
-            url = "https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.zip",
-            strip_prefix = "jsoncpp-1.9.4",
-            build_file = "@//:bazel/BUILD.jsoncpp.bazel",
-            sha256 = "6da6cdc026fe042599d9fce7b06ff2c128e8dd6b8b751fca91eb022bce310880",
-        )
-    if not native.existing_rule("com_github_ivmai_cudd"):
-        http_archive(
-            name = "com_github_ivmai_cudd",
-            build_file = "@//:bazel/BUILD.cudd.bazel",
-            strip_prefix = "cudd-cudd-3.0.0",
-            sha256 = "5fe145041c594689e6e7cf4cd623d5f2b7c36261708be8c9a72aed72cf67acce",
-            urls = ["https://github.com/ivmai/cudd/archive/cudd-3.0.0.tar.gz"],
-        )
-    if not native.existing_rule("com_gnu_gmp"):
-        http_archive(
-            name = "com_gnu_gmp",
-            urls = [
-                "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz",
-                "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
-            ],
-            strip_prefix = "gmp-6.2.1",
-            sha256 = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2",
-            build_file = "@//:bazel/BUILD.gmp.bazel",
-        )
-    if not native.existing_rule("com_github_z3prover_z3"):
-        http_archive(
-            name = "com_github_z3prover_z3",
-            url = "https://github.com/Z3Prover/z3/archive/z3-4.8.12.tar.gz",
-            strip_prefix = "z3-z3-4.8.12",
-            sha256 = "e3aaefde68b839299cbc988178529535e66048398f7d083b40c69fe0da55f8b7",
-            build_file = "@//:bazel/BUILD.z3.bazel",
-        )
-    if not native.existing_rule("rules_foreign_cc"):
-        http_archive(
-            name = "rules_foreign_cc",
-            sha256 = "d54742ffbdc6924f222d2179f0e10e911c5c659c4ae74158e9fe827aad862ac6",
-            strip_prefix = "rules_foreign_cc-0.2.0",
-            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.2.0.tar.gz",
-        )
-    if not native.existing_rule("rules_proto"):
-        http_archive(
-            name = "rules_proto",
-            urls = [
-                "https://github.com/bazelbuild/rules_proto/archive/3f1ab99b718e3e7dd86ebdc49c580aa6a126b1cd.tar.gz",
-            ],
-            strip_prefix = "rules_proto-3f1ab99b718e3e7dd86ebdc49c580aa6a126b1cd",
-            sha256 = "c9cc7f7be05e50ecd64f2b0dc2b9fd6eeb182c9cc55daf87014d605c31548818",
-        )
     if not native.existing_rule("rules_pkg"):
         http_archive(
             name = "rules_pkg",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
-                "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+                "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
             ],
-            sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
+            sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
+        )
+
+    # Bazel toolchain to build go-lang.
+    if not native.existing_rule("bazel_gazelle"):
+        http_archive(
+          name = "bazel_gazelle",
+          sha256 = "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
+          urls = [
+              "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
+              "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
+          ],
+        )
+
+    if not native.existing_rule("platforms"):
+        http_archive(
+          name = "platforms",
+          url = "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        )
+
+    if not native.existing_rule("com_github_nelhage_rules_boost"):
+        git_repository(
+            name = "com_github_nelhage_rules_boost",
+            # Newest commit on main branch as of May 3, 2021.
+            commit = "2598b37ce68226fab465c0f0e10988af872b6dc9",
+            remote = "https://github.com/nelhage/rules_boost",
+            shallow_since = "1611019749 -0800",
+            patch_args = ["-p1"],
+            patches = [
+                "//:bazel/patches/nelhage_fix_bazel_platforms.patch",
+            ],
+        )
+
+    if not native.existing_rule("com_github_google_pins_infra"):
+        git_repository(
+          name = "com_github_google_pins_infra",
+          remote = "https://github.com/pins/pins-infra.git",
+          patch_args = ["-p1"],
+          patches = [
+              "//:bazel/patches/com_github_google_pins_infra_deps_fix.patch",
+          ],
+          commit = "3a543cc9eb9f7eee93ae785d7b748a750f0454ba" # main as on Oct 10th
+        )
+
+    if not native.existing_rule("com_github_sonic_net_sonic_pins"):
+        git_repository(
+          name = "com_github_sonic_net_sonic_pins",
+          remote = "https://github.com/sonic-net/sonic-pins.git",
+          patch_args = ["-p1"],
+          patches = [
+              "//:bazel/patches/com_github_sonic_net_sonic_pins.patch",
+          ],
+          commit = "b3c410fb6890edb7fc9009526e3a08ed1a345177" # main as on feb 25, 2025
+        )
+
+    if not native.existing_rule("rules_proto_grpc"):
+        http_archive(
+            name = "rules_proto_grpc",
+            sha256 = "f87d885ebfd6a1bdf02b4c4ba5bf6fb333f90d54561e4d520a8413c8d1fb7beb",
+            strip_prefix = "rules_proto_grpc-4.5.0",
+            urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.5.0.tar.gz"],
+            patch_args = ["-p1"],
+            patches = [
+                "//:bazel/patches/rules_proto_grpc.patch",
+            ],
         )


### PR DESCRIPTION
Build Result:
~/KS/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build ...
INFO: Analyzed 8 targets (316 packages loaded, 13994 targets configured).
INFO: Found 8 targets...
INFO: From Compiling src/google/protobuf/arena.cc [for tool]:
external/com_google_protobuf/src/google/protobuf/arena.cc: In member function 'void* google::protobuf::internal::SerialArena::AllocateAlignedFallback(size_t)':
external/com_google_protobuf/src/google/protobuf/arena.cc:200:10: warning: 'ret' may be used uninitialized in this function [-Wmaybe-uninitialized]
  200 |   return ret;
      |          ^~~
INFO: From Compiling src/google/protobuf/message_lite.cc [for tool]:
external/com_google_protobuf/src/google/protobuf/message_lite.cc: In member function 'int google::protobuf::MessageLite::GetCachedSize() const':
external/com_google_protobuf/src/google/protobuf/message_lite.cc:69:71: warning: 'int google::protobuf::MessageLite::ByteSize() const' is deprecated: Please use ByteSizeLong() instead [-Wdeprecated-declarations]
   69 |   if (PROTOBUF_PREDICT_FALSE(cached_size == nullptr)) return ByteSize();
      |                                                                       ^
In file included from external/com_google_protobuf/src/google/protobuf/message_lite.cc:13:
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/message_lite.h:454:59: note: declared here
  454 |   [[deprecated("Please use ByteSizeLong() instead")]] int ByteSize() const {
      |                                                           ^~~~~~~~
INFO: From Compiling src/google/protobuf/compiler/rust/relative_path.cc [for tool]:
external/com_google_protobuf/src/google/protobuf/compiler/rust/relative_path.cc: In member function 'std::string google::protobuf::compiler::rust::RelativePath::Relative(const google::protobuf::compiler::rust::RelativePath&) const':
external/com_google_protobuf/src/google/protobuf/compiler/rust/relative_path.cc:66:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<absl::lts_20240116::string_view>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   66 |   for (int i = 0; i < current_segments.size(); ++i) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc [for tool]:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:22,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:22:
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1125:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1125 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1125:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:830:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  830 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:830:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:753:29: warning: 'always_inline' function might not be inlinable [-Wattributes]
  753 | PROTOBUF_ALWAYS_INLINE bool EnumIsValidAux(int32_t val, uint16_t xform_val,
      |                             ^~~~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:741:29: warning: 'always_inline' function might not be inlinable [-Wattributes]
  741 | PROTOBUF_ALWAYS_INLINE void PrefetchEnumData(uint16_t xform_val,
      |                             ^~~~~~~~~~~~~~~~
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//acctz:acctz_proto:
github.com/openconfig/gnsi/acctz/acctz.proto:36:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//authz:authz_proto:
github.com/openconfig/gnsi/authz/authz.proto:23:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//certz:certz_proto:
github.com/openconfig/gnsi/certz/certz.proto:22:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//credentialz:credentialz_proto:
github.com/openconfig/gnsi/credentialz/credentialz.proto:21:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: From Generating Descriptor Set proto_library @com_github_openconfig_gnsi//pathz:pathz_proto:
github.com/openconfig/gnsi/pathz/authorization.proto:43:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
github.com/openconfig/gnsi/pathz/pathz.proto:25:1: warning: Import github.com/openconfig/gnsi/version/version.proto is unused.
INFO: Elapsed time: 575.493s, Critical Path: 194.67s
INFO: 993 processes: 254 internal, 739 linux-sandbox.
INFO: Build completed successfully, 993 total actions
