### PR TITLE
[Mellanox] Skip test_check_sfp_eeprom_with_option_dom on spc3 and later

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -772,6 +772,14 @@ platform_tests/mellanox:
     conditions:
       - "asic_type not in ['mellanox', 'nvidia-bluefield']"
 
+platform_tests/mellanox/test_check_sfp_eeprom.py:
+  skip:
+    reason: "202405 and 202411 not support command like 'mlxlink -d /dev/mst/mt53104_pci_cr0 -p 1 -m' on mellanox spc3 devices when software control is enabled"
+    conditions_logical_operator: or
+    conditions:
+      - "SN4 in hwsku"
+      - "SN5 in hwsku"
+
 platform_tests/mellanox/test_check_sfp_using_ethtool.py:
   skip:
     reason: "Deprecated as Mellanox do not use ethtool in release 202305 or higher / Mellanox platform tests only supported on Mellanox devices"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -777,8 +777,8 @@ platform_tests/mellanox/test_check_sfp_eeprom.py:
     reason: "202405 and 202411 not support command like 'mlxlink -d /dev/mst/mt53104_pci_cr0 -p 1 -m' on mellanox spc3 devices when software control is enabled"
     conditions_logical_operator: or
     conditions:
-      - "SN4 in hwsku"
-      - "SN5 in hwsku"
+      - "SN4 in hwsku and (release in ['202405', '202411'])"
+      - "SN5 in hwsku and (release in ['202405', '202411'])"
 
 platform_tests/mellanox/test_check_sfp_using_ethtool.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Skip test_check_sfp_eeprom_with_option_dom on spc3 and later because the device doesn't support the command like 'mlxlink -d /dev/mst/mt53104_pci_cr0 -p 1 -m' on mellanox spc3 and later when software control is enabled 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Skip test_check_sfp_eeprom_with_option_dom on spc3 and later for mellanox device

#### How did you do it?
Add skip condition

#### How did you verify/test it?
Run test_check_sfp_eeprom_with_option_dom on spc3 and later

#### Any platform specific information?
spc3 and later

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
