### PR TITLE
Revert "Fix the issue introduced by the PR #16716"

### DIFF
--- a/ansible/roles/vm_set/tasks/get_dut_port.yml
+++ b/ansible/roles/vm_set/tasks/get_dut_port.yml
@@ -54,6 +54,6 @@
 
 - set_fact:
     duts_fp_ports: "{{ duts_fp_ports|default({}) | combine( { dut_name: dut_fp_ports } ) }}"
-    duts_midplane_ports: "{{ duts_midplane_ports|default({}) | combine( { dut_name: dut_midplane_ports|default([]) } ) }}"
-    duts_inband_ports: "{{ duts_inband_ports|default({}) | combine( { dut_name: dut_inband_ports|default([]) } ) }}"
+    duts_midplane_ports: "{{ duts_midplane_ports|default({}) | combine( { dut_name: dut_midplane_ports } ) }}"
+    duts_inband_ports: "{{ duts_inband_ports|default({}) | combine( { dut_name: dut_inband_ports } ) }}"
     duts_mgmt_port: "{{ duts_mgmt_port|default([]) + [ dut_mgmt_port ] }}"


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#17516

Originally #17516 was intended to fix an issue introduced in #16716. However, it turns out that it does not work.
We have to revert #16716. Before reverting 16716, #17516 must be reverted first. Otherwise, there will be conflicts.