### PR TITLE
[test_server_reboot] Fix the consistency check

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1400,7 +1400,11 @@ def show_muxcable_status(duthost):
 
     ret = {}
     for port, muxcable in list(output['MUX_CABLE'].items()):
-        ret[port] = {'status': muxcable['STATUS'], 'health': muxcable['HEALTH']}
+        ret[port] = {
+            'status': muxcable['STATUS'],
+            'health': muxcable['HEALTH'],
+            'hwstatus': muxcable['HWSTATUS']
+        }
 
     return ret
 

--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -16,6 +16,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host                  
 from tests.common.dualtor.dual_tor_utils import lower_tor_host                                          # noqa F401
 from tests.common.dualtor.dual_tor_utils import lower_tor_fanouthosts, fanout_lower_tor_port_control    # noqa F401
 from tests.common.dualtor.dual_tor_utils import upper_tor_fanouthosts, fanout_upper_tor_port_control    # noqa F401
+from tests.common.dualtor.dual_tor_utils import show_muxcable_status                                    # noqa F401
 from tests.common.dualtor.nic_simulator_control import simulator_server_down_active_active              # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, run_garp_service, \
                                                 run_icmp_responder                                      # noqa: F401
@@ -111,6 +112,11 @@ def test_server_reboot(request, cable_type, tbinfo,                             
     """
     Test verifies that TOR health returns back to healthy status after a server reboot.
     """
+    def _check_consistency(duthost):
+        ret = show_muxcable_status(duthost)
+        return all((status.get("hwstatus") == "consistent" and
+                    status.get("health") == "healthy") for status in ret.values())
+
     if cable_type == CableType.active_standby:
         interface_name = random.choice(active_standby_ports)
         # Set upper_tor as active
@@ -145,8 +151,10 @@ def test_server_reboot(request, cable_type, tbinfo,                             
         start_icmp_responder()
         # The ToRs must then reconcile to a consistent state
         # Upper ToR switches to standby and Lower to active.
-        verify_tor_states(expected_active_host=lower_tor_host,
-                          expected_standby_host=upper_tor_host, cable_type=cable_type)
+        pytest_assert(
+            wait_until(60, 5, 0, lambda: _check_consistency(upper_tor_host) and _check_consistency(lower_tor_host)),
+            "fail to reconcile to a consistent state"
+        )
     elif cable_type == CableType.active_active:
         interface_name = random.choice(active_active_ports)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
After server reboot (simulated by port down on both sides), the mux ports can reconcile to consistent && healthy, but without the gurantee which side is fixed to be active/standby.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Change the check condition to validate both sides are consistent && healthy.

#### How did you verify/test it?
```
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-standby] PASSED                                                                                                                                                                                         [ 50%]
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-active] SKIPPED (Skip as no mux ports of 'active-active' cable type)                                                                                                                                    [100%]

============================================================================================================================== warnings summary ==============================================================================================================================
../../../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

dualtor_mgmt/test_server_failure.py::test_server_reboot[active-standby]
  /home/lolv/workspace/repo/sonic-mgmt/tests/common/dualtor/control_plane_utils.py:266: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    if not isinstance(expected_active_host, collections.Iterable):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================ 1 passed, 1 skipped, 2 warnings in 268.19s (0:04:28) ============================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
