### PR TITLE
[SONiCMgmtBoost] Boost acl test by only running reboot/port toggle once

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1362,8 +1362,9 @@ class TestAclWithReboot(TestBasicAcl):
     Verify that configuration persists correctly after reboot and is applied properly
     upon startup.
     """
-
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa: F811
+    # Flag to ensure reboot only happens once
+    dut_rebooted = False
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa F811
         """Save configuration and reboot after rules are applied.
 
         Args:
@@ -1372,6 +1373,9 @@ class TestAclWithReboot(TestBasicAcl):
             populate_vlan_arp_entries: A fixture to populate ARP/FDB tables for VLAN interfaces.
 
         """
+        if TestAclWithReboot.dut_rebooted:
+            return
+        TestAclWithReboot.dut_rebooted = True
         dut.command("config save -y")
         reboot(dut, localhost, safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
         # We need some additional delay on e1031
@@ -1401,8 +1405,9 @@ class TestAclWithPortToggle(TestBasicAcl):
 
     Verify that ACLs still function as expected after links flap.
     """
-
-    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa: F811
+    # Flag to ensure port toggle only happens once
+    dut_port_toggled = False
+    def post_setup_hook(self, dut, localhost, populate_vlan_arp_entries, tbinfo, conn_graph_facts):     # noqa F811
         """Toggle ports after rules are applied.
 
         Args:
@@ -1411,6 +1416,9 @@ class TestAclWithPortToggle(TestBasicAcl):
             populate_vlan_arp_entries: A fixture to populate ARP/FDB tables for VLAN interfaces.
 
         """
+        if TestAclWithPortToggle.dut_port_toggled:
+            return
+        TestAclWithPortToggle.dut_port_toggled = True
         # todo: remove the extra sleep on chassis device after bgp suppress fib pending feature is enabled
         # We observe flakiness failure on chassis devices
         # Suspect it's because the route is not programmed into hardware


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to reduce the time cost for running acl test.
**Before this change:**
`port_toggle` and `cold reboot` are issued for each param combination. That's 8 times in total.
The time cost for acl test is 90 minutes on a T0 testbed.

**After this change:**
Only run `port_toggle` and `cold_reboot` once, and then run test with different param combinations. This is closer to the production scenario.
The time cost for acl test is 60 minutes on a T0 testbed.

So the change can save 30% of the time cost for running acl test.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to improve `test_acl`.

#### How did you do it?
Add two static variable to ensure DUT only run `port_toggle` and `reboot` once.

#### How did you verify/test it?
The change is verified on a physical T0 testbed.
```
collected 800 items                                                                                                                                                                                                           

acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                    [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-downlink->uplink-default-Vlan1000] SKIPPED (Only run for egress)                                                                            [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                    [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                     [  0%] ^H
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                       [  0%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                      [  0%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                        [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                      [  1%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                [  1%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                  [  1%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                                 [  1%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-Vlan1000] PASSED                                                                                               [  1%]
...
acl/test_acl.py::TestAclWithPortToggle::test_l4_dport_match_dropped[ipv6-ingress-uplink->downlink-default-Vlan1000] SKIPPED (IPV6 ACL test not currently supported on t0 testbeds)                                      [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_l4_sport_match_dropped[ipv6-ingress-uplink->downlink-default-Vlan1000] SKIPPED (IPV6 ACL test not currently supported on t0 testbeds)                                      [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_ip_proto_match_dropped[ipv6-ingress-uplink->downlink-default-Vlan1000] SKIPPED (IPV6 ACL test not currently supported on t0 testbeds)                                      [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_tcp_flags_match_dropped[ipv6-ingress-uplink->downlink-default-Vlan1000] SKIPPED (IPV6 ACL test not currently supported on t0 testbeds)                                     [ 99%]
acl/test_acl.py::TestAclWithPortToggle::test_icmp_match_forwarded[ipv6-ingress-uplink->downlink-default-Vlan1000] SKIPPED (IPV6 ACL test not currently supported on t0 testbeds)                                        [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
