### PR TITLE
[pretest] Patch dualtor mux service to increase tunnel wait timeout

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -435,7 +435,7 @@ def test_patch_dualtor_mux_simulator(duthosts, tbinfo):
             write_standby_path = duthost.shell("which write_standby.py")["stdout"].strip()
 
         duthost.shell('sed -i "s/timeout=90/timeout=160/g" %s' % write_standby_path)
-        duthost.shell('sed -i "/\[Service\]/a TimeoutStartSec=180" /lib/systemd/system/mux.service')
+        duthost.shell('sed -i "/\[Service\]/a TimeoutStartSec=180" /lib/systemd/system/mux.service')        # noqa W605
         duthost.shell('systemctl daemon-reload')
         duthost.shell('systemctl restart mux.service')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Patch PR https://github.com/sonic-net/sonic-buildimage/pull/21992 into 202405 dualtor nightly DUTs.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
```
test_pretest.py::test_patch_dualtor_mux_simulator PASSED                                                                                                                                                                                                               [100%]

============================================================================================================================== warnings summary ==============================================================================================================================
../../../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

common/helpers/dut_utils.py:310
  /home/lolv/workspace/repo/sonic-mgmt/tests/common/helpers/dut_utils.py:310: DeprecationWarning: invalid escape sequence \[
    regexp="(^[^#]*@\[10\.20\.6\.16\]:514)",

common/helpers/dut_utils.py:311
  /home/lolv/workspace/repo/sonic-mgmt/tests/common/helpers/dut_utils.py:311: DeprecationWarning: invalid escape sequence \g
    line="# \g<1>"

test_pretest.py:522
  /home/lolv/workspace/repo/sonic-mgmt/tests/test_pretest.py:522: DeprecationWarning: invalid escape sequence \[
    duthost.shell('sed -i "/\[Service\]/a TimeoutStartSec=180" /lib/systemd/system/mux.service')

common/helpers/buffer.py:48
  /home/lolv/workspace/repo/sonic-mgmt/tests/common/helpers/buffer.py:48: DeprecationWarning: invalid escape sequence \d
    match = re.match("(.*):(.*?)(\d+)(.*)", line)

common/helpers/buffer.py:23
  /home/lolv/workspace/repo/sonic-mgmt/tests/common/helpers/buffer.py:23: DeprecationWarning: invalid escape sequence \d
    match = re.match("(.*)default_cable(.*?)(\d+)(.*)", line)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================= 1 passed, 6 warnings in 137.23s (0:02:17) ==================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
