### PR TITLE
Skip radv container in test_container_checker on dualtor-aa

### DIFF
--- a/tests/container_checker/test_container_checker.py
+++ b/tests/container_checker/test_container_checker.py
@@ -210,7 +210,8 @@ def test_container_checker(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand
     skip_containers = disabled_containers[:]
 
     # Skip 'radv' container on devices whose role is not T0/M0.
-    if tbinfo["topo"]["type"] not in ["t0", "m0"]:
+    # Skip 'radv' container on dualtor-aa as radv is forcefully killed on dualtor-aa (#13408 in sonic-buildimage)
+    if tbinfo["topo"]["type"] not in ["t0", "m0"] or 'dualtor-aa' in tbinfo['topo']['name']:
         skip_containers.append("radv")
     pytest_require(service_name not in skip_containers,
                    "Container '{}' is skipped for testing.".format(container_name))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip the test on `radv` container on `dualtor-aa` platform in `test_container_checker`.
It's because container `radv` is killed forcefully on `dualtor-aa` platform.
Related PR https://github.com/sonic-net/sonic-buildimage/pull/13408

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to skip the test on `radv` container on `dualtor-aa` platform in `test_container_checker`.

#### How did you do it?
Add `radv` container into the skip list if topo is `dualtor-aa`.

#### How did you verify/test it?
Verified on a physical dualtor testbed.

#### Any platform specific information?
Dualtor-aa platform.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
