### PR TITLE
Fix dualtor/test_orchagent_standby_tor_downstream.py for t0-d18u8s4

### DIFF
--- a/tests/common/dualtor/dual_tor_mock.py
+++ b/tests/common/dualtor/dual_tor_mock.py
@@ -315,8 +315,17 @@ def apply_dual_tor_peer_switch_route(cleanup_mocked_configs, rand_selected_dut, 
     bgp_neighbors = list(dut.bgp_facts()['ansible_facts']['bgp_neighbors'].keys())
 
     ipv4_neighbors = []
+    portchannel_neighbors = []
+
+    ip_intf_facts = dut.show_ip_interface()['ansible_facts']['ip_interfaces']
+    for intf in ip_intf_facts:
+        if 'PortChannel' in intf:
+            portchannel_neighbors.append(ip_intf_facts[intf]['peer_ipv4'])
 
     for neighbor in bgp_neighbors:
+        if neighbor not in portchannel_neighbors:
+            continue
+
         neighbor_ip = ip_address(neighbor)
 
         if type(neighbor_ip) is IPv4Address:

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1511,10 +1511,19 @@ def add_nexthop_routes(standby_tor, route_dst, nexthops=None):
     """
     logging.info("Applying route on {} to dst {}".format(standby_tor.hostname, route_dst))
     bgp_neighbors = list(standby_tor.bgp_facts()['ansible_facts']['bgp_neighbors'].keys())
+    portchannel_neighbors = []
+    ip_intf_facts = standby_tor.show_ip_interface()['ansible_facts']['ip_interfaces']
+    for intf in ip_intf_facts:
+        if 'PortChannel' in intf:
+            portchannel_neighbors.append(ip_intf_facts[intf]['peer_ipv4'])
+            if 'peer_ipv6' in ip_intf_facts[intf]:
+               portchannel_neighbors.append(ip_intf_facts[intf]['peer_ipv6'])
 
     route_dst = ipaddress.ip_address(six.text_type(route_dst))
     ip_neighbors = []
     for neighbor in bgp_neighbors:
+        if neighbor not in portchannel_neighbors:
+            continue
         if ipaddress.ip_address(neighbor).version == route_dst.version:
             ip_neighbors.append(neighbor)
 

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1517,7 +1517,7 @@ def add_nexthop_routes(standby_tor, route_dst, nexthops=None):
         if 'PortChannel' in intf:
             portchannel_neighbors.append(ip_intf_facts[intf]['peer_ipv4'])
             if 'peer_ipv6' in ip_intf_facts[intf]:
-               portchannel_neighbors.append(ip_intf_facts[intf]['peer_ipv6'])
+                portchannel_neighbors.append(ip_intf_facts[intf]['peer_ipv6'])
 
     route_dst = ipaddress.ip_address(six.text_type(route_dst))
     ip_neighbors = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix dualtor/test_orchagent_standby_tor_downstream.py for topo t0-d18u8s4
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The verification step assumes that packets should be received only on the bgp peers in portchannel by function send_and_verify_packets in https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/roles/test/files/ptftests/py3/ip_in_ip_tunnel_test.py#L247.

Topo t0-d18u8s4 has bgp neighbors not in portchannel.

The change here is to fix the parameter used by "ip route replace", so the route is not towards those bgp peers not in portchannel.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
