### PR TITLE
Enhance the fib test to run on dualtor active active setup

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -233,6 +233,7 @@ def updated_tbinfo(tbinfo):
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, True, 1514)])
 def test_basic_fib(duthosts, ptfhost, tbinfo, ipv4, ipv6, mtu,
+                   setup_standby_ports_on_rand_unselected_tor,          # noqa F811
                    toggle_all_simulator_ports_to_random_side,           # noqa F811
                    updated_tbinfo, mux_server_url,                      # noqa F401
                    mux_status_from_nic_simulator,
@@ -471,6 +472,7 @@ def setup_active_active_ports(
 
 def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noqa F811
               hash_keys, ptfhost, ipver, toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
+              setup_standby_ports_on_rand_unselected_tor,                                       # noqa F811
               updated_tbinfo, mux_server_url, mux_status_from_nic_simulator, ignore_ttl,        # noqa F811
               single_fib_for_duts, duts_running_config_facts, duts_minigraph_facts,             # noqa F811
               setup_active_active_ports, active_active_ports, request):                         # noqa F811


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The port toggle method of case test_basic_fib and test_hash could not work on dualtor active active setup 
Enhance it on dualtor active active testbed

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The port toggle method of case test_basic_fib and test_hash could not work on dualtor active active setup 
#### How did you do it?
Enhance it on dualtor active active testbed
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
