### PR TITLE
T2:pfcwd:Fix the asic_id check - It fails for asic0

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -309,6 +309,6 @@ def set_pfc_timer_cisco_8000(duthost, asic_id, script, port):
         dst="/")
 
     asic_arg = ""
-    if asic_id:
+    if asic_id != "":
         asic_arg = f"-n asic{asic_id}"
     duthost.shell(f"show platform npu script {asic_arg} -s {script_name}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the issue:
raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
E           tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
E           failed = True
E           changed = True
E           rc = 2
E           cmd = show platform npu script  -s set_pfc_time.py
E           start = 2025-01-23 04:05:01.590011
E           end = 2025-01-23 04:05:03.007243
E           delta = 0:00:01.417232
E           msg = non-zero return code
E           invocation = {'module_args': {'_raw_params': 'show platform npu script  -s set_pfc_time.py', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
E           _ansible_no_log = None
E           stdout =
E           stderr =
E           Usage: show platform npu script [OPTIONS]
E           Try "show platform npu script -h" for help.
E           
E           Error: Missing option "-n".  Choose from:
E               asic0,
E               asic1,
E               asic2.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [X] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Pls see the description. "if asic_id" doesn't work if asic_id = 0. It has to be 'if asic_id == ""'.

#### How did you do it?
Changed the check condition as mentioned above.

#### How did you verify/test it?
Verification in progress.

#### Any platform specific information?
Specific to cisco-8000.