### PR TITLE
Extend bmp table entries retry timeout into 360s

### DIFF
--- a/tests/bmp/test_bmp_statedb.py
+++ b/tests/bmp/test_bmp_statedb.py
@@ -13,7 +13,7 @@ pytestmark = [
 ]
 
 
-def check_dut_bmp_neighbor_status(duthost, neighbor_addr, expected_state, max_attempts=12, retry_interval=3):
+def check_dut_bmp_neighbor_status(duthost, neighbor_addr, expected_state, max_attempts=120, retry_interval=3):
     for i in range(max_attempts + 1):
         bmp_info = duthost.shell("sonic-db-cli BMP_STATE_DB HGETALL 'BGP_NEIGHBOR_TABLE|{}'"
                                  .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']
@@ -31,7 +31,7 @@ def check_dut_bmp_neighbor_status(duthost, neighbor_addr, expected_state, max_at
     assert expected_state in parsed_output  # If all attempts fail, raise an assertion error
 
 
-def check_dut_bmp_rib_in_status(duthost, neighbor_addr, max_attempts=12, retry_interval=3):
+def check_dut_bmp_rib_in_status(duthost, neighbor_addr, max_attempts=120, retry_interval=3):
     for i in range(max_attempts + 1):
         bmp_info = duthost.shell("sonic-db-cli BMP_STATE_DB HGETALL 'BGP_RIB_IN_TABLE|*|{}'"
                                  .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']
@@ -48,7 +48,7 @@ def check_dut_bmp_rib_in_status(duthost, neighbor_addr, max_attempts=12, retry_i
     assert entry_num != 0  # If all attempts fail, raise an assertion error
 
 
-def check_dut_bmp_rib_out_status(duthost, neighbor_addr, max_attempts=12, retry_interval=3):
+def check_dut_bmp_rib_out_status(duthost, neighbor_addr, max_attempts=120, retry_interval=3):
     for i in range(max_attempts + 1):
         bmp_info = duthost.shell("sonic-db-cli BMP_STATE_DB HGETALL 'BGP_RIB_OUT_TABLE|*|{}'"
                                  .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Extend bmp test case timeout, which will contain the time that bmp table is enable, and bgpd will send bgp updates to bmpd daemon, then bmpd daemon will populate BMP_STATE_DB, finally read from BMP_STATE_DB, previously the entire flow timeout is set as 360s which gets failed from time to time, now extend it into 6 minutes, once it get the entities it will return immediately instead of waiting for that long time.

Microsoft ADO (number only):31380216

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
BMP state db retrieve case only uses 36s as timeout which is not enough for some slow devices.

#### How did you do it?
Extend the timeout value.

#### How did you verify/test it?

![image](https://github.com/user-attachments/assets/6f1ec71d-3d76-474f-bfe7-de1f09f504c2)

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
