### PR TITLE
Skipped unsupported features on mellanox asic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1509,10 +1509,10 @@ mvrf:
 
 mvrf/test_mgmtvrf.py:
   skip:
-    reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M0/MX topo, kvm testbed"
+    reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M0/MX topo, kvm testbed, mellanox asic from 202411 and later"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs', 'mellanox']"
       - "topo_type in ['m0', 'mx']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 
@@ -1521,9 +1521,11 @@ mvrf/test_mgmtvrf.py:
 #######################################
 nat:
   skip:
-    reason: "Nat feature is not enabled with image version"
+    reason: "Nat feature is not enabled with image version, skipped on mellanox asic from 202411 and later "
+    conditions_logical_operator: or
     conditions:
       - "'nat' not in feature_status"
+      - "asic_type in ['mellanox']"
 
 #######################################
 #####             ospf            #####
@@ -2282,8 +2284,10 @@ ssh/test_ssh_stress.py::test_ssh_stress:
 sub_port_interfaces:
   skip:
     reason: "Unsupported platform or asic"
+    conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True or asic_gen not in ['td2', 'spc1', 'spc2', 'spc3', 'spc4'] and asic_type not in ['barefoot','marvell-teralynx']"
+      - "asic_type in ['mellanox']"
 
 sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port]:
   skip:
@@ -2506,9 +2510,10 @@ voq/test_voq_fabric_status_all.py:
 #######################################
 vrf/test_vrf.py:
   skip:
-    reason: "Vrf tests are skipped both in nightly and PR testing."
+    reason: "Vrf tests are skipped both in nightly and PR testing, not supported on mellanox asic from 202411 and later"
     conditions:
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs', 'mellanox']"
+
 
 vrf/test_vrf.py::TestVrfAclRedirect:
   skip:
@@ -2520,9 +2525,9 @@ vrf/test_vrf.py::TestVrfAclRedirect:
 
 vrf/test_vrf_attr.py:
   skip:
-    reason: "Vrf tests are skipped in PR testing."
+    reason: "Vrf tests are skipped in PR testing, not supported on mellanox asic from 202411 and later"
     conditions:
-      - "asic_type in ['vs']"
+      - "asic_type in ['vs', 'mellanox']"
 
 vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1280,9 +1280,9 @@ platform_tests/test_sequential_restart.py::test_restart_syncd:
 #######################################
 platform_tests/test_service_warm_restart.py:
   skip:
-    reason: "Testcase ignored due to sonic-mgmt issue: https://github.com/sonic-net/sonic-mgmt/issues/10362"
+    reason: "Skipped on mellanox asic from 202411 and later"
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/10362"
+      - "asic_type in ['mellanox']"
 
 #######################################
 #####   test_xcvr_info_in_db.py   #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Added skips to tests due to unsupported features from 202411 and later branches:    
    - Service warm restart
    - VRF
    - MVRF
    - NAT
    - Sub Port interfaces


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Skip tests unsupported features on mellanox asic
#### How did you do it?
Updated skips yaml file
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
