### PR TITLE
snmp: modify tests to also consider fans under fabric module

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -45,6 +45,7 @@ MODULE_INDEX_MULTIPLE = 1000000
 MODULE_TYPE_MGMT = 2 * MODULE_TYPE_MULTIPLE
 MODULE_TYPE_FAN_DRAWER = 5 * MODULE_TYPE_MULTIPLE
 MODULE_TYPE_PSU = 6 * MODULE_TYPE_MULTIPLE
+MODULE_TYPE_FABRIC_CARD = 7 * MODULE_TYPE_MULTIPLE
 MODULE_TYPE_PORT = 1000000000
 
 # Device Type Definition
@@ -227,6 +228,50 @@ def get_entity_and_sensor_mib(duthost, localhost, creds_all_duts):
     return mib_info
 
 
+def test_fabric_card_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_entity_and_sensor_info):
+    """
+    Verify fabric module information in physical entity mib with redis database
+    :param duthost: DUT host object
+    :param snmp_physical_entity_info: Physical entity information from snmp fact
+    :return:
+    """
+    snmp_physical_entity_info = snmp_physical_entity_and_sensor_info["entity_mib"]
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if not duthost.is_supervisor_node():
+        pytest.skip("Not supported on non supervisor node")
+    keys = redis_get_keys(
+        duthost, STATE_DB, PHYSICAL_ENTITY_KEY_TEMPLATE.format('FABRIC-CARD*'))
+    # Ignore the test if the platform does not support fan drawer
+    if not keys:
+        pytest.skip(
+            'Fabric Card information does not exist in DB, skipping this test')
+    for key in keys:
+        fc_info = redis_hgetall(duthost, STATE_DB, key)
+        name = key.split(TABLE_NAME_SEPARATOR_VBAR)[-1]
+        entity_info_key = PHYSICAL_ENTITY_KEY_TEMPLATE.format(name)
+        entity_info = redis_hgetall(duthost, STATE_DB, entity_info_key)
+        position = int(entity_info['position_in_parent'])
+        expect_oid = MODULE_TYPE_FABRIC_CARD + position * MODULE_INDEX_MULTIPLE
+        assert expect_oid in snmp_physical_entity_info, 'Cannot find fan drawer {} in physical entity mib'.format(
+            name)
+
+        fc_snmp_fact = snmp_physical_entity_info[expect_oid]
+        assert fc_snmp_fact['entPhysDescr'] == name
+        assert fc_snmp_fact['entPhysContainedIn'] == CHASSIS_SUB_ID
+        assert fc_snmp_fact['entPhysClass'] == PHYSICAL_CLASS_MODULE
+        assert fc_snmp_fact['entPhyParentRelPos'] == position
+        assert fc_snmp_fact['entPhysName'] == name
+        assert fc_snmp_fact['entPhysHwVer'] == ''
+        assert fc_snmp_fact['entPhysFwVer'] == ''
+        assert fc_snmp_fact['entPhysSwVer'] == ''
+        assert fc_snmp_fact['entPhysSerialNum'] == '' if is_null_str(fc_info['serial']) else fc_info['serial']
+        assert fc_snmp_fact['entPhysMfgName'] == ''
+        assert fc_snmp_fact['entPhysModelName'] == '' if is_null_str(
+            fc_info['model']) else fc_info['model']
+        assert fc_snmp_fact['entPhysIsFRU'] == REPLACEABLE if fc_info[
+            'is_replaceable'] == 'True' else NOT_REPLACEABLE
+
+
 def test_fan_drawer_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_entity_and_sensor_info):
     """
     Verify fan drawer information in physical entity mib with redis database
@@ -299,7 +344,10 @@ def test_fan_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_enti
             parent_entity_info = redis_hgetall(
                 duthost, STATE_DB, PHYSICAL_ENTITY_KEY_TEMPLATE.format(parent_name))
             parent_position = int(parent_entity_info['position_in_parent'])
-            parent_oid = MODULE_TYPE_FAN_DRAWER + parent_position * MODULE_INDEX_MULTIPLE
+            if 'FABRIC-CARD' in parent_name:
+                parent_oid = MODULE_TYPE_FABRIC_CARD + parent_position * MODULE_INDEX_MULTIPLE
+            else:
+                parent_oid = MODULE_TYPE_FAN_DRAWER + parent_position * MODULE_INDEX_MULTIPLE
         expect_oid = parent_oid + DEVICE_TYPE_FAN + position * DEVICE_INDEX_MULTIPLE
         assert expect_oid in snmp_physical_entity_info, 'Cannot find fan {} in physical entity mib'.format(
             name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Modify tests to also consider fans under fabric modules.
Fixes #16189 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Currently, `test_fan_info` operates under the assumption
that fans are only present in fan drawers. But, with Modular
Chassis, fans can also be present in the fabric modules.

Modify the test to consider this scenario while testing for fan
information.

#### How did you do it?

1. Added a new test which only tests for fans under fabric cards.

2. Modified `test_fan_info` in such a way that depending on where
the fan is present (i.e fabric card or fan drawer) appropriate parent
is chosen and its information is verified.

#### How did you verify/test it?

Tested it manually on Arista machines.

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Other PRs of interest for this change: https://github.com/sonic-net/sonic-platform-daemons/pull/601, https://github.com/sonic-net/sonic-snmpagent/pull/349
