### PR TITLE
Fix test_copp on non T2 topologies

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -259,7 +259,11 @@ def copp_testbed(
 
     if not is_backend_topology:
         # There is no upstream neighbor in T1 backend topology. Test is skipped on T0 backend.
-        upStreamDuthost = find_duthost_on_role(duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+        # For Non T2 topologies, setting upStreamDuthost as duthost to cover dualTOR and MLAG scenarios.
+        if 't2' in tbinfo["topo"]["name"]:
+            upStreamDuthost = find_duthost_on_role(duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+        else:
+            upStreamDuthost = duthost
 
     try:
         _setup_multi_asic_proxy(duthost, creds, test_params, tbinfo)


### PR DESCRIPTION
For non T2 topologies, setting upStreamDuthost as duthost to cover dualToR scenarios.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_copp on non T2 topologies
Fix flaky test copp/test_copp.py on dualtor
Fixes # [#435](https://github.com/aristanetworks/sonic-qual.msft/issues/435)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
BGP is shutdown on a TOR different from the one where package download is supposed to happen in DualTOR topology. The cause of the issue is T2 approach is being extended to multi DUT topologies which is leading to failures.

#### How did you do it?
The DUT where package download is supposed to happen should match the one where BGP is being shutdown. In multi DUT  topologies with this change, we are making sure that BGP shutdown happens in the appropriate DUT.


#### How did you verify/test it?
Test is consistently passing with the fix. Tested with 202411 image on Arista-7050CX3 with dualtor-aa.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
