### PR TITLE
Ignore ERR: Data Loading Failed:Invalid JSON data

### DIFF
--- a/tests/generic_config_updater/test_mgmt_interface.py
+++ b/tests/generic_config_updater/test_mgmt_interface.py
@@ -16,6 +16,25 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_exceptions(duthosts, rand_one_dut_hostname, loganalyzer):
+    """
+       Ignore expected errors in logs during test execution
+
+       Args:
+           loganalyzer: Loganalyzer utility fixture
+           duthost: DUT host object
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    if loganalyzer:
+        loganalyzer_ignore_regex = [
+            ".*ERR sonic_yang: Data Loading Failed:Invalid JSON data (unexpected value).*",
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(loganalyzer_ignore_regex)
+
+    yield
+
+
 @pytest.fixture(scope="function")
 def ensure_dut_readiness(duthost):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # [[config] config apply-patch generates a log error when op is set to remove #21674](https://github.com/sonic-net/sonic-buildimage/issues/21674)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The "Invalid JSON data (unexpected value)" error occurs when the libyang parser encounters an empty array ([]) for the forced_mgmt_routes leaf-list in the YANG model. The parser's implementation lacks explicit handling for empty arrays, leading to a validation failure.

#### How did you do it?

As result, we should ignore it from loganalyzer.

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
