### PR TITLE
chore: add option to specify image-tag for ptf/ixia image

### DIFF
--- a/ansible/testbed_add_vm_topology.yml
+++ b/ansible/testbed_add_vm_topology.yml
@@ -80,6 +80,19 @@
     fail: msg="Define topo variable with -e topo=something"
     when: topo is not defined
 
+  - name: Set ptf_imagetag
+    set_fact:
+      ptf_imagetag: >-
+        {{ (lookup('file', "testbed.yaml")|from_yaml)
+        | selectattr('conf-name', 'equalto', testbed_name)
+        | map(attribute='ptf_imagetag')
+        | first }}
+    when: >-
+      (lookup('file', "testbed.yaml")|from_yaml)
+      | selectattr('conf-name', 'equalto', testbed_name)
+      | map(attribute='ptf_imagetag')
+      | first is defined
+
   - set_fact:
       base_topo: "{{ topo.split('_') | first }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) Add option to specify ptf image, in case we need to support different image version per testbed

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

We run into this problem where a few testbed needs to change the versioning of ptf (ixia) image. This is not possible with the current add-topo when integrate with pipeline and need to do manually

By adding this option, we can specify the image version in the testbed.yaml file using `ptf_imagetag`. For example

For testbed that doesn't specify this option, we will fall back to the default that was set in add_topo.

```yml
- conf-name: vms-snappi-sonic-multidut
  group-name: vms6-1
  topo: ptf64
  ptf_image_name: docker-ptf-snappi
  ptf_imagetag: 10.25.2405.106 # Specify the image version here
  ptf: snappi-sonic-ptf
  ptf_ip: 10.251.0.232
  ptf_ipv6:
  server: Server_6
  vm_base:
  dut:
    - sonic-s6100-dut1
    - sonic-s6100-dut2
  inv_name: snappi-sonic
  auto_recover: 'True'
  comment: Batman
```

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
