### PR TITLE
improve timing in test_auto_techsupport testcase

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -1020,7 +1020,7 @@ def get_expected_oldest_timestamp_datetime(duthost, since_value_in_seconds):
     current_time_str = duthost.shell('date "+%b %d %H:%M"')['stdout']
     current_time = dateutil.parser.parse(current_time_str)
 
-    syslog_file_list = duthost.shell('sudo ls -l /var/log/syslog*')['stdout'].splitlines()
+    syslog_file_list = duthost.shell('sudo ls -lt /var/log/syslog*')['stdout'].splitlines()
 
     syslogs_creation_date_dict = {}
     syslog_file_name_index = 8
@@ -1034,9 +1034,9 @@ def get_expected_oldest_timestamp_datetime(duthost, since_value_in_seconds):
             syslogs_creation_date_dict[file_timestamp] = [syslog_file_name]
 
     # Sorted from new to old
-    syslogs_sorted = sorted(list(syslogs_creation_date_dict.keys()), reverse=True)
+    syslogs = list(syslogs_creation_date_dict.keys())
     expected_files_in_techsupport_list = []
-    for date in syslogs_sorted:
+    for date in syslogs:
         expected_files_in_techsupport_list.extend(syslogs_creation_date_dict[date])
         if (current_time - date).seconds > since_value_in_seconds and current_time > date:
             break


### PR DESCRIPTION
**Description of PR**
**Summary:**
In test_auto_techsupport.py script, there is a function named get_expected_oldest_timestamp_datetime whcih finds the oldest timestamp that should be present in the generated techsupport. This function is called before checking if the expected show-techsupport process is present. If there are lot of syslog files on DUT, this method was taking a long time and show-techsupport process was already ending before the script checks it. This was causing a failure like "AssertionError: Expected techsupport generation not started'"
This PR improves the method get_expected_oldest_timestamp_datetime to make it more efficient

**Type of change**
Bug fix

**Back port request**
202405
202411
202311

**Approach**

**How did you do it?**
The method get_expected_oldest_timestamp_datetime used a command 'sudo ls -l /var/log/syslog*' to get a list of syslog files. It then sorts the list based on the timestamp.
I changed the command to 'sudo ls -lt /var/log/syslog*' so that there is no need for sorting.

**How did you verify/test it?**
Verified that the TC passed after this change.