### PR TITLE
[dualtor io][control plane utils] Allow for polling more times

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -69,6 +69,12 @@ EXPECTED_TUNNEL_ROUTE_MAP = {
 }
 
 
+def wait_until_with_last_check(timeout, interval, delay, condition, *args, **kwargs):
+    """Always allow for extra check after timeout."""
+    check_result = wait_until(timeout, interval, delay, condition, *args, **kwargs)
+    return check_result or condition(*args, **kwargs)
+
+
 class DBChecker:
 
     def __init__(self, duthost, state, health, intf_names='all',
@@ -106,8 +112,8 @@ class DBChecker:
 
     def verify_db(self, db):
         pytest_assert(
-            wait_until(self.VERIFY_DB_TIMEOUT, 10, 0,
-                       self.get_mismatched_ports, db),
+            wait_until_with_last_check(self.VERIFY_DB_TIMEOUT, 10, 0,
+                                       self.get_mismatched_ports, db),
             "Database states don't match expected state {state},"
             "incorrect {db_name} values {db_states}"
             .format(state=self.state, db_name=DB_NAME_MAP[db],

--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -69,7 +69,7 @@ EXPECTED_TUNNEL_ROUTE_MAP = {
 }
 
 
-def wait_until_with_last_check(timeout, interval, delay, condition, *args, **kwargs):
+def wait_until_with_final_check(timeout, interval, delay, condition, *args, **kwargs):
     """Always allow for extra check after timeout."""
     check_result = wait_until(timeout, interval, delay, condition, *args, **kwargs)
     return check_result or condition(*args, **kwargs)
@@ -112,8 +112,8 @@ class DBChecker:
 
     def verify_db(self, db):
         pytest_assert(
-            wait_until_with_last_check(self.VERIFY_DB_TIMEOUT, 10, 0,
-                                       self.get_mismatched_ports, db),
+            wait_until_with_final_check(self.VERIFY_DB_TIMEOUT, 10, 0,
+                                        self.get_mismatched_ports, db),
             "Database states don't match expected state {state},"
             "incorrect {db_name} values {db_states}"
             .format(state=self.state, db_name=DB_NAME_MAP[db],


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To fix the `test_upper_tor_config_reload_downstream_lower_tor` db validate failure:
```
self = <tests.common.dualtor.control_plane_utils.DBChecker object at 0x7f4ca6d98490>
db = 6

    def verify_db(self, db):
>       pytest_assert(
            wait_until(self.VERIFY_DB_TIMEOUT, 10, 0,
                       self.get_mismatched_ports, db),
            "Database states don't match expected state {state},"
            "incorrect {db_name} values {db_states}"
            .format(state=self.state, db_name=DB_NAME_MAP[db],
                    db_states=json.dumps(self.mismatch_ports,
                                         indent=4,
                                         sort_keys=True)))
E       Failed: Database states don't match expected state standby,incorrect STATE_DB values {
E           "MUX_LINKMGR_TABLE|Ethernet64": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet72": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet76": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet80": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet84": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet88": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet92": {
E               "state": "unhealthy"
E           },
E           "MUX_LINKMGR_TABLE|Ethernet96": {
E               "state": "unhealthy"
E           }
E       }

db         = 6
self       = <tests.common.dualtor.control_plane_utils.DBChecker object at 0x7f4ca6d98490>
```
* the failure is due to the data polling takes around 4+ seconds, the check function with 30s timeout/10s interval is only able to poll the data 2 times; sometimes the device recovers in the last ten-seconds interval:
```
18/03/2025 05:24:43 utilities.wait_until                     L0133 DEBUG  | Wait until get_mismatched_ports is True, timeout is 30 seconds, checking interval is 10, delay is 0 seconds
18/03/2025 05:24:43 utilities.wait_until                     L0143 DEBUG  | Time elapsed: 0.000000 seconds
18/03/2025 05:24:43 control_plane_utils.get_mismatched_ports L0144 INFO   | Verifying STATE_DB values on <MultiAsicSonicHost str2-7050cx3-acs-08>: expected state = standby, expected health = healthy
18/03/2025 05:24:49 utilities.wait_until                     L0161 DEBUG  | get_mismatched_ports is False, wait 10 seconds and check again
18/03/2025 05:24:59 utilities.wait_until                     L0143 DEBUG  | Time elapsed: 15.993076 seconds
18/03/2025 05:24:59 control_plane_utils.get_mismatched_ports L0144 INFO   | Verifying STATE_DB values on <MultiAsicSonicHost str2-7050cx3-acs-08>: expected state = standby, expected health = healthy
18/03/2025 05:25:04 utilities.wait_until                     L0161 DEBUG  | get_mismatched_ports is False, wait 10 seconds and check again
18/03/2025 05:25:14 utilities.wait_until                     L0166 DEBUG  | get_mismatched_ports is still False after 30 seconds, exit with False
18/03/2025 05:25:14 __init__._log_sep_line                   L0170 INFO   | ==================== dualtor_io/test_normal_op.py::test_upper_tor_config_reload_downstream_lower_tor[active-standby] teardown ====================
```
```
2025 Mar 18 05:25:05.519630 str2-7050cx3-acs-08 NOTICE mux#linkmgrd: link_manager/LinkManagerStateMachineActiveStandby.cpp:562 handleStateChange: Ethernet76: Received link state event, new state: Up
2025 Mar 18 05:25:05.519805 str2-7050cx3-acs-08 NOTICE mux#linkmgrd: link_manager/LinkManagerStateMachineActiveStandby.cpp:596 handleStateChange: Ethernet76: (P: Standby, M: Standby, L: Down) -> (P: Standby, M: Standby, L: Up)
2025 Mar 18 05:25:05.519960 str2-7050cx3-acs-08 NOTICE mux#linkmgrd: link_manager/LinkManagerStateMachineActiveStandby.cpp:232 setLabel: Ethernet76: Linkmgrd state is: Standby Healthy
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Allow polling for an extra time if the check function fails with the original timeout.

#### How did you verify/test it?
```
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_downstream_lower_tor[active-standby] PASSED           [ 50%]
dualtor_io/test_normal_op.py::test_upper_tor_config_reload_downstream_lower_tor[active-active] SKIPPED (Skip
cable type 'active-active')                                                                                      [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
