### PR TITLE
[202411] Support qos sai test in KVM

### DIFF
--- a/tests/qos/files/vs/dutConfig.json
+++ b/tests/qos/files/vs/dutConfig.json
@@ -243,7 +243,7 @@
   },
   "qosConfigs": {
     "qos_params": {
-      "kvm": {
+      "vs": {
         "topo-any": {
           "100000_120000m": {
             "lossy_queue_1": {
@@ -276,6 +276,15 @@
               "pkts_num_margin": 6,
               "pkts_num_trig_pfc": 6412,
               "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
             },
             "wm_pg_shared_lossless": {
               "cell_size": 8192,
@@ -427,6 +436,15 @@
               "pkts_num_hysteresis": 1877,
               "pkts_num_dismiss_pfc": 2,
               "packet_size": 1350
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
             },
             "wm_pg_shared_lossless": {
               "ecn": 1,
@@ -673,6 +691,15 @@
               "pkts_num_margin": 20,
               "pkts_num_trig_pfc": 23085,
               "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
             },
             "wm_pg_shared_lossless": {
               "cell_size": 8192,
@@ -1077,6 +1104,15 @@
               "pkts_num_trig_pfc": 642,
               "queue": 3
             },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
             "wm_pg_shared_lossless": {
               "cell_size": 8192,
               "dscp": 3,
@@ -1217,6 +1253,15 @@
               "pkts_num_trig_pfc": 3415,
               "queue": 3
             },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
+            },
             "wm_pg_shared_lossless": {
               "cell_size": 384,
               "dscp": 3,
@@ -1330,6 +1375,15 @@
               "pkts_num_fill_ingr_min": 140,
               "pkts_num_trig_pfc": 642,
               "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
             },
             "wm_pg_shared_lossless": {
               "cell_size": 8192,
@@ -1470,6 +1524,15 @@
               "pkts_num_fill_ingr_min": 0,
               "pkts_num_trig_pfc": 3038,
               "queue": 3
+            },
+            "wm_pg_headroom": {
+              "cell_size": 4096,
+              "dscp": 3,
+              "ecn": 1,
+              "pg": 3,
+              "pkts_num_margin": 30,
+              "pkts_num_trig_ingr_drp": 10861,
+              "pkts_num_trig_pfc": 9874
             },
             "wm_pg_shared_lossless": {
               "cell_size": 384,

--- a/tests/qos/files/vs/dutQosConfig.json
+++ b/tests/qos/files/vs/dutQosConfig.json
@@ -32,6 +32,15 @@
         "pkts_num_trig_pfc": 6412,
         "queue": 3
       },
+      "wm_pg_headroom": {
+        "cell_size": 4096,
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "pkts_num_margin": 30,
+        "pkts_num_trig_ingr_drp": 10861,
+        "pkts_num_trig_pfc": 9874
+      },
       "wm_pg_shared_lossless": {
         "cell_size": 8192,
         "dscp": 3,
@@ -182,6 +191,15 @@
         "pkts_num_hysteresis": 1877,
         "pkts_num_dismiss_pfc": 2,
         "packet_size": 1350
+      },
+      "wm_pg_headroom": {
+        "cell_size": 4096,
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "pkts_num_margin": 30,
+        "pkts_num_trig_ingr_drp": 10861,
+        "pkts_num_trig_pfc": 9874
       },
       "wm_pg_shared_lossless": {
         "ecn": 1,
@@ -428,6 +446,15 @@
         "pkts_num_margin": 20,
         "pkts_num_trig_pfc": 23085,
         "queue": 3
+      },
+      "wm_pg_headroom": {
+        "cell_size": 4096,
+        "dscp": 3,
+        "ecn": 1,
+        "pg": 3,
+        "pkts_num_margin": 30,
+        "pkts_num_trig_ingr_drp": 10861,
+        "pkts_num_trig_pfc": 9874
       },
       "wm_pg_shared_lossless": {
         "cell_size": 8192,

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -580,11 +580,15 @@ class QosSaiBase(QosBase):
             Returns:
                 None
         """
+        asic_type = duthosts[0].facts["asic_type"]
         if 'dualtor' in tbinfo['topo']['name']:
             dut_list = [lower_tor_host]
         else:
             dut_list = duthosts.frontend_nodes
         swapSyncd = request.config.getoption("--qos_swap_syncd")
+        if asic_type == "vs":
+            logger.info("Swap syncd is not supported on VS platform")
+            swapSyncd = False
         public_docker_reg = request.config.getoption("--public_docker_registry")
         try:
             if swapSyncd:
@@ -1195,35 +1199,42 @@ class QosSaiBase(QosBase):
             # restore currently assigned IPs
             testPortIps.update(dutPortIps)
 
-        qosConfigs = {}
-        with open(r"qos/files/qos.yml") as file:
-            qosConfigs = yaml.load(file, Loader=yaml.FullLoader)
-        # Assuming the same chipset for all DUTs so can use src_dut to get asic type
         vendor = src_dut.facts["asic_type"]
-        hostvars = src_dut.host.options['variable_manager']._hostvars[src_dut.hostname]
-        dutAsic = None
-        for asic in self.SUPPORTED_ASIC_LIST:
-            vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-            if vendorAsic in hostvars.keys() and src_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
-                dutAsic = asic
-                break
-
-        pytest_assert(dutAsic, "Cannot identify DUT ASIC type")
-
-        # Get dst_dut asic type
-        if dst_dut != src_dut:
-            vendor = dst_dut.facts["asic_type"]
-            hostvars = dst_dut.host.options['variable_manager']._hostvars[dst_dut.hostname]
-            dstDutAsic = None
+        qosConfigs = {}
+        if vendor == "vs":
+            with open(r"qos/files/vs/dutConfig.json") as file:
+                dutConfig = json.load(file)
+                qosConfigs = dutConfig["qosConfigs"]
+                dutAsic = "vs"
+                dstDutAsic = "vs"
+        else:
+            with open(r"qos/files/qos.yml") as file:
+                qosConfigs = yaml.load(file, Loader=yaml.FullLoader)
+            # Assuming the same chipset for all DUTs so can use src_dut to get asic type
+            hostvars = src_dut.host.options['variable_manager']._hostvars[src_dut.hostname]
+            dutAsic = None
             for asic in self.SUPPORTED_ASIC_LIST:
                 vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
-                if vendorAsic in hostvars.keys() and dst_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
-                    dstDutAsic = asic
+                if vendorAsic in hostvars.keys() and src_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
+                    dutAsic = asic
                     break
 
-            pytest_assert(dstDutAsic, "Cannot identify dst DUT ASIC type")
-        else:
-            dstDutAsic = dutAsic
+            pytest_assert(dutAsic, "Cannot identify DUT ASIC type")
+
+            # Get dst_dut asic type
+            if dst_dut != src_dut:
+                vendor = dst_dut.facts["asic_type"]
+                hostvars = dst_dut.host.options['variable_manager']._hostvars[dst_dut.hostname]
+                dstDutAsic = None
+                for asic in self.SUPPORTED_ASIC_LIST:
+                    vendorAsic = "{0}_{1}_hwskus".format(vendor, asic)
+                    if vendorAsic in hostvars.keys() and dst_mgFacts["minigraph_hwsku"] in hostvars[vendorAsic]:
+                        dstDutAsic = asic
+                        break
+
+                pytest_assert(dstDutAsic, "Cannot identify dst DUT ASIC type")
+            else:
+                dstDutAsic = dutAsic
 
         dutTopo = "topo-"
 
@@ -1707,6 +1718,11 @@ class QosSaiBase(QosBase):
                       portSpeedCableLength)
 
             qosParams = qpm.run()
+        elif dutAsic == 'vs':
+            with open(r"qos/files/vs/dutQosConfig.json") as file:
+                dutQosConfig = json.load(file)
+                qosParams = dutQosConfig["param"]
+                portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
         else:
             qosParams = qosConfigs['qos_params'][dutAsic][dutTopo]
         yield {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
But some traffic test can't be tested on KVM platform, we need to skip traffic test if needed.
#### How did you do it?
Cherry-pick from https://github.com/sonic-net/sonic-mgmt/pull/16875
This PR adds qos tests to the KVM-based PR test framework with the following scope and modifications:
1.Update kvm qos config template
2.In kvm qos sai test, read kvm qos config from template json
3.Skip traffic test in qos sai test
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
