### PR TITLE
Remove admin down ports in BUFFER PG check logic

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2966,6 +2966,9 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
     # no lossless traffic on DPU NPU ports, so skip them for the test
     dpu_npu_port_list = get_dpu_npu_ports_from_hwsku(duthost)
     configdb_ports = list(set(configdb_ports) - set(dpu_npu_port_list))
+
+    configdb_ports = [port for port in configdb_ports if duthost.shell(
+        f'redis-cli -n 4 hget "PORT|{port}" "admin_status"')['stdout'] == 'up']
     logging.info(f"test ports is {configdb_ports}")
     profiles_checked = {}
     lossless_pool_oid = None


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Remove admin down ports in BUFFER PG check logic.
After PR https://github.com/sonic-net/sonic-buildimage/pull/21874 merged, the admin down ports in table BUFFER_PG_TABLE only contain PG 0.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test update for design PR https://github.com/sonic-net/sonic-buildimage/pull/21874
#### How did you do it?
Remove admin down ports in BUFFER PG check logic.
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
