### PR TITLE
Fix flakiness in pfcwd/test_pfcwd_cli.py

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -15,6 +15,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.helpers.pfcwd_helper import send_background_traffic, verify_pfc_storm_in_expected_state, parser_show_pfcwd_stat # noqa E501
 from tests.common.utilities import wait_until
 from tests.common.cisco_data import is_cisco_device
+from tests.common import config_reload
 
 pytestmark = [
     pytest.mark.topology("t0", "t1")
@@ -298,6 +299,43 @@ class SendVerifyTraffic():
 
 class TestPfcwdFunc(SetupPfcwdFunc):
     """ Test PFC function and supporting methods """
+    def __shutdown_lag_members(self, duthost, selected_port):
+
+        if self.ports[selected_port]['test_port_type']!='portchannel':
+            return
+
+        config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+        portChannels = config_facts['PORTCHANNEL_MEMBER']
+        portChannel = None
+        portChannelMembers = None
+        for intf in portChannels:
+            if selected_port in portChannels[intf]:
+                portChannel = intf
+                portChannelMembers = portChannels[intf]
+                break
+
+        cmd_data = f'.PORTCHANNEL.{portChannel}.min_links = "1"'
+
+        for port in portChannelMembers:
+           if port == selected_port:
+              continue
+           cmd_data += f' | .PORT.{port}.admin_status="down"'
+
+        cmd = f"""jq '{cmd_data}' /etc/sonic/config_db.json > /tmp/config_db.json"""
+
+        duthost.command("cp /etc/sonic/config_db.json /tmp/config_db_backup.json", _uses_shell=True)
+        duthost.command(cmd, _uses_shell=True)
+        duthost.command("sudo cp /tmp/config_db.json /etc/sonic/config_db.json", _uses_shell=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+
+    def __restore_original_config(self, duthost, selected_port):
+
+        if self.ports[selected_port]['test_port_type']!='portchannel':
+            return
+
+        duthost.command("sudo mv /tmp/config_db_backup.json /etc/sonic/config.json", _uses_shell=True)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+
     def storm_detect_path(self, dut, port, action):
         """
         Storm detection action and associated verifications
@@ -476,6 +514,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
         # for idx, port in enumerate(self.ports):
         port = list(self.ports.keys())[0]
+
+        self.__shutdown_lag_members(duthost, port)
+
         logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
         self.setup_test_params(port, setup_info['vlan'], init=True)
         self.traffic_inst = SendVerifyTraffic(
@@ -506,3 +547,4 @@ class TestPfcwdFunc(SetupPfcwdFunc):
                     self.storm_hndle.stop_storm()
                 logger.info("--- Stop PFC WD ---")
                 self.dut.command("pfcwd stop")
+        self.__restore_original_config(duthost, port)

--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -301,7 +301,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
     """ Test PFC function and supporting methods """
     def __shutdown_lag_members(self, duthost, selected_port):
 
-        if self.ports[selected_port]['test_port_type']!='portchannel':
+        if self.ports[selected_port]['test_port_type'] != 'portchannel':
             return
 
         config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
@@ -317,9 +317,9 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         cmd_data = f'.PORTCHANNEL.{portChannel}.min_links = "1"'
 
         for port in portChannelMembers:
-           if port == selected_port:
-              continue
-           cmd_data += f' | .PORT.{port}.admin_status="down"'
+            if port == selected_port:
+                continue
+            cmd_data += f' | .PORT.{port}.admin_status="down"'
 
         cmd = f"""jq '{cmd_data}' /etc/sonic/config_db.json > /tmp/config_db.json"""
 
@@ -330,7 +330,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
     def __restore_original_config(self, duthost, selected_port):
 
-        if self.ports[selected_port]['test_port_type']!='portchannel':
+        if self.ports[selected_port]['test_port_type'] != 'portchannel':
             return
 
         duthost.command("sudo mv /tmp/config_db_backup.json /etc/sonic/config.json", _uses_shell=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix flakiness in pfcwd/test_pfcwd_cli.py
Fixes [#383](https://github.com/aristanetworks/sonic-qual.msft/issues/383)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Sometimes the test ends up picking an egress interface which happens to be a member of a LAG. If the LAG has multiple members and only one of them is stormed the drop/forwards expectations don't take into account lag hashing.

Some of the traffic is hashed to another LAG member which is not being stormed and no drops will occur. 

#### How did you do it?
The proposed fix is to shutdown the remaining LAG members.

#### How did you verify/test it?
Tested on Arista-7260CX3 with dualtor-120 topology and 202411 image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
