### PR TITLE
Ignore subnet decap test when no portchannels found

### DIFF
--- a/tests/decap/test_subnet_decap.py
+++ b/tests/decap/test_subnet_decap.py
@@ -50,9 +50,11 @@ def prepare_subnet_decap_config(rand_selected_dut):
 def prepare_vlan_subnet_test_port(rand_selected_dut, tbinfo):
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
+
+    if not mg_facts['minigraph_portchannels']:
+        pytest.skip('No portchannels found in minigraph')
+
     dut_port = list(mg_facts['minigraph_portchannels'].keys())[0]
-    if not dut_port:
-        pytest.skip('No portchannels found')
     dut_eth_port = mg_facts["minigraph_portchannels"][dut_port]["members"][0]
     ptf_src_port = mg_facts["minigraph_ptf_indices"][dut_eth_port]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Solve IndexError: list index out of range in dut_port = list(mg_facts['minigraph_portchannels'].keys())[0] when minigraph_portchannels is empty.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Solve IndexError: list index out of range in dut_port = list(mg_facts['minigraph_portchannels'].keys())[0] because minigraph_portchannels is empty.

#### How did you do it?
This checks if any portchannels exist before attempting to access them, preventing the IndexError.

#### How did you verify/test it?
```
========================================================================================================================================================================================= short test summary info ==========================================================================================================================================================================================
SKIPPED [4] decap/test_subnet_decap.py:207: No portchannels found in minigraph
================================================================================================================================================================================ 4 skipped, 1 warning in 797.40s (0:13:17) =================================================================================================================================================================================
```
#### Any platform specific information?
str4-sn5600-1
#### Supported testbed topology if it's a new test case?
t0-isolated-u16d16s1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
