### PR TITLE
[performance_meter] allow specific run number for each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,12 +248,6 @@ def pytest_addoption(parser):
                      help="File that contains testcases to execute per iteration")
 
     #################################
-    #   Performance test options    #
-    #################################
-    parser.addoption("--performance-meter-run", action="store", default=1, type=int,
-                     help="Number of run for performance meter")
-
-    #################################
     #   Stress test options         #
     #################################
     parser.addoption("--run-stress-tests", action="store_true", default=False, help="Run only tests stress tests")

--- a/tests/performance_meter/config/sample_test_config
+++ b/tests/performance_meter/config/sample_test_config
@@ -1,11 +1,12 @@
-run_when: duthost.hostname == "HOSTNAME"
+run_when: '"HOSTNAME" in tbinfo["duts"]'
 
 performance_meter:
   sample_test_1:
+    run: 10
     op: noop
     success_criteria: random_success_20_perc
     random_success_20_perc_timeout: 10
-    random_success_20_perc_delay: 5
+    random_success_20_perc_interval: 1
     random_success_20_perc_foo: 42
     random_success_20_perc_success_rate_op: 1
     random_success_20_perc_success_rate: 0.7
@@ -13,6 +14,7 @@ performance_meter:
     random_success_20_perc_max: 10
     random_success_20_perc_mean: 8
   sample_test_2:
+    run: 10
     op: bad_op
     success_criteria: random_success_20_perc
     random_success_20_perc_timeout: 10

--- a/tests/performance_meter/config/sample_test_reboot_by_cmd
+++ b/tests/performance_meter/config/sample_test_reboot_by_cmd
@@ -2,7 +2,9 @@ run_when: tbinfo["topo"]["type"] in []
 
 performance_meter:
   reboot_by_cmd_to_bgp_up:
+    run: 10
     op: reboot_by_cmd
     success_criteria: bgp_up
     bgp_up_timeout: 1200
-    bgp_up_delay: 5
+    bgp_up_delay: 60
+    bgp_up_interval: 10

--- a/tests/performance_meter/conftest.py
+++ b/tests/performance_meter/conftest.py
@@ -3,51 +3,65 @@ import os
 import yaml
 import logging
 from tests.common.plugins.sanity_check import _sanity_check
+from tests.common.testbed import TestbedInfo
+from tests.conftest import cache
 
 
 TEST_DIR = "performance_meter"
 CONFIG_FILE_DIR = os.path.join(TEST_DIR, "config")
 
 
-test_result = None
-
-
-@pytest.fixture(scope="module")
 def load_test_config():
     if not os.path.exists(CONFIG_FILE_DIR):
         os.makedirs(CONFIG_FILE_DIR)
     config_paths = os.listdir(CONFIG_FILE_DIR)
-    open_config_files = {path: open(os.path.join(CONFIG_FILE_DIR, path)) for path in config_paths}
-
-    yield {path: yaml.safe_load(fp) for path, fp in open_config_files.items()}
-
-    for fp in open_config_files.values():
-        fp.close()
-
-
-def eval_condition(condition, duthost, tbinfo):
-    return eval(condition, {}, {"duthost": duthost, "tbinfo": tbinfo})
+    config_file_yaml = {}
+    for path in config_paths:
+        with open(os.path.join(CONFIG_FILE_DIR, path)) as f:
+            config_file_yaml[path] = yaml.safe_load(f.read())
+    return config_file_yaml
 
 
-@pytest.fixture(scope="module")
-def filter_test_config(duthosts, rand_one_dut_hostname, tbinfo, load_test_config):
-    duthost = duthosts[rand_one_dut_hostname]
+def eval_condition(condition, tbinfo):
+    return eval(condition, {}, {"tbinfo": tbinfo})
 
+
+def filter_test_config(tbinfo, load_test_config):
     def checker(item):
+        if "run_when" not in item[1]:
+            return True
+        if "performance_meter" not in item[1]:
+            return False
         run_condition = item[1]["run_when"]
         if isinstance(run_condition, list):
