### PR TITLE
[KubeSonic] add auditd test cases

### DIFF
--- a/tests/auditd/32-test.rules
+++ b/tests/auditd/32-test.rules
@@ -1,0 +1,1 @@
+-a always,exit -F arch=b64 -S unlink -S unlinkat -F auid>=1000 -F auid!=4294967295 -F key=test

--- a/tests/auditd/conftest.py
+++ b/tests/auditd/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
@@ -38,3 +39,17 @@ def check_auditd_failure(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost.command("sudo systemctl restart auditd")
     output = duthost.command("sudo systemctl is-active auditd")["stdout"]
     pytest_assert(output == "active", "auditd service did not restart after test")
+
+
+@pytest.fixture(scope="module")
+def check_auditd_failure_32bit(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "32-test.rules")
+    duthost.copy(src=test_path, dest="/etc/audit/rules.d/32-test.rules")
+    duthost.shell("sudo systemctl restart auditd")
+
+    yield
+
+    duthost.command("sudo rm -f /etc/audit/rules.d/32-test.rules")
+    duthost.command("sudo systemctl restart auditd")

--- a/tests/auditd/conftest.py
+++ b/tests/auditd/conftest.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.assertions import pytest_assert as py_assert
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ def check_auditd(duthosts, enum_rand_one_per_hwsku_hostname):
         logger.info("auditd is not active. Restarting...")
         duthost.command("sudo systemctl restart auditd")
         output = duthost.command("sudo systemctl is-active auditd")["stdout"]
-        pytest_assert(output == "active", "auditd service failed to start")
+        py_assert(output == "active", "auditd service failed to start")
 
     yield
 
@@ -23,7 +23,7 @@ def check_auditd(duthosts, enum_rand_one_per_hwsku_hostname):
     if output != "active":
         logger.warning("auditd became inactive during the test. Restarting...")
         duthost.command("sudo systemctl restart auditd")
-    pytest_assert(output == "active", "auditd service is not running after test")
+    py_assert(output == "active", "auditd service is not running after test")
 
 
 @pytest.fixture(scope="module")
@@ -32,13 +32,13 @@ def check_auditd_failure(duthosts, enum_rand_one_per_hwsku_hostname):
 
     duthost.command("sudo systemctl stop auditd")
     output = duthost.command("sudo systemctl is-active auditd")["stdout"]
-    pytest_assert(output != "active", "auditd service is still running when it should be inactive")
+    py_assert(output != "active", "auditd service is still running when it should be inactive")
 
     yield
 
     duthost.command("sudo systemctl restart auditd")
     output = duthost.command("sudo systemctl is-active auditd")["stdout"]
-    pytest_assert(output == "active", "auditd service did not restart after test")
+    py_assert(output == "active", "auditd service did not restart after test")
 
 
 @pytest.fixture(scope="module")

--- a/tests/auditd/conftest.py
+++ b/tests/auditd/conftest.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def check_auditd(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    output = duthost.command("sudo systemctl is-active auditd", module_ignore_errors=True)["stdout"]
     if output != "active":
         logger.info("auditd is not active. Restarting...")
         duthost.command("sudo systemctl restart auditd")
@@ -19,7 +19,7 @@ def check_auditd(duthosts, enum_rand_one_per_hwsku_hostname):
 
     yield
 
-    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    output = duthost.command("sudo systemctl is-active auditd", module_ignore_errors=True)["stdout"]
     if output != "active":
         logger.warning("auditd became inactive during the test. Restarting...")
         duthost.command("sudo systemctl restart auditd")
@@ -31,13 +31,13 @@ def check_auditd_failure(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     duthost.command("sudo systemctl stop auditd")
-    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    output = duthost.command("sudo systemctl is-active auditd", module_ignore_errors=True)["stdout"]
     py_assert(output != "active", "auditd service is still running when it should be inactive")
 
     yield
 
     duthost.command("sudo systemctl restart auditd")
-    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    output = duthost.command("sudo systemctl is-active auditd", module_ignore_errors=True)["stdout"]
     py_assert(output == "active", "auditd service did not restart after test")
 
 

--- a/tests/auditd/conftest.py
+++ b/tests/auditd/conftest.py
@@ -1,0 +1,40 @@
+import pytest
+import logging
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def check_auditd(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    if output != "active":
+        logger.info("auditd is not active. Restarting...")
+        duthost.command("sudo systemctl restart auditd")
+        output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+        pytest_assert(output == "active", "auditd service failed to start")
+
+    yield
+
+    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    if output != "active":
+        logger.warning("auditd became inactive during the test. Restarting...")
+        duthost.command("sudo systemctl restart auditd")
+    pytest_assert(output == "active", "auditd service is not running after test")
+
+
+@pytest.fixture(scope="module")
+def check_auditd_failure(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+
+    duthost.command("sudo systemctl stop auditd")
+    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    pytest_assert(output != "active", "auditd service is still running when it should be inactive")
+
+    yield
+
+    duthost.command("sudo systemctl restart auditd")
+    output = duthost.command("sudo systemctl is-active auditd")["stdout"]
+    pytest_assert(output == "active", "auditd service did not restart after test")

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -1,0 +1,243 @@
+import re
+import os
+import json
+import pytest
+import logging
+from tests.tacacs.conftest import check_tacacs
+from tests.common.fixtures.tacacs import tacacs_creds
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import is_container_running
+from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run
+
+pytestmark = [
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+DOCKER_EXEC_CMD = "docker exec {} bash -c "
+NSENTER_CMD = "nsenter --target 1 --pid --mount --uts --ipc --net "
+logger = logging.getLogger(__name__)
+
+
+def verify_container_running(duthost, container_name):
+    is_running = is_container_running(duthost, container_name)
+    pytest_assert(is_running, "Container {} is not running".format(container_name))
+
+
+def test_auditd_functionality(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    container_name = "auditd"
+    verify_container_running(duthost, container_name)
+    hwsku = duthost.facts["hwsku"]
+    if "Nokia-7215" in hwsku or "Nokia-7215-M0" in hwsku:
+        rule_checksum = "bd574779fb4e1116838d18346187bb7f7bd089c9"
+    else:
+        rule_checksum = "f88174f901ec8709bacaf325158f10ec62909d13"
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + """'{} find /etc/audit/rules.d/ -type f -name "[0-9][0-9]-*.rules" ! -name "30-audisp-tacplus.rules" -exec cat {{}} + | sort | sha1sum'""".format(NSENTER_CMD))["stdout"]
+    pytest_assert(rule_checksum in output, "Rule files checksum is not as expected")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'{} cat /etc/audit/auditd.conf | sha1sum'".format(NSENTER_CMD))["stdout"]
+    pytest_assert("7cdbd1450570c7c12bdc67115b46d9ae778cbd76" in output, "auditd.conf checksum is not as expected")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + """'{} grep "^active = yes" /etc/audit/plugins.d/syslog.conf'""".format(NSENTER_CMD))["stdout"]
+    pytest_assert("active = yes" in output, "syslog.conf does not contain active=yes as expected")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + """'{} grep "^CPUQuota=10%" /lib/systemd/system/auditd.service'""".format(NSENTER_CMD))["stdout"]
+    pytest_assert("CPUQuota=10%" in output, "auditd.service does not contain CPUQuota=10% as expected")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'{} systemctl is-active auditd'".format(NSENTER_CMD))["stdout"]
+    pytest_assert(output == "active", "Auditd daemon is not running")
+
+    output = duthost.shell("show logging | grep 'audisp-syslog'")["stdout_lines"]
+    pytest_assert(len(output) > 0, "Auditd logs are not sent to syslog")
+
+
+def test_auditd_watchdog_functionality(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    container_name = "auditd_watchdog"
+    verify_container_running(duthost, container_name)
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'curl --fail-with-body -s -o /dev/null -w \%\{http_code\} http://localhost:8080'", module_ignore_errors=True)["stdout"]
+    pytest_assert(output == "200", "Auditd watchdog reports auditd container is unhealthy")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'{} curl --fail-with-body http://localhost:8080'".format(NSENTER_CMD))["stdout"]
+    try:
+        response = json.loads(output)
+    except json.JSONDecodeError:
+        pytest.fail("Invalid JSON response from auditd watchdog: {}".format(output))
+
+    # Define expected keys
+    expected_keys = [
+        "cpu_usage",
+        "mem_usage",
+        "auditd_conf",
+        "syslog_conf",
+        "auditd_rules",
+        "auditd_service",
+        "auditd_active",
+        "auditd_reload"
+    ]
+
+    # Check if all expected keys exist and have the value "OK"
+    for key in expected_keys:
+        pytest_assert(response.get(key) == "OK", "Auditd watchdog check failed for {}: {}".format(key, response.get(key)))
+
+
+def test_auditd_file_deletion(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    container_name = "auditd"
+    verify_container_running(duthost, container_name)
+
+    duthost.command("rm -f /tmp/test_file_deletion")
+    res = ssh_remote_run(localhost,
+                         dutip,
+                         tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'],
+                         "sudo touch /tmp/test_file_deletion && sudo rm -f /tmp/test_file_deletion")
+    result = duthost.shell("""show logging | grep 'audisp-syslog' | grep 'file_deletion' | grep 'AUID="test_rwuser"' """)["stdout_lines"]
+    assert len(result) > 0, "Auditd file_deletion rule does not contain the expected logs"
+
+
+def test_auditd_process_audit(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    container_name = "auditd"
+    verify_container_running(duthost, container_name)
+
+    res = ssh_remote_run(localhost,
+                         dutip,
+                         tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'],
+                         "echo 'Test Process Audit'")
+    result = duthost.shell("""show logging | grep 'audisp-syslog' | grep 'process_audit' | grep 'AUID="test_rwuser"' """)['stdout_lines']
+    assert len(result) > 0, "Auditd process_audit rule does not contain the expected logs"
+
+
+def test_auditd_user_group_management(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    container_name = "auditd"
+    verify_container_running(duthost, container_name)
+
+    res = ssh_remote_run(localhost,
+                         dutip,
+                         tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'],
+                         "sudo su - anotheruser -c 'whoami'")
+    result = duthost.shell("""show logging | grep 'audisp-syslog' | grep 'user_group_management' | grep 'AUID="test_rwuser"' """)['stdout_lines']
+    assert len(result) > 0, "Auditd user_group_management rule does not contain the expected logs"
+
+
+def test_auditd_docker_commands(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    container_name = "auditd"
+    verify_container_running(duthost, container_name)
+
+    res = ssh_remote_run(localhost,
+                         dutip,
+                         tacacs_creds['tacacs_rw_user'],
+                         tacacs_creds['tacacs_rw_user_passwd'],
+                         "sudo docker ps")
+    result = duthost.shell("""show logging | grep 'audisp-syslog' | grep 'docker_commands' | grep 'AUID="test_rwuser"' """)['stdout_lines']
+    assert len(result) > 0, "Auditd docker_commands rule does not contain the expected logs"
+
+
+def test_auditd_config_changes(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dutip = duthost.mgmt_ip
+    container_name = "auditd"
+    verify_container_running(duthost, container_name)
+
+    watch_files = {
+        "group_changes": ["/etc/group"],
+        "hosts_changes": ["/etc/hosts"],
+        "passwd_changes": ["/etc/passwd"],
+        "shadow_changes": ["/etc/shadow"],
+        "sudoers_changes": ["/etc/sudoers"],
+        "time_changes": ["/etc/localtime"],
+        "auth_logs": ["/var/log/auth.log", "/var/log.tmpfs/auth.log"],
+        "cron_changes": ["/etc/crontab", "/etc/cron.d", "/etc/cron.daily", "/etc/cron.hourly", "/etc/cron.weekly", "/etc/cron.monthly"],
+        "dns_change": ["/etc/resolv.conf"],
+        "docker_config": ["/etc/docker/daemon.json"],
+        "docker_daemon": ["/usr/bin/dockerd"],
+        "docker_service": ["/lib/systemd/system/docker.service"],
+        "docker_socket": ["/lib/systemd/system/docker.socket"],
+        "modules_changes": ["/sbin/insmod", "/sbin/rmmod", "/sbin/modprobe"],
+        "log_changes": ["/var/log/testfile", "/var/log.tmpfs/testfile"],
+        "bin_changes": ["/bin/testfile"],
+        "sbin_changes": ["/sbin/testfile"],
+        "usr_bin_changes": ["/usr/bin/testfile"],
+        "usr_sbin_changes": ["/usr/sbin/testfile"],
+        "docker_storage": ["/var/lib/docker/testfile"]
+    }
+
+    for rule, files in watch_files.items():
+        for file in files:
+            res = ssh_remote_run(localhost,
+                                 dutip,
+                                 tacacs_creds['tacacs_rw_user'],
+                                 tacacs_creds['tacacs_rw_user_passwd'],
+                                 f"sudo touch {file}")
+            result = duthost.shell(f"""show logging | grep 'audisp-syslog' | grep '{rule}' | grep 'AUID="test_rwuser"' """)['stdout_lines']
+            assert len(result) > 0, f"Auditd {rule} rule does not contain the expected logs"
+
+
+def test_auditd_host_failure(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    container_name = "auditd_watchdog"
+    verify_container_running(duthost, container_name)
+
+    # Simulate auditd service failure
+    duthost.shell("sudo systemctl stop auditd")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'curl --fail-with-body -s -o /dev/null -w \%\{http_code\} http://localhost:8080'", module_ignore_errors=True)["stdout"]
+    pytest_assert(output == "500", "Auditd watchdog reports auditd container is healthy")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'{} curl --fail-with-body http://localhost:8080'".format(NSENTER_CMD), module_ignore_errors=True)["stdout"]
+    try:
+        response = json.loads(output)
+    except json.JSONDecodeError:
+        pytest.fail("Invalid JSON response from auditd watchdog: {}".format(output))
+
+    # Define expected keys
+    expected_keys = [
+        "cpu_usage",
+        "mem_usage",
+        "auditd_active"
+    ]
+
+    # Check if all expected keys exist and have the value "OK"
+    for key in expected_keys:
+        pytest_assert(response.get(key) != "FAIL", "Auditd watchdog check not failed for {}: {}".format(key, response.get(key)))
+
+    # Restart auditd service
+    duthost.command("sudo systemctl restart auditd")
+
+
+def test_32bit_failure(duthosts, enum_rand_one_per_hwsku_hostname, check_tacacs, tacacs_creds):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    container_name = "auditd_watchdog"
+    verify_container_running(duthost, container_name)
+
+    hwsku = duthost.facts["hwsku"]
+    if "Nokia-7215" not in hwsku and "Nokia-7215-M0" not in hwsku:
+        pytest.skip("This test is only for Nokia-7215 and Nokia-7215-M0")
+
+    # Apply a 64-bit rule to Nokia device
+    test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "32-test.rules")
+    duthost.copy(src=test_path, dest="/etc/audit/rules.d/32-test.rules")
+    duthost.shell("sudo systemctl restart auditd")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'curl --fail-with-body -s -o /dev/null -w \%\{http_code\} http://localhost:8080'", module_ignore_errors=True)["stdout"]
+    pytest_assert(output == "500", "Auditd watchdog reports auditd container is healthy")
+
+    output = duthost.command(DOCKER_EXEC_CMD.format(container_name) + "'{} curl --fail-with-body http://localhost:8080'".format(NSENTER_CMD), module_ignore_errors=True)["stdout"]
+    pytest_assert('"auditd_reload":"FAIL 'in output, "Auditd watchdog reports auditd container is healthy")
+
+    # Restart auditd service
+    duthost.command("sudo rm -f /etc/audit/rules.d/32-test.rules")
+    duthost.command("sudo systemctl restart auditd")

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -2,11 +2,10 @@ import os
 import json
 import pytest
 import logging
-from tests.tacacs.conftest import check_tacacs # noqa F401
 from tests.common.fixtures.tacacs import tacacs_creds # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.dut_utils import is_container_running
-from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run
+from tests.common.helpers.tacacs.tacacs_helper import check_tacacs, ssh_remote_run # noqa F401
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -1,4 +1,3 @@
-import os
 import json
 import pytest
 import logging

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 
 def verify_container_running(duthost, container_name):
     is_running = is_container_running(duthost, container_name)
-    pytest_assert(is_running, "Container {} is not running".format(container_name))
+    if not is_running:
+        pytest.skip("Container {} is not running".format(container_name))
 
 
 def test_auditd_functionality(duthosts, enum_rand_one_per_hwsku_hostname):

--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -354,3 +354,35 @@ def ssh_remote_run_retry(localhost, dutip, ptfhost, user, password, command, ret
             return res
 
     pytest_assert(False, "cat command failed because TACACS server not running")
+
+
+def check_nss_config(duthost):
+    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)
+    if nss_config_attribute['failed']:
+        logger.error("NSS config file missing: %s", nss_config_attribute['stderr'])
+    else:
+        logger.debug("NSS config file attribute: %s", nss_config_attribute['stdout'])
+
+
+@pytest.fixture(scope="module")
+def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds): # noqa F811
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    tacacs_server_ip = ptfhost.mgmt_ip
+    tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
+
+    # Accounting test case randomly failed, need debug info to confirm NSS config file missing issue.
+    check_nss_config(duthost)
+
+    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey, ptfhost)
+    setup_tacacs_server(ptfhost, tacacs_creds, duthost)
+
+    check_nss_config(duthost)
+
+    yield
+
+    check_nss_config(duthost)
+
+    cleanup_tacacs(ptfhost, tacacs_creds, duthost)
+    restore_tacacs_servers(duthost)
+
+    check_nss_config(duthost)

--- a/tests/container_upgrade/container_upgrade_helper.py
+++ b/tests/container_upgrade/container_upgrade_helper.py
@@ -22,7 +22,9 @@ CONTAINER_STRING_KEY = "container_bundle"
 
 container_name_mapping = {
     "docker-sonic-telemetry": "telemetry",
-    "docker-sonic-gnmi": "gnmi"
+    "docker-sonic-gnmi": "gnmi",
+    "docker-auditd": "auditd",
+    "docker-auditd-watchdog": "auditd_watchdog",
 }
 
 

--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -1,9 +1,9 @@
 {
     "docker-auditd": {
-        "parameters": "--privileged --pid=host --net=host -v /etc/audit/rules.d:/etc/audit/rules.d:rw -v /etc/audit/plugins.d:/etc/audit/plugins.d:rw -v /lib/systemd/system:/lib/systemd/system:rw -v /etc/audit:/etc/audit:rw -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro --name auditd docker-auditd:latest"
+        "parameters": "--privileged --pid=host --net=host -v /etc/audit/rules.d:/etc/audit/rules.d:rw -v /etc/audit/plugins.d:/etc/audit/plugins.d:rw -v /lib/systemd/system:/lib/systemd/system:rw -v /etc/audit:/etc/audit:rw -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"
     },
     "docker-auditd-watchdog": {
-        "parameters": "docker run -d --privileged --pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro --name auditd_watchdog docker-auditd-watchdog:latest"
+        "parameters": "--privileged --pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"
     },
     "docker-sonic-telemetry": {
         "parameters": ""

--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -2,6 +2,9 @@
     "docker-auditd": {
         "parameters": "--privileged --pid=host --net=host -v /etc/audit/rules.d:/etc/audit/rules.d:rw -v /etc/audit/plugins.d:/etc/audit/plugins.d:rw -v /lib/systemd/system:/lib/systemd/system:rw -v /etc/audit:/etc/audit:rw -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro --name auditd docker-auditd:latest"
     },
+    "docker-auditd-watchdog": {
+        "parameters": "docker run -d --privileged --pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro --name auditd_watchdog docker-auditd-watchdog:latest"
+    },
     "docker-sonic-telemetry": {
         "parameters": ""
     },

--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -1,4 +1,7 @@
 {
+    "docker-auditd": {
+        "parameters": "--privileged --pid=host --net=host -v /etc/audit/rules.d:/etc/audit/rules.d:rw -v /etc/audit/plugins.d:/etc/audit/plugins.d:rw -v /lib/systemd/system:/lib/systemd/system:rw -v /etc/audit:/etc/audit:rw -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro --name auditd docker-auditd:latest"
+    },
     "docker-sonic-telemetry": {
         "parameters": ""
     },

--- a/tests/container_upgrade/testcases.json
+++ b/tests/container_upgrade/testcases.json
@@ -1,5 +1,6 @@
 {
 	"testcases": [
+		"auditd/test_auditd.py",
 		"telemetry/test_telemetry.py::test_config_db_parameters"
 	]
 }

--- a/tests/tacacs/conftest.py
+++ b/tests/tacacs/conftest.py
@@ -1,42 +1,9 @@
 import logging
 import pytest
 from tests.common.fixtures.tacacs import tacacs_creds     # noqa F401
-from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_client, setup_tacacs_server,\
-                    cleanup_tacacs, restore_tacacs_servers, tacacs_v6_context
+from tests.common.helpers.tacacs.tacacs_helper import tacacs_v6_context
 
 logger = logging.getLogger(__name__)
-
-
-def check_nss_config(duthost):
-    nss_config_attribute = duthost.command("ls -la /etc/nsswitch.conf", module_ignore_errors=True)
-    if nss_config_attribute['failed']:
-        logger.error("NSS config file missing: %s", nss_config_attribute['stderr'])
-    else:
-        logger.debug("NSS config file attribute: %s", nss_config_attribute['stdout'])
-
-
-@pytest.fixture(scope="module")
-def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds): # noqa F811
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    tacacs_server_ip = ptfhost.mgmt_ip
-    tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
-
-    # Accounting test case randomly failed, need debug info to confirm NSS config file missing issue.
-    check_nss_config(duthost)
-
-    setup_tacacs_client(duthost, tacacs_creds, tacacs_server_ip, tacacs_server_passkey, ptfhost)
-    setup_tacacs_server(ptfhost, tacacs_creds, duthost)
-
-    check_nss_config(duthost)
-
-    yield
-
-    check_nss_config(duthost)
-
-    cleanup_tacacs(ptfhost, tacacs_creds, duthost)
-    restore_tacacs_servers(duthost)
-
-    check_nss_config(duthost)
 
 
 @pytest.fixture(scope="module")

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -3,7 +3,7 @@ import time
 import pytest
 from tests.common.devices.ptf import PTFHost
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
-    per_command_accounting_skip_versions, remove_all_tacacs_server
+    per_command_accounting_skip_versions, remove_all_tacacs_server, check_tacacs  # noqa: F401
 from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_line_count, \
     ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command, cleanup_tacacs_log  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
@@ -181,7 +181,7 @@ def test_accounting_tacacs_only(
                             duthosts,
                             enum_rand_one_per_hwsku_hostname,
                             tacacs_creds,
-                            check_tacacs,
+                            check_tacacs,  # noqa: F811
                             rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, "sudo config aaa accounting tacacs+")
@@ -200,7 +200,7 @@ def test_accounting_tacacs_only_all_tacacs_server_down(
                                                     duthosts,
                                                     enum_rand_one_per_hwsku_hostname,
                                                     tacacs_creds,
-                                                    check_tacacs,
+                                                    check_tacacs,  # noqa: F811
                                                     rw_user_client,
                                                     ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -238,7 +238,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
                                                     duthosts,
                                                     enum_rand_one_per_hwsku_hostname,
                                                     tacacs_creds,
-                                                    check_tacacs,
+                                                    check_tacacs,  # noqa: F811
                                                     rw_user_client):
     """
         Setup multiple tacacs server for this UT.
@@ -279,7 +279,7 @@ def test_accounting_local_only(
                             duthosts,
                             enum_rand_one_per_hwsku_hostname,
                             tacacs_creds,
-                            check_tacacs,
+                            check_tacacs,  # noqa: F811
                             rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -301,7 +301,7 @@ def test_accounting_tacacs_and_local(
                                     duthosts,
                                     enum_rand_one_per_hwsku_hostname,
                                     tacacs_creds,
-                                    check_tacacs,
+                                    check_tacacs,  # noqa: F811
                                     rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -326,7 +326,7 @@ def test_accounting_tacacs_and_local_all_tacacs_server_down(
                                                         duthosts,
                                                         enum_rand_one_per_hwsku_hostname,
                                                         tacacs_creds,
-                                                        check_tacacs,
+                                                        check_tacacs,  # noqa: F811
                                                         rw_user_client,
                                                         ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -354,7 +354,7 @@ def test_send_remote_address(
                             duthosts,
                             enum_rand_one_per_hwsku_hostname,
                             tacacs_creds,
-                            check_tacacs,
+                            check_tacacs,  # noqa: F811
                             rw_user_client):
     """
         Verify TACACS+ send remote address to server.

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -5,7 +5,8 @@ from _pytest.outcomes import Failed
 import time
 
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
-    per_command_authorization_skip_versions, remove_all_tacacs_server, get_ld_path
+    per_command_authorization_skip_versions, remove_all_tacacs_server, get_ld_path, \
+    check_tacacs  # noqa: F401
 from tests.tacacs.utils import change_and_wait_aaa_config_update, ensure_tacacs_server_running_after_ut, \
     ssh_connect_remote_retry, ssh_run_command, TIMEOUT_LIMIT, \
     cleanup_tacacs_log, count_authorization_request       # noqa: F401
@@ -158,7 +159,7 @@ def test_authorization_tacacs_only(
                                 enum_rand_one_per_hwsku_hostname,
                                 setup_authorization_tacacs,
                                 tacacs_creds,
-                                check_tacacs,
+                                check_tacacs,  # noqa: F811
                                 remote_user_client,
                                 remote_rw_user_client):
 
@@ -229,7 +230,7 @@ def test_authorization_tacacs_only_some_server_down(
         setup_authorization_tacacs,
         tacacs_creds,
         ptfhost,
-        check_tacacs,
+        check_tacacs,  # noqa: F811
         remote_user_client):
     """
         Setup multiple tacacs server for this UT.
@@ -265,7 +266,7 @@ def test_authorization_tacacs_only_some_server_down(
 
 
 def test_authorization_tacacs_only_then_server_down_after_login(
-        setup_authorization_tacacs, ptfhost, check_tacacs,
+        setup_authorization_tacacs, ptfhost, check_tacacs,  # noqa: F811
         remote_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
 
     # Verify when server are accessible, TACACS+ user can run command in server side whitelist.
@@ -288,7 +289,7 @@ def test_authorization_tacacs_only_then_server_down_after_login(
 
 def test_authorization_tacacs_and_local(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        setup_authorization_tacacs_local, tacacs_creds, check_tacacs, remote_user_client):
+        setup_authorization_tacacs_local, tacacs_creds, check_tacacs, remote_user_client):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     """
@@ -355,7 +356,7 @@ def test_authorization_tacacs_and_local_then_server_down_after_login(
 
 def test_authorization_local(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        tacacs_creds, ptfhost, check_tacacs,
+        tacacs_creds, ptfhost, check_tacacs,  # noqa: F811
         remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -392,7 +393,7 @@ def test_authorization_local(
 
 def test_bypass_authorization(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        setup_authorization_tacacs, check_tacacs, remote_user_client):
+        setup_authorization_tacacs, check_tacacs, remote_user_client):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     """
@@ -450,7 +451,7 @@ def test_bypass_authorization(
 
 def test_backward_compatibility_disable_authorization(
         duthosts, enum_rand_one_per_hwsku_hostname,
-        tacacs_creds, ptfhost, check_tacacs,
+        tacacs_creds, ptfhost, check_tacacs,  # noqa: F811
         remote_user_client, local_user_client, ensure_tacacs_server_running_after_ut):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
@@ -500,7 +501,7 @@ def test_tacacs_authorization_wildcard(
                                     enum_rand_one_per_hwsku_hostname,
                                     setup_authorization_tacacs,
                                     tacacs_creds,
-                                    check_tacacs,
+                                    check_tacacs,  # noqa: F811
                                     remote_user_client,
                                     remote_rw_user_client):
     # Create files for command with wildcards
@@ -551,7 +552,7 @@ def test_stop_request_next_server_after_reject(
                                             setup_authorization_tacacs,
                                             tacacs_creds,
                                             ptfhost,
-                                            check_tacacs):
+                                            check_tacacs):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
     # not ignore on version >= 202305
@@ -596,7 +597,7 @@ def test_fallback_to_local_authorization_with_config_reload(
                                     enum_rand_one_per_hwsku_hostname,
                                     setup_authorization_tacacs,
                                     tacacs_creds,
-                                    check_tacacs,
+                                    check_tacacs,  # noqa: F811
                                     remote_user_client,
                                     remote_rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -652,7 +653,7 @@ def test_tacacs_authorization_commands_during_login(
                                                 enum_rand_one_per_hwsku_hostname,
                                                 setup_authorization_tacacs,
                                                 tacacs_creds,
-                                                check_tacacs,
+                                                check_tacacs,  # noqa: F811
                                                 remote_rw_user_client):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     duthost.shell("sudo config aaa authentication debug disable")

--- a/tests/tacacs/test_jit_user.py
+++ b/tests/tacacs/test_jit_user.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run
-from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_server
+from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_server, check_tacacs  # noqa: F401
 from tests.common.utilities import check_output
 
 pytestmark = [
@@ -13,7 +13,8 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
-def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+def test_jit_user(localhost, duthosts, ptfhost, enum_rand_one_per_hwsku_hostname, tacacs_creds,
+                  check_tacacs):  # noqa: F811
     """check jit user. netuser -> netadmin -> netuser"""
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -12,7 +12,7 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import wait
 from tests.common.utilities import pdu_reboot
 from tests.common.reboot import reboot
-from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, check_tacacs # noqa: F401
+from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, check_tacacs  # noqa: F401
 from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_client
 from .utils import change_and_wait_aaa_config_update
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports

--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -12,7 +12,7 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import wait
 from tests.common.utilities import pdu_reboot
 from tests.common.reboot import reboot
-from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run
+from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, check_tacacs # noqa: F401
 from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_client
 from .utils import change_and_wait_aaa_config_update
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
@@ -174,7 +174,7 @@ def log_rotate(duthost):
 
 
 def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
-                 tacacs_creds, check_tacacs, pdu_controller):
+                 tacacs_creds, check_tacacs, pdu_controller):  # noqa: F811
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]

--- a/tests/tacacs/test_ro_user.py
+++ b/tests/tacacs/test_ro_user.py
@@ -2,7 +2,7 @@ import pytest
 import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import check_output
-from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, ssh_remote_run_retry
+from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, ssh_remote_run_retry, check_tacacs  # noqa: F401
 
 import logging
 
@@ -72,7 +72,7 @@ def wait_for_tacacs(localhost, remote_ip, username, password):
                 current_attempt += 1
 
 
-def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
     res = ssh_remote_run(localhost, dutip, tacacs_creds['tacacs_ro_user'],
@@ -81,7 +81,8 @@ def test_ro_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_c
     check_output(res, 'test', 'remote_user')
 
 
-def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds,
+                                 check_tacacs):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
 
@@ -160,7 +161,7 @@ def test_ro_user_allowed_command(localhost, duthosts, enum_rand_one_per_hwsku_ho
 
 
 def test_ro_user_banned_by_sudoers_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
-                                           tacacs_creds, check_tacacs):
+                                           tacacs_creds, check_tacacs):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
 
@@ -184,7 +185,8 @@ def test_ro_user_banned_by_sudoers_command(localhost, duthosts, enum_rand_one_pe
             logger.info('"{}" not found on DUT, skipping...'.format(command))
 
 
-def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+def test_ro_user_banned_command(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds,
+                                check_tacacs):  # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     dutip = duthost.mgmt_ip
 

--- a/tests/tacacs/test_rw_user.py
+++ b/tests/tacacs/test_rw_user.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, ssh_remote_run_retry
+from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, ssh_remote_run_retry, check_tacacs  # noqa: F401
 from tests.common.utilities import check_output
 
 pytestmark = [
@@ -10,7 +10,7 @@ pytestmark = [
 ]
 
 
-def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):
+def test_rw_user(localhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, check_tacacs):  # noqa: F811
     """test tacacs rw user
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add auditd test cases to qualify auditd and auditd_watchdog containers in container upgrade nightly test in KubeSonic
Fixes # (issue)
Microsoft ADO: 30451821, 30451826

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Test the functionality of auditd feature on SONiC switch, auditd and auditd_watchdog containers, which are deployed or upgraded by a Kubernetes master outside SONiC. 
#### How did you do it?

#### How did you verify/test it?
Utilize and run test plans 
https://elastictest.org/scheduler/testplan/67d86de4607a6896f60ddf7f
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
Any topo
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
auditd test plan: https://microsoft.sharepoint.com/:w:/r/teams/SONiC2/_layouts/15/doc2.aspx?sourcedoc=%7B62B19989-2A2C-432C-A97A-5B96DF4BF02F%7D&file=[auditd_container_watchdog_testplan.docx](https://microsoft.sharepoint.com/:w:/r/teams/SONiC2/_layouts/15/doc2.aspx?sourcedoc=%7B62B19989-2A2C-432C-A97A-5B96DF4BF02F%7D&file=auditd_container_watchdog_testplan.docx&action=default&mobileredirect=true)&action=default&mobileredirect=true, will add this test plan to wiki in the next PR.
