### PR TITLE
[isolated topo] adjust podset parameters and add tornum

### DIFF
--- a/ansible/vars/topo_t0-isolated-d2u254.yml
+++ b/ansible/vars/topo_t0-isolated-d2u254.yml
@@ -1039,11 +1039,11 @@ configuration_properties:
     dut_asn: 4200000000
     dut_type: ToRRouter
     swrole: leaf
-    podset_number: 200
-    tor_number: 16
+    podset_number: 1
+    tor_number: 512
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     spine_asn: 4200200000
     leaf_asn_start: 4200100000
     tor_asn_start: 4200000000

--- a/ansible/vars/topo_t0-isolated-d2u254s1.yml
+++ b/ansible/vars/topo_t0-isolated-d2u254s1.yml
@@ -1043,11 +1043,11 @@ configuration_properties:
     dut_asn: 4200000000
     dut_type: ToRRouter
     swrole: leaf
-    podset_number: 200
-    tor_number: 16
+    podset_number: 1
+    tor_number: 512
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     spine_asn: 4200200000
     leaf_asn_start: 4200100000
     tor_asn_start: 4200000000

--- a/ansible/vars/topo_t0-isolated-d2u254s2.yml
+++ b/ansible/vars/topo_t0-isolated-d2u254s2.yml
@@ -1047,11 +1047,11 @@ configuration_properties:
     dut_asn: 4200000000
     dut_type: ToRRouter
     swrole: leaf
-    podset_number: 200
-    tor_number: 16
+    podset_number: 1
+    tor_number: 512
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     spine_asn: 4200200000
     leaf_asn_start: 4200100000
     tor_asn_start: 4200000000

--- a/ansible/vars/topo_t0-isolated-d2u510.yml
+++ b/ansible/vars/topo_t0-isolated-d2u510.yml
@@ -2063,11 +2063,11 @@ configuration_properties:
     dut_asn: 4200000000
     dut_type: ToRRouter
     swrole: leaf
-    podset_number: 200
-    tor_number: 16
+    podset_number: 1
+    tor_number: 512
     tor_subnet_number: 2
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     spine_asn: 4200200000
     leaf_asn_start: 4200100000
     tor_asn_start: 4200000000

--- a/ansible/vars/topo_t1-isolated-d254u2.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2.yml
@@ -1029,11 +1029,11 @@ configuration_properties:
   common:
     dut_asn: 4200100000
     dut_type: LeafRouter
-    podset_number: 200
-    tor_number: 16
-    tor_subnet_number: 2
+    podset_number: 1
+    tor_number: 512
+    tor_subnet_number: 1
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     nhipv6: FC0A::FF
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
@@ -1084,6 +1084,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 01
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -1102,6 +1103,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 02
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -1120,6 +1122,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 03
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -1138,6 +1141,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 04
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -1156,6 +1160,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 05
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -1174,6 +1179,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 06
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -1192,6 +1198,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 07
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -1210,6 +1217,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 08
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -1228,6 +1236,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 09
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008
@@ -1246,6 +1255,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 10
     bgp:
       router-id: 0.12.0.12
       asn: 4200000009
@@ -1264,6 +1274,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 11
     bgp:
       router-id: 0.12.0.13
       asn: 4200000010
@@ -1282,6 +1293,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 12
     bgp:
       router-id: 0.12.0.14
       asn: 4200000011
@@ -1300,6 +1312,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 13
     bgp:
       router-id: 0.12.0.15
       asn: 4200000012
@@ -1318,6 +1331,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 14
     bgp:
       router-id: 0.12.0.16
       asn: 4200000013
@@ -1336,6 +1350,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 15
     bgp:
       router-id: 0.12.0.17
       asn: 4200000014
@@ -1354,6 +1369,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 16
     bgp:
       router-id: 0.12.0.18
       asn: 4200000015
@@ -1372,6 +1388,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 17
     bgp:
       router-id: 0.12.0.19
       asn: 4200000016
@@ -1390,6 +1407,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 18
     bgp:
       router-id: 0.12.0.20
       asn: 4200000017
@@ -1408,6 +1426,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 19
     bgp:
       router-id: 0.12.0.21
       asn: 4200000018
@@ -1426,6 +1445,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 20
     bgp:
       router-id: 0.12.0.22
       asn: 4200000019
@@ -1444,6 +1464,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 21
     bgp:
       router-id: 0.12.0.23
       asn: 4200000020
@@ -1462,6 +1483,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 22
     bgp:
       router-id: 0.12.0.24
       asn: 4200000021
@@ -1480,6 +1502,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 23
     bgp:
       router-id: 0.12.0.25
       asn: 4200000022
@@ -1498,6 +1521,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 24
     bgp:
       router-id: 0.12.0.26
       asn: 4200000023
@@ -1516,6 +1540,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 25
     bgp:
       router-id: 0.12.0.27
       asn: 4200000024
@@ -1534,6 +1559,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 26
     bgp:
       router-id: 0.12.0.28
       asn: 4200000025
@@ -1552,6 +1578,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 27
     bgp:
       router-id: 0.12.0.29
       asn: 4200000026
@@ -1570,6 +1597,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 28
     bgp:
       router-id: 0.12.0.30
       asn: 4200000027
@@ -1588,6 +1616,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 29
     bgp:
       router-id: 0.12.0.31
       asn: 4200000028
@@ -1606,6 +1635,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 30
     bgp:
       router-id: 0.12.0.32
       asn: 4200000029
@@ -1624,6 +1654,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 31
     bgp:
       router-id: 0.12.0.33
       asn: 4200000030
@@ -1642,6 +1673,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 32
     bgp:
       router-id: 0.12.0.34
       asn: 4200000031
@@ -1660,6 +1692,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 33
     bgp:
       router-id: 0.12.0.35
       asn: 4200000032
@@ -1678,6 +1711,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 34
     bgp:
       router-id: 0.12.0.36
       asn: 4200000033
@@ -1696,6 +1730,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 35
     bgp:
       router-id: 0.12.0.37
       asn: 4200000034
@@ -1714,6 +1749,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 36
     bgp:
       router-id: 0.12.0.38
       asn: 4200000035
@@ -1732,6 +1768,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 37
     bgp:
       router-id: 0.12.0.39
       asn: 4200000036
@@ -1750,6 +1787,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 38
     bgp:
       router-id: 0.12.0.40
       asn: 4200000037
@@ -1768,6 +1806,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 39
     bgp:
       router-id: 0.12.0.41
       asn: 4200000038
@@ -1786,6 +1825,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 40
     bgp:
       router-id: 0.12.0.42
       asn: 4200000039
@@ -1804,6 +1844,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 41
     bgp:
       router-id: 0.12.0.43
       asn: 4200000040
@@ -1822,6 +1863,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 42
     bgp:
       router-id: 0.12.0.44
       asn: 4200000041
@@ -1840,6 +1882,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 43
     bgp:
       router-id: 0.12.0.45
       asn: 4200000042
@@ -1858,6 +1901,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 44
     bgp:
       router-id: 0.12.0.46
       asn: 4200000043
@@ -1876,6 +1920,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 45
     bgp:
       router-id: 0.12.0.47
       asn: 4200000044
@@ -1894,6 +1939,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 46
     bgp:
       router-id: 0.12.0.48
       asn: 4200000045
@@ -1912,6 +1958,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 47
     bgp:
       router-id: 0.12.0.49
       asn: 4200000046
@@ -1930,6 +1977,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 48
     bgp:
       router-id: 0.12.0.50
       asn: 4200000047
@@ -1948,6 +1996,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 49
     bgp:
       router-id: 0.12.0.51
       asn: 4200000048
@@ -1966,6 +2015,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 50
     bgp:
       router-id: 0.12.0.52
       asn: 4200000049
@@ -1984,6 +2034,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 51
     bgp:
       router-id: 0.12.0.53
       asn: 4200000050
@@ -2002,6 +2053,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 52
     bgp:
       router-id: 0.12.0.54
       asn: 4200000051
@@ -2020,6 +2072,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 53
     bgp:
       router-id: 0.12.0.55
       asn: 4200000052
@@ -2038,6 +2091,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 54
     bgp:
       router-id: 0.12.0.56
       asn: 4200000053
@@ -2056,6 +2110,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 55
     bgp:
       router-id: 0.12.0.57
       asn: 4200000054
@@ -2074,6 +2129,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 56
     bgp:
       router-id: 0.12.0.58
       asn: 4200000055
@@ -2092,6 +2148,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 57
     bgp:
       router-id: 0.12.0.59
       asn: 4200000056
@@ -2110,6 +2167,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 58
     bgp:
       router-id: 0.12.0.60
       asn: 4200000057
@@ -2128,6 +2186,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 59
     bgp:
       router-id: 0.12.0.61
       asn: 4200000058
@@ -2146,6 +2205,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 60
     bgp:
       router-id: 0.12.0.62
       asn: 4200000059
@@ -2164,6 +2224,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 61
     bgp:
       router-id: 0.12.0.63
       asn: 4200000060
@@ -2182,6 +2243,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 62
     bgp:
       router-id: 0.12.0.64
       asn: 4200000061
@@ -2200,6 +2262,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 63
     bgp:
       router-id: 0.12.0.65
       asn: 4200000062
@@ -2218,6 +2281,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 64
     bgp:
       router-id: 0.12.0.66
       asn: 4200000063
@@ -2236,6 +2300,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 65
     bgp:
       router-id: 0.12.0.67
       asn: 4200000064
@@ -2254,6 +2319,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 66
     bgp:
       router-id: 0.12.0.68
       asn: 4200000065
@@ -2272,6 +2338,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 67
     bgp:
       router-id: 0.12.0.69
       asn: 4200000066
@@ -2290,6 +2357,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 68
     bgp:
       router-id: 0.12.0.70
       asn: 4200000067
@@ -2308,6 +2376,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 69
     bgp:
       router-id: 0.12.0.71
       asn: 4200000068
@@ -2326,6 +2395,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 70
     bgp:
       router-id: 0.12.0.72
       asn: 4200000069
@@ -2344,6 +2414,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 71
     bgp:
       router-id: 0.12.0.73
       asn: 4200000070
@@ -2362,6 +2433,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 72
     bgp:
       router-id: 0.12.0.74
       asn: 4200000071
@@ -2380,6 +2452,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 73
     bgp:
       router-id: 0.12.0.75
       asn: 4200000072
@@ -2398,6 +2471,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 74
     bgp:
       router-id: 0.12.0.76
       asn: 4200000073
@@ -2416,6 +2490,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 75
     bgp:
       router-id: 0.12.0.77
       asn: 4200000074
@@ -2434,6 +2509,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 76
     bgp:
       router-id: 0.12.0.78
       asn: 4200000075
@@ -2452,6 +2528,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 77
     bgp:
       router-id: 0.12.0.79
       asn: 4200000076
@@ -2470,6 +2547,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 78
     bgp:
       router-id: 0.12.0.80
       asn: 4200000077
@@ -2488,6 +2566,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 79
     bgp:
       router-id: 0.12.0.81
       asn: 4200000078
@@ -2506,6 +2585,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 80
     bgp:
       router-id: 0.12.0.82
       asn: 4200000079
@@ -2524,6 +2604,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 81
     bgp:
       router-id: 0.12.0.83
       asn: 4200000080
@@ -2542,6 +2623,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 82
     bgp:
       router-id: 0.12.0.84
       asn: 4200000081
@@ -2560,6 +2642,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 83
     bgp:
       router-id: 0.12.0.85
       asn: 4200000082
@@ -2578,6 +2661,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 84
     bgp:
       router-id: 0.12.0.86
       asn: 4200000083
@@ -2596,6 +2680,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 85
     bgp:
       router-id: 0.12.0.87
       asn: 4200000084
@@ -2614,6 +2699,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 86
     bgp:
       router-id: 0.12.0.88
       asn: 4200000085
@@ -2632,6 +2718,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 87
     bgp:
       router-id: 0.12.0.89
       asn: 4200000086
@@ -2650,6 +2737,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 88
     bgp:
       router-id: 0.12.0.90
       asn: 4200000087
@@ -2668,6 +2756,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 89
     bgp:
       router-id: 0.12.0.91
       asn: 4200000088
@@ -2686,6 +2775,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 90
     bgp:
       router-id: 0.12.0.92
       asn: 4200000089
@@ -2704,6 +2794,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 91
     bgp:
       router-id: 0.12.0.93
       asn: 4200000090
@@ -2722,6 +2813,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 92
     bgp:
       router-id: 0.12.0.94
       asn: 4200000091
@@ -2740,6 +2832,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 93
     bgp:
       router-id: 0.12.0.95
       asn: 4200000092
@@ -2758,6 +2851,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 94
     bgp:
       router-id: 0.12.0.96
       asn: 4200000093
@@ -2776,6 +2870,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 95
     bgp:
       router-id: 0.12.0.97
       asn: 4200000094
@@ -2794,6 +2889,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 96
     bgp:
       router-id: 0.12.0.98
       asn: 4200000095
@@ -2812,6 +2908,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 97
     bgp:
       router-id: 0.12.0.99
       asn: 4200000096
@@ -2830,6 +2927,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 98
     bgp:
       router-id: 0.12.0.100
       asn: 4200000097
@@ -2848,6 +2946,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 99
     bgp:
       router-id: 0.12.0.101
       asn: 4200000098
@@ -2866,6 +2965,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 100
     bgp:
       router-id: 0.12.0.102
       asn: 4200000099
@@ -2884,6 +2984,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 101
     bgp:
       router-id: 0.12.0.103
       asn: 4200000100
@@ -2902,6 +3003,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 102
     bgp:
       router-id: 0.12.0.104
       asn: 4200000101
@@ -2920,6 +3022,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 103
     bgp:
       router-id: 0.12.0.105
       asn: 4200000102
@@ -2938,6 +3041,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 104
     bgp:
       router-id: 0.12.0.106
       asn: 4200000103
@@ -2956,6 +3060,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 105
     bgp:
       router-id: 0.12.0.107
       asn: 4200000104
@@ -2974,6 +3079,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 106
     bgp:
       router-id: 0.12.0.108
       asn: 4200000105
@@ -2992,6 +3098,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 107
     bgp:
       router-id: 0.12.0.109
       asn: 4200000106
@@ -3010,6 +3117,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 108
     bgp:
       router-id: 0.12.0.110
       asn: 4200000107
@@ -3028,6 +3136,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 109
     bgp:
       router-id: 0.12.0.111
       asn: 4200000108
@@ -3046,6 +3155,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 110
     bgp:
       router-id: 0.12.0.112
       asn: 4200000109
@@ -3064,6 +3174,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 111
     bgp:
       router-id: 0.12.0.113
       asn: 4200000110
@@ -3082,6 +3193,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 112
     bgp:
       router-id: 0.12.0.114
       asn: 4200000111
@@ -3100,6 +3212,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 113
     bgp:
       router-id: 0.12.0.115
       asn: 4200000112
@@ -3118,6 +3231,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 114
     bgp:
       router-id: 0.12.0.116
       asn: 4200000113
@@ -3136,6 +3250,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 115
     bgp:
       router-id: 0.12.0.117
       asn: 4200000114
@@ -3154,6 +3269,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 116
     bgp:
       router-id: 0.12.0.118
       asn: 4200000115
@@ -3172,6 +3288,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 117
     bgp:
       router-id: 0.12.0.119
       asn: 4200000116
@@ -3190,6 +3307,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 118
     bgp:
       router-id: 0.12.0.120
       asn: 4200000117
@@ -3208,6 +3326,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 119
     bgp:
       router-id: 0.12.0.121
       asn: 4200000118
@@ -3226,6 +3345,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 120
     bgp:
       router-id: 0.12.0.122
       asn: 4200000119
@@ -3244,6 +3364,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 121
     bgp:
       router-id: 0.12.0.123
       asn: 4200000120
@@ -3262,6 +3383,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 122
     bgp:
       router-id: 0.12.0.124
       asn: 4200000121
@@ -3280,6 +3402,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 123
     bgp:
       router-id: 0.12.0.125
       asn: 4200000122
@@ -3298,6 +3421,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 124
     bgp:
       router-id: 0.12.0.126
       asn: 4200000123
@@ -3316,6 +3440,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 125
     bgp:
       router-id: 0.12.0.127
       asn: 4200000124
@@ -3334,6 +3459,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 126
     bgp:
       router-id: 0.12.0.128
       asn: 4200000125
@@ -3352,6 +3478,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 127
     bgp:
       router-id: 0.12.0.129
       asn: 4200000126
@@ -3370,6 +3497,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 128
     bgp:
       router-id: 0.12.0.130
       asn: 4200000127
@@ -3388,6 +3516,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 129
     bgp:
       router-id: 0.12.0.131
       asn: 4200000128
@@ -3406,6 +3535,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 130
     bgp:
       router-id: 0.12.0.132
       asn: 4200000129
@@ -3424,6 +3554,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 131
     bgp:
       router-id: 0.12.0.133
       asn: 4200000130
@@ -3442,6 +3573,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 132
     bgp:
       router-id: 0.12.0.134
       asn: 4200000131
@@ -3460,6 +3592,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 133
     bgp:
       router-id: 0.12.0.135
       asn: 4200000132
@@ -3478,6 +3611,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 134
     bgp:
       router-id: 0.12.0.136
       asn: 4200000133
@@ -3496,6 +3630,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 135
     bgp:
       router-id: 0.12.0.137
       asn: 4200000134
@@ -3514,6 +3649,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 136
     bgp:
       router-id: 0.12.0.138
       asn: 4200000135
@@ -3532,6 +3668,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 137
     bgp:
       router-id: 0.12.0.139
       asn: 4200000136
@@ -3550,6 +3687,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 138
     bgp:
       router-id: 0.12.0.140
       asn: 4200000137
@@ -3568,6 +3706,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 139
     bgp:
       router-id: 0.12.0.141
       asn: 4200000138
@@ -3586,6 +3725,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 140
     bgp:
       router-id: 0.12.0.142
       asn: 4200000139
@@ -3604,6 +3744,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 141
     bgp:
       router-id: 0.12.0.143
       asn: 4200000140
@@ -3622,6 +3763,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 142
     bgp:
       router-id: 0.12.0.144
       asn: 4200000141
@@ -3640,6 +3782,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 143
     bgp:
       router-id: 0.12.0.145
       asn: 4200000142
@@ -3658,6 +3801,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 144
     bgp:
       router-id: 0.12.0.146
       asn: 4200000143
@@ -3676,6 +3820,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 145
     bgp:
       router-id: 0.12.0.147
       asn: 4200000144
@@ -3694,6 +3839,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 146
     bgp:
       router-id: 0.12.0.148
       asn: 4200000145
@@ -3712,6 +3858,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 147
     bgp:
       router-id: 0.12.0.149
       asn: 4200000146
@@ -3730,6 +3877,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 148
     bgp:
       router-id: 0.12.0.150
       asn: 4200000147
@@ -3748,6 +3896,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 149
     bgp:
       router-id: 0.12.0.151
       asn: 4200000148
