### PR TITLE
[pre-commit] Use correct comment format # noqa: not # noqa in tests/b*

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -4,7 +4,7 @@ import time
 import json
 import logging
 
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa:F401
 from tests.common.snappi_tests.common_helpers import get_egress_queue_count
 
 pytestmark = [
@@ -471,7 +471,7 @@ def test_bfd_scale(request, rand_selected_dut, ptfhost, tbinfo, ipv6):
 
 @pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
 def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo,
-                      toggle_all_simulator_ports_to_rand_selected_tor_m, ipv6):    # noqa F811
+                      toggle_all_simulator_ports_to_rand_selected_tor_m, ipv6):    # noqa:F811
     duthost = rand_selected_dut
 
     bfd_session_cnt = int(request.config.getoption('--num_sessions'))

--- a/tests/bgp/test_bgp_allow_list.py
+++ b/tests/bgp/test_bgp_allow_list.py
@@ -10,7 +10,7 @@ from bgp_helpers import ALLOW_LIST_PREFIX_JSON_FILE, PREFIX_LISTS, TEST_COMMUNIT
 from bgp_helpers import apply_allow_list, remove_allow_list, check_routes_on_from_neighbor, get_default_action
 from bgp_helpers import check_routes_on_neighbors_empty_allow_list, checkout_bgp_mon_routes, check_routes_on_neighbors
 # Fixtures
