### PR TITLE
lldp_entry_table: Fix syntax error while parsing HGETALL lldp_entry output

### DIFF
--- a/tests/common/helpers/sonic_db.py
+++ b/tests/common/helpers/sonic_db.py
@@ -115,7 +115,7 @@ class SonicDbCli(object):
                 v = result['stdout'].decode('unicode-escape')
             else:
                 v = result['stdout']
-            v_sanitized = v.replace('\n', '\\n')
+            v_sanitized = v.replace('\r', '\\r').replace('\n', '\\n')
             v_dict = ast.literal_eval(v_sanitized)
             return v_dict
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes the following syntax error while parsing output of "_SONIC-DB-CLI:  APPL_DB HGETALL LLDP_ENTRY_TABLE:eth0_"
- Currently there is a chance that 'lldp_entry_table' tests would fail with this error.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
- Fix the following error for lldp_entry_table tests.
```
E         File "<unknown>", line 1
E           {'lldp_rem_sys_name': 'wfr-io-d-6-tor-1', 'lldp_rem_port_id': '36044800', 'lldp_rem_chassis_id_subtype': '4', 'lldp_rem_port_id_subtype': '7', 'lldp_rem_time_mark': '1044', 'lldp_rem_port_desc': '1/1/12, 10/100/Gig Ethernet TX', 'lldp_rem_man_addr': '', 'lldp_rem_sys_desc': 'TiMOS-B-20.9.R3 both/hops Nokia SAS-S 24T4SFP+ 7210 Copyright (c) 2000-2021 Nokia.
E                                                                                                                                                                                                                                                                                                                                                                                ^
E       SyntaxError: EOL while scanning string literal
``` 

#### How did you do it?

- Currently, the existing code replaces all newline (\n) with the literal string "\n". In addition to that, this fix replaces all occurrences of carriage return (\r) with the literal string "\r" to eliminate the parsing error.

#### How did you verify/test it?

- Ran all lldp_entry table tests and made sure tests are passing without any issues.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

![image](https://github.com/user-attachments/assets/6895b272-28f9-4ddd-baed-107fcf3b4e00)
