### PR TITLE
[Cisco Specific] Fix to verify ecn marking when egress port is on long link (HBM) card

### DIFF
--- a/tests/snappi_tests/ecn/files/helper.py
+++ b/tests/snappi_tests/ecn/files/helper.py
@@ -9,12 +9,13 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, config_wred, \
     enable_ecn, config_ingress_lossless_buffer_alpha, stop_pfcwd, disable_packet_aging,\
-    config_capture_pkt, traffic_flow_mode, calc_pfc_pause_flow_rate  # noqa: F401
+    config_capture_pkt, traffic_flow_mode, calc_pfc_pause_flow_rate, get_pfc_frame_count  # noqa: F401
 from tests.common.snappi_tests.read_pcap import get_ipv4_pkts
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, generate_test_flows, \
     generate_pause_flows, run_traffic                                       # noqa: F401
 import json
+from tests.snappi_tests.files.helper import get_fabric_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -45,20 +46,100 @@ def get_npu_voq_queue_counters(duthost, interface, priority, clear=False):
 
     return dict_output
 
+#  When bp_fabric_ecn_marking_check is True
+#
+#  The traffic is flowing from short link to long link
+#
+# Step 1: Clear all counters  on egress, fabric, and ingress DUT
+# Step 2: Send traffic for the test.
+# Step 3: Verify egress port queue counter at possible congestion points.
+# Step 4: If no marking, verify no backpressure#
+# - If PFC Tx is zero, fail the test and log the result.
+# - Pass the otherwise
 
-def verify_ecn_counters(ecn_counters, link_state_toggled=False):
+
+def clear_bp_fabric_queue_counters(ingress_fabric_mapping_dict, egress_fabric_mapping, supervisor_dut, test_prio_list):
+    """
+    Clears VOQ queue counters of the ingress DUT BP ports and the Fabric ports connected to the Egress DUT.
+    """
+    for priority in test_prio_list:
+        for fabric_egress_bp in egress_fabric_mapping.values():
+            get_npu_voq_queue_counters(supervisor_dut, fabric_egress_bp, priority, clear=True)
+
+        for ingress_duthost, ingress_fabric_mappings in ingress_fabric_mapping_dict.items():
+            for fabric_mapping in ingress_fabric_mappings.values():
+                for lc_egress_bp in fabric_mapping.keys():
+                    get_npu_voq_queue_counters(ingress_duthost, lc_egress_bp, priority, clear=True)
+
+    logger.info("Counters cleared for ingress DUT BP ports and Fabric Egress ports")
+
+
+def check_bp_fabric_ecn_marking(ingress_fabric_mapping_dict, egress_fabric_mapping, supervisor_dut, test_prio_list):
+    """
+    Checks for ECN marked packets across ingress and egress fabric mappings.
+    Returns True if ECN marking is found, otherwise False.
+    """
+
+    all_priorities_marked = True
+
+    for priority in test_prio_list:
+        ecn_marked_for_priority = False
+
+        ecn_marked_packets_egress = 0
+        for fabric_egress_bp in egress_fabric_mapping.values():
+            ctr_egress = get_npu_voq_queue_counters(supervisor_dut, fabric_egress_bp, priority)
+            ecn_marked_fb = ctr_egress.get('SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS', 0)
+            ecn_marked_packets_egress += ecn_marked_fb
+            if ecn_marked_fb > 0:
+                logging.info("ECN marking : {} on Fabric interface: {}, priority: {}".format(
+                    ecn_marked_fb, fabric_egress_bp, priority))
+                ecn_marked_for_priority = True
+
+        if ecn_marked_packets_egress:
+            logging.info("Total Fabric ECN marking detected: {}  on priority: {} ".format(
+                ecn_marked_packets_egress, priority))
+
+        ecn_marked_packets_ingress = 0
+        for ingress_duthost, ingress_fabric_mappings in ingress_fabric_mapping_dict.items():
+            for fabric_mapping in ingress_fabric_mappings.values():
+                for lc_egress_bp in fabric_mapping.keys():
+                    ctr_ingress = get_npu_voq_queue_counters(ingress_duthost, lc_egress_bp, priority)
+                    ecn_marked_bp = ctr_ingress.get('SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS', 0)
+                    ecn_marked_packets_ingress += ecn_marked_bp
+                    if ecn_marked_bp > 0:
+                        logging.info("ECN marking : {}  on ingress DUT {}, interface: {}, priority: {}".format(
+                            ecn_marked_bp, ingress_duthost, lc_egress_bp, priority))
+                        ecn_marked_for_priority = True
+
+                if ecn_marked_packets_ingress:
+                    logging.info("Total Ingress BP ECN marking detected: {}  on priority: {} ".format(
+                        ecn_marked_packets_ingress, priority))
+
+        if not ecn_marked_for_priority:
+            all_priorities_marked = False
+
+    if all_priorities_marked:
+        logger.info("ECN Marking detected for all priorities")
+        return True
+    else:
+        logger.info("ECN Marking missing for some priorities")
+        return False
+
+
+def verify_ecn_counters(ecn_counters, is_bp_fabric_ecn_check_required=False, link_state_toggled=False):
 
     toggle_msg = " post link state toggle" if link_state_toggled else ""
     # verify that each flow had packets
     init_ctr_3, post_ctr_3 = ecn_counters[0]
     init_ctr_4, post_ctr_4 = ecn_counters[1]
     flow3_total = post_ctr_3['SAI_QUEUE_STAT_PACKETS'] - init_ctr_3['SAI_QUEUE_STAT_PACKETS']
