### PR TITLE
Adjust argument passing based on Python version

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -2023,7 +2023,8 @@ class VMTopologyWorker(object):
             self._map_helper = self.thread_pool.map
             if hasattr(self.thread_pool, "shutdown"):
                 self._shutdown_helper = \
-                    lambda: self.thread_pool.shutdown(wait=True, cancel_futures=True)
+                    lambda: self.thread_pool.shutdown(wait=True, cancel_futures=True) if sys.version_info>=(3,9) else \
+                        self.thread_pool.shutdown(wait=True)
             else:
                 self._shutdown_helper = \
                     lambda: self.thread_pool.terminate()


### PR DESCRIPTION
Added an if-else condition to check the Python version and adjust argument passing accordingly in ThreadPool shutdown function

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The ThreadPool shutdown function's parameters vary depending on the Python version. Specifically, older Python versions don't support the cancel_futures parameter. This PR adds version checking logic to ensure compatibility by adjusting the parameters passed to shutdown based on the Python version being used.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
When running tests on systems with older Python versions, the code was failing because it tried to use the cancel_futures parameter which was introduced in newer Python versions. This PR ensures backward compatibility across different Python versions.

#### How did you do it?
Added version checking using Python's sys.version_info
For older versions: use basic shutdown parameters
For newer versions: include the cancel_futures parameter

#### How did you verify/test it?
Verified the fix through topology deployment tests and nightly regression testing.


#### Any platform specific information?
No 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
