### PR TITLE
Fix wr_arp slow arp response time on big topos

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -24,6 +24,7 @@ import ptf
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
 import ptf.testutils as testutils
+from scapy.arch.linux import attach_filter as attach_filter
 from device_connection import DeviceConnection
 from utilities import parse_show
 import ipaddress
@@ -221,6 +222,11 @@ class ArpTest(BaseTest):
 
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
+
+        # Apply filters
+        for p in self.dataplane.ports.values():
+            port = p.get_packet_source()
+            attach_filter(port.socket, 'arp and not ether dst ff:ff:ff:ff:ff:ff', port.interface_name)
 
         config = self.get_param('config_file')
         self.ferret_ip = self.get_param('ferret_ip')

--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -24,6 +24,7 @@ import ptf
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
 import ptf.testutils as testutils
+import ptf.packet as scapy    # noqa: F401
 from scapy.arch.linux import attach_filter as attach_filter
 from device_connection import DeviceConnection
 from utilities import parse_show


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use socket filters to filter barodcast packets, so PTF will not be flooded by huge amounts of broadcast packets when the topology has many interfaces.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
During `arp/test_wr_arp.py`, we observe slow arp response time only on large topologies. It is found that the PTF test was not able to match the expected packet, even though the packet exists in the pcap file.

It is observed there is a huge flood of ARP broadcast packets in the pcap, and upon filtering the broadcast packets, the test is able to pass consistently.

#### How did you do it?
Apply socket filter to remove broadcast ARP packets that the PTF will not need to parse.

#### How did you verify/test it?
`arp/test_wr_arp.py::test_wr_arp` passes 5 times in a row on`Arista-7260CX3-D108C8`.
The other test cases in the test file also passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
