### PR TITLE
[macsec] Temporarily skip macsec TestInteropProtocol::test_port_channel test since it will cause vsonic neighbor lost route to dut

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1471,9 +1471,9 @@ macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
     conditions:
       - "'t2' in topo_name"
 
-macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp:
+macsec/test_interop_protocol.py::TestInteropProtocol::test_port_channel:
   skip:
-    reason: "Skip SNMP test for continuously failing in PR testing"
+    reason: "Skip port channel test for causing continuously failing in PR testing"
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17519"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1475,7 +1475,7 @@ macsec/test_interop_protocol.py::TestInteropProtocol::test_port_channel:
   skip:
     reason: "Skip port channel test for causing continuously failing in PR testing"
     conditions:
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17519"
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-buildimage/issues/22081"
 
 #######################################
 #####           mclag             #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1471,6 +1471,12 @@ macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
     conditions:
       - "'t2' in topo_name"
 
+macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp:
+  skip:
+    reason: "Skip SNMP test for continuously failing in PR testing"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17519"
+
 #######################################
 #####           mclag             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
macsec/test_interop_protocol.py::TestInteropProtocol::test_port_channel test will cause vsonic neighbor lost route to dut, which caused following test_snmp has high failure rate in PR testing, need to skip test_port_channel test with issue to unblock community
![image](https://github.com/user-attachments/assets/4714af68-ae57-4bf0-9940-da9ec70c4c83)
#### How did you do it?
Skip test_port_channel test with issue https://github.com/sonic-net/sonic-mgmt/issues/17519
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
