### PR TITLE
Clarify which Cisco-8000 devices use separate VOQ flow configuration

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -7,6 +7,9 @@ logger = logging.getLogger(__name__)
 class QosParamCisco(object):
     SMALL_SMS_PLATFORMS = ["x86_64-8102_64h_o-r0"]
     DEEP_BUFFER_PLATFORMS = ["x86_64-8111_32eh_o-r0"]
+    SEPARATE_VOQ_PLATFORMS = ["x86_64-8101_32fh_o-r0", "x86_64-8102_64h_o-r0"]
+    VOQ_ASICS = ["gb", "gr"]
+
     LOG_PREFIX = "QosParamCisco: "
 
     def __init__(self, qos_params, duthost, dutAsic, topo, bufferConfig, portSpeedCableLength):
@@ -14,6 +17,7 @@ class QosParamCisco(object):
         Initialize parameters all tests will use
         '''
         self.qos_params = qos_params
+        self.duthost = duthost
         self.dutAsic = dutAsic
         self.bufferConfig = bufferConfig
         self.portSpeedCableLength = portSpeedCableLength
@@ -44,19 +48,20 @@ class QosParamCisco(object):
         # 0: Max queue depth in bytes
         # 1: Flow control configuration on this device, either 'separate' or 'shared'.
         # 2: Number of packets margin for the quantized queue watermark tests.
-        asic_params = {"gb": (6144000, "separate", 3072, 384, 1350, 2, 3),
-                       "gr": (24576000, "shared", 18000, 384, 1350, 2, 3),
-                       "gr2": (None, None, 1, 512, 64, 1, 3)}
+        asic_params = {"gb": (6144000, 3072, 384, 1350, 2, 3),
+                       "gr": (24576000, 18000, 384, 1350, 2, 3),
+                       "gr2": (None, 1, 512, 64, 1, 3)}
         self.supports_autogen = dutAsic in asic_params and topo == "topo-any"
         if self.supports_autogen:
             # Asic dependent parameters
             (max_queue_depth,
-             self.flow_config,
              self.q_wmk_margin,
              self.buffer_size,
              self.preferred_packet_size,
              self.lossless_pause_tuning_pkts,
              self.lossless_drop_tuning_pkts) = asic_params[dutAsic]
+
+            self.flow_config = self.get_expected_flow_config()
 
             # Calculate attempted pause threshold
             if "dynamic_th" in lossless_prof:
@@ -158,6 +163,18 @@ class QosParamCisco(object):
             self.dscp_queue1 = self.get_one_dscp_from_queue(1)
             # DSCP, queue, weight list
             self.dscp_list, self.q_list, self.weight_list = self.get_dscp_q_weight_list()
+
+    def get_expected_flow_config(self):
+        '''
+        Return the expected type of VOQs present based on the device info
+        '''
+        if self.dutAsic not in self.VOQ_ASICS:
+            flow_config = None
+        elif self.duthost.facts['platform'] in self.SEPARATE_VOQ_PLATFORMS:
+            flow_config = "separate"
+        else:
+            flow_config = "shared"
+        return flow_config
 
     def get_one_dscp_from_queue(self, queue):
         '''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Only specific Cisco-8000 platforms use separate VOQ'ing to assist in burst absorption. 
Changed the test cases to expect separate VOQ'ing on specific 'gb' platforms, otherwise expect the shared model. 
This helps validate and clarify via hardcoded test expectations which VOQ platforms use each VOQ'ing paradigm. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix cases for GB devices that are running the shared voq model rather than the `separate` VOQ use-case. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Cisco-8000 only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