-            return all(map(lambda item: eval_condition(item, duthost, tbinfo), run_condition))
+            return all(map(lambda item: eval_condition(item, tbinfo), run_condition))
         if isinstance(run_condition, str):
-            return eval_condition(run_condition, duthost, tbinfo)
+            return eval_condition(run_condition, tbinfo)
         return False
     return dict(filter(checker, load_test_config.items()))
 
 
+# Original config structure similar to the config files as defined by user
 @pytest.fixture(scope="module")
-def reorg_test_config(filter_test_config):
+def filtered_test_config(tbinfo):
+    all_test_config = load_test_config()
+    filtered_test_config = filter_test_config(tbinfo, all_test_config)
+    yield filtered_test_config
+
+
+required_items_for_each_test = ["op", "success_criteria", "run"]
+
+
+# Reorg config structure around ops
+@pytest.fixture(scope="module")
+def reorged_test_config(filtered_test_config):
     all_test_config = {}
-    for path, config in filter_test_config.items():
+    for path, config in filtered_test_config.items():
         for test_name, test_config in config["performance_meter"].items():
+            assert all(map(lambda item: item in test_config, required_items_for_each_test)), \
+                   "{} should be in config".format(required_items_for_each_test)
+            assert (test_config["success_criteria"] + "_timeout") in test_config, \
+                   "success_criteria timeout should be in config"
             op = test_config["op"]
             test_config_for_op = all_test_config.get(op, {})
             test_config_under_path_for_op = test_config_for_op.get(path, {})
@@ -57,8 +71,18 @@ def reorg_test_config(filter_test_config):
     return all_test_config
 
 
+test_result = {}
+
+
+# Test result structures are structured around ops like reorged_test_config
 @pytest.fixture(scope="module")
-def store_test_result():
+def store_test_result(reorged_test_config):
+    for op, test_config_for_op in reorged_test_config.items():
+        test_result[op] = [None] * \
+                          max(map(lambda test_config_under_path_for_op:
+                                  max(map(lambda test_config: test_config["run"],
+                                          test_config_under_path_for_op.values())),
+                                  test_config_for_op.values()))
     return test_result
 
 
@@ -69,6 +93,9 @@ def store_test_result():
 # The run_index and op param is purely for logging and is optional
 @pytest.fixture(scope="function")
 def call_sanity_check(request, parallel_run_context):
+    if request.config.option.skip_sanity:
+        return lambda *args, **kwargs: True, lambda *args, **kwargs: True
+
     generator = None
 
     def sanity_check_setup(run_index=None, op=None):
@@ -97,9 +124,35 @@ def call_sanity_check(request, parallel_run_context):
     return sanity_check_setup, sanity_check_cleanup
 
 
+def get_tbinfo(config):
+    tbname = config.getoption("--testbed")
+    tbfile = config.getoption("--testbed_file")
+    if tbname is None or tbfile is None:
+        raise ValueError("testbed and testbed_file are required!")
+    testbedinfo = cache.read(tbname, "tbinfo")
+    if testbedinfo is cache.NOTEXIST:
+        testbedinfo = TestbedInfo(tbfile)
+        cache.write(tbname, "tbinfo", testbedinfo)
+    return testbedinfo.testbed_topo.get(tbname, {})
+
+
 def pytest_generate_tests(metafunc):
