### PR TITLE
Update gnoi and mvrf test cases for chrony support

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -60,18 +60,22 @@ def setup_ntp_func(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
         yield result
 
 
-@pytest.fixture(scope="module")
-def ntp_daemon_in_use(duthost):
-    ntpsec_conf_stat = duthost.stat(path="/etc/ntpsec/ntp.conf")
+def get_ntp_daemon_in_use(host):
+    ntpsec_conf_stat = host.stat(path="/etc/ntpsec/ntp.conf")
     if ntpsec_conf_stat["stat"]["exists"]:
         return NtpDaemon.NTPSEC
-    chrony_conf_stat = duthost.stat(path="/etc/chrony/chrony.conf")
+    chrony_conf_stat = host.stat(path="/etc/chrony/chrony.conf")
     if chrony_conf_stat["stat"]["exists"]:
         return NtpDaemon.CHRONY
-    ntp_conf_stat = duthost.stat(path="/etc/ntp.conf")
+    ntp_conf_stat = host.stat(path="/etc/ntp.conf")
     if ntp_conf_stat["stat"]["exists"]:
         return NtpDaemon.NTP
     pytest.fail("Unable to determine NTP daemon in use")
+
+
+@pytest.fixture(scope="module")
+def ntp_daemon_in_use(duthost):
+    return get_ntp_daemon_in_use(duthost)
 
 
 def check_ntp_status(host, ntp_daemon_in_use):

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -149,21 +149,20 @@ def check_system_time_sync(duthost):
     If not synchronized, it attempts to restart the NTP service.
     """
 
-    ntp_status_cmd = "ntpstat"
-    restart_ntp_cmd = "sudo systemctl restart ntp"
+    ntp_status_cmd = "chronyc -c tracking"
+    restart_ntp_cmd = "sudo systemctl restart chrony"
 
-    ntp_status = duthost.shell(ntp_status_cmd, module_ignore_errors=True)
-    if "synchronised" in ntp_status["stdout"]:
+    ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
+    if "Not synchronised" not in ntp_status["stdout"]:
         logger.info("DUT %s is synchronized with NTP server.", duthost)
         return True
-
     else:
         logger.info("DUT %s is NOT synchronized. Restarting NTP service...", duthost)
-        duthost.shell(restart_ntp_cmd)
+        duthost.command(restart_ntp_cmd)
         time.sleep(5)
         # Rechecking status after restarting NTP
-        ntp_status = duthost.shell(ntp_status_cmd, module_ignore_errors=True)
-        if "synchronised" in ntp_status["stdout"]:
+        ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
+        if "Not synchronised" not in ntp_status["stdout"]:
             logger.info("DUT %s is now synchronized with NTP server.", duthost)
             return True
         else:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -144,13 +144,15 @@ def recover_cert_config(duthost):
     assert wait_until(60, 3, 0, check_gnmi_status, duthost), "GNMI service failed to start"
 
 
-def check_system_time_sync(duthost, ntp_daemon_in_use):  # noqa: F811
+def check_system_time_sync(duthost):
     """
     Checks if the DUT's time is synchronized with the NTP server.
     If not synchronized, it attempts to restart the NTP service.
     """
 
-    if ntp_daemon_in_use == NtpDaemon.CHRONY:
+    ntp_daemon = ntp_daemon_in_use(duthost)
+
+    if ntp_daemon == NtpDaemon.CHRONY:
         ntp_status_cmd = "chronyc -c tracking"
         restart_ntp_cmd = "sudo systemctl restart chrony"
     else:
@@ -158,8 +160,8 @@ def check_system_time_sync(duthost, ntp_daemon_in_use):  # noqa: F811
         restart_ntp_cmd = "sudo systemctl restart ntp"
 
     ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
-    if (ntp_daemon_in_use == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
-            (ntp_daemon_in_use != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
+    if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
+            (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
         logger.info("DUT %s is synchronized with NTP server.", duthost)
         return True
     else:
@@ -168,8 +170,8 @@ def check_system_time_sync(duthost, ntp_daemon_in_use):  # noqa: F811
         time.sleep(5)
         # Rechecking status after restarting NTP
         ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
-        if (ntp_daemon_in_use == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
-                (ntp_daemon_in_use != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
+        if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
+                (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
             logger.info("DUT %s is now synchronized with NTP server.", duthost)
             return True
         else:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -161,7 +161,7 @@ def check_system_time_sync(duthost):
 
     ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
     if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
-            (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
+            (ntp_daemon != NtpDaemon.CHRONY and "synchronised" in ntp_status["stdout"]):
         logger.info("DUT %s is synchronized with NTP server.", duthost)
         return True
     else:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from tests.common.utilities import wait_until
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
-from tests.common.helpers.ntp_helper import NtpDaemon, ntp_daemon_in_use   # noqa: F401
+from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
 
 
 logger = logging.getLogger(__name__)
@@ -150,7 +150,7 @@ def check_system_time_sync(duthost):
     If not synchronized, it attempts to restart the NTP service.
     """
 
-    ntp_daemon = ntp_daemon_in_use(duthost)
+    ntp_daemon = get_ntp_daemon_in_use(duthost)
 
     if ntp_daemon == NtpDaemon.CHRONY:
         ntp_status_cmd = "chronyc -c tracking"

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -118,10 +118,11 @@ def change_critical_services(duthosts, rand_one_dut_hostname):
 
 
 def check_ntp_status(host):
-    ntpstat_cmd = 'ntpstat'
     if isinstance(host, PTFHost):
+        ntpstat_cmd = 'ntpstat'
         res = host.command(ntpstat_cmd, module_ignore_errors=True)
     else:
+        ntpstat_cmd = 'chronyc -c tracking'
         res = execute_dut_command(host, ntpstat_cmd, mvrf=True, ignore_errors=True)
     return res['rc'] == 0
 
@@ -148,11 +149,7 @@ def execute_dut_command(duthost, command, mvrf=True, ignore_errors=False):
     result = {}
     prefix = ""
     if mvrf:
-        dut_kernel = duthost.shell("cat /proc/version | awk '{ print $3 }' | cut -d '-' -f 1")["stdout"]
-        if parse_version(dut_kernel) > parse_version("4.9.0"):
-            prefix = "sudo ip vrf exec mgmt "
-        else:
-            prefix = "sudo cgexec -g l3mdev:mgmt "
+        prefix = "sudo ip vrf exec mgmt "
     result = duthost.command(prefix + command, module_ignore_errors=ignore_errors)
     return result
 

--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -117,15 +117,14 @@ def change_critical_services(duthosts, rand_one_dut_hostname):
     duthost.reset_critical_services_tracking_list(backup)
 
 
-def check_ntp_status(host, ntp_daemon_in_use):
+def check_ntp_status(host, ntp_daemon_in_use):  # noqa: F811
+    if ntp_daemon_in_use == NtpDaemon.CHRONY:
+        ntpstat_cmd = "chronyc -c tracking"
+    else:
+        ntpstat_cmd = "ntpstat"
     if isinstance(host, PTFHost):
-        ntpstat_cmd = 'ntpstat'
         res = host.command(ntpstat_cmd, module_ignore_errors=True)
     else:
-        if ntp_daemon_in_use == NtpDaemon.CHRONY:
-            ntpstat_cmd = "chronyc -c tracking"
-        else:
-            ntpstat_cmd = "ntpstat"
         res = execute_dut_command(host, ntpstat_cmd, mvrf=True, ignore_errors=True)
     return res['rc'] == 0
 

--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -1,6 +1,6 @@
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.helpers.ntp_helper import check_ntp_status, run_ntp, setup_ntp_context, NtpDaemon, ntp_daemon_in_use   # noqa F401
+from tests.common.helpers.ntp_helper import check_ntp_status, run_ntp, setup_ntp_context, NtpDaemon, ntp_daemon_in_use  # noqa: F401, E501
 import logging
 import time
 import pytest


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

With the NTP daemon being changed from ntpd to chrony, commands that refer to the ntpd daemon need to be updated to point to chrony instead.

#### How did you do it?

Update the gnoi and mvrf test cases to point to chrony-related commands instead of ntpd-related commands.

#### How did you verify/test it?

Tested on physical T0 and T2 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
