### PR TITLE
Fix a bug that ntpdate cannot reset the date back in test_clock

### DIFF
--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -374,7 +374,7 @@ def test_config_clock_date(duthosts, init_timezone, restore_time, tbinfo):
     is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
     time_margin = ClockConsts.TIME_MARGIN_MODULAR if is_modular_chassis else ClockConsts.TIME_MARGIN
     with allure.step('Select valid date and time to set'):
-        new_date = dt.now() + dt.timedelta(days=1)
+        new_date = dt.datetime.today() + dt.timedelta(days=1)
         new_time = ClockUtils.select_random_time()
         new_datetime = new_date.strftime('%Y-%m-%d') + ' ' + new_time
 

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -376,7 +376,7 @@ def test_config_clock_date(duthosts, init_timezone, restore_time, tbinfo):
     with allure.step('Select valid date and time to set'):
         new_date = dt.now() + dt.timedelta(days=1)
         new_time = ClockUtils.select_random_time()
-        new_datetime = new_date + ' ' + new_time
+        new_datetime = new_date.strftime('%Y-%m-%d') + ' ' + new_time
 
     with allure.step(f'Set new date and time "{new_datetime}"'):
         output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_CLOCK_DATE, new_datetime)

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -374,7 +374,7 @@ def test_config_clock_date(duthosts, init_timezone, restore_time, tbinfo):
     is_modular_chassis = duthosts[0].get_facts().get("modular_chassis")
     time_margin = ClockConsts.TIME_MARGIN_MODULAR if is_modular_chassis else ClockConsts.TIME_MARGIN
     with allure.step('Select valid date and time to set'):
-        new_date = ClockUtils.select_random_date()
+        new_date = dt.now() + dt.timedelta(days=1)
         new_time = ClockUtils.select_random_time()
         new_datetime = new_date + ' ' + new_time
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During test_clock testcase, the date will be set randomly.
When the TC finishes, the date will be set back by using "ntpdate a.b.c.d".
However, there is a bug ntpdate cannot handle if date difference is too big. The error is:
```
root@bjw-can-2700-2:~# ntpdate 10.150.22.222
Traceback (most recent call last):
  File "/usr/bin/ntpdig", line 418, in <module>
    returned += queryhost(server=server,
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/ntpdig", line 94, in queryhost
    packet = request.flatten()
             ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/ntp/packet.py", line 447, in flatten
    body = struct.pack(SyncPacket.format,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: int too large to convert
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
See test_clock cannot change date back.

#### How did you do it?
Change the date only after 1 day on based current date.

#### How did you verify/test it?
On bjw-can-2700-2

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