-    global test_result
-    if "run_index" in metafunc.fixturenames:
-        total_run = metafunc.config.getoption("--performance-meter-run")
-        test_result = [None] * total_run
-        metafunc.parametrize("run_index", range(total_run))
+    if metafunc.function.__name__ != "test_performance":
+        return
+
+    config = metafunc.config
+    tbinfo = get_tbinfo(config)
+
+    all_test_config = load_test_config()
+    filtered_test_config = filter_test_config(tbinfo, all_test_config)
+
+    params = []
+    for path, config in filtered_test_config.items():
+        for test_name, test_config in config["performance_meter"].items():
+            assert all(map(lambda item: item in test_config, required_items_for_each_test)), \
+                   "{} should be in config".format(required_items_for_each_test)
+            op = test_config["op"]
+            success_criteria = test_config["success_criteria"]
+            run = test_config["run"]
+            params.extend(map(lambda run_index: [path, test_name, op, success_criteria, run_index], range(run)))
+    metafunc.parametrize("path,test_name,op,success_criteria,run_index", params)

--- a/tests/performance_meter/ops.py
+++ b/tests/performance_meter/ops.py
@@ -44,3 +44,9 @@ async def reboot_by_cmd(duthost):
     command = asyncio.create_task(async_command_ignore_errors(duthost, "reboot"))
     yield True
     await command
+
+
+async def config_reload_by_cmd(duthost):
+    command = asyncio.create_task(async_command_ignore_errors(duthost, "config reload -y"))
+    yield True
+    await command

--- a/tests/performance_meter/success_criteria.py
+++ b/tests/performance_meter/success_criteria.py
@@ -1,15 +1,22 @@
 import logging
 import random
 import statistics
+import datetime
 from tests.common.helpers.assertions import pytest_assert
 
 
+# find success criteria function by exact name match
 def get_success_criteria_by_name(success_criteria):
     return globals()[success_criteria]
 
 
-def get_success_criteria_stats_by_name(success_criteria):
-    return globals().get(success_criteria + "_stats", None)
+# find succes criteria stats function
+# it is always expected to end in stats to distinguish from others
+def get_success_criteria_stats_by_name(name):
+    if name.endswith("_stats"):
+        return globals().get(name, None)
+    else:
+        return globals().get(name + "_stats", None)
 
 
 def suppress_exception(func):
@@ -27,7 +34,7 @@ def suppress_exception(func):
 # and all variables defined in config that starts with the
 # name of said criteria, as keyword args. If we have "bgp_up",
 # then it will take "bgp_up_timeout", "bgp_up_delay", "bgp_up_foo",
-# etc, and have "timeout", "delay", "foo" etc, as kwargs. kwarg can
+# etc, and have "timeout", "delay", "foo" etc, as kwargs. kwargs can
 # be used to pass any additional arguments and limitations
 # from config file to the success criteria function. Additionally a
 # timeout is always expected in config file because test can't hang
@@ -37,14 +44,14 @@ def suppress_exception(func):
 
 
 # sample success criteria function, returns True 20% of times.
-def random_success_20_perc(duthost, **kwarg):
+def random_success_20_perc(duthost, test_result, **kwargs):
     return lambda: random.random() < 0.2
 
 
 # Because each test run is separate, success criteria function cannot
 # process results of all runs, so there could be an optional success
 # criteria stats function, named with a "_stats" suffix, like
-# "bgp_up_stats", taking all the same kwarg variables as its single run
+# "bgp_up_stats", taking all the same kwargs variables as its single run
 # version. Unlike the single test run counter part, it takes
 # passed_op_precheck which is the test result of all test runs that
 # passed pre op sanity_check. The passed_op_precheck is a list of test
@@ -61,39 +68,118 @@ def random_success_20_perc(duthost, **kwarg):
 
 
 # sample success criteria stats
-def random_success_20_perc_stats(passed_op_precheck, **kwarg):
+def random_success_20_perc_stats(passed_op_precheck, **kwargs):
     finished_op = list(filter(lambda item: item["op_success"], passed_op_precheck))
-    if "success_rate_op" in kwarg:
+    if "success_rate_op" in kwargs:
         success_rate_op = len(finished_op) / len(passed_op_precheck)
         logging.warning("Success rate of op is {}".format(success_rate_op))
