### PR TITLE
refactor: optimize pretest for mult-DUT devices

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -4,6 +4,8 @@ import os
 import pytest
 import random
 import time
+
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.helpers.port_utils import get_common_supported_speeds
 
 from collections import defaultdict
@@ -29,26 +31,29 @@ FEATURE_STATE_VERIFYING_THRESHOLD_SECS = 600
 FEATURE_STATE_VERIFYING_INTERVAL_SECS = 10
 
 
-def test_features_state(duthosts, enum_dut_hostname, localhost):
+def test_features_state(duthosts, localhost):
     """Checks whether the state of each feature is valid or not.
     Args:
-      duthosts: Fixture returns a list of Ansible object DuT.
-      enum_dut_hostname: Fixture returns name of DuT.
+      duthosts: Fixture returns a list of Ansible object DuT..
 
     Returns:
       None.
     """
-    duthost = duthosts[enum_dut_hostname]
-    logger.info("Checking the state of each feature in 'CONFIG_DB' ...")
-    if not wait_until(180, FEATURE_STATE_VERIFYING_INTERVAL_SECS, 0, verify_features_state, duthost):
-        logger.warning("Not all states of features in 'CONFIG_DB' are valid, rebooting DUT {}".format(duthost.hostname))
-        reboot(duthost, localhost)
-        # Some services are not ready immeidately after reboot
-        wait_critical_processes(duthost)
+    def check_feature_state(dut):
+        logger.info("Checking the state of each feature in 'CONFIG_DB' of {}...".format(dut.hostname))
+        if not wait_until(180, FEATURE_STATE_VERIFYING_INTERVAL_SECS, 0, verify_features_state, dut):
+            logger.warning("Not all states of features in 'CONFIG_DB' are valid, rebooting DUT {}".format(dut.hostname))
+            reboot(dut, localhost)
+            # Some services are not ready immeidately after reboot
+            wait_critical_processes(dut)
 
-    pytest_assert(wait_until(FEATURE_STATE_VERIFYING_THRESHOLD_SECS, FEATURE_STATE_VERIFYING_INTERVAL_SECS, 0,
-                             verify_features_state, duthost), "Not all service states are valid!")
-    logger.info("The states of features in 'CONFIG_DB' are all valid.")
+        pytest_assert(wait_until(FEATURE_STATE_VERIFYING_THRESHOLD_SECS, FEATURE_STATE_VERIFYING_INTERVAL_SECS, 0,
+                                 verify_features_state, dut), "Not all service states are valid!")
+        logger.info("The states of features in 'CONFIG_DB' are all valid.")
+
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts:
+            executor.submit(check_feature_state, duthost)
 
 
 def test_cleanup_cache():
@@ -57,23 +62,28 @@ def test_cleanup_cache():
         os.system('rm -rf {}'.format(folder))
 
 
-def test_cleanup_testbed(duthosts, enum_dut_hostname, request, ptfhost):
-    duthost = duthosts[enum_dut_hostname]
+def test_cleanup_testbed(duthosts, request, ptfhost):
     deep_clean = request.config.getoption("--deep_clean")
     if deep_clean:
-        logger.info("Deep cleaning DUT {}".format(duthost.hostname))
-        # Remove old log files.
-        duthost.shell("sudo find /var/log/ -name '*.gz' | sudo xargs rm -f", executable="/bin/bash")
-        # Remove old core files.
-        duthost.shell("sudo rm -f /var/core/*", executable="/bin/bash")
-        # Remove old dump files.
-        duthost.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")
 
-        # delete other log files that are more than a day old,
-        # this step is needed to remove some backup files or the debug files added by users
-        # which can create issue for log-analyzer
-        duthost.shell("sudo find /var/log/ -mtime +1 | sudo xargs rm -f",
+        def deep_clean_dut(dut):
+            logger.info("Deep cleaning DUT {}".format(dut.hostname))
+            # Remove old log files.
+            dut.shell("sudo find /var/log/ -name '*.gz' | sudo xargs rm -f", executable="/bin/bash")
+            # Remove old core files.
+            dut.shell("sudo rm -f /var/core/*", executable="/bin/bash")
+            # Remove old dump files.
+            dut.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")
+
+            # delete other log files that are more than a day old,
+            # this step is needed to remove some backup files or the debug files added by users
+            # which can create issue for log-analyzer
+            dut.shell("sudo find /var/log/ -mtime +1 | sudo xargs rm -f",
                       module_ignore_errors=True, executable="/bin/bash")
+
+        with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+            for duthost in duthosts:
+                executor.submit(deep_clean_dut, duthost)
 
     # Cleanup rsyslog configuration file that might have damaged by test_syslog.py
     if ptfhost:
@@ -81,15 +91,17 @@ def test_cleanup_testbed(duthosts, enum_dut_hostname, request, ptfhost):
                       "uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")
 
 
