### PR TITLE
Fix condition to check psu_num variable check for null in test_turn_on_off_psu_and_check_status

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -252,7 +252,7 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
     psu_line_pattern = get_dut_psu_line_pattern(duthost)
 
     psu_num = get_healthy_psu_num(duthost)
-    if psu_num:
+    if psu_num is not None:
         pytest_require(
             psu_num >= 2, "At least 2 PSUs required for rest of the testing in this case")
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_status, the condition to verify psu_num variable as null is returning False and is not honored when psu_num value is 0. This is because in Python, both None (representing null) and 0 are considered "false" values. This means that when used in a boolean context, such as an if statement, they evaluate to False.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix healthy psu check condition before proceeding the test
#### How did you do it?
Modified condition to verify psu_num value is not None
#### How did you verify/test it?
run platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_status on nokia-armhf platforms
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