-        pytest_assert(success_rate_op >= kwarg["success_rate_op"],
+        pytest_assert(success_rate_op >= kwargs["success_rate_op"],
                       "Success rate of op {} is less than expected {}".format(success_rate_op,
-                                                                              kwarg["success_rate_op"]))
+                                                                              kwargs["success_rate_op"]))
     passed_success_criteria = list(filter(lambda result: result["passed"], finished_op))
-    if "success_rate" in kwarg:
+    if "success_rate" in kwargs:
         success_rate = len(passed_success_criteria) / len(finished_op)
         logging.warning("Success rate is {}".format(success_rate))
-        pytest_assert(success_rate >= kwarg["success_rate"],
-                      "Success rate {} is less than expected {}".format(success_rate, kwarg["success_rate"]))
-    if "max" in kwarg:
-        max_time_to_pass = max(map(lambda item: item["time_to_pass"], passed_success_criteria))
+        pytest_assert(success_rate >= kwargs["success_rate"],
+                      "Success rate {} is less than expected {}".format(success_rate, kwargs["success_rate"]))
+    all_time_to_pass = list(map(lambda item: item["time_to_pass"], passed_success_criteria))
+    if "max" in kwargs:
+        max_time_to_pass = max(all_time_to_pass)
         logging.warning("Max time_to_pass is {}".format(max_time_to_pass))
-        pytest_assert(max_time_to_pass <= kwarg["max"],
-                      "Max time_to_pass {} is more than defined max {}".format(max_time_to_pass, kwarg["max"]))
-    if "min" in kwarg:
-        min_time_to_pass = min(map(lambda item: item["time_to_pass"], passed_success_criteria))
+        pytest_assert(max_time_to_pass <= kwargs["max"],
+                      "Max time_to_pass {} is more than defined max {}".format(max_time_to_pass, kwargs["max"]))
+    if "min" in kwargs:
+        min_time_to_pass = min(all_time_to_pass)
         logging.warning("Min time_to_pass is {}".format(min_time_to_pass))
-        pytest_assert(min_time_to_pass >= kwarg["min"],
-                      "Min time_to_pass {} is less than defined min {}".format(min_time_to_pass, kwarg["min"]))
-    if "mean" in kwarg:
-        mean_time_to_pass = statistics.mean(map(lambda item: item["time_to_pass"], passed_success_criteria))
+        pytest_assert(min_time_to_pass >= kwargs["min"],
+                      "Min time_to_pass {} is less than defined min {}".format(min_time_to_pass, kwargs["min"]))
+    if "mean" in kwargs:
+        mean_time_to_pass = statistics.mean(all_time_to_pass)
         logging.warning("Mean time_to_pass is {}".format(mean_time_to_pass))
-        pytest_assert(mean_time_to_pass <= kwarg["mean"],
-                      "Mean time_to_pass {} is more than defined mean {}".format(mean_time_to_pass, kwarg["mean"]))
-    logging.warning("Foo is {}".format(kwarg["foo"]))
+        pytest_assert(mean_time_to_pass <= kwargs["mean"],
+                      "Mean time_to_pass {} is more than defined mean {}".format(mean_time_to_pass, kwargs["mean"]))
+    if "stdev" in kwargs:
+        stdev_time_to_pass = statistics.stdev(all_time_to_pass)
+        logging.warning("Stdev time_to_pass is {}".format(stdev_time_to_pass))
+        pytest_assert(stdev_time_to_pass <= kwargs["stdev"],
+                      "Stdev time_to_pass {} is more than defined stdev {}".format(stdev_time_to_pass, kwargs["stdev"]))
+    logging.warning("Foo is {}".format(kwargs["foo"]))
 
 
-def bgp_up(duthost, **kwarg):
-    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
-    bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {}).keys()
+def display_variable_stats(passed_op_precheck, **kwargs):
+    finished_op = list(filter(lambda item: item["op_success"], passed_op_precheck))
+    success_rate_op = len(finished_op) / len(passed_op_precheck)
+    logging.warning("Success rate of op is {}".format(success_rate_op))
+    passed_success_criteria = list(filter(lambda result: result["passed"], finished_op))
+    success_rate = len(passed_success_criteria) / len(finished_op)
+    logging.warning("Success rate is {}".format(success_rate))
+    if "display_variable" in kwargs:
+        display_variable = kwargs["display_variable"]
+        all_display_variable = list(map(lambda item: item[display_variable], passed_success_criteria))
+        max_display_variable = max(all_display_variable)
+        logging.warning("Max {} is {}".format(display_variable, max_display_variable))
+        min_display_variable = min(all_display_variable)
+        logging.warning("Min {} is {}".format(display_variable, min_display_variable))
+        mean_display_variable = statistics.mean(all_display_variable)
+        logging.warning("Mean {} is {}".format(display_variable, mean_display_variable))
+        stdev_display_variable = statistics.stdev(all_display_variable)
+        logging.warning("Stdev {} is {}".format(display_variable, stdev_display_variable))
+
+
+def bgp_up(duthost, test_result, **kwargs):
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+    bgp_neighbors = config_facts.get("BGP_NEIGHBOR", {}).keys()
     return suppress_exception(lambda: duthost.check_bgp_session_state(bgp_neighbors))
