### PR TITLE
Add retry when checking fec mode restore status in tests/platform_tests/test_intf_fec.py

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -40,6 +40,13 @@ def get_fec_oper_mode(duthost, interface):
     return fec_status[0].get('fec oper', '').lower()
 
 
+def check_intf_fec_mode(duthost, intf, exp_fec_mode):
+    post_fec = get_fec_oper_mode(duthost, intf)
+    if post_fec == exp_fec_mode:
+        return True
+    return False
+
+
 def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     @Summary: Verify the FEC operational mode is valid, for all the interfaces with
@@ -84,9 +91,8 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
             pytest_assert(wait_until(30, 2, 0, duthost.is_interface_status_up, intf),
                           "Interface {} did not come up after configuring FEC mode".format(intf))
             # Verify the FEC operational mode is restored
-            post_fec = get_fec_oper_mode(duthost, intf)
-            if not (post_fec == fec_mode):
-                pytest.fail("FEC status is not restored for interface {}".format(intf))
+            pytest_assert(wait_until(30, 2, 0, check_intf_fec_mode, duthost, intf, fec_mode),
+                          f"FEC status of Interface {intf} is not restored to {fec_mode}")
 
 
 def get_interface_speed(duthost, interface_name):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add retry when checking fec mode restore status in test_intf_fec.py
It may need some seconds for fec mode to restore to the original value

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
tests/platform_tests/test_intf_fec.py failed with low chance
#### How did you do it?
Add retry when checking fec mode restore status in test_intf_fec.py
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