-def test_disable_container_autorestart(duthosts, enum_dut_hostname, disable_container_autorestart):
-    duthost = duthosts[enum_dut_hostname]
-    disable_container_autorestart(duthost)
+def test_disable_container_autorestart(duthosts, disable_container_autorestart):
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts:
+            executor.submit(disable_container_autorestart, duthost)
+
     # Wait sometime for snmp reloading
-    SNMP_RELOADING_TIME = 30
-    time.sleep(SNMP_RELOADING_TIME)
+    snmp_reloading_time = 30
+    time.sleep(snmp_reloading_time)
 
 
-def collect_dut_info(dut):
+def collect_dut_info(dut, metadata):
     status = dut.show_interface(command='status')['ansible_facts']['int_status']
     features, _ = dut.get_feature_status()
 
@@ -126,7 +138,7 @@ def collect_dut_info(dut):
             }
         )
 
-    return dut_info
+    metadata[dut.hostname] = dut_info
 
 
 def test_update_testbed_metadata(duthosts, tbinfo, fanouthosts):
@@ -134,9 +146,9 @@ def test_update_testbed_metadata(duthosts, tbinfo, fanouthosts):
     tbname = tbinfo['conf-name']
     pytest_require(tbname, "skip test due to lack of testbed name.")
 
-    for dut in duthosts:
-        dutinfo = collect_dut_info(dut)
-        metadata[dut.hostname] = dutinfo
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts:
+            executor.submit(collect_dut_info, duthost, metadata)
 
     info = {tbname: metadata}
     folder = 'metadata'
@@ -152,47 +164,53 @@ def test_update_testbed_metadata(duthosts, tbinfo, fanouthosts):
     prepare_autonegtest_params(duthosts, fanouthosts)
 
 
-def test_disable_rsyslog_rate_limit(duthosts, enum_dut_hostname):
-    duthost = duthosts[enum_dut_hostname]
-    features_dict, succeed = duthost.get_feature_status()
-    if not succeed:
-        # Something unexpected happened.
-        # We don't want to fail here because it's an util
-        logging.warning("Failed to retrieve feature status")
-        return
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")
-    try:
-        is_dhcp_server_enable = config_facts["ansible_facts"]["DEVICE_METADATA"]["localhost"]["dhcp_server"]
-    except KeyError:
-        is_dhcp_server_enable = None
+def test_disable_rsyslog_rate_limit(duthosts):
 
-    output = duthost.command('config syslog --help')['stdout']
-    manually_enable_feature = False
-    feature_exception_dict = dict()
-    if 'rate-limit-feature' in output:
-        # in 202305, the feature is disabled by default for warmboot/fastboot
-        # performance, need manually enable it via command
-        duthost.command('config syslog rate-limit-feature enable')
-        manually_enable_feature = True
-    for feature_name, state in list(features_dict.items()):
-        if 'enabled' not in state:
-            continue
-        # Skip dhcp_relay check if dhcp_server is enabled
-        if is_dhcp_server_enable is not None and "enabled" in is_dhcp_server_enable and feature_name == "dhcp_relay":
-            continue
-        if feature_name == "telemetry":
-            # Skip telemetry if there's no docker image
-            output = duthost.shell("docker images", module_ignore_errors=True)['stdout']
-            if "sonic-telemetry" not in output:
-                continue
+    def disable_rsyslog_rate_limit(dut):
+        features_dict, succeed = dut.get_feature_status()
+        if not succeed:
+            # Something unexpected happened.
+            # We don't want to fail here because it's an util
+            logging.warning("Failed to retrieve feature status")
+            return
+        config_facts = dut.config_facts(host=dut.hostname, source="running")
         try:
