### PR TITLE
SNMP Queue Counters Failures

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -34,9 +34,9 @@ def get_queuestat_ctrs(duthost, cmd):
     return queue_cnt
 
 
-def check_snmp_cmd_output(duthost, cmd):
+def check_snmp_cmd_output(duthost, cmd, count):
     out_len = len(duthost.shell(cmd)["stdout_lines"])
-    if out_len > 1:
+    if out_len >= count:
         return True
     else:
         return False
@@ -139,7 +139,7 @@ def test_snmp_queue_counters(duthosts,
         = "true"
     load_new_cfg(duthost, data, loganalyzer)
     stat_queue_counters_cnt_pre = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
-    wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
+    wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd, stat_queue_counters_cnt_pre)
     queue_counters_cnt_pre = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
 
     # snmpwalk output should get info for same number of buffers as queuestat -p dose
@@ -151,7 +151,7 @@ def test_snmp_queue_counters(duthosts,
     del data['BUFFER_QUEUE'][buffer_queue_to_del]
     load_new_cfg(duthost, data, loganalyzer)
     stat_queue_counters_cnt_post = get_queuestat_ctrs(duthost, get_queue_stat_cmd) * UNICAST_CTRS
-    wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd)
+    wait_until(60, 20, 0, check_snmp_cmd_output, duthost, get_bfr_queue_cntrs_cmd, stat_queue_counters_cnt_post)
     queue_counters_cnt_post = get_queue_ctrs(duthost, get_bfr_queue_cntrs_cmd)
     pytest_assert((queue_counters_cnt_post == stat_queue_counters_cnt_post),
                   "Snmpwalk Queue counters actual count {} differs from expected queue stat count values {}".


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Queue Counters fetched via SNMP Walk isn't accurate because of delay in OIDs being registered after config reload, thereby causing tests to fail.

Fixes # (issue)
- Just changed the logic for `check_snmp_cmd_output` function, which now will return True only after the SNMP Walk outcome count is same as Queue Stat command outcome. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
- Issue had been seen in 202405 failures.
- Issue seen was - "Snmpwalk Queue counters actual count 4 differs from expected queue stat count values 36"

#### How did you do it?
- Just changed the logic for `check_snmp_cmd_output` function, which now will return True only after the SNMP Walk outcome count is same as Queue Stat command outcome

#### How did you verify/test it?
- validated on our platforms & it passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
