### PR TITLE
fix: handle UnpicklingError in cache read

### DIFF
--- a/tests/common/cache/facts_cache.py
+++ b/tests/common/cache/facts_cache.py
@@ -4,11 +4,13 @@ import inspect
 import logging
 import os
 import pickle
+import random
 import shutil
 import sys
 import time
 
 from collections import defaultdict
+from pickle import UnpicklingError
 from threading import Lock
 from six import with_metaclass
 
@@ -94,26 +96,32 @@ class FactsCache(with_metaclass(Singleton, object)):
             try:
                 return self._read_facts_file(facts_file, zone, key)
             except (IOError, ValueError) as e:
-                logger.info('[Cache] Load cache file "{}" failed with exception: {}'
+                logger.info('[Cache] Load cache file "{}" failed with IOError or ValueError: {}'
                             .format(os.path.abspath(facts_file), repr(e)))
                 return self.NOTEXIST
-            except EOFError as eof_err:
+            except (EOFError, UnpicklingError) as e:
                 # When parallel run is enabled, multiple processes may try to read/write the same cache file,
-                # so there will be a chance that the file is being written by process 1 while process 2 is reading
-                # it, which will cause EOFError in process 2. In this case, we will retry reading the file in
-                # process 2. If we still get EOFError after retrying, we will return NOTEXIST to overwrite the file.
+                # so there will be a chance that
+                #   - a file is being written by process1 while process2 is reading it, causing EOFError in process2
+                #   - a file is being read by multiple processes at the same time, causing UnpicklingError in some of
+                #     the processes
+                # In these cases, we will retry to read the file after a short random sleep. If we still get the same
+                # error after retrying, we will return NOTEXIST to overwrite the file.
                 retry_attempts = 3
-                retry_interval = 5
                 for attempt in range(retry_attempts):
-                    time.sleep(retry_interval)
+                    time.sleep(random.randint(3, 6))
                     try:
                         return self._read_facts_file(facts_file, zone, key)
-                    except EOFError:
+                    except (EOFError, UnpicklingError):
                         logger.warning('[Cache] Retry {}/{} failed for file "{}"'
                                        .format(attempt + 1, retry_attempts, facts_file))
 
-                logger.error('[Cache] Load cache file "{}" failed with exception: {}'
-                             .format(facts_file, repr(eof_err)))
+                logger.error('[Cache] Load cache file "{}" failed with EOFError or UnpicklingError: {}'
+                             .format(facts_file, repr(e)))
+                return self.NOTEXIST
+            except Exception as e:
+                logger.info('[Cache] Load cache file "{}" failed with unknown exception: {}'
+                            .format(os.path.abspath(facts_file), repr(e)))
                 return self.NOTEXIST
 
     def write(self, zone, key, value):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Handle `UnpicklingError` edge case in `FactsCache::read()` when parallel run is enabled.

Summary:
Fixes # (issue) Microsoft ADO 31839137

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
When parallel run is enabled, multiple processes may try to read/write the same cache file, so there will be a chance that a file is being read by multiple processes at the same time, causing UnpicklingError in some of the processes. Therefore, we decided to retry to read the file after a short random sleep. If we still get the same error after retrying, we will return NOTEXIST to overwrite the file.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
