### PR TITLE
[add_rack]: Add ignore of apsel, host lane and media lane count attributes preset in TRANSCEIVER_INFO for add rack test case

### DIFF
--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -126,26 +126,15 @@ scan_dbs = {
             "db_no": 6,
             "keys_to_compare": {
                 "NEIGH_STATE_TABLE",
-                "TRANSCEIVER_INFO",
-                "TRANSCEIVER_STATUS",
                 "VLAN_MEMBER_TABLE",
                 "VLAN_TABLE"
             },
             "keys_to_skip_comp": {
-                "PORT_TABLE"
+                "PORT_TABLE",
+                "TRANSCEIVER_INFO",
+                "TRANSCEIVER_STATUS"
             },
-            "keys_skip_val_comp": {
-                "active_apsel_hostlane1",
-                "active_apsel_hostlane2",
-                "active_apsel_hostlane3",
-                "active_apsel_hostlane4",
-                "active_apsel_hostlane5",
-                "active_apsel_hostlane6",
-                "active_apsel_hostlane7",
-                "active_apsel_hostlane8",
-                "host_lane_count",
-                "media_lane_count"
-            }
+            "keys_skip_val_comp": set()
         }
     }
 

--- a/tests/configlet/util/common.py
+++ b/tests/configlet/util/common.py
@@ -134,7 +134,18 @@ scan_dbs = {
             "keys_to_skip_comp": {
                 "PORT_TABLE"
             },
-            "keys_skip_val_comp": set()
+            "keys_skip_val_comp": {
+                "active_apsel_hostlane1",
+                "active_apsel_hostlane2",
+                "active_apsel_hostlane3",
+                "active_apsel_hostlane4",
+                "active_apsel_hostlane5",
+                "active_apsel_hostlane6",
+                "active_apsel_hostlane7",
+                "active_apsel_hostlane8",
+                "host_lane_count",
+                "media_lane_count"
+            }
         }
     }
 


### PR DESCRIPTION
Double commit of https://github.com/sonic-net/sonic-mgmt/pull/17307 to 202405 branch.

Issue was exposed as part of test_add_rack.py on an internal cisco run. The optic module type on the setup is OSFP 8X Pluggable Transceiver which supports attributes - apsel (application select), media_lane, host_lane count.
As part of add rack test case, it is testing adding/removing a T0 neighbor on a existing T1 setup by [1] config reload(with T0, without T0) and [2] config apply-patch(patch-add, patch remove) CLI and as part of validation it compares the DB data pre and post config application.
Currently we see a failure on db comparison after patch_rm on TRANSCEIVER_INFO table in state-db on these attributes- active_apsel[1,2,3..], media_lane and host_lane count. Going through xcvrd code;
When admin_status is updated to status ‘up’ through patch add config, CMIS states transitions through the below states and transceiver info gets updated to DB at the final state ‘CMIS_STATE_DP_ACTIVATE'
[sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py at 202405 · sonic-net/sonic-platform-daemons](https://github.com/sonic-net/sonic-platform-daemons/blob/202405/sonic-xcvrd/xcvrd/xcvrd.py#L1490)
CMIS_STATE_INSERTED → CMIS_STATE_DP_DEINIT → CMIS_STATE_AP_CONF → CMIS_STATE_DP_INIT → CMIS_STATE_DP_TXON → CMIS_STATE_DP_ACTIVATE - > CMIS_STATE_INSERTED
On patch rm- removal of admin status and config interface shutdown , CMIS state remains unchanged and it only disables transmission channel and returns from this point and does NOT parse through the flow which updates the transceiver info to DB.
[sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py at 202405 · sonic-net/sonic-platform-daemons](https://github.com/sonic-net/sonic-platform-daemons/blob/202405/sonic-xcvrd/xcvrd/xcvrd.py#L1310)
As the interfaces are already configured and these attributes do not change as part of shutdown of admin status, db data on said attributes not changing as part of patch rm is in alignment with xcvrd code flow. This will not be applicable to copper modules as these attributes are not supported on them. It is possible that this test was written at the time when these optic modules were not actively supported/used and would need to be be handled now as part of the test case.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
