### PR TITLE
[202411] Modify ptf_imagetag default value to branch based tag value

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -7,7 +7,7 @@
 # By using this practice, we suggest to add different tags for different PTF image versions in docker registry.
 - name: Set default value for ptf_imagetag
   set_fact:
-    ptf_imagetag: "latest"
+    ptf_imagetag: "202411"
   when: ptf_imagetag is not defined
 
 - name: set "PTF" container type, by default

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -12,7 +12,7 @@
   block:
   - name: Set default value for ptf_imagetag
     set_fact:
-      ptf_imagetag: "latest"
+      ptf_imagetag: "202411"
     when: ptf_imagetag is not defined
 
   - name: Stop mux simulator


### PR DESCRIPTION
### Description of PR

Set the default value of PTF image tag (`ptf_imagetag`) to branch based tags published by the release branch builds. The branch based docker-ptf builds continue to be mixed (Python 2 + Python 3) images and the master branch builds will be migrated to Python 3 only image.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Set the default value of PTF image tag (`ptf_imagetag`) to branch based tags published by the release branch builds. The branch based docker-ptf builds continue to be mixed (Python 2 + Python 3) images and the master branch builds will be migrated to Python 3 only image.

#### How did you do it?

Change default value in add-topo and renumber-topo YAMLs.

#### How did you verify/test it?

Will be verified in this CI run

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA