### PR TITLE
Modify wr_arp PTF script to generate an ARP packet of only 42 bytes

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -176,6 +176,7 @@ class ArpTest(BaseTest):
         )
 
         exp_pkt = testutils.simple_arp_packet(
+            pktlen=42,
             ip_snd=gw,
             ip_tgt=port_ip,
             eth_src=self.dut_mac,


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #17502

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

In KVM environments, it's possible that an ARP response that gets forwarded is less than 60 bytes, less than the minimum Ethernet frame size. In physical environments, it'll almost always be at least the minimum Ethernet frame size. In the lab, the `arp_responder.py` script adds a marker in the padding at the end of the ARP packet to indicate that it came from that script.

#### How did you do it?

To gracefully handle all cases, generate the expected ARP response packet as a 42-byte packet, and ignore extra bytes.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