@@ -3766,6 +3915,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 150
     bgp:
       router-id: 0.12.0.152
       asn: 4200000149
@@ -3784,6 +3934,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 151
     bgp:
       router-id: 0.12.0.153
       asn: 4200000150
@@ -3802,6 +3953,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 152
     bgp:
       router-id: 0.12.0.154
       asn: 4200000151
@@ -3820,6 +3972,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 153
     bgp:
       router-id: 0.12.0.155
       asn: 4200000152
@@ -3838,6 +3991,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 154
     bgp:
       router-id: 0.12.0.156
       asn: 4200000153
@@ -3856,6 +4010,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 155
     bgp:
       router-id: 0.12.0.157
       asn: 4200000154
@@ -3874,6 +4029,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 156
     bgp:
       router-id: 0.12.0.158
       asn: 4200000155
@@ -3892,6 +4048,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 157
     bgp:
       router-id: 0.12.0.159
       asn: 4200000156
@@ -3910,6 +4067,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 158
     bgp:
       router-id: 0.12.0.160
       asn: 4200000157
@@ -3928,6 +4086,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 159
     bgp:
       router-id: 0.12.0.161
       asn: 4200000158
@@ -3946,6 +4105,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 160
     bgp:
       router-id: 0.12.0.162
       asn: 4200000159
@@ -3964,6 +4124,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 161
     bgp:
       router-id: 0.12.0.163
       asn: 4200000160
@@ -3982,6 +4143,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 162
     bgp:
       router-id: 0.12.0.164
       asn: 4200000161
@@ -4000,6 +4162,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 163
     bgp:
       router-id: 0.12.0.165
       asn: 4200000162
@@ -4018,6 +4181,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 164
     bgp:
       router-id: 0.12.0.166
       asn: 4200000163
@@ -4036,6 +4200,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 165
     bgp:
       router-id: 0.12.0.167
       asn: 4200000164
@@ -4054,6 +4219,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 166
     bgp:
       router-id: 0.12.0.168
       asn: 4200000165
@@ -4072,6 +4238,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 167
     bgp:
       router-id: 0.12.0.169
       asn: 4200000166
@@ -4090,6 +4257,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 168
     bgp:
       router-id: 0.12.0.170
       asn: 4200000167
@@ -4108,6 +4276,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 169
     bgp:
       router-id: 0.12.0.171
       asn: 4200000168
@@ -4126,6 +4295,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 170
     bgp:
       router-id: 0.12.0.172
       asn: 4200000169
@@ -4144,6 +4314,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 171
     bgp:
       router-id: 0.12.0.173
       asn: 4200000170
@@ -4162,6 +4333,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 172
     bgp:
       router-id: 0.12.0.174
       asn: 4200000171
@@ -4180,6 +4352,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 173
     bgp:
       router-id: 0.12.0.175
       asn: 4200000172
@@ -4198,6 +4371,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 174
     bgp:
       router-id: 0.12.0.176
       asn: 4200000173
@@ -4216,6 +4390,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 175
     bgp:
       router-id: 0.12.0.177
       asn: 4200000174
@@ -4234,6 +4409,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 176
     bgp:
       router-id: 0.12.0.178
       asn: 4200000175
@@ -4252,6 +4428,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 177
     bgp:
       router-id: 0.12.0.179
       asn: 4200000176
@@ -4270,6 +4447,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 178
     bgp:
       router-id: 0.12.0.180
       asn: 4200000177
@@ -4288,6 +4466,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 179
     bgp:
       router-id: 0.12.0.181
       asn: 4200000178
@@ -4306,6 +4485,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 180
     bgp:
       router-id: 0.12.0.182
       asn: 4200000179
@@ -4324,6 +4504,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 181
     bgp:
       router-id: 0.12.0.183
       asn: 4200000180
@@ -4342,6 +4523,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 182
     bgp:
       router-id: 0.12.0.184
       asn: 4200000181
@@ -4360,6 +4542,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 183
     bgp:
       router-id: 0.12.0.185
       asn: 4200000182
@@ -4378,6 +4561,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 184
     bgp:
       router-id: 0.12.0.186
       asn: 4200000183
@@ -4396,6 +4580,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 185
     bgp:
       router-id: 0.12.0.187
       asn: 4200000184
@@ -4414,6 +4599,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 186
     bgp:
       router-id: 0.12.0.188
       asn: 4200000185
@@ -4432,6 +4618,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 187
     bgp:
       router-id: 0.12.0.189
       asn: 4200000186
@@ -4450,6 +4637,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 188
     bgp:
       router-id: 0.12.0.190
       asn: 4200000187
@@ -4468,6 +4656,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 189
     bgp:
       router-id: 0.12.0.191
       asn: 4200000188
@@ -4486,6 +4675,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 190
     bgp:
       router-id: 0.12.0.192
       asn: 4200000189
@@ -4504,6 +4694,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 191
     bgp:
       router-id: 0.12.0.193
       asn: 4200000190
@@ -4522,6 +4713,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 192
     bgp:
       router-id: 0.12.0.194
       asn: 4200000191
@@ -4540,6 +4732,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 193
     bgp:
       router-id: 0.12.0.195
       asn: 4200000192
@@ -4558,6 +4751,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 194
     bgp:
       router-id: 0.12.0.196
       asn: 4200000193
@@ -4576,6 +4770,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 195
     bgp:
       router-id: 0.12.0.197
       asn: 4200000194
@@ -4594,6 +4789,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 196
     bgp:
       router-id: 0.12.0.198
       asn: 4200000195
@@ -4612,6 +4808,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 197
     bgp:
       router-id: 0.12.0.199
       asn: 4200000196
@@ -4630,6 +4827,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 198
     bgp:
       router-id: 0.12.0.200
       asn: 4200000197
@@ -4648,6 +4846,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 199
     bgp:
       router-id: 0.12.0.201
       asn: 4200000198
@@ -4666,6 +4865,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 200
     bgp:
       router-id: 0.12.0.202
       asn: 4200000199
@@ -4684,6 +4884,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 201
     bgp:
       router-id: 0.12.0.203
       asn: 4200000200
@@ -4702,6 +4903,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 202
     bgp:
       router-id: 0.12.0.204
       asn: 4200000201
@@ -4720,6 +4922,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 203
     bgp:
       router-id: 0.12.0.205
       asn: 4200000202
@@ -4738,6 +4941,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 204
     bgp:
       router-id: 0.12.0.206
       asn: 4200000203
@@ -4756,6 +4960,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 205
     bgp:
       router-id: 0.12.0.207
       asn: 4200000204
@@ -4774,6 +4979,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 206
     bgp:
       router-id: 0.12.0.208
       asn: 4200000205
@@ -4792,6 +4998,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 207
     bgp:
       router-id: 0.12.0.209
       asn: 4200000206
@@ -4810,6 +5017,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 208
     bgp:
       router-id: 0.12.0.210
       asn: 4200000207
@@ -4828,6 +5036,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 209
     bgp:
       router-id: 0.12.0.211
       asn: 4200000208
@@ -4846,6 +5055,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 210
     bgp:
       router-id: 0.12.0.212
       asn: 4200000209
@@ -4864,6 +5074,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 211
     bgp:
       router-id: 0.12.0.213
       asn: 4200000210
@@ -4882,6 +5093,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 212
     bgp:
       router-id: 0.12.0.214
       asn: 4200000211
@@ -4900,6 +5112,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 213
     bgp:
       router-id: 0.12.0.215
       asn: 4200000212
@@ -4918,6 +5131,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 214
     bgp:
       router-id: 0.12.0.216
       asn: 4200000213
@@ -4936,6 +5150,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 215
     bgp:
       router-id: 0.12.0.217
       asn: 4200000214
@@ -4954,6 +5169,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 216
     bgp:
       router-id: 0.12.0.218
       asn: 4200000215
@@ -4972,6 +5188,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 217
     bgp:
       router-id: 0.12.0.219
       asn: 4200000216
@@ -4990,6 +5207,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 218
     bgp:
       router-id: 0.12.0.220
       asn: 4200000217
@@ -5008,6 +5226,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 219
     bgp:
       router-id: 0.12.0.221
       asn: 4200000218
@@ -5026,6 +5245,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 220
     bgp:
       router-id: 0.12.0.222
       asn: 4200000219
@@ -5044,6 +5264,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 221
     bgp:
       router-id: 0.12.0.223
       asn: 4200000220
@@ -5062,6 +5283,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 222
     bgp:
       router-id: 0.12.0.224
       asn: 4200000221
@@ -5080,6 +5302,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 223
     bgp:
       router-id: 0.12.0.225
       asn: 4200000222
@@ -5098,6 +5321,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 224
     bgp:
       router-id: 0.12.0.226
       asn: 4200000223
@@ -5116,6 +5340,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 225
     bgp:
       router-id: 0.12.0.227
       asn: 4200000224
@@ -5134,6 +5359,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 226
     bgp:
       router-id: 0.12.0.228
       asn: 4200000225
@@ -5152,6 +5378,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 227
     bgp:
       router-id: 0.12.0.229
       asn: 4200000226
@@ -5170,6 +5397,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 228
     bgp:
       router-id: 0.12.0.230
       asn: 4200000227
@@ -5188,6 +5416,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 229
     bgp:
       router-id: 0.12.0.231
       asn: 4200000228
@@ -5206,6 +5435,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 230
     bgp:
       router-id: 0.12.0.232
       asn: 4200000229
@@ -5224,6 +5454,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 231
     bgp:
       router-id: 0.12.0.233
       asn: 4200000230
@@ -5242,6 +5473,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 232
     bgp:
       router-id: 0.12.0.234
       asn: 4200000231
@@ -5260,6 +5492,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 233
     bgp:
       router-id: 0.12.0.235
       asn: 4200000232
@@ -5278,6 +5511,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 234
     bgp:
       router-id: 0.12.0.236
       asn: 4200000233
@@ -5296,6 +5530,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 235
     bgp:
       router-id: 0.12.0.237
       asn: 4200000234
@@ -5314,6 +5549,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 236
     bgp:
       router-id: 0.12.0.238
       asn: 4200000235
@@ -5332,6 +5568,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 237
     bgp:
       router-id: 0.12.0.239
       asn: 4200000236
@@ -5350,6 +5587,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 238
     bgp:
       router-id: 0.12.0.240
       asn: 4200000237
@@ -5368,6 +5606,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 239
     bgp:
       router-id: 0.12.0.241
       asn: 4200000238
@@ -5386,6 +5625,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 240
     bgp:
       router-id: 0.12.0.242
       asn: 4200000239
@@ -5404,6 +5644,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 241
     bgp:
       router-id: 0.12.0.243
       asn: 4200000240
@@ -5422,6 +5663,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 242
     bgp:
       router-id: 0.12.0.244
       asn: 4200000241
@@ -5440,6 +5682,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 243
     bgp:
       router-id: 0.12.0.245
       asn: 4200000242
@@ -5458,6 +5701,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 244
     bgp:
       router-id: 0.12.0.246
       asn: 4200000243
@@ -5476,6 +5720,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 245
     bgp:
       router-id: 0.12.0.247
       asn: 4200000244
@@ -5494,6 +5739,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 246
     bgp:
       router-id: 0.12.0.248
       asn: 4200000245
@@ -5512,6 +5758,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 247
     bgp:
       router-id: 0.12.0.249
       asn: 4200000246
@@ -5530,6 +5777,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 248
     bgp:
       router-id: 0.12.0.250
       asn: 4200000247
@@ -5548,6 +5796,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 249
     bgp:
       router-id: 0.12.0.251
       asn: 4200000248
@@ -5566,6 +5815,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 250
     bgp:
       router-id: 0.12.0.252
       asn: 4200000249
@@ -5584,6 +5834,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 251
     bgp:
       router-id: 0.12.0.253
       asn: 4200000250
@@ -5602,6 +5853,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 252
     bgp:
       router-id: 0.12.0.254
       asn: 4200000251
@@ -5620,6 +5872,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 253
     bgp:
       router-id: 0.12.0.255
       asn: 4200000252
@@ -5638,6 +5891,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 254
     bgp:
       router-id: 0.12.1.0
       asn: 4200000253

--- a/ansible/vars/topo_t1-isolated-d254u2.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2.yml
@@ -1084,7 +1084,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 01
+    tornum: 1
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -1103,7 +1103,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 02
+    tornum: 2
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -1122,7 +1122,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 03
+    tornum: 3
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -1141,7 +1141,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 04
+    tornum: 4
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -1160,7 +1160,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 05
+    tornum: 5
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -1179,7 +1179,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 06
+    tornum: 6
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -1198,7 +1198,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 07
+    tornum: 7
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -1217,7 +1217,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 08
+    tornum: 8
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -1236,7 +1236,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 09
+    tornum: 9
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008

--- a/ansible/vars/topo_t1-isolated-d254u2.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2.yml
@@ -1031,7 +1031,7 @@ configuration_properties:
     dut_type: LeafRouter
     podset_number: 1
     tor_number: 512
-    tor_subnet_number: 1
+    tor_subnet_number: 2
     max_tor_subnet_number: 16
     tor_subnet_size: 256
     nhipv6: FC0A::FF

--- a/ansible/vars/topo_t1-isolated-d254u2s1.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2s1.yml
@@ -1033,11 +1033,11 @@ configuration_properties:
   common:
     dut_asn: 4200100000
     dut_type: LeafRouter
-    podset_number: 200
-    tor_number: 16
-    tor_subnet_number: 2
+    podset_number: 1
+    tor_number: 512
+    tor_subnet_number: 1
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     nhipv6: FC0A::FF
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
@@ -1088,6 +1088,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 01
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -1106,6 +1107,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 02
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -1124,6 +1126,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 03
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -1142,6 +1145,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 04
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -1160,6 +1164,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 05
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -1178,6 +1183,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 06
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -1196,6 +1202,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 07
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -1214,6 +1221,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 08
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -1232,6 +1240,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 09
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008
@@ -1250,6 +1259,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 10
     bgp:
       router-id: 0.12.0.12
       asn: 4200000009
@@ -1268,6 +1278,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 11
     bgp:
       router-id: 0.12.0.13
       asn: 4200000010
@@ -1286,6 +1297,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 12
     bgp:
       router-id: 0.12.0.14
       asn: 4200000011
@@ -1304,6 +1316,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 13
     bgp:
       router-id: 0.12.0.15
       asn: 4200000012
@@ -1322,6 +1335,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 14
     bgp:
       router-id: 0.12.0.16
       asn: 4200000013
@@ -1340,6 +1354,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 15
     bgp:
       router-id: 0.12.0.17
       asn: 4200000014
@@ -1358,6 +1373,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 16
     bgp:
       router-id: 0.12.0.18
       asn: 4200000015
@@ -1376,6 +1392,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 17
     bgp:
       router-id: 0.12.0.19
       asn: 4200000016
@@ -1394,6 +1411,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 18
     bgp:
       router-id: 0.12.0.20
       asn: 4200000017
@@ -1412,6 +1430,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 19
     bgp:
       router-id: 0.12.0.21
       asn: 4200000018
@@ -1430,6 +1449,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 20
     bgp:
       router-id: 0.12.0.22
       asn: 4200000019
@@ -1448,6 +1468,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 21
     bgp:
       router-id: 0.12.0.23
       asn: 4200000020
@@ -1466,6 +1487,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 22
     bgp:
       router-id: 0.12.0.24
       asn: 4200000021
@@ -1484,6 +1506,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 23
     bgp:
       router-id: 0.12.0.25
       asn: 4200000022
@@ -1502,6 +1525,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 24
     bgp:
       router-id: 0.12.0.26
       asn: 4200000023
@@ -1520,6 +1544,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 25
     bgp:
       router-id: 0.12.0.27
       asn: 4200000024
@@ -1538,6 +1563,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 26
     bgp:
       router-id: 0.12.0.28
       asn: 4200000025
@@ -1556,6 +1582,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 27
     bgp:
       router-id: 0.12.0.29
       asn: 4200000026
@@ -1574,6 +1601,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 28
     bgp:
       router-id: 0.12.0.30
       asn: 4200000027
@@ -1592,6 +1620,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 29
     bgp:
       router-id: 0.12.0.31
       asn: 4200000028
@@ -1610,6 +1639,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 30
     bgp:
       router-id: 0.12.0.32
       asn: 4200000029
@@ -1628,6 +1658,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 31
     bgp:
       router-id: 0.12.0.33
       asn: 4200000030
@@ -1646,6 +1677,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 32
     bgp:
       router-id: 0.12.0.34
       asn: 4200000031
@@ -1664,6 +1696,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 33
     bgp:
       router-id: 0.12.0.35
       asn: 4200000032
@@ -1682,6 +1715,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 34
     bgp:
       router-id: 0.12.0.36
       asn: 4200000033
@@ -1700,6 +1734,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 35
     bgp:
       router-id: 0.12.0.37
       asn: 4200000034
@@ -1718,6 +1753,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 36
     bgp:
       router-id: 0.12.0.38
       asn: 4200000035
@@ -1736,6 +1772,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 37
     bgp:
       router-id: 0.12.0.39
       asn: 4200000036
@@ -1754,6 +1791,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 38
     bgp:
       router-id: 0.12.0.40
       asn: 4200000037
@@ -1772,6 +1810,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 39
     bgp:
       router-id: 0.12.0.41
       asn: 4200000038
@@ -1790,6 +1829,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 40
     bgp:
       router-id: 0.12.0.42
       asn: 4200000039
@@ -1808,6 +1848,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 41
     bgp:
       router-id: 0.12.0.43
       asn: 4200000040
@@ -1826,6 +1867,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 42
     bgp:
       router-id: 0.12.0.44
       asn: 4200000041
@@ -1844,6 +1886,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 43
     bgp:
       router-id: 0.12.0.45
       asn: 4200000042
@@ -1862,6 +1905,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 44
     bgp:
       router-id: 0.12.0.46
       asn: 4200000043
@@ -1880,6 +1924,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 45
     bgp:
       router-id: 0.12.0.47
       asn: 4200000044
@@ -1898,6 +1943,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 46
     bgp:
       router-id: 0.12.0.48
       asn: 4200000045
@@ -1916,6 +1962,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 47
     bgp:
       router-id: 0.12.0.49
       asn: 4200000046
@@ -1934,6 +1981,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 48
     bgp:
       router-id: 0.12.0.50
       asn: 4200000047
@@ -1952,6 +2000,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 49
     bgp:
       router-id: 0.12.0.51
       asn: 4200000048
@@ -1970,6 +2019,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 50
     bgp:
       router-id: 0.12.0.52
       asn: 4200000049
@@ -1988,6 +2038,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 51
     bgp:
       router-id: 0.12.0.53
       asn: 4200000050
@@ -2006,6 +2057,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 52
     bgp:
       router-id: 0.12.0.54
       asn: 4200000051
@@ -2024,6 +2076,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 53
     bgp:
       router-id: 0.12.0.55
       asn: 4200000052
@@ -2042,6 +2095,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 54
     bgp:
       router-id: 0.12.0.56
       asn: 4200000053
