### PR TITLE
platform_api_server exception handling

### DIFF
--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -94,6 +94,8 @@ class PlatformAPITestService(BaseHTTPRequestHandler):
             res = getattr(obj, api)(*args)
         except NotImplementedError:
             syslog.syslog(syslog.LOG_WARNING, "API '{}' not implemented".format(api))
+        except Exception as e:
+            syslog.syslog(syslog.LOG_ERR, "Error executing API '{}': {}".format(api, str(e)))
 
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')

--- a/tests/common/helpers/platform_api/scripts/platform_api_server.py
+++ b/tests/common/helpers/platform_api/scripts/platform_api_server.py
@@ -95,7 +95,7 @@ class PlatformAPITestService(BaseHTTPRequestHandler):
         except NotImplementedError:
             syslog.syslog(syslog.LOG_WARNING, "API '{}' not implemented".format(api))
         except Exception as e:
-            syslog.syslog(syslog.LOG_ERR, "Error executing API '{}': {}".format(api, str(e)))
+            syslog.syslog(syslog.LOG_ERR, "Error executing API '{}': {}".format(api, repr(e)))
 
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Current platform api will abort if any exception happens.
If there are multiple SFP which having the same error, it will only report the first one.

Before the fix: current errors when multiple SFP has EEPROM issues:
```
08/03/2025 22:51:37 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 47, arguments: "[]", result: "NJMMER-0001     "
08/03/2025 22:51:37 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt_vms71-t1-7060x6-th5p-1_6797592eae70b09bc552ed3d/tests/platform_tests/api/test_sfp.py", line 368, in test_get_model
    model = sfp.get_model(platform_api_conn, i)
  File "/var/src/sonic-mgmt_vms71-t1-7060x6-th5p-1_6797592eae70b09bc552ed3d/tests/common/helpers/platform_api/sfp.py", line 39, in get_model
    return sfp_api(conn, index, 'get_model')
  File "/var/src/sonic-mgmt_vms71-t1-7060x6-th5p-1_6797592eae70b09bc552ed3d/tests/common/helpers/platform_api/sfp.py", line 16, in sfp_api
    resp = conn.getresponse()
  File "/usr/lib/python3.8/http/client.py", line 1348, in getresponse
    response.begin()
  File "/usr/lib/python3.8/http/client.py", line 316, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.8/http/client.py", line 285, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
```

After the change:

```
logs:
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 49, arguments: "[]", result: "None"
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 51, arguments: "[]", result: "NJMMER-0001     "
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 53, arguments: "[]", result: "NJMMER-0001     "
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 55, arguments: "[]", result: "NJMMER-0001     "
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 57, arguments: "[]", result: "None"
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 59, arguments: "[]", result: "NJMMER-0001     "
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 61, arguments: "[]", result: "NJMMER-0001     "
10/03/2025 11:38:32 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_model", index: 63, arguments: "[]", result: "None"

Error:
self = <tests.platform_tests.api.test_sfp.TestSfpApi object at 0x7f725fa04310>

    def assert_expectations(self):
        """
        Checks if there are any error messages waiting in failed_expectations.
        If so, it will fail an assert and pass a concatenation of all pending
        error messages. It will also clear failed_expectations to prepare it
        for the next use.
        """
        if len(self.failed_expectations) > 0:
            err_msg = ", ".join(self.failed_expectations)
            # TODO: When we move to Python 3.3+, we can use self.failed_expectations.clear() instead
            del self.failed_expectations[:]
>           pytest_assert(False, err_msg)
E           Failed: Unable to retrieve transceiver 49 model, Unable to retrieve transceiver 57 model, Unable to retrieve transceiver 63 model

err_msg    = 'Unable to retrieve transceiver 49 model, Unable to retrieve transceiver 57 model, Unable to retrieve transceiver 63 model'
self       = <tests.platform_tests.api.test_sfp.TestSfpApi object at 0x7f725fa04310>
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Easy to debug platform_api related errors.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
