### PR TITLE
feat: support skipping iBGP check in reboot/reload

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -114,7 +114,7 @@ def pfcwd_feature_enabled(duthost):
 
 @support_ignore_loganalyzer
 def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=True, start_dynamic_buffer=True,
-                  safe_reload=False, wait_before_force_reload=0, wait_for_bgp=False,
+                  safe_reload=False, wait_before_force_reload=0, wait_for_bgp=False, wait_for_ibgp=True,
                   check_intf_up_ports=False, traffic_shift_away=False, override_config=False,
                   golden_config_path=DEFAULT_GOLDEN_CONFIG_PATH, is_dut=True, exec_tsb=False):
     """
@@ -123,6 +123,8 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
     :param config_source: configuration source is 'config_db', 'minigraph' or 'running_golden_config'
     :param wait: wait timeout for sonic_host to initialize after configuration reload
     :param wait_for_bgp: True to wait for all BGP connections to come up after configuration reload
+    :param wait_for_ibgp: True to wait for all iBGP connections to come up after configuration reload. This
+                          parameter is only used when `wait_for_bgp` is True.
     :param override_config: override current config with '/etc/sonic/golden_config_db.json'
     :param is_dut: True if the host is DUT, False if the host may be neighbor device.
                     To the non-DUT host, it may lack of some runtime variables like `topo_type`
@@ -216,6 +218,20 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
 
     if wait_for_bgp:
         bgp_neighbors = sonic_host.get_bgp_neighbors_per_asic(state="all")
+        if not wait_for_ibgp:
+            # Filter out iBGP neighbors
+            filtered_bgp_neighbors = {}
+            for asic, interfaces in bgp_neighbors.items():
+                filtered_interfaces = {
+                    ip: details for ip, details in interfaces.items()
+                    if details["local AS"] != details["remote AS"]
+                }
+
+                if filtered_interfaces:
+                    filtered_bgp_neighbors[asic] = filtered_interfaces
+
+            bgp_neighbors = filtered_bgp_neighbors
+
         pytest_assert(
             wait_until(wait + 120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
             "Not all bgp sessions are established after config reload",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add option to skip iBGP check during health check after reboot and reload

Summary:
Fixes # (issue) Microsoft ADO 30056122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Sometimes we do not want to wait for iBGP to be up after reboot and reload as it's not related to our test and it's stopping us from utilizing the parallel run infrastructure. After adding this option, we can skip the iBGP check during health check after reboot and reload, so we can parallel run some test modules (e.g. `pc/test_po_cleanup.py`). After the test module is done, we can enable post-test sanity check to wait for all the BGP sessions (eBGP & iBGP) to be up before starting the next module.

#### How did you do it?

#### How did you verify/test it?
I ran the updated code and can confirm it's working well.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