@@ -2060,6 +2114,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 55
     bgp:
       router-id: 0.12.0.57
       asn: 4200000054
@@ -2078,6 +2133,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 56
     bgp:
       router-id: 0.12.0.58
       asn: 4200000055
@@ -2096,6 +2152,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 57
     bgp:
       router-id: 0.12.0.59
       asn: 4200000056
@@ -2114,6 +2171,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 58
     bgp:
       router-id: 0.12.0.60
       asn: 4200000057
@@ -2132,6 +2190,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 59
     bgp:
       router-id: 0.12.0.61
       asn: 4200000058
@@ -2150,6 +2209,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 60
     bgp:
       router-id: 0.12.0.62
       asn: 4200000059
@@ -2168,6 +2228,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 61
     bgp:
       router-id: 0.12.0.63
       asn: 4200000060
@@ -2186,6 +2247,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 62
     bgp:
       router-id: 0.12.0.64
       asn: 4200000061
@@ -2204,6 +2266,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 63
     bgp:
       router-id: 0.12.0.65
       asn: 4200000062
@@ -2222,6 +2285,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 64
     bgp:
       router-id: 0.12.0.66
       asn: 4200000063
@@ -2240,6 +2304,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 65
     bgp:
       router-id: 0.12.0.67
       asn: 4200000064
@@ -2258,6 +2323,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 66
     bgp:
       router-id: 0.12.0.68
       asn: 4200000065
@@ -2276,6 +2342,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 67
     bgp:
       router-id: 0.12.0.69
       asn: 4200000066
@@ -2294,6 +2361,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 68
     bgp:
       router-id: 0.12.0.70
       asn: 4200000067
@@ -2312,6 +2380,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 69
     bgp:
       router-id: 0.12.0.71
       asn: 4200000068
@@ -2330,6 +2399,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 70
     bgp:
       router-id: 0.12.0.72
       asn: 4200000069
@@ -2348,6 +2418,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 71
     bgp:
       router-id: 0.12.0.73
       asn: 4200000070
@@ -2366,6 +2437,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 72
     bgp:
       router-id: 0.12.0.74
       asn: 4200000071
@@ -2384,6 +2456,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 73
     bgp:
       router-id: 0.12.0.75
       asn: 4200000072
@@ -2402,6 +2475,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 74
     bgp:
       router-id: 0.12.0.76
       asn: 4200000073
@@ -2420,6 +2494,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 75
     bgp:
       router-id: 0.12.0.77
       asn: 4200000074
@@ -2438,6 +2513,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 76
     bgp:
       router-id: 0.12.0.78
       asn: 4200000075
@@ -2456,6 +2532,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 77
     bgp:
       router-id: 0.12.0.79
       asn: 4200000076
@@ -2474,6 +2551,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 78
     bgp:
       router-id: 0.12.0.80
       asn: 4200000077
@@ -2492,6 +2570,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 79
     bgp:
       router-id: 0.12.0.81
       asn: 4200000078
@@ -2510,6 +2589,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 80
     bgp:
       router-id: 0.12.0.82
       asn: 4200000079
@@ -2528,6 +2608,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 81
     bgp:
       router-id: 0.12.0.83
       asn: 4200000080
@@ -2546,6 +2627,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 82
     bgp:
       router-id: 0.12.0.84
       asn: 4200000081
@@ -2564,6 +2646,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 83
     bgp:
       router-id: 0.12.0.85
       asn: 4200000082
@@ -2582,6 +2665,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 84
     bgp:
       router-id: 0.12.0.86
       asn: 4200000083
@@ -2600,6 +2684,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 85
     bgp:
       router-id: 0.12.0.87
       asn: 4200000084
@@ -2618,6 +2703,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 86
     bgp:
       router-id: 0.12.0.88
       asn: 4200000085
@@ -2636,6 +2722,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 87
     bgp:
       router-id: 0.12.0.89
       asn: 4200000086
@@ -2654,6 +2741,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 88
     bgp:
       router-id: 0.12.0.90
       asn: 4200000087
@@ -2672,6 +2760,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 89
     bgp:
       router-id: 0.12.0.91
       asn: 4200000088
@@ -2690,6 +2779,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 90
     bgp:
       router-id: 0.12.0.92
       asn: 4200000089
@@ -2708,6 +2798,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 91
     bgp:
       router-id: 0.12.0.93
       asn: 4200000090
@@ -2726,6 +2817,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 92
     bgp:
       router-id: 0.12.0.94
       asn: 4200000091
@@ -2744,6 +2836,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 93
     bgp:
       router-id: 0.12.0.95
       asn: 4200000092
@@ -2762,6 +2855,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 94
     bgp:
       router-id: 0.12.0.96
       asn: 4200000093
@@ -2780,6 +2874,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 95
     bgp:
       router-id: 0.12.0.97
       asn: 4200000094
@@ -2798,6 +2893,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 96
     bgp:
       router-id: 0.12.0.98
       asn: 4200000095
@@ -2816,6 +2912,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 97
     bgp:
       router-id: 0.12.0.99
       asn: 4200000096
@@ -2834,6 +2931,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 98
     bgp:
       router-id: 0.12.0.100
       asn: 4200000097
@@ -2852,6 +2950,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 99
     bgp:
       router-id: 0.12.0.101
       asn: 4200000098
@@ -2870,6 +2969,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 100
     bgp:
       router-id: 0.12.0.102
       asn: 4200000099
@@ -2888,6 +2988,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 101
     bgp:
       router-id: 0.12.0.103
       asn: 4200000100
@@ -2906,6 +3007,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 102
     bgp:
       router-id: 0.12.0.104
       asn: 4200000101
@@ -2924,6 +3026,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 103
     bgp:
       router-id: 0.12.0.105
       asn: 4200000102
@@ -2942,6 +3045,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 104
     bgp:
       router-id: 0.12.0.106
       asn: 4200000103
@@ -2960,6 +3064,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 105
     bgp:
       router-id: 0.12.0.107
       asn: 4200000104
@@ -2978,6 +3083,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 106
     bgp:
       router-id: 0.12.0.108
       asn: 4200000105
@@ -2996,6 +3102,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 107
     bgp:
       router-id: 0.12.0.109
       asn: 4200000106
@@ -3014,6 +3121,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 108
     bgp:
       router-id: 0.12.0.110
       asn: 4200000107
@@ -3032,6 +3140,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 109
     bgp:
       router-id: 0.12.0.111
       asn: 4200000108
@@ -3050,6 +3159,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 110
     bgp:
       router-id: 0.12.0.112
       asn: 4200000109
@@ -3068,6 +3178,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 111
     bgp:
       router-id: 0.12.0.113
       asn: 4200000110
@@ -3086,6 +3197,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 112
     bgp:
       router-id: 0.12.0.114
       asn: 4200000111
@@ -3104,6 +3216,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 113
     bgp:
       router-id: 0.12.0.115
       asn: 4200000112
@@ -3122,6 +3235,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 114
     bgp:
       router-id: 0.12.0.116
       asn: 4200000113
@@ -3140,6 +3254,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 115
     bgp:
       router-id: 0.12.0.117
       asn: 4200000114
@@ -3158,6 +3273,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 116
     bgp:
       router-id: 0.12.0.118
       asn: 4200000115
@@ -3176,6 +3292,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 117
     bgp:
       router-id: 0.12.0.119
       asn: 4200000116
@@ -3194,6 +3311,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 118
     bgp:
       router-id: 0.12.0.120
       asn: 4200000117
@@ -3212,6 +3330,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 119
     bgp:
       router-id: 0.12.0.121
       asn: 4200000118
@@ -3230,6 +3349,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 120
     bgp:
       router-id: 0.12.0.122
       asn: 4200000119
@@ -3248,6 +3368,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 121
     bgp:
       router-id: 0.12.0.123
       asn: 4200000120
@@ -3266,6 +3387,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 122
     bgp:
       router-id: 0.12.0.124
       asn: 4200000121
@@ -3284,6 +3406,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 123
     bgp:
       router-id: 0.12.0.125
       asn: 4200000122
@@ -3302,6 +3425,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 124
     bgp:
       router-id: 0.12.0.126
       asn: 4200000123
@@ -3320,6 +3444,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 125
     bgp:
       router-id: 0.12.0.127
       asn: 4200000124
@@ -3338,6 +3463,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 126
     bgp:
       router-id: 0.12.0.128
       asn: 4200000125
@@ -3356,6 +3482,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 127
     bgp:
       router-id: 0.12.0.129
       asn: 4200000126
@@ -3374,6 +3501,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 128
     bgp:
       router-id: 0.12.0.130
       asn: 4200000127
@@ -3392,6 +3520,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 129
     bgp:
       router-id: 0.12.0.131
       asn: 4200000128
@@ -3410,6 +3539,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 130
     bgp:
       router-id: 0.12.0.132
       asn: 4200000129
@@ -3428,6 +3558,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 131
     bgp:
       router-id: 0.12.0.133
       asn: 4200000130
@@ -3446,6 +3577,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 132
     bgp:
       router-id: 0.12.0.134
       asn: 4200000131
@@ -3464,6 +3596,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 133
     bgp:
       router-id: 0.12.0.135
       asn: 4200000132
@@ -3482,6 +3615,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 134
     bgp:
       router-id: 0.12.0.136
       asn: 4200000133
@@ -3500,6 +3634,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 135
     bgp:
       router-id: 0.12.0.137
       asn: 4200000134
@@ -3518,6 +3653,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 136
     bgp:
       router-id: 0.12.0.138
       asn: 4200000135
@@ -3536,6 +3672,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 137
     bgp:
       router-id: 0.12.0.139
       asn: 4200000136
@@ -3554,6 +3691,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 138
     bgp:
       router-id: 0.12.0.140
       asn: 4200000137
@@ -3572,6 +3710,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 139
     bgp:
       router-id: 0.12.0.141
       asn: 4200000138
@@ -3590,6 +3729,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 140
     bgp:
       router-id: 0.12.0.142
       asn: 4200000139
@@ -3608,6 +3748,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 141
     bgp:
       router-id: 0.12.0.143
       asn: 4200000140
@@ -3626,6 +3767,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 142
     bgp:
       router-id: 0.12.0.144
       asn: 4200000141
@@ -3644,6 +3786,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 143
     bgp:
       router-id: 0.12.0.145
       asn: 4200000142
@@ -3662,6 +3805,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 144
     bgp:
       router-id: 0.12.0.146
       asn: 4200000143
@@ -3680,6 +3824,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 145
     bgp:
       router-id: 0.12.0.147
       asn: 4200000144
@@ -3698,6 +3843,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 146
     bgp:
       router-id: 0.12.0.148
       asn: 4200000145
@@ -3716,6 +3862,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 147
     bgp:
       router-id: 0.12.0.149
       asn: 4200000146
@@ -3734,6 +3881,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 148
     bgp:
       router-id: 0.12.0.150
       asn: 4200000147
@@ -3752,6 +3900,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 149
     bgp:
       router-id: 0.12.0.151
       asn: 4200000148
@@ -3770,6 +3919,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 150
     bgp:
       router-id: 0.12.0.152
       asn: 4200000149
@@ -3788,6 +3938,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 151
     bgp:
       router-id: 0.12.0.153
       asn: 4200000150
@@ -3806,6 +3957,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 152
     bgp:
       router-id: 0.12.0.154
       asn: 4200000151
@@ -3824,6 +3976,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 153
     bgp:
       router-id: 0.12.0.155
       asn: 4200000152
@@ -3842,6 +3995,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 154
     bgp:
       router-id: 0.12.0.156
       asn: 4200000153
@@ -3860,6 +4014,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 155
     bgp:
       router-id: 0.12.0.157
       asn: 4200000154
@@ -3878,6 +4033,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 156
     bgp:
       router-id: 0.12.0.158
       asn: 4200000155
@@ -3896,6 +4052,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 157
     bgp:
       router-id: 0.12.0.159
       asn: 4200000156
@@ -3914,6 +4071,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 158
     bgp:
       router-id: 0.12.0.160
       asn: 4200000157
@@ -3932,6 +4090,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 159
     bgp:
       router-id: 0.12.0.161
       asn: 4200000158
@@ -3950,6 +4109,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 160
     bgp:
       router-id: 0.12.0.162
       asn: 4200000159
@@ -3968,6 +4128,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 161
     bgp:
       router-id: 0.12.0.163
       asn: 4200000160
@@ -3986,6 +4147,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 162
     bgp:
       router-id: 0.12.0.164
       asn: 4200000161
@@ -4004,6 +4166,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 163
     bgp:
       router-id: 0.12.0.165
       asn: 4200000162
@@ -4022,6 +4185,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 164
     bgp:
       router-id: 0.12.0.166
       asn: 4200000163
@@ -4040,6 +4204,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 165
     bgp:
       router-id: 0.12.0.167
       asn: 4200000164
@@ -4058,6 +4223,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 166
     bgp:
       router-id: 0.12.0.168
       asn: 4200000165
@@ -4076,6 +4242,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 167
     bgp:
       router-id: 0.12.0.169
       asn: 4200000166
@@ -4094,6 +4261,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 168
     bgp:
       router-id: 0.12.0.170
       asn: 4200000167
@@ -4112,6 +4280,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 169
     bgp:
       router-id: 0.12.0.171
       asn: 4200000168
@@ -4130,6 +4299,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 170
     bgp:
       router-id: 0.12.0.172
       asn: 4200000169
@@ -4148,6 +4318,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 171
     bgp:
       router-id: 0.12.0.173
       asn: 4200000170
@@ -4166,6 +4337,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 172
     bgp:
       router-id: 0.12.0.174
       asn: 4200000171
@@ -4184,6 +4356,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 173
     bgp:
       router-id: 0.12.0.175
       asn: 4200000172
@@ -4202,6 +4375,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 174
     bgp:
       router-id: 0.12.0.176
       asn: 4200000173
@@ -4220,6 +4394,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 175
     bgp:
       router-id: 0.12.0.177
       asn: 4200000174
@@ -4238,6 +4413,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 176
     bgp:
       router-id: 0.12.0.178
       asn: 4200000175
@@ -4256,6 +4432,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 177
     bgp:
       router-id: 0.12.0.179
       asn: 4200000176
@@ -4274,6 +4451,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 178
     bgp:
       router-id: 0.12.0.180
       asn: 4200000177
@@ -4292,6 +4470,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 179
     bgp:
       router-id: 0.12.0.181
       asn: 4200000178
@@ -4310,6 +4489,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 180
     bgp:
       router-id: 0.12.0.182
       asn: 4200000179
@@ -4328,6 +4508,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 181
     bgp:
       router-id: 0.12.0.183
       asn: 4200000180
@@ -4346,6 +4527,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 182
     bgp:
       router-id: 0.12.0.184
       asn: 4200000181
@@ -4364,6 +4546,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 183
     bgp:
       router-id: 0.12.0.185
       asn: 4200000182
@@ -4382,6 +4565,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 184
     bgp:
       router-id: 0.12.0.186
       asn: 4200000183
@@ -4400,6 +4584,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 185
     bgp:
       router-id: 0.12.0.187
       asn: 4200000184
@@ -4418,6 +4603,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 186
     bgp:
       router-id: 0.12.0.188
       asn: 4200000185
@@ -4436,6 +4622,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 187
     bgp:
       router-id: 0.12.0.189
       asn: 4200000186
@@ -4454,6 +4641,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 188
     bgp:
       router-id: 0.12.0.190
       asn: 4200000187
@@ -4472,6 +4660,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 189
     bgp:
       router-id: 0.12.0.191
       asn: 4200000188
@@ -4490,6 +4679,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 190
     bgp:
       router-id: 0.12.0.192
       asn: 4200000189
@@ -4508,6 +4698,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 191
     bgp:
       router-id: 0.12.0.193
       asn: 4200000190
@@ -4526,6 +4717,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 192
     bgp:
       router-id: 0.12.0.194
       asn: 4200000191
@@ -4544,6 +4736,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 193
     bgp:
       router-id: 0.12.0.195
       asn: 4200000192
@@ -4562,6 +4755,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 194
     bgp:
       router-id: 0.12.0.196
       asn: 4200000193
@@ -4580,6 +4774,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 195
     bgp:
       router-id: 0.12.0.197
       asn: 4200000194
@@ -4598,6 +4793,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 196
     bgp:
       router-id: 0.12.0.198
       asn: 4200000195
@@ -4616,6 +4812,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 197
     bgp:
       router-id: 0.12.0.199
       asn: 4200000196
@@ -4634,6 +4831,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 198
     bgp:
       router-id: 0.12.0.200
       asn: 4200000197
@@ -4652,6 +4850,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 199
     bgp:
       router-id: 0.12.0.201
       asn: 4200000198
@@ -4670,6 +4869,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 200
     bgp:
       router-id: 0.12.0.202
       asn: 4200000199
@@ -4688,6 +4888,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 201
     bgp:
       router-id: 0.12.0.203
       asn: 4200000200
@@ -4706,6 +4907,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 202
     bgp:
       router-id: 0.12.0.204
       asn: 4200000201
@@ -4724,6 +4926,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 203
     bgp:
       router-id: 0.12.0.205
       asn: 4200000202
@@ -4742,6 +4945,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 204
     bgp:
       router-id: 0.12.0.206
       asn: 4200000203
@@ -4760,6 +4964,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 205
     bgp:
       router-id: 0.12.0.207
       asn: 4200000204
@@ -4778,6 +4983,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 206
     bgp:
       router-id: 0.12.0.208
       asn: 4200000205
@@ -4796,6 +5002,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 207
     bgp:
       router-id: 0.12.0.209
       asn: 4200000206
@@ -4814,6 +5021,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 208
     bgp:
       router-id: 0.12.0.210
       asn: 4200000207
@@ -4832,6 +5040,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 209
     bgp:
       router-id: 0.12.0.211
       asn: 4200000208
@@ -4850,6 +5059,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 210
     bgp:
       router-id: 0.12.0.212
       asn: 4200000209
@@ -4868,6 +5078,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 211
     bgp:
       router-id: 0.12.0.213
       asn: 4200000210
@@ -4886,6 +5097,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 212
     bgp:
       router-id: 0.12.0.214
       asn: 4200000211
@@ -4904,6 +5116,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 213
     bgp:
       router-id: 0.12.0.215
       asn: 4200000212
@@ -4922,6 +5135,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 214
     bgp:
       router-id: 0.12.0.216
       asn: 4200000213
@@ -4940,6 +5154,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 215
     bgp:
       router-id: 0.12.0.217
       asn: 4200000214
@@ -4958,6 +5173,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 216
     bgp:
       router-id: 0.12.0.218
       asn: 4200000215
@@ -4976,6 +5192,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 217
     bgp:
       router-id: 0.12.0.219
       asn: 4200000216
@@ -4994,6 +5211,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 218
     bgp:
       router-id: 0.12.0.220
       asn: 4200000217
@@ -5012,6 +5230,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 219
     bgp:
       router-id: 0.12.0.221
       asn: 4200000218
@@ -5030,6 +5249,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 220
     bgp:
       router-id: 0.12.0.222
       asn: 4200000219
