### PR TITLE
[PR#17130] - fib - Changes for VOQ single-dut multi-asic 

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -53,7 +53,10 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts, testname=None):
             dut_port_channels.setdefault(duthost.hostname, {}).update(asic_cfg_facts[1].get('PORTCHANNEL_MEMBER', {}))
     sys_neigh = {}
     if switch_type == "voq":
-        voq_db = VoqDbCli(duthosts.supervisor_nodes[0])
+        if len(duthosts) == 1:
+            voq_db = VoqDbCli(duthosts.frontend_nodes[0])
+        else:
+            voq_db = VoqDbCli(duthosts.supervisor_nodes[0])
         for entry in voq_db.dump_neighbor_table():
             neigh_key = entry.split('|')
             neigh_ip = neigh_key[-1]
@@ -321,7 +324,7 @@ def fib_info_files(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_
 @pytest.fixture(scope="module")
 def single_fib_for_duts(tbinfo, duthosts):
     # For a T2 topology, we are generating a single fib file across all asics, but have multiple frontend nodes (DUTS).
-    if tbinfo['topo']['type'] == "t2":
+    if tbinfo['topo']['type'] == "t2" and len(duthosts) > 1:
         if duthosts[0].facts['switch_type'] == "voq":
             return "single-fib-single-hop"
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- Split the original PR https://github.com/sonic-net/sonic-mgmt/pull/17130 into individual PRs for each test.
- This is an enhancement to support VOQ Single DUT Multi-ASIC setup for T2 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

- New testbed modification of VOQ Single DUT and multi-asic.

#### How did you do it?

- If switch type is VOQ, decide based on the number of Duts and also based on if the DUT is modular chassis or not.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

- T2 VOQ Single Dut Multi ASIC

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
