### PR TITLE
Add a test for verifying cpu queue shaper config

### DIFF
--- a/tests/cpu_shaper/conftest.py
+++ b/tests/cpu_shaper/conftest.py
@@ -1,0 +1,17 @@
+"""
+    Pytest configuration used by the cpu queue shaper tests.
+"""
+
+
+def pytest_addoption(parser):
+    """
+        Adds options to pytest that are used by the cpu queue shaper tests.
+    """
+
+    parser.addoption(
+        "--reboot_type",
+        action="store",
+        type=str,
+        default="cold",
+        help="reboot type such as cold, fast, warm, soft"
+    )

--- a/tests/cpu_shaper/scripts/get_shaper.c
+++ b/tests/cpu_shaper/scripts/get_shaper.c
@@ -1,0 +1,15 @@
+int get_cosq_shaper(bcm_port_t port, bcm_cos_queue_t cosq, uint32 kbits_sec_min, uint32 kbits_sec_max, uint32 flags)
+{
+    int rv=0;
+    rv = bcm_cosq_port_bandwidth_get(0,port,cosq, &kbits_sec_min, &kbits_sec_max, &flags);
+    if (rv < 0) {
+        printf("bcm_cosq_port_bandwidth_get failed for port=%d, cos=%d, pps_max=%d, rv=%d\n", port, cosq, kbits_sec_max,rv);
+        return rv;
+    }
+    printf("bcm_cosq_port_bandwidth_get for port=%d, cos=%d pps_max=%d\n", port, cosq, kbits_sec_max);
+    return 0;
+}
+
+print get_cosq_shaper(0, 0, 0, 0, 0);
+print get_cosq_shaper(0, 1, 0, 0, 0);
+print get_cosq_shaper(0, 7, 0, 0, 0);

--- a/tests/cpu_shaper/test_cpu_shaper.py
+++ b/tests/cpu_shaper/test_cpu_shaper.py
@@ -1,0 +1,76 @@
+"""
+    Tests the cpu queue shaper configuration in BRCM platforms
+    is as expected across reboot/warm-reboots.
+    Mellanox and Cisco platforms do not have CPU shaper
+    configurations and are not included in this test.
+
+"""
+
+import logging
+import pytest
+import re
+
+from tests.common import config_reload
+from tests.common.reboot import reboot
+from tests.common.platform.processes_utils import wait_critical_processes
+
+pytestmark = [
+    pytest.mark.topology("t0", "t1"),
+    pytest.mark.asic("broadcom")
+]
+
+logger = logging.getLogger(__name__)
+
+BCM_CINT_FILENAME = "get_shaper.c"
+DEST_DIR = "/tmp"
+CMD_GET_SHAPER = "bcmcmd 'cint {}'".format(BCM_CINT_FILENAME)
+
+
+def verify_cpu_queue_shaper(dut):
+    """
+    Verify cpu queue shaper configuration is as expected
+
+    Args:
+        dut (SonicHost): The target device
+    """
+    # Copy cint script to /tmp on the device
+    dut.copy(src="cpu_shaper/scripts/{}".format(BCM_CINT_FILENAME), dest=DEST_DIR)
+
+    # Copy cint script to the syncd container
+    dut.shell("docker cp {}/{} syncd:/".format(DEST_DIR, BCM_CINT_FILENAME))
+
+    # Execute the cint script and parse the output
+    res = dut.shell(CMD_GET_SHAPER)['stdout']
+
+    # Expected shaper PPS configuration for CPU queues 0, 1 and 7 respectively
+    expected_pps = {0: 600, 1: 6000, 7: 600}
+    pattern = r'cos=(\d+) pps_max=(\d+)'
+    matches = re.findall(pattern, res)
+    actual_pps = {int(cos): int(pps) for cos, pps in matches}
+    assert (expected_pps == actual_pps)
+
+
+@pytest.mark.disable_loganalyzer
+def test_cpu_queue_shaper(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname, request):
+    """
+    Validates the cpu queue shaper configuration after reboot(reboot, warm-reboot)
+
+    """
+    try:
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        reboot_type = request.config.getoption("--reboot_type")
+
+        # Perform reboot as specified via the reboot_type parameter
+        logger.info("Do {} reboot".format(reboot_type))
+        reboot(duthost, localhost, reboot_type=reboot_type, reboot_helper=None, reboot_kwargs=None)
+
+        # Wait for critical processes to be up
+        wait_critical_processes(duthost)
+        logger.info("Verify cpu queue shaper config after {} reboot".format(reboot_type))
+
+        # Verify cpu queue shaper configuration
+        verify_cpu_queue_shaper(duthost)
+
+    finally:
+        duthost.shell("rm {}/{}".format(DEST_DIR, BCM_CINT_FILENAME))
+        config_reload(duthost)


### PR DESCRIPTION
 * This test verifies the cpu queue shaper configuration on broadcom platforms. This may be extended to other platforms once they implement cpu queue shapers.

 * Note that the test itself doesn't run any traffic tests as those may not provide a reflection of the cpu queue shaper configuration due to trap policer configurations on sonic.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes Microsoft ADO# (31575264)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
To verify that cpu queue shaper configuration is consistent across SAI/sonic releases on all broadcom platforms.
#### How did you do it?

#### How did you verify/test it?
By running the newly added sonic-mgmt test
#### Any platform specific information?
Broadcom ASIC specific
#### Supported testbed topology if it's a new test case?
T0/T1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
