### PR TITLE
Added testcase to verify ecn marking on the Fabric and Back plane interfaces in T2 [ Cisco specific]

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -932,6 +932,18 @@ def get_pfc_frame_count(duthost, port, priority, is_tx=False):
     return int(pause_frame_count.replace(',', ''))
 
 
+def get_all_port_stats(duthost):
+    """
+    Runs the portstat command and retrieves JSON output.
+
+    Returns:
+        dict: Parsed JSON output from portstat.
+    """
+    raw_output = duthost.shell("portstat -j -s all")['stdout']
+    raw_out_stripped = re.sub(r'^(?:(?!{).)*\n', '', raw_output, count=1)
+    return json.loads(raw_out_stripped)
+
+
 def get_port_stats(duthost, port, stat):
     """
     Get the port stats for a given port from SONiC CLI

--- a/tests/snappi_tests/ecn/files/bpfabric_helper.py
+++ b/tests/snappi_tests/ecn/files/bpfabric_helper.py
@@ -1,0 +1,302 @@
+import logging
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts             # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+     snappi_api                                                                                     # noqa: F401
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, config_wred, \
+    enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging,\
+    config_capture_pkt, traffic_flow_mode, calc_pfc_pause_flow_rate, get_all_port_stats  # noqa: F401
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
+    generate_pause_flows, run_traffic                                       # noqa: F401
+from tests.snappi_tests.files.helper import get_fabric_mapping, load_port_stats, \
+    infer_ecmp_backplane_ports, set_cir_cisco_8000, get_npu_voq_queue_counters, compute_expected_packets
+import time
+
+
+logger = logging.getLogger(__name__)
+
+DATA_FLOW_PKT_SIZE = 1350
+DATA_FLOW_DURATION_SEC = 2
+DATA_FLOW_DELAY_SEC = 1
+DATA_FLOW_NAME = 'Data Flow'
+PAUSE_FLOW_NAME = 'Pause Storm'
+
+
+def verify_ecn_marking_counters(ecn_counters, lossless_prio, intf):
+    # verify that each flow had packets
+    init_ctr, post_ctr = ecn_counters[0]
+
+    flow_total = post_ctr['SAI_QUEUE_STAT_PACKETS'] - init_ctr['SAI_QUEUE_STAT_PACKETS']
+
+    pytest_assert(flow_total > 0,
+                  'Queue {} counters at start {} at end {} did not increment of {}'.format(
+                      lossless_prio, init_ctr['SAI_QUEUE_STAT_PACKETS'], post_ctr['SAI_QUEUE_STAT_PACKETS'], intf))
+
+    flow_ecn = post_ctr['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS'] -\
+        init_ctr['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS']
+
+    pytest_assert(flow_ecn > 0,
+                  'Must have ecn marked packets on queue {} of {}'.format(lossless_prio, intf))
+
+
+def _generate_traffic_config(testbed_config,
+                             snappi_extra_params,
+                             port_config_list,
+                             test_prio_list,
+                             test_flow_percent,
+                             prio_dscp_map,
+                             congested=False):
+    TEST_FLOW_NAME = DATA_FLOW_NAME + ' ' + str(test_prio_list[0])
+
+    port_id = 0
+    # Generate base traffic config
+    base_flow_config1 = setup_base_traffic_config(testbed_config=testbed_config,
+                                                  port_config_list=port_config_list,
+                                                  port_id=port_id)
+
+    # Create a dictionary with priorities as keys and flow rates as values
+    flow_rate_dict = {
+        prio: round(flow / len(test_prio_list), 2) for prio, flow in zip(test_prio_list, test_flow_percent)
+    }
+
+    snappi_extra_params.base_flow_config = base_flow_config1
+
+    # Set default traffic flow configs if not set
+    if snappi_extra_params.traffic_flow_config.data_flow_config is None:
+        snappi_extra_params.traffic_flow_config.data_flow_config = {
+            "flow_name": TEST_FLOW_NAME,
+            "flow_dur_sec": DATA_FLOW_DURATION_SEC,
+            "flow_rate_percent": flow_rate_dict,
+            "flow_rate_pps": None,
+            "flow_rate_bps": None,
+            "flow_pkt_size": DATA_FLOW_PKT_SIZE,
+            "flow_pkt_count": None,
+            "flow_delay_sec": DATA_FLOW_DELAY_SEC,
+            "flow_traffic_type": traffic_flow_mode.FIXED_DURATION
+        }
+
+    generate_test_flows(testbed_config=testbed_config,
+                        test_flow_prio_list=test_prio_list,
+                        prio_dscp_map=prio_dscp_map,
+                        snappi_extra_params=snappi_extra_params,
+                        congested=congested,
+                        number_of_streams=1)
+
+
+def get_traffic_path(
+                    api,
+                    testbed_config,
+                    port_config_list,
+                    dut_port,
+                    test_prio_list,
+                    prio_dscp_map,
+                    snappi_extra_params):
+
+    """
+    Returns:
+        list: Returns traffic path [ingress_port, tx_bp, fabric_rx, fabric_tx, rx_bp, egress_port]
+    """
+
+    test_flow_percent = [49] * len(test_prio_list)
+
+    if snappi_extra_params is None:
+        snappi_extra_params = SnappiTestParams()
+
+    # Traffic flow:
+    # tx_port (TGEN) --- ingress DUT ---Fabric---- egress DUT --- rx_port (TGEN)
+
+    rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
+    egress_duthost = rx_port['duthost']
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
+
+    # Append the duthost here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost)
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
+    duthost = egress_duthost
+
+    _generate_traffic_config(testbed_config, snappi_extra_params,
+                             port_config_list, test_prio_list,
+                             test_flow_percent, prio_dscp_map)
+
+    flows = testbed_config.flows
+
+    all_flow_names = [flow.name for flow in flows]
+    data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
+
+    speed_str = testbed_config.layer1[0].speed
+    speed_gbps = int(speed_str.split('_')[1])
+
+    # Find the expected packets for the given traffic duration and flow percent.
+    # This helps find the bp interfaces involved in the traffic path more accurately
+    pkt_threshold = compute_expected_packets(speed_gbps * 10**9 * test_flow_percent[0]/100,
+                                             DATA_FLOW_PKT_SIZE, DATA_FLOW_DURATION_SEC)
+
+    """ Run traffic """
+    _, _, _ = run_traffic(
+                            duthost,
+                            api=api,
+                            config=testbed_config,
+                            data_flow_names=data_flow_names,
+                            all_flow_names=all_flow_names,
+                            exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                            DATA_FLOW_DELAY_SEC,
+                            snappi_extra_params=snappi_extra_params)
+
+    # get all the port stats
+    ingress_stats = get_all_port_stats(ingress_duthost)
+    egress_stats = get_all_port_stats(egress_duthost)
+
+    # Find the active data path interfaces using the expected pkt threshold.
+    ingress_active_interfaces = load_port_stats(ingress_stats, pkt_threshold, direction="tx")
+    egress_active_interfaces = load_port_stats(egress_stats, pkt_threshold, direction="rx")
+
+    # Find the fabric mapping from the CLI
+    ingress_fabric_mapping = get_fabric_mapping(ingress_duthost)
+    egress_fabric_mapping = get_fabric_mapping(egress_duthost)
+
+    # Infer the traffic path from ingress to egress port via BP and Fabric port
+    traffic_paths = infer_ecmp_backplane_ports(ingress_active_interfaces, egress_active_interfaces,
+                                               snappi_extra_params.multi_dut_params.multi_dut_ports[1]['peer_port'],
+                                               dut_port, ingress_fabric_mapping, egress_fabric_mapping)
+
+    pytest_assert(traffic_paths, "Unable to find traffic path for the given ingress and egress port")
+
+    logger.info("Traffic paths {}".format(traffic_paths))
+    return traffic_paths
+
+
+def adjust_shaper_and_verify(dut, egress_intfs, test_prio_list, api):
+    egress_asic_map = {}
+
+    # Create a map of asic instance and egress ports involved in the traffic path
+    for intf in egress_intfs:
+        asic_instance = dut.get_port_asic_instance(intf)
+        if asic_instance not in egress_asic_map:
+            egress_asic_map[asic_instance] = []
+
+        egress_asic_map[asic_instance].append(intf)
+
+    try:
+        # Iterate over the egress port map and call set_cir_cisco_8000
+        for asic_instance, intf_list in egress_asic_map.items():
+            # Set the shaper to 5GB to induce congestion on the egress ports
+            set_cir_cisco_8000(dut, intf_list, asic_instance, speed=5 * 1000 * 1000 * 1000)
+
+        queue_counters = {}
+        for intf in egress_intfs:
+            init_ctr = get_npu_voq_queue_counters(dut, intf, test_prio_list[0])
+
+            queue_counters[intf] = init_ctr
+
+        # Start traffic again
+        ts = api.transmit_state()
+        ts.state = ts.START
+        api.set_transmit_state(ts)
+
+        time.sleep(DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC)
+
+        # Stop traffic
+        ts.state = ts.STOP
+        api.set_transmit_state(ts)
+
+        for intf in egress_intfs:
+            post_ctr = get_npu_voq_queue_counters(dut, intf, test_prio_list[0])
+
+            init_ctr = queue_counters[intf]
+
+            ecn_counters = [
+                (init_ctr, post_ctr)
+            ]
+
+            verify_ecn_marking_counters(ecn_counters, test_prio_list[0], intf)
+    finally:
+        # Iterate over the fabric egress port map and call set_cir_cisco_8000
+        for asic_instance, intf_list in egress_asic_map.items():
+            # Reset the shaper on the egress ports
+            set_cir_cisco_8000(dut, intf_list, asic_instance)
+
+
+def run_fabric_ecn_marking_test(api,
+                                testbed_config,
+                                port_config_list,
+                                dut_port,
+                                test_prio_list,
+                                prio_dscp_map,
+                                supervisor_dut,
+                                snappi_extra_params=None):
+
+    """
+    Run a ECN test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        dut_port (str): DUT port to test
+        test_prio_list (list): priority of test flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        supervisor_dut (duthost): dutHost obj for supervisor in case of multi-DUT
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+
+    Returns:
+        N/A
+    """
+
+    pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
+    pytest_assert(len(test_prio_list) >= 1, 'Must have atleast one lossless priorities')
+
+    traffic_paths = get_traffic_path(api,
+                                     testbed_config, port_config_list,
+                                     dut_port, test_prio_list, prio_dscp_map, snappi_extra_params)
+
+    # Get list of Fabric egress ports only
+    fabric_egress = [path[3] for path in traffic_paths]
+
+    adjust_shaper_and_verify(supervisor_dut, fabric_egress, test_prio_list, api)
+
+
+def run_backplane_ecn_marking_test(
+                                    api,
+                                    testbed_config,
+                                    port_config_list,
+                                    dut_port,
+                                    test_prio_list,
+                                    prio_dscp_map,
+                                    snappi_extra_params=None):
+
+    """
+    Run a ECN test
+    Args:
+        api (obj): snappi session
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        port_config_list (list): list of port configuration
+        conn_data (dict): the dictionary returned by conn_graph_fact.
+        fanout_data (dict): the dictionary returned by fanout_graph_fact.
+        dut_port (str): DUT port to test
+        test_prio_list (list): priority of test flows
+        prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+
+    Returns:
+        N/A
+    """
+
+    pytest_assert(testbed_config is not None, 'Failed to get L2/3 testbed config')
+    pytest_assert(len(test_prio_list) >= 1, 'Must have atleast one lossless priorities')
+
+    traffic_paths = get_traffic_path(api,
+                                     testbed_config, port_config_list,
+                                     dut_port, test_prio_list, prio_dscp_map, snappi_extra_params)
+
+    # Get list of backplane egress ports only
+    backplane_egress = [path[1] for path in traffic_paths]
+
+    tx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost = tx_port['duthost']
+
+    adjust_shaper_and_verify(ingress_duthost, backplane_egress, test_prio_list, api)

--- a/tests/snappi_tests/ecn/files/ecnhelper.py
+++ b/tests/snappi_tests/ecn/files/ecnhelper.py
@@ -14,10 +14,8 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port # noqa F
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp # noqa F401
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows,\
     run_traffic
-
+from tests.snappi_tests.files.helper import get_npu_voq_queue_counters
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-import json
-
 
 logger = logging.getLogger(__name__)
 
@@ -26,17 +24,6 @@ DATA_FLOW_DURATION_SEC = 2
 DATA_FLOW_DELAY_SEC = 1
 TEST_FLOW_NAME = ['Test Flow 3', 'Test Flow 4']
 PAUSE_FLOW_NAME = 'Pause Storm'
-
-
-def get_npu_voq_queue_counters(duthost, interface, priority):
-    full_line = "".join(duthost.shell(
-        "show platform npu voq queue_counters -t {} -i {} -d".
-        format(priority, interface))['stdout_lines'])
-    dict_output = json.loads(full_line)
-    for entry, value in zip(dict_output['stats_name'], dict_output['counters']):
-        dict_output[entry] = value
-
-    return dict_output
 
 
 def verify_ecn_counters(ecn_counters, link_state_toggled=False):

--- a/tests/snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py
@@ -1,0 +1,147 @@
+import pytest
+import logging
+import random
+from tabulate import tabulate # noqa F401
+from tests.common.helpers.assertions import pytest_assert, pytest_require     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
+    fanout_graph_facts_multidut         # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
+    is_snappi_multidut, get_snappi_ports_multi_dut, get_snappi_ports_single_dut   # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
+    lossless_prio_list, disable_pfcwd   # noqa F401
+from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut, enable_debug_shell  # noqa: F401
+from tests.snappi_tests.ecn.files.bpfabric_helper import run_fabric_ecn_marking_test, run_backplane_ecn_marking_test
+from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.cisco_data import is_cisco_device
+logger = logging.getLogger(__name__)
+pytestmark = [pytest.mark.topology('multidut-tgen')]
+
+
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
+def validate_snappi_ports(snappi_ports):
+    '''
+        To use Backplane and fabric ports for traffic
+         - the ingress port and the egress port should be on diff DUT.
+         - or they both should be on diff asic instance on same DUT
+    '''
+
+    # Extract duthost and peer_port values for rx_dut and tx_dut configurations
+    rx_dut = snappi_ports[0]['duthost']
+    rx_peer_port = snappi_ports[0]['peer_port']
+    tx_dut = snappi_ports[1]['duthost']
+    tx_peer_port = snappi_ports[1]['peer_port']
+
+    # get the ASIC namespace for a given duthost and peer_port
+    def get_asic(duthost, peer_port):
+        return duthost.get_port_asic_instance(peer_port).namespace
+
+    # Retrieve ASIC namespace
+    rx_asic = get_asic(rx_dut, rx_peer_port)
+    tx_asic = get_asic(tx_dut, tx_peer_port)
+
+    if (rx_dut != tx_dut) or (rx_asic != tx_asic):
+        pytest_require(is_cisco_device(rx_dut) and is_cisco_device(tx_dut), "Test supported on Cisco DUT only")
+        return True
+
+    return False
+
+
+def test_fabric_ecn_marking_lossless_prio(
+                                snappi_api,                       # noqa: F811
+                                conn_graph_facts,                 # noqa: F811
+                                fanout_graph_facts_multidut,               # noqa: F811
+                                duthosts,
+                                lossless_prio_list,     # noqa: F811
+                                get_snappi_ports,     # noqa: F811
+                                tbinfo,      # noqa: F811
+                                disable_pfcwd,     # noqa: F811
+                                prio_dscp_map,  # noqa: F811
+                                setup_ports_and_dut):                    # noqa: F811
+    """
+    Verify Egress Fabric port to Egress DUT ECN marking on lossless prio
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        tbinfo (pytest fixture): fixture provides information about testbed
+    Returns:
+        N/A
+    """
+
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+
+    # find the supervisor DUT as the fabric ports are available in it.
+    supervisor_dut = next((duthost for duthost in duthosts if duthost.is_supervisor_node()), None)
+
+    pytest_assert(supervisor_dut, "Supervisor DUT not found")
+
+    pytest_require(is_cisco_device(supervisor_dut), "Test supported on Cisco Supervisor DUT only")
+
+    pytest_require(validate_snappi_ports(snappi_ports), "Invalid combination of duthosts or ASICs in snappi_ports")
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    run_fabric_ecn_marking_test(
+                            api=snappi_api,
+                            testbed_config=testbed_config,
+                            port_config_list=port_config_list,
+                            dut_port=snappi_ports[0]['peer_port'],
+                            test_prio_list=random.sample(lossless_prio_list, 1),
+                            prio_dscp_map=prio_dscp_map,
+                            supervisor_dut=supervisor_dut,
+                            snappi_extra_params=snappi_extra_params)
+
+
+def test_backplane_ecn_marking_lossless_prio(
+                                snappi_api,                       # noqa: F811
+                                conn_graph_facts,                 # noqa: F811
+                                fanout_graph_facts_multidut,               # noqa: F811
+                                duthosts,
+                                lossless_prio_list,     # noqa: F811
+                                get_snappi_ports,     # noqa: F811
+                                tbinfo,      # noqa: F811
+                                disable_pfcwd,     # noqa: F811
+                                prio_dscp_map,  # noqa: F811
+                                setup_ports_and_dut):                    # noqa: F811
+    """
+    Verify Ingress DUT Egress backplane port ECN marking on lossless prio
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        tbinfo (pytest fixture): fixture provides information about testbed
+    Returns:
+        N/A
+    """
+
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+
+    pytest_require(validate_snappi_ports(snappi_ports), "Invalid combination of duthosts or ASICs in snappi_ports")
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    run_backplane_ecn_marking_test(
+                            api=snappi_api,
+                            testbed_config=testbed_config,
+                            port_config_list=port_config_list,
+                            dut_port=snappi_ports[0]['peer_port'],
+                            test_prio_list=random.sample(lossless_prio_list, 1),
+                            prio_dscp_map=prio_dscp_map,
+                            snappi_extra_params=snappi_extra_params)

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -1,6 +1,9 @@
 import logging
 import re
 import pytest
+import re
+import json
+from itertools import cycle
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.helpers.assertions import pytest_require
 from tests.common.cisco_data import is_cisco_device
@@ -189,6 +192,24 @@ def enable_debug_shell(setup_ports_and_dut):  # noqa: F811
         pass
 
 
+def compute_expected_packets(flow_rate_bps, pkt_size_bytes, duration_s, num_streams=1):
+    """
+    Computes the expected packet count and threshold based on traffic parameters.
+
+    Args:
+        flow_rate_bps (int): Flow rate in bits per second.
+        pkt_size_bytes (int): Packet size in bytes.
+        duration_s (int): Duration in seconds.
+        threshold_pct (int): Percentage threshold for filtering significant traffic.
+
+    Returns:
+        int: Minimum packet count threshold.
+    """
+    pkt_size_bits = (pkt_size_bytes + 20) * 8
+    expected_packets = (flow_rate_bps * duration_s) // pkt_size_bits
+    return int(expected_packets / num_streams * 0.95)  # 5 % margin
+
+
 def get_fabric_mapping(duthost, asic=""):
     """
     Retrieves the mapping between backplane and fabric interfaces dynamically.
