### PR TITLE
Packet drop threshold test across different packet sizes

### DIFF
--- a/tests/snappi_tests/dataplane/test_packet_drop_threshold.py
+++ b/tests/snappi_tests/dataplane/test_packet_drop_threshold.py
@@ -23,7 +23,7 @@ test_results = pd.DataFrame(
     ]
 )
 
-route_ranges = {"IPv6": [["777:777:777::1", 64, 5000]], "IPv4": [["100.1.1.1", 24, 5000]]}
+ROUTE_RANGES = {"IPv6": [[["777:777:777::1", 64, 16]]], "IPv4": [[["100.1.1.1", 24, 16]]]}
 
 
 @pytest.mark.parametrize("ip_version", ["IPv6"])
@@ -47,12 +47,13 @@ def test_packet_drop_threshold(
     """
     no_loss_max_rate = GaugeMetric("no_loss_max_rate", "No Loss Max Rate", UNIT_PERCENT, db_reporter)
     snappi_extra_params = SnappiTestParams()
-    snappi_ports = get_duthost_bgp_details(duthosts, get_snappi_ports, ip_version)
+    snappi_ports = get_duthost_interface_details(duthosts, get_snappi_ports, ip_version, protocol_type="bgp")
     port_distrbution = (slice(0, len(snappi_ports) // 2), slice(len(snappi_ports) // 2, None))
     tx_ports, rx_ports = snappi_ports[port_distrbution[0]], snappi_ports[port_distrbution[1]]
+    ranges = ROUTE_RANGES[ip_version]*(len(snappi_ports))
     snappi_extra_params.protocol_config = {
         "Tx": {
-            "route_ranges": route_ranges[ip_version],
+            "route_ranges": ranges,
             "network_group": False,
             "protocol_type": "bgp",
             "ports": tx_ports,
@@ -60,7 +61,7 @@ def test_packet_drop_threshold(
             "is_rdma": False,
         },
         "Rx": {
-            "route_ranges": route_ranges[ip_version],
+            "route_ranges": ranges,
             "network_group": False,
             "protocol_type": "bgp",
             "ports": rx_ports,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Test aims to determine the maximum traffic rate that results in 0% packet loss across different packet sizes.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This test aims to determine the maximum traffic rate that results in 0% packet loss across different packet sizes. By identifying this threshold, we can assess the switch's forwarding capability and validate its performance under various traffic conditions.
#### How did you do it?
During the pretest phase, the test will leverage the traffic generator or the device connected directly to the traffic 
generator to inject the routes into the testbed. This facilitates the traffic routing and allows us to inject the any number of routes into the testbed for testing purposes.

- Configurate traffic based on the test parameters in traffic generator, such as IP version, frame size, and RFC2889 mode.
- Start with 100% of the line rate and check for packet loss.
- If any traffic flow experiences packet loss, reduce the traffic rate to 10% of the line rate and test again.
- Continue adjusting the traffic rate using a binary search approach to determine the maximum rate at which 0% packet loss is observed.
- Log and report the result.
#### How did you verify/test it?
This test aims to determine the maximum traffic rate that results in 0% packet loss across different packet sizes.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
The test is designed to be topology-agnostic. It expects the testbed to be built following the [Multi-device multi-tier testbed HLD](https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testbed/README.testbed.NUT.md), which allows us to test the latency of either a single switch or a multi-tier network.

### Documentation
Test Case Details: https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/snappi/switch-packet-drop-threshold-tests.md
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
