### PR TITLE
Fix for dualtor_io/test_tor_bgp_failure.py on dt/dt120

### DIFF
--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -68,7 +68,7 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
         "failed with error.*",
         r".* ERR syncd#syncd: .*SAI_API_TUNNEL:_brcm_sai_mptnl_process_route_add_mode_default_and_host:\d+ "
         "_brcm_sai_mptnl_tnl_route_event_add failed with error.*",
-        r".* ERR bgp#mgmtd\[33\]: \[X3G8F-PM93W\] BE-adapter: mgmt_msg_read: got EOF/disconnect",
+        r".* ERR bgp#mgmtd\[\d+\]: \[X3G8F-PM93W\] BE-adapter: mgmt_msg_read: got EOF/disconnect",
         r".* ERR bgp#bgpmon: \*ERROR\* Failed with rc:1 when execute: "
         r"\['vtysh', '-H', '/dev/null', '-c', 'show bgp summary json'\]"
     ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #[445](https://github.com/aristanetworks/sonic-qual.msft/issues/445)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Improving regex match in [17173](https://github.com/sonic-net/sonic-mgmt/pull/17173) 

Some examples of the syslog entries encountered when running dualtor_io/test_tor_bgp_failure.py - 
ERR bgp#mgmtd[34]: [X3G8F-PM93W] BE-adapter: mgmt_msg_read: got EOF/disconnect
ERR bgp#mgmtd[38]: [X3G8F-PM93W] BE-adapter: mgmt_msg_read: got EOF/disconnect
ERR bgp#mgmtd[32]: [X3G8F-PM93W] BE-adapter: mgmt_msg_read: got EOF/disconnect


#### How did you do it?
Changed regex to match any decimal digits instead of just 33

#### How did you verify/test it?
Ran dualtor_io/test_tor_bgp_failure.py on DCS-7260CX3 and DCS-7050CX3

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
