### PR TITLE
Fixed syslog rate-limit tests

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -151,7 +151,7 @@ class LogAnalyzer:
             if (self.expect_regex and (self.expected_matches_target > 0) and
                     result["total"]["expected_match"] != self.expected_matches_target):
                 err_target = "Log analyzer expected {} messages but found only {}\n"\
-                    .format(self.expected_matches_target, len(self.expect_regex))
+                    .format(self.expected_matches_target, result["total"]["expected_match"])
                 raise LogAnalyzerError(err_target + result_str)
 
     def save_matching_errors(self, result_log_errors):

--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -22,7 +22,7 @@ LOCAL_LOG_GENERATOR_FILE = os.path.join(BASE_DIR, 'log_generator.py')
 REMOTE_LOG_GENERATOR_FILE = os.path.join('/tmp', 'log_generator.py')
 DOCKER_LOG_GENERATOR_FILE = '/log_generator.py'
 # rsyslogd prints this log when rate-limiting reached
-LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*begin to drop messages due to rate-limiting.*'
+LOG_EXPECT_SYSLOG_RATE_LIMIT_REACHED = '.*rate-limit-test>: begin to drop messages due to rate-limiting.*'
 # Log pattern for tests/syslog/log_generator.py
 LOG_EXPECT_LAST_MESSAGE = '.*{}rate-limit-test: This is a test log:.*'
 


### PR DESCRIPTION
### Description of PR
Summary: Fixed syslog rate-limit tests
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/507

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
- The testcase (`"test_syslog_rate_limit.py"`) was flaky.

#### How did you do it?
- Fixed flakiness in the test(`"test_syslog_rate_limit.py"`) by ensuring it includes the source application that triggered the test. Previously, valid rate-limit scenarios could add an extra log entry matching the search criteria, causing a count mismatch and test failure. Now, the test pattern explicitly includes the test application name.
- Refined error logs to provide more relevant context.

#### How did you verify/test it?
Ran `"tests/syslog/test_syslog_rate_limit.py"` repeatedly 20 times with dualtor topology on ARISTA switches, 
- 4/20 times it failed without the fix.
- It never failed with the fix.

Logs with fix:-
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[0] PASSED                                                                                                                                                                                                     [  5%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[1] PASSED                                                                                                                                                                                                     [ 10%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[2] PASSED                                                                                                                                                                                                     [ 15%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[3] PASSED                                                                                                                                                                                                     [ 20%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[4] PASSED                                                                                                                                                                                                     [ 25%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[5] PASSED                                                                                                                                                                                                     [ 30%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[6] PASSED                                                                                                                                                                                                     [ 35%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[7] PASSED                                                                                                                                                                                                     [ 40%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[8] PASSED                                                                                                                                                                                                     [ 45%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[9] PASSED                                                                                                                                                                                                     [ 50%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[10] PASSED                                                                                                                                                                                                    [ 55%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[11] PASSED                                                                                                                                                                                                    [ 60%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[12] PASSED                                                                                                                                                                                                    [ 65%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[13] PASSED                                                                                                                                                                                                    [ 70%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[14] PASSED                                                                                                                                                                                                    [ 75%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[15] PASSED                                                                                                                                                                                                    [ 80%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[16] PASSED                                                                                                                                                                                                    [ 85%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[17] PASSED                                                                                                                                                                                                    [ 90%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[18] PASSED                                                                                                                                                                                                    [ 95%]
syslog/test_syslog_rate_limit.py::test_syslog_rate_limit[19] PASSED                                                                                                                                                                                                    [100%]



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
