### PR TITLE
adding new cisco 8101 platform to watchdog.yml

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -163,6 +163,12 @@ x86_64-8101_32fh_o-r0:
     greater_timeout: 6553
     too_big_timeout: 6554
 
+x86_64-8101_32fh_o_c01-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
 x86_64-8111_32eh_o-r0:
   default:
     valid_timeout: 10


### PR DESCRIPTION
**What is the motivation for this PR?**
Adding Cisco x86_64-8101_32fh_o_c01-r0 platform to platform_tests/api/watchdog.yml file. This is needed for testcase platform_tests/api/test_watchdog.py

**How did you do it?**
Added the details for x86_64-8101_32fh_o_c01-r0 platform to watchdog.yml file

**Type of change** 
-Test modification

**Back port request** 
-202405
-202411

**How did you verify/test it?**
Testcase passed on Cisco x86_64-8101_32fh_o_c01-r0 platform after adding platform details in platform_tests/api/watchdog.yml file