-            duthost.modify_syslog_rate_limit(feature_name, rl_option='disable')
-        except Exception as e:
-            feature_exception_dict[feature_name] = str(e)
-    if manually_enable_feature:
-        duthost.command('config syslog rate-limit-feature disable')
-    if feature_exception_dict:
-        pytest.fail(f"The test failed on some of the dockers. feature_exception_dict = {feature_exception_dict}")
+            is_dhcp_server_enable = config_facts["ansible_facts"]["DEVICE_METADATA"]["localhost"]["dhcp_server"]
+        except KeyError:
+            is_dhcp_server_enable = None
+
+        output = dut.command('config syslog --help')['stdout']
+        manually_enable_feature = False
+        feature_exception_dict = dict()
+        if 'rate-limit-feature' in output:
+            # in 202305, the feature is disabled by default for warmboot/fastboot
+            # performance, need manually enable it via command
+            dut.command('config syslog rate-limit-feature enable')
+            manually_enable_feature = True
+        for feature_name, state in list(features_dict.items()):
+            if 'enabled' not in state:
+                continue
+            # Skip dhcp_relay check if dhcp_server is enabled
+            if (is_dhcp_server_enable is not None and "enabled" in is_dhcp_server_enable and
+                    feature_name == "dhcp_relay"):
+                continue
+            if feature_name == "telemetry":
+                # Skip telemetry if there's no docker image
+                output = dut.shell("docker images", module_ignore_errors=True)['stdout']
+                if "sonic-telemetry" not in output:
+                    continue
+            try:
+                dut.modify_syslog_rate_limit(feature_name, rl_option='disable')
+            except Exception as e:
+                feature_exception_dict[feature_name] = str(e)
+        if manually_enable_feature:
+            dut.command('config syslog rate-limit-feature disable')
+        if feature_exception_dict:
+            pytest.fail(f"The test failed on some of the dockers. feature_exception_dict = {feature_exception_dict}")
+
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts:
+            executor.submit(disable_rsyslog_rate_limit, duthost)
 
 
 def collect_dut_lossless_prio(dut):
@@ -354,23 +372,30 @@ def prepare_autonegtest_params(duthosts, fanouthosts):
     max_interfaces_per_dut = 3
     filepath = os.path.join('metadata', 'autoneg-test-params.json')
     try:
-        for duthost in duthosts:
-            all_ports = list_dut_fanout_connections(duthost, fanouthosts)
+
+        def select_test_ports(dut):
+            all_ports = list_dut_fanout_connections(dut, fanouthosts)
             selected_ports = {}
             for dut_port, fanout, fanout_port in all_ports:
                 if len(selected_ports) == max_interfaces_per_dut:
                     break
                 auto_neg_mode = fanout.get_auto_negotiation_mode(fanout_port)
-                fec_mode = duthost.get_port_fec(dut_port)
+                fec_mode = dut.get_port_fec(dut_port)
                 if auto_neg_mode is not None and fec_mode is not None:
-                    speeds = get_common_supported_speeds(duthost, dut_port, fanout, fanout_port)
+                    speeds = get_common_supported_speeds(dut, dut_port, fanout, fanout_port)
                     selected_ports[dut_port] = {
                         'fanout': fanout.hostname,
                         'fanout_port': fanout_port,
                         'common_port_speeds': speeds
                     }
+
             if len(selected_ports) > 0:
-                cadidate_test_ports[duthost.hostname] = selected_ports
+                cadidate_test_ports[dut.hostname] = selected_ports
+
+        with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+            for duthost in duthosts:
+                executor.submit(select_test_ports, duthost)
+
         if len(cadidate_test_ports) > 0:
             with open(filepath, 'w') as yf:
                 json.dump(cadidate_test_ports, yf, indent=4)
