### PR TITLE
Add check for max root dispersion on the PTF's NTP daemon

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -24,6 +24,13 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
                   "NTP server was not started in PTF container {}; NTP service start result {}"
                   .format(ptfhost.hostname, ntp_en_res))
 
+    # When using Chrony as the NTP daemon on the DUT, Chrony will not use NTP sources that have a
+    # root dispersion of more than 3 seconds (configurable via /etc/chrony/chrony.conf, but we currently
+    # don't touch that setting). Therefore, block here until the root dispersion is less than 3 seconds
+    # so that we don't incorrectly fail the test.
+    pytest_assert(wait_until(180, 10, 0, check_max_root_dispersion, ptfhost, 3, NtpDaemon.NTP),
+                  "NTP timing hasn't converged enough in PTF container {}".format(ptfhost.hostname))
+
     # check to see if iburst option is present
     ntp_add_help = duthost.command("config ntp add --help")
     ntp_add_iburst_present = False
@@ -88,6 +95,18 @@ def check_ntp_status(host, ntp_daemon_in_use):
     else:
         return False
 
+
+def check_max_root_dispersion(host, max_dispersion, ntp_daemon_in_use):
+    if ntp_daemon_in_use == NtpDaemon.CHRONY:
+        res = host.command("sudo chronyc -n -c ntpdata")
+        root_dispersion = float(res["stdout"].split(",")[14]) / 100
+        return root_dispersion < max_dispersion
+    elif ntp_daemon_in_use == NtpDaemon.NTP or ntp_daemon_in_use == NtpDaemon.NTPSEC:
+        res = host.shell("ntpq -c sysinfo | grep 'root dispersion' | awk '{ print $3; }'")
+        root_dispersion = float(res["stdout"]) / 100
+        return root_dispersion < max_dispersion
+    else:
+        return False
 
 def run_ntp(duthost, ntp_daemon_in_use):
     """ Verify that DUT is synchronized with configured NTP server """

--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -103,10 +103,11 @@ def check_max_root_dispersion(host, max_dispersion, ntp_daemon_in_use):
         return root_dispersion < max_dispersion
     elif ntp_daemon_in_use == NtpDaemon.NTP or ntp_daemon_in_use == NtpDaemon.NTPSEC:
         res = host.shell("ntpq -c sysinfo | grep 'root dispersion' | awk '{ print $3; }'")
-        root_dispersion = float(res["stdout"]) / 100
+        root_dispersion = float(res["stdout"]) / 1000
         return root_dispersion < max_dispersion
     else:
         return False
+
 
 def run_ntp(duthost, ntp_daemon_in_use):
     """ Verify that DUT is synchronized with configured NTP server """


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

When using Chrony as the NTP daemon on the DUT, Chrony will not use NTP sources that have a root dispersion of more than 3 seconds (configurable via /etc/chrony/chrony.conf, but we currently don't touch that setting).

#### How did you do it?

Block here until the root dispersion is less than 3 seconds so that we don't incorrectly fail the test.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
