### PR TITLE
update isolated 512 and v6 only topo in veos

### DIFF
--- a/ansible/veos
+++ b/ansible/veos
@@ -24,6 +24,13 @@ all:
           - t1-isolated-d128
           - t1-isolated-d28u1
           - t1-isolated-d224u8
+          - t1-isolated-v6-d128
+          - t1-isolated-v6-d224u8
+          - t1-isolated-v6-d28u1
+          - t1-isolated-d448u16
+          - t1-isolated-d56u2
+          - t1-isolated-v6-d448u16
+          - t1-isolated-v6-d56u2
           - t0
           - t0-d18u8s4
           - t0-16
@@ -46,6 +53,17 @@ all:
           - t0-isolated-d16u16s2
           - t0-isolated-d128u128s1
           - t0-isolated-d128u128s2
+          - t0-isolated-d2u254s1
+          - t0-isolated-d2u254s2
+          - t0-isolated-v6-d128u128s1
+          - t0-isolated-v6-d128u128s2
+          - t0-isolated-v6-d16u16s1
+          - t0-isolated-v6-d16u16s2
+          - t0-isolated-v6-d96u32s2
+          - t0-isolated-d256u256s2
+          - t0-isolated-d32u32s2
+          - t0-isolated-v6-d256u256s2
+          - t0-isolated-v6-d32u32s2
           - dualtor
           - dualtor-56
           - cable-test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add the new topologies in #17642 and #17599 into the supported veos topologies list:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add the topologies into the supported list.

#### How did you do it?

#### How did you verify/test it?
run add-topo on a physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
