### PR TITLE
Fix vlan vs router mac issue with test_qos_dscp_mapping.py

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1054,6 +1054,8 @@ def get_ipv4_loopback_ip(duthost):
                 if is_ipv4_address(ip):
                     loopback_ip = ip
                     break
+        if loopback_ip is not None:
+            break
 
     return loopback_ip
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1040,11 +1040,11 @@ def recover_acl_rule(duthost, data_acl):
 
 def get_ipv4_loopback_ip(duthost):
     """
-    Get ipv4 loopback ip address
+    Get the first valid ipv4 loopback ip address
     """
     config_facts = duthost.get_running_config_facts()
     los = config_facts.get("LOOPBACK_INTERFACE", {})
-    loopback_ip = None
+    selected_loopback_ip = None
 
     for key, _ in los.items():
         if "Loopback" in key:
@@ -1052,12 +1052,12 @@ def get_ipv4_loopback_ip(duthost):
             for ip_str, _ in loopback_ips.items():
                 ip = ip_str.split("/")[0]
                 if is_ipv4_address(ip):
-                    loopback_ip = ip
+                    selected_loopback_ip = ip
                     break
-        if loopback_ip is not None:
+        if selected_loopback_ip is not None:
             break
 
-    return loopback_ip
+    return selected_loopback_ip
 
 
 def get_dscp_to_queue_value(dscp_value, dscp_to_tc_map, tc_to_queue_map):

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1416,6 +1416,27 @@ def get_iface_ip(mg_facts, ifacename):
     return None
 
 
+def get_vlan_mac(duthost, member_port):
+    '''
+    Returns the mac of the VLAN that has the given member port.
+    If no VLAN or appropriate member found, returns None.
+    '''
+    mg_facts = duthost.get_extended_minigraph_facts()
+    if 'minigraph_vlans' not in mg_facts:
+        return None
+    vlan_name = None
+    for vlan in mg_facts['minigraph_vlans']:
+        for member in mg_facts['minigraph_vlans'][vlan]['members']:
+            if member == member_port:
+                vlan_name = vlan
+                break
+        if vlan_name is not None:
+            break
+    if vlan_name is None:
+        return None
+    return duthost.get_dut_iface_mac(vlan_name)
+
+
 def cleanup_prev_images(duthost):
     logger.info("Cleaning up previously installed images on DUT")
     current_os_version = duthost.shell('sonic_installer list | grep Current | cut -f2 -d " "')['stdout']

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1416,9 +1416,9 @@ def get_iface_ip(mg_facts, ifacename):
     return None
 
 
-def get_vlan_mac(duthost, member_port):
+def get_vlan_from_port(duthost, member_port):
     '''
-    Returns the mac of the VLAN that has the given member port.
+    Returns the name of the VLAN that has the given member port.
     If no VLAN or appropriate member found, returns None.
     '''
     mg_facts = duthost.get_extended_minigraph_facts()
@@ -1432,9 +1432,7 @@ def get_vlan_mac(duthost, member_port):
                 break
         if vlan_name is not None:
             break
-    if vlan_name is None:
-        return None
-    return duthost.get_dut_iface_mac(vlan_name)
+    return vlan_name
 
 
 def cleanup_prev_images(duthost):

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -15,7 +15,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link,\
     get_stream_ptf_ports, get_dut_pair_port_from_ptf_port, apply_dscp_cfg_setup, apply_dscp_cfg_teardown # noqa F401
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue,\
-    get_egress_queue_pkt_count_all_prio, wait_until
+    get_egress_queue_pkt_count_all_prio, wait_until, get_vlan_mac
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module # noqa F401
 
