### PR TITLE
refactor: change set_static_route fixture level

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2327,7 +2327,7 @@ class QosSaiBase(QosBase):
 
         return dualtor_ports_set
 
-    @pytest.fixture(scope='function', autouse=True)
+    @pytest.fixture(scope='class', autouse=True)
     def set_static_route(
             self, get_src_dst_asic_and_duts, dutTestParams, dutConfig):
         # Get portchannels.
@@ -2556,7 +2556,7 @@ class QosSaiBase(QosBase):
                 ptfhost, testCase=saiQosTest, testParams=testParams
             )
 
-    @pytest.fixture(scope="function", autouse=False)
+    @pytest.fixture(scope="class", autouse=False)
     def set_static_route_ptf64(self, dutConfig, get_src_dst_asic_and_duts, dutTestParams, enum_frontend_asic_index):
         def generate_ip_address(base_ip, new_first_octet):
             octets = base_ip.split('.')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Change `set_static_route` fixture and `set_static_route_ptf64` fixture in `qos/test_qos_sai.py` to class level. 

Summary:
Fixes # (issue) Microsoft ADO 30056122

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The `qos/test_qos_sai.py` is taking too long on T2 devices, so we wanted to optimize the way `set_static_route` and `set_static_route_ptf64` instantiated to reduce the running time.

#### How did you do it?
According to pytest official doc:
- There are only 3 ways that pytest handles the instantiation order of fixtures (doc [link](https://docs.pytest.org/en/stable/reference/fixtures.html#fixture-instantiation-order)): scope, dependencies & autouse 
- Higher-scoped fixtures are executed first (doc [link](https://docs.pytest.org/en/stable/reference/fixtures.html#higher-scoped-fixtures-are-executed-first))
- A fixture will only be invoked once per its scope (doc [link](https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session))

Therefore, in our case, we changed the scope of `set_static_route` and `set_static_route_ptf64` from `function` to `class` since all their dependencies are session, module or class level. By doing this, the instantiation of `set_static_route` (i.e. setup & teardown) will decrease from 185 times to 5 times for a T2 topo, which makes the running time decrease from ~7.5 hours to ~5.2 hours.


#### How did you verify/test it?
Verified on multiple topo platforms and can confirm the running and skipped test cases are the same:

T0:
- Before: https://elastictest.org/scheduler/testplan/67e3d97964daab61251ceb70?testcase=qos%2Ftest_qos_sai.py&type=console
- After: https://elastictest.org/scheduler/testplan/67e3d7dd8a5f97849658cb49?testcase=qos%2Ftest_qos_sai.py&type=console

T1:
- Before: https://elastictest.org/scheduler/testplan/67e4eb1564daab61251cece4?testcase=qos%2Ftest_qos_sai.py&type=console
- After: https://elastictest.org/scheduler/testplan/67e4e539b76b94a44dd23d93?testcase=qos%2Ftest_qos_sai.py&type=console

T2:
- Before: https://elastictest.org/scheduler/testplan/67e126b3c04834fb7c2afadb?testcase=qos%2Ftest_qos_sai.py&type=console
- After: https://elastictest.org/scheduler/testplan/67e369b5e55cd54a70ae8cd2?testcase=qos%2Ftest_qos_sai.py&type=console


As we can see, T2 gains a lot of benefit from this change, while the running time on T0 and T1 does not change too much.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
