### PR TITLE
update timeout value and skip warm reboot on isolated topology for test_bgp_session.py

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -130,9 +130,12 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     '''
     # Skip the test on dualtor with reboot test type
     pytest_require(
-        ("dualtor" not in tbinfo["topo"]["name"] or test_type != "reboot"),
+        ("dualtor" not in tbinfo["topo"]["name"]
+         or test_type != "reboot"),
         "warm reboot is not supported on dualtor"
     )
+    if test_type == "reboot" and "isolated" in tbinfo["topo"]["name"]:
+        pytest.skip("Warm Reboot is not supported on isolated topology")
 
     duthost = duthosts[rand_one_dut_hostname]
 

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -174,8 +174,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
             time.sleep(1)
 
     duthost.shell('show ip bgp summary', module_ignore_errors=True)
+    # default keepalive is 60 seconds, timeout 180 seconds. Hence wait for 180 seconds before timeout.
     pytest_assert(
-        wait_until(90, 5, 0, verify_bgp_session_down, duthost, neighbor),
+        wait_until(180, 10, 0, verify_bgp_session_down, duthost, neighbor),
         "neighbor {} state is still established".format(neighbor)
     )
 

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -130,8 +130,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     '''
     # Skip the test on dualtor with reboot test type
     pytest_require(
-        ("dualtor" not in tbinfo["topo"]["name"]
-         or test_type != "reboot"),
+        ("dualtor" not in tbinfo["topo"]["name"] or test_type != "reboot"),
         "warm reboot is not supported on dualtor"
     )
     if test_type == "reboot" and "isolated" in tbinfo["topo"]["name"]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the following error in `test_bgp_session.py`:

```
>           raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           tests.common.errors.RunAnsibleModuleFail: run module command failed, Ansible Results =>
E           failed = True
E           changed = True
E           rc = 101
E           cmd = ['warm-reboot']
E           start = 2025-02-28 21:50:57.537650
E           end = 2025-02-28 21:51:03.919474
E           delta = 0:00:06.381824
E           msg = non-zero return code
E           invocation = {'module_args': {'_raw_params': 'warm-reboot', '_uses_shell': False, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
E           _ansible_no_log = None
E           stdout =
E           stderr =
E           ISSU is not enabled on this HWSKU
E           Warm reboot is not supported

FAILED bgp/test_bgp_session.py::test_bgp_session_interface_down[interface-reboot]
FAILED bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-bgp_docker]
FAILED bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-swss_docker]
FAILED bgp/test_bgp_session.py::test_bgp_session_interface_down[neighbor-reboot]
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
warm/fast reboot is not supported on t0-isolated or t1-isolated topology. 

#### How did you do it?
skip it on `isolated` topology
also update the wait time after shutdown bgp neighbor to align with default hold-timer

#### How did you verify/test it?
Verified on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
