### PR TITLE
Specify 1-1 default map for TC_TO_DSCP for Cisco-8000

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -178,8 +178,14 @@ def tunnel_qos_maps(rand_selected_dut, dut_qos_maps_module): # noqa F811
     # inner_dscp_to_outer_dscp_map, a map for rewriting DSCP in the encapsulated packets
     ret['inner_dscp_to_outer_dscp_map'] = {}
     if 'cisco-8000' in asic_type:
+        dscps_present = []
         for k, v in list(maps['TC_TO_DSCP_MAP'][TUNNEL_MAP_NAME].items()):
             ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(v)
+            dscps_present.append(int(k))
+        # Fill in default-values in the map to be 1-1
+        for dscp in range(64):
+            if dscp not in dscps_present:
+                ret['inner_dscp_to_outer_dscp_map'][dscp] = dscp
     else:
         for k, v in list(maps['DSCP_TO_TC_MAP'][MAP_NAME].items()):
             ret['inner_dscp_to_outer_dscp_map'][int(k)] = int(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
TC_TO_DSCP map defaults to 1-1 to help preserve encapsulated packet DSCPs during T1-transit. Reflect the default in the test configuration. 
Fixes a couple tests that would fail to find some extra configuration when producing a DSCP->DSCP map. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Validated 2 failing tests in qos/test_tunnel_qos_remap.py passed on Cisco-8000 dualtor:
- test_encap_dscp_rewrite
- test_tunnel_decap_dscp_to_pg_mapping

#### Any platform specific information?
Specific to Cisco-8000 dualtor platform. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
