### PR TITLE
test_bgp_ session.py fails when DUT is running FRR unified framework

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -8,6 +8,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.reboot import reboot
 
 logger = logging.getLogger(__name__)
+vrfname = 'default'
 
 pytestmark = [
     pytest.mark.topology("t0", "t1"),
@@ -37,7 +38,12 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
     duthost = duthosts[rand_one_dut_hostname]
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+    # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
+    if check_frr_mgmt_framework_config(duthost):
+        bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+        bgp_neighbors = bgp_neighbors[vrfname]
+    else:
+        bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     portchannels = config_facts.get('PORTCHANNEL_MEMBER', {})
     dev_nbrs = config_facts.get('DEVICE_NEIGHBOR', {})
     bgp_neighbor = list(bgp_neighbors.keys())[0]
@@ -50,10 +56,11 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
     logger.debug("setup test_neighbor {}".format(bgp_neighbor))
 
     # verify sessions are established
-    pytest_assert(wait_until(30, 5, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
+    pytest_assert(wait_until(120, 5, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                   "Not all BGP sessions are established on DUT")
 
     ip_intfs = duthost.show_and_parse('show ip interface')
+    ipv6_intfs = duthost.show_and_parse('show ipv6 interfaces')
     logger.debug("setup ip_intfs {}".format(ip_intfs))
 
     # Create a mapping of neighbor IP to interfaces and their details
@@ -75,10 +82,34 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
         elif interface_name in dev_nbrs and dev_nbrs[interface_name]['name'] == ip_intf['bgp neighbor']:
             neighbor_ip_to_interfaces[neighbor_ip][interface_name] = dev_nbrs[interface_name]
 
+    # Loop through the ip_intfs list to populate the mapping
+    for ipv6_intf in ipv6_intfs:
+        neighbor_ip = ipv6_intf['neighbor ip']
+        interface_name = ipv6_intf['interface']
+        if neighbor_ip not in neighbor_ip_to_interfaces:
+            neighbor_ip_to_interfaces[neighbor_ip] = {}
+
+        # Check if the interface is in portchannels and get the relevant devices
+        if interface_name in portchannels:
+            for dev_name in portchannels[interface_name]:
+                if dev_name in dev_nbrs and dev_nbrs[dev_name]['name'] == ipv6_intf['bgp neighbor']:
+                    neighbor_ip_to_interfaces[neighbor_ip][dev_name] = dev_nbrs[dev_name]
+        # If not in portchannels, check directly in dev_nbrs
+        elif interface_name in dev_nbrs and dev_nbrs[interface_name]['name'] == ipv6_intf['bgp neighbor']:
+            neighbor_ip_to_interfaces[neighbor_ip][interface_name] = dev_nbrs[interface_name]
+
     # Update bgp_neighbors with the new 'interface' key
+    # If frr_mgmt_framework_config is set to true, expect vrf name in the config facts
     for ip, details in bgp_neighbors.items():
-        if ip in neighbor_ip_to_interfaces:
-            details['interface'] = neighbor_ip_to_interfaces[ip]
+        logger.debug(ip)
+        if check_frr_mgmt_framework_config(duthost):
+            get_ip = f"({vrfname}, '{ip}')"
+        else:
+            get_ip = ip
+        logger.debug(neighbor_ip_to_interfaces)
+        logger.debug(neighbor_ip_to_interfaces[get_ip])
+        if get_ip in neighbor_ip_to_interfaces:
+            details['interface'] = neighbor_ip_to_interfaces[get_ip]
 
     setup_info = {
         'neighhosts': bgp_neighbors,
@@ -103,8 +134,22 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
             nbrhosts[neighbor_name]['host'].no_shutdown(neighbor_port)
             time.sleep(1)
 
-        pytest_assert(wait_until(60, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
+        pytest_assert(wait_until(120, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                       "Not all BGP sessions are established on DUT")
+
+
+def check_frr_mgmt_framework_config(duthost):
+    """
+    Check if frr_mgmt_framework_config is set to "true" in DEVICE_METADATA
+
+    Args:
+        duthost: DUT host object
+
+    Returns:
+        bool: True if frr_mgmt_framework_config is "true", False otherwise
+    """
+    frr_config = duthost.shell('sonic-db-cli CONFIG_DB HGET "DEVICE_METADATA|localhost" "frr_mgmt_framework_config"')
+    return frr_config == "true"
 
 
 def verify_bgp_session_down(duthost, bgp_neighbor):
@@ -207,5 +252,5 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     pytest_assert(wait_until(120, 10, 30, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")
-    pytest_assert(wait_until(60, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
+    pytest_assert(wait_until(120, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
                   "Not all BGP sessions are established on DUT")


### PR DESCRIPTION
### Description of PR

This PR adds following updates to script `test_bgp_session.py`:
1. It adds support to run this script when frr_mgmt_framework_config is set to "true" in DEVICE_METADATA. This change includes check for the knob and if it is enabled the it adds an extra parsing step for bgp_neighbors to consider namespace key in the table.
2. The second change is to look for any BGP IPv6 neighbors. The script was looking for only 'show ip interface' output and not the 'show ipv6 interface' to populate the interface mapping.
3. Timeouts in wait_until are increased to give enough time for BGP peers to come up in scale/stress scenario. Tested scenario which needed these timeout values: T1 topology with >6k route scale per neighbor, 16 BGP neighbors with timers 3/10.
4. It is same as [16934](https://github.com/sonic-net/sonic-mgmt/pull/16934) which was closed because my personal repo was accidentally deleted.

Summary:
Fixes #16933 

### Type of change

- Test case improvement

### Approach
#### What is the motivation for this PR?
test_bgp_session.py
 fails on the DUT which has BGP-FRR unified framework enabled. The change is to update the script to work for frr_mgmt_framework_config set to true.
frr_mgmt_framework_config setting is in config_db DEVICE_METADATA section.
The change also includes updates to the test_bgp_session.py
 script to support BGP IPv6 neighbors. The script was failing when there were IPv6 neighbors configured on the DUT.
Also, timeouts for some wait_until are increased to support T1 topology with >6k route scale, 16 BGP neighbors with timers 3/10.

#### How did you do it?

Updated the script to add a new def check_frr_mgmt_framework_config, which is called to handle the retrieval of bgp neighbor and neighbor ip values correctly. An if loop is added so the script works for both frr_mgmt_framework_config values.

#### How did you verify/test it?

bgp/test_bgp_session1.py::test_bgp_session_interface_down[interface-bgp_docker] PASSED [ 16%]
bgp/test_bgp_session1.py::test_bgp_session_interface_down[interface-swss_docker] PASSED [ 33%]
bgp/test_bgp_session1.py::test_bgp_session_interface_down[interface-reboot] PASSED [ 50%]
bgp/test_bgp_session1.py::test_bgp_session_interface_down[neighbor-bgp_docker] PASSED [ 66%]
bgp/test_bgp_session1.py::test_bgp_session_interface_down[neighbor-swss_docker] PASSED [ 83%]
bgp/test_bgp_session1.py::test_bgp_session_interface_down[neighbor-reboot] PASSED [100%]

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
