### PR TITLE
Skip secondary subnet selection for base ip in setup_vlan_arp_responder fixture

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -190,6 +190,8 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     for vlan, attrs in vlan_intf_config.items():
         for val in attrs:
             try:
+                if attrs[val].get('secondary') == 'true':
+                    continue
                 ip = ip_interface(val)
                 if ip.version == 4:
                     ipv4_base = ip


### PR DESCRIPTION
Have fixture setup_vlan_arp_responder skip choosing secondary subnet IP as the base ip

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #17537

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Fix https://github.com/sonic-net/sonic-mgmt/issues/17537

#### How did you do it?

Have fixture setup_vlan_arp_responder select the primary VLAN ip as the base ip instead of the secondary subnet ip.

#### How did you verify/test it?

Tested on t0-118

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
