### PR TITLE
Fix the issue introduced when handle the 2 PRs #16948 and #16970

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -210,15 +210,16 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     if 'dualtor' in tbinfo['topo']['name']:
         server_ip = mux_cable_server_ip(rand_selected_dut)
 
+    ip_offset = 0
     for port in vlan_members:
         ptf_index = dut_to_ptf_port_map[port]
+        ip_offset = ptf_index + 1  # Add one since PTF indices start at 0
         if 'dualtor' in tbinfo['topo']['name']:
             arp_responder_cfg['eth{}'.format(ptf_index)] = [
                 server_ip[port]['server_ipv4'].split('/')[0],
                 server_ip[port]['server_ipv6'].split('/')[0]
             ]
             continue
-        ip_offset = ptf_index + 1  # Add one since PTF indices start at 0
         arp_responder_cfg['eth{}'.format(ptf_index)] = [
             str(ipv4_base.ip + ip_offset), str(ipv6_base.ip + ip_offset)
         ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix the issue introduced when handle the 2 PRs #16948 and #16970 (the test case failed on the dualtor when the 2 PRs merged.)
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
After the 2 PRs merged, since the conflict is not handled properly, it has problem when run on the dualtor setup:

        for port in vlan_members:
            ptf_index = dut_to_ptf_port_map[port]
            if 'dualtor' in tbinfo['topo']['name']:
                arp_responder_cfg['eth{}'.format(ptf_index)] = [
                    server_ip[port]['server_ipv4'].split('/')[0],
                    server_ip[port]['server_ipv6'].split('/')[0]
                ]
                continue
            ip_offset = ptf_index + 1  # Add one since PTF indices start at 0
            arp_responder_cfg['eth{}'.format(ptf_index)] = [
                str(ipv4_base.ip + ip_offset), str(ipv6_base.ip + ip_offset)
            ]
    
        CFG_FILE = '/tmp/arp_responder_vlan.json'
        with open(CFG_FILE, 'w') as file:
            json.dump(arp_responder_cfg, file)
        ptfhost.copy(src=CFG_FILE, dest=CFG_FILE)
    
        extra_vars = {
                'arp_responder_args': '--conf {}'.format(CFG_FILE)
        }
    
        ptfhost.host.options['variable_manager'].extra_vars.update(extra_vars)
        ptfhost.template(src='templates/arp_responder.conf.j2',
                         dest='/etc/supervisor/conf.d/arp_responder.conf')
        ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, ARP_RESPONDER_PY),
                     dest=OPT_DIR)
    
        ptfhost.command('supervisorctl reread')
        ptfhost.command('supervisorctl update')
    
        logger.info("Start arp_responder")
        ptfhost.command('supervisorctl start arp_responder')
    
>       yield vlan, ipv4_base, ipv6_base, ip_offset
E       UnboundLocalError: local variable 'ip_offset' referenced before assignment

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
