### PR TITLE
[cisco] [dut_console] [serial] Add a logic to terminate occupied serial connection.

### DIFF
--- a/ansible/group_vars/lab/secrets.yml
+++ b/ansible/group_vars/lab/secrets.yml
@@ -8,6 +8,7 @@ console_login:
   console_telnet:
     user: "root"
     passwd: ["password1", "password2"]
+    server_password: ["password1"]
   console_ssh:
     user: "root"
     passwd: ["password1", "password2"]

--- a/tests/common/connections/terminate_serial_connection.py
+++ b/tests/common/connections/terminate_serial_connection.py
@@ -1,0 +1,79 @@
+import telnetlib
+from tests.common.cisco_data import is_cisco_device
+
+
+def terminate_occupied_serial_connection(duthost, creds: dict, console_host: str, console_port: int) -> bool:
+    """
+    Terminates a occupied serial connection on a device.
+
+    This function serves as a placeholder for other SONiC vendors to add their own
+    implementations. Different vendors may use different methods for terminating
+    serial connections, such as Telnet, Minicom, etc.
+
+    Args:
+        duthost: The device under test instance.
+        creds (dict): A dictionary containing credentials.
+        console_host (str): The hostname or IP address of the console server.
+        console_port (int): The Telnet port number on the console server.
+
+    Returns:
+        bool: True if the serial connection was terminated successfully, False otherwise.
+    """
+    if is_cisco_device(duthost):
+        return cisco_telnet_kill_session(console_host, console_port, creds)
+    else:
+        return False
+
+
+def cisco_telnet_kill_session(host: str, port: int, creds: dict) -> bool:
+    """
+    Terminates a Telnet session on a Cisco device.
+
+    This function connects to a Cisco device using Telnet, enters enable mode, and
+    terminates the specified Telnet session by sending the appropriate command.
+
+    Args:
+        host (str): The Telnet server IP address.
+        port (int): The Telnet port number.
+        creds (dict): A dictionary containing credentials.
+
+    Returns:
+        bool: True if the Telnet session was terminated successfully, False otherwise.
+    """
+    password = creds.get("console_login", {}).get("console_telnet", {}).get("server_password", [None])[0]
+
+    if password is None or port is None or host is None:
+        return False
+
+    # Assuming the line number is derived from the last digit of the telnet port
+    line_number = port % 100
+
+    try:
+        with telnetlib.Telnet(host) as tn:
+            # Wait for the initial prompt and send the password
+            tn.read_until(b"Password: ")
+            tn.write(password.encode("ascii") + b"\n")
+
+            # Enter enable mode
+            tn.read_until(b">")
+            tn.write(b"enable\n")
+            tn.read_until(b"Password: ")
+            tn.write(password.encode("ascii") + b"\n")
+
+            # Clear the specified line
+            tn.read_until(b"#")
+            command = f"clear line {line_number}\n"
+            tn.write(command.encode("ascii"))
+
+            # Handle the confirmation prompt
+            tn.read_until(b"[confirm]")
+            tn.write(b"\n")
+
+            # Wait for the OK message
+            tn.read_until(b"[OK]")
+
+            # Close the connection
+            tn.write(b"exit\n")
+        return True
+    except (EOFError, OSError):
+        return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a logic to terminate occupied serial connection for Cisco environment and a placeholder for other SONiC vendors.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add logic to terminate occupied serial connection.
In case when some developer forget to exit the telnet this logic will kill existing telnet session.

#### How did you do it?
Add a function `terminate_occupied_serial_connection` and provide a `Cisco-specific` implementation.
This function serves as a placeholder for other SONiC vendors to add their own implementations. Different vendors may use different methods for terminating serial connections, such as Telnet, Minicom, etc.

#### How did you verify/test it?
1. Establish serial connection with a DUT.
2. Run the `dut_console/test_escape_character.py` test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
