### PR TITLE
[TACACS] Added additional show command check as tacacs user

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -182,6 +182,7 @@ def test_authorization_tacacs_only(
         "portstat -c",
         "show interfaces portchannel",
         "show platform summary",
+        "show interfaces status",
         "show version",
         "show lldp table",
         "show reboot-cause",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Recently an issue was found where the TACACs user was not able to execute the `show interfaces status` on a Nvidia smartswitch due to platform specific permission issue for a TACACS user. This test case update is to add this check for a TACACs user to execute the `show interfaces status` command so that this test case passes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Failure of `show interfaces status` which was not caught by sonic-mgmt test.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
