### PR TITLE
[PR#17130] - VOQ Lag - Changes for VOQ single-dut multi-asic

### DIFF
--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -39,8 +39,14 @@ def get_lag_id_from_chassis_db(duthosts, pc=TMP_PC):
     Returns:
         lag_id: LAG ID of LAG
     """
-    for sup in duthosts.supervisor_nodes:
-        voqdb = VoqDbCli(sup)
+    duthosts[0].facts['switch_type'] == "voq"
+    is_chassis = duthosts[0].get_facts().get("modular_chassis")
+    if duthosts[0].facts['switch_type'] == "voq" and not is_chassis:
+        nodes = [duthosts[0]]
+    else:
+        nodes = duthosts.supervisor_nodes
+    for node in nodes:
+        voqdb = VoqDbCli(node)
         lag_list = voqdb.get_lag_list()
         for lag in lag_list:
             if pc in lag:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- Split the original PR https://github.com/sonic-net/sonic-mgmt/pull/17130 into individual PRs for each test.
- This is an enhancement to support VOQ Single DUT Multi-ASIC setup for T2 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

- New testbed modification of VOQ Single DUT and multi-asic.

#### How did you do it?

- If switch type is VOQ, decide supervisor based on the number of Duts and also based on if the DUT is modular chassis or not.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

- T2 VOQ Single Dut Multi ASIC

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