+
+
+def _extract_timestamp(duthost, line):
+    timestamp = line[:line.index(duthost.hostname) - 1]
+    formats = ["%Y %b %d %H:%M:%S.%f", "%b %d %H:%M:%S.%f", "%b %d %H:%M:%S"]
+    for f in formats:
+        try:
+            return datetime.datetime.strptime(timestamp, f)
+        except ValueError:
+            continue
+    raise ValueError("Unable to parse {}".format(timestamp))
+
+
+def _get_last_timestamp(duthost):
+    stdout = duthost.shell("show logging | tail -n 1")["stdout"]
+    return _extract_timestamp(duthost, stdout)
+
+
+def swss_up(duthost, test_result, **kwargs):
+    last_timestamp = _get_last_timestamp(duthost)
+    cur_swss_start = None
+    swss_start_cmd = "show logging | grep 'docker cmd: start for swss' | grep -v ansible | tail -n 1"
+    swss_started_cmd = "show logging | grep 'Feature swss is enabled and started' | grep -v ansible | tail -n 1"
+
+    @suppress_exception
+    def swss_up_checker():
+        nonlocal cur_swss_start
+        if cur_swss_start is None:
+            stdout = duthost.shell(swss_start_cmd)["stdout"]
+            swss_start = _extract_timestamp(duthost, stdout)
+            if swss_start > last_timestamp:
+                cur_swss_start = swss_start
+        if cur_swss_start is not None:
+            stdout = duthost.shell(swss_started_cmd)["stdout"]
+            swss_started = _extract_timestamp(duthost, stdout)
+            if swss_started > cur_swss_start:
+                test_result["swss_start_time"] = (swss_started - cur_swss_start).seconds
+                return True
+        return False
+    return swss_up_checker
+
+
+def startup_mem_usage_after_bgp_up(duthost, test_result, **kwargs):
+    bgp_up_checker = bgp_up(duthost, test_result, **kwargs)
+
+    @suppress_exception
+    def checker():
+        if bgp_up_checker():
+            cmd = "cat /proc/meminfo | grep MemAvailable | egrep -o '[0-9]+'"
+            test_result["mem_available"] = int(duthost.shell(cmd)["stdout"])
+            return True
+        return False
+    return checker

--- a/tests/performance_meter/test_performance.py
+++ b/tests/performance_meter/test_performance.py
@@ -12,6 +12,12 @@ from success_criteria import get_success_criteria_by_name
 from success_criteria import get_success_criteria_stats_by_name
 
 
+pytestmark = [
+    pytest.mark.sanity_check(skip_sanity=True),  # will be invoked manually in test
+    pytest.mark.disable_loganalyzer
+]
+
+
 # This tests is designed to test the performance of certain operation
 # on designated devices. The process is separated into 2 test cases.
 # test_performance will run N times as designated by user input.
