### PR TITLE
enable multiasic support for bmp feature

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -6,6 +6,7 @@
 
 
 import copy
+import logging
 import json
 import re
 
@@ -27,6 +28,8 @@ GOLDEN_CONFIG_DB_PATH = "/etc/sonic/golden_config_db.json"
 TEMP_DHCP_SERVER_CONFIG_PATH = "/tmp/dhcp_server.json"
 TEMP_SMARTSWITCH_CONFIG_PATH = "/tmp/smartswitch.json"
 DUMMY_QUOTA = "dummy_single_quota"
+
+logger = logging.getLogger(__name__)
 
 
 class GenerateGoldenConfigDBModule(object):
@@ -94,25 +97,26 @@ class GenerateGoldenConfigDBModule(object):
         gold_config_db.update(dhcp_server_config_obj)
         return gold_config_db
 
-    def check_bmp_version(self):
-        # skip multi_asic first
-        if multi_asic.is_multi_asic():
-            return False
-
+    def check_version_for_bmp(self):
         output_version = device_info.get_sonic_version_info()
         build_version = output_version['build_version']
 
         if re.match(r'^(\d{8})', build_version):
             version_number = int(re.findall(r'\d{8}', build_version)[0])
-            if version_number < 20241130:
+            if version_number > 20241130:
+                return True
+            else:
                 return False
         elif re.match(r'^internal-(\d{8})', build_version):
             internal_version_number = int(re.findall(r'\d{8}', build_version)[0])
-            if internal_version_number < 20241130:
+            if internal_version_number > 20241130:
+                return True
+            else:
                 return False
-        else:
+        elif re.match(r'^master', build_version) or re.match(r'^HEAD', build_version):
             return True
