### PR TITLE
Add test to verify db_migrator with DNS_NAMESERVER

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -353,6 +353,15 @@ dash/test_relaxed_match_negative.py:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
 
 #######################################
+#####       db_migrator           #####
+#######################################
+db_migrator/test_db_migrator.py::test_migrate_dns_03:
+  xfail:
+    reason: "db_migrator does not support SonicQosProfile in minigraph"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/22120"
+
+#######################################
 #####            decap            #####
 #######################################
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -355,7 +355,7 @@ dash/test_relaxed_match_negative.py:
 #######################################
 #####       db_migrator           #####
 #######################################
-db_migrator/test_db_migrator.py::test_migrate_dns_03:
+db_migrator/test_migrate_dns.py::test_migrate_dns_03:
   xfail:
     reason: "db_migrator does not support SonicQosProfile in minigraph"
     conditions:

--- a/tests/db_migrator/test_migrate_dns.py
+++ b/tests/db_migrator/test_migrate_dns.py
@@ -231,7 +231,7 @@ def test_migrate_dns_03(duthost):
     pytest_assert(golden_config_dns not in dns_servers,
                   "DNS server from golden config is present in config db")
     pytest_assert(minigraph_dns in dns_servers,
-                    "DNS server from minigraph is not present in config db")
+                  "DNS server from minigraph is not present in config db")
 
 
 def test_migrate_dns_04(duthost):