@@ -35,102 +41,86 @@ def filter_vars(my_vars, prefix):
     return dict(map_vars)
 
 
-async def check_success_criteria(timeout, delay, checker, result):
+async def check_success_criteria(timeout, delay, interval, checker, result):
     start_time = time.time()
-    result["passed"] = wait_until(timeout=timeout, interval=1, delay=delay, condition=checker)
+    result["passed"] = wait_until(timeout=timeout, interval=interval, delay=delay, condition=checker)
     end_time = time.time()
     result["time_to_pass"] = end_time - start_time
 
 
-async def async_test_performance(duthosts, rand_one_dut_hostname, call_sanity_check,
-                                 reorg_test_config, run_index, store_test_result):
-    duthost = duthosts[rand_one_dut_hostname]
-    logging.info("Test run {} of performance test on {}".format(run_index, rand_one_dut_hostname))
-
-    single_run_result = {}
-    store_test_result[run_index] = single_run_result
-
+async def run_test_performance_for_op(duthost, call_sanity_check, reorged_test_config, op, run_index):
     sanity_check_setup, sanity_check_cleanup = call_sanity_check
 
-    # run and test each op one by one
-    for op, test_config_for_op in reorg_test_config.items():
-        op_test_result = {}
-        single_run_result[op] = op_test_result
+    single_run_result = {}
+    test_config_for_op = reorged_test_config[op]
 
-        # before do_op, check that dut is healthy
-        if sanity_check_setup(run_index, op) is False:
-            op_test_result["op_precheck_success"] = False
-            continue
-        op_test_result["op_precheck_success"] = True
+    # before do_op, check that dut is healthy
+    op_precheck_success = sanity_check_setup(run_index, op)
+    single_run_result["op_precheck_success"] = op_precheck_success
+    if op_precheck_success is False:
+        return single_run_result
 
-        # prior to op, prepare for checking success criteria
-        coros = []
-        for path, test_config_under_path in test_config_for_op.items():
-            path_test_result = {}
-            op_test_result[path] = path_test_result
-            for test_name, test_config in test_config_under_path.items():
-                success_criteria = test_config["success_criteria"]
-                filtered_vars = filter_vars(test_config, success_criteria)
-                pytest_assert("timeout" in filtered_vars, "{}_timeout variable is not defined for {}"
-                                                          .format(success_criteria, success_criteria))
-                timeout = filtered_vars["timeout"]
-                delay = filtered_vars.get("delay", 0)
-                checker = get_success_criteria_by_name(success_criteria)(duthost, **filtered_vars)
-                test_result = {}
-                path_test_result[test_name] = test_result
-                coros.append(check_success_criteria(timeout, delay, checker, test_result))
+    # prior to op, prepare for checking success criteria
+    coros = []
+    for path, test_config_under_path in test_config_for_op.items():
+        path_test_result = {}
+        single_run_result[path] = path_test_result
+        for test_name, test_config in test_config_under_path.items():
+            if run_index > test_config["run"]:
+                continue
+            test_result = {}
+            path_test_result[test_name] = test_result
+            success_criteria = test_config["success_criteria"]
+            filtered_vars = filter_vars(test_config, success_criteria)
+            timeout = filtered_vars["timeout"]
+            delay = filtered_vars.get("delay", 0)
+            interval = filtered_vars.get("interval", 1)
+            checker = get_success_criteria_by_name(success_criteria)(duthost, test_result, **filtered_vars)
+            coros.append(check_success_criteria(timeout, delay, interval, checker, test_result))
 
