### PR TITLE
Revert "Fix BMP tests"

### DIFF
--- a/tests/bmp/helper.py
+++ b/tests/bmp/helper.py
@@ -1,8 +1,6 @@
 
-import pytest
 import logging
 from tests.common.helpers.bmp_utils import BMPEnvironment
-from tests.common import config_reload
 
 
 logger = logging.getLogger(__name__)
@@ -130,19 +128,3 @@ def show_bmp_tables(duthost):
     ret = duthost.command(cmd_show_tables, module_ignore_errors=True)
     logging.debug("show_bmp_tables output is: {}".format(ret))
     return ret
-
-
-@pytest.fixture
-def enable_bmp_feature(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    duthost.shell('sudo config feature state bmp enabled')
-    duthost.shell('sudo config save -y')
-    # Config reload is needed so that bgpd can restart with `-M bmp` argument
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
-
-    yield
-
-    duthost.shell('sudo config feature state bmp disabled')
-    duthost.shell('sudo config save -y')
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)

--- a/tests/bmp/test_bmp_statedb.py
+++ b/tests/bmp/test_bmp_statedb.py
@@ -3,7 +3,7 @@ import pytest
 import time
 import re
 import json
-from bmp.helper import enable_bmp_neighbor_table, enable_bmp_rib_in_table, enable_bmp_rib_out_table, enable_bmp_feature # noqa F401
+from bmp.helper import enable_bmp_neighbor_table, enable_bmp_rib_in_table, enable_bmp_rib_out_table
 
 logger = logging.getLogger(__name__)
 
@@ -91,9 +91,8 @@ def get_ipv6_neighbors(duthost):
     return ipv6_addresses
 
 
-def test_bmp_population(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost,
-                        enable_bmp_feature): # noqa F811
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+def test_bmp_population(duthosts, rand_one_dut_hostname, localhost):
+    duthost = duthosts[rand_one_dut_hostname]
 
     # neighbor table - ipv4 neighbor
     # only pick-up sent_cap attributes for typical check first.

--- a/tests/bmp/test_docker_restart.py
+++ b/tests/bmp/test_docker_restart.py
@@ -4,8 +4,6 @@ import logging
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 
-from bmp.helper import enable_bmp_feature # noqa F401
-
 logger = logging.getLogger(__name__)
 
 pytestmark = [
@@ -13,8 +11,8 @@ pytestmark = [
 ]
 
 
-def test_restart_bmp_docker(duthosts, enable_bmp_feature,               # noqa F811
-                            enum_rand_one_per_hwsku_frontend_hostname): # noqa F811
+def test_restart_bmp_docker(duthosts,
+                            enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#17179

BMP will be enabled by default by deploy-mg for all the tests due to this change: https://github.com/sonic-net/sonic-mgmt/pull/16081.

Therefore https://github.com/sonic-net/sonic-mgmt/pull/17179 is no longer needed.