--- a/tests/db_migrator/test_migrate_dns.py
+++ b/tests/db_migrator/test_migrate_dns.py
@@ -1,0 +1,206 @@
+import pytest
+import logging
+import json
+from tests.common.constants import RESOLV_CONF_NAMESERVERS
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.config_reload import config_reload
+from tests.common.utilities import backup_config, restore_config
+
+pytestmark = [
+    pytest.mark.topology("t0", "t1"),
+    pytest.mark.disable_loganalyzer
+]
+
+GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
+GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
+CONFIG_DB = "/etc/sonic/config_db.json"
+CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
+MINIGRAPH = "/etc/sonic/minigraph.xml"
+MINIGRAPH_BACKUP = "/etc/sonic/minigraph.xml_before_override"
+DNS_TEMPLATE = "/usr/share/sonic/templates/dns.j2"
+DNS_TEMPLATE_BACKUP = "/usr/share/sonic/templates/dns.j2_before_override"
+
+logger = logging.getLogger(__name__)
+
+minigraph_dns = "1.1.1.1"
+golden_config_dns = "2.2.2.2"
+
+
+def file_exists_on_dut(duthost, filename):
+    return duthost.stat(path=filename).get('stat', {}).get('exists', False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_env(duthost):
+    """
+    Setup/teardown
+    Args:
+        duthost: DUT.
+        golden_config_exists_on_dut: Check if golden config exists on DUT.
+    """
+    if duthost.is_multi_asic:
+        pytest.skip("Skip test on multi-asic platforms as it is designed for single asic.")
+
+    # Backup configDB
+    backup_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
+    if file_exists_on_dut(duthost, GOLDEN_CONFIG):
+        backup_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
+    # Backup minigraph
+    backup_config(duthost, MINIGRAPH, MINIGRAPH_BACKUP)
+    # Backup dns template
+    backup_config(duthost, DNS_TEMPLATE, DNS_TEMPLATE_BACKUP)
+
+    yield
+
+    # Restore configDB after test.
+    restore_config(duthost, CONFIG_DB, CONFIG_DB_BACKUP)
+    if file_exists_on_dut(duthost, GOLDEN_CONFIG_BACKUP):
+        restore_config(duthost, GOLDEN_CONFIG, GOLDEN_CONFIG_BACKUP)
+    else:
+        duthost.file(path=GOLDEN_CONFIG, state='absent')
+    # Restore minigraph
+    restore_config(duthost, MINIGRAPH, MINIGRAPH_BACKUP)
+    # Restore dns template
+    restore_config(duthost, DNS_TEMPLATE, DNS_TEMPLATE_BACKUP)
+
+    # Restore config
+    config_reload(duthost, safe_reload=True)
+
+
+def get_nameserver_from_config_db(duthost):
+    """
+    Get the DNS nameserver configured in the config db
+    :param duthost: DUT host object
+    :return: DNS nameserver list
+    """
+    nameservers = duthost.show_and_parse("show dns nameserver")
+    return [str(nameserver["nameserver"]) for nameserver in nameservers]
+
+
+def del_dns_nameserver(duthost, ip_addr):
+    return duthost.shell(f"config dns nameserver del {ip_addr}", module_ignore_errors=True)
+
+
+def test_migrate_dns_01(duthost):
+    """Minigraph exists, and golden config exists
+    db_migrator should use DNS_NAMESERVER from golden config
+
+    Args:
+        duthost: AnsibleHost instance for DUT
+    """
+    # Restore minigraph
+    backup_config(duthost, MINIGRAPH_BACKUP, MINIGRAPH)
+    # Update the DNS template to include the DNS server specified by minigraph_dns
+    file_content = json.dumps({
+        "DNS_NAMESERVER": {
+            minigraph_dns: {}
+        }
+    }, indent=2)
+    duthost.copy(content=file_content, dest=DNS_TEMPLATE)
+    # Update the golden config to include the DNS server specified by golden_config_dns
+    file_content = json.dumps({
+        "DNS_NAMESERVER": {
+            golden_config_dns: {}
+        }
+    }, indent=2)
+    duthost.copy(content=file_content, dest=GOLDEN_CONFIG)
+
+    # Update database VERSIONS
+    origin_version = "version_202305_01"
+    cmd = f"sonic-db-cli CONFIG_DB hset 'VERSIONS|DATABASE' VERSION {origin_version}"
+    duthost.command(cmd, module_ignore_errors=True)
+    # Cleanup DNS_NAMESERVER from config db
+    dns_servers = get_nameserver_from_config_db(duthost)
+    for dns_server in dns_servers:
+        del_dns_nameserver(duthost, dns_server)
+
+    # Run db_migrator
+    result = duthost.command("db_migrator.py -o migrate", module_ignore_errors=True)
+    pytest_assert(result["rc"] == 0, f"db_migrator failed with error: {result.get('stderr', '')}")
+
+    # Check if the DNS server from golden config is present in config db
+    dns_servers = get_nameserver_from_config_db(duthost)
+    pytest_assert(golden_config_dns in dns_servers,
+                  "DNS server from golden config is not present in config db")
+    pytest_assert(minigraph_dns not in dns_servers,
+                  "DNS server from minigraph is present in config db")
+
+
+def test_migrate_dns_02(duthost):
+    """Minigraph exists, and golden config does not exist
+    db_migrator should use DNS_NAMESERVER from minigraph
+
+    Args:
+        duthost: AnsibleHost instance for DUT
+    """
+    # Restore minigraph
+    backup_config(duthost, MINIGRAPH_BACKUP, MINIGRAPH)
+    # Update the DNS template to include the DNS server specified by minigraph_dns
+    file_content = json.dumps({
+        "DNS_NAMESERVER": {
+            minigraph_dns: {}
+        }
+    }, indent=2)
+    duthost.copy(content=file_content, dest=DNS_TEMPLATE)
+    # Remove golden config if it exists
+    if file_exists_on_dut(duthost, GOLDEN_CONFIG):
+        duthost.file(path=GOLDEN_CONFIG, state='absent')
+
+    # Update database VERSIONS
+    origin_version = "version_202305_01"
+    cmd = f"sonic-db-cli CONFIG_DB hset 'VERSIONS|DATABASE' VERSION {origin_version}"
+    duthost.command(cmd, module_ignore_errors=True)
+    # Cleanup DNS_NAMESERVER from config db
+    dns_servers = get_nameserver_from_config_db(duthost)
+    for dns_server in dns_servers:
+        del_dns_nameserver(duthost, dns_server)
+
+    # Run db_migrator
+    result = duthost.command("db_migrator.py -o migrate", module_ignore_errors=True)
+    pytest_assert(result["rc"] == 0, f"db_migrator failed with error: {result.get('stderr', '')}")
+
+    # Check if the DNS server from minigraph is present in config db
+    dns_servers = get_nameserver_from_config_db(duthost)
+    pytest_assert(golden_config_dns not in dns_servers,
+                  "DNS server from golden config is present in config db")
+    pytest_assert(minigraph_dns in dns_servers,
+                  "DNS server from minigraph is present in config db")
+
+
+def test_migrate_dns_03(duthost):
+    """Minigraph does not exist, and golden config exists
+    db_migrator should use DNS_NAMESERVER from golden config
+
+    Args:
+        duthost: AnsibleHost instance for DUT
+    """
+    # Restore MINIGRAPH
+    if file_exists_on_dut(duthost, MINIGRAPH):
+        duthost.file(path=MINIGRAPH, state='absent')
+    # Update the golden config to include the DNS server specified by golden_config_dns
+    file_content = json.dumps({
+        "DNS_NAMESERVER": {
+            golden_config_dns: {}
+        }
+    }, indent=2)
+    duthost.copy(content=file_content, dest=GOLDEN_CONFIG)
+
+    # Update database VERSIONS
+    origin_version = "version_202305_01"
+    cmd = f"sonic-db-cli CONFIG_DB hset 'VERSIONS|DATABASE' VERSION {origin_version}"
+    duthost.command(cmd, module_ignore_errors=True)
+    # Cleanup DNS_NAMESERVER from config db
+    dns_servers = get_nameserver_from_config_db(duthost)
+    for dns_server in dns_servers:
+        del_dns_nameserver(duthost, dns_server)
+
+    # Run db_migrator
+    result = duthost.command("db_migrator.py -o migrate", module_ignore_errors=True)
+    pytest_assert(result["rc"] == 0, f"db_migrator failed with error: {result.get('stderr', '')}")
+
+    # Check if the DNS server from golden config is present in config db
+    dns_servers = get_nameserver_from_config_db(duthost)
+    pytest_assert(golden_config_dns in dns_servers,
+                  "DNS server from golden config is not present in config db")
+    pytest_assert(minigraph_dns not in dns_servers,
+                  "DNS server from minigraph is present in config db")

--- a/tests/db_migrator/test_migrate_dns.py
+++ b/tests/db_migrator/test_migrate_dns.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 import json
-from tests.common.constants import RESOLV_CONF_NAMESERVERS
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
 from tests.common.utilities import backup_config, restore_config

--- a/tests/db_migrator/test_migrate_dns.py
+++ b/tests/db_migrator/test_migrate_dns.py
@@ -173,7 +173,7 @@ def test_migrate_dns_03(duthost):
     Args:
         duthost: AnsibleHost instance for DUT
     """
-    # Restore MINIGRAPH
+    # Remove MINIGRAPH
     if file_exists_on_dut(duthost, MINIGRAPH):
         duthost.file(path=MINIGRAPH, state='absent')
     # Update the golden config to include the DNS server specified by golden_config_dns


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 31757149

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
There's a test gap, we don't have test to verify db_migrator

#### How did you do it?
This test will modify CONFIG_DB and run db_migrator, and verify that DNS_NAMESERVER is from minigraph or golden config.
* test_migrate_dns_02: there's minigraph.xml and dns.j2, and there's no golden config. After migration, there's DNS_NAMESERVER in CONFIG_DB, because db_migrator can migrate from minigraph.
* test_migrate_dns_03 is used to reproduce SonicQosProfile issue: there's minigraph.xml and dns.j2, and I added SonicQosProfile in minigraph.xml, and there'no golden config. After migration, there's no DNS_NAMESERVER in CONFIG_DB, because db_migrator can't migrate from minigraph.

#### How did you verify/test it?
Run end to end test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