@@ -211,3 +232,155 @@ def get_fabric_mapping(duthost, asic=""):
             fabric_map[match.group(1)] = match.group(2)
 
     return fabric_map
+
+def load_port_stats(stats, threshold, direction="both"):
+    """
+    Parses port statistics and filters interfaces involved in traffic forwarding.
+
+    Args:
+        stats (dict): Dictionary containing port statistics.
+        threshold (int): Minimum packet count to consider an interface active.
+        direction (str): Filter interfaces based on "tx", "rx", or "both"
+
+    Returns:
+        dict: Dictionary of interfaces with nonzero TX_OK and RX_OK above threshold.
+    """
+    active_interfaces = {}
+
+    for interface, data in stats.items():
+        tx_ok = int(data.get("TX_OK", 0).replace(",", ""))
+        rx_ok = int(data.get("RX_OK", 0).replace(",", ""))
+
+        # Consider interfaces with TX/RX OK counts above threshold
+        if (direction == "tx" and tx_ok > threshold):
+            active_interfaces[interface] = {"TX_OK": tx_ok}
+
+        if (direction == "rx" and rx_ok > threshold):
+            active_interfaces[interface] = {"RX_OK": rx_ok}
+
+        if (direction == "both" and (tx_ok > threshold or rx_ok > threshold)):
+            active_interfaces[interface] = {"TX_OK": tx_ok, "RX_OK": rx_ok}
+
+    return active_interfaces
+
+
+def infer_ecmp_backplane_ports(
+                                ingress_active_interfaces,
+                                egress_active_interfaces,
+                                ingress,
+                                egress,
+                                ingress_fabric_mapping,
+                                egress_fabric_mapping):
+    """
+    Identifies all backplane ports involved in ECMP traffic forwarding.
+
+    Args:
+        ingress_active_interfaces (dict): Interfaces on ingress DUT with TX_OK > threshold.
+        egress_active_interfaces (dict): Interfaces on egress DUT with RX_OK > threshold.
+        ingress (str): Known ingress port.
+        egress (str): Known egress port.
+        ingress_fabric_mapping (dict): Mapping of ingress DUT backplane interfaces to fabric interfaces.
+        egress_fabric_mapping (dict): Mapping of egress DUT backplane interfaces to fabric interfaces.
+
+    Returns:
+        list: List of traffic paths, each as an ordered list of interfaces.
+    """
+    # Step 1: Remove ingress and egress from active interfaces
+    ingress_active_interfaces = {k: v for k, v in ingress_active_interfaces.items() if k not in {ingress, egress}}
+    egress_active_interfaces = {k: v for k, v in egress_active_interfaces.items() if k not in {ingress, egress}}
+
+    tx_ports = []
+    rx_ports = []
+
+    for interface, stats in ingress_active_interfaces.items():
+        tx_ok = stats.get('TX_OK', 0)
+        rx_ok = stats.get('RX_OK', 0)
+
+        if tx_ok > rx_ok:  # Ports with more TX are considered transmitting backplanes
+            tx_ports.append((interface, tx_ok))
+
+    for interface, stats in egress_active_interfaces.items():
+        tx_ok = stats.get('TX_OK', 0)
+        rx_ok = stats.get('RX_OK', 0)
+
+        if rx_ok > tx_ok:
+            rx_ports.append((interface, rx_ok))
+
+    # Sort the lists based on TX_OK (for transmitting) or RX_OK (for receiving)
+    tx_ports = sorted(tx_ports, key=lambda x: x[1], reverse=True)
+    rx_ports = sorted(rx_ports, key=lambda x: x[1], reverse=True)
+
+    backplane_tx_ports = [port[0] for port in tx_ports]
+    backplane_rx_ports = [port[0] for port in rx_ports]
+
+    traffic_paths = []
+
+    # Always cycle the smaller list
+    if len(backplane_tx_ports) >= len(backplane_rx_ports):
+        rx_cycle = cycle(backplane_rx_ports)  # RX cycles if fewer or equal
+        for tx_bp in backplane_tx_ports:
+            rx_bp = next(rx_cycle)
+            fabric_rx = ingress_fabric_mapping.get(tx_bp)
+            fabric_tx = egress_fabric_mapping.get(rx_bp)
+            if fabric_rx and fabric_tx:
+                path = [ingress, tx_bp, fabric_rx, fabric_tx, rx_bp, egress]
+                traffic_paths.append(path)
+    else:
+        tx_cycle = cycle(backplane_tx_ports)  # TX cycles if fewer
+        for rx_bp in backplane_rx_ports:
+            tx_bp = next(tx_cycle)
+            fabric_rx = ingress_fabric_mapping.get(tx_bp)
+            fabric_tx = egress_fabric_mapping.get(rx_bp)
+            if fabric_rx and fabric_tx:
+                path = [ingress, tx_bp, fabric_rx, fabric_tx, rx_bp, egress]
+                traffic_paths.append(path)
+
+    return traffic_paths
+
+
+def set_cir_cisco_8000(dut, ports, asic="", speed=240151205000):
+    dshell_script = '''
+from common import *
+from sai_utils import *
+
+def set_port_cir(interface, rate):
+    mp = get_mac_port(interface)
+    sch = mp.get_scheduler()
+    sch.set_credit_cir(rate)
+'''
+
+    for intf in ports:
+        dshell_script += f'\nset_port_cir("{intf}", {speed})'
+
+    script_path = "/tmp/set_scheduler.py"
+    dut.copy(content=dshell_script, dest=script_path)
+    dest = f"syncd{asic.asic_index}"
+
+    dut.docker_copy_to_all_asics(
+        container_name=dest,
+        src=script_path,
+        dst="/")
+
+    cmd = "sudo show platform npu script -n {} -s set_scheduler.py".format(asic.namespace)
+    dut.shell(cmd)
+
+
+def get_npu_voq_queue_counters(duthost, interface, priority, clear=False):
+    asic_namespace_string = ""
+    if duthost.is_multi_asic:
+        asic = duthost.get_port_asic_instance(interface)
+        asic_namespace_string = " -n " + asic.namespace
+
+    clear_cmd = ""
+    if clear:
+        clear_cmd = " -c"
+
+    full_line = "".join(duthost.shell(
+        "show platform npu voq queue_counters -t {} -i {} -d{}{}".
+        format(priority, interface, asic_namespace_string, clear_cmd))['stdout_lines'])
+    dict_output = json.loads(full_line)
+    for entry, value in zip(dict_output['stats_name'], dict_output['counters']):
+        dict_output[entry] = value
+
+    return dict_output
+>>>>>>> b1a1eb3b6 (Added test case for fabric egress port and backplane egress port ecn marking)

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import pytest
-import re
 import json
 from itertools import cycle
 from tests.common.broadcom_data import is_broadcom_device
