### PR TITLE
Fixing loganalyzer for macsec

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -43,9 +43,9 @@ r, ".* ERR swss#orchagent: :- querySwitchLagHashAlgorithmEnumCapabilities: Faile
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed with error Feature unavailable.*"
 
 # White list below messages found on KVM for now. Need to address them later.
-r, ".* ERR macsec#wpa_supplicant.*l2_packet_send.*Network is down.*"
-r, ".* ERR macsec#wpa_supplicant.*could not process SIGINT or SIGTERM in two seconds.*"
-r, ".* ERR macsec#wpa_supplicant.*KaY: Life time has not elapsed since prior SAK distributed.*"
+r, ".* ERR macsec\d*#wpa_supplicant.*l2_packet_send.*Network is down.*"
+r, ".* ERR macsec\d*#wpa_supplicant.*could not process SIGINT or SIGTERM in two seconds.*"
+r, ".* ERR macsec\d*#wpa_supplicant.*KaY: Life time has not elapsed since prior SAK distributed.*"
 r, ".* ERR systemd.*Failed to start dhcp_relay container.*"
 r, ".* ERR monit.* 'rsyslog' failed to get service data.*"
 r, ".* ERR monit.* 'rsyslog' process is not running.*"


### PR DESCRIPTION
### Description of PR

Summary:
- In multi asic linecards we have "macsec0", "macsec1" ... containers
- Without this fix, Log analyzer failed to ignore macsec messages on multi asic linecards.

Fixes : https://github.com/aristanetworks/sonic-qual.msft/issues/505
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix

### Back port request
- [x] 202405
- [x] 202411

#### How did you verify/test it?
- With the fix, macsec tests are passing on multi asic linecards
