### PR TITLE
Fix pfcwd/test_pfcwd_function.py for dualtor topologies

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class TrafficPorts(object):
     """ Generate a list of ports needed for the PFC Watchdog test"""
-    def __init__(self, mg_facts, neighbors, vlan_nw):
+    def __init__(self, mg_facts, neighbors, vlan_nw, topo, config_facts):
         """
         Args:
             mg_facts (dict): parsed minigraph info
@@ -51,6 +51,8 @@ class TrafficPorts(object):
         self.pfc_wd_rx_port_addr = None
         self.pfc_wd_rx_neighbor_addr = None
         self.pfc_wd_rx_port_id = None
+        self.topo = topo
+        self.config_facts = config_facts
 
     def build_port_list(self):
         """
@@ -225,7 +227,9 @@ class TrafficPorts(object):
         rx_port = self.pfc_wd_rx_port if isinstance(self.pfc_wd_rx_port, list) else [self.pfc_wd_rx_port]
         rx_port_id = self.pfc_wd_rx_port_id if isinstance(self.pfc_wd_rx_port_id, list) else [self.pfc_wd_rx_port_id]
         for item in vlan_members:
-            temp_ports[item] = {'test_neighbor_addr': self.vlan_nw,
+            ip_addr = self.vlan_nw if 'dualtor' not in self.topo else \
+                      self.config_facts['MUX_CABLE'][item]['server_ipv4'].split('/')[0]
+            temp_ports[item] = {'test_neighbor_addr': ip_addr,
                                 'rx_port': rx_port,
                                 'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
                                 'peer_device': self.neighbors.get(item, {}).get('peerdevice', ''),

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -149,8 +149,11 @@ def setup_pfc_test(
             exclude_ips=[vlan_addr])['ansible_facts']['generated_ips']
         vlan_nw = vlan_ips[0].split('/')[0]
 
+    topo = tbinfo["topo"]["name"]
+
     # build the port list for the test
-    tp_handle = TrafficPorts(mg_facts, neighbors, vlan_nw)
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    tp_handle = TrafficPorts(mg_facts, neighbors, vlan_nw, topo, config_facts)
     test_ports = tp_handle.build_port_list()
     mg_facts['minigraph_port_indices'] = {
         key: value for key, value in mg_facts['minigraph_ptf_indices'].items()
@@ -161,7 +164,6 @@ def setup_pfc_test(
         if not key.startswith('Ethernet-BP')
     }
     # In T1 topology update test ports by removing inactive ports
-    topo = tbinfo["topo"]["name"]
     if topo in SUPPORTED_T1_TOPOS:
         test_ports = update_t1_test_ports(
             duthost, mg_facts, test_ports, tbinfo


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix pfcwd/test_pfcwd_function.py for dualtor topologies
Fixes: [#495](https://github.com/aristanetworks/sonic-qual.msft/issues/495)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions is flaky and fails with the following signature.

```
======================================================================
FAIL: pfc_wd.PfcWdTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ptftests/py3/pfc_wd.py", line 148, in runTest
    return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
  File "/root/env-python3/lib/python3.7/site-packages/ptf/testutils.py", line 3437, in verify_packet_any_port
    % (result.port, device_number, ports, result.format())
AssertionError: Received expected packet on port 1 for device 0, but it should have arrived on one of these ports: [23].
========== RECEIVED ==========
0000  82 FD E1 7F 90 01 00 AA BB CC DD EE 08 00 45 0D  ..............E.
0010  00 56 00 01 00 00 3F 06 1B DF 64 5B 3A B0 C0 A8  .V....?...d[:...
0020  00 02 EA F5 27 6F 00 00 00 00 00 00 00 00 50 02  ....'o........P.
0030  20 00 21 87 00 00 00 01 02 03 04 05 06 07 08 09   .!.............
0040  0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19  ................
0050  1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28 29  ...... !"#$%&'()
0060  2A 2B 2C 2D                                      *+,-
==============================
```

#### How did you do it?
The test randomly selects a `dst_port` but always assigns the IP `192.168.0.2` to it. In dualtor topologies there is a notion of static/fixed IP addresses on the ToR's side 

```
admin@ld301:~$ show mux config
SWITCH_NAME    PEER_TOR
-------------  ----------
ld302          10.1.0.33
port        state    ipv4             ipv6
----------  -------  ---------------  -----------------
Ethernet4   auto     192.168.0.2/32   fc02:1000::2/128
Ethernet8   auto     192.168.0.3/32   fc02:1000::3/128
Ethernet12  auto     192.168.0.4/32   fc02:1000::4/128
Ethernet16  auto     192.168.0.5/32   fc02:1000::5/128
Ethernet20  auto     192.168.0.6/32   fc02:1000::6/128
Ethernet24  auto     192.168.0.7/32   fc02:1000::7/128
Ethernet28  auto     192.168.0.8/32   fc02:1000::8/128
Ethernet32  auto     192.168.0.9/32   fc02:1000::9/128
Ethernet36  auto     192.168.0.10/32  fc02:1000::a/128
Ethernet40  auto     192.168.0.11/32  fc02:1000::b/128
Ethernet44  auto     192.168.0.12/32  fc02:1000::c/128
Ethernet48  auto     192.168.0.13/32  fc02:1000::d/128
Ethernet52  auto     192.168.0.14/32  fc02:1000::e/128
Ethernet56  auto     192.168.0.15/32  fc02:1000::f/128
Ethernet60  auto     192.168.0.16/32  fc02:1000::10/128
Ethernet64  auto     192.168.0.17/32  fc02:1000::11/128
Ethernet68  auto     192.168.0.18/32  fc02:1000::12/128
Ethernet72  auto     192.168.0.19/32  fc02:1000::13/128
Ethernet76  auto     192.168.0.20/32  fc02:1000::14/128
Ethernet80  auto     192.168.0.21/32  fc02:1000::15/128
Ethernet84  auto     192.168.0.22/32  fc02:1000::16/128
Ethernet88  auto     192.168.0.23/32  fc02:1000::17/128
Ethernet92  auto     192.168.0.24/32  fc02:1000::18/128
Ethernet96  auto     192.168.0.25/32  fc02:1000::19/128
``` 

Due to this packet sometimes ends up being forwarded to Ethernet4 (port1) instead of the port expected by the test.

The proposed fix is that in case of dualtor alone choose destination IP according to `MUX_CONFIG` for the interface chosen as the dst_port.


#### How did you verify/test it?
Ran all pfcwd tests on Arista-7260CX3 with dualtor-120 topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
