### PR TITLE
Improve disabling packet aging to support swap_syncd

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -27,7 +27,7 @@ from .tunnel_qos_remap_base import build_testing_packet, check_queue_counter,\
     dut_config, qos_config, tunnel_qos_maps, run_ptf_test, toggle_mux_to_host,\
     setup_module, update_docker_services, swap_syncd, counter_poll_config                               # noqa F401
 from .tunnel_qos_remap_base import leaf_fanout_peer_info, start_pfc_storm, \
-    stop_pfc_storm, get_queue_counter, get_queue_watermark, disable_packet_aging                        # noqa F401
+    stop_pfc_storm, get_queue_counter, get_queue_watermark                                              # noqa F401
 from ptf import testutils
 from ptf.testutils import simple_tcp_packet
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -310,30 +310,6 @@ def qos_config(rand_selected_dut, tbinfo, dut_config):
     return speed_cable_to_params[speed_cable]
 
 
-@pytest.fixture(scope='module', autouse=True)
-def disable_packet_aging(rand_selected_dut, duthosts):
-    """
-        For Nvidia(Mellanox) platforms, packets in buffer will be aged after a timeout. Need to disable this
-        before any buffer tests.
-    """
-    for duthost in duthosts:
-        asic = duthost.get_asic_name()
-        if 'spc' in asic:
-            logger.info("Disable Mellanox packet aging")
-            duthost.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
-            duthost.command("docker cp /tmp/packets_aging.py syncd:/")
-            duthost.command("docker exec syncd python /packets_aging.py disable")
-
-    yield
-
-    for duthost in duthosts:
-        asic = duthost.get_asic_name()
-        if 'spc' in asic:
-            logger.info("Enable Mellanox packet aging")
-            duthost.command("docker exec syncd python /packets_aging.py enable")
-            duthost.command("docker exec syncd rm -rf /packets_aging.py")
-
-
 def _create_ssh_tunnel_to_syncd_rpc(duthost):
     dut_asic = duthost.asic_instance()
     dut_asic.create_ssh_tunnel_sai_rpc()
@@ -394,12 +370,24 @@ def update_docker_services(rand_selected_dut, swap_syncd, disable_container_auto
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="stop", **service)
 
+    asic = rand_selected_dut.get_asic_name()
+    if 'spc' in asic:
+        logger.info("Disable Mellanox packet aging")
+        rand_selected_dut.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
+        rand_selected_dut.command("docker cp /tmp/packets_aging.py syncd:/")
+        rand_selected_dut.command("docker exec syncd python /packets_aging.py disable")
+
     yield
 
     enable_container_autorestart(
         rand_selected_dut, testcase="test_tunnel_qos_remap", feature_list=feature_list)
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="start", **service)
+
+    if 'spc' in asic:
+        logger.info("Enable Mellanox packet aging")
+        rand_selected_dut.command("docker exec syncd python /packets_aging.py enable")
+        rand_selected_dut.command("docker exec syncd rm -rf /packets_aging.py")
 
 
 def _update_mux_feature(duthost, state):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix an error in `test_tunnel_qos_remap`. The error message is
```
invocation = {'module_args': {'_raw_params': 'docker exec syncd python /packets_aging.py enable', '_uses_shell': False, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = None
stdout =
stderr =
python: can't open file '/packets_aging.py': [Errno 2] No such file or directory
```
The error is because fixture `disable_packet_aging` is executed before fixture `swap_syncd`. Hence, script `packets_aging.py` is not available in the new syncd container.
This PR addressed the issue by integrating fixture `disable_packet_aging` into fixture `update_docker_services` to ensure fixture `swap_syncd` is always running before script `packets_aging.py` is copied.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix a test issue in `test_tunnel_qos_remap`.

#### How did you do it?
This PR addressed the issue by integrating fixture `disable_packet_aging` into fixture `update_docker_services` to ensure fixture `swap_syncd` is always running before script `packets_aging.py` is copied.

#### How did you verify/test it?
The change is verified by running on a physical testbed 
```
collected 4 items                                                                                                                                                                                                             

qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_1]  ^H ^HPASSED                                                                                                                                                    [ 25%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_2] PASSED                                                                                                                                                    [ 50%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_3] PASSED                                                                                                                                                    [ 75%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_4] PASSED                                                                                                                                                    [100%] ^H
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
