### PR TITLE
[202411] Support pc lag member test in KVM

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -225,6 +225,7 @@ t0:
   - fdb/test_fdb_mac_learning.py
   - ip/test_mgmt_ipv6_only.py
   - zmq/test_gnmi_zmq.py
+  - pc/test_lag_member_forwarding.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcpv6_relay.py
@@ -433,6 +434,7 @@ t1-lag:
   - vxlan/test_vxlan_route_advertisement.py
   - lldp/test_lldp_syncd.py
   - ipfwd/test_nhop_group.py
+  - pc/test_lag_member_forwarding.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -286,6 +286,15 @@ ipfwd/test_nhop_group.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####            pc               #####
+#######################################
+pc/test_lag_member_forwarding.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
+#######################################
 #####            qos              #####
 #######################################
 qos/test_qos_dscp_mapping.py:

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -2,11 +2,14 @@ import ipaddr as ipaddress
 import json
 import pytest
 import time
+import logging
 from tests.common import config_reload
 from ptf.mask import Mask
 import ptf.packet as scapy
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -138,14 +141,17 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
         pkt, exp_pkt = build_pkt(rtr_mac, ip_route, ip_ttl)
         testutils.send(ptfadapter, send_port, pkt, 10)
         if expected:
-            (_, recv_pkt) = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
-                                                             ports=recv_port)
+            result = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt, ports=recv_port)
+            if isinstance(result, bool):
+                logger.info("Using dummy testutils to skip traffic test, skip following verify steps.")
+                return
+
+            (_, recv_pkt) = result
             assert recv_pkt
             # Make sure routing is done
             pytest_assert(scapy.Ether(recv_pkt).ttl == (ip_ttl - 1), "Routed Packet TTL not decremented")
         else:
-            testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt,
-                                           ports=recv_port)
+            testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=recv_port)
 
     if peer_device_dest_ip:
         ptfadapter.dataplane.flush()
@@ -174,6 +180,10 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
         if peer_device_dest_ip:
             ptfadapter.dataplane.flush()
             built_and_send_tcp_ip_packet(False)
+
+        if duthost.facts['asic_type'] == "vs":
+            logger.info("KVM could not perform actual asic actions, skip following verify steps.")
+            return
 
         # make sure ping should fail
         for ip in peer_device_ip_set:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test can't be tested on KVM platform, we need to skip traffic test if needed.
#### How did you do it?
Cherry-pick PR from https://github.com/sonic-net/sonic-mgmt/pull/16379, Support pc lag member test in KVM and skip traffic test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
