### PR TITLE
Update outer UDP sport range to exclude port 53

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -62,6 +62,12 @@ class HashTest(BaseTest):
             if param not in self.test_params:
                 raise Exception("Missing required parameter {}".format(param))
 
+    def generate_random_sport(self):
+        while True:
+            port = random.randint(0, 65535)
+            if port != 53:
+                return port
+
     def setUp(self):
         '''
         @summary: Setup for the test
@@ -928,7 +934,7 @@ class VxlanHashTest(HashTest):
         ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        outer_sport = random.randint(0, 65535) if hash_key == 'outer-src-port' else 1234
+        outer_sport = self.generate_random_sport() if hash_key == 'outer-src-port' else 1234
 
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
@@ -1046,7 +1052,7 @@ class VxlanHashTest(HashTest):
             if hash_key == 'dst-mac' else self.base_mac
         router_mac = self.ptf_test_port_map[str(src_port)]['target_dest_mac']
 
-        outer_sport = random.randint(0, 65535) if hash_key == 'outer-src-port' else 1234
+        outer_sport = self.generate_random_sport() if hash_key == 'outer-src-port' else 1234
 
         if self.ipver == 'ipv6-ipv6':
             pkt_opts = {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
UDP sport 53 is a special port to be used in DNS and there is a rule in test server ovs switch 
It would forward packet with UDP sport 53 to VM instead of to PTF port due to an existing ovs rule:
`cookie=0x0, duration=8133.286s, table=0, n_packets=0, n_bytes=0, idle_age=8133, priority=8,udp,in_port=3,tp_src=53 actions=output:1`

Summary:
Fixes # (issue)
When UDP outer sport == 53, the packet would not be received at PTF ports in fib/test_fib.py::test_vxlan_hash test
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
When UDP outer sport == 53, the packet would not be received at PTF ports in fib/test_fib.py::test_vxlan_hash test
#### How did you do it?
Exclude 53 from the port range
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
