### PR TITLE
[sonic-mgmt][BFD][issues/17418]fix bfd responder crash

### DIFF
--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -16,6 +16,7 @@ IPv4 = '4'
 IPv6 = '6'
 BFD_FLAG_P_BIT = 5
 BFD_FLAG_F_BIT = 4
+UDP_BFD_PKT_LEN = 32
 
 
 def get_if(iff, cmd):
@@ -94,6 +95,10 @@ class BFDResponder(object):
             return
         session = self.sessions[ip_dst]
         if bfd_state == 3:
+            # If packet is not initialized yet, ignore the received UP packet per RFC5880 FSM
+            # wait for DUT timeout and DUT will send DOWN BFD packet
+            if len(session["pkt"]) == 0:
+                return
             # Respond with F bit if P bit is set
             if (bfd_flags & (1 << BFD_FLAG_P_BIT)):
                 session["pkt"].payload.payload.payload.load.flags = (1 << BFD_FLAG_F_BIT)
@@ -121,6 +126,9 @@ class BFDResponder(object):
         mac_dst = ether.dst
         ip_src = ether.payload.src
         ip_dst = ether.payload.dst
+        #ignore the packet not for me or incomplete BFD packet
+        if ip_dst not in self.sessions or len(ether.payload.payload)<UDP_BFD_PKT_LEN:
+            return mac_src, mac_dst, ip_src, ip_dst, None, None, None
         ip_version = str(ether.payload.version)
         ip_priority_field = 'tos' if ip_version == IPv4 else 'tc'
         ip_priority = getattr(ether.payload, ip_priority_field)

--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -127,7 +127,7 @@ class BFDResponder(object):
         ip_src = ether.payload.src
         ip_dst = ether.payload.dst
         # ignore the packet not for me or incomplete BFD packet
-        if ip_dst not in self.sessions or len(ether.payload.payload)<UDP_BFD_PKT_LEN:
+        if ip_dst not in self.sessions or len(ether.payload.payload) < UDP_BFD_PKT_LEN:
             return mac_src, mac_dst, ip_src, ip_dst, None, None, None
         ip_version = str(ether.payload.version)
         ip_priority_field = 'tos' if ip_version == IPv4 else 'tc'

--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -126,7 +126,7 @@ class BFDResponder(object):
         mac_dst = ether.dst
         ip_src = ether.payload.src
         ip_dst = ether.payload.dst
-        #ignore the packet not for me or incomplete BFD packet
+        # ignore the packet not for me or incomplete BFD packet
         if ip_dst not in self.sessions or len(ether.payload.payload)<UDP_BFD_PKT_LEN:
             return mac_src, mac_dst, ip_src, ip_dst, None, None, None
         ip_version = str(ether.payload.version)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
fix bug https://github.com/sonic-net/sonic-mgmt/issues/17418
These 2 cases may cause BFD related mgmt test fails:
1, bfd responder can receive the packet it sent. and at the time of restart, partial packet could be process and cause it crash
2, In the case of bfd_responder restart and it get BFD UP packet, the packet become uninitialized, it cause socket sending packet error.

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/17418

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202012
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

set a breakpoint in a sonic_mgmt test (test_bfd.py),  using a separately python script to craft and send BFD packet from the DUT to bfd_responder. it can trigger the second issue listed in the description section.  

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