-        # do the op setup, it can block but should NEVER block forever
-        # return True on success, False on fail
-        # failure will stop test for op
-        async with asynccontextmanager(get_op_by_name(op))(duthost) as op_success:
-            op_test_result["op_success"] = op_success
-            if op_success:
-                asyncio.gather(*coros)
-            else:
-                logging.warning("Test run {} op {} failed".format(run_index, op))
-                for coro in coros:
-                    coro.close()
+    # do the op setup, it can block but should NEVER block forever
+    # return True on success, False on fail
+    # failure will stop test for op
+    async with asynccontextmanager(get_op_by_name(op))(duthost) as op_success:
+        single_run_result["op_success"] = op_success
+        if op_success:
+            asyncio.gather(*coros)
+        else:
+            for coro in coros:
+                coro.close()
 
-        # after op finishes cleanup, check that dut is healthy
-        if sanity_check_cleanup(run_index, op) is False:
-            op_test_result["op_postcheck_success"] = False
-            continue
-        op_test_result["op_postcheck_success"] = True
+    # after op finishes cleanup, check that dut is healthy
+    single_run_result["op_postcheck_success"] = sanity_check_cleanup(run_index, op)
+    return single_run_result
 
-    logging.info("Test run {} result {}".format(run_index, single_run_result))
+
+async def async_test_performance(duthost, call_sanity_check, reorged_test_config, store_test_result,
+                                 path, test_name, op, success_criteria, run_index):
+    if op not in reorged_test_config or path not in reorged_test_config[op]:
+        pytest.skip("Test condition run_when does not match")
+    logging.info("Running path {} test_name {} op {} success_criteria {} run_index {}"
+                 .format(path, test_name, op, success_criteria, run_index))
+    if not store_test_result[op][run_index]:
+        logging.info("The {}th op {} has not been run, running now".format(run_index, op))
+        store_test_result[op][run_index] = await run_test_performance_for_op(duthost, call_sanity_check,
+                                                                             reorged_test_config, op, run_index)
+    test_result = store_test_result[op][run_index]
+    logging.info("Result of path {} test_name {} op {} success_criteria {} run_index {}: {}"
+                 .format(path, test_name, op, success_criteria, run_index, test_result))
 
 
 # Ideally, test_performance should not give errors and only collect results regardless of the
 # errors received. Analyzing the result is reserved for test_performance_stats
-@pytest.mark.disable_loganalyzer
-def test_performance(duthosts, rand_one_dut_hostname, call_sanity_check, reorg_test_config,
-                     run_index, store_test_result):     # noqa F811
-    asyncio.run(async_test_performance(duthosts, rand_one_dut_hostname, call_sanity_check,
-                reorg_test_config, run_index, store_test_result))
+def test_performance(duthost, call_sanity_check, reorged_test_config, store_test_result,
+                     path, test_name, op, success_criteria, run_index):     # noqa F811
+    asyncio.run(async_test_performance(duthost, call_sanity_check, reorged_test_config, store_test_result,
+                                       path, test_name, op, success_criteria, run_index))
 
 
-def reorg_test_result(test_config, test_result):
-    total_run = len(test_result)
-    reorged_test_result = {path: {test_name: [None] * total_run
-                                  for test_name, _ in config["performance_meter"].items()}
-                           for path, config in test_config.items()}
-    for run_index, single_run_result in enumerate(test_result):
-        if single_run_result is None:
-            continue
-        for op, op_test_result in single_run_result.items():
-            for path, reorged_path_test_result in reorged_test_result.items():
-                for test_name, result in reorged_path_test_result.items():
-                    if test_config[path]["performance_meter"][test_name]["op"] == op:
-                        result[run_index] = {**op_test_result,
-                                             **op_test_result.get(path, {}).get(test_name, {})}
-    return reorged_test_result
-
-
-def process_single_test_case(test_config, single_test_result):
+def process_single_test_case(test_config, single_test_results):
     # test environment issue
     success_criteria = test_config["success_criteria"]
-    passed_sanity_check = list(filter(lambda item: item is not None, single_test_result))
+    passed_sanity_check = list(filter(lambda item: item is not None, single_test_results))
     logging.warning("{} runs passed sanity check".format(len(passed_sanity_check)))
     passed_op_precheck = list(filter(lambda item: item["op_precheck_success"], passed_sanity_check))
     logging.warning("{} runs passed op precheck".format(len(passed_op_precheck)))
