### PR TITLE
thinkit files

### DIFF
--- a/sdn_tests/pins_ondatra/.bazelrc
+++ b/sdn_tests/pins_ondatra/.bazelrc
@@ -1,0 +1,10 @@
+build --cxxopt='-std=c++17'
+build --host_cxxopt='-std=c++17'
+run --cxxopt='-std=c++17'
+run --host_cxxopt='-std=c++17'
+
+# To allow loops with int and comparison against a .size() that's size_t.
+build --copt='-Wno-error=sign-compare'
+build --host_copt='-Wno-error=sign-compare'
+run --copt='-Wno-error=sign-compare'
+run --host_copt='-Wno-error=sign-compare'

--- a/sdn_tests/pins_ondatra/bazel/patches/ondatra.patch
+++ b/sdn_tests/pins_ondatra/bazel/patches/ondatra.patch
@@ -49,4 +49,96 @@ index 780e978..1821141 100644
 +	grpb "github.com/openconfig/gribi/proto/service"
  	p4pb "github.com/p4lang/p4runtime/go/p4/v1"
  )
+
+diff --git a/proto/BUILD.bazel b/proto/BUILD.bazel
+index 8302111..e72ab58 100644
+--- a/proto/BUILD.bazel
++++ b/proto/BUILD.bazel
+@@ -1,5 +1,10 @@
+ load("@io_bazel_rules_go//go:def.bzl", "go_library")
+ 
++package(
++    default_visibility = ["//visibility:public"],
++    licenses = ["notice"],
++)
++
+ go_library(
+     name = "proto",
+     srcs = [
+@@ -16,6 +21,27 @@ go_library(
+     ],
+ )
+ 
++proto_library(
++    name = "ondatra_proto",
++    srcs = [
++        "ate.proto",
++        "testbed.proto",
++    ],
++    import_prefix = "github.com/openconfig/ondatra",
++    deps = [
++        "@com_google_protobuf//:any_proto",
++        "@com_google_protobuf//:duration_proto",
++        "@com_google_protobuf//:empty_proto",
++        "@com_google_protobuf//:descriptor_proto",
++    ],
++)
++
++cc_proto_library(
++    name = "ondatra_cc_proto",
++    deps = [":ondatra_proto"],
++)
++
++
+ alias(
+     name = "go_default_library",
+     actual = ":proto",
+diff --git a/proxy/BUILD.bazel b/proxy/BUILD.bazel
+index a7e40f4..5dab6bb 100644
+--- a/proxy/BUILD.bazel
++++ b/proxy/BUILD.bazel
+@@ -43,3 +43,4 @@ go_test(
+         "@org_golang_x_net//context:go_default_library",
+     ],
+ )
++
+diff --git a/proxy/proto/BUILD.bazel b/proxy/proto/BUILD.bazel
+new file mode 100644
+index 0000000..9d6160a
+--- /dev/null
++++ b/proxy/proto/BUILD.bazel
+@@ -0,0 +1,21 @@
++package(
++    default_visibility = ["//visibility:public"],
++    licenses = ["notice"],
++)
++
++proto_library(
++    name = "reservation_proto",
++    srcs = [
++        "reservation.proto",
++    ],
++    import_prefix = "github.com/openconfig/ondatra",
++    deps = [
++        "@com_github_openconfig_ondatra//proto:ondatra_proto"
++    ],
++)
++
++cc_proto_library(
++    name = "reservation_cc_proto",
++    deps = [":reservation_proto"],
++)
++
+diff --git a/proxy/proto/reservation.proto b/proxy/proto/reservation.proto
+index 7145250..85cb489 100644
+--- a/proxy/proto/reservation.proto
++++ b/proxy/proto/reservation.proto
+@@ -15,7 +15,7 @@ syntax = "proto3";
+ 
+ package reservation;
+ 
+-import "proto/testbed.proto";
++import "github.com/openconfig/ondatra/proto/testbed.proto";
+ 
+ option go_package = "github.com/openconfig/ondatra/proto/reservation";
  

--- a/sdn_tests/pins_ondatra/infrastructure/thinkit/BUILD.bazel
+++ b/sdn_tests/pins_ondatra/infrastructure/thinkit/BUILD.bazel
@@ -1,0 +1,66 @@
+# Copyright (c) 2025, Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "thinkit",
+    testonly = True,
+    srcs = ["thinkit.go"],
+    cgo = True,
+    importpath = "github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit",
+    deps = [
+        "//infrastructure/binding:pinsbind",
+        "@com_github_golang_glog//:glog",
+        "@com_github_openconfig_gnmi//errlist",
+        "@com_github_openconfig_ondatra//binding",
+        "@com_github_openconfig_ondatra//proto:go_default_library",
+        "@com_github_openconfig_ondatra//proxy",
+        "@com_github_openconfig_ondatra//proxy/proto/reservation:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/local",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_binary(
+    name = "thinkit_cgo",
+    testonly = True,
+    embed = [":thinkit"],
+    linkmode = "c-archive",
+)
+
+cc_library(
+    name = "cthinkit",
+    testonly = True,
+    srcs = ["thinkit.cc"],
+    hdrs = ["thinkit.h"],
+    deps = [
+        ":thinkit_cgo.cc",
+        "@com_github_sonic_net_sonic_pins//gutil:status",
+        "@com_github_openconfig_ondatra//proto:ondatra_cc_proto",
+        "@com_github_openconfig_ondatra//proxy/proto:reservation_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/time",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit.cc
+++ b/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2025, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "infrastructure/thinkit/thinkit.h"
+
+#include <cstddef>
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/time.h"
+#include "github.com/openconfig/ondatra/proto/testbed.pb.h"
+#include "github.com/openconfig/ondatra/proxy/proto/reservation.pb.h"
+#include "google/protobuf/message.h"
+#include "gutil/status.h"
+#include "infrastructure/thinkit/thinkit_cgo.h"
+
+namespace pins_test {
+namespace {
+
+ProtoIn ToProtoIn(absl::string_view serialized_message) {
+  return {.data = serialized_message.data(),
+          .length = serialized_message.size()};
+}
+
+ProtoOut ToProtoOut(google::protobuf::Message& message) {
+  return {.proto = &message,
+          .write_proto = [](void* proto_handle, char* data, size_t length) {
+            google::protobuf::Message& proto =
+                *static_cast<google::protobuf::Message*>(proto_handle);
+            proto.ParseFromArray(data, length);
+          }};
+}
+
+StringOut ToStringOut(std::string& string) {
+  return {.string = &string, .resize = [](void* string_handle, size_t length) {
+            std::string& string = *static_cast<std::string*>(string_handle);
+            string.resize(length);
+            return string.data();
+          }};
+}
+
+absl::Status FromErrorMessage(absl::string_view error_message) {
+  if (error_message.empty()) {
+    return absl::OkStatus();
+  } else {
+    return absl::InternalError(error_message);
+  }
+}
+
+}  // namespace
+
+absl::Status OndatraInit(const ondatra::Testbed& testbed_request,
+                         absl::Duration wait_time, absl::Duration run_time) {
+  std::string error_message;
+  platforms_networking_pins_ondatra_thinkit_Init(
+      ToProtoIn(testbed_request.SerializePartialAsString()),
+      absl::ToInt64Nanoseconds(wait_time), absl::ToInt64Nanoseconds(run_time),
+      ToStringOut(error_message));
+  return FromErrorMessage(error_message);
+}
+
+absl::StatusOr<reservation::Reservation> OndatraTestbed() {
+  std::string error_message;
+  reservation::Reservation reservation;
+  platforms_networking_pins_ondatra_thinkit_Testbed(
+      ToProtoOut(reservation), ToStringOut(error_message));
+  RETURN_IF_ERROR(FromErrorMessage(error_message));
+  return reservation;
+}
+
+absl::Status OndatraRelease() {
+  std::string error_message;
+  platforms_networking_pins_ondatra_thinkit_Release(
+      ToStringOut(error_message));
+  return FromErrorMessage(error_message);
+}
+
+}  // namespace pins_test

--- a/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit.go
+++ b/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2025, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package thinkit provides the cgo binding for ondatra to thinkit based tests.
+package main
+
+/*
+#include <stddef.h>
+#include <stdint.h>
+
+struct ProtoIn {
+  const char* data;
+	size_t length;
+};
+
+struct ProtoOut {
+  void* proto;
+	void (*write_proto)(void* proto, char* data, size_t length);
+};
+
+struct StringOut {
+  void* string;
+	char* (*resize)(void* string, size_t length);
+};
+
+static void write_proto(struct ProtoOut proto_out, char* data, size_t length) {
+  proto_out.write_proto(proto_out.proto, data, length);
+}
+
+static char* resize_string(struct StringOut string_out, size_t length) {
+  return string_out.resize(string_out.string, length);
+}
+*/
+import (
+	"C"
+)
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+	"unsafe"
+
+	log "github.com/golang/glog"
+	"github.com/openconfig/gnmi/errlist"
+
+	"github.com/openconfig/ondatra/binding"
+	"github.com/openconfig/ondatra/proxy"
+	"github.com/sonic-net/sonic-mgmt/sdn_tests/pins_ondatra/infrastructure/binding/pinsbind"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/local"
+	"google.golang.org/protobuf/proto"
+
+	opb "github.com/openconfig/ondatra/proto"
+	rpb "github.com/openconfig/ondatra/proxy/proto/reservation"
+)
+
+func main() {}
+
+func readProto(msg proto.Message, protoIn C.struct_ProtoIn) {
+	err := proto.UnmarshalOptions{AllowPartial: true}.Unmarshal(unsafe.Slice((*byte)(unsafe.Pointer(protoIn.data)), (int)(protoIn.length)), msg)
+	if err != nil {
+		log.Fatalf("Failed to parse proto from byte array from C++; err: %v", err)
+	}
+}
+
+func writeProto(msg proto.Message, protoOut C.struct_ProtoOut) {
+	b, err := proto.MarshalOptions{AllowPartial: true}.Marshal(msg)
+	if err != nil {
+		log.Fatalf("Failed to marshal proto to byte array for outputing proto to C++; err: %v", err)
+	}
+	ptr := unsafe.Pointer(unsafe.SliceData(b))
+	C.write_proto(protoOut, (*C.char)(ptr), (C.size_t)(len(b)))
+}
+
+func writeErrorString(err error, strOut C.struct_StringOut) {
+	str := ""
+	if err != nil {
+		str = err.Error()
+	}
+	size := len(str)
+	ptr := C.resize_string(strOut, (C.size_t)(size))
+	if size != 0 {
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size), str)
+	}
+}
+
+//export platforms_networking_pins_ondatra_thinkit_Init
+func platforms_networking_pins_ondatra_thinkit_Init(testbedIn C.struct_ProtoIn, waitTime, runTime C.long, errMsg C.struct_StringOut) {
+	tb := &opb.Testbed{}
+	readProto(tb, testbedIn)
+	err := Init(context.TODO(), tb, waitTime, runTime)
+	writeErrorString(err, errMsg)
+}
+
+//export platforms_networking_pins_ondatra_thinkit_Testbed
+func platforms_networking_pins_ondatra_thinkit_Testbed(resvOut C.struct_ProtoOut, errMsg C.struct_StringOut) {
+	resv, err := Testbed()
+	writeProto(resv, resvOut)
+	writeErrorString(err, errMsg)
+}
+
+//export platforms_networking_pins_ondatra_thinkit_Release
+func platforms_networking_pins_ondatra_thinkit_Release(errMsg C.struct_StringOut) {
+	err := Release(context.TODO())
+	writeErrorString(err, errMsg)
+}
+
+type proxyBinding interface {
+	proxy.Dialer
+	Reserve(ctx context.Context, tb *opb.Testbed, waitTime time.Duration, runTime time.Duration, partial map[string]string) (*binding.Reservation, error)
+	Release(ctx context.Context) error
+}
+
+var (
+	mu         sync.Mutex
+	p          *proxy.Proxy
+	resv       *binding.Reservation
+	b          proxyBinding
+	newBinding = defaultBinding
+)
+
+func defaultBinding() (proxyBinding, error) {
+	return pinsbind.NewWithOpts()
+}
+
+// Init will init the binding and setup the proxy.
+func Init(ctx context.Context, tb *opb.Testbed, waitTime, runTime C.long) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if p != nil {
+		return fmt.Errorf("proxy already initialized, Init must only be called once")
+	}
+	var err error
+	b, err = newBinding()
+	if err != nil {
+		return err
+	}
+	resv, err = b.Reserve(ctx, tb, time.Duration(int64(waitTime)), time.Duration(int64(runTime)), nil)
+	if err != nil {
+		return err
+	}
+	p, err = proxy.New(b, grpc.Creds(local.NewCredentials()))
+	return err
+}
+
+func addProxyTarget(s *rpb.Service, proxyAddr string) error {
+	switch v := s.GetEndpoint().(type) {
+	case *rpb.Service_ProxiedGrpc:
+		v.ProxiedGrpc.Proxy = append([]string{proxyAddr}, v.ProxiedGrpc.Proxy...)
+	case *rpb.Service_HttpOverGrpc:
+		v.HttpOverGrpc.Address = proxyAddr
+	default:
+		return fmt.Errorf("invalid service endpoint type: %s:%T (must be proxiable)", s.GetId(), v)
+	}
+	return nil
+}
+
+// Testbed will return the resolved testbed proto.
+func Testbed() (*rpb.Reservation, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if p == nil || b == nil {
+		return nil, fmt.Errorf("Init must be called before Testbed()")
+	}
+	proxyEndpoints := p.Endpoints()
+	r, err := b.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve reservation: %w", err)
+	}
+	// Add Proxy to DUT.
+	for _, d := range r.GetDevices() {
+		for name, service := range d.GetServices() {
+			ep, ok := proxyEndpoints[service.GetProxiedGrpc().GetAddress()]
+			if !ok {
+				return nil, fmt.Errorf("failed to find proxy for address %q for service %s on target %q", service.GetProxiedGrpc().GetAddress(), name, d.GetName())
+			}
+			if err := addProxyTarget(service, ep.Addr); err != nil {
+				return nil, err
+			}
+		}
+	}
+	// Add Proxy to ATE.
+	for k, d := range r.GetAtes() {
+		if ep, ok := proxyEndpoints[k]; ok {
+			gService, ok := d.GetServices()["http"]
+			if !ok {
+				return nil, fmt.Errorf("failed to find 'http' service on target %q", d.GetName())
+			}
+			if err := addProxyTarget(gService, ep.Addr); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return r, nil
+}
+
+// Release will release the testbed after use.
+func Release(ctx context.Context) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if p == nil || b == nil {
+		return fmt.Errorf("Init must be called before Release()")
+	}
+	var errs errlist.List
+	if err := b.Release(ctx); err != nil {
+		errs.Add(err)
+	}
+	if err := p.Stop(); err != nil {
+		errs.Add(err)
+	}
+	p = nil
+	return errs.Err()
+}

