### PR TITLE
Update syslog rate limit test to make it more stable

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -22,7 +22,7 @@ LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
 # rsyslogd prints this log when rate-limiting reached
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*begin to drop messages due to rate-limiting.*'
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*rate-limit-test.*begin to drop messages due to rate-limiting.*'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update expect syslog rate limit reach regex to only match the correct log

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The rsyslog rate limit is easy to reach for many services, such as /usr/bin/orchagent or /usr/bin/portsyncd.
When reaching the limit, the modules would print "begin to drop messages due to rate-limiting" to the syslog.
And it may lead to test failed due to more log matched than expectation.
#### How did you do it?
Update LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED  to '.*rate-limit-test.*begin to drop messages due to rate-limiting.*'
It would only match the destination log.
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