@@ -5048,6 +5268,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 221
     bgp:
       router-id: 0.12.0.223
       asn: 4200000220
@@ -5066,6 +5287,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 222
     bgp:
       router-id: 0.12.0.224
       asn: 4200000221
@@ -5084,6 +5306,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 223
     bgp:
       router-id: 0.12.0.225
       asn: 4200000222
@@ -5102,6 +5325,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 224
     bgp:
       router-id: 0.12.0.226
       asn: 4200000223
@@ -5120,6 +5344,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 225
     bgp:
       router-id: 0.12.0.227
       asn: 4200000224
@@ -5138,6 +5363,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 226
     bgp:
       router-id: 0.12.0.228
       asn: 4200000225
@@ -5156,6 +5382,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 227
     bgp:
       router-id: 0.12.0.229
       asn: 4200000226
@@ -5174,6 +5401,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 228
     bgp:
       router-id: 0.12.0.230
       asn: 4200000227
@@ -5192,6 +5420,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 229
     bgp:
       router-id: 0.12.0.231
       asn: 4200000228
@@ -5210,6 +5439,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 230
     bgp:
       router-id: 0.12.0.232
       asn: 4200000229
@@ -5228,6 +5458,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 231
     bgp:
       router-id: 0.12.0.233
       asn: 4200000230
@@ -5246,6 +5477,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 232
     bgp:
       router-id: 0.12.0.234
       asn: 4200000231
@@ -5264,6 +5496,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 233
     bgp:
       router-id: 0.12.0.235
       asn: 4200000232
@@ -5282,6 +5515,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 234
     bgp:
       router-id: 0.12.0.236
       asn: 4200000233
@@ -5300,6 +5534,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 235
     bgp:
       router-id: 0.12.0.237
       asn: 4200000234
@@ -5318,6 +5553,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 236
     bgp:
       router-id: 0.12.0.238
       asn: 4200000235
@@ -5336,6 +5572,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 237
     bgp:
       router-id: 0.12.0.239
       asn: 4200000236
@@ -5354,6 +5591,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 238
     bgp:
       router-id: 0.12.0.240
       asn: 4200000237
@@ -5372,6 +5610,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 239
     bgp:
       router-id: 0.12.0.241
       asn: 4200000238
@@ -5390,6 +5629,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 240
     bgp:
       router-id: 0.12.0.242
       asn: 4200000239
@@ -5408,6 +5648,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 241
     bgp:
       router-id: 0.12.0.243
       asn: 4200000240
@@ -5426,6 +5667,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 242
     bgp:
       router-id: 0.12.0.244
       asn: 4200000241
@@ -5444,6 +5686,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 243
     bgp:
       router-id: 0.12.0.245
       asn: 4200000242
@@ -5462,6 +5705,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 244
     bgp:
       router-id: 0.12.0.246
       asn: 4200000243
@@ -5480,6 +5724,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 245
     bgp:
       router-id: 0.12.0.247
       asn: 4200000244
@@ -5498,6 +5743,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 246
     bgp:
       router-id: 0.12.0.248
       asn: 4200000245
@@ -5516,6 +5762,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 247
     bgp:
       router-id: 0.12.0.249
       asn: 4200000246
@@ -5534,6 +5781,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 248
     bgp:
       router-id: 0.12.0.250
       asn: 4200000247
@@ -5552,6 +5800,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 249
     bgp:
       router-id: 0.12.0.251
       asn: 4200000248
@@ -5570,6 +5819,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 250
     bgp:
       router-id: 0.12.0.252
       asn: 4200000249
@@ -5588,6 +5838,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 251
     bgp:
       router-id: 0.12.0.253
       asn: 4200000250
@@ -5606,6 +5857,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 252
     bgp:
       router-id: 0.12.0.254
       asn: 4200000251
@@ -5624,6 +5876,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 253
     bgp:
       router-id: 0.12.0.255
       asn: 4200000252
@@ -5642,6 +5895,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 254
     bgp:
       router-id: 0.12.1.0
       asn: 4200000253

--- a/ansible/vars/topo_t1-isolated-d254u2s1.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2s1.yml
@@ -1088,7 +1088,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 01
+    tornum: 1
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -1107,7 +1107,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 02
+    tornum: 2
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -1126,7 +1126,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 03
+    tornum: 3
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -1145,7 +1145,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 04
+    tornum: 4
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -1164,7 +1164,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 05
+    tornum: 5
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -1183,7 +1183,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 06
+    tornum: 6
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -1202,7 +1202,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 07
+    tornum: 7
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -1221,7 +1221,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 08
+    tornum: 8
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -1240,7 +1240,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 09
+    tornum: 9
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008

--- a/ansible/vars/topo_t1-isolated-d254u2s1.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2s1.yml
@@ -1035,7 +1035,7 @@ configuration_properties:
     dut_type: LeafRouter
     podset_number: 1
     tor_number: 512
-    tor_subnet_number: 1
+    tor_subnet_number: 2
     max_tor_subnet_number: 16
     tor_subnet_size: 256
     nhipv6: FC0A::FF

--- a/ansible/vars/topo_t1-isolated-d254u2s2.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2s2.yml
@@ -1092,7 +1092,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 01
+    tornum: 1
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -1111,7 +1111,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 02
+    tornum: 2
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -1130,7 +1130,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 03
+    tornum: 3
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -1149,7 +1149,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 04
+    tornum: 4
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -1168,7 +1168,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 05
+    tornum: 5
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -1187,7 +1187,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 06
+    tornum: 6
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -1206,7 +1206,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 07
+    tornum: 7
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -1225,7 +1225,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 08
+    tornum: 8
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -1244,7 +1244,7 @@ configuration:
     properties:
     - common
     - tor
-    tornum: 09
+    tornum: 9
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008

--- a/ansible/vars/topo_t1-isolated-d254u2s2.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2s2.yml
@@ -1037,11 +1037,11 @@ configuration_properties:
   common:
     dut_asn: 4200100000
     dut_type: LeafRouter
-    podset_number: 200
-    tor_number: 16
-    tor_subnet_number: 2
+    podset_number: 1
+    tor_number: 512
+    tor_subnet_number: 1
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     nhipv6: FC0A::FF
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
@@ -1092,6 +1092,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 01
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -1110,6 +1111,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 02
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -1128,6 +1130,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 03
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -1146,6 +1149,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 04
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -1164,6 +1168,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 05
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -1182,6 +1187,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 06
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -1200,6 +1206,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 07
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -1218,6 +1225,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 08
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -1236,6 +1244,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 09
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008
@@ -1254,6 +1263,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 10
     bgp:
       router-id: 0.12.0.12
       asn: 4200000009
@@ -1272,6 +1282,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 11
     bgp:
       router-id: 0.12.0.13
       asn: 4200000010
@@ -1290,6 +1301,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 12
     bgp:
       router-id: 0.12.0.14
       asn: 4200000011
@@ -1308,6 +1320,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 13
     bgp:
       router-id: 0.12.0.15
       asn: 4200000012
@@ -1326,6 +1339,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 14
     bgp:
       router-id: 0.12.0.16
       asn: 4200000013
@@ -1344,6 +1358,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 15
     bgp:
       router-id: 0.12.0.17
       asn: 4200000014
@@ -1362,6 +1377,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 16
     bgp:
       router-id: 0.12.0.18
       asn: 4200000015
@@ -1380,6 +1396,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 17
     bgp:
       router-id: 0.12.0.19
       asn: 4200000016
@@ -1398,6 +1415,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 18
     bgp:
       router-id: 0.12.0.20
       asn: 4200000017
@@ -1416,6 +1434,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 19
     bgp:
       router-id: 0.12.0.21
       asn: 4200000018
@@ -1434,6 +1453,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 20
     bgp:
       router-id: 0.12.0.22
       asn: 4200000019
@@ -1452,6 +1472,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 21
     bgp:
       router-id: 0.12.0.23
       asn: 4200000020
@@ -1470,6 +1491,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 22
     bgp:
       router-id: 0.12.0.24
       asn: 4200000021
@@ -1488,6 +1510,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 23
     bgp:
       router-id: 0.12.0.25
       asn: 4200000022
@@ -1506,6 +1529,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 24
     bgp:
       router-id: 0.12.0.26
       asn: 4200000023
@@ -1524,6 +1548,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 25
     bgp:
       router-id: 0.12.0.27
       asn: 4200000024
@@ -1542,6 +1567,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 26
     bgp:
       router-id: 0.12.0.28
       asn: 4200000025
@@ -1560,6 +1586,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 27
     bgp:
       router-id: 0.12.0.29
       asn: 4200000026
@@ -1578,6 +1605,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 28
     bgp:
       router-id: 0.12.0.30
       asn: 4200000027
@@ -1596,6 +1624,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 29
     bgp:
       router-id: 0.12.0.31
       asn: 4200000028
@@ -1614,6 +1643,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 30
     bgp:
       router-id: 0.12.0.32
       asn: 4200000029
@@ -1632,6 +1662,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 31
     bgp:
       router-id: 0.12.0.33
       asn: 4200000030
@@ -1650,6 +1681,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 32
     bgp:
       router-id: 0.12.0.34
       asn: 4200000031
@@ -1668,6 +1700,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 33
     bgp:
       router-id: 0.12.0.35
       asn: 4200000032
@@ -1686,6 +1719,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 34
     bgp:
       router-id: 0.12.0.36
       asn: 4200000033
@@ -1704,6 +1738,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 35
     bgp:
       router-id: 0.12.0.37
       asn: 4200000034
@@ -1722,6 +1757,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 36
     bgp:
       router-id: 0.12.0.38
       asn: 4200000035
@@ -1740,6 +1776,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 37
     bgp:
       router-id: 0.12.0.39
       asn: 4200000036
@@ -1758,6 +1795,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 38
     bgp:
       router-id: 0.12.0.40
       asn: 4200000037
@@ -1776,6 +1814,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 39
     bgp:
       router-id: 0.12.0.41
       asn: 4200000038
@@ -1794,6 +1833,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 40
     bgp:
       router-id: 0.12.0.42
       asn: 4200000039
@@ -1812,6 +1852,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 41
     bgp:
       router-id: 0.12.0.43
       asn: 4200000040
@@ -1830,6 +1871,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 42
     bgp:
       router-id: 0.12.0.44
       asn: 4200000041
@@ -1848,6 +1890,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 43
     bgp:
       router-id: 0.12.0.45
       asn: 4200000042
@@ -1866,6 +1909,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 44
     bgp:
       router-id: 0.12.0.46
       asn: 4200000043
@@ -1884,6 +1928,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 45
     bgp:
       router-id: 0.12.0.47
       asn: 4200000044
@@ -1902,6 +1947,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 46
     bgp:
       router-id: 0.12.0.48
       asn: 4200000045
@@ -1920,6 +1966,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 47
     bgp:
       router-id: 0.12.0.49
       asn: 4200000046
@@ -1938,6 +1985,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 48
     bgp:
       router-id: 0.12.0.50
       asn: 4200000047
@@ -1956,6 +2004,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 49
     bgp:
       router-id: 0.12.0.51
       asn: 4200000048
@@ -1974,6 +2023,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 50
     bgp:
       router-id: 0.12.0.52
       asn: 4200000049
@@ -1992,6 +2042,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 51
     bgp:
       router-id: 0.12.0.53
       asn: 4200000050
@@ -2010,6 +2061,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 52
     bgp:
       router-id: 0.12.0.54
       asn: 4200000051
@@ -2028,6 +2080,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 53
     bgp:
       router-id: 0.12.0.55
       asn: 4200000052
@@ -2046,6 +2099,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 54
     bgp:
       router-id: 0.12.0.56
       asn: 4200000053
@@ -2064,6 +2118,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 55
     bgp:
       router-id: 0.12.0.57
       asn: 4200000054
@@ -2082,6 +2137,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 56
     bgp:
       router-id: 0.12.0.58
       asn: 4200000055
@@ -2100,6 +2156,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 57
     bgp:
       router-id: 0.12.0.59
       asn: 4200000056
@@ -2118,6 +2175,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 58
     bgp:
       router-id: 0.12.0.60
       asn: 4200000057
@@ -2136,6 +2194,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 59
     bgp:
       router-id: 0.12.0.61
       asn: 4200000058
@@ -2154,6 +2213,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 60
     bgp:
       router-id: 0.12.0.62
       asn: 4200000059
@@ -2172,6 +2232,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 61
     bgp:
       router-id: 0.12.0.63
       asn: 4200000060
@@ -2190,6 +2251,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 62
     bgp:
       router-id: 0.12.0.64
       asn: 4200000061
@@ -2208,6 +2270,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 63
     bgp:
       router-id: 0.12.0.65
       asn: 4200000062
@@ -2226,6 +2289,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 64
     bgp:
       router-id: 0.12.0.66
       asn: 4200000063
@@ -2244,6 +2308,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 65
     bgp:
       router-id: 0.12.0.67
       asn: 4200000064
@@ -2262,6 +2327,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 66
     bgp:
       router-id: 0.12.0.68
       asn: 4200000065
@@ -2280,6 +2346,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 67
     bgp:
       router-id: 0.12.0.69
       asn: 4200000066
@@ -2298,6 +2365,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 68
     bgp:
       router-id: 0.12.0.70
       asn: 4200000067
@@ -2316,6 +2384,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 69
     bgp:
       router-id: 0.12.0.71
       asn: 4200000068
@@ -2334,6 +2403,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 70
     bgp:
       router-id: 0.12.0.72
       asn: 4200000069
@@ -2352,6 +2422,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 71
     bgp:
       router-id: 0.12.0.73
       asn: 4200000070
@@ -2370,6 +2441,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 72
     bgp:
       router-id: 0.12.0.74
       asn: 4200000071
@@ -2388,6 +2460,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 73
     bgp:
       router-id: 0.12.0.75
       asn: 4200000072
@@ -2406,6 +2479,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 74
     bgp:
       router-id: 0.12.0.76
       asn: 4200000073
@@ -2424,6 +2498,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 75
     bgp:
       router-id: 0.12.0.77
       asn: 4200000074
@@ -2442,6 +2517,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 76
     bgp:
       router-id: 0.12.0.78
       asn: 4200000075
@@ -2460,6 +2536,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 77
     bgp:
       router-id: 0.12.0.79
       asn: 4200000076
@@ -2478,6 +2555,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 78
     bgp:
       router-id: 0.12.0.80
       asn: 4200000077
@@ -2496,6 +2574,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 79
     bgp:
       router-id: 0.12.0.81
       asn: 4200000078
@@ -2514,6 +2593,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 80
     bgp:
       router-id: 0.12.0.82
       asn: 4200000079
@@ -2532,6 +2612,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 81
     bgp:
       router-id: 0.12.0.83
       asn: 4200000080
@@ -2550,6 +2631,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 82
     bgp:
       router-id: 0.12.0.84
       asn: 4200000081
@@ -2568,6 +2650,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 83
     bgp:
       router-id: 0.12.0.85
       asn: 4200000082
@@ -2586,6 +2669,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 84
     bgp:
       router-id: 0.12.0.86
       asn: 4200000083
@@ -2604,6 +2688,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 85
     bgp:
       router-id: 0.12.0.87
       asn: 4200000084
@@ -2622,6 +2707,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 86
     bgp:
       router-id: 0.12.0.88
       asn: 4200000085
@@ -2640,6 +2726,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 87
     bgp:
       router-id: 0.12.0.89
       asn: 4200000086
@@ -2658,6 +2745,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 88
     bgp:
       router-id: 0.12.0.90
       asn: 4200000087
@@ -2676,6 +2764,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 89
     bgp:
       router-id: 0.12.0.91
       asn: 4200000088
@@ -2694,6 +2783,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 90
     bgp:
       router-id: 0.12.0.92
       asn: 4200000089
@@ -2712,6 +2802,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 91
     bgp:
       router-id: 0.12.0.93
       asn: 4200000090
@@ -2730,6 +2821,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 92
     bgp:
       router-id: 0.12.0.94
       asn: 4200000091
@@ -2748,6 +2840,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 93
     bgp:
       router-id: 0.12.0.95
       asn: 4200000092
@@ -2766,6 +2859,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 94
     bgp:
       router-id: 0.12.0.96
       asn: 4200000093
@@ -2784,6 +2878,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 95
     bgp:
       router-id: 0.12.0.97
       asn: 4200000094
@@ -2802,6 +2897,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 96
     bgp:
       router-id: 0.12.0.98
       asn: 4200000095
@@ -2820,6 +2916,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 97
     bgp:
       router-id: 0.12.0.99
       asn: 4200000096
@@ -2838,6 +2935,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 98
     bgp:
       router-id: 0.12.0.100
       asn: 4200000097
@@ -2856,6 +2954,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 99
     bgp:
       router-id: 0.12.0.101
       asn: 4200000098
@@ -2874,6 +2973,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 100
     bgp:
       router-id: 0.12.0.102
       asn: 4200000099
@@ -2892,6 +2992,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 101
     bgp:
       router-id: 0.12.0.103
       asn: 4200000100
@@ -2910,6 +3011,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 102
     bgp:
       router-id: 0.12.0.104
       asn: 4200000101
@@ -2928,6 +3030,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 103
     bgp:
       router-id: 0.12.0.105
       asn: 4200000102
@@ -2946,6 +3049,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 104
     bgp:
       router-id: 0.12.0.106
       asn: 4200000103
@@ -2964,6 +3068,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 105
     bgp:
       router-id: 0.12.0.107
       asn: 4200000104
@@ -2982,6 +3087,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 106
     bgp:
       router-id: 0.12.0.108
       asn: 4200000105
@@ -3000,6 +3106,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 107
     bgp:
       router-id: 0.12.0.109
       asn: 4200000106
@@ -3018,6 +3125,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 108
     bgp:
       router-id: 0.12.0.110
       asn: 4200000107
@@ -3036,6 +3144,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 109
     bgp:
       router-id: 0.12.0.111
       asn: 4200000108
@@ -3054,6 +3163,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 110
     bgp:
       router-id: 0.12.0.112
       asn: 4200000109
@@ -3072,6 +3182,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 111
     bgp:
       router-id: 0.12.0.113
       asn: 4200000110
@@ -3090,6 +3201,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 112
     bgp:
       router-id: 0.12.0.114
       asn: 4200000111
@@ -3108,6 +3220,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 113
     bgp:
       router-id: 0.12.0.115
       asn: 4200000112
@@ -3126,6 +3239,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 114
     bgp:
       router-id: 0.12.0.116
       asn: 4200000113
@@ -3144,6 +3258,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 115
     bgp:
       router-id: 0.12.0.117
       asn: 4200000114
@@ -3162,6 +3277,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 116
     bgp:
       router-id: 0.12.0.118
       asn: 4200000115
@@ -3180,6 +3296,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 117
     bgp:
       router-id: 0.12.0.119
       asn: 4200000116
@@ -3198,6 +3315,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 118
     bgp:
       router-id: 0.12.0.120
       asn: 4200000117
@@ -3216,6 +3334,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 119
     bgp:
       router-id: 0.12.0.121
       asn: 4200000118
