### PR TITLE
Choose correct vlan ip for 2vlan config in advance_reboot

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -21,6 +21,7 @@ from tests.common.dualtor.data_plane_utils import get_peerhost
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 from tests.common.fixtures.duthost_utils import check_bgp_router_id
 from tests.common.utilities import wait_until
+from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 logger = logging.getLogger(__name__)
 
@@ -205,9 +206,11 @@ class AdvancedReboot:
                                                   self.mgFacts['minigraph_lo_interfaces'][0]['prefixlen'])
 
         vlan_ip_range = dict()
-        for vlan in self.mgFacts['minigraph_vlan_interfaces']:
-            if type(ipaddress.ip_network(vlan['subnet'])) is ipaddress.IPv4Network:
-                vlan_ip_range[vlan['attachto']] = vlan['subnet']
+        vlan_interfaces = get_vlan_interface_list(self.duthost)
+        for vlan_if_name in vlan_interfaces:
+            vlan_ipv4_entry = get_vlan_interface_info(self.duthost, tbinfo, vlan_if_name, "ipv4")
+            vlan_ip_range[vlan_if_name] = vlan_ipv4_entry['subnet']
+        logger.info('Vlan IP range: {}'.format(vlan_ip_range))
         self.rebootData['vlan_ip_range'] = json.dumps(vlan_ip_range)
 
         self.rebootData['dut_username'] = self.creds['sonicadmin_user']

--- a/tests/common/helpers/dut_ports.py
+++ b/tests/common/helpers/dut_ports.py
@@ -99,7 +99,7 @@ def get_vlan_interfaces_dict(duthost, tbinfo):
             ip_with_prefix = f"{interface['addr']}/{interface['prefixlen']}"
             if ip_with_prefix in config_facts['VLAN_INTERFACE'][vlan]:
                 config = config_facts['VLAN_INTERFACE'][vlan][ip_with_prefix]
-                if config.get('secondary') == 'true':
+                if isinstance(config, dict) and config.get('secondary') == 'true':
                     interface_info['secondary'] = True
 
         # Add to appropriate IP version list
@@ -155,7 +155,7 @@ def get_vlan_interface_info(duthost, tbinfo, vlan_name, ip_version="ipv4"):
 
     for interface in vlan_interfaces_dict[vlan_name][ip_version]:
         # Skip secondary addresses
-        if interface.get('secondary'):
+        if isinstance(interface, dict) and interface.get('secondary'):
             continue
 
         result = interface


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Address https://github.com/aristanetworks/sonic-qual.msft/issues/518

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
There are 2 Vlans on the t0-118 topology. We observe that the ptftest launched from upgrade_path tests will default to using the 192.169.0.0/22 IP for Vlan1000 and the test would fail with DUT is not ready due to packets sent by the PTF does not have any response from the DUT.

However, by switching to use 192.168.0.0/25 for Vlan2000, upgrade_path no longer fails on DUT is not ready and is able to pass normal warm upgrade.

#### How did you do it?
Call the common help function `get_vlan_interface_list` and `get_vlan_interface_info` to get vlan interface and ipv4 address.

#### How did you verify/test it?
Run platform_tests.test_advanced_reboot on T0 testbeds.

#### Any platform specific information?
T0 platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