-from bgp_helpers import bgp_allow_list_setup, prepare_eos_routes    # noqa F401
+from bgp_helpers import bgp_allow_list_setup, prepare_eos_routes    # noqa:F401
 
 pytestmark = [
     pytest.mark.topology('t1', 'm1', 'm2', 'm3'),
@@ -37,7 +37,7 @@ ALLOW_LIST = {
 
 
 @pytest.fixture
-def load_remove_allow_list(duthosts, bgp_allow_list_setup, rand_one_dut_hostname, request):     # noqa F811
+def load_remove_allow_list(duthosts, bgp_allow_list_setup, rand_one_dut_hostname, request):     # noqa:F811
     allowed_list_prefixes = ALLOW_LIST['BGP_ALLOWED_PREFIXES']
     for _, value in list(allowed_list_prefixes.items()):
         value['default_action'] = request.param
@@ -61,7 +61,7 @@ def check_routes_on_dut(duthost, namespace):
             pytest_assert(dut_route, 'Route {} is not found on DUT'.format(prefix))
 
 
-def test_default_allow_list_preconfig(duthosts, rand_one_dut_hostname, bgp_allow_list_setup, nbrhosts,  # noqa F811
+def test_default_allow_list_preconfig(duthosts, rand_one_dut_hostname, bgp_allow_list_setup, nbrhosts,  # noqa:F811
                                       ptfhost, bgpmon_setup_teardown):
     """
     Before applying allow list, verify bgp policy by default config
@@ -79,7 +79,7 @@ def test_default_allow_list_preconfig(duthosts, rand_one_dut_hostname, bgp_allow
 
 
 @pytest.mark.parametrize('load_remove_allow_list', ["permit", "deny"], indirect=['load_remove_allow_list'])
-def test_allow_list(duthosts, rand_one_dut_hostname, bgp_allow_list_setup, nbrhosts,    # noqa F811
+def test_allow_list(duthosts, rand_one_dut_hostname, bgp_allow_list_setup, nbrhosts,    # noqa:F811
                     load_remove_allow_list, ptfhost, bgpmon_setup_teardown):
     permit = True if load_remove_allow_list == "permit" else False
     duthost = duthosts[rand_one_dut_hostname]
@@ -95,10 +95,10 @@ def test_allow_list(duthosts, rand_one_dut_hostname, bgp_allow_list_setup, nbrho
     checkout_bgp_mon_routes(duthost, ptfhost)
 
 
-def test_default_allow_list_postconfig(duthosts, rand_one_dut_hostname, bgp_allow_list_setup,   # noqa F811
+def test_default_allow_list_postconfig(duthosts, rand_one_dut_hostname, bgp_allow_list_setup,   # noqa:F811
                                        nbrhosts, ptfhost, bgpmon_setup_teardown):
     """
     After removing allow list, verify bgp policy
     """
-    test_default_allow_list_preconfig(duthosts, rand_one_dut_hostname, bgp_allow_list_setup,    # noqa F811
+    test_default_allow_list_preconfig(duthosts, rand_one_dut_hostname, bgp_allow_list_setup,    # noqa:F811
                                       nbrhosts, ptfhost, bgpmon_setup_teardown)

--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -316,7 +316,7 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
             logging.warning('No route for {} found on {}'.format(route.prefix, tor1))
             return False
         tor1_route_aspath = tor1_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
-            ['asPathEntry']['asPath']   # noqa E211
+            ['asPathEntry']['asPath']   # noqa:E211
         if not tor1_route_aspath == route.aspath:
             logging.warning(
                 'On {} expected aspath: {}, actual aspath: {}'.format(tor1, route.aspath, tor1_route_aspath)
@@ -383,7 +383,7 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
                 vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
             else:
                 tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
-                    ['asPathEntry']['asPath']   # noqa E211
+                    ['asPathEntry']['asPath']   # noqa:E211
                 # Route path from other VMs: -> DUT(T1) -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
                 tor_route_aspath_expected = '{} {} {}'.format(dut_asn, tor1_asn, route.aspath)
                 if tor_route_aspath != tor_route_aspath_expected:
@@ -466,9 +466,10 @@ def test_bbr_status_consistent_after_reload(duthosts, rand_one_dut_hostname, set
     pytest_assert(bbr_status_after_reload == bbr_status, "BGP BBR status is not consistent after config reload")
 
     # Check if BBR is enabled or disabled using the running configuration
-    bbr_status_running_config = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)\
-        ['stdout'] # noqa E211
+    bbr_status_running_config = duthost.shell(
+        "show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']    # noqa:E211
     if bbr_status == 'enabled':
         pytest_assert('allowas-in' in bbr_status_running_config, "BGP BBR is not enabled in running configuration")
     else:
-        pytest_assert('allowas-in' not in bbr_status_running_config, "BGP BBR is not disabled in running configuration")
+        pytest_assert('allowas-in' not in bbr_status_running_config,
+                      "BGP BBR is not disabled in running configuration")

--- a/tests/bgp/test_bgp_dual_asn.py
+++ b/tests/bgp/test_bgp_dual_asn.py
@@ -21,7 +21,7 @@ from tests.common.gu_utils import (
     delete_checkpoint,
     rollback_or_reload,
 )
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa:F401
 from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 pytestmark = [pytest.mark.topology("t0")]
@@ -72,7 +72,7 @@ def lo_intfs(duthost, tbinfo):
 
 @pytest.fixture(autouse=True)
 def setup_env(
-    duthosts, rand_one_dut_hostname, toggle_all_simulator_ports_to_rand_selected_tor_m, # noqa F811
+    duthosts, rand_one_dut_hostname, toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa:F811
 ):
     """
     Setup/teardown fixture for bgp speaker config

--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -3,7 +3,7 @@ import pytest
 from tests.common import reboot
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.dualtor.mux_simulator_control import \
-    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m  # noqa F401
+    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m  # noqa:F401
 from tests.common.utilities import wait_until, delete_running_config
 from tests.common.helpers.assertions import pytest_require
 
@@ -68,7 +68,7 @@ def bgp_slb_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname, setup_
 @pytest.mark.disable_loganalyzer
 def test_bgp_slb_neighbor_persistence_across_advanced_reboot(
     duthosts, enum_rand_one_per_hwsku_frontend_hostname, bgp_slb_neighbor,
-    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, reboot_type, localhost     # noqa F811
+    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, reboot_type, localhost     # noqa:F811
 ):
 
     def verify_bgp_session(duthost, bgp_neighbor):

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -7,15 +7,16 @@ import ipaddress
 import json
 
 from tests.common import constants
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
-from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode # noqa F401
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa:F401
+from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa:F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa:F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa:F401
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_tcp_connection
 from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import wait_until
-from tests.common.flow_counter.flow_counter_utils import RouteFlowCounterTestContext, is_route_flow_counter_supported  # noqa F401
+from tests.common.flow_counter.flow_counter_utils import RouteFlowCounterTestContext, \
+    is_route_flow_counter_supported  # noqa:F401
 from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 
@@ -263,7 +264,7 @@ def is_all_neighbors_learned(duthost, speaker_ips):
 def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
                                        ptfhost, ipv4, ipv6, mtu,
                                        family, prefix, nexthop_ips, vlan_mac,
-                                       is_route_flow_counter_supported):    # noqa F811
+                                       is_route_flow_counter_supported):    # noqa:F811
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """
@@ -354,7 +355,7 @@ def bgp_speaker_announce_routes_common(common_setup_teardown, tbinfo, duthost,
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, False, 9114)])
 def test_bgp_speaker_announce_routes(common_setup_teardown, tbinfo, duthosts,
                                      rand_one_dut_hostname, ptfhost, ipv4, ipv6, mtu,
-                                     vlan_mac, is_route_flow_counter_supported):        # noqa F811
+                                     vlan_mac, is_route_flow_counter_supported):        # noqa:F811
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """
@@ -367,7 +368,7 @@ def test_bgp_speaker_announce_routes(common_setup_teardown, tbinfo, duthosts,
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(False, True, 9114)])
 def test_bgp_speaker_announce_routes_v6(common_setup_teardown, tbinfo, duthosts,
                                         rand_one_dut_hostname, ptfhost, ipv4, ipv6, mtu,
-                                        vlan_mac, is_route_flow_counter_supported):     # noqa F811
+                                        vlan_mac, is_route_flow_counter_supported):     # noqa:F811
     """Setup bgp speaker on T0 topology and verify routes advertised by bgp speaker is received by T0 TOR
 
     """

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -20,11 +20,11 @@ from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until, delete_running_config
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.dualtor.dual_tor_common import active_active_ports  # noqa F401
-from tests.common.dualtor.dual_tor_common import active_standby_ports  # noqa F401
-from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup # noqa F401
-from tests.common.dualtor.mux_simulator_control import mux_server_url  # noqa F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401
+from tests.common.dualtor.dual_tor_common import active_active_ports  # noqa:F401
+from tests.common.dualtor.dual_tor_common import active_standby_ports  # noqa:F401
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup    # noqa:F401
+from tests.common.dualtor.mux_simulator_control import mux_server_url  # noqa:F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m    # noqa:F401 E501
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
 
 
@@ -254,8 +254,8 @@ def test_bgp_update_timer_single_route(
     duthosts,
     enum_rand_one_per_hwsku_frontend_hostname,
     request,
-    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa F811
-    validate_active_active_dualtor_setup,  # noqa F811
+    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa:F811
+    validate_active_active_dualtor_setup,  # noqa:F811
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
@@ -376,8 +376,8 @@ def test_bgp_update_timer_session_down(
     duthosts,
     enum_rand_one_per_hwsku_frontend_hostname,
     request,
-    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa F811
-    validate_active_active_dualtor_setup,  # noqa F811
+    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,  # noqa:F811
+    validate_active_active_dualtor_setup,  # noqa:F811
 ):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 

--- a/tests/bgp/test_bgpmon.py
+++ b/tests/bgp/test_bgpmon.py
@@ -6,8 +6,8 @@ from jinja2 import Template
 import ptf.packet as scapy
 from ptf.mask import Mask
 import json
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa:F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa:F401
 from tests.common.helpers.generators import generate_ip_through_default_route
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until

--- a/tests/bgp/test_bgpmon_v6.py
+++ b/tests/bgp/test_bgpmon_v6.py
@@ -5,8 +5,8 @@ from netaddr import IPNetwork
 from jinja2 import Template
 import json
 import random
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa:F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa:F401
 from tests.common.helpers.generators import generate_ip_through_default_route, generate_ip_through_default_v6_route
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
In pre-commit, we were using # noqa to ignore failures/errors/warnings in our code, but once we use # noqa, it will ignore all pre-commit errors in this line, the correct solution is using # noqa: so only specific failures/errors/warnings would be ignored.
#### How did you do it?
Replace # noqa with # noqa: in tests/b*
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
