### PR TITLE
Check for Gr2 in single lossy priority case

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -724,14 +724,20 @@ def verify_pause_frame_count_dut(rx_dut,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
-                if len(prios) > 1 and is_cisco_device(tx_dut) and not test_traffic_pause:
-                    pytest_assert(pfc_pause_rx_frames == 0,
-                                  "PFC pause frames should not be counted in RX PFC counters for priority {}"
-                                  .format(prios))
+                if len(prios) > 1:
+                    if is_cisco_device(tx_dut) and not test_traffic_pause:
+                        pytest_assert(pfc_pause_rx_frames == 0,
+                                "PFC pause frames should not be counted in RX PFC counters for priority {}"
+                                .format(prios))
                 else:
-                    pytest_assert(pfc_pause_rx_frames > 0,
-                                  "PFC pause frames should be received and counted in RX PFC counters for priority {}"
-                                  .format(prio))
+                    if is_cisco_device(tx_dut) and "x86_64-8122" in tx_dut.facts['platform'] and not test_traffic_pause:
+                        pytest_assert(pfc_pause_rx_frames == 0,
+                                "PFC pause frames should not be counted in RX PFC counters for priority {}"
+                                .format(prios))
+                    else:
+                        pytest_assert(pfc_pause_rx_frames > 0,
+                                "PFC pause frames should be received and counted in RX PFC counters for priority {}"
+                                .format(prio))
 
     for peer_port, prios in dut_port_config[0].items():  # PFC pause frames sent by DUT's ingress port to TGEN
         for prio in prios:

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -736,9 +736,9 @@ def verify_pause_frame_count_dut(rx_dut,
                                       .format(prios))
                     else:
                         pytest_assert(pfc_pause_rx_frames > 0,
-                                      "PFC pause frames should be received and counted in RX PFC counters for priority {}"
-                                      .format(prio))
-
+                                      "PFC pause frames should be received and counted in RX PFC counters for "
+                                      "priority {}".format(prio)
+                                      )
     for peer_port, prios in dut_port_config[0].items():  # PFC pause frames sent by DUT's ingress port to TGEN
         for prio in prios:
             pfc_pause_tx_frames = get_pfc_frame_count(rx_dut, peer_port, prio, is_tx=True)

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -727,17 +727,17 @@ def verify_pause_frame_count_dut(rx_dut,
                 if len(prios) > 1:
                     if is_cisco_device(tx_dut) and not test_traffic_pause:
                         pytest_assert(pfc_pause_rx_frames == 0,
-                                "PFC pause frames should not be counted in RX PFC counters for priority {}"
-                                .format(prios))
+                                      "PFC pause frames should not be counted in RX PFC counters for priority {}"
+                                      .format(prios))
                 else:
                     if is_cisco_device(tx_dut) and "x86_64-8122" in tx_dut.facts['platform'] and not test_traffic_pause:
                         pytest_assert(pfc_pause_rx_frames == 0,
-                                "PFC pause frames should not be counted in RX PFC counters for priority {}"
-                                .format(prios))
+                                      "PFC pause frames should not be counted in RX PFC counters for priority {}"
+                                      .format(prios))
                     else:
                         pytest_assert(pfc_pause_rx_frames > 0,
-                                "PFC pause frames should be received and counted in RX PFC counters for priority {}"
-                                .format(prio))
+                                      "PFC pause frames should be received and counted in RX PFC counters for priority {}"
+                                      .format(prio))
 
     for peer_port, prios in dut_port_config[0].items():  # PFC pause frames sent by DUT's ingress port to TGEN
         for prio in prios:

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -724,21 +724,16 @@ def verify_pause_frame_count_dut(rx_dut,
                 pytest_assert(pfc_pause_rx_frames == 0,
                               "PFC pause frames with no bit set in the class enable vector should be dropped")
             else:
-                if len(prios) > 1:
-                    if is_cisco_device(tx_dut) and not test_traffic_pause:
-                        pytest_assert(pfc_pause_rx_frames == 0,
-                                      "PFC pause frames should not be counted in RX PFC counters for priority {}"
-                                      .format(prios))
+                if ((len(prios) > 1 and is_cisco_device(tx_dut) and not test_traffic_pause) or
+                    (len(prios) == 1 and is_cisco_device(tx_dut) and
+                     "x86_64-8122" in tx_dut.facts['platform'] and not test_traffic_pause)):
+                    pytest_assert(pfc_pause_rx_frames == 0,
+                                  "PFC pause frames should not be counted in RX PFC counters for priority {}"
+                                  .format(prios))
                 else:
-                    if is_cisco_device(tx_dut) and "x86_64-8122" in tx_dut.facts['platform'] and not test_traffic_pause:
-                        pytest_assert(pfc_pause_rx_frames == 0,
-                                      "PFC pause frames should not be counted in RX PFC counters for priority {}"
-                                      .format(prios))
-                    else:
-                        pytest_assert(pfc_pause_rx_frames > 0,
-                                      "PFC pause frames should be received and counted in RX PFC counters for "
-                                      "priority {}".format(prio)
-                                      )
+                    pytest_assert(pfc_pause_rx_frames > 0,
+                                  "PFC pause frames should be received and counted in RX PFC counters for priority {}"
+                                  .format(prio))
     for peer_port, prios in dut_port_config[0].items():  # PFC pause frames sent by DUT's ingress port to TGEN
         for prio in prios:
             pfc_pause_tx_frames = get_pfc_frame_count(rx_dut, peer_port, prio, is_tx=True)


### PR DESCRIPTION


### Description of PR
<!--
Adding the condition for Gr2 for single priority case as we do not count the lossy PFC pause frame
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Following tests were failing on Gr2:
snappi_tests.pfc.test_pfc_pause_lossy_with_snappi#test_pfc_pause_single_lossy_prio::test_pfc_pause_single_lossy_prio
Error:
Failed: PFC pause frames should be received and counted in RX PFC counters for priority 2
#### How did you do it?

#### How did you verify/test it?
Ran the test with changes and test passed

#### Any platform specific information?
Only for cisco-8000

