### PR TITLE
[platform/api/test_module]: Increase timeout for test_reboot for t2

### DIFF
--- a/tests/platform_tests/api/test_module.py
+++ b/tests/platform_tests/api/test_module.py
@@ -488,6 +488,9 @@ class TestModuleApi(PlatformApiTestBase):
         reboot_type = 'default'
         reboot_timeout = 300
 
+        if duthosts[enum_rand_one_per_hwsku_hostname].get_facts().get("modular_chassis"):
+            reboot_timeout = 360
+
         # Extend ignore fabric port msgs for T2 chassis with DNX chipset on Linecards
         ignore_t2_syslog_msgs(duthosts[enum_rand_one_per_hwsku_hostname])
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Increase timeout for module api test_reboot for t2, as 300 sec is not long enough
Also also provide a helpful fail message on teardown

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ x] 202405
- [ x] 202411

### Approach
#### What is the motivation for this PR?
Test is failing because it is not waiting long enough after reboot

#### How did you do it?

#### How did you verify/test it?
ran on arista t2 chassis
#### Any platform specific information?
t2
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
