### PR TITLE
[manual] [PR:16089] Fix typo on route_consistency

### DIFF
--- a/tests/route/test_route_consistency.py
+++ b/tests/route/test_route_consistency.py
@@ -79,7 +79,7 @@ class TestRouteConsistency():
         for idx, dut in enumerate(duthosts.frontend_nodes):
             for asic in dut.asics:
                 dut_instance_name = dut.hostname + '-' + str(asic.asic_index)
-                if dut.facts['switch_type'] == "voq" and idx == 0:
+                if dut.facts['switch_type'] in ["voq", "chassis-packet"] and idx == 0:
                     dut_instance_name = dut_instance_name + "UpstreamLc"
                     threading.Thread(target=retrieve_route_snapshot, args=(asic, prefix_snapshot,
                                                                            dut_instance_name, signal_queue)).start()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This is a cherry-picked PR with resolved auto merge conflict issue to merge test_route_consistency changes already delivered to master and 202405, and now targeting 202411 branch.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
add upstream linecard check for chassis_packet, T2 Cisco device in get_route_prefix_snapshot_from_asicdb
This was to use correct num_routes_withdrawn during asserts, where we only had upstream support for 'voq' and failed for 'chassis_packet'

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/route/test_route_consistency.xml ------------------------------------------------------
============================================================================= 3 passed, 1 warning in 1482.39s (0:24:42)
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
