### PR TITLE
Fix time zone changed issue after test_clock

### DIFF
--- a/tests/clock/conftest.py
+++ b/tests/clock/conftest.py
@@ -42,6 +42,9 @@ def init_timezone(duthosts):
     duthost = duthosts[0]
     timezone_output = duthost.shell("timedatectl | grep 'Time zone'")['stdout']
     original_timezone = timezone_output.split(':')[1].strip().split()[0]
+    if not original_timezone:
+        # in case of empty timezone, set it to UTC
+        original_timezone = "UTC"
     logging.info(f'Original timezone: {original_timezone}')
     logging.info(f'Set timezone to {ClockConsts.TEST_TIMEZONE} before test')
     ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_TIMEZONE, ClockConsts.TEST_TIMEZONE)

--- a/tests/clock/conftest.py
+++ b/tests/clock/conftest.py
@@ -37,14 +37,19 @@ def init_timezone(duthosts):
     """
     @summary: fixture to init timezone before and after each test
     """
-
+    # Get the original timezone before changing it
+    logging.info('Check current timezone before test')
+    duthost = duthosts[0]
+    timezone_output = duthost.shell("timedatectl | grep 'Time zone'")['stdout']
+    original_timezone = timezone_output.split(':')[1].strip().split()[0]
+    logging.info(f'Original timezone: {original_timezone}')
     logging.info(f'Set timezone to {ClockConsts.TEST_TIMEZONE} before test')
     ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_TIMEZONE, ClockConsts.TEST_TIMEZONE)
 
     yield
 
-    logging.info(f'Set timezone to {ClockConsts.TEST_TIMEZONE} after test')
-    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_TIMEZONE, ClockConsts.TEST_TIMEZONE)
+    logging.info(f'Set timezone to {original_timezone} after test')
+    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_TIMEZONE, original_timezone)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
After this PR, the test_clock.py was enabled [Enable skipped test due to extra param requirement by augusdn · Pull Request #17059 · sonic-net/sonic-mgmt](https://github.com/sonic-net/sonic-mgmt/pull/17059)

Before that, this case was skipped. And this case will always set timezone to Asia/Jerusalem before and after test case, which is definitely a problem.

```
@pytest.fixture(scope="function")
def init_timezone(duthosts):
    """
    @summary: fixture to init timezone before and after each test
    """

    logging.info(f'Set timezone to {ClockConsts.TEST_TIMEZONE} before test')
    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_TIMEZONE, ClockConsts.TEST_TIMEZONE)

    yield

    logging.info(f'Set timezone to {ClockConsts.TEST_TIMEZONE} after test')
    ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_TIMEZONE, ClockConsts.TEST_TIMEZONE)

```

    `TEST_TIMEZONE = "Asia/Jerusalem"`

After the time zone changed to IST, in `tests/common/devices/sonic.py` `get_networking_uptime` will return None and cause sanity check failure.

```
    def get_networking_uptime(self):
        start_time = self.get_service_props("networking", props=["ExecMainStartTimestamp", ])
        try:
            return self.get_now_time() - datetime.strptime(start_time["ExecMainStartTimestamp"],
                                                           "%a %Y-%m-%d %H:%M:%S %Z")
        except Exception as e:
            logging.error("Exception raised while getting networking restart time: %s" % repr(e))
            return None
```
`datetime.strptime` doesn't recognize `IST` by default. 

`ValueError: time data 'Thu 2025-03-06 14:28:53 IST' does not match format '%a %Y-%m-%d %H:%M:%S %Z'`


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
1. Fix ValueError: time data doesn't match  issue
2. Enhance find_timezone_str_and_matching_format to support 4 different formats
#### How did you do it?
1. Recover the time zone to UTC after test_clock
2. Return correct time parse format for different clock format.

#### How did you verify/test it?
Run test_clock on different testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->