@@ -3234,6 +3353,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 120
     bgp:
       router-id: 0.12.0.122
       asn: 4200000119
@@ -3252,6 +3372,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 121
     bgp:
       router-id: 0.12.0.123
       asn: 4200000120
@@ -3270,6 +3391,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 122
     bgp:
       router-id: 0.12.0.124
       asn: 4200000121
@@ -3288,6 +3410,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 123
     bgp:
       router-id: 0.12.0.125
       asn: 4200000122
@@ -3306,6 +3429,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 124
     bgp:
       router-id: 0.12.0.126
       asn: 4200000123
@@ -3324,6 +3448,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 125
     bgp:
       router-id: 0.12.0.127
       asn: 4200000124
@@ -3342,6 +3467,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 126
     bgp:
       router-id: 0.12.0.128
       asn: 4200000125
@@ -3360,6 +3486,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 127
     bgp:
       router-id: 0.12.0.129
       asn: 4200000126
@@ -3378,6 +3505,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 128
     bgp:
       router-id: 0.12.0.130
       asn: 4200000127
@@ -3396,6 +3524,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 129
     bgp:
       router-id: 0.12.0.131
       asn: 4200000128
@@ -3414,6 +3543,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 130
     bgp:
       router-id: 0.12.0.132
       asn: 4200000129
@@ -3432,6 +3562,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 131
     bgp:
       router-id: 0.12.0.133
       asn: 4200000130
@@ -3450,6 +3581,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 132
     bgp:
       router-id: 0.12.0.134
       asn: 4200000131
@@ -3468,6 +3600,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 133
     bgp:
       router-id: 0.12.0.135
       asn: 4200000132
@@ -3486,6 +3619,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 134
     bgp:
       router-id: 0.12.0.136
       asn: 4200000133
@@ -3504,6 +3638,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 135
     bgp:
       router-id: 0.12.0.137
       asn: 4200000134
@@ -3522,6 +3657,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 136
     bgp:
       router-id: 0.12.0.138
       asn: 4200000135
@@ -3540,6 +3676,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 137
     bgp:
       router-id: 0.12.0.139
       asn: 4200000136
@@ -3558,6 +3695,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 138
     bgp:
       router-id: 0.12.0.140
       asn: 4200000137
@@ -3576,6 +3714,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 139
     bgp:
       router-id: 0.12.0.141
       asn: 4200000138
@@ -3594,6 +3733,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 140
     bgp:
       router-id: 0.12.0.142
       asn: 4200000139
@@ -3612,6 +3752,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 141
     bgp:
       router-id: 0.12.0.143
       asn: 4200000140
@@ -3630,6 +3771,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 142
     bgp:
       router-id: 0.12.0.144
       asn: 4200000141
@@ -3648,6 +3790,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 143
     bgp:
       router-id: 0.12.0.145
       asn: 4200000142
@@ -3666,6 +3809,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 144
     bgp:
       router-id: 0.12.0.146
       asn: 4200000143
@@ -3684,6 +3828,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 145
     bgp:
       router-id: 0.12.0.147
       asn: 4200000144
@@ -3702,6 +3847,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 146
     bgp:
       router-id: 0.12.0.148
       asn: 4200000145
@@ -3720,6 +3866,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 147
     bgp:
       router-id: 0.12.0.149
       asn: 4200000146
@@ -3738,6 +3885,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 148
     bgp:
       router-id: 0.12.0.150
       asn: 4200000147
@@ -3756,6 +3904,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 149
     bgp:
       router-id: 0.12.0.151
       asn: 4200000148
@@ -3774,6 +3923,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 150
     bgp:
       router-id: 0.12.0.152
       asn: 4200000149
@@ -3792,6 +3942,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 151
     bgp:
       router-id: 0.12.0.153
       asn: 4200000150
@@ -3810,6 +3961,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 152
     bgp:
       router-id: 0.12.0.154
       asn: 4200000151
@@ -3828,6 +3980,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 153
     bgp:
       router-id: 0.12.0.155
       asn: 4200000152
@@ -3846,6 +3999,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 154
     bgp:
       router-id: 0.12.0.156
       asn: 4200000153
@@ -3864,6 +4018,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 155
     bgp:
       router-id: 0.12.0.157
       asn: 4200000154
@@ -3882,6 +4037,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 156
     bgp:
       router-id: 0.12.0.158
       asn: 4200000155
@@ -3900,6 +4056,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 157
     bgp:
       router-id: 0.12.0.159
       asn: 4200000156
@@ -3918,6 +4075,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 158
     bgp:
       router-id: 0.12.0.160
       asn: 4200000157
@@ -3936,6 +4094,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 159
     bgp:
       router-id: 0.12.0.161
       asn: 4200000158
@@ -3954,6 +4113,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 160
     bgp:
       router-id: 0.12.0.162
       asn: 4200000159
@@ -3972,6 +4132,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 161
     bgp:
       router-id: 0.12.0.163
       asn: 4200000160
@@ -3990,6 +4151,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 162
     bgp:
       router-id: 0.12.0.164
       asn: 4200000161
@@ -4008,6 +4170,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 163
     bgp:
       router-id: 0.12.0.165
       asn: 4200000162
@@ -4026,6 +4189,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 164
     bgp:
       router-id: 0.12.0.166
       asn: 4200000163
@@ -4044,6 +4208,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 165
     bgp:
       router-id: 0.12.0.167
       asn: 4200000164
@@ -4062,6 +4227,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 166
     bgp:
       router-id: 0.12.0.168
       asn: 4200000165
@@ -4080,6 +4246,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 167
     bgp:
       router-id: 0.12.0.169
       asn: 4200000166
@@ -4098,6 +4265,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 168
     bgp:
       router-id: 0.12.0.170
       asn: 4200000167
@@ -4116,6 +4284,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 169
     bgp:
       router-id: 0.12.0.171
       asn: 4200000168
@@ -4134,6 +4303,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 170
     bgp:
       router-id: 0.12.0.172
       asn: 4200000169
@@ -4152,6 +4322,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 171
     bgp:
       router-id: 0.12.0.173
       asn: 4200000170
@@ -4170,6 +4341,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 172
     bgp:
       router-id: 0.12.0.174
       asn: 4200000171
@@ -4188,6 +4360,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 173
     bgp:
       router-id: 0.12.0.175
       asn: 4200000172
@@ -4206,6 +4379,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 174
     bgp:
       router-id: 0.12.0.176
       asn: 4200000173
@@ -4224,6 +4398,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 175
     bgp:
       router-id: 0.12.0.177
       asn: 4200000174
@@ -4242,6 +4417,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 176
     bgp:
       router-id: 0.12.0.178
       asn: 4200000175
@@ -4260,6 +4436,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 177
     bgp:
       router-id: 0.12.0.179
       asn: 4200000176
@@ -4278,6 +4455,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 178
     bgp:
       router-id: 0.12.0.180
       asn: 4200000177
@@ -4296,6 +4474,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 179
     bgp:
       router-id: 0.12.0.181
       asn: 4200000178
@@ -4314,6 +4493,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 180
     bgp:
       router-id: 0.12.0.182
       asn: 4200000179
@@ -4332,6 +4512,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 181
     bgp:
       router-id: 0.12.0.183
       asn: 4200000180
@@ -4350,6 +4531,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 182
     bgp:
       router-id: 0.12.0.184
       asn: 4200000181
@@ -4368,6 +4550,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 183
     bgp:
       router-id: 0.12.0.185
       asn: 4200000182
@@ -4386,6 +4569,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 184
     bgp:
       router-id: 0.12.0.186
       asn: 4200000183
@@ -4404,6 +4588,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 185
     bgp:
       router-id: 0.12.0.187
       asn: 4200000184
@@ -4422,6 +4607,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 186
     bgp:
       router-id: 0.12.0.188
       asn: 4200000185
@@ -4440,6 +4626,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 187
     bgp:
       router-id: 0.12.0.189
       asn: 4200000186
@@ -4458,6 +4645,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 188
     bgp:
       router-id: 0.12.0.190
       asn: 4200000187
@@ -4476,6 +4664,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 189
     bgp:
       router-id: 0.12.0.191
       asn: 4200000188
@@ -4494,6 +4683,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 190
     bgp:
       router-id: 0.12.0.192
       asn: 4200000189
@@ -4512,6 +4702,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 191
     bgp:
       router-id: 0.12.0.193
       asn: 4200000190
@@ -4530,6 +4721,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 192
     bgp:
       router-id: 0.12.0.194
       asn: 4200000191
@@ -4548,6 +4740,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 193
     bgp:
       router-id: 0.12.0.195
       asn: 4200000192
@@ -4566,6 +4759,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 194
     bgp:
       router-id: 0.12.0.196
       asn: 4200000193
@@ -4584,6 +4778,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 195
     bgp:
       router-id: 0.12.0.197
       asn: 4200000194
@@ -4602,6 +4797,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 196
     bgp:
       router-id: 0.12.0.198
       asn: 4200000195
@@ -4620,6 +4816,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 197
     bgp:
       router-id: 0.12.0.199
       asn: 4200000196
@@ -4638,6 +4835,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 198
     bgp:
       router-id: 0.12.0.200
       asn: 4200000197
@@ -4656,6 +4854,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 199
     bgp:
       router-id: 0.12.0.201
       asn: 4200000198
@@ -4674,6 +4873,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 200
     bgp:
       router-id: 0.12.0.202
       asn: 4200000199
@@ -4692,6 +4892,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 201
     bgp:
       router-id: 0.12.0.203
       asn: 4200000200
@@ -4710,6 +4911,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 202
     bgp:
       router-id: 0.12.0.204
       asn: 4200000201
@@ -4728,6 +4930,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 203
     bgp:
       router-id: 0.12.0.205
       asn: 4200000202
@@ -4746,6 +4949,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 204
     bgp:
       router-id: 0.12.0.206
       asn: 4200000203
@@ -4764,6 +4968,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 205
     bgp:
       router-id: 0.12.0.207
       asn: 4200000204
@@ -4782,6 +4987,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 206
     bgp:
       router-id: 0.12.0.208
       asn: 4200000205
@@ -4800,6 +5006,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 207
     bgp:
       router-id: 0.12.0.209
       asn: 4200000206
@@ -4818,6 +5025,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 208
     bgp:
       router-id: 0.12.0.210
       asn: 4200000207
@@ -4836,6 +5044,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 209
     bgp:
       router-id: 0.12.0.211
       asn: 4200000208
@@ -4854,6 +5063,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 210
     bgp:
       router-id: 0.12.0.212
       asn: 4200000209
@@ -4872,6 +5082,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 211
     bgp:
       router-id: 0.12.0.213
       asn: 4200000210
@@ -4890,6 +5101,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 212
     bgp:
       router-id: 0.12.0.214
       asn: 4200000211
@@ -4908,6 +5120,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 213
     bgp:
       router-id: 0.12.0.215
       asn: 4200000212
@@ -4926,6 +5139,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 214
     bgp:
       router-id: 0.12.0.216
       asn: 4200000213
@@ -4944,6 +5158,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 215
     bgp:
       router-id: 0.12.0.217
       asn: 4200000214
@@ -4962,6 +5177,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 216
     bgp:
       router-id: 0.12.0.218
       asn: 4200000215
@@ -4980,6 +5196,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 217
     bgp:
       router-id: 0.12.0.219
       asn: 4200000216
@@ -4998,6 +5215,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 218
     bgp:
       router-id: 0.12.0.220
       asn: 4200000217
@@ -5016,6 +5234,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 219
     bgp:
       router-id: 0.12.0.221
       asn: 4200000218
@@ -5034,6 +5253,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 220
     bgp:
       router-id: 0.12.0.222
       asn: 4200000219
@@ -5052,6 +5272,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 221
     bgp:
       router-id: 0.12.0.223
       asn: 4200000220
@@ -5070,6 +5291,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 222
     bgp:
       router-id: 0.12.0.224
       asn: 4200000221
@@ -5088,6 +5310,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 223
     bgp:
       router-id: 0.12.0.225
       asn: 4200000222
@@ -5106,6 +5329,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 224
     bgp:
       router-id: 0.12.0.226
       asn: 4200000223
@@ -5124,6 +5348,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 225
     bgp:
       router-id: 0.12.0.227
       asn: 4200000224
@@ -5142,6 +5367,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 226
     bgp:
       router-id: 0.12.0.228
       asn: 4200000225
@@ -5160,6 +5386,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 227
     bgp:
       router-id: 0.12.0.229
       asn: 4200000226
@@ -5178,6 +5405,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 228
     bgp:
       router-id: 0.12.0.230
       asn: 4200000227
@@ -5196,6 +5424,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 229
     bgp:
       router-id: 0.12.0.231
       asn: 4200000228
@@ -5214,6 +5443,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 230
     bgp:
       router-id: 0.12.0.232
       asn: 4200000229
@@ -5232,6 +5462,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 231
     bgp:
       router-id: 0.12.0.233
       asn: 4200000230
@@ -5250,6 +5481,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 232
     bgp:
       router-id: 0.12.0.234
       asn: 4200000231
@@ -5268,6 +5500,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 233
     bgp:
       router-id: 0.12.0.235
       asn: 4200000232
@@ -5286,6 +5519,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 234
     bgp:
       router-id: 0.12.0.236
       asn: 4200000233
@@ -5304,6 +5538,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 235
     bgp:
       router-id: 0.12.0.237
       asn: 4200000234
@@ -5322,6 +5557,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 236
     bgp:
       router-id: 0.12.0.238
       asn: 4200000235
@@ -5340,6 +5576,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 237
     bgp:
       router-id: 0.12.0.239
       asn: 4200000236
@@ -5358,6 +5595,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 238
     bgp:
       router-id: 0.12.0.240
       asn: 4200000237
@@ -5376,6 +5614,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 239
     bgp:
       router-id: 0.12.0.241
       asn: 4200000238
@@ -5394,6 +5633,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 240
     bgp:
       router-id: 0.12.0.242
       asn: 4200000239
@@ -5412,6 +5652,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 241
     bgp:
       router-id: 0.12.0.243
       asn: 4200000240
@@ -5430,6 +5671,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 242
     bgp:
       router-id: 0.12.0.244
       asn: 4200000241
@@ -5448,6 +5690,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 243
     bgp:
       router-id: 0.12.0.245
       asn: 4200000242
@@ -5466,6 +5709,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 244
     bgp:
       router-id: 0.12.0.246
       asn: 4200000243
@@ -5484,6 +5728,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 245
     bgp:
       router-id: 0.12.0.247
       asn: 4200000244
@@ -5502,6 +5747,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 246
     bgp:
       router-id: 0.12.0.248
       asn: 4200000245
@@ -5520,6 +5766,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 247
     bgp:
       router-id: 0.12.0.249
       asn: 4200000246
@@ -5538,6 +5785,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 248
     bgp:
       router-id: 0.12.0.250
       asn: 4200000247
@@ -5556,6 +5804,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 249
     bgp:
       router-id: 0.12.0.251
       asn: 4200000248
@@ -5574,6 +5823,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 250
     bgp:
       router-id: 0.12.0.252
       asn: 4200000249
@@ -5592,6 +5842,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 251
     bgp:
       router-id: 0.12.0.253
       asn: 4200000250
@@ -5610,6 +5861,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 252
     bgp:
       router-id: 0.12.0.254
       asn: 4200000251
@@ -5628,6 +5880,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 253
     bgp:
       router-id: 0.12.0.255
       asn: 4200000252
@@ -5646,6 +5899,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 254
     bgp:
       router-id: 0.12.1.0
       asn: 4200000253

--- a/ansible/vars/topo_t1-isolated-d254u2s2.yml
+++ b/ansible/vars/topo_t1-isolated-d254u2s2.yml
@@ -1039,7 +1039,7 @@ configuration_properties:
     dut_type: LeafRouter
     podset_number: 1
     tor_number: 512
-    tor_subnet_number: 1
+    tor_subnet_number: 2
     max_tor_subnet_number: 16
     tor_subnet_size: 256
     nhipv6: FC0A::FF

--- a/ansible/vars/topo_t1-isolated-d510u2.yml
+++ b/ansible/vars/topo_t1-isolated-d510u2.yml
@@ -2053,11 +2053,11 @@ configuration_properties:
   common:
     dut_asn: 4200100000
     dut_type: LeafRouter
-    podset_number: 200
-    tor_number: 16
-    tor_subnet_number: 2
+    podset_number: 1
+    tor_number: 512
+    tor_subnet_number: 1
     max_tor_subnet_number: 16
-    tor_subnet_size: 128
+    tor_subnet_size: 256
     nhipv6: FC0A::FF
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
@@ -2108,6 +2108,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 01
     bgp:
       router-id: 0.12.0.3
       asn: 4200000000
@@ -2126,6 +2127,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 02
     bgp:
       router-id: 0.12.0.4
       asn: 4200000001
@@ -2144,6 +2146,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 03
     bgp:
       router-id: 0.12.0.5
       asn: 4200000002
@@ -2162,6 +2165,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 04
     bgp:
       router-id: 0.12.0.6
       asn: 4200000003
@@ -2180,6 +2184,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 05
     bgp:
       router-id: 0.12.0.7
       asn: 4200000004
@@ -2198,6 +2203,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 06
     bgp:
       router-id: 0.12.0.8
       asn: 4200000005
@@ -2216,6 +2222,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 07
     bgp:
       router-id: 0.12.0.9
       asn: 4200000006
@@ -2234,6 +2241,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 08
     bgp:
       router-id: 0.12.0.10
       asn: 4200000007
@@ -2252,6 +2260,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 09
     bgp:
       router-id: 0.12.0.11
       asn: 4200000008
@@ -2270,6 +2279,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 10
     bgp:
       router-id: 0.12.0.12
       asn: 4200000009
@@ -2288,6 +2298,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 11
     bgp:
       router-id: 0.12.0.13
       asn: 4200000010
@@ -2306,6 +2317,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 12
     bgp:
       router-id: 0.12.0.14
       asn: 4200000011
@@ -2324,6 +2336,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 13
     bgp:
       router-id: 0.12.0.15
       asn: 4200000012
@@ -2342,6 +2355,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 14
     bgp:
       router-id: 0.12.0.16
       asn: 4200000013
@@ -2360,6 +2374,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 15
     bgp:
       router-id: 0.12.0.17
       asn: 4200000014
@@ -2378,6 +2393,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 16
     bgp:
       router-id: 0.12.0.18
       asn: 4200000015
@@ -2396,6 +2412,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 17
     bgp:
       router-id: 0.12.0.19
       asn: 4200000016
@@ -2414,6 +2431,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 18
     bgp:
       router-id: 0.12.0.20
       asn: 4200000017
@@ -2432,6 +2450,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 19
     bgp:
       router-id: 0.12.0.21
       asn: 4200000018
@@ -2450,6 +2469,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 20
     bgp:
       router-id: 0.12.0.22
       asn: 4200000019
@@ -2468,6 +2488,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 21
     bgp:
       router-id: 0.12.0.23
       asn: 4200000020
