### PR TITLE
[202405] Fixed two issues causing test failures in `test_vxlan_bfd_tsa.py`

### DIFF
--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -17,7 +17,6 @@ from tests.common.fixtures.ptfhost_utils \
     import copy_ptftests_directory     # noqa: F401
 from tests.ptf_runner import ptf_runner
 from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
-from tests.common.config_reload import config_system_checks_passed
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.config_reload import config_reload
 Logger = logging.getLogger(__name__)
@@ -204,6 +203,13 @@ def fixture_setUp(duthosts,
     outer_layer_version = ecmp_utils.get_outer_layer_version(encap_type)
     payload_version = ecmp_utils.get_payload_version(encap_type)
 
+    # In case any of the tests fail, this method will cleanup the VNET routes.
+    ecmp_utils.set_routes_in_dut(
+        data['duthost'],
+        data[encap_type]['dest_to_nh_map'],
+        payload_version,
+        "DEL")
+
     for intf in data[encap_type]['selected_interfaces']:
         redis_string = "INTERFACE"
         if "PortChannel" in intf:
@@ -225,6 +231,7 @@ def fixture_setUp(duthosts,
         data['duthost'].shell(
             "redis-cli -n 4 del \"VXLAN_TUNNEL|{}\"".format(tunnel))
     time.sleep(1)
+    ecmp_utils.stop_bfd_responder(data['ptfhost'])
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -233,6 +240,17 @@ def restore_config_by_config_reload(duthosts, rand_one_dut_hostname, localhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     config_reload(duthost, safe_reload=True)
+
+
+def is_vnet_route_configured_on_asic(duthost, dest):
+    '''
+        Function to check if a VNET route to dest is configured on ASIC DB.
+        A VNET route to dest must be configured on ASIC DB before running
+        PTF tests.
+    '''
+    result = duthost.shell(f"sonic-db-cli ASIC_DB KEYS \
+                           'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY*{dest}*'")["stdout_lines"]
+    return bool(result)
 
 
 class Test_VxLAN_BFD_TSA():
@@ -523,13 +541,12 @@ class Test_VxLAN_BFD_TSA():
 
         self.dump_self_info_and_run_ptf("test4", encap_type, True, [])
 
-        duthost.shell("sudo config reload -y",
-                      executable="/bin/bash", module_ignore_errors=True)
-        assert wait_until(300, 20, 0, config_system_checks_passed, duthost, [])
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
         # readd routes as they are removed by config reload
         ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=4789, dutmac=self.vxlan_test_setup['dut_mac'])
         dest, ep_list = self.create_vnet_route(encap_type)
+        wait_until(20, 2, 0, is_vnet_route_configured_on_asic, duthost, dest)
 
         self.dump_self_info_and_run_ptf("test4b", encap_type, True, [])
 
@@ -565,13 +582,12 @@ class Test_VxLAN_BFD_TSA():
         pytest_assert(self.in_maintainence())
         self.verfiy_bfd_down(ep_list)
 
-        duthost.shell("sudo config reload -y",
-                      executable="/bin/bash", module_ignore_errors=True)
-        assert wait_until(300, 20, 0, config_system_checks_passed, duthost, [])
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
         # readd routes as they are removed by config reload
         ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=4789, dutmac=self.vxlan_test_setup['dut_mac'])
         dest, ep_list = self.create_vnet_route(encap_type)
+        wait_until(20, 2, 0, is_vnet_route_configured_on_asic, duthost, dest)
 
         self.apply_tsb()
         pytest_assert(not self.in_maintainence())
@@ -611,13 +627,12 @@ class Test_VxLAN_BFD_TSA():
 
         self.verfiy_bfd_down(ep_list)
 
-        duthost.shell("sudo config reload -y",
-                      executable="/bin/bash", module_ignore_errors=True)
-        assert wait_until(300, 20, 0, config_system_checks_passed, duthost, [])
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
         # readd routes as they are removed by config reload
         ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=4789, dutmac=self.vxlan_test_setup['dut_mac'])
         dest, ep_list = self.create_vnet_route(encap_type)
+        wait_until(20, 2, 0, is_vnet_route_configured_on_asic, duthost, dest)
 
         self.apply_tsb()
         pytest_assert(not self.in_maintainence())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR fixes test failures in `test_vxlan_bfd_tsa.py::Test_VxLAN_BFD_TSA`. These failures were observed on some platforms such as Mellanox msn4600c and Cisco 8102.

Summary:
Fixes #15728
Microsoft ADO ID: 31220198
PR for the master branch: #17511
The following two fixed were applied for `test_tsa_case4`, `test_tsa_case5`, and `test_tsa_case6`:
1. Replaced the manual execution of `sudo config reload -y` with a call to `config_reload` so that all interfaces and ports are up before configuring a VXLAN on the switch.
2. Added a check after configuring VNET routes to ensure that VNET routes are applied to the ASIC DB before running PTF tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
`test_tsa_case4`, `test_tsa_case5`, and `test_tsa_case6` failed on some platforms such as Mellanox msn4600c and Cisco 8102.

#### How did you do it?
By using `config_reload` instead of executing `sudo config reload -y` directly and making sure that VNET routes are applied to the ASIC DB before running PTF tests.

#### How did you verify/test it?
Ran the tests on a Mellanox msn4600c switch.
Note: In order for the tests to pass, the image running on the switch must have the following fix from sonic-utilities:
[revert YANG check in db_migrator](https://github.com/sonic-net/sonic-utilities/pull/3793)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
