### PR TITLE
Improve the wait after reboot logic in fwutil test

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -9,6 +9,7 @@ import re
 from copy import deepcopy
 
 from tests.common.utilities import wait_until
+from tests.common.reboot import SONIC_SSH_REGEX
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,8 @@ POWER_CYCLE = "power off"
 FAST_REBOOT = "fast"
 
 DEVICES_PATH = "usr/share/sonic/device"
-TIMEOUT = 1200
+TIMEOUT = 2100
+
 REBOOT_TYPES = {
     COLD_REBOOT: "reboot",
     WARM_REBOOT: "warm-reboot",
@@ -81,14 +83,23 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, auto_reboot=F
             logger.info("Rebooting switch using {} boot".format(boot_type))
             duthost.command("sonic-installer set-default {}".format(current))
             reboot(duthost, pdu_ctrl, boot_type, pdu_delay)
+            logger.info("Waiting on switch to shutdown...")
+            localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=timeout)
+            # Wait for 30s in case there is ssh flap
+            time.sleep(30)
+            logger.info("Waiting on switch to come up in SONiC....")
+            localhost.wait_for(host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10, timeout=600)
+        else:
+            # For auto reboot scenario, it takes some time in ONIE to update the firmware
+            logger.info("Waiting on switch to shutdown after auto reboot...")
+            # Need wait longer for CPLD/FPGA which requires power off reboot
+            auto_reboot_timeout = timeout if boot_type == 'power off' else 120
+            localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=auto_reboot_timeout)
+            # Wait for 30s in case there is ssh flap
+            time.sleep(30)
+            logger.info("Waiting on switch to come up in SONiC....")
+            localhost.wait_for(host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10, timeout=1200)
 
-        logger.info("Waiting on switch to shutdown...")
-        # Wait for ssh flap
-        localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=timeout)
-        logger.info("Letting switch get through ONIE / BIOS before pinging....")
-        time.sleep(300)
-        logger.info("Waiting on switch to come up....")
-        localhost.wait_for(host=hn, port=22, state='started', delay=10, timeout=300)
         logger.info("Waiting on critical systems to come online...")
         wait_until(300, 30, 0, duthost.critical_services_fully_started)
         time.sleep(60)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. There was a hardcoded 300s sleep in the wait logic, remove it and improve the logic to make it work for all components.
2. Increase the TIMEOUT for it takes more time to burn the CPLD/FPGA on some new platforms.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
1. Improve the wait after reboot logic in fwutil test to decrease the run time.
2. Increase the TIMEOUT for new platforms.
#### How did you do it?

#### How did you verify/test it?
Tested on all Mellanox platforms, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
