### PR TITLE
[acl/test_acl.py] Ensure frontend dut is used for T2 in ACL testing

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -261,7 +261,8 @@ def get_t2_info(duthosts, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter, topo_scenario, vlan_name):
+def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, rand_unselected_dut,
+          tbinfo, ptfadapter, topo_scenario, vlan_name):
     """Gather all required test information from DUT and tbinfo.
 
     Args:
@@ -275,8 +276,12 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
     """
 
     pytest_assert(vlan_name in ["Vlan1000", "Vlan2000", "no_vlan"], "Invalid vlan name.")
-    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
+    # NOTE: We cannot use rand_unselected_dut in this case
+    # ATM it's only used if 'dualtor' in tbinfo['topo']['name']
+    if topo == "t2":
+        rand_selected_dut = rand_selected_front_end_dut
+    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
 
     vlan_ports = []
     vlan_mac = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #17048 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Previously ACL test change picks up loopback ip from `rand_selected_dut`, on T2 devices supervisor card doesn't have a loopback ip causing errors
#### How did you do it?
Use `rand_selected_front_end_dut` instead of `rand_selected_dut` for T2
#### How did you verify/test it?
Ran 61 iterations of basic ACL test to make sure it passes on T2 device
Additionally:
T0: [Test plan 67daa46be946313de56c8bf2: ACL changes regression test T0 - Elastictest (elastictest.org)](https://elastictest.org/scheduler/testplan/67daa46be946313de56c8bf2)
T1: [Test plan 67daa4a42f30cd54926394de: ACL changes regression test T1 - Elastictest (elastictest.org)](https://elastictest.org/scheduler/testplan/67daa4a42f30cd54926394de)
T2: [Test plan 67daa4ebe946313de56c8bf4: ACL changes regression test T2 - Elastictest (elastictest.org)](https://elastictest.org/scheduler/testplan/67daa4ebe946313de56c8bf4)
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A