### PR TITLE
[bgp] Add time wait for test_bgp_router_id

### DIFF
--- a/tests/bgp/test_bgp_router_id.py
+++ b/tests/bgp/test_bgp_router_id.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import re
+import time
 
 from tests.common.helpers.assertions import pytest_require, pytest_assert
 from tests.common.helpers.bgp import run_bgp_facts
@@ -71,6 +72,8 @@ def restart_bgp(duthost):
     duthost.restart_service("bgp")
     pytest_assert(wait_until(100, 10, 10, duthost.is_service_fully_started_per_asic_or_host, "bgp"), "BGP not started.")
     pytest_assert(wait_until(100, 10, 10, duthost.check_default_route, "bgp"), "Default route not ready")
+    # After restarting bgp, add time wait for bgp_facts to fetch latest status
+    time.sleep(20)
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
After restart BGP, low performance devices need more time to sync bgp_facts, hence add time wait after restarting bgp.

#### How did you do it?
Add time wait after restarting bgp

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
