### PR TITLE
Fix test_arp_update on some T0 topology

### DIFF
--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -54,10 +54,15 @@ def test_kernel_asic_mac_mismatch(
         else:
             target_ip = servers[intf]['server_ipv6'].split('/')[0]
     else:
+        mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+        # Randomly select a VLAN member to ping
+        vlan_member = mg_facts['minigraph_vlans'][vlan_name]['members'][0]
+        vlan_member_offset = mg_facts['minigraph_ptf_indices'][vlan_member]
+        # The IP address is the base_ip + offset + 1
         if ip_version == 4:
-            target_ip = ipv4_base.ip + 2
+            target_ip = ipv4_base.ip + vlan_member_offset + 1
         else:
-            target_ip = ipv6_base.ip + 2
+            target_ip = ipv6_base.ip + vlan_member_offset + 1
 
     rand_selected_dut.shell(f"ping -c1 -W1 {target_ip}; true")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix test failure in [test_arp_update.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:sonic-mgmt:fix_arp_update#diff-d68fc48bdae8caa1fa0f5172826bd06be06e2ab8ab88d3b24462f8c9048e05a5) on some T0 topologies, such as `T0-64`.
The error is 
```
  File "/var/src/sonic-mgmt_testbed-bjw-can-4600c-1_646f1406735219c3e54440f8/tests/arp/test_arp_update.py", line 61, in test_kernel_asic_mac_mismatch
    pt_assert(neighbor_info[4].lower() == asic_db_mac.lower())
IndexError: list index out of range
```
It's becasue there are some admin down ports on some topologies, so the port with hardcoded offset `2` could be down. Hence the ping failed because the arp_responder doesn't respond on admin down ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix test failure in [test_arp_update.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:sonic-mgmt:fix_arp_update#diff-d68fc48bdae8caa1fa0f5172826bd06be06e2ab8ab88d3b24462f8c9048e05a5) on some T0 topologies, such as `T0-64`.

#### How did you do it?
Read the admin up vlan ports from minigraph and use that port for test.

#### How did you verify/test it?
The change is verified on a `T0-64` topology.
```
collected 2 items                                                                                                                                                                                                             

arp/test_arp_update.py::test_kernel_asic_mac_mismatch[ipv4] PASSED                                                                                                                                                      [ 50%]
arp/test_arp_update.py::test_kernel_asic_mac_mismatch[ipv6] PASSED                                                                                                                                                      [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
