### PR TITLE
Improve TACACS local accounting test case by add retry

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -92,7 +92,7 @@ def check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds):
     pytest_assert(len(logs) == 0, "Expected to find no accounting logs but found: {}".format(logs))
 
 
-def check_local_log_exist(duthost, tacacs_creds, command):
+def check_local_log_exist(duthost, tacacs_creds, command, ptfhost, rw_user_client, retry=6):
     """
         Remove all ansible command log with /D command,
         which will match following format:
@@ -103,26 +103,36 @@ def check_local_log_exist(duthost, tacacs_creds, command):
                 "INFO audisp-tacplus: Accounting: user: tacacs_rw_user,.*, command: .*command,"
             Print matched logs with /P command.
     """
+
+    logs = []
     username = tacacs_creds['tacacs_rw_user']
     log_pattern = "/ansible.legacy.command Invoked/D;\
-                  /INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
-                  .format(username, command)
-    logs = wait_for_log(duthost, "/var/log/syslog", log_pattern)
+                /INFO audisp-tacplus.+Accounting: user: {0},.*, command: .*{1},/P" \
+                .format(username, command)
 
-    if len(logs) == 0:
-        # Print recent logs for debug
-        recent_logs = duthost.command("tail /var/log/syslog -n 1000")
-        logger.debug("Found logs: %s", recent_logs)
+    while retry > 0:
+        retry -= 1
 
-        # Missing log may caused by incorrect NSS config
-        tacacs_config = duthost.command("cat /etc/tacplus_nss.conf")
-        logger.debug("tacplus_nss.conf: %s", tacacs_config)
+        cleanup_tacacs_log(ptfhost, rw_user_client)
 
-    pytest_assert(len(logs) > 0)
+        ssh_run_command(rw_user_client, command)
 
-    # exclude logs of the sed command produced by Ansible
-    logs = list([line for line in logs if 'sudo sed' not in line])
-    logger.info("Found logs: %s", logs)
+        logs = wait_for_log(duthost, "/var/log/syslog", log_pattern, timeout=120)
+
+        # exclude logs of the sed command produced by Ansible
+        logs = list([line for line in logs if 'sudo sed' not in line])
+
+        if len(logs) == 0:
+            # Print recent logs for debug
+            recent_logs = duthost.command("tail /var/log/syslog -n 2000")
+            logger.debug("Found logs: %s", recent_logs)
+
+            # Missing log may caused by incorrect NSS config
+            tacacs_config = duthost.command("cat /etc/tacplus_nss.conf")
+            logger.debug("tacplus_nss.conf: %s", tacacs_config)
+        else:
+            logger.info("Found logs: %s", logs)
+            break
 
     pytest_assert(logs, 'Failed to find an expected log message by pattern: ' + log_pattern)
 
@@ -285,9 +295,6 @@ def test_accounting_local_only(
                             rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting local")
-    cleanup_tacacs_log(ptfhost, rw_user_client)
-
-    ssh_run_command(rw_user_client, "grep")
 
     # Verify syslog have user command record.
     check_local_log_exist(duthost, tacacs_creds, "grep")
@@ -305,13 +312,12 @@ def test_accounting_tacacs_and_local(
                                     rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
-    cleanup_tacacs_log(ptfhost, rw_user_client)
 
-    ssh_run_command(rw_user_client, "grep")
+    check_local_log_exist(duthost, tacacs_creds, "grep")
 
     # Verify TACACS+ server and syslog have user command record.
     check_tacacs_server_log_exist(ptfhost, tacacs_creds, "grep")
-    check_local_log_exist(duthost, tacacs_creds, "grep")
+
     # Verify TACACS+ server and syslog not have any command record which not run by user.
     check_tacacs_server_no_other_user_log(ptfhost, tacacs_creds)
     check_local_no_other_user_log(duthost, tacacs_creds)
@@ -327,16 +333,9 @@ def test_accounting_tacacs_and_local_all_tacacs_server_down(
                                                         ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
-    cleanup_tacacs_log(ptfhost, rw_user_client)
 
     # Shutdown tacacs server
     stop_tacacs_server(ptfhost)
-
-    """
-        After all server not accessible, run some command
-        Verify local user still can run command without any issue.
-    """
-    ssh_run_command(rw_user_client, "grep")
 
     # Verify syslog have user command record.
     check_local_log_exist(duthost, tacacs_creds, "grep")


### PR DESCRIPTION
Improve TACACS local accounting test case by add retry

#### Why I did it
TACACS local accounting test case not stable but can't reproduce manually

##### Work item tracking
- Microsoft ADO: 29228990

#### How I did it
Add retry to local accounting test case

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Improve TACACS local accounting test case by add retry

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