@@ -233,6 +232,7 @@ def get_fabric_mapping(duthost, asic=""):
 
     return fabric_map
 
+
 def load_port_stats(stats, threshold, direction="both"):
     """
     Parses port statistics and filters interfaces involved in traffic forwarding.
@@ -383,4 +383,3 @@ def get_npu_voq_queue_counters(duthost, interface, priority, clear=False):
         dict_output[entry] = value
 
     return dict_output
->>>>>>> b1a1eb3b6 (Added test case for fabric egress port and backplane egress port ecn marking)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Test Cases for ECN Marking Verification on Cisco-8000 (Packet Mode)

Fabric Card : Verify ECN marking on the egress interface under congestion.
Ingress Line Card: Verify ECN marking on the interface towards the fabric card under congestion.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Added test case to verify the ecn marking on 
-- the Fabric egress interface 
-- the backplane egress interface of the LC

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Verify ecn marking functionality of the fabric and back plane interfaces

#### How did you do it?

Wrote snappi based test case 

#### How did you verify/test it?

Verified the test case on T2 ixia snappi test bed with sonic-mgmt

```

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================================ PASSES =============================================================================================================================================
__________________________________________________________________________________________________________________ test_fabric_ecn_marking_lossless_prio[multidut_port_info0] ___________________________________________________________________________________________________________________
__________________________________________________________________________________________________________________ test_fabric_ecn_marking_lossless_prio[multidut_port_info1] ___________________________________________________________________________________________________________________
__________________________________________________________________________________________________________________ test_fabric_ecn_marking_lossless_prio[multidut_port_info2] ___________________________________________________________________________________________________________________
_________________________________________________________________________________________________________________ test_backplane_ecn_marking_lossless_prio[multidut_port_info0] _________________________________________________________________________________________________________________
_________________________________________________________________________________________________________________ test_backplane_ecn_marking_lossless_prio[multidut_port_info1] _________________________________________________________________________________________________________________
_________________________________________________________________________________________________________________ test_backplane_ecn_marking_lossless_prio[multidut_port_info2] _________________________________________________________________________________________________________________
---------------------------------------------------------------------------------------------------- generated xml file: /run_logs/ixia/21831/2025-03-18-16-55-53/tr_2025-03-18-16-55-53.xml ----------------------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------------------------------------------------ live log sessionfinish -------------------------------------------------------------------------------------------------------------------------------------
17:27:03 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
==================================================================================================================================== short test summary info ====================================================================================================================================
PASSED snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_fabric_ecn_marking_lossless_prio[multidut_port_info0]
PASSED snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_fabric_ecn_marking_lossless_prio[multidut_port_info1]
PASSED snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_fabric_ecn_marking_lossless_prio[multidut_port_info2]
PASSED snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_backplane_ecn_marking_lossless_prio[multidut_port_info0]
PASSED snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_backplane_ecn_marking_lossless_prio[multidut_port_info1]
PASSED snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py::test_backplane_ecn_marking_lossless_prio[multidut_port_info2]
========================================================================================================================== 6 passed, 9 warnings in 1868.20s (0:31:08) ===========================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

cisco-8000 distributed system

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
