### PR TITLE
tests/hash/test_generic_hash.py test_reboot  warm boot to config save before reboot

### DIFF
--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -667,7 +667,7 @@ def test_reboot(duthost, tbinfo, ptfhost, localhost, fine_params, mg_facts, rest
 
     with allure.step(f'Randomly choose a reboot type: {reboot_type}, and reboot'):
         # Save config if reboot type is config reload or cold reboot
-        if reboot_type in ['cold', 'reload']:
+        if reboot_type in ['cold', 'reload', 'warm']:
             duthost.shell('config save -y')
         # Reload/Reboot the dut
         if reboot_type == 'reload':


### PR DESCRIPTION

### Description of PR
tests/hash/test_generic_hash.py test_reboot does not config save when the warm reboot is selected.
Test tries to configure the global hash configuration, and does warm reboot. In warm reboot all the containers are restarted, which looses the configuration that is not saved.

Summary:
Fixes # (issue)

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added warm boot aslo part of config save check.

#### How did you verify/test it?
Ran Sonic-mgmt with the fix 
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------ generated xml file: /data/tests/logs/tr_2025-04-03-19-04-31.xml ------------------------------------
=============================================== 1 passed, 1 warning in 847.24s (0:14:07) ================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_reboot[CRC_CCITT-DST_IP-ipv6-None-None-warm]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'core_dump_check_pass': True, 'config_db_check_pass': False}}
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
