### PR TITLE
Skip qos incremental test in case of no lossless buffer.

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -129,6 +129,9 @@ def get_neighbor_type_to_pg_headroom_map(duthost):
 
         cable_length = duthost.shell('sonic-db-cli CONFIG_DB hget "CABLE_LENGTH|AZURE" {}'
                                      .format(interface))['stdout']
+        if cable_length == "0m":
+            pytest.skip("skip the test due to no buffer lossless pg")
+
         port_speed = duthost.shell('sonic-db-cli CONFIG_DB hget "PORT|{}" speed'
                                    .format(interface))['stdout']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Skip qos incremental test in case of no lossless buffer.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Skip the test to avoid 0m length cable and test failure in case of no lossless buffer.
#### How did you do it?
Added a skip condition based on cable length.

#### How did you verify/test it?
Ran the test
#### Any platform specific information?
5600/5610 only

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
