### PR TITLE
for T1 role dhcp and dhcp6 packets to be punted to cpu since dhcp_relay is enabled

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -310,13 +310,12 @@ class ARPTest(PolicyTest):
         return packet
 
 
-# SONIC configuration has no packets to CPU for DHCP-T1 Topo
+# SONIC configuration has packets to CPU for DHCP-T1 Topo
 class DHCPTopoT1Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # T1 DHCP no packet to packet to CPU so police rate is 0
+        # T1 DHCP packets to be punted to cpu
         self.PPS_LIMIT_MIN = 0
-        self.PPS_LIMIT_MAX = 0
 
     def runTest(self):
         self.log("DHCPTopoT1Test")
@@ -436,13 +435,12 @@ class DHCP6Test(PolicyTest):
         return packet
 
 
-# SONIC configuration has no packets to CPU for DHCPv6-T1 Topo
+# SONIC configuration has packets to CPU for DHCPv6-T1 Topo
 class DHCP6TopoT1Test(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
-        # T1 DHCP6 no packet to packet to CPU so police rate is 0
+        # T1 DHCP6 packets to be punted to cpu
         self.PPS_LIMIT_MIN = 0
-        self.PPS_LIMIT_MAX = 0
 
     def runTest(self):
         self.log("DHCP6TopoT1Test")


### PR DESCRIPTION
…ay is enabled

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:For T1 role dhcp and dhcp6 packets to be punted to cpu since dhcp_relay is enabled
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405
- [ X] 202411

### Approach
modified PPS_LIMIT_MAX 
#### What is the motivation for this PR?
The existing behavior is not correct for the DHCP and DHCP6 tests for T1 role

#### How did you do it?
adjusted PPS_LIMIT_MAX  to correct values for  DHCP and DHCP6 tests for T1 role
#### How did you verify/test it?
Re run below tests after the fix and tests passed
copp/test_copp.py::TestCOPP::test_policer[MtFuji-dut-DHCP]
copp/test_copp.py::TestCOPP::test_policer[MtFuji-dut-DHCP6]


#### Any platform specific information?
Platform: x86_64-8102_28fh_dpu_o-r0
HwSKU: Cisco-8102-28FH-DPU-O-T1
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
