### PR TITLE
Add python script to collect dump on all duts

### DIFF
--- a/.azure-pipelines/collect_dump.py
+++ b/.azure-pipelines/collect_dump.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import sys
+import datetime
+import traceback
+import tarfile
+import gzip
+
+_self_dir = os.path.dirname(os.path.abspath(__file__))
+base_path = os.path.realpath(os.path.join(_self_dir, ".."))
+if base_path not in sys.path:
+    sys.path.append(base_path)
+ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
+if ansible_path not in sys.path:
+    sys.path.append(ansible_path)
+
+from devutil.devices.factory import init_testbed_sonichosts  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+RC_INIT_FAILED = 1
+RC_GET_TECHSUPPORT_FAILED = 2
+TECHSUPPORT_SAVE_PATH = '../tests/logs/'
+LOGS_DIR = os.path.join(_self_dir, TECHSUPPORT_SAVE_PATH)
+
+
+def get_techsupport(dut, time_since):
+    """Runs 'show techsupport' on SONiC devices and saves the output to logs/"""
+    try:
+        logger.info(f"Collecting techsupport from {dut.hostname}")
+        # Run "show techsupport" command
+        result = dut.command(f"show techsupport --since {time_since}")
+        if result['rc'] == 0:
+            tar_file = result['stdout_lines'][-1]
+            dut.fetch_no_slurp(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
+
+    except Exception as e:
+        logger.info(f"Failed to get techsupport on {dut.hostname} for {e}")
+        sys.exit(RC_GET_TECHSUPPORT_FAILED)
+
+
+def extract_dump_tar_gz(tar_file_path, extract_path):
+    with tarfile.open(tar_file_path, 'r') as tar:
+        members = tar.getmembers()
+        for member in members:
+            logger.info("Extracting {} {}".format(member.path, member.name))
+            if "log/syslog" in member.path:
+                try:
+                    logger.info("Extracting {} {} to {}".format(member.path, member.name, extract_path))
+                    tar.extract(member, path=extract_path)
+                except Exception as e:
+                    logger.info("Error extracting {} {}: {}".format(member.path, member.name, e))
+
+
+def extract_gz_file(gz_file_path):
+    extracted_file_path = os.path.splitext(gz_file_path)[0]
+    try:
+        with gzip.open(gz_file_path, 'rb') as f_in:
+            with open(extracted_file_path, 'wb') as f_out:
+                f_out.write(f_in.read())
+        os.remove(gz_file_path)
+    except Exception as e:
+        logger.info("Extract gz file {} failed: {}".format(gz_file_path, str(e)))
+        traceback.logger.info_exc()
+
+
+def extract_dump_file(testbed_name_with_idx, hostname):
+    try:
+        # extract dump file
+        dump_file = [file for file in os.listdir(LOGS_DIR)
+                     if file.startswith("sonic_dump") and file.endswith(".tar.gz")][0]
+        dump_file_path = os.path.join(TECHSUPPORT_SAVE_PATH, dump_file)
+        extract_dump_tar_gz(dump_file_path, TECHSUPPORT_SAVE_PATH)
+
+        # rename dump file
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        new_file_name = testbed_name_with_idx + "_" + hostname + "_" + timestamp
+        new_file_path = os.path.join(LOGS_DIR, new_file_name)
+        os.rename(os.path.join(_self_dir, dump_file_path), os.path.join(LOGS_DIR, new_file_name + ".tar.gz"))
+        os.rename(os.path.join(_self_dir, dump_file_path.split(".tar.gz")[0]), new_file_path)
+
+        # extract syslog gz files
+        syslog_dir = os.path.join(new_file_path, "log")
+        syslog_gz_files = [file for file in os.listdir(os.path.join(LOGS_DIR, syslog_dir))
+                           if file.startswith("syslog") and file.endswith(".gz")]
+        logger.info("Syslog files: {}".format(syslog_gz_files))
+        for syslog_gz in syslog_gz_files:
+            syslog_gz_files_path = os.path.join(syslog_dir, syslog_gz)
+            extract_gz_file(syslog_gz_files_path)
+
+    except Exception as e:
+        logger.info("Extract dump file failed: " + str(e))
+        traceback.logger.info_exc()
+
+
+def main(args):
+    logger.info("Initializing hosts")
+    sonichosts = init_testbed_sonichosts(
+        args.inventory, args.testbed_name, testbed_file=args.tbfile, options={"verbosity": args.verbosity}
+    )
+
+    if not sonichosts:
+        sys.exit(RC_INIT_FAILED)
+
+    if not os.path.exists(LOGS_DIR):
+        os.makedirs(LOGS_DIR)
+
+    for dut in sonichosts:
+        get_techsupport(dut, time_since=args.time_since)
+        extract_dump_file(testbed_name_with_idx=args.testbed_name_with_idx, hostname=dut.hostname)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Tool for getting techsupport logs from SONiC devices."
+    )
+
+    parser.add_argument(
+        "-i", "--inventory",
+        dest="inventory",
+        nargs="+",
+        help="Ansible inventory file"
+    )
+
+    parser.add_argument(
+        "-t", "--testbed-name",
+        type=str,
+        required=True,
+        dest="testbed_name",
+        help="Testbed name."
+    )
+
+    parser.add_argument(
+        "-n", "--testbed-name-with-idx",
+        type=str,
+        required=True,
+        dest="testbed_name_with_idx",
+        help="Testbed name with idx."
+    )
+
+    parser.add_argument(
+        "-f",
+        type=str,
+        dest="tbfile",
+        default="testbed.yaml",
+        help="Testbed definition file."
+    )
+
+    parser.add_argument(
+        "-s",
+        type=str,
+        dest="time_since",
+        default="yesterday",
+        help="Collect dump since."
+    )
+
+    parser.add_argument(
+        "-v", "--verbosity",
+        type=int,
+        dest="verbosity",
+        default=2,
+        help="Log verbosity (0-3)."
+    )
+
+    args = parser.parse_args()
+    main(args)

