### PR TITLE
Update the vendor_id string for Marvell Teralynx ASIC

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -98,7 +98,7 @@ def tag_image(duthost, tag, image_name, image_version="latest"):
         image_version (str): The version of the image to tag.
     """
     vendor_id = _get_vendor_id(duthost)
-    if vendor_id in ['invm']:
+    if vendor_id in ['mrvl-teralynx']:
         image_name = "docker-syncd-{}-rpc".format(vendor_id)
 
     duthost.command("docker tag {}:{} {}".format(image_name, image_version, tag))
@@ -245,7 +245,7 @@ def _get_vendor_id(duthost):
     elif is_cisco_device(duthost):
         vendor_id = "cisco"
     elif is_marvell_teralynx_device(duthost):
-        vendor_id = "invm"
+        vendor_id = "mrvl-teralynx"
     else:
         error_message = '"{}" does not currently support swap_syncd'.format(duthost.facts["asic_type"])
         logger.error(error_message)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adding the changes to support vendor_id string for Marvell Teralynx ASIC.

Summary:
Fixes # (issue)
The vendor_id string for Marvell Teralynx ASIC needs to be  changed from 'invm' to 'mrvl-teralynx'


### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Applicable only to Marvell Teralynx ASIC family
https://github.com/sonic-net/sonic-buildimage/pull/19829

#### Supported testbed topology if it's a new test case?

### Documentation

