### PR TITLE
Address fixes to make sure t2 topology deploy works with and without macsec enabled.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -603,7 +603,6 @@
           topo_name: "{{ topo }}"
           port_index_map: "{{ port_index_map | default({}) }}"
         become: true
-        when: "'t2' not in topo"
 
       - name: Copy macsec profile json to dut
         copy: src=../tests/common/macsec/profile.json

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -407,7 +407,7 @@ class GenerateGoldenConfigDBModule(object):
         elif self.topo_name in ["t1-smartswitch-ha", "t1-28-lag", "smartswitch-t1"]:
             config = self.generate_smartswitch_golden_config_db()
             self.module.run_command("sudo rm -f {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))
-        elif "t2" in self.topo_name:
+        elif "t2" in self.topo_name and self.macsec_profile:
             config = self.generate_t2_golden_config_db()
             self.module.run_command("sudo rm -f {}".format(MACSEC_PROFILE_PATH))
             self.module.run_command("sudo rm -f {}".format(GOLDEN_CONFIG_TEMPLATE_PATH))

--- a/ansible/library/get_macsec_profile.py
+++ b/ansible/library/get_macsec_profile.py
@@ -5,7 +5,24 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 
 
-def get_macsec_profile(module, macsec_profile):
+def convert_to_eos(cipher_name):
+    # Set the cipher suite as 256 xpn by default
+    eos_cipher_name = 'aes256-gcm-xpn'
+
+    if cipher_name == 'GCM-AES-XPN-256':
+        eos_cipher_name = 'aes256-gcm-xpn'
+    elif cipher_name == 'GCM-AES-128':
+        eos_cipher_name = 'aes128-gcm'
+    elif cipher_name == 'GCM-AES-256':
+        eos_cipher_name = 'aes256-gcm'
+    elif cipher_name == 'GCM-AES-XPN-128':
+        eos_cipher_name = 'aes128-gcm-xpn'
+
+    return eos_cipher_name
+
+
+# This API support EoS based templates now
+def get_macsec_profile(module, macsec_profile, vm_type):
     with open('/tmp/profile.json') as f:
         macsec_profiles = json.load(f)
 
@@ -13,14 +30,23 @@ def get_macsec_profile(module, macsec_profile):
         if profile:
             profile['macsec_profile'] = macsec_profile
 
+            # Currently handling ceos, add more cases for vsonic etc
+            if vm_type == 'ceos':
+                # Get the cipher suite in eos terminology
+                eos_cipher_suite_name = convert_to_eos(profile['cipher_suite'])
+                profile['cipher_suite'] = eos_cipher_suite_name
+
     return profile
 
 
 def main():
-    module = AnsibleModule(argument_spec=dict(macsec_profile=dict(required=True, type='str')))
+    module = AnsibleModule(argument_spec=dict(
+                           macsec_profile=dict(required=True, type='str'),
+                           vm_type=dict(required=True, type='str')))
 
     macsec_profile = module.params['macsec_profile']
-    module.exit_json(profile=get_macsec_profile(module, macsec_profile), changed=False)
+    vm_type = module.params['vm_type']
+    module.exit_json(profile=get_macsec_profile(module, macsec_profile, vm_type), changed=False)
 
 
 if __name__ == "__main__":

--- a/ansible/roles/eos/tasks/ceos_config.yml
+++ b/ansible/roles/eos/tasks/ceos_config.yml
@@ -42,6 +42,7 @@
 - name: Get the macsec profile data from profile_name
   get_macsec_profile:
     macsec_profile: "{{ macsec_profile }}"
+    vm_type: "{{ vm_type }}"
   register: profile_raw
   become: true
   when: "'t2' == base_topo and enable_macsec is defined"

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,6 +1,7 @@
 {%- set ns = namespace(link_metadata_defined=False) -%}
 
-{%- if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) -%}
+{%- if 'dualtor' in topo or
+       (macsec_card is defined and enable_macsec is defined and macsec_card == True and 't2' in topo) -%}
     {% set ns.link_metadata_defined = True %}
 {%- endif -%}
 
@@ -38,7 +39,7 @@
       </a:LinkMetadata>
 {% endfor %}
 {% endif %}
-{% if macsec_card is defined and macsec_card == True and 't2' in topo %}
+{% if macsec_card is defined and enable_macsec is defined and macsec_card == True and 't2' in topo %}
 {% for index in range(vms_number) %}
 {% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
 {% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}

--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -226,7 +226,7 @@
             <a:Value>{{ switch_type }}</a:Value>
          </a:DeviceProperty>
 {% endif %}
-{% if macsec_card is defined and macsec_card == True and 't2' in topo %}
+{% if macsec_card is defined and enable_macsec is defined and macsec_card == True and 't2' in topo %}
     <a:DeviceProperty>
       <a:Name>MacSecProfile</a:Name>
       <a:Value>PrimaryKey="MACSEC_PROFILE" FallbackKey="macsec-profile2" MacsecPolicy=""</a:Value>


### PR DESCRIPTION
### Description of PR
This PR is separating the code changes made in PR : https://github.com/sonic-net/sonic-mgmt/pull/17087, to just take care of fixes to get the t2 toplogy deploy work with and without macsec_enabled.

Additional change is to support any cipher suite give in the arguments. In below eg: it uses MACSEC_PROFILE which is defined as **GCM-AES-XPN-256** here https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/macsec/profile.json#L69

```
./testbed-cli.sh -t testbed.yaml deploy-mg <testbed_name> <inventory_file> -e enable_macsec=True -e macsec_profile=MACSEC_PROFILE 
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
