### PR TITLE
feat: support trimming lab inv file

### DIFF
--- a/tests/common/helpers/inventory_utils.py
+++ b/tests/common/helpers/inventory_utils.py
@@ -8,7 +8,7 @@ from tests.common.helpers.yaml_utils import BlankNone
 logger = logging.getLogger(__name__)
 
 
-def trim_inventory(inv_files, tbinfo):
+def trim_inventory(inv_files, tbinfo, target_hostname):
     """
     Trim the useless topology neighbor the inv_files according to testbed to speed up ansible inventory initialization.
 
@@ -21,12 +21,14 @@ def trim_inventory(inv_files, tbinfo):
     The useless ansible_host extremely slow down the initialization.
 
     Hence, will trim and generate a temporary inventory file, for example:
-    ['../ansible/veos', '../ansible/inv1'] -> ['../ansible/veos_kvm-t0_trim_tmp', '../ansible/inv1']
-    Then pytest will use the light inventory file '../ansible/veos_kvm-t0_trim_tmp' to initialize the ansible_hosts.
+    ['../ansible/veos', '../ansible/lab1'] -> ['../ansible/veos_kvm-t0_trim_tmp', '../ansible/lab1_kvm-t0_trim_tmp']
+    Then pytest will use the light inventory files '../ansible/veos_kvm-t0_trim_tmp' and
+    '../ansible/lab1_kvm-t0_trim_tmp' to initialize the ansible_hosts.
 
     Args:
-        inv_files: inventory file list, sample: ['../ansible/veos', '../ansible/inv1']
+        inv_files: inventory file list, sample: ['../ansible/veos', '../ansible/lab1']
         tbinfo: tbinfo
+        target_hostname: target_hostname, will be None if parallel run is disabled
 
     Returns:
         Direct update inv_files and return nothing
@@ -34,8 +36,19 @@ def trim_inventory(inv_files, tbinfo):
 
     vm_base = tbinfo.get("vm_base", None)
     tb_name = tbinfo.get("conf-name", None)
+    ptf = tbinfo.get("ptf", None)
+    inv_name = tbinfo.get("inv_name", None)
+    duts = tbinfo.get("duts", None)
+
+    # TODO: Trim fanout hosts and PDU hosts. Currently blocked by https://github.com/sonic-net/sonic-mgmt/issues/17347
+    # graph_facts = get_graph_facts(localhost, duts)
+    # fanout_hosts_set = get_fanout_hosts_set(graph_facts) if graph_facts else set()
+    # pdu_hosts_set = get_pdu_hosts_set(graph_facts) if graph_facts else set()
+
     pattern = r'VM\d{3,7}'
-    logger.info(f"Start to trim inventory, tb[{tb_name}] vm_base [{vm_base}], inv file {inv_files}")
+
+    logger.info(f"Start to trim inventory, inv_files: {inv_files}, vm_base: {vm_base}, tb_name: {tb_name}, "
+                f"ptf: {ptf}, inv_name: {inv_name}, duts: {duts}")
 
     # Find a key in all the levels of a dict,
     # Return the val of the key and the vm_base_path of the key
@@ -55,36 +68,143 @@ def trim_inventory(inv_files, tbinfo):
                     stack.append((value, path + [key]))
         return None, []
 
-    # Remove all the matched
+    def get_value_by_key_path(d: dict, key_path: list):
+        for k in key_path:
+            d = d[k]
+
+        return d
+
+    def dump_trimmed_inv_to_file(trimmed_inv, trimmed_inventory_file_name):
+        with BlankNone(), open(trimmed_inventory_file_name, 'w') as f:
+            yaml.dump(trimmed_inv, f)
+
+    # Remove all the unnecessary nodes in the inventory file(s)
     for idx in range(len(inv_files)):
         inv_file = inv_files[idx]
+        if target_hostname is not None:
+            trimmed_inv_file_name = f"{inv_file}_{tb_name}_{target_hostname}_trim_tmp"
+        else:
+            trimmed_inv_file_name = f"{inv_file}_{tb_name}_trim_tmp"
+
         with open(inv_file, 'r') as file:
             inv = yaml.safe_load(file)
-            # If the vm_base is found in the inv_file,
-            # then other useless topology neighbor definition are in it,
-            # that's the inventory to be trimmed
-            _, vm_base_path = find_key(d=inv, target_key=vm_base)
-            if vm_base_path:
-                keys_to_del = set()
-                logger.info(f"Find vm_base {vm_base} in inv file {inv_file}, path: {vm_base_path}")
+            if inv_file.split('/')[-1] == inv_name:
 
-                for root_key in inv.keys():
-                    neighbor_val, neighbor_path = find_key(d=inv[root_key], regex=pattern)
-                    if neighbor_path:
-                        # Keep the neighbor server for the testbed
-                        if root_key == vm_base_path[0]:
-                            logger.info(f"vm_base[{vm_base}] located in {root_key}, inv file {inv_file}, keep it")
-                        # Remove all the useless neighbor server ansible_hosts
-                        else:
-                            logger.info(f"Attempt to remove {root_key} in inv file {inv_file}")
-                            keys_to_del.add(root_key)
+                def trim_value_of_key_path(key_path, keys_to_keep):
+                    original_val = get_value_by_key_path(d=inv, key_path=key_path)
+                    all_keys = set(original_val.keys())
+                    for key in all_keys:
+                        if key not in keys_to_keep:
+                            del original_val[key]
 
-                for key_to_del in keys_to_del:
-                    del inv[key_to_del]
+                vars_to_trim = ["ptf", "hwsku"]
+                for var in vars_to_trim:
+                    if var == "ptf" and ptf:
+                        _, ptf_key_path = find_key(d=inv, target_key=ptf)
+                        if ptf_key_path:
+                            logger.info(f"Keep PTF host {ptf} and trim the rest PTF hosts")
+                            trim_value_of_key_path(ptf_key_path[:-1], {ptf})
+                    # elif var == "pdu" and pdu_hosts_set:
+                    #     _, pdu_key_path = find_key(d=inv, target_key=next(iter(pdu_hosts_set)))
+                    #     if pdu_key_path:
+                    #         trim_value_of_key_path(pdu_key_path, pdu_hosts_set)
+                    # elif var == "fanout" and fanout_hosts_set:
+                    #     _, fanout_key_path = find_key(d=inv, target_key=next(iter(fanout_hosts_set)))
+                    #     if fanout_key_path:
+                    #         trim_value_of_key_path(fanout_key_path, fanout_hosts_set)
+                    elif var == "hwsku" and duts:
+                        # We have all the user-defined HwSKUs as the root keys of this inv file, and these
+                        # HwSKUs combined should be a subset of the keys under the sonic.children node.
+                        # We want to keep the active HwSKU(s) based on the DUTs info and trim the rest.
+                        # Besides, we should also trim the DUT hosts under active HwSKU(s) based on DUTs info.
+                        # Note: if we find an active DUT's HwSKU is somehow not a value under sonic.children node,
+                        # we will skip the HwSKU trimming to avoid potential data loss.
+                        all_hwskus = set(inv["sonic"]["children"].keys())
+                        should_trim_hwsku = True
+                        hwskus_to_keep = dict()
+                        for dut in duts:
+                            _, dut_key_path = find_key(d=inv, target_key=dut)
+                            curr_hwksu = dut_key_path[0] if dut_key_path else None
+                            if not curr_hwksu or curr_hwksu in hwskus_to_keep:
+                                continue
 
-                # dump and replace trimmed inventory file
-                trimmed_inventory_file_name = f"{inv_file}_{tb_name}_trim_tmp"
-                with BlankNone(), open(trimmed_inventory_file_name, 'w') as f:
-                    yaml.dump(inv, f)
+                            if curr_hwksu in all_hwskus:
+                                hwskus_to_keep[curr_hwksu] = dut_key_path
+                            else:
+                                logger.warning(
+                                    f"DUT {dut}'s hwsku is not a value under sonic.children node, skip trimming hwsku"
+                                )
 
-                inv_files[idx] = trimmed_inventory_file_name
+                                should_trim_hwsku = False
+                                break
+
+                        if should_trim_hwsku:
+                            for hwsku in all_hwskus:
+                                if hwsku in hwskus_to_keep:
+                                    trim_value_of_key_path(hwskus_to_keep[hwsku][:-1], set(duts))
+                                else:
+                                    del inv["sonic"]["children"][hwsku]
+                                    if hwsku in inv:
+                                        logger.info(f"Attempt to delete {hwsku} in inv file {inv_file}")
+                                        del inv[hwsku]
+                    else:
+                        logger.warning(f"Unknown or invalid var {var} to trim")
+
+                dump_trimmed_inv_to_file(inv, trimmed_inv_file_name)
+                inv_files[idx] = trimmed_inv_file_name
+            else:
+                # If the vm_base is found in the inv_file,
+                # then other useless topology neighbor definition are in it,
+                # that's the inventory to be trimmed
+                _, vm_base_path = find_key(d=inv, target_key=vm_base)
+                if vm_base_path:
+                    keys_to_del = set()
+                    logger.info(f"Find vm_base {vm_base} in inv file {inv_file}, path: {vm_base_path}")
+
+                    for root_key in inv.keys():
+                        neighbor_val, neighbor_path = find_key(d=inv[root_key], regex=pattern)
+                        if neighbor_path:
+                            # Keep the neighbor server for the testbed
+                            if root_key == vm_base_path[0]:
+                                logger.info(f"vm_base[{vm_base}] located in {root_key}, inv file {inv_file}, keep it")
+                            # Remove all the useless neighbor server ansible_hosts
+                            else:
+                                logger.info(f"Attempt to remove {root_key} in inv file {inv_file}")
+                                keys_to_del.add(root_key)
+
+                    for key_to_del in keys_to_del:
+                        del inv[key_to_del]
+
+                    dump_trimmed_inv_to_file(inv, trimmed_inv_file_name)
+                    inv_files[idx] = trimmed_inv_file_name
+
+# def get_graph_facts(localhost, duts):
+#     try:
+#         return localhost.conn_graph_facts(hosts=duts, filepath="../ansible/files")["ansible_facts"]
+#     except Exception as e:
+#         logger.error(f"Failed to get graph facts: {e}")
+#         return None
+#
+#
+# def get_fanout_hosts_set(graph_facts):
+#     try:
+#         return {
+#             str(details["peerdevice"])
+#             for device, ports in graph_facts['device_conn'].items()
+#             for port, details in ports.items()
+#         }
+#     except Exception as e:
+#         logger.error(f"Failed to get fanout hosts set: {e}")
+#         return set()
+#
+#
+# def get_pdu_hosts_set(graph_facts):
+#     try:
+#         return {
+#             str(details["Hostname"])
+#             for device, pdus in graph_facts['device_pdu_info'].items()
+#             for pdu, details in pdus.items()
+#         }
+#     except Exception as e:
+#         logger.error(f"Failed to get PDU hosts set: {e}")
+#         return set()

--- a/tests/common/helpers/inventory_utils.py
+++ b/tests/common/helpers/inventory_utils.py
@@ -40,13 +40,9 @@ def trim_inventory(inv_files, tbinfo, target_hostname):
     inv_name = tbinfo.get("inv_name", None)
     duts = tbinfo.get("duts", None)
 
-    # TODO: Trim fanout hosts and PDU hosts. Currently blocked by https://github.com/sonic-net/sonic-mgmt/issues/17347
-    # graph_facts = get_graph_facts(localhost, duts)
-    # fanout_hosts_set = get_fanout_hosts_set(graph_facts) if graph_facts else set()
-    # pdu_hosts_set = get_pdu_hosts_set(graph_facts) if graph_facts else set()
-
     pattern = r'VM\d{3,7}'
 
+    # TODO: Trim fanout hosts and PDU hosts. Currently blocked by https://github.com/sonic-net/sonic-mgmt/issues/17347
     logger.info(f"Start to trim inventory, inv_files: {inv_files}, vm_base: {vm_base}, tb_name: {tb_name}, "
                 f"ptf: {ptf}, inv_name: {inv_name}, duts: {duts}")
 
@@ -104,14 +100,6 @@ def trim_inventory(inv_files, tbinfo, target_hostname):
                         if ptf_key_path:
                             logger.info(f"Keep PTF host {ptf} and trim the rest PTF hosts")
                             trim_value_of_key_path(ptf_key_path[:-1], {ptf})
-                    # elif var == "pdu" and pdu_hosts_set:
-                    #     _, pdu_key_path = find_key(d=inv, target_key=next(iter(pdu_hosts_set)))
-                    #     if pdu_key_path:
-                    #         trim_value_of_key_path(pdu_key_path, pdu_hosts_set)
-                    # elif var == "fanout" and fanout_hosts_set:
-                    #     _, fanout_key_path = find_key(d=inv, target_key=next(iter(fanout_hosts_set)))
-                    #     if fanout_key_path:
-                    #         trim_value_of_key_path(fanout_key_path, fanout_hosts_set)
                     elif var == "hwsku" and duts:
                         # We have all the user-defined HwSKUs as the root keys of this inv file, and these
                         # HwSKUs combined should be a subset of the keys under the sonic.children node.
@@ -177,34 +165,3 @@ def trim_inventory(inv_files, tbinfo, target_hostname):
 
                     dump_trimmed_inv_to_file(inv, trimmed_inv_file_name)
                     inv_files[idx] = trimmed_inv_file_name
-
-# def get_graph_facts(localhost, duts):
-#     try:
-#         return localhost.conn_graph_facts(hosts=duts, filepath="../ansible/files")["ansible_facts"]
-#     except Exception as e:
-#         logger.error(f"Failed to get graph facts: {e}")
-#         return None
-#
-#
-# def get_fanout_hosts_set(graph_facts):
-#     try:
-#         return {
-#             str(details["peerdevice"])
-#             for device, ports in graph_facts['device_conn'].items()
-#             for port, details in ports.items()
-#         }
-#     except Exception as e:
-#         logger.error(f"Failed to get fanout hosts set: {e}")
-#         return set()
-#
-#
-# def get_pdu_hosts_set(graph_facts):
-#     try:
-#         return {
-#             str(details["Hostname"])
-#             for device, pdus in graph_facts['device_pdu_info'].items()
-#             for pdu, details in pdus.items()
-#         }
-#     except Exception as e:
-#         logger.error(f"Failed to get PDU hosts set: {e}")
-#         return set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,8 @@ def enhance_inventory(request, tbinfo):
     inv_files = [inv_file.strip() for inv_file in inv_opt.split(",")]
 
     if request.config.getoption("trim_inv"):
-        trim_inventory(inv_files, tbinfo)
+        target_hostname = get_target_hostname(request)
+        trim_inventory(inv_files, tbinfo, target_hostname)
 
     try:
         logger.info(f"Inventory file: {inv_files}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Support trimming the inventory files such as `ansible/lab`, `ansible/t2_lab` etc when passing `--trim_inv` option.

Summary:
Fixes # (issue) Microsoft ADO 30056122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
When we enable inventory trimming by passing the `--trim_inv` option, the current logic is to only trim the `ansible/veos` file, but we noticed that the other inventory file (such as `ansible/lab`) should also be trimmed because it contains the configs of all the devices in that lab, but we only need the configs related to the current test run. Therefore, we decided to support trimming these inventory files as well.

Please note that the PDU & Fanout hosts trimming is not supported in this PR as it's currently blocked by #17347 

#### How did you do it?

#### How did you verify/test it?
I ran the new trimming logic on various lab files and can confirm it's working well:
- https://elastictest.org/scheduler/testplan/67c7ad505048655bf9cf8a58
- https://elastictest.org/scheduler/testplan/67c78be48dcac0cdc64a3998
- https://elastictest.org/scheduler/testplan/67c78cc7f60a7a79ff1ae585
- https://elastictest.org/scheduler/testplan/67c78c9c8dcac0cdc64a399c
- https://elastictest.org/scheduler/testplan/67c7b419d0bae94c81d8a9d6
- https://elastictest.org/scheduler/testplan/67ca846a5048655bf9cf8f7b

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
