### PR TITLE
[Mellanox] Align the sensors data for SN4280 with sonic-buildimage PR#21845

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -2549,8 +2549,6 @@ sensors_checks:
       - mp2855-i2c-39-69/PMIC-14 COMEX VDDCR_CPU PHASE TEMP/temp1_crit_alarm
       - mp2855-i2c-39-69/PMIC-14 COMEX VDDCR_SOC PHASE TEMP/temp2_crit_alarm
 
-      - 00000800400-mdio-8/temp1/temp1_max_alarm
-
       - jc42-i2c-43-1e/SODIMM3 Temp/temp1_max_alarm
       - jc42-i2c-43-1e/SODIMM3 Temp/temp1_min_alarm
       - jc42-i2c-43-1e/SODIMM3 Temp/temp1_crit_alarm
@@ -2613,9 +2611,6 @@ sensors_checks:
 
       - - mp2855-i2c-39-69/PMIC-14 COMEX VDDCR_SOC PHASE TEMP/temp2_input
         - mp2855-i2c-39-69/PMIC-14 COMEX VDDCR_SOC PHASE TEMP/temp2_crit
-
-      - - 00000800400-mdio-8/temp1/temp1_input
-        - 00000800400-mdio-8/temp1/temp1_crit
 
       - - jc42-i2c-43-1e/SODIMM3 Temp/temp1_input
         - jc42-i2c-43-1e/SODIMM3 Temp/temp1_crit


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Align the sensors data for SN4280 with [sonic-buildimage PR#21845](https://github.com/sonic-net/sonic-buildimage/pull/21845).
The temperature sensor for "\*-mdio-\*" is ignore in sensor conf, the test data should be aligned.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
