### PR TITLE
[202411] Add pfcwd and qos sai test scripts to PR test

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -226,6 +226,11 @@ t0:
   - ip/test_mgmt_ipv6_only.py
   - zmq/test_gnmi_zmq.py
   - pc/test_lag_member_forwarding.py
+  - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_function.py
+  - pfcwd/test_pfcwd_timer_accuracy.py
+  - pfcwd/test_pfcwd_warm_reboot.py
+  - qos/test_qos_sai.py
 
 t0-2vlans:
   - dhcp_relay/test_dhcpv6_relay.py
@@ -435,6 +440,11 @@ t1-lag:
   - lldp/test_lldp_syncd.py
   - ipfwd/test_nhop_group.py
   - pc/test_lag_member_forwarding.py
+  - pfcwd/test_pfcwd_all_port_storm.py
+  - pfcwd/test_pfcwd_function.py
+  - pfcwd/test_pfcwd_timer_accuracy.py
+  - pfcwd/test_pfcwd_warm_reboot.py
+  - qos/test_qos_sai.py
 
 multi-asic-t1-lag:
   - bgp/test_bgp_bbr.py

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1553,7 +1553,7 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
         - "'t2' in topo_name"
         - "'standalone' in topo_name"
         - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
-        - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16233"
+        - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17803"
         - "release in ['202412']"
 
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1545,6 +1545,17 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - "'dualtor' in topo_name"
         - https://github.com/sonic-net/sonic-mgmt/issues/8400
 
+pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
+   skip:
+     reason: "Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on M* testbed. / Currently async_storm test is not supported on VS platform / Warm reboot is not required for 202412"
+     conditions_logical_operator: or
+     conditions:
+        - "'t2' in topo_name"
+        - "'standalone' in topo_name"
+        - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+        - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16233"
+        - "release in ['202412']"
+
 #######################################
 #####     process_monitoring      #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Elastictest performs well in distribute running PR test in multiple KVMs, which support us to add more test scripts to PR checker.
#### How did you do it?
In https://github.com/sonic-net/sonic-mgmt/pull/17565 and https://github.com/sonic-net/sonic-mgmt/pull/17751, we added pfcwd and qos sai support on KVM, so we can add them to PR test now.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
