### PR TITLE
[dualtor_io] Collect syslogs for failure ToR

### DIFF
--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -29,3 +29,16 @@ def pytest_generate_tests(metafunc):
         if fixturedef.argname == "check_simulator_flap_counter":
             metafunc.fixturenames.remove(fixturedef.argname)
             metafunc.fixturenames.append(fixturedef.argname)
+
+
+@pytest.fixture
+def setup_loganalyzer(loganalyzer):
+    """Fixture to allow customize loganalyzer behaviors."""
+
+    def _setup_loganalyzer(duthost, collect_only):
+        if collect_only:
+            loganalyzer[duthost.hostname].match_regex = []
+            loganalyzer[duthost.hostname].expect_regex = []
+            loganalyzer[duthost.hostname].ignore_regex = []
+
+    return _setup_loganalyzer

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -141,17 +141,18 @@ def test_normal_op_active_server_to_standby_server(upper_tor_host, lower_tor_hos
     # TODO: Add per-port db check
 
 
-@pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,               # noqa F811
                                           send_server_to_t1_with_action,                # noqa F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa F811
+                                          setup_loganalyzer,
                                           cable_type):                                  # noqa F811
     """
     Send upstream traffic and `config reload` the active ToR.
     Confirm switchover occurs and disruption lasted < 1 second for active-standby ports.
     Confirm both ToRs in active after config reload and no disruption for active-active ports.
     """
+    setup_loganalyzer(upper_tor_host, collect_only=True)
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
                                       action=lambda: config_reload(upper_tor_host, wait=0))
@@ -166,15 +167,16 @@ def test_upper_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
                           cable_type=cable_type)
 
 
-@pytest.mark.disable_loganalyzer
 def test_lower_tor_config_reload_upstream(upper_tor_host, lower_tor_host,               # noqa F811
                                           send_server_to_t1_with_action,                # noqa F811
                                           toggle_all_simulator_ports_to_upper_tor,      # noqa F811
+                                          setup_loganalyzer,
                                           cable_type):                                  # noqa F811
     """
     Send upstream traffic and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption.
     """
+    setup_loganalyzer(lower_tor_host, collect_only=True)
     if cable_type == CableType.active_standby:
         send_server_to_t1_with_action(upper_tor_host, verify=True,
                                       action=lambda: config_reload(lower_tor_host, wait=0))
@@ -182,16 +184,17 @@ def test_lower_tor_config_reload_upstream(upper_tor_host, lower_tor_host,       
                           expected_standby_host=lower_tor_host)
 
 
-@pytest.mark.disable_loganalyzer
 @pytest.mark.enable_active_active
 def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_host,           # noqa F811
                                                       send_t1_to_server_with_action,            # noqa F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa F811
+                                                      setup_loganalyzer,
                                                       cable_type):                              # noqa F811
     """
     Send downstream traffic to the upper ToR and `config reload` the lower ToR.
     Confirm no switchover occurs and no disruption
     """
+    setup_loganalyzer(lower_tor_host, collect_only=True)
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(upper_tor_host, verify=True,
                                       action=lambda: config_reload(lower_tor_host, wait=0))
@@ -206,16 +209,17 @@ def test_lower_tor_config_reload_downstream_upper_tor(upper_tor_host, lower_tor_
                           cable_type=cable_type)
 
 
-@pytest.mark.disable_loganalyzer
 def test_upper_tor_config_reload_downstream_lower_tor(upper_tor_host, lower_tor_host,           # noqa F811
                                                       send_t1_to_server_with_action,            # noqa F811
                                                       toggle_all_simulator_ports_to_upper_tor,  # noqa F811
+                                                      setup_loganalyzer,
                                                       cable_type):                              # noqa F811
     """
     Send downstream traffic to the lower ToR and `config reload` the upper ToR.
     Confirm switchover occurs and disruption lasts < 1 second for active-standby ports.
     Confirm no state change in the end and no disruption for active-active ports.
     """
+    setup_loganalyzer(upper_tor_host, collect_only=True)
     if cable_type == CableType.active_standby:
         send_t1_to_server_with_action(lower_tor_host, verify=True, delay=CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC,
                                       action=lambda: config_reload(upper_tor_host, wait=0))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
dualtor_io testcases always skip loganalyzer on those testcases with reboot/reload.
better to collect syslog, but no analyze; this is to help debug.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add fixture `setup_loganalyzer` to enable collect only.

#### How did you verify/test it?

```
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_upstream[active-active] PASSED                                                                                                                                                                              [100%]

========================================================================================================== 1 passed, 1 deselected, 2 warnings in 568.14s (0:09:28) ===========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
