### PR TITLE
[XFAIL] xfail test_lag_member_forwarding.py for platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1557,6 +1557,13 @@ pc/test_lag_member.py:
         - "'dualtor' in topo_name or 't0-backend' in topo_name"
         - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/13898"
 
+pc/test_lag_member_forwarding.py:
+  xfail:
+    reason: "Not supported on BRCM before SDK 13.x"
+    conditions_logical_operator: and
+    conditions:
+        - "asic_type in ['broadcom'] and https://github.com/sonic-net/sonic-mgmt/issues/17304"
+
 pc/test_po_cleanup.py:
   skip:
     reason: "Skip test due to there is no portchannel exists in current topology."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
The feature is not ready for BRCM platform, need to xfail for BRCM before the fix is in place.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To xfail the test_lag_member_forwarding on BRCM platform. 

#### How did you do it?
Xfail the test_lag_member_forwarding in conditional mark file. 

#### How did you verify/test it?
Run test.

#### Any platform specific information?
Only xfail for BRCM platform.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