-        return True
+        else:
+            return False
 
     def get_config_from_minigraph(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -120,20 +124,88 @@ class GenerateGoldenConfigDBModule(object):
             self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
         return out
 
-    def generate_bmp_golden_config_db(self, config):
+    def get_multiasic_feature_config(self, feature_key):
+        rc, out, err = self.module.run_command("show runningconfiguration all")
+        if rc != 0:
+            self.module.fail_json(msg="Failed to get config from runningconfiguration: {}".format(err))
+        running_config_db = json.loads(out)
+
+        feature_data = {
+            feature_key: {
+                "auto_restart": "enabled",
+                "check_up_status": "false",
+                "delayed": "False",
+                "has_global_scope": "False",
+                "has_per_asic_scope": "True",
+                "high_mem_alert": "disabled",
+                "set_owner": "local",
+                "state": "enabled",
+                "support_syslog_rate_limit": "false"
+            }
+        }
+
+        features_data = {}
+        for key, value in running_config_db.items():
+            if "FEATURE" in value:
+                updated_feature = value["FEATURE"]
+                updated_feature.update(feature_data)
+                features_data[key] = {"FEATURE": updated_feature}
+
+        return json.dumps(features_data, indent=4)
+
+    def overwrite_feature_golden_config_db_multiasic(self, config, feature_key):
+        full_config = config
+        onlyFeature = config == "{}"  # FEATURE needs special handling since it does not support incremental update.
+        if config == "{}":  # FEATURE needs special handling since it does not support incremental update.
+            full_config = self.get_multiasic_feature_config(feature_key)
+
+        ori_config_db = json.loads(full_config)
+        if "FEATURE" not in ori_config_db:  # need dump running config FEATURE + selected feature
+            feature_data = json.loads(self.get_multiasic_feature_config(feature_key))
+            ori_config_db_with_feature = {}
+            for key, value in ori_config_db.items():
+                ori_config_db_with_feature = value.get("FEATURE", {})
+                ori_config_db_with_feature.update(feature_data)
+                value["FEATURE"] = ori_config_db_with_feature
+                ori_config_db_with_feature[key] = value
+            gold_config_db = ori_config_db_with_feature
+        else:  # need existing config + selected feature
+            if not onlyFeature:
+                feature_data = {
+                    feature_key: {
+                        "auto_restart": "enabled",
+                        "check_up_status": "false",
+                        "delayed": "False",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "local",
+                        "state": "enabled",
+                        "support_syslog_rate_limit": "false"
+                    }
+                }
+                for section, section_data in ori_config_db.items():
+                    if "FEATURE" in section_data:
+                        feature_section = section_data["FEATURE"]
+                        feature_section.update(feature_data)
+                        section_data["FEATURE"] = feature_section
+            gold_config_db = ori_config_db
+
+        return json.dumps(gold_config_db, indent=4)
+
+    def overwrite_feature_golden_config_db_singleasic(self, config, feature_key):
         full_config = config
         onlyFeature = config == "{}"  # FEATURE needs special handling since it does not support incremental update.
         if config == "{}":
             full_config = self.get_config_from_minigraph()
-
         ori_config_db = json.loads(full_config)
         if "FEATURE" not in ori_config_db:
             full_config = self.get_config_from_minigraph()
             feature_config_db = json.loads(full_config)
             ori_config_db["FEATURE"] = feature_config_db.get("FEATURE", {})
 
-        # Append "bmp" section to the original "FEATURE" section
-        ori_config_db.setdefault("FEATURE", {}).setdefault("bmp", {}).update({
+        # Append the specified feature section to the original "FEATURE" section
+        ori_config_db.setdefault("FEATURE", {}).setdefault(feature_key, {}).update({
             "auto_restart": "enabled",
             "check_up_status": "false",
             "delayed": "False",
@@ -145,13 +217,14 @@ class GenerateGoldenConfigDBModule(object):
             "support_syslog_rate_limit": "false"
         })
 
-        # Create the gold_config_db dictionary with both "FEATURE" and "bmp" sections
+        # Create the gold_config_db dictionary with both "FEATURE" and the specified feature section
         if onlyFeature:
             gold_config_db = {
                 "FEATURE": copy.deepcopy(ori_config_db["FEATURE"])
             }
         else:
             gold_config_db = ori_config_db
+
         return json.dumps(gold_config_db, indent=4)
 
     def generate_smartswitch_golden_config_db(self):
@@ -186,9 +259,12 @@ class GenerateGoldenConfigDBModule(object):
         else:
             config = "{}"
 
-        # version check
-        if self.check_bmp_version() is True:
-            config = self.generate_bmp_golden_config_db(config)
+        # To enable bmp feature
+        if self.check_version_for_bmp() is True:
+            if multi_asic.is_multi_asic():
+                config = self.overwrite_feature_golden_config_db_multiasic(config, "bmp")
+            else:
+                config = self.overwrite_feature_golden_config_db_singleasic(config, "bmp")
 
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
manual cherrypick for PR:17024
Enable multiasic support in mgmt by ovewriting golden config. And refactor existing code to generalize the feature overwrite functions, so that other feature is able to turn-on easily with it.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Enable multiasic support in mgmt by ovewriting golden config. And refactor existing code to generalize the feature overwrite functions, so that other feature is able to turn-on easily with it.

#### How did you do it?
FEATURE needs special handling since it does not support incremental update, which means the config passed in this library function will be below cases:

For multi-asic:
1. config without FEATURE, this needs load runningconfig to get all asics' FEATURE, and append BMP set, overwrite entire golden config.
2. config with other entities, but without FEATURE. This also needs load runningconfig to get all asics' FEATURE, and append BMP set, then merge all entities together to overwrite entire golden config.
3. config with all entities, includes FEATURE, this needs append BMP set, and overwrite entire golden config.

For single-asic:
1. config without FEATURE, this needs reload miniGraph, and append BMP set, overwrite entire golden config.
2. config with other entities, but without FEATURE. This also needs reload miniGraph, and append BMP set, then merge all entities together to overwrite entire golden config.
3. config with all entities, includes FEATURE, this needs append BMP set, and overwrite entire golden config.

This PR makes this feature overwrite path as general function for all features, and bmp is the first consumer.

#### How did you verify/test it?
This PR will turn on multi-asic and verify the corresponding cases.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
