### PR TITLE
[sonic-mgmt][dualtor-aa] Fix flakiness of fdb/test_fdb_mac_learning.py

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -206,7 +206,7 @@ class TestFdbMacLearning:
         Make sure interfaces are ready for sending traffic.
         """
         if "dualtor-aa" in tbinfo['topo']['name']:
-            pytest_assert(wait_until(150, 5, 0, self.check_mux_status_consistency, duthost, ports))
+            pytest_assert(wait_until(300, 5, 0, self.check_mux_status_consistency, duthost, ports))
         else:
             time.sleep(30)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix flakiness of fdb/test_fdb_mac_learning.py for dualtor-aa
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/515

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
After link bringup, it's taking some time for mux status to be consistent in `dualtor-aa` topology (i.e SERVER_STATUS is 'unknown'). And it's not a test specific issue, I can see similar behaviour on dut where dualtor-aa is deployed.

#### How did you do it?
 So increasing the timeout to 300 (currently it's 150 secs) to fix flakiness.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