@@ -2486,6 +2507,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 22
     bgp:
       router-id: 0.12.0.24
       asn: 4200000021
@@ -2504,6 +2526,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 23
     bgp:
       router-id: 0.12.0.25
       asn: 4200000022
@@ -2522,6 +2545,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 24
     bgp:
       router-id: 0.12.0.26
       asn: 4200000023
@@ -2540,6 +2564,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 25
     bgp:
       router-id: 0.12.0.27
       asn: 4200000024
@@ -2558,6 +2583,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 26
     bgp:
       router-id: 0.12.0.28
       asn: 4200000025
@@ -2576,6 +2602,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 27
     bgp:
       router-id: 0.12.0.29
       asn: 4200000026
@@ -2594,6 +2621,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 28
     bgp:
       router-id: 0.12.0.30
       asn: 4200000027
@@ -2612,6 +2640,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 29
     bgp:
       router-id: 0.12.0.31
       asn: 4200000028
@@ -2630,6 +2659,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 30
     bgp:
       router-id: 0.12.0.32
       asn: 4200000029
@@ -2648,6 +2678,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 31
     bgp:
       router-id: 0.12.0.33
       asn: 4200000030
@@ -2666,6 +2697,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 32
     bgp:
       router-id: 0.12.0.34
       asn: 4200000031
@@ -2684,6 +2716,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 33
     bgp:
       router-id: 0.12.0.35
       asn: 4200000032
@@ -2702,6 +2735,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 34
     bgp:
       router-id: 0.12.0.36
       asn: 4200000033
@@ -2720,6 +2754,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 35
     bgp:
       router-id: 0.12.0.37
       asn: 4200000034
@@ -2738,6 +2773,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 36
     bgp:
       router-id: 0.12.0.38
       asn: 4200000035
@@ -2756,6 +2792,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 37
     bgp:
       router-id: 0.12.0.39
       asn: 4200000036
@@ -2774,6 +2811,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 38
     bgp:
       router-id: 0.12.0.40
       asn: 4200000037
@@ -2792,6 +2830,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 39
     bgp:
       router-id: 0.12.0.41
       asn: 4200000038
@@ -2810,6 +2849,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 40
     bgp:
       router-id: 0.12.0.42
       asn: 4200000039
@@ -2828,6 +2868,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 41
     bgp:
       router-id: 0.12.0.43
       asn: 4200000040
@@ -2846,6 +2887,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 42
     bgp:
       router-id: 0.12.0.44
       asn: 4200000041
@@ -2864,6 +2906,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 43
     bgp:
       router-id: 0.12.0.45
       asn: 4200000042
@@ -2882,6 +2925,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 44
     bgp:
       router-id: 0.12.0.46
       asn: 4200000043
@@ -2900,6 +2944,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 45
     bgp:
       router-id: 0.12.0.47
       asn: 4200000044
@@ -2918,6 +2963,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 46
     bgp:
       router-id: 0.12.0.48
       asn: 4200000045
@@ -2936,6 +2982,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 47
     bgp:
       router-id: 0.12.0.49
       asn: 4200000046
@@ -2954,6 +3001,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 48
     bgp:
       router-id: 0.12.0.50
       asn: 4200000047
@@ -2972,6 +3020,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 49
     bgp:
       router-id: 0.12.0.51
       asn: 4200000048
@@ -2990,6 +3039,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 50
     bgp:
       router-id: 0.12.0.52
       asn: 4200000049
@@ -3008,6 +3058,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 51
     bgp:
       router-id: 0.12.0.53
       asn: 4200000050
@@ -3026,6 +3077,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 52
     bgp:
       router-id: 0.12.0.54
       asn: 4200000051
@@ -3044,6 +3096,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 53
     bgp:
       router-id: 0.12.0.55
       asn: 4200000052
@@ -3062,6 +3115,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 54
     bgp:
       router-id: 0.12.0.56
       asn: 4200000053
@@ -3080,6 +3134,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 55
     bgp:
       router-id: 0.12.0.57
       asn: 4200000054
@@ -3098,6 +3153,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 56
     bgp:
       router-id: 0.12.0.58
       asn: 4200000055
@@ -3116,6 +3172,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 57
     bgp:
       router-id: 0.12.0.59
       asn: 4200000056
@@ -3134,6 +3191,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 58
     bgp:
       router-id: 0.12.0.60
       asn: 4200000057
@@ -3152,6 +3210,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 59
     bgp:
       router-id: 0.12.0.61
       asn: 4200000058
@@ -3170,6 +3229,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 60
     bgp:
       router-id: 0.12.0.62
       asn: 4200000059
@@ -3188,6 +3248,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 61
     bgp:
       router-id: 0.12.0.63
       asn: 4200000060
@@ -3206,6 +3267,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 62
     bgp:
       router-id: 0.12.0.64
       asn: 4200000061
@@ -3224,6 +3286,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 63
     bgp:
       router-id: 0.12.0.65
       asn: 4200000062
@@ -3242,6 +3305,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 64
     bgp:
       router-id: 0.12.0.66
       asn: 4200000063
@@ -3260,6 +3324,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 65
     bgp:
       router-id: 0.12.0.67
       asn: 4200000064
@@ -3278,6 +3343,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 66
     bgp:
       router-id: 0.12.0.68
       asn: 4200000065
@@ -3296,6 +3362,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 67
     bgp:
       router-id: 0.12.0.69
       asn: 4200000066
@@ -3314,6 +3381,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 68
     bgp:
       router-id: 0.12.0.70
       asn: 4200000067
@@ -3332,6 +3400,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 69
     bgp:
       router-id: 0.12.0.71
       asn: 4200000068
@@ -3350,6 +3419,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 70
     bgp:
       router-id: 0.12.0.72
       asn: 4200000069
@@ -3368,6 +3438,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 71
     bgp:
       router-id: 0.12.0.73
       asn: 4200000070
@@ -3386,6 +3457,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 72
     bgp:
       router-id: 0.12.0.74
       asn: 4200000071
@@ -3404,6 +3476,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 73
     bgp:
       router-id: 0.12.0.75
       asn: 4200000072
@@ -3422,6 +3495,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 74
     bgp:
       router-id: 0.12.0.76
       asn: 4200000073
@@ -3440,6 +3514,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 75
     bgp:
       router-id: 0.12.0.77
       asn: 4200000074
@@ -3458,6 +3533,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 76
     bgp:
       router-id: 0.12.0.78
       asn: 4200000075
@@ -3476,6 +3552,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 77
     bgp:
       router-id: 0.12.0.79
       asn: 4200000076
@@ -3494,6 +3571,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 78
     bgp:
       router-id: 0.12.0.80
       asn: 4200000077
@@ -3512,6 +3590,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 79
     bgp:
       router-id: 0.12.0.81
       asn: 4200000078
@@ -3530,6 +3609,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 80
     bgp:
       router-id: 0.12.0.82
       asn: 4200000079
@@ -3548,6 +3628,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 81
     bgp:
       router-id: 0.12.0.83
       asn: 4200000080
@@ -3566,6 +3647,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 82
     bgp:
       router-id: 0.12.0.84
       asn: 4200000081
@@ -3584,6 +3666,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 83
     bgp:
       router-id: 0.12.0.85
       asn: 4200000082
@@ -3602,6 +3685,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 84
     bgp:
       router-id: 0.12.0.86
       asn: 4200000083
@@ -3620,6 +3704,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 85
     bgp:
       router-id: 0.12.0.87
       asn: 4200000084
@@ -3638,6 +3723,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 86
     bgp:
       router-id: 0.12.0.88
       asn: 4200000085
@@ -3656,6 +3742,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 87
     bgp:
       router-id: 0.12.0.89
       asn: 4200000086
@@ -3674,6 +3761,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 88
     bgp:
       router-id: 0.12.0.90
       asn: 4200000087
@@ -3692,6 +3780,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 89
     bgp:
       router-id: 0.12.0.91
       asn: 4200000088
@@ -3710,6 +3799,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 90
     bgp:
       router-id: 0.12.0.92
       asn: 4200000089
@@ -3728,6 +3818,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 91
     bgp:
       router-id: 0.12.0.93
       asn: 4200000090
@@ -3746,6 +3837,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 92
     bgp:
       router-id: 0.12.0.94
       asn: 4200000091
@@ -3764,6 +3856,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 93
     bgp:
       router-id: 0.12.0.95
       asn: 4200000092
@@ -3782,6 +3875,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 94
     bgp:
       router-id: 0.12.0.96
       asn: 4200000093
@@ -3800,6 +3894,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 95
     bgp:
       router-id: 0.12.0.97
       asn: 4200000094
@@ -3818,6 +3913,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 96
     bgp:
       router-id: 0.12.0.98
       asn: 4200000095
@@ -3836,6 +3932,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 97
     bgp:
       router-id: 0.12.0.99
       asn: 4200000096
@@ -3854,6 +3951,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 98
     bgp:
       router-id: 0.12.0.100
       asn: 4200000097
@@ -3872,6 +3970,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 99
     bgp:
       router-id: 0.12.0.101
       asn: 4200000098
@@ -3890,6 +3989,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 100
     bgp:
       router-id: 0.12.0.102
       asn: 4200000099
@@ -3908,6 +4008,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 101
     bgp:
       router-id: 0.12.0.103
       asn: 4200000100
@@ -3926,6 +4027,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 102
     bgp:
       router-id: 0.12.0.104
       asn: 4200000101
@@ -3944,6 +4046,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 103
     bgp:
       router-id: 0.12.0.105
       asn: 4200000102
@@ -3962,6 +4065,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 104
     bgp:
       router-id: 0.12.0.106
       asn: 4200000103
@@ -3980,6 +4084,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 105
     bgp:
       router-id: 0.12.0.107
       asn: 4200000104
@@ -3998,6 +4103,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 106
     bgp:
       router-id: 0.12.0.108
       asn: 4200000105
@@ -4016,6 +4122,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 107
     bgp:
       router-id: 0.12.0.109
       asn: 4200000106
@@ -4034,6 +4141,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 108
     bgp:
       router-id: 0.12.0.110
       asn: 4200000107
@@ -4052,6 +4160,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 109
     bgp:
       router-id: 0.12.0.111
       asn: 4200000108
@@ -4070,6 +4179,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 110
     bgp:
       router-id: 0.12.0.112
       asn: 4200000109
@@ -4088,6 +4198,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 111
     bgp:
       router-id: 0.12.0.113
       asn: 4200000110
@@ -4106,6 +4217,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 112
     bgp:
       router-id: 0.12.0.114
       asn: 4200000111
@@ -4124,6 +4236,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 113
     bgp:
       router-id: 0.12.0.115
       asn: 4200000112
@@ -4142,6 +4255,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 114
     bgp:
       router-id: 0.12.0.116
       asn: 4200000113
@@ -4160,6 +4274,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 115
     bgp:
       router-id: 0.12.0.117
       asn: 4200000114
@@ -4178,6 +4293,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 116
     bgp:
       router-id: 0.12.0.118
       asn: 4200000115
@@ -4196,6 +4312,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 117
     bgp:
       router-id: 0.12.0.119
       asn: 4200000116
@@ -4214,6 +4331,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 118
     bgp:
       router-id: 0.12.0.120
       asn: 4200000117
@@ -4232,6 +4350,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 119
     bgp:
       router-id: 0.12.0.121
       asn: 4200000118
@@ -4250,6 +4369,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 120
     bgp:
       router-id: 0.12.0.122
       asn: 4200000119
@@ -4268,6 +4388,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 121
     bgp:
       router-id: 0.12.0.123
       asn: 4200000120
@@ -4286,6 +4407,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 122
     bgp:
       router-id: 0.12.0.124
       asn: 4200000121
@@ -4304,6 +4426,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 123
     bgp:
       router-id: 0.12.0.125
       asn: 4200000122
@@ -4322,6 +4445,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 124
     bgp:
       router-id: 0.12.0.126
       asn: 4200000123
@@ -4340,6 +4464,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 125
     bgp:
       router-id: 0.12.0.127
       asn: 4200000124
@@ -4358,6 +4483,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 126
     bgp:
       router-id: 0.12.0.128
       asn: 4200000125
@@ -4376,6 +4502,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 127
     bgp:
       router-id: 0.12.0.129
       asn: 4200000126
@@ -4394,6 +4521,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 128
     bgp:
       router-id: 0.12.0.130
       asn: 4200000127
@@ -4412,6 +4540,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 129
     bgp:
       router-id: 0.12.0.131
       asn: 4200000128
@@ -4430,6 +4559,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 130
     bgp:
       router-id: 0.12.0.132
       asn: 4200000129
@@ -4448,6 +4578,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 131
     bgp:
       router-id: 0.12.0.133
       asn: 4200000130
@@ -4466,6 +4597,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 132
     bgp:
       router-id: 0.12.0.134
       asn: 4200000131
@@ -4484,6 +4616,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 133
     bgp:
       router-id: 0.12.0.135
       asn: 4200000132
@@ -4502,6 +4635,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 134
     bgp:
       router-id: 0.12.0.136
       asn: 4200000133
@@ -4520,6 +4654,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 135
     bgp:
       router-id: 0.12.0.137
       asn: 4200000134
@@ -4538,6 +4673,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 136
     bgp:
       router-id: 0.12.0.138
       asn: 4200000135
@@ -4556,6 +4692,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 137
     bgp:
       router-id: 0.12.0.139
       asn: 4200000136
@@ -4574,6 +4711,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 138
     bgp:
       router-id: 0.12.0.140
       asn: 4200000137
@@ -4592,6 +4730,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 139
     bgp:
       router-id: 0.12.0.141
       asn: 4200000138
@@ -4610,6 +4749,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 140
     bgp:
       router-id: 0.12.0.142
       asn: 4200000139
@@ -4628,6 +4768,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 141
     bgp:
       router-id: 0.12.0.143
       asn: 4200000140
@@ -4646,6 +4787,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 142
     bgp:
       router-id: 0.12.0.144
       asn: 4200000141
@@ -4664,6 +4806,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 143
     bgp:
       router-id: 0.12.0.145
       asn: 4200000142
@@ -4682,6 +4825,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 144
     bgp:
       router-id: 0.12.0.146
       asn: 4200000143
@@ -4700,6 +4844,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 145
     bgp:
       router-id: 0.12.0.147
       asn: 4200000144
@@ -4718,6 +4863,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 146
     bgp:
       router-id: 0.12.0.148
       asn: 4200000145
@@ -4736,6 +4882,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 147
     bgp:
       router-id: 0.12.0.149
       asn: 4200000146
@@ -4754,6 +4901,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 148
     bgp:
       router-id: 0.12.0.150
       asn: 4200000147
@@ -4772,6 +4920,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 149
     bgp:
       router-id: 0.12.0.151
       asn: 4200000148
@@ -4790,6 +4939,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 150
     bgp:
       router-id: 0.12.0.152
       asn: 4200000149
@@ -4808,6 +4958,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 151
     bgp:
       router-id: 0.12.0.153
       asn: 4200000150
@@ -4826,6 +4977,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 152
     bgp:
       router-id: 0.12.0.154
       asn: 4200000151
@@ -4844,6 +4996,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 153
     bgp:
       router-id: 0.12.0.155
       asn: 4200000152
@@ -4862,6 +5015,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 154
     bgp:
       router-id: 0.12.0.156
       asn: 4200000153
@@ -4880,6 +5034,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 155
     bgp:
       router-id: 0.12.0.157
       asn: 4200000154
@@ -4898,6 +5053,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 156
     bgp:
       router-id: 0.12.0.158
       asn: 4200000155
@@ -4916,6 +5072,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 157
     bgp:
       router-id: 0.12.0.159
       asn: 4200000156
@@ -4934,6 +5091,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 158
     bgp:
       router-id: 0.12.0.160
       asn: 4200000157
@@ -4952,6 +5110,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 159
     bgp:
       router-id: 0.12.0.161
       asn: 4200000158
@@ -4970,6 +5129,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 160
     bgp:
       router-id: 0.12.0.162
       asn: 4200000159
@@ -4988,6 +5148,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 161
     bgp:
       router-id: 0.12.0.163
       asn: 4200000160
@@ -5006,6 +5167,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 162
     bgp:
       router-id: 0.12.0.164
       asn: 4200000161
@@ -5024,6 +5186,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 163
     bgp:
       router-id: 0.12.0.165
       asn: 4200000162
@@ -5042,6 +5205,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 164
     bgp:
       router-id: 0.12.0.166
       asn: 4200000163
@@ -5060,6 +5224,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 165
     bgp:
       router-id: 0.12.0.167
       asn: 4200000164
@@ -5078,6 +5243,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 166
     bgp:
       router-id: 0.12.0.168
       asn: 4200000165
@@ -5096,6 +5262,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 167
     bgp:
       router-id: 0.12.0.169
       asn: 4200000166
@@ -5114,6 +5281,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 168
     bgp:
       router-id: 0.12.0.170
       asn: 4200000167
@@ -5132,6 +5300,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 169
     bgp:
       router-id: 0.12.0.171
       asn: 4200000168
@@ -5150,6 +5319,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 170
     bgp:
       router-id: 0.12.0.172
       asn: 4200000169
@@ -5168,6 +5338,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 171
     bgp:
       router-id: 0.12.0.173
       asn: 4200000170
@@ -5186,6 +5357,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 172
     bgp:
       router-id: 0.12.0.174
       asn: 4200000171
@@ -5204,6 +5376,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 173
     bgp:
       router-id: 0.12.0.175
       asn: 4200000172
@@ -5222,6 +5395,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 174
     bgp:
       router-id: 0.12.0.176
       asn: 4200000173
@@ -5240,6 +5414,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 175
     bgp:
       router-id: 0.12.0.177
       asn: 4200000174
@@ -5258,6 +5433,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 176
     bgp:
       router-id: 0.12.0.178
       asn: 4200000175
@@ -5276,6 +5452,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 177
     bgp:
       router-id: 0.12.0.179
       asn: 4200000176
@@ -5294,6 +5471,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 178
     bgp:
       router-id: 0.12.0.180
       asn: 4200000177
@@ -5312,6 +5490,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 179
     bgp:
       router-id: 0.12.0.181
       asn: 4200000178
@@ -5330,6 +5509,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 180
     bgp:
       router-id: 0.12.0.182
       asn: 4200000179
@@ -5348,6 +5528,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 181
     bgp:
       router-id: 0.12.0.183
       asn: 4200000180
@@ -5366,6 +5547,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 182
     bgp:
       router-id: 0.12.0.184
       asn: 4200000181
@@ -5384,6 +5566,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 183
     bgp:
       router-id: 0.12.0.185
       asn: 4200000182
@@ -5402,6 +5585,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 184
     bgp:
       router-id: 0.12.0.186
       asn: 4200000183
@@ -5420,6 +5604,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 185
     bgp:
       router-id: 0.12.0.187
       asn: 4200000184
@@ -5438,6 +5623,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 186
     bgp:
       router-id: 0.12.0.188
       asn: 4200000185
