### PR TITLE
Remove null bytes in the SNMP test

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -827,7 +827,7 @@ def redis_hgetall(duthost, db_id, key):
         if not output:
             return {}
         # fix to make literal_eval() work with nested dictionaries
-        content = output.replace("'{", '"{').replace("}'", '}"')
+        content = output.replace('\x00', '').replace("'{", '"{').replace("}'", '}"')
         return ast.literal_eval(content)
 
     if duthost.is_multi_asic:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove null bytes in the SNMP test
Fixes #

#### **1. Symptoms**
SNMP case `test_transceiver_info` fail with error `ValueError: source code string cannot contain null bytes`


#### **2. Root Cause**
The case execute command `sonic-db-cli STATE_DB HGETALL "TRANSCEIVER_INFO|Ethernet32"`, the `vendor_date` value include null value
```
admin@arc-switch1004:~$ sonic-db-cli STATE_DB HGETALL "TRANSCEIVER_INFO|Ethernet32"
{'dom_capability': 'N/A', 'manufacturer': 'Mellanox        ', 'vendor_date': '2019-01-17 ', 'is_replaceable': 'True', 'ext_identifier': 'Power Class 3 Module (2.5W max.), No CLEI code present in Page 02h, CDR present in TX, CDR present in RX', 'vendor_oui': '00-02-c9', 'encoding': '64B/66B', 'cable_type': 'Length Cable Assembly(m)', 'cable_length': '3.0', 'model': 'MFA1A00-C003    ', 'application_advertisement': 'N/A', 'ext_rateselect_compliance': 'Unknown', 'vendor_rev': 'B2', 'specification_compliance': "{'10/40G Ethernet Compliance Code': 'Extended', 'SONET Compliance Codes': 'Unknown', 'SAS/SATA Compliance Codes': 'Unknown', 'Gigabit Ethernet Compliant Codes': 'Unknown', 'Fibre Channel Link Length': 'Unknown', 'Fibre Channel Transmitter Technology': 'Unknown', 'Fibre Channel Transmission Media': 'Unknown', 'Fibre Channel Speed': 'Unknown', 'Extended Specification Compliance': '100G AOC (Active Optical Cable) or 25GAUI C2M AOC'}", 'connector': 'No separable connector', 'serial': 'MT1903FT05955   ', 'type': 'QSFP28 or later', 'nominal_bit_rate': '255'}
```

This is the output during pdb debug, we can see the `\x00\x00` in `vendor_date`, which lead to case fail
```
(Pdb) content
'{\'dom_capability\': \'N/A\', \'manufacturer\': \'Mellanox        \', \'vendor_date\': \'2019-01-17 \x00\x00\', \'is_replaceable\': \'True\', \'ext_identifier\': \'Power Class 3 Module (2.5W max.), No CLEI code present in Page 02h, CDR present in TX, CDR present in RX\', \'vendor_oui\': \'00-02-c9\', \'encoding\': \'64B/66B\', \'cable_type\': \'Length Cable Assembly(m)\', \'cable_length\': \'3.0\', \'model\': \'MFA1A00-C003    \', \'application_advertisement\': \'N/A\', \'ext_rateselect_compliance\': \'Unknown\', \'vendor_rev\': \'B2\', \'specification_compliance\': "{\'10/40G Ethernet Compliance Code\': \'Extended\', \'SONET Compliance Codes\': \'Unknown\', \'SAS/SATA Compliance Codes\': \'Unknown\', \'Gigabit Ethernet Compliant Codes\': \'Unknown\', \'Fibre Channel Link Length\': \'Unknown\', \'Fibre Channel Transmitter Technology\': \'Unknown\', \'Fibre Channel Transmission Media\': \'Unknown\', \'Fibre Channel Speed\': \'Unknown\', \'Extended Specification Compliance\': \'100G AOC (Active Optical Cable) or 25GAUI C2M AOC\'}", \'connector\': \'No separable connector\', \'serial\': \'MT1903FT05955   \', \'type\': \'QSFP28 or later\', \'nominal_bit_rate\': \'255\'}'
```

#### **3. Fix**
Replace `\x00` to `""`. After that case pass



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
