### PR TITLE
Fix for the syslog source ip test in the teardown of restore_config_by_config_reload.

### DIFF
--- a/tests/syslog/test_syslog_source_ip.py
+++ b/tests/syslog/test_syslog_source_ip.py
@@ -95,7 +95,7 @@ def restore_config_by_config_reload(duthosts, enum_rand_one_per_hwsku_frontend_h
         # we need remove mgmt vrf, otherwise it will cause host unreachable
         remove_vrf(duthost, VRF_LIST[2])
         localhost.wait_for(host=duthost.mgmt_ip, port=SONIC_SSH_PORT, search_regex=SONIC_SSH_REGEX,
-                           state='absent', delay=1, timeout=30)
+                           state='absent', delay=1, connect_timeout=1, timeout=30)
         localhost.wait_for(host=duthost.mgmt_ip, port=SONIC_SSH_PORT, search_regex=SONIC_SSH_REGEX,
                            state='started', delay=2, timeout=180)
     config_reload(duthost, safe_reload=True)
@@ -297,7 +297,7 @@ class TestSSIP:
             create_vrf(self.duthost, VRF_LIST[2])
             # when create mgmt vrf, dut connection will be lost for a while
             localhost.wait_for(host=self.duthost.mgmt_ip, port=SONIC_SSH_PORT, search_regex=SONIC_SSH_REGEX,
-                               state='absent', delay=1, timeout=30)
+                               state='absent', delay=1, connect_timeout=1, timeout=30)
             localhost.wait_for(host=self.duthost.mgmt_ip, port=SONIC_SSH_PORT, search_regex=SONIC_SSH_REGEX,
                                state='started', delay=2, timeout=180)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There could be a failure in the teardown of tests/syslog/test_syslog_source_ip.py.
The reason is in restore_config_by_config_reload, there is a step to remove the vrf configured in the test, which will cause ssh flap.
There is a wait_for for the ssh down, but the default connect_timeout for ssh connection in the the wait_for is 5s, meaning if in 5s the ssh connection is restored, it will not consider the connection as down.
The 5s is too long, the ssh could have already been restored from the flap caused by removing the vrf, shorten it to 1s.

And the same for the wait_for in configure_mgmt_vrf_test_data.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix for the syslog source ip test in the teardown of restore_config_by_config_reload.
#### How did you do it?

#### How did you verify/test it?
Run the test, the failure didn't reproduce.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