--- a/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit.h
+++ b/sdn_tests/pins_ondatra/infrastructure/thinkit/thinkit.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2025, Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PINS_INFRASTRUCTURE_THINKIT_THINKIT_H_
+#define PINS_INFRASTRUCTURE_THINKIT_THINKIT_H_
+
+#include <functional>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/time/time.h"
+#include "github.com/openconfig/ondatra/proto/testbed.pb.h"
+#include "github.com/openconfig/ondatra/proxy/proto/reservation.pb.h"
+
+namespace pins_test {
+
+absl::Status OndatraInit(const ondatra::Testbed& testbed_request,
+                         absl::Duration wait_time, absl::Duration run_time);
+
+absl::StatusOr<reservation::Reservation> OndatraTestbed();
+
+absl::Status OndatraRelease();
+
+struct OndatraHooks {
+  std::function<absl::Status(const ondatra::Testbed&, absl::Duration,
+                             absl::Duration)>
+      init = OndatraInit;
+  std::function<absl::StatusOr<reservation::Reservation>()> testbed =
+      OndatraTestbed;
+  std::function<absl::Status()> release = OndatraRelease;
+};
+
+}  // namespace pins_test
+
+#endif  // PINS_INFRASTRUCTURE_THINKIT_THINKIT_H_

--- a/sdn_tests/pins_ondatra/pins_deps.bzl
+++ b/sdn_tests/pins_ondatra/pins_deps.bzl
@@ -2,6 +2,12 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def pins_deps():
+    if not native.existing_rule("com_github_sonic_net_sonic_pins"):
+        git_repository(
+          name = "com_github_sonic_net_sonic_pins",
+          remote = "https://github.com/sonic-net/sonic-pins.git",
+          commit = "b3c410fb6890edb7fc9009526e3a08ed1a345177" # main as on feb 25, 2025
+        )
     if not native.existing_rule("com_github_grpc_grpc"):
         http_archive(
             name = "com_github_grpc_grpc",
@@ -38,9 +44,9 @@ def pins_deps():
     if not native.existing_rule("com_google_protobuf"):
         http_archive(
             name = "com_google_protobuf",
-            url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v25.1.zip",
-            strip_prefix = "protobuf-25.1",
-            sha256 = "eaafa4e19a6619c15df4c30d7213efbfd0f33ad16021cc5f72bbc5d0877346b5",
+            url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v23.1.zip",
+            strip_prefix = "protobuf-23.1",
+            sha256 = "c0ea9f4d75b37ea8e9d78ce4c670d066bcb7cebdba190fa5fc8c57b1f00c0c2c",
         )
     if not native.existing_rule("com_googlesource_code_re2"):
         http_archive(


### PR DESCRIPTION
Build Result:
/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 11 targets (455 packages loaded, 20908 targets configured).
INFO: Found 11 targets...
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc:
In file included from bazel-out/k8-fastbuild/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-fastbuild/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1150:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1150 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc [for tool]:
In file included from bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1150:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1150 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Compiling src/google/protobuf/generated_message_tctable_lite.cc [for tool]:
In file included from bazel-out/k8-opt-exec-2B5CBBC6-ST-1dd6bf738d96/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/generated_message_tctable_decl.h:45,
                 from external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:37:
bazel-out/k8-opt-exec-2B5CBBC6-ST-1dd6bf738d96/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/parse_context.h:1150:1: warning: 'always_inline' function might not be inlinable [-Wattributes]
 1150 | ParseContext::ParseLengthDelimitedInlined(const char* ptr, const Func& func) {
      | ^~~~~~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
  871 | PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
      |                                    ^~~~~~~~
external/com_google_protobuf/src/google/protobuf/generated_message_tctable_lite.cc:871:36: warning: 'always_inline' function might not be inlinable [-Wattributes]
INFO: From Compiling src/google/protobuf/compiler/retention.cc [for tool]:
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc: In function 'void google::protobuf::compiler::{anonymous}::StripSourceCodeInfo(std::vector<std::vector<int> >&, google::protobuf::SourceCodeInfo&)':
external/com_google_protobuf/src/google/protobuf/compiler/retention.cc:216:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<google::protobuf::SourceCodeInfo_Location*>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  216 |   for (int i = 0; i < old_locations.size(); ++i) {
INFO: From Compiling src/core/ext/transport/binder/client/channel_create_impl.cc:
In file included from external/com_github_grpc_grpc/src/core/ext/filters/client_channel/client_channel.h:46,
                 from external/com_github_grpc_grpc/src/core/ext/transport/binder/client/binder_connector.h:30,
                 from external/com_github_grpc_grpc/src/core/ext/transport/binder/client/channel_create_impl.cc:24:
external/com_github_grpc_grpc/src/core/lib/channel/call_tracer.h:45:1: warning: multi-line comment [-Wcomment]
   45 | //                      /          \
      | ^
external/com_github_grpc_grpc/src/core/lib/channel/call_tracer.h:47:1: warning: multi-line comment [-Wcomment]
   47 | //                                /             \
      | ^
INFO: From Compiling infrastructure/thinkit/thinkit.cc:
In file included from infrastructure/thinkit/thinkit.cc:28:
thinkit.go:41:14: warning: 'char* resize_string(StringOut, size_t)' defined but not used [-Wunused-function]
thinkit.go:37:13: warning: 'void write_proto(ProtoOut, char*, size_t)' defined but not used [-Wunused-function]
INFO: Elapsed time: 1072.155s, Critical Path: 254.93s
INFO: 3651 processes: 662 internal, 2989 linux-sandbox.
INFO: Build completed successfully, 3651 total actions


















<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
