### PR TITLE
Ignore netlink socket readData error=-33

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -71,7 +71,7 @@ r, ".* ERR bgp#bgpcfgd: .*BGPVac.*attribute is supported.*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/14233938
 r, ".* ERR swss\d*#fdbsyncd: :- readData: netlink reports an error=-25 on reading a netlink socket.*"
-r, ".* ERR swss\d*#.*syncd: :- readData: netlink reports an error=-33 on reading a netlink socket.*"
+r, ".* ERR .*\d*#.*syncd: :- readData: netlink reports an error=-33 on reading a netlink socket.*"
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14213168
 r, ".* ERR /hostcfgd: sonic-kdump-config --disable - failed.*"


### PR DESCRIPTION
### Description of PR

Ignore netlink socket readData error logs in syslog that are causing some tests to fail

Fixes # (issue)

This error message was ignored earlier, but only from swss. But the message is seen for teamd as well. Since there is no functional impact due to these logs, these are ignored.

More details abot the message are in https://github.com/sonic-net/sonic-swss/issues/353

The fix for swss was done under https://github.com/sonic-net/sonic-mgmt/pull/13639

But it was not done for teamd container.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

