### PR TITLE
[sonic-mgmt][dualtor-120] Fix flakiness of fdb/test_fdb_mac_learning.py

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -205,7 +205,7 @@ class TestFdbMacLearning:
         """
         Make sure interfaces are ready for sending traffic.
         """
-        if "dualtor" in tbinfo['topo']['name']:
+        if "dualtor-aa" in tbinfo['topo']['name']:
             pytest_assert(wait_until(150, 5, 0, self.check_mux_status_consistency, duthost, ports))
         else:
             time.sleep(30)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix flakiness of fdb/test_fdb_mac_learning.py
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/487

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Test is failing sometimes with error `Failed: After starting Ethernet0 and populating fdb, corresponding mac address entry not seen in mac table`

#### How did you do it?
In case of dualtor active-standby, interface flap doesn't have any effect on mux status and thus there is no need to wait for mux status consistency. Updating the if condition to wait for mux consistency only for `dualtor-aa` which also allows delay (`time.sleep(30)`) needed to fix flakiness of this test for dualtor-120.

#### How did you verify/test it?
Stressed the test and no failures are seen with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
