### PR TITLE
fix the issue when the timezone on the DUT is not UTC

### DIFF
--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -107,7 +107,7 @@ def ntp_service_restarted(duthost, start_time):
         return False
 
     output = duthost.command(f"systemctl show {systemd_service} --timestamp unix -P ExecMainStartTimestamp")
-    return datetime.datetime.utcfromtimestamp(int(output['stdout'][1:])) > start_time
+    return int(output['stdout'][1:]) > start_time.timestamp()
 
 
 def ntp_server_tc1_add_config(duthost):


### PR DESCRIPTION
In the ntp test case, if the timezone is earlier than the UTC, then test will fail The issue is introduced by PR: https://github.com/sonic-net/sonic-mgmt/pull/17554

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In the ntp test case, if the timezone is earlier than the UTC, then test will fail The issue is introduced by PR: https://github.com/sonic-net/sonic-mgmt/pull/17554
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When the timezone of the test bed env is not UTC, the test will fail. 
#### How did you do it?

#### How did you verify/test it?
Run the test case on the testbed which is not UTC timezone and could pass
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