--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -14,30 +14,6 @@ pytestmark = [
 ]
 
 
-def test_collect_techsupport(request, duthosts, enum_dut_hostname):
-    since = request.config.getoption("--posttest_show_tech_since")
-    if since == '':
-        since = 'yesterday'
-    duthost = duthosts[enum_dut_hostname]
-    """
-    A util for collecting techsupport after tests.
-
-    Since nightly test on Jenkins will do a cleanup at the beginning of tests,
-    we need a method to save history logs and dumps. This util does the job.
-    """
-    logger.info("Collecting techsupport since {}".format(since))
-    # Because Jenkins is configured to save artifacts from tests/logs,
-    # and this util is mainly designed for running on Jenkins,
-    # save path is fixed to logs for now.
-    TECHSUPPORT_SAVE_PATH = 'logs/'
-    out = duthost.command("show techsupport --since {}".format(since), module_ignore_errors=True)
-    if out['rc'] == 0:
-        tar_file = out['stdout_lines'][-1]
-        duthost.fetch_no_slurp(src=tar_file, dest=TECHSUPPORT_SAVE_PATH, flat=True)
-
-    assert True
-
-
 def test_restore_container_autorestart(duthosts, enum_dut_hostname, enable_container_autorestart):
     duthost = duthosts[enum_dut_hostname]
     enable_container_autorestart(duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
posttest will collect techsupport and store in tests/logs, then elastictest will parse syslogs in dump file then upload both syslog and sonic dump file, but once posttest failed, then there will be no syslog and dumps.
#### How did you do it?
1. Use a separate python script to collect dump and rename with testbed_name_with_idx, dut_name and timestamp, then parse syslog files
2. In dualtor, will collect on both duts
3. Use elastictest upload syslog and dump files
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
