### PR TITLE
[GCU] Change to fixture to save test running time

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -46,6 +46,13 @@ def get_iptable_rules(duthost):
 
 
 @pytest.fixture(scope="module", autouse=True)
+def restore_test_env(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    config_reload(duthost, config_source="minigraph", safe_reload=True)
+    yield
+
+
+@pytest.fixture(scope="module", autouse=True)
 def disable_port_toggle(duthosts, tbinfo):
     # set mux mode to manual on both TORs to avoid port state change during test
     if "dualtor" in tbinfo['topo']['name']:
@@ -67,7 +74,6 @@ def setup_env(duthosts, rand_one_dut_hostname):
     """
     duthost = duthosts[rand_one_dut_hostname]
 
-    config_reload(duthost, config_source="minigraph", safe_reload=True)
     original_iptable_rules = get_iptable_rules(duthost)
     original_cacl_tables = get_cacl_tables(duthost)
     create_checkpoint(duthost)

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -53,7 +53,7 @@ def restore_test_env(duthosts, rand_one_dut_hostname):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def disable_port_toggle(duthosts, tbinfo):
+def disable_port_toggle(duthosts, tbinfo, restore_test_env):
     # set mux mode to manual on both TORs to avoid port state change during test
     if "dualtor" in tbinfo['topo']['name']:
         for dut in duthosts:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Modify config_reload as fixture and execute only once to save time
Fixes # (issue) ADO: 31983138

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
One time env setup is enough. Save running time
#### How did you do it?
Change to fixture
#### How did you verify/test it?
E2E
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