@@ -388,21 +413,25 @@ def test_disable_startup_tsa_tsb_service(duthosts, localhost):
     Returns:
         None.
     """
-    for duthost in duthosts.frontend_nodes:
-        platform = duthost.facts['platform']
-        file_check = {}
+
+    def disable_startup_tsa_tsb(dut):
+        platform = dut.facts['platform']
         startup_tsa_tsb_file_path = "/usr/share/sonic/device/{}/startup-tsa-tsb.conf".format(platform)
         backup_tsa_tsb_file_path = "/usr/share/sonic/device/{}/backup-startup-tsa-tsb.bck".format(platform)
-        file_check = duthost.shell("[ -f {} ]".format(startup_tsa_tsb_file_path), module_ignore_errors=True)
+        file_check = dut.shell("[ -f {} ]".format(startup_tsa_tsb_file_path), module_ignore_errors=True)
         if file_check.get('rc') == 0:
-            out = duthost.shell("cat {}".format(startup_tsa_tsb_file_path), module_ignore_errors=True)['rc']
+            out = dut.shell("cat {}".format(startup_tsa_tsb_file_path), module_ignore_errors=True)['rc']
             if not out:
-                duthost.shell("sudo mv {} {}".format(startup_tsa_tsb_file_path, backup_tsa_tsb_file_path))
-                output = duthost.shell("TSB", module_ignore_errors=True)
+                dut.shell("sudo mv {} {}".format(startup_tsa_tsb_file_path, backup_tsa_tsb_file_path))
+                output = dut.shell("TSB", module_ignore_errors=True)
                 pytest_assert(not output['rc'], "Failed TSB")
         else:
             logger.info("{} file does not exist in the specified path on dut {}".
-                        format(startup_tsa_tsb_file_path, duthost.hostname))
+                        format(startup_tsa_tsb_file_path, dut.hostname))
+
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts.frontend_nodes:
+            executor.submit(disable_startup_tsa_tsb, duthost)
 
 
 """
@@ -433,10 +462,15 @@ def test_generate_running_golden_config(duthosts):
     """
     Generate running golden config after pre test.
     """
-    for duthost in duthosts:
-        duthost.shell("sonic-cfggen -d --print-data > /etc/sonic/running_golden_config.json")
-        if duthost.is_multi_asic:
-            for asic_index in range(0, duthost.facts.get('num_asic')):
+
+    def generate_running_golden_config(dut):
+        dut.shell("sonic-cfggen -d --print-data > /etc/sonic/running_golden_config.json")
+        if dut.is_multi_asic:
+            for asic_index in range(0, dut.facts.get('num_asic')):
                 asic_ns = 'asic{}'.format(asic_index)
-                duthost.shell("sonic-cfggen -n {} -d --print-data > /etc/sonic/running_golden_config{}.json".
-                              format(asic_ns, asic_index))
+                dut.shell("sonic-cfggen -n {} -d --print-data > /etc/sonic/running_golden_config{}.json".
+                          format(asic_ns, asic_index))
+
+    with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
+        for duthost in duthosts:
+            executor.submit(generate_running_golden_config, duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Optimize `test_pretest.py` by Python multithreading to reduce the running time.

Summary:
Fixes # (issue) Microsoft ADO 30056122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We noticed that some test cases in `test_pretest.py` can be run in parallel with Python multithreading to reduce the running time. 

After this PR, I will create an internal PR to optimize the test_pretest.py test cases that only exists in our internal repo.

#### How did you do it?

#### How did you verify/test it?
I ran the updated code and can confirm it's working well. 

- For dual ToR topo, the running time will be decreased from ~21 min to ~13 min (Elastictest [link](https://elastictest.org/scheduler/testplan/67d23f4ebac211a23b2c82e7?leftSideViewMode=detail&testcase=test_pretest.py%7C%7C%7Cbjw2-can-dual-t0-7260-2&type=console) before the change, Elastictest [link](https://elastictest.org/scheduler/testplan/67d4c8bb14a0c3680c255569?leftSideViewMode=detail&testcase=test_pretest.py%7C%7C%7Cbjw2-can-dual-t0-7260-2&type=log) after the change)
- For T2 topo, the running time be decreased from ~46 min to ~18 min (Elastictest [link](https://elastictest.org/scheduler/testplan/67d406ca41044f5c820b8174?leftSideViewMode=detail&testcase=test_pretest.py%7C%7C%7Cvms69-t2-8800-1&type=console) before the change, Elastictest [link](https://elastictest.org/scheduler/testplan/67d79e1606bd43461b9eecb2?leftSideViewMode=detail&testcase=test_pretest.py%7C%7C%7Cvms69-t2-8800-1&type=console) after the change)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
