### PR TITLE
Skip pipe mode tests on broadcom SKUs

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1733,7 +1733,7 @@ qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to
       - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
 
 qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping_uniform_mode:
-  skip:
+  xfail:
     reason: "Uniform decap mode not enabled on these asic types"
     conditions_logical_operator: or
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip pipe mode tests on broadcom SKUs after flipping to pipe mode on other SKUs - https://github.com/sonic-net/sonic-buildimage/pull/21868
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
From 202505, only Broadcom ASIC devices will support uniform mode for IP-IP packet decapsulation. Other platforms like Cisco and Mellanox have now began supporting pipe mode. The PR xfails the uniform mode test on Mellanox and Cisco SKUs and xfails the pipe mode test on Broadcom SKUs.

#### How did you do it?
Introduce a xfail condition.

#### How did you verify/test it?
Locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
