### PR TITLE
T2:Fixing the static-route function for other plats.

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1312,7 +1312,7 @@ def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=Tr
     global DEST_TO_GATEWAY_MAP
     if dut is None:
         if addr not in DEST_TO_GATEWAY_MAP:
-            raise RuntimeError(f"Request for dest addr: {addr} without setting it in advance.")
+            logger.warn(f"Request for dest addr: {addr} without setting it in advance.")
             return addr
         return DEST_TO_GATEWAY_MAP[addr]['dest']
 

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1313,10 +1313,13 @@ def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=Tr
     if dut is None:
         if addr not in DEST_TO_GATEWAY_MAP:
             raise RuntimeError(f"Request for dest addr: {addr} without setting it in advance.")
+            return addr
         return DEST_TO_GATEWAY_MAP[addr]['dest']
 
     if (dut.facts['asic_type'] != "cisco-8000" or
             not dut.get_facts().get("modular_chassis", None)):
+        DEST_TO_GATEWAY_MAP[addr] = {}
+        DEST_TO_GATEWAY_MAP[addr]['dest'] = addr
         return addr
 
     if setup:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 17611

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
The recent addition for static route in snappi tests for cisco-8000 broke other platform runs. This PR attempts to fix the new function for the other platforms.

#### How did you do it?
Converted the runtimeError to a warning, and return the same address.

#### How did you verify/test it?
Ran it with my TB, with both == cisco-8000, and != cisco-8000 checks.

and verified that the issue in the above git issue is not seen(global_pause is unsupported in cisco-8000):
```=========================================================================================================== PASSES ===========================================================================================================
___________________________________________________________________________________________ test_global_pause[multidut_port_info1] ___________________________________________________________________________________________
--------------------------------------------------------------------------- generated xml file: /run_logs/ixia/pretest/2025-03-20-07-23-24/tr.xml ----------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
================================================================================================== short test summary info ===================================================================================================
PASSED snappi_tests/pfc/test_global_pause_with_snappi.py::test_global_pause[multidut_port_info1]
ERROR snappi_tests/pfc/test_global_pause_with_snappi.py::test_global_pause[multidut_port_info3] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost yy39top-lc2>']" failed with exit code "1"
FAILED snappi_tests/pfc/test_global_pause_with_snappi.py::test_global_pause[multidut_port_info0] - Failed: Background Flow Prio 1 should not have any dropped packet
FAILED snappi_tests/pfc/test_global_pause_with_snappi.py::test_global_pause[multidut_port_info2] - Failed: Background Flow Prio 1 should not have any dropped packet
FAILED snappi_tests/pfc/test_global_pause_with_snappi.py::test_global_pause[multidut_port_info3] - Failed: Background Flow Prio 1 should not have any dropped packet
=============================================================================== 3 failed, 1 passed, 8 warnings, 1 error in 2068.50s (0:34:28) ================================================================================
sonic@snappi-sonic-mgmt-msft-t2:/data/tests$ vi common/plugins/conditional_mark/tests_mark_conditions.yaml
```

@amitpawar12 , @sdszhang : Pls try it out and let me know how it goes. Thanks.