### PR TITLE
Ignore expected invalid syslog in test_process_reboot_cause

### DIFF
--- a/tests/platform_tests/test_process_reboot_cause.py
+++ b/tests/platform_tests/test_process_reboot_cause.py
@@ -34,6 +34,24 @@ class TestProcessRebootCause():
     reason = None
 
     @pytest.fixture(autouse=True)
+    def ignore_expected_loganalyzer_errors(self, duthosts, enum_rand_one_per_hwsku_hostname, loganalyzer):
+        """
+        Ignore expected error during TC execution
+
+        Args:
+                duthosts: list of DUTs.
+                rand_one_dut_hostname: Hostname of a random chosen dut
+                loganalyzer: Loganalyzer utility fixture
+        """
+        # When loganalyzer is disabled, the object could be None
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        if loganalyzer:
+            ignoreRegex = [
+                            ".*ERR process-reboot-cause.*Unable to process reload cause file.*"
+            ]
+            loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
+
+    @pytest.fixture(autouse=True)
     def setup_create_and_delete_json_files(self, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa: E501
         if self.duthost is None:
             self.duthost = duthosts[enum_rand_one_per_hwsku_hostname]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

`test_process_reboot_cause` was added in [Added sonic-mgmt tests for process-reboot-cause script by assrinivasan · Pull Request #14615 · sonic-net/sonic-mgmt](https://github.com/sonic-net/sonic-mgmt/pull/14615)

In test_empty_json_file, it will try to create an empty json file and test the process reboot cause.
`touch /host/reboot-cause/history/reboot-cause-2025_03_06_11_19_33.json`


But it will have an error syslog after test:
```
E               Match Messages:
E               2025 Mar  6 11:19:35.170923 bjw-can-7260-8 ERR process-reboot-cause[266617]: Unable to process reload cause file /host/reboot-cause/history/reboot-cause-2025_03_06_11_19_33.json: Expecting value: line 2 column 1 (char 1)
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add the expected invalid syslog into ignore list before running case.

#### How did you do it?
Add a new fixture `ignore_expected_loganalyzer_errors`
#### How did you verify/test it?

```
collected 4 items                                                                                                                                                                                                                            

platform_tests/test_process_reboot_cause.py ....                                                                                                                                                                                       [100%]

============================================================================================================== warnings summary ==============================================================================================================

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================= 4 passed, 9 warnings in 191.55s (0:03:11) ==================================================================================================
zhaohuisun@sonic-mgmt-zhaohuisun2:/data/sonic-mgmt-int/tests$ 


```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
