### PR TITLE
Fix bgp/test_bgp_queue.py for t0-d18u8s4

### DIFF
--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -105,7 +105,7 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
         # or "VOQ_CHASSIS_PEER_V4" or "VOQ_CHASSIS_PEER_V6" for VOQ_CHASSIS
         # If it's external it will be "RH_V4", "RH_V6", "AH_V4", "AH_V6", ...
         # Skip internal neighbors for VOQ_CHASSIS until BRCM fixes iBGP traffic in 2024011
-        if ("INTERNAL" in v["peer group"] or 'VOQ_CHASSIS' in v["peer group"]):
+        if 'peer group' in v and ("INTERNAL" in v["peer group"] or 'VOQ_CHASSIS' in v["peer group"]):
             # Skip iBGP neighbors since we only want to verify eBGP
             continue
         # Only consider established bgp sessions


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix bgp/test_bgp_queue.py for t0-d18u8s4
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We had to remove internal bgp peer from peer group to avoid frr error by the change https://github.com/sonic-net/sonic-buildimage/pull/22022, after which the internal bgp peer is not in any peer group. Here relax the testcase on reading peer group for each bgp neighbor.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
