### PR TITLE
Fix failures for test_wr_arp and test_advanced_reboot with secondary subnet enabled

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -444,9 +444,9 @@ class ReloadTest(BaseTest):
                     addr = self.host_ip(prefix, i)
                 except Exception as e:
                     # If the number of hosts exceeds the number of available IPs in the subnet
-                    # we will get an exception. In this case, we will randomly assign an IP
+                    # half host number to avoid the exception and ip collision
                     self.log("Capture exception for host_ip: {}".format(repr(e)))
-                    addr = self.random_ip(prefix)
+                    addr = self.host_ip(prefix, int(i//2))
                 self.vlan_host_ping_map[port][addr] = mac
 
             self.nr_vl_pkts += n_hosts

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -440,7 +440,13 @@ class ReloadTest(BaseTest):
                 mac = self.VLAN_BASE_MAC_PATTERN.format(counter)
                 port = self.ports_per_vlan[vlan][i %
                                                  len(self.ports_per_vlan[vlan])]
-                addr = self.host_ip(prefix, i)
+                try:
+                    addr = self.host_ip(prefix, i)
+                except Exception as e:
+                    # If the number of hosts exceeds the number of available IPs in the subnet
+                    # we will get an exception. In this case, we will randomly assign an IP
+                    self.log("Capture exception for host_ip: {}".format(repr(e)))
+                    addr = self.random_ip(prefix)
                 self.vlan_host_ping_map[port][addr] = mac
 
             self.nr_vl_pkts += n_hosts

--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -404,7 +404,15 @@ class ArpTest(BaseTest):
             self.log("release version does not support advance test case")
             return
 
+        first_run = True
+        final_elapsed = 0
         for test in self.tests:
+            start_time = time.time()
+            # The case should wait long enough for next warm reboot
+            # To make sure to wait the previous warm reboot to finish
+            if not first_run and final_elapsed < self.how_long:
+                self.log(f"Sleeping for {self.how_long - final_elapsed} seconds before next test")
+                time.sleep(self.how_long - final_elapsed)
             port = random.choice(test['acc_ports'])
             test_non_broadcast_reply_thread = threading.Thread(target=self.test_non_broadcast_reply_thr,
                                                                kwargs={'port': port})
@@ -431,6 +439,8 @@ class ArpTest(BaseTest):
                          (uptime_before, uptime_after))
                 self.assertTrue(uptime_before != uptime_after,
                                 "The DUT wasn't rebooted. Uptime: %s vs %s" % (uptime_before, uptime_after))
+            final_elapsed = time.time() - start_time
+            first_run = False
 
     def test_non_broadcast_reply_thr(self, port):
         pkt, exp_pkt = self.gen_pkts[port]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- `platform_tests.test_advanced_reboot` failed due to

`Exception: host number 127 is greater than number of hosts 126 in the network 192.168.0.0/25`

```
Vlan1000                  192.168.0.1/25       up/up         N/A             N/A
                          192.169.0.1/22                     N/A             N/A
Vlan2000                  192.168.0.129/25     up/up         N/A             N/A
```

prefix is 192.168.0.1/25 , i = 127
`addr = self.host_ip(prefix, i)`

 ```
   def host_ip(self, net_ip, host_number):
        src_addr, mask = net_ip.split('/')
        n_hosts = 2**(32 - int(mask))
        if host_number > (n_hosts - 2):
            raise Exception("host number %d is greater than number of hosts %d in the network %s" % (
                host_number, n_hosts - 2, net_ip))
```

`n_hosts = 2**(32 - int(25)) = 128`, so host_ip will throw Exception.
For this small subnet case, will choose a random ip address instead.

- `arp/test_wr_arp.py::TestWrArp::testWrArpAdvance` failed due to

```
2025-01-17 22:22:45 : Rebooting remote side
2025-01-17 22:22:45 : Executing cmd='sudo warm-reboot -c 10.150.23.73'
2025-01-17 22:22:46 : return_code=0, stdout=['Warm restart flag for system is set. Please check if a warm restart for system is in progress.\n'], stderr=[]
2025-01-17 22:22:46 : reply: ok: ['Warm restart flag for system is set. Please check if a warm restart for system is in progress.\n']
2025-01-17 22:22:46 : WR OK!
2025-01-17 22:22:46 : retrieve rule_arp EVERFLOW counter N/A
2025-01-17 22:22:48 : retrieve rule_arp EVERFLOW counter N/A
2025-01-17 22:22:54 : cmd: uptime
2025-01-17 22:22:54 : Check uptime remote side
2025-01-17 22:22:54 : Executing cmd='uptime -s'
2025-01-17 22:22:54 : return_code=0, stdout=['2025-01-17 22:20:47\n'], stderr=[]
2025-01-17 22:22:54 : reply: ok: ['2025-01-17 22:20:47\n']
2025-01-17 22:22:54 : The DUT wasn't rebooted. Uptime: ok: ['2025-01-17 22:20:47\n'] vs ok: ['2025-01-17 22:20:47\n']
```
`sudo warm-reboot -c 10.150.23.73` is not executed successfully, since we have 2 vlans setting in `self.tests`, need to run twice.
But while trying to run the second warm-reboot, the previous one is not finished yet. Will return `"Warm restart flag for system is set. Please check if a warm restart for system is in progress"`
So need to wait long enough for the second run.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
1. for `wr_arp.py`, wait long enough for the second warm-reboot operation
2. for `advanced_reboot.py`, need to pick up a random ip if the host number is out of subnet range.
3. 
#### How did you verify/test it?

`test_wr_arp.py` test evidence on secondary subnet enabled testbed.
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
04:34:20 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================================================= 1 passed, 10 warnings in 821.46s (0:13:41) =========================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function testWrArpAdvance>
INFO:root:Can not get Allure report URL. Please check logs
```


`test_advanced_reboot.py` test evidence on secondary subnet enabled testbed:
```
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
17:21:49 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 12 passed, 2 skipped, 8 warnings in 35623.46s (9:53:43) ===================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_cancelled_warm_reboot[bjw-can-7260-11]>
INFO:root:Can not get Allure report URL. Please check logs
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