@@ -5456,6 +5642,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 187
     bgp:
       router-id: 0.12.0.189
       asn: 4200000186
@@ -5474,6 +5661,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 188
     bgp:
       router-id: 0.12.0.190
       asn: 4200000187
@@ -5492,6 +5680,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 189
     bgp:
       router-id: 0.12.0.191
       asn: 4200000188
@@ -5510,6 +5699,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 190
     bgp:
       router-id: 0.12.0.192
       asn: 4200000189
@@ -5528,6 +5718,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 191
     bgp:
       router-id: 0.12.0.193
       asn: 4200000190
@@ -5546,6 +5737,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 192
     bgp:
       router-id: 0.12.0.194
       asn: 4200000191
@@ -5564,6 +5756,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 193
     bgp:
       router-id: 0.12.0.195
       asn: 4200000192
@@ -5582,6 +5775,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 194
     bgp:
       router-id: 0.12.0.196
       asn: 4200000193
@@ -5600,6 +5794,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 195
     bgp:
       router-id: 0.12.0.197
       asn: 4200000194
@@ -5618,6 +5813,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 196
     bgp:
       router-id: 0.12.0.198
       asn: 4200000195
@@ -5636,6 +5832,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 197
     bgp:
       router-id: 0.12.0.199
       asn: 4200000196
@@ -5654,6 +5851,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 198
     bgp:
       router-id: 0.12.0.200
       asn: 4200000197
@@ -5672,6 +5870,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 199
     bgp:
       router-id: 0.12.0.201
       asn: 4200000198
@@ -5690,6 +5889,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 200
     bgp:
       router-id: 0.12.0.202
       asn: 4200000199
@@ -5708,6 +5908,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 201
     bgp:
       router-id: 0.12.0.203
       asn: 4200000200
@@ -5726,6 +5927,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 202
     bgp:
       router-id: 0.12.0.204
       asn: 4200000201
@@ -5744,6 +5946,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 203
     bgp:
       router-id: 0.12.0.205
       asn: 4200000202
@@ -5762,6 +5965,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 204
     bgp:
       router-id: 0.12.0.206
       asn: 4200000203
@@ -5780,6 +5984,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 205
     bgp:
       router-id: 0.12.0.207
       asn: 4200000204
@@ -5798,6 +6003,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 206
     bgp:
       router-id: 0.12.0.208
       asn: 4200000205
@@ -5816,6 +6022,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 207
     bgp:
       router-id: 0.12.0.209
       asn: 4200000206
@@ -5834,6 +6041,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 208
     bgp:
       router-id: 0.12.0.210
       asn: 4200000207
@@ -5852,6 +6060,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 209
     bgp:
       router-id: 0.12.0.211
       asn: 4200000208
@@ -5870,6 +6079,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 210
     bgp:
       router-id: 0.12.0.212
       asn: 4200000209
@@ -5888,6 +6098,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 211
     bgp:
       router-id: 0.12.0.213
       asn: 4200000210
@@ -5906,6 +6117,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 212
     bgp:
       router-id: 0.12.0.214
       asn: 4200000211
@@ -5924,6 +6136,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 213
     bgp:
       router-id: 0.12.0.215
       asn: 4200000212
@@ -5942,6 +6155,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 214
     bgp:
       router-id: 0.12.0.216
       asn: 4200000213
@@ -5960,6 +6174,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 215
     bgp:
       router-id: 0.12.0.217
       asn: 4200000214
@@ -5978,6 +6193,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 216
     bgp:
       router-id: 0.12.0.218
       asn: 4200000215
@@ -5996,6 +6212,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 217
     bgp:
       router-id: 0.12.0.219
       asn: 4200000216
@@ -6014,6 +6231,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 218
     bgp:
       router-id: 0.12.0.220
       asn: 4200000217
@@ -6032,6 +6250,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 219
     bgp:
       router-id: 0.12.0.221
       asn: 4200000218
@@ -6050,6 +6269,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 220
     bgp:
       router-id: 0.12.0.222
       asn: 4200000219
@@ -6068,6 +6288,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 221
     bgp:
       router-id: 0.12.0.223
       asn: 4200000220
@@ -6086,6 +6307,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 222
     bgp:
       router-id: 0.12.0.224
       asn: 4200000221
@@ -6104,6 +6326,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 223
     bgp:
       router-id: 0.12.0.225
       asn: 4200000222
@@ -6122,6 +6345,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 224
     bgp:
       router-id: 0.12.0.226
       asn: 4200000223
@@ -6140,6 +6364,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 225
     bgp:
       router-id: 0.12.0.227
       asn: 4200000224
@@ -6158,6 +6383,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 226
     bgp:
       router-id: 0.12.0.228
       asn: 4200000225
@@ -6176,6 +6402,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 227
     bgp:
       router-id: 0.12.0.229
       asn: 4200000226
@@ -6194,6 +6421,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 228
     bgp:
       router-id: 0.12.0.230
       asn: 4200000227
@@ -6212,6 +6440,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 229
     bgp:
       router-id: 0.12.0.231
       asn: 4200000228
@@ -6230,6 +6459,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 230
     bgp:
       router-id: 0.12.0.232
       asn: 4200000229
@@ -6248,6 +6478,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 231
     bgp:
       router-id: 0.12.0.233
       asn: 4200000230
@@ -6266,6 +6497,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 232
     bgp:
       router-id: 0.12.0.234
       asn: 4200000231
@@ -6284,6 +6516,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 233
     bgp:
       router-id: 0.12.0.235
       asn: 4200000232
@@ -6302,6 +6535,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 234
     bgp:
       router-id: 0.12.0.236
       asn: 4200000233
@@ -6320,6 +6554,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 235
     bgp:
       router-id: 0.12.0.237
       asn: 4200000234
@@ -6338,6 +6573,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 236
     bgp:
       router-id: 0.12.0.238
       asn: 4200000235
@@ -6356,6 +6592,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 237
     bgp:
       router-id: 0.12.0.239
       asn: 4200000236
@@ -6374,6 +6611,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 238
     bgp:
       router-id: 0.12.0.240
       asn: 4200000237
@@ -6392,6 +6630,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 239
     bgp:
       router-id: 0.12.0.241
       asn: 4200000238
@@ -6410,6 +6649,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 240
     bgp:
       router-id: 0.12.0.242
       asn: 4200000239
@@ -6428,6 +6668,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 241
     bgp:
       router-id: 0.12.0.243
       asn: 4200000240
@@ -6446,6 +6687,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 242
     bgp:
       router-id: 0.12.0.244
       asn: 4200000241
@@ -6464,6 +6706,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 243
     bgp:
       router-id: 0.12.0.245
       asn: 4200000242
@@ -6482,6 +6725,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 244
     bgp:
       router-id: 0.12.0.246
       asn: 4200000243
@@ -6500,6 +6744,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 245
     bgp:
       router-id: 0.12.0.247
       asn: 4200000244
@@ -6518,6 +6763,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 246
     bgp:
       router-id: 0.12.0.248
       asn: 4200000245
@@ -6536,6 +6782,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 247
     bgp:
       router-id: 0.12.0.249
       asn: 4200000246
@@ -6554,6 +6801,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 248
     bgp:
       router-id: 0.12.0.250
       asn: 4200000247
@@ -6572,6 +6820,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 249
     bgp:
       router-id: 0.12.0.251
       asn: 4200000248
@@ -6590,6 +6839,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 250
     bgp:
       router-id: 0.12.0.252
       asn: 4200000249
@@ -6608,6 +6858,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 251
     bgp:
       router-id: 0.12.0.253
       asn: 4200000250
@@ -6626,6 +6877,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 252
     bgp:
       router-id: 0.12.0.254
       asn: 4200000251
@@ -6644,6 +6896,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 253
     bgp:
       router-id: 0.12.0.255
       asn: 4200000252
@@ -6662,6 +6915,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 254
     bgp:
       router-id: 0.12.1.0
       asn: 4200000253
@@ -6680,6 +6934,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 255
     bgp:
       router-id: 0.12.1.1
       asn: 4200000254
@@ -6698,6 +6953,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 256
     bgp:
       router-id: 0.12.1.2
       asn: 4200000255
@@ -6716,6 +6972,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 257
     bgp:
       router-id: 0.12.1.3
       asn: 4200000256
@@ -6734,6 +6991,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 258
     bgp:
       router-id: 0.12.1.4
       asn: 4200000257
@@ -6752,6 +7010,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 259
     bgp:
       router-id: 0.12.1.5
       asn: 4200000258
@@ -6770,6 +7029,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 260
     bgp:
       router-id: 0.12.1.6
       asn: 4200000259
@@ -6788,6 +7048,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 261
     bgp:
       router-id: 0.12.1.7
       asn: 4200000260
@@ -6806,6 +7067,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 262
     bgp:
       router-id: 0.12.1.8
       asn: 4200000261
@@ -6824,6 +7086,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 263
     bgp:
       router-id: 0.12.1.9
       asn: 4200000262
@@ -6842,6 +7105,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 264
     bgp:
       router-id: 0.12.1.10
       asn: 4200000263
@@ -6860,6 +7124,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 265
     bgp:
       router-id: 0.12.1.11
       asn: 4200000264
@@ -6878,6 +7143,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 266
     bgp:
       router-id: 0.12.1.12
       asn: 4200000265
@@ -6896,6 +7162,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 267
     bgp:
       router-id: 0.12.1.13
       asn: 4200000266
@@ -6914,6 +7181,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 268
     bgp:
       router-id: 0.12.1.14
       asn: 4200000267
@@ -6932,6 +7200,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 269
     bgp:
       router-id: 0.12.1.15
       asn: 4200000268
@@ -6950,6 +7219,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 270
     bgp:
       router-id: 0.12.1.16
       asn: 4200000269
@@ -6968,6 +7238,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 271
     bgp:
       router-id: 0.12.1.17
       asn: 4200000270
@@ -6986,6 +7257,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 272
     bgp:
       router-id: 0.12.1.18
       asn: 4200000271
@@ -7004,6 +7276,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 273
     bgp:
       router-id: 0.12.1.19
       asn: 4200000272
@@ -7022,6 +7295,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 274
     bgp:
       router-id: 0.12.1.20
       asn: 4200000273
@@ -7040,6 +7314,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 275
     bgp:
       router-id: 0.12.1.21
       asn: 4200000274
@@ -7058,6 +7333,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 276
     bgp:
       router-id: 0.12.1.22
       asn: 4200000275
@@ -7076,6 +7352,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 277
     bgp:
       router-id: 0.12.1.23
       asn: 4200000276
@@ -7094,6 +7371,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 278
     bgp:
       router-id: 0.12.1.24
       asn: 4200000277
@@ -7112,6 +7390,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 279
     bgp:
       router-id: 0.12.1.25
       asn: 4200000278
@@ -7130,6 +7409,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 280
     bgp:
       router-id: 0.12.1.26
       asn: 4200000279
@@ -7148,6 +7428,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 281
     bgp:
       router-id: 0.12.1.27
       asn: 4200000280
@@ -7166,6 +7447,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 282
     bgp:
       router-id: 0.12.1.28
       asn: 4200000281
@@ -7184,6 +7466,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 283
     bgp:
       router-id: 0.12.1.29
       asn: 4200000282
@@ -7202,6 +7485,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 284
     bgp:
       router-id: 0.12.1.30
       asn: 4200000283
@@ -7220,6 +7504,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 285
     bgp:
       router-id: 0.12.1.31
       asn: 4200000284
@@ -7238,6 +7523,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 286
     bgp:
       router-id: 0.12.1.32
       asn: 4200000285
@@ -7256,6 +7542,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 287
     bgp:
       router-id: 0.12.1.33
       asn: 4200000286
@@ -7274,6 +7561,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 288
     bgp:
       router-id: 0.12.1.34
       asn: 4200000287
@@ -7292,6 +7580,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 289
     bgp:
       router-id: 0.12.1.35
       asn: 4200000288
@@ -7310,6 +7599,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 290
     bgp:
       router-id: 0.12.1.36
       asn: 4200000289
@@ -7328,6 +7618,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 291
     bgp:
       router-id: 0.12.1.37
       asn: 4200000290
@@ -7346,6 +7637,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 292
     bgp:
       router-id: 0.12.1.38
       asn: 4200000291
@@ -7364,6 +7656,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 293
     bgp:
       router-id: 0.12.1.39
       asn: 4200000292
@@ -7382,6 +7675,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 294
     bgp:
       router-id: 0.12.1.40
       asn: 4200000293
@@ -7400,6 +7694,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 295
     bgp:
       router-id: 0.12.1.41
       asn: 4200000294
@@ -7418,6 +7713,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 296
     bgp:
       router-id: 0.12.1.42
       asn: 4200000295
@@ -7436,6 +7732,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 297
     bgp:
       router-id: 0.12.1.43
       asn: 4200000296
@@ -7454,6 +7751,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 298
     bgp:
       router-id: 0.12.1.44
       asn: 4200000297
@@ -7472,6 +7770,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 299
     bgp:
       router-id: 0.12.1.45
       asn: 4200000298
@@ -7490,6 +7789,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 300
     bgp:
       router-id: 0.12.1.46
       asn: 4200000299
@@ -7508,6 +7808,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 301
     bgp:
       router-id: 0.12.1.47
       asn: 4200000300
@@ -7526,6 +7827,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 302
     bgp:
       router-id: 0.12.1.48
       asn: 4200000301
@@ -7544,6 +7846,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 303
     bgp:
       router-id: 0.12.1.49
       asn: 4200000302
@@ -7562,6 +7865,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 304
     bgp:
       router-id: 0.12.1.50
       asn: 4200000303
@@ -7580,6 +7884,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 305
     bgp:
       router-id: 0.12.1.51
       asn: 4200000304
@@ -7598,6 +7903,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 306
     bgp:
       router-id: 0.12.1.52
       asn: 4200000305
@@ -7616,6 +7922,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 307
     bgp:
       router-id: 0.12.1.53
       asn: 4200000306
@@ -7634,6 +7941,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 308
     bgp:
       router-id: 0.12.1.54
       asn: 4200000307
@@ -7652,6 +7960,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 309
     bgp:
       router-id: 0.12.1.55
       asn: 4200000308
@@ -7670,6 +7979,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 310
     bgp:
       router-id: 0.12.1.56
       asn: 4200000309
@@ -7688,6 +7998,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 311
     bgp:
       router-id: 0.12.1.57
       asn: 4200000310
@@ -7706,6 +8017,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 312
     bgp:
       router-id: 0.12.1.58
       asn: 4200000311
@@ -7724,6 +8036,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 313
     bgp:
       router-id: 0.12.1.59
       asn: 4200000312
@@ -7742,6 +8055,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 314
     bgp:
       router-id: 0.12.1.60
       asn: 4200000313
@@ -7760,6 +8074,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 315
     bgp:
       router-id: 0.12.1.61
       asn: 4200000314
@@ -7778,6 +8093,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 316
     bgp:
       router-id: 0.12.1.62
       asn: 4200000315
@@ -7796,6 +8112,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 317
     bgp:
       router-id: 0.12.1.63
       asn: 4200000316
@@ -7814,6 +8131,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 318
     bgp:
       router-id: 0.12.1.64
       asn: 4200000317
@@ -7832,6 +8150,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 319
     bgp:
       router-id: 0.12.1.65
       asn: 4200000318
@@ -7850,6 +8169,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 320
     bgp:
       router-id: 0.12.1.66
       asn: 4200000319
@@ -7868,6 +8188,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 321
     bgp:
       router-id: 0.12.1.67
       asn: 4200000320
@@ -7886,6 +8207,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 322
     bgp:
       router-id: 0.12.1.68
       asn: 4200000321
@@ -7904,6 +8226,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 323
     bgp:
       router-id: 0.12.1.69
       asn: 4200000322
@@ -7922,6 +8245,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 324
     bgp:
       router-id: 0.12.1.70
       asn: 4200000323
@@ -7940,6 +8264,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 325
     bgp:
       router-id: 0.12.1.71
       asn: 4200000324
@@ -7958,6 +8283,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 326
     bgp:
       router-id: 0.12.1.72
       asn: 4200000325
@@ -7976,6 +8302,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 327
     bgp:
       router-id: 0.12.1.73
       asn: 4200000326
@@ -7994,6 +8321,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 328
     bgp:
       router-id: 0.12.1.74
       asn: 4200000327
@@ -8012,6 +8340,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 329
     bgp:
       router-id: 0.12.1.75
       asn: 4200000328
@@ -8030,6 +8359,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 330
     bgp:
       router-id: 0.12.1.76
       asn: 4200000329
@@ -8048,6 +8378,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 331
     bgp:
       router-id: 0.12.1.77
       asn: 4200000330
@@ -8066,6 +8397,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 332
     bgp:
       router-id: 0.12.1.78
       asn: 4200000331
@@ -8084,6 +8416,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 333
     bgp:
       router-id: 0.12.1.79
       asn: 4200000332
@@ -8102,6 +8435,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 334
     bgp:
       router-id: 0.12.1.80
       asn: 4200000333
@@ -8120,6 +8454,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 335
     bgp:
       router-id: 0.12.1.81
       asn: 4200000334
@@ -8138,6 +8473,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 336
     bgp:
       router-id: 0.12.1.82
       asn: 4200000335
@@ -8156,6 +8492,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 337
     bgp:
       router-id: 0.12.1.83
       asn: 4200000336
@@ -8174,6 +8511,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 338
     bgp:
       router-id: 0.12.1.84
       asn: 4200000337
@@ -8192,6 +8530,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 339
     bgp:
       router-id: 0.12.1.85
       asn: 4200000338
@@ -8210,6 +8549,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 340
     bgp:
       router-id: 0.12.1.86
       asn: 4200000339
@@ -8228,6 +8568,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 341
     bgp:
       router-id: 0.12.1.87
       asn: 4200000340
@@ -8246,6 +8587,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 342
     bgp:
       router-id: 0.12.1.88
       asn: 4200000341
@@ -8264,6 +8606,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 343
     bgp:
       router-id: 0.12.1.89
       asn: 4200000342
@@ -8282,6 +8625,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 344
     bgp:
       router-id: 0.12.1.90
       asn: 4200000343
@@ -8300,6 +8644,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 345
     bgp:
       router-id: 0.12.1.91
       asn: 4200000344
@@ -8318,6 +8663,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 346
     bgp:
       router-id: 0.12.1.92
       asn: 4200000345
@@ -8336,6 +8682,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 347
     bgp:
       router-id: 0.12.1.93
       asn: 4200000346
@@ -8354,6 +8701,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 348
     bgp:
       router-id: 0.12.1.94
       asn: 4200000347
@@ -8372,6 +8720,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 349
     bgp:
       router-id: 0.12.1.95
       asn: 4200000348
@@ -8390,6 +8739,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 350
     bgp:
       router-id: 0.12.1.96
       asn: 4200000349
@@ -8408,6 +8758,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 351
     bgp:
       router-id: 0.12.1.97
       asn: 4200000350
@@ -8426,6 +8777,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 352
     bgp:
       router-id: 0.12.1.98
       asn: 4200000351
@@ -8444,6 +8796,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 353
     bgp:
       router-id: 0.12.1.99
       asn: 4200000352
@@ -8462,6 +8815,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 354
     bgp:
       router-id: 0.12.1.100
       asn: 4200000353
@@ -8480,6 +8834,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 355
     bgp:
       router-id: 0.12.1.101
       asn: 4200000354
@@ -8498,6 +8853,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 356
     bgp:
       router-id: 0.12.1.102
       asn: 4200000355
@@ -8516,6 +8872,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 357
     bgp:
       router-id: 0.12.1.103
       asn: 4200000356
@@ -8534,6 +8891,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 358
     bgp:
       router-id: 0.12.1.104
       asn: 4200000357
@@ -8552,6 +8910,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 359
     bgp:
       router-id: 0.12.1.105
       asn: 4200000358
@@ -8570,6 +8929,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 360
     bgp:
       router-id: 0.12.1.106
       asn: 4200000359
@@ -8588,6 +8948,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 361
     bgp:
       router-id: 0.12.1.107
       asn: 4200000360
@@ -8606,6 +8967,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 362
     bgp:
       router-id: 0.12.1.108
       asn: 4200000361
@@ -8624,6 +8986,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 363
     bgp:
       router-id: 0.12.1.109
       asn: 4200000362
@@ -8642,6 +9005,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 364
     bgp:
       router-id: 0.12.1.110
       asn: 4200000363
@@ -8660,6 +9024,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 365
     bgp:
       router-id: 0.12.1.111
       asn: 4200000364
@@ -8678,6 +9043,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 366
     bgp:
       router-id: 0.12.1.112
       asn: 4200000365
@@ -8696,6 +9062,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 367
     bgp:
       router-id: 0.12.1.113
       asn: 4200000366
@@ -8714,6 +9081,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 368
     bgp:
       router-id: 0.12.1.114
       asn: 4200000367
@@ -8732,6 +9100,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 369
     bgp:
       router-id: 0.12.1.115
       asn: 4200000368
@@ -8750,6 +9119,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 370
     bgp:
       router-id: 0.12.1.116
       asn: 4200000369
@@ -8768,6 +9138,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 371
     bgp:
       router-id: 0.12.1.117
       asn: 4200000370
@@ -8786,6 +9157,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 372
     bgp:
       router-id: 0.12.1.118
       asn: 4200000371
@@ -8804,6 +9176,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 373
     bgp:
       router-id: 0.12.1.119
       asn: 4200000372
@@ -8822,6 +9195,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 374
     bgp:
       router-id: 0.12.1.120
       asn: 4200000373
@@ -8840,6 +9214,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 375
     bgp:
       router-id: 0.12.1.121
       asn: 4200000374
@@ -8858,6 +9233,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 376
     bgp:
       router-id: 0.12.1.122
       asn: 4200000375
@@ -8876,6 +9252,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 377
     bgp:
       router-id: 0.12.1.123
       asn: 4200000376
@@ -8894,6 +9271,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 378
     bgp:
       router-id: 0.12.1.124
       asn: 4200000377
@@ -8912,6 +9290,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 379
     bgp:
       router-id: 0.12.1.125
       asn: 4200000378
@@ -8930,6 +9309,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 380
     bgp:
       router-id: 0.12.1.126
       asn: 4200000379
@@ -8948,6 +9328,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 381
     bgp:
       router-id: 0.12.1.127
       asn: 4200000380
@@ -8966,6 +9347,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 382
     bgp:
       router-id: 0.12.1.128
       asn: 4200000381
@@ -8984,6 +9366,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 383
     bgp:
       router-id: 0.12.1.129
       asn: 4200000382
@@ -9002,6 +9385,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 384
     bgp:
       router-id: 0.12.1.130
       asn: 4200000383
@@ -9020,6 +9404,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 385
     bgp:
       router-id: 0.12.1.131
       asn: 4200000384
@@ -9038,6 +9423,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 386
     bgp:
       router-id: 0.12.1.132
       asn: 4200000385
@@ -9056,6 +9442,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 387
     bgp:
       router-id: 0.12.1.133
       asn: 4200000386
@@ -9074,6 +9461,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 388
     bgp:
       router-id: 0.12.1.134
       asn: 4200000387
@@ -9092,6 +9480,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 389
     bgp:
       router-id: 0.12.1.135
       asn: 4200000388
@@ -9110,6 +9499,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 390
     bgp:
       router-id: 0.12.1.136
       asn: 4200000389
@@ -9128,6 +9518,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 391
     bgp:
       router-id: 0.12.1.137
       asn: 4200000390
@@ -9146,6 +9537,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 392
     bgp:
       router-id: 0.12.1.138
       asn: 4200000391
@@ -9164,6 +9556,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 393
     bgp:
       router-id: 0.12.1.139
       asn: 4200000392
@@ -9182,6 +9575,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 394
     bgp:
       router-id: 0.12.1.140
       asn: 4200000393
@@ -9200,6 +9594,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 395
     bgp:
       router-id: 0.12.1.141
       asn: 4200000394
@@ -9218,6 +9613,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 396
     bgp:
       router-id: 0.12.1.142
       asn: 4200000395
@@ -9236,6 +9632,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 397
     bgp:
       router-id: 0.12.1.143
       asn: 4200000396
@@ -9254,6 +9651,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 398
     bgp:
       router-id: 0.12.1.144
       asn: 4200000397
@@ -9272,6 +9670,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 399
     bgp:
       router-id: 0.12.1.145
       asn: 4200000398
@@ -9290,6 +9689,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 400
     bgp:
       router-id: 0.12.1.146
       asn: 4200000399
@@ -9308,6 +9708,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 401
     bgp:
       router-id: 0.12.1.147
       asn: 4200000400
@@ -9326,6 +9727,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 402
     bgp:
       router-id: 0.12.1.148
       asn: 4200000401
@@ -9344,6 +9746,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 403
     bgp:
       router-id: 0.12.1.149
       asn: 4200000402
@@ -9362,6 +9765,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 404
     bgp:
       router-id: 0.12.1.150
       asn: 4200000403
@@ -9380,6 +9784,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 405
     bgp:
       router-id: 0.12.1.151
       asn: 4200000404
@@ -9398,6 +9803,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 406
     bgp:
       router-id: 0.12.1.152
       asn: 4200000405
@@ -9416,6 +9822,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 407
     bgp:
       router-id: 0.12.1.153
       asn: 4200000406
@@ -9434,6 +9841,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 408
     bgp:
       router-id: 0.12.1.154
       asn: 4200000407
@@ -9452,6 +9860,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 409
     bgp:
       router-id: 0.12.1.155
       asn: 4200000408
@@ -9470,6 +9879,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 410
     bgp:
       router-id: 0.12.1.156
       asn: 4200000409
@@ -9488,6 +9898,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 411
     bgp:
       router-id: 0.12.1.157
       asn: 4200000410
@@ -9506,6 +9917,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 412
     bgp:
       router-id: 0.12.1.158
       asn: 4200000411
@@ -9524,6 +9936,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 413
     bgp:
       router-id: 0.12.1.159
       asn: 4200000412
@@ -9542,6 +9955,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 414
     bgp:
       router-id: 0.12.1.160
       asn: 4200000413
@@ -9560,6 +9974,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 415
     bgp:
       router-id: 0.12.1.161
       asn: 4200000414
@@ -9578,6 +9993,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 416
     bgp:
       router-id: 0.12.1.162
       asn: 4200000415
@@ -9596,6 +10012,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 417
     bgp:
       router-id: 0.12.1.163
       asn: 4200000416
@@ -9614,6 +10031,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 418
     bgp:
       router-id: 0.12.1.164
       asn: 4200000417
@@ -9632,6 +10050,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 419
     bgp:
       router-id: 0.12.1.165
       asn: 4200000418
@@ -9650,6 +10069,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 420
     bgp:
       router-id: 0.12.1.166
       asn: 4200000419
@@ -9668,6 +10088,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 421
     bgp:
       router-id: 0.12.1.167
       asn: 4200000420
@@ -9686,6 +10107,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 422
     bgp:
       router-id: 0.12.1.168
       asn: 4200000421
@@ -9704,6 +10126,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 423
     bgp:
       router-id: 0.12.1.169
       asn: 4200000422
@@ -9722,6 +10145,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 424
     bgp:
       router-id: 0.12.1.170
       asn: 4200000423
@@ -9740,6 +10164,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 425
     bgp:
       router-id: 0.12.1.171
       asn: 4200000424
@@ -9758,6 +10183,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 426
     bgp:
       router-id: 0.12.1.172
       asn: 4200000425
@@ -9776,6 +10202,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 427
     bgp:
       router-id: 0.12.1.173
       asn: 4200000426
@@ -9794,6 +10221,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 428
     bgp:
       router-id: 0.12.1.174
       asn: 4200000427
@@ -9812,6 +10240,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 429
     bgp:
       router-id: 0.12.1.175
       asn: 4200000428
@@ -9830,6 +10259,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 430
     bgp:
       router-id: 0.12.1.176
       asn: 4200000429
@@ -9848,6 +10278,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 431
     bgp:
       router-id: 0.12.1.177
       asn: 4200000430
@@ -9866,6 +10297,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 432
     bgp:
       router-id: 0.12.1.178
       asn: 4200000431
@@ -9884,6 +10316,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 433
     bgp:
       router-id: 0.12.1.179
       asn: 4200000432
@@ -9902,6 +10335,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 434
     bgp:
       router-id: 0.12.1.180
       asn: 4200000433
@@ -9920,6 +10354,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 435
     bgp:
       router-id: 0.12.1.181
       asn: 4200000434
@@ -9938,6 +10373,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 436
     bgp:
       router-id: 0.12.1.182
       asn: 4200000435
@@ -9956,6 +10392,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 437
     bgp:
       router-id: 0.12.1.183
       asn: 4200000436
@@ -9974,6 +10411,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 438
     bgp:
       router-id: 0.12.1.184
       asn: 4200000437
@@ -9992,6 +10430,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 439
     bgp:
       router-id: 0.12.1.185
       asn: 4200000438
@@ -10010,6 +10449,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 440
     bgp:
       router-id: 0.12.1.186
       asn: 4200000439
@@ -10028,6 +10468,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 441
     bgp:
       router-id: 0.12.1.187
       asn: 4200000440
@@ -10046,6 +10487,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 442
     bgp:
       router-id: 0.12.1.188
       asn: 4200000441
@@ -10064,6 +10506,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 443
     bgp:
       router-id: 0.12.1.189
       asn: 4200000442
@@ -10082,6 +10525,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 444
     bgp:
       router-id: 0.12.1.190
       asn: 4200000443
@@ -10100,6 +10544,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 445
     bgp:
       router-id: 0.12.1.191
       asn: 4200000444
@@ -10118,6 +10563,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 446
     bgp:
       router-id: 0.12.1.192
       asn: 4200000445
@@ -10136,6 +10582,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 447
     bgp:
       router-id: 0.12.1.193
       asn: 4200000446
@@ -10154,6 +10601,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 448
     bgp:
       router-id: 0.12.1.194
       asn: 4200000447
@@ -10172,6 +10620,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 449
     bgp:
       router-id: 0.12.1.195
       asn: 4200000448
@@ -10190,6 +10639,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 450
     bgp:
       router-id: 0.12.1.196
       asn: 4200000449
@@ -10208,6 +10658,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 451
     bgp:
       router-id: 0.12.1.197
       asn: 4200000450
@@ -10226,6 +10677,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 452
     bgp:
       router-id: 0.12.1.198
       asn: 4200000451
@@ -10244,6 +10696,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 453
     bgp:
       router-id: 0.12.1.199
       asn: 4200000452
@@ -10262,6 +10715,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 454
     bgp:
       router-id: 0.12.1.200
       asn: 4200000453
@@ -10280,6 +10734,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 455
     bgp:
       router-id: 0.12.1.201
       asn: 4200000454
@@ -10298,6 +10753,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 456
     bgp:
       router-id: 0.12.1.202
       asn: 4200000455
@@ -10316,6 +10772,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 457
     bgp:
       router-id: 0.12.1.203
       asn: 4200000456
@@ -10334,6 +10791,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 458
     bgp:
       router-id: 0.12.1.204
       asn: 4200000457
@@ -10352,6 +10810,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 459
     bgp:
       router-id: 0.12.1.205
       asn: 4200000458
@@ -10370,6 +10829,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 460
     bgp:
       router-id: 0.12.1.206
       asn: 4200000459
@@ -10388,6 +10848,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 461
     bgp:
       router-id: 0.12.1.207
       asn: 4200000460
@@ -10406,6 +10867,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 462
     bgp:
       router-id: 0.12.1.208
       asn: 4200000461
@@ -10424,6 +10886,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 463
     bgp:
       router-id: 0.12.1.209
       asn: 4200000462
@@ -10442,6 +10905,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 464
     bgp:
       router-id: 0.12.1.210
       asn: 4200000463
@@ -10460,6 +10924,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 465
     bgp:
       router-id: 0.12.1.211
       asn: 4200000464
@@ -10478,6 +10943,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 466
     bgp:
       router-id: 0.12.1.212
       asn: 4200000465
@@ -10496,6 +10962,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 467
     bgp:
       router-id: 0.12.1.213
       asn: 4200000466
@@ -10514,6 +10981,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 468
     bgp:
       router-id: 0.12.1.214
       asn: 4200000467
@@ -10532,6 +11000,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 469
     bgp:
       router-id: 0.12.1.215
       asn: 4200000468
@@ -10550,6 +11019,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 470
     bgp:
       router-id: 0.12.1.216
       asn: 4200000469
@@ -10568,6 +11038,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 471
     bgp:
       router-id: 0.12.1.217
       asn: 4200000470
@@ -10586,6 +11057,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 472
     bgp:
       router-id: 0.12.1.218
       asn: 4200000471
@@ -10604,6 +11076,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 473
     bgp:
       router-id: 0.12.1.219
       asn: 4200000472
@@ -10622,6 +11095,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 474
     bgp:
       router-id: 0.12.1.220
       asn: 4200000473
@@ -10640,6 +11114,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 475
     bgp:
       router-id: 0.12.1.221
       asn: 4200000474
@@ -10658,6 +11133,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 476
     bgp:
       router-id: 0.12.1.222
       asn: 4200000475
@@ -10676,6 +11152,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 477
     bgp:
       router-id: 0.12.1.223
       asn: 4200000476
@@ -10694,6 +11171,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 478
     bgp:
       router-id: 0.12.1.224
       asn: 4200000477
@@ -10712,6 +11190,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 479
     bgp:
       router-id: 0.12.1.225
       asn: 4200000478
@@ -10730,6 +11209,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 480
     bgp:
       router-id: 0.12.1.226
       asn: 4200000479
@@ -10748,6 +11228,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 481
     bgp:
       router-id: 0.12.1.227
       asn: 4200000480
@@ -10766,6 +11247,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 482
     bgp:
       router-id: 0.12.1.228
       asn: 4200000481
@@ -10784,6 +11266,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 483
     bgp:
       router-id: 0.12.1.229
       asn: 4200000482
@@ -10802,6 +11285,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 484
     bgp:
       router-id: 0.12.1.230
       asn: 4200000483
@@ -10820,6 +11304,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 485
     bgp:
       router-id: 0.12.1.231
       asn: 4200000484
@@ -10838,6 +11323,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 486
     bgp:
       router-id: 0.12.1.232
       asn: 4200000485
@@ -10856,6 +11342,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 487
     bgp:
       router-id: 0.12.1.233
       asn: 4200000486
@@ -10874,6 +11361,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 488
     bgp:
       router-id: 0.12.1.234
       asn: 4200000487
@@ -10892,6 +11380,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 489
     bgp:
       router-id: 0.12.1.235
       asn: 4200000488
@@ -10910,6 +11399,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 490
     bgp:
       router-id: 0.12.1.236
       asn: 4200000489
@@ -10928,6 +11418,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 491
     bgp:
       router-id: 0.12.1.237
       asn: 4200000490
@@ -10946,6 +11437,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 492
     bgp:
       router-id: 0.12.1.238
       asn: 4200000491
@@ -10964,6 +11456,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 493
     bgp:
       router-id: 0.12.1.239
       asn: 4200000492
@@ -10982,6 +11475,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 494
     bgp:
       router-id: 0.12.1.240
       asn: 4200000493
@@ -11000,6 +11494,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 495
     bgp:
       router-id: 0.12.1.241
       asn: 4200000494
@@ -11018,6 +11513,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 496
     bgp:
       router-id: 0.12.1.242
       asn: 4200000495
@@ -11036,6 +11532,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 497
     bgp:
       router-id: 0.12.1.243
       asn: 4200000496
@@ -11054,6 +11551,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 498
     bgp:
       router-id: 0.12.1.244
       asn: 4200000497
@@ -11072,6 +11570,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 499
     bgp:
       router-id: 0.12.1.245
       asn: 4200000498
@@ -11090,6 +11589,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 500
     bgp:
       router-id: 0.12.1.246
       asn: 4200000499
@@ -11108,6 +11608,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 501
     bgp:
       router-id: 0.12.1.247
       asn: 4200000500
@@ -11126,6 +11627,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 502
     bgp:
       router-id: 0.12.1.248
       asn: 4200000501
@@ -11144,6 +11646,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 503
     bgp:
       router-id: 0.12.1.249
       asn: 4200000502
@@ -11162,6 +11665,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 504
     bgp:
       router-id: 0.12.1.250
       asn: 4200000503
@@ -11180,6 +11684,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 505
     bgp:
       router-id: 0.12.1.251
       asn: 4200000504
@@ -11198,6 +11703,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 506
     bgp:
       router-id: 0.12.1.252
       asn: 4200000505
@@ -11216,6 +11722,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 507
     bgp:
       router-id: 0.12.1.253
       asn: 4200000506
@@ -11234,6 +11741,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 508
     bgp:
       router-id: 0.12.1.254
       asn: 4200000507
@@ -11252,6 +11760,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 509
     bgp:
       router-id: 0.12.1.255
       asn: 4200000508
@@ -11270,6 +11779,7 @@ configuration:
     properties:
     - common
     - tor
+    tornum: 510
     bgp:
       router-id: 0.12.2.0
       asn: 4200000509

--- a/ansible/vars/topo_t1-isolated-d510u2.yml
+++ b/ansible/vars/topo_t1-isolated-d510u2.yml
@@ -2055,7 +2055,7 @@ configuration_properties:
     dut_type: LeafRouter
     podset_number: 1
     tor_number: 512
-    tor_subnet_number: 1
+    tor_subnet_number: 2
     max_tor_subnet_number: 16
     tor_subnet_size: 256
     nhipv6: FC0A::FF


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
To setup bgp routes with correct count, we need to adjust podset parameters in topology files.
And to generate routes on ceos ToR, we need to add tornum in topology files.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We need to setup bgp routes with correct count and generate routes on ceos ToR.

#### How did you do it?
adjusted podset parameters in topology files and added tornum in topology files.
#### How did you verify/test it?
deploy topology in lab
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
