### PR TITLE
[topo script] Skip backplane address of ptf when generate topo file to avoid address duplication

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -6,6 +6,11 @@ from ipaddress import IPv4Network, IPv6Network
 import click
 import jinja2
 
+PTF_BACKPLANE_IPV4 = "10.10.246.254"
+BACKPLANE_ADDITIONAL_OFFSET_IPV4 = 0
+PTF_BACKPLANE_IPV6 = "fc0a::ff"
+BACKPLANE_ADDITIONAL_OFFSET_IPV6 = 0
+
 # Define the roles for the devices in the topology
 roles_cfg = {
     "t0": {
@@ -146,8 +151,16 @@ class VM:
         self.loopback_ipv6 = calc_ipv6("2064:100::", (self.ip_offset+1) * 2**64)
 
         # Backplane IPs
-        self.bp_ipv4 = calc_ipv4("10.10.246.1", self.ip_offset+1)
-        self.bp_ipv6 = calc_ipv6("fc0a::1", (self.ip_offset+1))
+        global BACKPLANE_ADDITIONAL_OFFSET_IPV4
+        self.bp_ipv4 = calc_ipv4("10.10.246.1", self.ip_offset+1+BACKPLANE_ADDITIONAL_OFFSET_IPV4)
+        if self.bp_ipv4 == PTF_BACKPLANE_IPV4:
+            BACKPLANE_ADDITIONAL_OFFSET_IPV4 = 1
+            self.bp_ipv4 = calc_ipv4("10.10.246.1", self.ip_offset+1+BACKPLANE_ADDITIONAL_OFFSET_IPV4)
+        global BACKPLANE_ADDITIONAL_OFFSET_IPV6
+        self.bp_ipv6 = calc_ipv6("fc0a::1", (self.ip_offset+1+BACKPLANE_ADDITIONAL_OFFSET_IPV6))
+        if self.bp_ipv6 == PTF_BACKPLANE_IPV6:
+            BACKPLANE_ADDITIONAL_OFFSET_IPV6 = 1
+            self.bp_ipv6 = calc_ipv6("fc0a::1", self.ip_offset+1+BACKPLANE_ADDITIONAL_OFFSET_IPV6)
 
 
 class HostInterface:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

When generate topology, we will assign backplane address sequentially, however, it may duplicate with ptf back plane address both in ipv4 and ipv6, to avoid address conflict, skip the ptf backplane address when generate topology.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When generate topology, we will assign backplane address sequentially, however, it may duplicate with ptf back plane address both in ipv4 and ipv6
#### How did you do it?
to avoid address conflict, skip the ptf backplane address when generate topology.
#### How did you verify/test it?
Run script locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
