### PR TITLE
Restore fixture disable_packet_aging

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -27,7 +27,7 @@ from .tunnel_qos_remap_base import build_testing_packet, check_queue_counter,\
     dut_config, qos_config, tunnel_qos_maps, run_ptf_test, toggle_mux_to_host,\
     setup_module, update_docker_services, swap_syncd, counter_poll_config                               # noqa F401
 from .tunnel_qos_remap_base import leaf_fanout_peer_info, start_pfc_storm, \
-    stop_pfc_storm, get_queue_counter, get_queue_watermark                                              # noqa F401
+    stop_pfc_storm, get_queue_counter, get_queue_watermark, disable_packet_aging                        # noqa F401
 from ptf import testutils
 from ptf.testutils import simple_tcp_packet
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401

--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -310,6 +310,30 @@ def qos_config(rand_selected_dut, tbinfo, dut_config):
     return speed_cable_to_params[speed_cable]
 
 
+@pytest.fixture(scope='module', autouse=True)
+def disable_packet_aging(duthosts):
+    """
+        For Nvidia(Mellanox) platforms, packets in buffer will be aged after a timeout. Need to disable this
+        before any buffer tests.
+    """
+    for duthost in duthosts:
+        asic = duthost.get_asic_name()
+        if 'spc' in asic:
+            logger.info("Disable Mellanox packet aging")
+            duthost.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
+            duthost.command("docker cp /tmp/packets_aging.py syncd:/")
+            duthost.command("docker exec syncd python /packets_aging.py disable")
+
+    yield
+
+    for duthost in duthosts:
+        asic = duthost.get_asic_name()
+        if 'spc' in asic:
+            logger.info("Enable Mellanox packet aging")
+            duthost.command("docker exec syncd python /packets_aging.py enable")
+            duthost.command("docker exec syncd rm -rf /packets_aging.py")
+
+
 def _create_ssh_tunnel_to_syncd_rpc(duthost):
     dut_asic = duthost.asic_instance()
     dut_asic.create_ssh_tunnel_sai_rpc()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix an issue introduced by https://github.com/sonic-net/sonic-mgmt/pull/17728

The auto-used PR is still required for the test cases in [tests/qos/test_tunnel_qos_remap.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:restore_disable_packet_aging_fixture?expand=1#diff-0bc1dc320b693a545a1dd0b09c307b3f13faf79f79650fc7a1fe4fb78e3c8480) because fixture `update_docker_services` is only called for several test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix an issue introduced by https://github.com/sonic-net/sonic-mgmt/pull/17728

#### How did you do it?
Add the fixture back.

#### How did you verify/test it?
Verified on a physical SN4700 dualtor testbed.

```
collected 4 items                                                                                                                                                                                                             

qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_1] PASSED                                                                                                                                                    [ 25%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_2] PASSED                                                                                                                                                    [ 50%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_3] PASSED                                                                                                                                                    [ 75%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_4] PASSED                                                                                                                                                    [100%]
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