@@ -153,6 +153,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
     """
     def _setup_test_params(self,
                            duthost,
+                           tbinfo,
                            downstream_links, # noqa F811
                            upstream_links, # noqa F811
                            decap_mode):
@@ -169,7 +170,16 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         downlink = select_random_link(downstream_links)
         uplink_ptf_ports = get_stream_ptf_ports(upstream_links)
         loopback_ip = get_ipv4_loopback_ip(duthost)
-        router_mac = duthost.facts["router_mac"]
+        ptf_downlink_port_id = downlink.get("ptf_port_id")
+
+        src_port_name = get_dut_pair_port_from_ptf_port(duthost, tbinfo, ptf_downlink_port_id)
+        pytest_assert(src_port_name, "No port on DUT found for ptf downlink port {}".format(ptf_downlink_port_id))
+        vlan_mac = get_vlan_mac(duthost, src_port_name)
+        if vlan_mac is not None:
+            logger.info("Using VLAN mac {} instead of router mac".format(vlan_mac))
+            dst_mac = vlan_mac
+        else:
+            dst_mac = duthost.facts["router_mac"]
 
         # Setup DSCP decap config on DUT
         apply_dscp_cfg_setup(duthost, decap_mode)
@@ -177,13 +187,13 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         pytest_assert(downlink is not None, "No downlink found")
         pytest_assert(uplink_ptf_ports is not None, "No uplink found")
         pytest_assert(loopback_ip is not None, "No loopback IP found")
-        pytest_assert(router_mac is not None, "No router MAC found")
+        pytest_assert(dst_mac is not None, "No router/vlan MAC found")
 
-        test_params["ptf_downlink_port"] = downlink.get("ptf_port_id")
+        test_params["ptf_downlink_port"] = ptf_downlink_port_id
         test_params["ptf_uplink_ports"] = uplink_ptf_ports
         test_params["outer_src_ip"] = '8.8.8.8'
         test_params["outer_dst_ip"] = loopback_ip
-        test_params["router_mac"] = router_mac
+        test_params["dst_mac"] = dst_mac
 
         return test_params
 
@@ -213,7 +223,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             pytest.skip("Dscp-queue mapping is not supported on {}".format(tbinfo["topo"]["type"]))
 
         asic_type = duthost.facts['asic_type']
-        router_mac = test_params['router_mac']
+        dst_mac = test_params['dst_mac']
         ptf_src_port_id = test_params['ptf_downlink_port']
         ptf_dst_port_ids = test_params['ptf_uplink_ports']
         outer_dst_pkt_ip = test_params['outer_dst_ip']
@@ -229,7 +239,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         logger.info("Inner Pkt Src IP: {}".format(inner_src_pkt_ip))
         logger.info("Inner Pkt Dst IP: {}".format(inner_dst_pkt_ip))
         logger.info("Pkt Src MAC: {}".format(ptf_src_mac))
-        logger.info("Pkt Dst MAC: {}".format(router_mac))
+        logger.info("Pkt Dst MAC: {}".format(dst_mac))
 
         pytest_assert(dut_qos_maps_module.get("dscp_to_tc_map") and dut_qos_maps_module.get("tc_to_queue_map"),
                       "No QoS map found on DUT")
@@ -245,7 +255,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
                 logger.info("Pipe mode: outer_dscp = {}, inner_dscp = {}".format(outer_dscp, inner_dscp))
 
             pkt, exp_pkt = create_ipip_packet(outer_src_mac=ptf_src_mac,
-                                              outer_dst_mac=router_mac,
+                                              outer_dst_mac=dst_mac,
                                               outer_src_pkt_ip=outer_src_pkt_ip,
                                               outer_dst_pkt_ip=outer_dst_pkt_ip,
                                               outer_dscp=outer_dscp,
@@ -346,7 +356,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "pipe" mode
         """
         duthost = rand_selected_dut
-        test_params = self._setup_test_params(duthost, downstream_links, upstream_links, "pipe")
+        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "pipe")
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "pipe")
         self._teardown_test(duthost)
 
