### PR TITLE
Skip warm/fast reboot for test_restapi.py for isolated topology

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -59,6 +59,7 @@ def test_check_reset_status(construct_url, duthosts, rand_one_dut_hostname, loca
     support_warm_fast_reboot = True
     if 'isolated' in duthosts.tbinfo['topo']['name']:
         support_warm_fast_reboot = False
+        logger.info("Skipping warm and fast reboot tests for isolated topology")
 
     # Check reset status post fast reboot
     if support_warm_fast_reboot:

--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -56,15 +56,23 @@ def test_check_reset_status(construct_url, duthosts, rand_one_dut_hostname, loca
     response = r.json()
     pytest_assert(response['reset_status'] == "true")
 
+    support_warm_fast_reboot = True
+    if 'isolated' in duthosts.tbinfo['topo']['name']:
+        support_warm_fast_reboot = False
+
     # Check reset status post fast reboot
-    check_reset_status_after_reboot(
-        'fast', "false", "true", duthost, localhost, construct_url)
+    if support_warm_fast_reboot:
+        check_reset_status_after_reboot(
+            'fast', "false", "true", duthost, localhost, construct_url)
+
     # Check reset status post cold reboot
     check_reset_status_after_reboot(
         'cold', "false", "true", duthost, localhost, construct_url)
+
     # Check reset status post warm reboot
-    check_reset_status_after_reboot(
-        'warm', "false", "false", duthost, localhost, construct_url)
+    if support_warm_fast_reboot:
+        check_reset_status_after_reboot(
+            'warm', "false", "false", duthost, localhost, construct_url)
 
 
 def check_reset_status_after_reboot(reboot_type, pre_reboot_status, post_reboot_status,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
t0-isolated/t1-isolated topology doesn't support warm/fast reboot. 
Skip warm/fast reboot for restapi test case for isolated topology.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Running this test with t1-isolated topology will result in failure.

#### How did you do it?
Skip it for isolated topologies.

#### How did you verify/test it?
Verified on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