@@ -139,32 +129,47 @@ def process_single_test_case(test_config, single_test_result):
     logging.warning("{} runs finished op".format(len(finished_op)))
     passed_success_criteria = list(filter(lambda result: result["passed"], finished_op))
     logging.warning("{} runs passed {} before timeout".format(len(passed_success_criteria), success_criteria))
-    if len(passed_success_criteria) == 0:
-        logging.warning("No meaningful result has been collected")
-    else:
-        time_to_pass = list(map(lambda result: result["time_to_pass"], passed_success_criteria))
+    time_to_pass = list(map(lambda result: result["time_to_pass"], passed_success_criteria))
+    if len(passed_success_criteria) > 0:
         mean = statistics.mean(time_to_pass)
         logging.warning("Mean time to pass: {}".format(mean))
+    else:
+        logging.warning("No meaningful mean has been collected")
+    if len(passed_success_criteria) > 1:
+        stdev = statistics.stdev(time_to_pass)
+        logging.warning("Stdev time to pass: {}".format(stdev))
+    else:
+        logging.warning("No meaningful stdev has been collected")
     passed_op_postcheck = list(filter(lambda item: item["op_postcheck_success"], finished_op))
     logging.warning("{} runs passed op postcheck".format(len(passed_op_postcheck)))
     # specific stats check
-    if passed_op_precheck and get_success_criteria_stats_by_name(success_criteria):
-        return get_success_criteria_stats_by_name(success_criteria)(passed_op_precheck,
-                                                                    **filter_vars(test_config,
-                                                                                  success_criteria))
+    success_criteria_stats = get_success_criteria_stats_by_name(test_config.get("success_criteria_stats",
+                                                                                success_criteria + "_stats"))
+    if success_criteria_stats:
+        try:
+            success_criteria_stats(passed_op_precheck, **filter_vars(test_config, success_criteria))
+        except pytest.fail.Exception as e:
+            # assertion error, we want to catch this and report this
+            return e
+        except Exception as e:
+            # when unexpected exception happen, it is typically not meaningful result
+            # we dont want it to block other tests, so we just log and continue
+            logging.warning("Unexpected error occured when processing {}: {}".format(success_criteria_stats, e))
+            pass
     return True
 
 
-def test_performance_stats(filter_test_config, store_test_result):
-    test_result = reorg_test_result(filter_test_config, store_test_result)
+def test_performance_stats(filtered_test_config, store_test_result):
     failed_tests = []
-    for path, path_test_result in test_result.items():
+    for path, test_config_for_path in filtered_test_config.items():
         logging.warning("Analyzing result for config file {}".format(path))
-        for test_name, result in path_test_result.items():
+        for test_name, test_config in test_config_for_path["performance_meter"].items():
             logging.warning("Analyzing result for test case {}".format(test_name))
-            test_config = filter_test_config[path]["performance_meter"][test_name]
-            if process_single_test_case(test_config, result) is False:
-                failed_tests.append((path, test_name))
+            single_test_results = map(lambda result: {**result, **result[path][test_name]},
+                                      store_test_result[test_config["op"]][:test_config["run"]])
+            result = process_single_test_case(test_config, single_test_results)
+            if result is not True:
+                failed_tests.append((path, test_name, result))
             logging.warning("Finished analyzing result for test case {}".format(test_name))
         logging.warning("Finished analyzing result for config file {}".format(path))
     pytest_assert(len(failed_tests) == 0, "{} tests failed: {}".format(len(failed_tests), failed_tests))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add configuration of run count on different test case

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Originally run count of all performance meter test cases are the same and is input by command line argument from run_tests. It can be inconvenient sometimes

#### How did you do it?
Add entry in config file and read it. The config file will be assessed in pytest_generate_tests

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
