### PR TITLE
[202411][sonic-mgmt]Fix test_vxlan_hash in fib/test_fib.py

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -447,7 +447,9 @@ def vxlan_ipver(request):
 def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_per_function,  # noqa F811
                      hash_keys, ptfhost, vxlan_ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
-                     duts_minigraph_facts):                                         # noqa F811
+                     duts_minigraph_facts, toggle_all_simulator_ports_to_rand_selected_tor_m,   # noqa F811
+                     mux_status_from_nic_simulator, setup_standby_ports_on_rand_unselected_tor, # noqa F811
+                     request):                                         # noqa F811
     # Query the default VxLAN UDP port from switch's APPL_DB
     vxlan_dport_check = duthost.shell('redis-cli -n 0 hget "SWITCH_TABLE:switch" "vxlan_port"')
     if 'stdout' in vxlan_dport_check and vxlan_dport_check['stdout'].isdigit():
@@ -471,8 +473,10 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts, fib_info_files_
                "hash_test.VxlanHashTest",
                platform_dir="ptftests",
                params={"fib_info_files": fib_info_files_per_function[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "ptf_test_port_map": ptf_test_port_map_active_active(
+                                                ptfhost, tbinfo, duthosts, mux_server_url,
+                                                duts_running_config_facts, duts_minigraph_facts,
+                                                mux_status_from_nic_simulator()),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),


### PR DESCRIPTION
Fix test_vxlan_hash in fib/test_fib.py for dualtor active-active topologies

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_vxlan_hash in fib/test_fib.py

Fixes [#476](https://github.com/aristanetworks/sonic-qual.msft/issues/476)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [] 202411

### Approach
#### What is the motivation for this PR?
This test fails on DualTor

#### How did you do it?
The approach to fix this is to replace the `ptf_test_port_map` fixture with dualtor compatible fixture ` ptf_test_port_map_active_active`

#### How did you verify/test it?
Ran tests on Arista-7260CX3 in Dualtor Setup

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
