### PR TITLE
Unify the ipv6 address to upper case in generic hash case

### DIFF
--- a/tests/hash/generic_hash_helper.py
+++ b/tests/hash/generic_hash_helper.py
@@ -142,7 +142,7 @@ def restore_configuration(duthost):
         # Re-config ip interface
         for ip_interface in ip_interface_to_restore:
             formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
-            duthost.shell(f"config interface ip add {ip_interface['attachto']} {formatted_ip_addr}")
+            duthost.shell(f"config interface ip add {ip_interface['attachto']} {formatted_ip_addr.upper()}")
         # Re-config vlan interface
         if vlan_member_to_restore:
             duthost.shell(f"config vlan member add {vlan_member_to_restore['vlan_id']} "
@@ -609,7 +609,7 @@ def remove_ip_interface_and_config_vlan(duthost, mg_facts, tbinfo, downlink_inte
         for ip_interface in mg_facts['minigraph_interfaces']:
             if ip_interface['attachto'] == downlink_interface:
                 formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
-                duthost.shell(f"config interface ip remove {ip_interface['attachto']} {formatted_ip_addr}")
+                duthost.shell(f"config interface ip remove {ip_interface['attachto']} {formatted_ip_addr.upper()}")
                 ip_interface_to_restore.append(ip_interface)
                 l2_ports.add(downlink_interface)
         for portchannel in mg_facts['minigraph_portchannels'].values():
@@ -619,14 +619,15 @@ def remove_ip_interface_and_config_vlan(duthost, mg_facts, tbinfo, downlink_inte
                         formatted_ip_addr = format_ip_mask(
                             f"{portchannel_ip_interface['addr']}/{portchannel_ip_interface['mask']}")
                         duthost.shell(
-                            f"config interface ip remove {portchannel_ip_interface['attachto']} {formatted_ip_addr}")
+                            f"config interface ip remove {portchannel_ip_interface['attachto']} "
+                            f"{formatted_ip_addr.upper()}")
                         ip_interface_to_restore.append(portchannel_ip_interface)
                         l2_ports.add(portchannel_ip_interface['attachto'])
     # re-config the uplink interfaces, remove the ip address on the egress portchannel interfaces
     for ip_interface in mg_facts['minigraph_portchannel_interfaces']:
         if ip_interface['attachto'] in uplink_interfaces:
             formatted_ip_addr = format_ip_mask(f"{ip_interface['addr']}/{ip_interface['mask']}")
-            duthost.shell(f"config interface ip remove {ip_interface['attachto']} {formatted_ip_addr}")
+            duthost.shell(f"config interface ip remove {ip_interface['attachto']} {formatted_ip_addr.upper()}")
             ip_interface_to_restore.append(ip_interface)
             l2_ports.add(ip_interface['attachto'])
     # Configure VLANs for VLAN_ID test


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Unify the ipv6 address to upper case in generic hash case

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Use upper case ipv6 address during add or remove ipv6 address, it would avoid config db recognizing lower case and upper case address as two different address. In this scenario, it may lead to intf creation or deletion issue.
#### How did you do it?
Use upper case ipv6 address during add or remove ipv6 address
#### How did you verify/test it?
Run it in local testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
