### PR TITLE
Add isolated v6 only topologies to veos

### DIFF
--- a/ansible/veos
+++ b/ansible/veos
@@ -24,6 +24,11 @@ all:
           - t1-isolated-d128
           - t1-isolated-d28u1
           - t1-isolated-d224u8
+          - t1-isolated-v6-d28u1
+          - t1-isolated-v6-d56u2
+          - t1-isolated-v6-d128
+          - t1-isolated-v6-d224u8
+          - t1-isolated-v6-d448u16
           - t0
           - t0-d18u8s4
           - t0-16
@@ -46,6 +51,13 @@ all:
           - t0-isolated-d16u16s2
           - t0-isolated-d128u128s1
           - t0-isolated-d128u128s2
+          - t0-isolated-v6-d16u16s1
+          - t0-isolated-v6-d16u16s2
+          - t0-isolated-v6-d32u32s2
+          - t0-isolated-v6-d96u32s2
+          - t0-isolated-v6-d128u128s1
+          - t0-isolated-v6-d128u128s2
+          - t0-isolated-v6-d256u256s2
           - dualtor
           - dualtor-56
           - cable-test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
After #17599 , add v6 only topo to veos file so we can continue deploy these topologies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202412

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>