### PR TITLE
Unskipped some ARP tests for the dualtor topology

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -149,8 +149,6 @@ def test_arp_update_for_failed_standby_neighbor(
     4. Run `arp_update` on the active ToR
     5. Verify the incomplete entry is now reachable
     """
-    if ip_address(neighbor_ip).version == 6 and rand_unselected_dut.facts["asic_type"] == "vs":
-        pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     # We only use ping to trigger an ARP request from the kernel, so exit early to save time
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)
 
@@ -192,8 +190,6 @@ def test_standby_unsolicited_neigh_learning(
     2. Run arp_update on the active ToR
     3. Confirm that the standby ToR learned the entry and it is REACHABLE
     """
-    if ip_address(neighbor_ip).version == 6 and rand_unselected_dut.facts["asic_type"] == "vs":
-        pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)
 
     rand_selected_dut.shell(ping_cmd, module_ignore_errors=True)

--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -65,9 +65,6 @@ def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfad
 
     ip_version, outgoing_packet, expected_packet = packets_for_test
 
-    if ip_version == "v6" and rand_selected_dut.facts["asic_type"] == "vs":
-        pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
-
     if ip_version == 'v4':
         pytest_require(ptf_intf_ipv4_addr is not None, 'No IPv4 VLAN address configured on device')
     elif ip_version == 'v6':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR unskips the dualtor ARP tests that were skipped in #16371, #16396, and #16426.

Summary:
After the sonic-swss PR [Fixing an issue causing mismatch between MAC and link-local IPv6 addresses of VLAN and Bridge interfaces](https://github.com/sonic-net/sonic-swss/pull/3476), the tests that are unskipped in this PR are expected to pass.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Making sure that dualtor ARP tests are run after PR submission.

#### How did you do it?
Removed the code that skipped the tests.

#### How did you verify/test it?
Tested on a dualtor testbed with Broadcom ASIC. Here are the test results (the device name is replaced by `...`):
```
arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor[v4-active-standby-...-None] SKIPPED [ 12%]
arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor[v4-active-active-...-None] SKIPPED  [ 25%]
arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor[v6-active-standby-...-None] SKIPPED [ 37%]
arp/test_arp_dualtor.py::test_proxy_arp_for_standby_neighbor[v6-active-active-...-None] SKIPPED  [ 50%]
arp/test_arp_dualtor.py::test_arp_update_for_failed_standby_neighbor[IPv4] PASSED                                [ 62%]
arp/test_arp_dualtor.py::test_arp_update_for_failed_standby_neighbor[IPv6] PASSED                                [ 75%]
arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning[IPv4] PASSED                                    [ 87%]
arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning[IPv6] PASSED                                    [100%]

arp/test_arp_extended.py::test_arp_garp_enabled[...-None] PASSED                                 [ 33%]
arp/test_arp_extended.py::test_proxy_arp[v4-...-None] PASSED                                     [ 66%]
arp/test_arp_extended.py::test_proxy_arp[v6-...-None] PASSED                                     [100%]
```

#### Any platform specific information?
The tests were skipped only on the VS platform to unblock sonic-swss submodule update, but the failure was also seen on other platforms.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A