### PR TITLE
Update GNMI test case to support cname role list.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2761,3 +2761,70 @@ zmq/test_gnmi_zmq.py:
     reason: "Test is for smartswitch"
     conditions:
       - "'arista' in platform"
+
+
+#######################################
+#####            GNMI             #####
+#######################################
+gnmi/test_gnmi.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_appldb.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_configdb.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_countersdb.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_smartswitch.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_killprocess.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_os.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_system.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_system_grpc.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1134,6 +1134,7 @@ gnmi/test_gnmi_configdb.py:
     conditions:
       - "'t2' in topo_name"
       - "is_multi_asic==True"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
 
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
   skip:
@@ -1148,6 +1149,62 @@ gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_restart:
 gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
+
+gnmi/test_gnmi.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_appldb.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_countersdb.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_smartswitch.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_killprocess.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_os.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_system.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_system_grpc.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
 
 #######################################
 #####           hash              #####
@@ -2761,70 +2818,3 @@ zmq/test_gnmi_zmq.py:
     reason: "Test is for smartswitch"
     conditions:
       - "'arista' in platform"
-
-
-#######################################
-#####            GNMI             #####
-#######################################
-gnmi/test_gnmi.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnmi_appldb.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnmi_configdb.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnmi_countersdb.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnmi_smartswitch.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnoi_killprocess.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnoi_os.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnoi_system.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnoi_system_grpc.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1127,6 +1127,20 @@ generic_config_updater/test_pg_headroom_update.py:
 #######################################
 #####           gnmi              #####
 #######################################
+gnmi/test_gnmi.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnmi_appldb.py:
+  skip:
+    reason: "GNMI cert name to role mapping change from single role to role list"
+    conditions_logical_operator: or
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
 gnmi/test_gnmi_configdb.py:
   skip:
     reason: "This feature is not supported for multi asic. Skipping these test for T2 and multi asic."
@@ -1141,28 +1155,6 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
     reason: "The test refers to a stale implementation of GNOI.System.Reboot."
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17436"
-
-gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_restart:
-  skip:
-    reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
-
-gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
-  skip:
-    reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
-
-gnmi/test_gnmi.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
-
-gnmi/test_gnmi_appldb.py:
-  skip:
-    reason: "GNMI cert name to role mapping change from single role to role list"
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
 
 gnmi/test_gnmi_countersdb.py:
   skip:
@@ -1184,6 +1176,14 @@ gnmi/test_gnoi_killprocess.py:
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17876"
+
+gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_restart:
+  skip:
+    reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
+
+gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
+  skip:
+    reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
 
 gnmi/test_gnoi_os.py:
   skip:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -68,8 +68,16 @@ def verify_tcp_port(localhost, ip, port):
 
 
 def add_gnmi_client_common_name(duthost, cname, role="readwrite"):
-    duthost.shell('sudo sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|{}" "role@" "{}"'.format(cname, role),
-                  module_ignore_errors=True)
+    res = duthost.shell("cat /usr/local/yang-models/sonic-gnmi.yang | grep role",
+                      module_ignore_errors=True)['stdout']
+
+    # set role mapping according to yang model:
+    #     in old yang module role is a string, in new yang model role is a list
+    command = 'sudo sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|{}" "role" "{}"'.format(cname, role)
+    if "leaf-list role" in res:
+        command = 'sudo sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|{}" "role@" "{}"'.format(cname, role)
+
+    duthost.shell(command, module_ignore_errors=True)
 
 
 def del_gnmi_client_common_name(duthost, cname):

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -68,7 +68,7 @@ def verify_tcp_port(localhost, ip, port):
 
 
 def add_gnmi_client_common_name(duthost, cname, role="readwrite"):
-    duthost.shell('sudo sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|{}" "role" "{}"'.format(cname, role),
+    duthost.shell('sudo sonic-db-cli CONFIG_DB hset "GNMI_CLIENT_CERT|{}" "role@" "{}"'.format(cname, role),
                   module_ignore_errors=True)
 
 

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -69,7 +69,7 @@ def verify_tcp_port(localhost, ip, port):
 
 def add_gnmi_client_common_name(duthost, cname, role="readwrite"):
     res = duthost.shell("cat /usr/local/yang-models/sonic-gnmi.yang | grep role",
-                       module_ignore_errors=True)['stdout']
+                        module_ignore_errors=True)['stdout']
 
     # set role mapping according to yang model:
     #     in old yang module role is a string, in new yang model role is a list

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -69,7 +69,7 @@ def verify_tcp_port(localhost, ip, port):
 
 def add_gnmi_client_common_name(duthost, cname, role="readwrite"):
     res = duthost.shell("cat /usr/local/yang-models/sonic-gnmi.yang | grep role",
-                      module_ignore_errors=True)['stdout']
+                       module_ignore_errors=True)['stdout']
 
     # set role mapping according to yang model:
     #     in old yang module role is a string, in new yang model role is a list


### PR DESCRIPTION
Update GNMI test case to support cname role list. 

#### Why I did it
GNMI service will change to mapping cname to a role list:
https://github.com/sonic-net/sonic-buildimage/pull/21849

To make sure GNMI test case in sonic-mgmt can pass with/without this change, we need improve test case to handle both case.

##### Work item tracking
- Microsoft ADO: 31561802

#### How I did it
Ignore test case bug github issue: https://github.com/sonic-net/sonic-mgmt/issues/17876
Change GNMI setup code to handle role list by check yang model

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Update GNMI test case to support cname role list. 

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
