### PR TITLE
[platform_tests/reload_config]: add retries to post reload checks

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -166,7 +166,17 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     wait_until(360, 1, 0, check_database_status, duthost)
 
     logging.info("Reload configuration check")
-    result, out = execute_config_reload_cmd(duthost, config_reload_timeout)
+
+    # sometimes redis is not up in time (eg. t2 chassis), so retry until it's up
+    for i in range(10):
+        result, out = execute_config_reload_cmd(duthost, config_reload_timeout)
+
+        # Redis is up - can stop looping
+        if result and "RuntimeError: Unable to connect to redis" not in out['stderr']:
+            break
+
+        time.sleep(1)
+
     # config reload command shouldn't work immediately after system reboot
     assert result and "Retry later" in out['stdout']
     assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services)


### PR DESCRIPTION
Sometimes redis does not come up in time after config reload, even though the database container is up.
Add retries if this happens.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405
- [x ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
