### PR TITLE
Temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py for cisco devices

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1309,7 +1309,7 @@ platform_tests/test_service_warm_restart.py:
 #####test_thermal_state_db.py #####
 #######################################
 
-platform_tests/test_thermal_state_db.py::test_thermal_state_db:
+platform_tests/test_thermal_state_db.py:
   skip:
     reason: "Skip in case of Cisco platform for T2 profile due to temperarory bug."
     conditions:


### PR DESCRIPTION
### Description of PR
Due to a Jira, temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py. Will revert it as soon as the jira is fixed

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Due to a Jira, temporarily skipping few testcases in platform_tests/api/test_thermal.py and test_thermal_state_db.py. Will revert it as soon as the jira is fixed

#### How did you do it?
Skip in conditional_mark file

#### How did you verify/test it?
SKIPPED [9] platform_tests/api/test_thermal.py: Unsupported platform API in mellanox. Skip in case of Cisco platform for T2 profile due to temperarory bug.

#### Any platform specific information?
Cisco 8808 chassis and T2 profile

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
