### PR TITLE
Fix dynamic buffer issue for x86_64-nvidia_sn4280-r0 platform (#17003)

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -17,7 +17,8 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import check_qos_db_fv_reference_with_table
 from tests.common.utilities import skip_release
 from tests.common.dualtor.dual_tor_utils import is_tunnel_qos_remap_enabled, dualtor_ports      # noqa F401
-from tests.qos.buffer_helpers import DutDbInfo
+from tests.qos.buffer_helpers import DutDbInfo, update_cable_len_for_all_ports    # noqa F401
+from tests.common.platform.interface_utils import get_dpu_npu_ports_from_hwsku
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -2954,6 +2955,10 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
 
     configdb_ports = [x.split('|')[1] for x in duthost.shell(
         'redis-cli -n 4 keys "PORT|*"')['stdout'].split()]
+    # no lossless traffic on DPU NPU ports, so skip them for the test
+    dpu_npu_port_list = get_dpu_npu_ports_from_hwsku(duthost)
+    configdb_ports = list(set(configdb_ports) - set(dpu_npu_port_list))
+    logging.info(f"test ports is {configdb_ports}")
     profiles_checked = {}
     lossless_pool_oid = None
     admin_up_ports = set()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
For x86_64-nvidia_sn4280-r0, because some ports are NPU DPU ports that do not have lossless traffic, so remove the ports from tested ports

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix qos buffer test issue for x86_64-nvidia_sn4280-r0

#### How did you do it?
Remove NPU DPU ports from the tested ports

#### How did you verify/test it?
run test buffer tests on x86_64-nvidia_sn4280-r0

#### Any platform specific information?
x86_64-nvidia_sn4280-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
