### PR TITLE
[GCU] Adding t2 support in gcu lo test case

### DIFF
--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -365,6 +365,7 @@ def setup_vrf_config(duthost, lo_intf):
         delete_tmpfile(duthost, tmpfile)
 
 
+@pytest.mark.topology('t0', 'm0', 'mx', 't2')
 def test_lo_interface_tc1_suite(rand_selected_dut, cfg_facts, lo_intf):
     cleanup_lo_interface_config(rand_selected_dut, cfg_facts)
     lo_interface_tc1_add_init(rand_selected_dut, lo_intf)

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -10,6 +10,7 @@ from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 from tests.common.gu_utils import create_path, check_show_ip_intf, check_vrf_route_for_intf
+from tests.bgp.bgp_helpers import restart_bgp_session
 
 # Test on t0 topo to verify functionality and to choose predefined variable
 # "LOOPBACK_INTERFACE": {
@@ -77,7 +78,7 @@ def setup_env(duthosts, rand_one_dut_hostname, lo_intf):
             [lo_intf["ipv6"].lower()], ["Vrf"], is_ipv4=False)
 
         # Loopback interface removal will impact default route. Restart bgp to recover routes.
-        duthost.shell("sudo systemctl restart bgp")
+        restart_bgp_session(duthost)
         if not wait_until(240, 10, 0, duthost.check_default_route):
             logger.warning(
                 "Default routes not recovered after restart bgp, restoring with `config_reload`"

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -123,7 +123,7 @@ def lo_interface_tc1_add_init(duthost, lo_intf):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -169,7 +169,7 @@ def lo_interface_tc1_add_duplicate(duthost, lo_intf):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -219,7 +219,7 @@ def lo_interface_tc1_xfail(duthost, lo_intf):
                 "value": {}
             }
         ]
-        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
+        json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
 
         tmpfile = generate_tmpfile(duthost)
         logger.info("tmpfile {}".format(tmpfile))
@@ -273,7 +273,7 @@ def lo_interface_tc1_replace(duthost, lo_intf):
             "value": {}
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -299,7 +299,7 @@ def lo_interface_tc1_remove(duthost, lo_intf):
             "path": "/LOOPBACK_INTERFACE"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -342,7 +342,7 @@ def setup_vrf_config(duthost, lo_intf):
             "value": "Vrf_01"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_host_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch)
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -396,7 +396,7 @@ def test_lo_interface_tc2_vrf_change(rand_selected_dut, lo_intf):
             "value": "Vrf_02"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=json_patch, is_host_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=rand_selected_dut, json_data=json_patch)
 
     tmpfile = generate_tmpfile(rand_selected_dut)
     logger.info("tmpfile {}".format(tmpfile))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The original change was included in https://github.com/sonic-net/sonic-mgmt/pull/15236/files. 
However, the code changes were handled in a different PR. This PR only adds support for T2.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ X] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran in kvm-t0, t2 chassis.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