@@ -358,6 +368,6 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" mode
         """
         duthost = rand_selected_dut
-        test_params = self._setup_test_params(duthost, downstream_links, upstream_links, "uniform")
+        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "uniform")
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "uniform")
         self._teardown_test(duthost)

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -15,7 +15,7 @@ from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_port
 from tests.common.helpers.ptf_tests_helper import downstream_links, upstream_links, select_random_link,\
     get_stream_ptf_ports, get_dut_pair_port_from_ptf_port, apply_dscp_cfg_setup, apply_dscp_cfg_teardown # noqa F401
 from tests.common.utilities import get_ipv4_loopback_ip, get_dscp_to_queue_value, find_egress_queue,\
-    get_egress_queue_pkt_count_all_prio, wait_until, get_vlan_mac
+    get_egress_queue_pkt_count_all_prio, wait_until, get_vlan_from_port
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import dut_qos_maps_module # noqa F401
 
@@ -174,7 +174,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
 
         src_port_name = get_dut_pair_port_from_ptf_port(duthost, tbinfo, ptf_downlink_port_id)
         pytest_assert(src_port_name, "No port on DUT found for ptf downlink port {}".format(ptf_downlink_port_id))
-        vlan_mac = get_vlan_mac(duthost, src_port_name)
+        vlan_name = get_vlan_from_port(duthost, src_port_name)
+        vlan_mac = None if vlan_name is None else duthost.get_dut_iface_mac(vlan_name)
         if vlan_mac is not None:
             logger.info("Using VLAN mac {} instead of router mac".format(vlan_mac))
             dst_mac = vlan_mac


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_qos_dscp_mapping.py was always directing traffic to the router's mac. However, some topos (primarily dualtor) use a vlan that overrides the mac address to be different from the router. This results in an incorrect VLAN broadcast operation, none of which goes to the uplink portchannels, causing the traffic to not be detected. 
- Added a common utility to retrieve the vlan name from a given port name
- Check if the src port is in a vlan, if so, grab its mac addr and use that instead of the router address. 
- Fix an issue with the ipv4 loopback getter where it would break, but not fully break the second loop. This would result in Loopback3 on dualtor being selected instead of Loopback0. Loopback3 has an OVS flow for packet duplication, which would result in traffic being received on both DUTs. 

New sample test-case packet on a dualtor system:
```
<Ether  dst=00:aa:bb:cc:dd:ee src=b'7e:d2:52:67:60:14' type=IPv4 |
<IP  ihl=None tos=0x1 id=1 flags= frag=0 ttl=64 proto=ipencap src=8.8.8.8 dst=10.1.0.33 |
<IP  ihl=None tos=0x11 id=1 frag=0 ttl=63 proto=tcp src=9.9.9.9 dst=10.10.10.10 |
<TCP  sport=1234 dport=http flags=S |
<Raw  load='tests.qos.test_qos_dscp_mapping tests.qos.test' |>>>>>
```
The dst mac is set to the VLAN mac, and the dst IP is set to 10.1.0.33, which is the first loopback interface on the lower tor (randomly selected tor):
```
# ifconfig Loopback0
Loopback0: flags=195<UP,BROADCAST,RUNNING,NOARP>  mtu 65536
        inet 10.1.0.33  netmask 255.255.255.255  broadcast 0.0.0.0
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
**Validation on hash 2ab8ec8**
- [x] Cisco Dualtor-AA 
Relevant logs:
```
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:181 Found VLAN Vlan1000 on port Ethernet16
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:184 Using VLAN mac 00:aa:bb:cc:dd:ee instead of router mac
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:248 Pkt Dst MAC: 00:aa:bb:cc:dd:ee
```
- [x] Cisco T0
Relevant logs:
```
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:181 Found VLAN Vlan1000 on port Ethernet228
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:184 Using VLAN mac 80:27:6c:47:8c:cc instead of router mac
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:248 Pkt Dst MAC: 80:27:6c:47:8c:cc
```
- [x] Cisco T1
Relevant logs:
```
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:181 Found VLAN None on port Ethernet240
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:187 VLAN mac not found, falling back to router mac
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:248 Pkt Dst MAC: 6c:4e:f6:41:67:fc
```

**Old validation**
- [x] Validate on Cisco dualtor-aa (T0) 
Relevant log:
```
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:180 Using VLAN mac 00:aa:bb:cc:dd:ee instead of router mac
```
- [x] Validate on a different T0 from dualtor to exercise the case where the VLAN is present but is the same is the router mac
Relevant log:

```
tests.qos.test_qos_dscp_mapping:test_qos_dscp_mapping.py:180 Using VLAN mac d4:7f:35:38:1a:00 instead of router mac
```
- [x] Validate on a T1 
No "Using VLAN" log. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
