### PR TITLE
[dualtor] Skip crm compare check on KVM testbed

### DIFF
--- a/tests/dualtor/test_orch_stress.py
+++ b/tests/dualtor/test_orch_stress.py
@@ -153,6 +153,7 @@ def test_change_mux_state(
         request):
 
     dut = rand_selected_dut
+    asic_type = dut.facts['asic_type']
 
     wait(20, 'extra wait for presetup flow')
 
@@ -178,8 +179,9 @@ def test_change_mux_state(
 
     # Check CRM values for leak
     unmatched_crm_facts = compare_crm_facts(crm_facts1, crm_facts2)
-    pytest_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
-                  .format(json.dumps(unmatched_crm_facts, indent=4)))
+    if asic_type != 'vs':
+        pytest_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
+                      .format(json.dumps(unmatched_crm_facts, indent=4)))
 
 
 def remove_neighbors(dut, neighbors, interface):
@@ -261,6 +263,7 @@ def test_flap_neighbor_entry_standby(
         mock_server_ip_mac_map):
 
     dut = rand_selected_dut
+    asic_type = dut.facts['asic_type']
 
     vlan_interface_name = list(dut.get_extended_minigraph_facts(tbinfo)['minigraph_vlans'].keys())[0]
 
@@ -282,5 +285,6 @@ def test_flap_neighbor_entry_standby(
     logger.info(json.dumps(crm_facts2, indent=4))
 
     unmatched_crm_facts = compare_crm_facts(crm_facts1, crm_facts2)
-    pytest_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
-                  .format(json.dumps(unmatched_crm_facts, indent=4)))
+    if asic_type != 'vs':
+        pytest_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
+                      .format(json.dumps(unmatched_crm_facts, indent=4)))

--- a/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
+++ b/tests/dualtor/test_standby_tor_upstream_mux_toggle.py
@@ -36,6 +36,8 @@ def test_standby_tor_upstream_mux_toggle(
     rand_selected_dut, tbinfo, ptfadapter, rand_selected_interface,                     # noqa F811
     toggle_all_simulator_ports, set_crm_polling_interval):                              # noqa F811
     itfs, ip = rand_selected_interface
+
+    asic_type = rand_selected_dut.facts['asic_type']
     PKT_NUM = 100
     # Step 1. Set mux state to standby and verify traffic is dropped by ACL rule and drop counters incremented
     set_mux_state(rand_selected_dut, tbinfo, 'standby', [itfs], toggle_all_simulator_ports)     # noqa F405
@@ -81,5 +83,6 @@ def test_standby_tor_upstream_mux_toggle(
                             drop=True)
     crm_facts1 = rand_selected_dut.get_crm_facts()
     unmatched_crm_facts = compare_crm_facts(crm_facts0, crm_facts1)
-    pt_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
-              .format(json.dumps(unmatched_crm_facts, indent=4)))
+    if asic_type != 'vs':
+        pt_assert(len(unmatched_crm_facts) == 0, 'Unmatched CRM facts: {}'
+                  .format(json.dumps(unmatched_crm_facts, indent=4)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Testbed will get crm resources from asic, but it's not completely supported on KVM testbed.
#### How did you do it?
Skip all crm facts check using `compare_crm_facts`
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
