### PR TITLE
Preload minigraph to flush golden_config_db.json for vs chassis

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -93,10 +93,14 @@
     delegate_to: localhost
     ignore_errors: true
 
+  - set_fact:
+      type: "unknown"
+    when: hostvars[inventory_hostname].type is not defined
+
   - name: determine whether to sort port_alias by index
     set_fact:
       sort_by_index: false
-    when: switch_type is defined and switch_type == "voq" and type is defined and type == "kvm"
+    when: switch_type is defined and switch_type == "voq" and type == "kvm"
 
   - name: find interface name mapping and individual interface speed if defined from dut
     port_alias:
@@ -633,11 +637,12 @@
           failed_when:
             - load_minigraph_result.rc != 0
             - "'no such option: --override_config' not in load_minigraph_result.stderr"
+          when: "'t2' not in topo or type != 'kvm'"
 
         - name: execute cli "config load_minigraph -y" to apply new minigraph
           become: true
           shell: config load_minigraph -y
-          when: "'no such option: --override_config' in load_minigraph_result.stderr"
+          when: "('t2' in topo and type == 'kvm') or 'no such option: --override_config' in load_minigraph_result.stderr"
 
         - name: remove DSCP_TO_TC_MAP for {{ hwsku }}. Some platform doesn't support this configuration
           become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -646,6 +646,7 @@
         - name: execute cli "config load_minigraph -y" to apply new minigraph
           become: true
           shell: config load_minigraph -y
+          when: "'no such option: --override_config' in load_minigraph_result.stderr"
 
         - name: remove DSCP_TO_TC_MAP for {{ hwsku }}. Some platform doesn't support this configuration
           become: true

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -585,6 +585,11 @@
           hwsku: "{{ hwsku }}"
         when: topo == "mx"
 
+      - name: Preload minigraph to flush config_db for Virtual Chassis
+        shell: config load_minigraph -y && config save -y
+        become: true
+        when: "'t2' in topo and type == 'kvm'"
+
       - name: Copy dhcp_server config hwsku {{ hwsku }}
         copy: src=golden_config_db/dhcp_server_mx.json
               dest=/tmp/dhcp_server.json
@@ -637,12 +642,10 @@
           failed_when:
             - load_minigraph_result.rc != 0
             - "'no such option: --override_config' not in load_minigraph_result.stderr"
-          when: "'t2' not in topo or type != 'kvm'"
 
         - name: execute cli "config load_minigraph -y" to apply new minigraph
           become: true
           shell: config load_minigraph -y
-          when: "('t2' in topo and type == 'kvm') or 'no such option: --override_config' in load_minigraph_result.stderr"
 
         - name: remove DSCP_TO_TC_MAP for {{ hwsku }}. Some platform doesn't support this configuration
           become: true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently, we setup VS chassis by dynamically transform the HwSKU. If we use the old golden_config_db with single-ASIC hwsku to overwrite the config loaded from minigraph.xml, the HwSKU dynamically encoded in minigraph.xml will be overwritten by the HwSKU in golden_config_db. So, we need to flush the config db with minigraph before we generated the golden_config_db for VS chassis.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
