### PR TITLE
Change max to min in pfc_gen_t2.py

### DIFF
--- a/tests/common/helpers/pfc_gen_t2.py
+++ b/tests/common/helpers/pfc_gen_t2.py
@@ -220,7 +220,7 @@ def main():
 
     # construct mmsg header to send in bulk for minimal latency
 
-    total_packets = max(1000, options.num)
+    total_packets = min(1000, options.num)
     m_msghdr = (struct_mmsghdr * total_packets)()
 
     iov = struct_iovec(cast(packet, c_void_p), len(packet))

--- a/tests/common/helpers/pfc_gen_t2.py
+++ b/tests/common/helpers/pfc_gen_t2.py
@@ -95,7 +95,7 @@ def main():
                       help="Total amount of time to send pkts. -n option is ignored if this is set",
                       metavar="sendtime", default=0)
     parser.add_option("-n", "--num", type="int", dest="num",
-                      help="Number of packets to be sent", metavar="number", default=1)
+                      help="Number of packets to be sent", metavar="number", default=0)
     parser.add_option("-r", "--rsyslog-server", type="string", dest="rsyslog_server",
                       default="127.0.0.1", help="Rsyslog server IPv4 address", metavar="IPAddress")
     parser.add_option('-g', "--global", action="store_true", dest="global_pf",
@@ -219,9 +219,8 @@ def main():
                 packet = packet + b"\x00\x00"
 
     # construct mmsg header to send in bulk for minimal latency
-
-    total_packets = min(1000, options.num)
-    m_msghdr = (struct_mmsghdr * total_packets)()
+    # Prepare 1000 buffers in advance.
+    m_msghdr = (struct_mmsghdr * 1000)()
 
     iov = struct_iovec(cast(packet, c_void_p), len(packet))
 
@@ -256,6 +255,7 @@ def main():
             num_to_send = 1000
         print("Generating Packet(s) over period of %f seconds" % options.sendtime)
         my_logger.debug(pre_str + '_STORM_START')
+        unable_to_send = 0
         while True:
             for s in sockets:
                 num_sent = _sendmmsg(s.fileno(), m_msghdr[0], num_to_send, 0)   # direct to c library api
@@ -263,8 +263,11 @@ def main():
                     errno = get_errno()
                     fo_logger.debug(fo_str + ' sendmmsg got errno ' + str(errno) + ' for socket ' +
                                     str(s.getsockname()))
-                    break
+                    unable_to_send += 1
+                    if unable_to_send > 30:
+                        break
                 else:
+                    unable_to_send = 0
                     if num_sent != num_to_send:
                         fo_logger.debug(fo_str + ' sendmmsg iteration ' + str(iters) + ' only sent ' +
                                         str(num_sent) + ' out of requested ' + str(num_to_send) +
@@ -281,7 +284,7 @@ def main():
         fo_logger.debug(fo_str + '_STORM_END_AFTER_RSYSLOG_CALL : sent ' + str(total_num_sent) + ' pkts in ' + str(
             iters) + ' iterations and elapsed time of ' + str(elapsed_time) + ' secs')
     # send according to requested number of pkts
-    else:
+    elif options.num:
         if length_of_list > 1:
             num_to_send_max = 1
         else:
@@ -291,9 +294,8 @@ def main():
         num_sockets = len(sockets)
         total_pkts_sent = [0] * num_sockets
         total_pkts_remaining = [total_num_remaining] * num_sockets
-        done = [False] * num_sockets
         keep_sending = True
-        test_failed = False
+        unable_to_send = 0
         while keep_sending is True:
             for s in sockets:
                 index = sockets.index(s)
@@ -305,20 +307,20 @@ def main():
                     errno = get_errno()
                     fo_logger.debug(fo_str + ' sendmmsg got errno ' + str(errno) + ' for socket ' +
                                     str(s.getsockname()))
-                    test_failed = True
-                    break
+                    unable_to_send += 1
+                    if unable_to_send > 30:
+                        break
+
                 else:
+                    unable_to_send = 0
                     if num_sent != num_to_send:
                         fo_logger.debug(fo_str + ' sendmmsg iteration ' + str(iters) +
                                         ' only sent ' + str(num_sent) +
                                         ' out of requested ' + str(num_to_send) + ' for socket ' +
                                         str(s.getsockname()))
+            if num_sent > 0:
                 total_pkts_remaining[index] -= num_sent
                 total_pkts_sent[index] += num_sent
-                if total_pkts_remaining[index] <= 0:
-                    done[index] = True
-            if test_failed is True:
-                break
             iters += 1
             keep_sending = False
             for i in range(0, num_sockets):
@@ -333,6 +335,8 @@ def main():
             fo_logger.debug(fo_str + '_STORM_END : socket ' + str(i) + ' sent ' + str(total_pkts_sent[i]) + ' pkts')
         fo_logger.debug(fo_str + '_STORM_END_AFTER_RSYSLOG_CALL : ' + str(iters) +
                         ' iterations and elapsed time of ' + str(elapsed_time) + ' secs')
+    else:
+        print("Pls provide atleast one -s or -n option.", file=sys.stderr)
 
     for s in sockets:
         s.close()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 17533
Change max to min in pfc_gen_t2.py. The current code results in out-of-memory conditions in sonic fanouts, if we give a large number of packets as argument.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
OOM in fanout when a large number of packets is requested in command line for pfc_gen_t2.py.

#### How did you do it?
Changed max to min in the code.

#### How did you verify/test it?
Ran it on T2 systems:
```
====================================================================================================== warnings summary ======================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------------- generated xml file: /run_logs/max_to_min/2025-03-16-03-56-13/pfcwd/pfcwd_2025-03-16-03-56-13.xml --------------------------------------------------------------
--------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------
07:50:08 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
SKIPPED [3] pfcwd/test_pfc_config.py: Forward action not supported in cisco-8000 / Pfcwd tests skipped on m0/mx testbed.
SKIPPED [3] pfcwd/test_pfcwd_cli.py: test requires topology in Mark(name='topology', args=('t0', 't1'), kwargs={})
SKIPPED [9] pfcwd/test_pfcwd_warm_reboot.py: Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on m0/mx testbed.
================================================================================== 45 passed, 15 skipped, 1 warning in 14032.83s (3:53:52) ===================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_pfcwd_wb[async_storm-xx37-lc7]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'config_db_check_pass': False, 'core_dump_check_pass': True}}
INFO:root:Can not get Allure report URL. Please check logs
sonic@202405-qos-sonic-mgmt-prod:/data/tests$ 
```
#### Any platform specific information?
Checked on cisco-8000 fanouts. I don't have other vendor devices to check this.

@auspham , @sanjair-git : for review.