### PR TITLE
Increase GCUTIMEOUT value for nokia-armhf platforms

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -15,7 +15,7 @@ CONTAINER_SERVICES_LIST = ["swss", "syncd", "radv", "lldp", "dhcp_relay", "teamd
 DEFAULT_CHECKPOINT_NAME = "test"
 GCU_FIELD_OPERATION_CONF_FILE = "gcu_field_operation_validators.conf.json"
 GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
-GCUTIMEOUT = 600
+GCUTIMEOUT_MAP = {'armhf-nokia_ixs7215_52x-r0': 1200}
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FILES_DIR = os.path.join(BASE_DIR, "files")
@@ -125,9 +125,8 @@ def apply_patch(duthost, json_data, dest_file):
     start_time = time.time()
     output = duthost.shell(cmds, module_ignore_errors=True)
     elapsed_time = time.time() - start_time
-    if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0':
-        GCUTIMEOUT = 1200
-    if elapsed_time > GCUTIMEOUT:
+    gcu_timeout = get_gcu_timeout(duthost)
+    if elapsed_time > gcu_timeout:
         logger.error("Command took too long: {} seconds".format(elapsed_time))
         raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))
 
@@ -578,3 +577,7 @@ def get_bgp_speaker_runningconfig(duthost):
     bgp_speaker_pattern = r"\s+neighbor.*update-source.*|\s+bgp listen range.*"
     bgp_speaker_config = re.findall(bgp_speaker_pattern, output['stdout'])
     return bgp_speaker_config
+
+
+def get_gcu_timeout(duthost):
+    return GCUTIMEOUT_MAP.get(duthost.facts['platform'], 600)

--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -125,6 +125,8 @@ def apply_patch(duthost, json_data, dest_file):
     start_time = time.time()
     output = duthost.shell(cmds, module_ignore_errors=True)
     elapsed_time = time.time() - start_time
+    if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0':
+        GCUTIMEOUT = 1200
     if elapsed_time > GCUTIMEOUT:
         logger.error("Command took too long: {} seconds".format(elapsed_time))
         raise TimeoutError("Command execution timeout: {} seconds".format(elapsed_time))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Summary:
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_scale_rules testcase fails for nokia-armhf platforms as it requires longer timer to scale acl rules due to the limited CPU computing power of ARM32 CPU. 
So , increased the GCUTIMEOUT value to wait for applying the patch to 1200 seconds.
Fixes # (issue)
Fixes failure of gcu test failure in nokia-armhf platforms
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix failure of test_gcu_acl_scale_rules  test by increasing timeout for apply-patch for nokia-armhf platforms
#### How did you do it?
Added platform specific check and modification of value for nokia-armhf platforms
#### How did you verify/test it?
Run generic_config_updater/test_dynamic_acl.py::test_gcu_acl_scale_rules on M0 topo on nokia-armhf platforms 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
