### PR TITLE
Fix BFD status check and ipv6 PTF intermittent issue.

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -405,6 +405,8 @@ def test_bfd_basic(request, rand_selected_dut, ptfhost, tbinfo, ipv6, dut_init_f
 
         for idx, neighbor_addr in enumerate(neighbor_addrs):
             if idx == update_idx:
+                # RFC 5880, section 6.2: Remote system (dut) to enter "Down"
+                # state when local system (ptf) is set to "AdminDown" state.
                 check_dut_bfd_status(duthost, neighbor_addr, "Down")
                 check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "AdminDown")
             else:

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -388,6 +388,10 @@ def test_bfd_basic(request, rand_selected_dut, ptfhost, tbinfo, ipv6, dut_init_f
         add_dut_ip(duthost, neighbor_devs, local_addrs, prefix_len)
         init_ptf_bfd(ptfhost)
         add_ipaddr(ptfhost, neighbor_addrs, prefix_len, neighbor_interfaces, ipv6)
+
+        # Delay to allow for IPv6 addresses to be fully programmed so IPv6
+        # neighborship can be resolved on PTF side.
+        time.sleep(5)
         create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs, dut_init_first)
 
         time.sleep(1)
@@ -401,7 +405,7 @@ def test_bfd_basic(request, rand_selected_dut, ptfhost, tbinfo, ipv6, dut_init_f
 
         for idx, neighbor_addr in enumerate(neighbor_addrs):
             if idx == update_idx:
-                check_dut_bfd_status(duthost, neighbor_addr, "Admin_Down")
+                check_dut_bfd_status(duthost, neighbor_addr, "Down")
                 check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "AdminDown")
             else:
                 check_dut_bfd_status(duthost, neighbor_addr, "Up")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

On Smartswitch, the following non-multihop specific failures are seen after running test_bfd.py:

Failure 1:

Testcases: bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first], bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first], bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first]

File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 493, in call
return self._hookexec([self.name](http://self.name/), self._hookimpls, kwargs, firstresult)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 115, in _hookexec
return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 113, in _multicall
raise exception.with_traceback(exception.traceback)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 77, in _multicall
res = hook_impl.function(*args)
File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 192, in pytest_pyfunc_call
result = testfunction(**testargs)
File "/data/tests/bfd/test_bfd.py", line 396, in test_bfd_basic
check_dut_bfd_status(duthost, neighbor_addr, "Admin_Down")
File "/data/tests/bfd/test_bfd.py", line 236, in check_dut_bfd_status
assert expected_state in bfd_state[0] # If all attempts fail, raise an assertion error
AssertionError

Failure 2:

Testcase: bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first]

File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1761, in runtest
self.ihook.pytest_pyfunc_call(pyfuncitem=self)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 493, in call
return self._hookexec([self.name](http://self.name/), self._hookimpls, kwargs, firstresult)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 115, in _hookexec
return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 113, in _multicall
raise exception.with_traceback(exception.traceback)
File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 77, in _multicall
res = hook_impl.function(*args)
File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 192, in pytest_pyfunc_call
result = testfunction(**testargs)
File "/data/tests/bfd/test_bfd.py", line 387, in test_bfd_basic
check_dut_bfd_status(duthost, neighbor_addr, "Up")
File "/data/tests/bfd/test_bfd.py", line 236, in check_dut_bfd_status
assert expected_state in bfd_state[0] # If all attempts fail, raise an assertion error
AssertionError

Failure 1 is happening because testcase is expecting AdminDown state in SONIC when AdminDown state is set on remote end (PTF). This expection is wrong because SONIC displays local BFD state and not remote. If PTF goes to AdminDown then local state will go to Down. This matches the RFC (see section 6.2):

https://datatracker.ietf.org/doc/html/rfc5880#section-6.8.16
https://datatracker.ietf.org/doc/html/rfc5880#section-6.2
"AdminDown state means that the session is being held administratively down. This causes the remote system to enter Down state, and remain there until the local system exits AdminDown state."

Failure 2 is intermittent. When IPv6 BFD sessions are configured on PTF before DUT then some sessions always stay in Down state. Initially, IPv6 addresses are configured on both DUT and BFD, then right away BFD sessions on PTF are started. PTF does not send IPv6 neighbor solicitation (NS) packets to DUT for some of the IPv6 addresses when BFD sessions are configured. Because these packets are missing, the IPv6 adjacency is not resolved on the DUT and BFD sessions stay down. The solution is add a 5 second delay between configuring IPv6 addresses on PTF and configuring BFD on PTF. This allows for enough delay so IPv6 addresses are fully programmed and BFD session can trigger sending of IPv6 NS packets on PTF.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix test run failures in the tests/bfd/test_bfd.py for ipv4/ipv6 singlehop testcases

#### How did you do it?
Added a delay to allow IPv6 adjacency to resolve before BFD sessions are programmed, updated state check to check for 'Down'. 

#### How did you verify/test it?
Ran sonic-mgmt test_bfd.py and it passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