+    flow4_total = post_ctr_4['SAI_QUEUE_STAT_PACKETS'] - init_ctr_4['SAI_QUEUE_STAT_PACKETS']
+
+    logging.info("Flow 3 total packets: {}, Flow 4 total packets: {}".format(flow3_total, flow4_total))
 
     pytest_assert(flow3_total > 0,
                   'Queue 3 counters at start {} at end {} did not increment{}'.format(
                    init_ctr_3['SAI_QUEUE_STAT_PACKETS'], post_ctr_3['SAI_QUEUE_STAT_PACKETS'], toggle_msg))
-
-    flow4_total = post_ctr_4['SAI_QUEUE_STAT_PACKETS'] - init_ctr_4['SAI_QUEUE_STAT_PACKETS']
 
     pytest_assert(flow4_total > 0,
                   'Queue 4 counters at start {} at end {} did not increment{}'.format(
@@ -69,6 +150,17 @@ def verify_ecn_counters(ecn_counters, link_state_toggled=False):
     flow4_ecn = post_ctr_4['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS'] -\
         init_ctr_4['SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS']
 
+    if is_bp_fabric_ecn_check_required:
+        if flow3_ecn == 0:
+            logging.info("ECN marking check failed on flow 3 on egress port")
+            return False  # Flow 3 ECN marking failed
+        elif flow4_ecn == 0:
+            logging.info("ECN marking check failed on flow 4 on egress port")
+            return False  # Flow 4 ECN marking failed
+        else:
+            logging.info("ECN marking check passed on both flow 3 and 4 on egress port")
+            return True  # Both flows had ECN marked packets (success)
+
     pytest_assert(flow3_ecn > 0,
                   'Must have ecn marked packets on flow 3{}'.
                   format(toggle_msg))
@@ -76,6 +168,7 @@ def verify_ecn_counters(ecn_counters, link_state_toggled=False):
     pytest_assert(flow4_ecn > 0,
                   'Must have ecn marked packets on flow 4{}'.
                   format(toggle_msg))
+    return True
 
 
 def verify_ecn_counters_for_flow_percent(
@@ -467,6 +560,8 @@ def run_ecn_marking_port_toggle_test(
                                     dut_port,
                                     test_prio_list,
                                     prio_dscp_map,
+                                    supervisor_dut=None,
+                                    is_bp_fabric_ecn_check_required=False,
                                     snappi_extra_params=None):
 
     """
@@ -480,6 +575,8 @@ def run_ecn_marking_port_toggle_test(
         dut_port (str): DUT port to test
         test_prio_list (list): priorities of test flows
         prio_dscp_map (dict): Priority vs. DSCP map (key = priority).
+        supervisor_dut (obj): Supervisor DUT, if ECN check is required
+        is_bp_fabric_ecn_check_required (bool): Flag to indicate if BP fabric ECN check is required
         snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
     Returns:
         N/A
@@ -504,8 +601,26 @@ def run_ecn_marking_port_toggle_test(
 
     duthost = egress_duthost
 
-    init_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
-    init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+    tx_port_1 = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost_1 = tx_port_1['duthost']
+
+    tx_port_2 = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost_2 = tx_port_2['duthost']
+
+    # Append the duthost here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost_1)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost_2)
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
+    # Find fabric mapping per ASIC instance
+    ingress_fabric_mapping_dict = {}
+    for ingress_duthost, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]:
+        asic_instance = ingress_duthost.get_port_asic_instance(tx_port['peer_port'])
+        fabric_mapping = get_fabric_mapping(ingress_duthost, asic_instance)
+        ingress_fabric_mapping_dict.setdefault(ingress_duthost, {})[asic_instance] = fabric_mapping
+
+    egress_asic_instance = egress_duthost.get_port_asic_instance(rx_port['peer_port'])
+    egress_fabric_mapping = get_fabric_mapping(egress_duthost, egress_asic_instance)
 
     _generate_traffic_config(testbed_config, snappi_extra_params,
                              port_config_list, test_prio_list,
@@ -516,52 +631,61 @@ def run_ecn_marking_port_toggle_test(
     all_flow_names = [flow.name for flow in flows]
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
-    """ Run traffic """
-    _tgen_flow_stats, _switch_flow_stats, _in_flight_flow_metrics = run_traffic(
-                                                                duthost,
-                                                                api=api,
-                                                                config=testbed_config,
-                                                                data_flow_names=data_flow_names,
-                                                                all_flow_names=all_flow_names,
-                                                                exp_dur_sec=DATA_FLOW_DURATION_SEC +
-                                                                DATA_FLOW_DELAY_SEC,
-                                                                snappi_extra_params=snappi_extra_params)
+    link_state_toggled = False
 
-    post_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
-    post_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+    # Function to clear  ECN counters
+    def clear_ecn_counters():
+        if is_bp_fabric_ecn_check_required:
+            snappi_extra_params.multi_dut_params.ingress_duthosts.append(supervisor_dut)
+            clear_bp_fabric_queue_counters(ingress_fabric_mapping_dict, egress_fabric_mapping,
+                                           supervisor_dut, test_prio_list)
 
-    ecn_counters = [
-        (init_ctr_3, post_ctr_3),
-        (init_ctr_4, post_ctr_4)
-    ]
+            for priority in test_prio_list:
+                get_npu_voq_queue_counters(duthost, dut_port, priority, True)
 
-    verify_ecn_counters(ecn_counters)
+    # Function to run traffic and check ECN marking
+    def run_traffic_and_check_ecn():
+        """Run traffic and verify ECN marking"""
+        initial_counters = {priority: get_npu_voq_queue_counters(duthost, dut_port, priority)
+                            for priority in test_prio_list}
 
+        run_traffic(
+            duthost, api=api, config=testbed_config, data_flow_names=data_flow_names,
+            all_flow_names=all_flow_names, exp_dur_sec=DATA_FLOW_DURATION_SEC + DATA_FLOW_DELAY_SEC,
+            snappi_extra_params=snappi_extra_params
+        )
+
+        post_counters = {priority: get_npu_voq_queue_counters(duthost, dut_port, priority)
+                         for priority in test_prio_list}
+        ecn_counters = [(initial_counters[p], post_counters[p]) for p in test_prio_list]
+
+        return verify_ecn_counters(ecn_counters, is_bp_fabric_ecn_check_required, link_state_toggled)
+
+    def check_ecn_marking():
+        """Check ECN marking before or after port toggle"""
+        clear_ecn_counters()
+        ecn_marking_verified_on_egress = run_traffic_and_check_ecn()
+
+        if not ecn_marking_verified_on_egress:
+            if not check_bp_fabric_ecn_marking(ingress_fabric_mapping_dict, egress_fabric_mapping,
+                                               supervisor_dut, test_prio_list):
+                total_ingress_pfc_tx_count = sum(
+                    get_pfc_frame_count(dut, tx_port['peer_port'], priority, True)
+                    for dut, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]
+                    for priority in test_prio_list
+                )
+                pytest_assert(total_ingress_pfc_tx_count, "No ECN marking in the data path")
+
+    # Initial ECN verification
+    check_ecn_marking()
+
+    # Toggle port state
     toggle_dut_port_state(api)
 
-    init_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
-    init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+    link_state_toggled = True
 
-    """ Run traffic """
-    _tgen_flow_stats, _switch_flow_stats, _in_flight_flow_metrics = run_traffic(
-                                                                duthost,
-                                                                api=api,
-                                                                config=testbed_config,
-                                                                data_flow_names=data_flow_names,
-                                                                all_flow_names=all_flow_names,
-                                                                exp_dur_sec=DATA_FLOW_DURATION_SEC +
-                                                                DATA_FLOW_DELAY_SEC,
-                                                                snappi_extra_params=snappi_extra_params)
-
-    post_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
-    post_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
-
-    ecn_counters = [
-        (init_ctr_3, post_ctr_3),
-        (init_ctr_4, post_ctr_4)
-    ]
-
-    verify_ecn_counters(ecn_counters, link_state_toggled=True)
+    # Post toggle ECN verification
+    check_ecn_marking()
 
 
 def run_ecn_marking_test(api,
@@ -841,6 +965,8 @@ def run_ecn_marking_ect_marked_pkts(
                                     dut_port,
                                     test_prio_list,
                                     prio_dscp_map,
+                                    supervisor_dut=None,
+                                    is_bp_fabric_ecn_check_required=False,
                                     snappi_extra_params=None):
 
     """
@@ -875,11 +1001,39 @@ def run_ecn_marking_ect_marked_pkts(
 
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
     egress_duthost = rx_port['duthost']
-
     duthost = egress_duthost
 
-    init_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
-    init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+    tx_port_1 = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost_1 = tx_port_1['duthost']
+
+    tx_port_2 = snappi_extra_params.multi_dut_params.multi_dut_ports[1]
+    ingress_duthost_2 = tx_port_2['duthost']
+
+    # Append the duthost here for run_traffic to clear its counters
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost_1)
+    snappi_extra_params.multi_dut_params.ingress_duthosts.append(ingress_duthost_2)
+    snappi_extra_params.multi_dut_params.egress_duthosts.append(egress_duthost)
+
+    # Find fabric mapping per ASIC instance
+    ingress_fabric_mapping_dict = {}
+    for ingress_duthost, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]:
+        asic_instance = ingress_duthost.get_port_asic_instance(tx_port['peer_port'])
+        fabric_mapping = get_fabric_mapping(ingress_duthost, asic_instance)
+        ingress_fabric_mapping_dict.setdefault(ingress_duthost, {})[asic_instance] = fabric_mapping
+
+    egress_asic_instance = egress_duthost.get_port_asic_instance(rx_port['peer_port'])
+    egress_fabric_mapping = get_fabric_mapping(egress_duthost, egress_asic_instance)
+
+    if is_bp_fabric_ecn_check_required:
+        snappi_extra_params.multi_dut_params.ingress_duthosts.append(supervisor_dut)
+        clear_bp_fabric_queue_counters(ingress_fabric_mapping_dict,
+                                       egress_fabric_mapping, supervisor_dut, test_prio_list)
+
+        for priority in test_prio_list:
+            get_npu_voq_queue_counters(duthost, dut_port, priority, True)
+
+    initial_counters = {priority: get_npu_voq_queue_counters(duthost, dut_port, priority)
+                        for priority in test_prio_list}
 
     _generate_traffic_config(testbed_config, snappi_extra_params,
                              port_config_list, test_prio_list,
@@ -892,22 +1046,27 @@ def run_ecn_marking_ect_marked_pkts(
     data_flow_names = [flow.name for flow in flows if PAUSE_FLOW_NAME not in flow.name]
 
     """ Run traffic """
-    _tgen_flow_stats, _switch_flow_stats, _in_flight_flow_metrics = run_traffic(
-                                                                duthost,
-                                                                api=api,
-                                                                config=testbed_config,
-                                                                data_flow_names=data_flow_names,
-                                                                all_flow_names=all_flow_names,
-                                                                exp_dur_sec=DATA_FLOW_DURATION_SEC +
-                                                                DATA_FLOW_DELAY_SEC,
-                                                                snappi_extra_params=snappi_extra_params)
+    _, _, _ = run_traffic(
+                            duthost,
+                            api=api,
+                            config=testbed_config,
+                            data_flow_names=data_flow_names,
+                            all_flow_names=all_flow_names,
+                            exp_dur_sec=DATA_FLOW_DURATION_SEC +
+                            DATA_FLOW_DELAY_SEC,
+                            snappi_extra_params=snappi_extra_params)
 
-    post_ctr_3 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[0])
-    post_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
+    post_counters = {priority: get_npu_voq_queue_counters(duthost, dut_port, priority)
+                     for priority in test_prio_list}
+    ecn_counters = [(initial_counters[p], post_counters[p]) for p in test_prio_list]
 
-    ecn_counters = [
-        (init_ctr_3, post_ctr_3),
-        (init_ctr_4, post_ctr_4)
-    ]
-
-    verify_ecn_counters(ecn_counters)
+    ecn_marking_verified_on_egress = verify_ecn_counters(ecn_counters, is_bp_fabric_ecn_check_required)
+    if not ecn_marking_verified_on_egress:
+        if not check_bp_fabric_ecn_marking(ingress_fabric_mapping_dict, egress_fabric_mapping,
+                                           supervisor_dut, test_prio_list):
+            total_ingress_pfc_tx_count = sum(
+                get_pfc_frame_count(dut, tx_port['peer_port'], priority, True)
+                for dut, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]
+                for priority in test_prio_list
+            )
+            pytest_assert(total_ingress_pfc_tx_count, "No ECN marking in the data path")

--- a/tests/snappi_tests/ecn/files/helper.py
+++ b/tests/snappi_tests/ecn/files/helper.py
@@ -53,9 +53,9 @@ def get_npu_voq_queue_counters(duthost, interface, priority, clear=False):
 # Step 1: Clear all counters  on egress, fabric, and ingress DUT
 # Step 2: Send traffic for the test.
 # Step 3: Verify egress port queue counter at possible congestion points.
-# Step 4: If no marking, verify no backpressure#
-# - If PFC Tx is zero, fail the test and log the result.
-# - Pass the otherwise
+# Step 4: If no marking,
+# - check and log  backpressure
+# - Fail the testcase
 
 
 def clear_bp_fabric_queue_counters(ingress_fabric_mapping_dict, egress_fabric_mapping, supervisor_dut, test_prio_list):
@@ -669,12 +669,13 @@ def run_ecn_marking_port_toggle_test(
         if not ecn_marking_verified_on_egress:
             if not check_bp_fabric_ecn_marking(ingress_fabric_mapping_dict, egress_fabric_mapping,
                                                supervisor_dut, test_prio_list):
-                total_ingress_pfc_tx_count = sum(
-                    get_pfc_frame_count(dut, tx_port['peer_port'], priority, True)
-                    for dut, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]
-                    for priority in test_prio_list
-                )
-                pytest_assert(total_ingress_pfc_tx_count, "No ECN marking in the data path")
+                # Log PFC frame counts
+                for dut, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]:
+                    for priority in test_prio_list:
+                        pfc_count = get_pfc_frame_count(dut, tx_port['peer_port'], priority, True)
+                        logging.info("PFC Tx frame count for DUT {}, Port {}, Priority {}: {}".format(
+                            dut.hostname, tx_port['peer_port'], priority, pfc_count))
+                pytest_assert(False, "No ECN marking in the data path")
 
     # Initial ECN verification
     check_ecn_marking()
@@ -1064,9 +1065,11 @@ def run_ecn_marking_ect_marked_pkts(
     if not ecn_marking_verified_on_egress:
         if not check_bp_fabric_ecn_marking(ingress_fabric_mapping_dict, egress_fabric_mapping,
                                            supervisor_dut, test_prio_list):
-            total_ingress_pfc_tx_count = sum(
-                get_pfc_frame_count(dut, tx_port['peer_port'], priority, True)
-                for dut, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]
-                for priority in test_prio_list
-            )
-            pytest_assert(total_ingress_pfc_tx_count, "No ECN marking in the data path")
+            # Log PFC frame counts
+            for dut, tx_port in [(ingress_duthost_1, tx_port_1), (ingress_duthost_2, tx_port_2)]:
+                for priority in test_prio_list:
+                    pfc_count = get_pfc_frame_count(dut, tx_port['peer_port'], priority, True)
+                    logging.info("PFC Tx frame count for DUT {}, Port {}, Priority {}: {}".format(
+                        dut.hostname, tx_port['peer_port'], priority, pfc_count))
+
+            pytest_assert(False, "No ECN marking in the data path")

--- a/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
@@ -100,7 +100,6 @@ def validate_snappi_ports(snappi_ports):
 
     # Retrieve ASIC namespace
     rx_asic = get_asic(rx_dut, rx_peer_port)
-    # print(rx_asic, rx_peer_port)
     tx_asic_1 = get_asic(tx_dut_1, tx_peer_port_1)
     tx_asic_2 = get_asic(tx_dut_2, tx_peer_port_2)
 
@@ -210,7 +209,8 @@ def test_ecn_marking_lossless_prio(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    input_port_same_asic, input_port_same_dut, single_dut, egress_port_short_link = snappi_port_dut_info(snappi_ports)
+    input_port_same_asic, input_port_same_dut, single_dut, _, \
+        egress_port_short_link = snappi_port_dut_info(snappi_ports)
     pytest_require(egress_port_short_link, "Egress port must be on short link")
 
     logger.info("Snappi Ports : {}".format(snappi_ports))

--- a/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
@@ -47,20 +47,29 @@ def snappi_port_dut_info(snappi_ports):
     if (tx_dut_1 == tx_dut_2):
         input_ports_same_dut = True
 
-    cmd_part = f"-n {rx_asic}"
-    if rx_asic is None:
-        cmd_part = ""
-    cmd = 'sonic-db-cli ' + f'{cmd_part}' + ' CONFIG_DB hget "CABLE_LENGTH|AZURE" ' + rx_peer_port
+    def check_dut_short_link(dut_asic, dut, dut_port):
+        cmd_part = f"-n {dut_asic}"
+        if dut_asic is None:
+            cmd_part = ""
+        cmd = 'sonic-db-cli ' + f'{cmd_part}' + ' CONFIG_DB hget "CABLE_LENGTH|AZURE" ' + dut_port
 
-    len_str = rx_dut.shell(cmd)['stdout_lines']
-    cable_len = int(len_str[0][:-1])
-    # 120000m -> 120000
-    if cable_len < 1000:
-        egress_port_short_link = True
-    else:
-        egress_port_short_link = False
+        len_str = dut.shell(cmd)['stdout_lines']
+        cable_len = int(len_str[0][:-1])
+        # 120000m -> 120000
+        return True if cable_len < 1000 else False
 
-    return input_ports_same_asic, input_ports_same_dut, single_dut, egress_port_short_link
+    egress_port_short_link = check_dut_short_link(rx_asic, rx_dut, rx_peer_port)
+
+    # Check if ingress ports are short link
+    ingress_ports_1_short_link = check_dut_short_link(tx_asic_1, tx_dut_1, tx_peer_port_1)
+    ingress_ports_2_short_link = check_dut_short_link(tx_asic_2, tx_dut_2, tx_peer_port_2)
+
+    # ECN mark check on bp or fabric port only when both ingress are on short and egress is on long link
+    is_bp_fabric_ecn_check_required = ingress_ports_1_short_link and ingress_ports_2_short_link \
+        and not egress_port_short_link
+
+    return input_ports_same_asic, input_ports_same_dut, single_dut, \
+        is_bp_fabric_ecn_check_required, egress_port_short_link
 
 
 def validate_snappi_ports(snappi_ports):
@@ -144,6 +153,12 @@ def test_ecn_marking_port_toggle(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
+    _, _, _, is_bp_fabric_ecn_check_required, _ = snappi_port_dut_info(snappi_ports)
+
+    supervisor_dut = None
+    if is_bp_fabric_ecn_check_required:
+        supervisor_dut = next((duthost for duthost in duthosts if duthost.is_supervisor_node()), None)
+
     logger.info("Snappi Ports : {}".format(snappi_ports))
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -155,6 +170,8 @@ def test_ecn_marking_port_toggle(
                             dut_port=snappi_ports[0]['peer_port'],
                             test_prio_list=lossless_prio_list,
                             prio_dscp_map=prio_dscp_map,
+                            supervisor_dut=supervisor_dut,
+                            is_bp_fabric_ecn_check_required=is_bp_fabric_ecn_check_required,
                             snappi_extra_params=snappi_extra_params)
 
 
@@ -176,7 +193,6 @@ def test_ecn_marking_lossless_prio(
                                 setup_ports_and_dut):                    # noqa: F811
     """
     Verify ECN marking on lossless prio with same DWRR weight
-
     Args:
         request (pytest fixture): pytest request object
         snappi_api (pytest fixture): SNAPPI session
@@ -246,6 +262,12 @@ def test_ecn_marking_ect_marked_pkts(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
+    _, _, _, is_bp_fabric_ecn_check_required, _ = snappi_port_dut_info(snappi_ports)
+
+    supervisor_dut = None
+    if is_bp_fabric_ecn_check_required:
+        supervisor_dut = next((duthost for duthost in duthosts if duthost.is_supervisor_node()), None)
+
     logger.info("Snappi Ports : {}".format(snappi_ports))
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -257,4 +279,6 @@ def test_ecn_marking_ect_marked_pkts(
                             dut_port=snappi_ports[0]['peer_port'],
                             test_prio_list=lossless_prio_list,
                             prio_dscp_map=prio_dscp_map,
+                            supervisor_dut=supervisor_dut,
+                            is_bp_fabric_ecn_check_required=is_bp_fabric_ecn_check_required,
                             snappi_extra_params=snappi_extra_params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

for cisco-8000 chassis in packet mode, add a test to verify ecn marking at congestion points based on traffic pattern 


<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

When multiple backplane traffic flows share the same slice of a asic on long-link card and use the default VOQ (as HBM-based long-link cards operate in default VOQ mode), the XOFF threshold gets breached.

This results in an XOFF signal being generated to the Fabric port, which leads to ECN marking at the Fabric port.

However, since no actual congestion is experienced on the egress port, it does not trigger ECN marking, leading to the test case failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

- if ecn counter is not zero at egress port->success

- if ecn counter is zero:

- check the backplane ports on all FC - some of them should have non-zero ecn counters. pass the test else step 2

- check the backplane ports on the ingress port LC — some of them should have non-zero ecn counters. pass the test else step 3

- If the two checks above led to all zero ecn counter -

Check that the ingress ports did generate XOFF else fail the test case

#### How did you verify/test it?

Verify correctness by checking that ecn marking occurs before signaling XOFF 

#### Any platform specific information?

Cisco T2 

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================================ PASSES =============================================================================================================================================
_______________________________________________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info0] _______________________________________________________________________________________________________________________
_______________________________________________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info1] _______________________________________________________________________________________________________________________
_______________________________________________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info2] _______________________________________________________________________________________________________________________
_______________________________________________________________________________________________________________________ test_ecn_marking_port_toggle[multidut_port_info3] _______________________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent0] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent1] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent2] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent3] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent4] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent5] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info1-test_flow_percent6] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent0] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent1] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent2] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent3] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent4] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent5] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent6] _____________________________________________________________________________________________________________
____________________________________________________________________________________________________________ test_ecn_marking_lossless_prio[multidut_port_info2-test_flow_percent7] _____________________________________________________________________________________________________________
_____________________________________________________________________________________________________________________ test_ecn_marking_ect_marked_pkts[multidut_port_info0] _____________________________________________________________________________________________________________________
_____________________________________________________________________________________________________________________ test_ecn_marking_ect_marked_pkts[multidut_port_info1] _____________________________________________________________________________________________________________________
_____________________________________________________________________________________________________________________ test_ecn_marking_ect_marked_pkts[multidut_port_info2] _____________________________________________________________________________________________________________________
_____________________________________________________________________________________________________________________ test_ecn_marking_ect_marked_pkts[multidut_port_info3] _____________________________________________________________________________________________________________________
-------------------------------------------------------------------------------------------------------------- generated xml file: /run_logs/ixia/21831/2025-03-25-11-57-36/tr.xml --------------------------------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
```

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
