### PR TITLE
Fix loganalyzer regex to ignore chronyd related ERR logs

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -313,7 +313,7 @@ r, ".* ERR sshd\[\d*\]: auth fail.*"
 
 # ignore NTP nss_tacplus error, which will happen when reload config, because ntpd and chrony will invoke getpwnap API but nss_tacplus will re-render during reload config
 r, ".* ERR ntpd\[\d*\]: nss_tacplus: .*"
-r, ".* ERR chrony\[\d*\]: nss_tacplus: .*"
+r, ".* ERR chronyd\[\d*\]: nss_tacplus: .*"
 
 # ignore leap second file NTP daemon (ntpd) is using has passed its expiration date
 r, ".* ERR ntpd\[\d*\]:.*leapsecond file ('/usr/share/zoneinfo/leap-seconds.list'): expired.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fix chrony related loganalyzer regex to ignore ERR logs that was added in #17801 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/16239 ignored an error message coming from ntpd (actually written by nss_tacplus). As that PR explains, this can happen when a config reload is run, and chrony calls getpwnam when /etc/tacplus_nss.conf is still being regenerated. However, it is not a failure.
#### How did you do it?
With the change of NTP daemons, this loganalyzer ignore regex needs to be updated to match the right chrony log.
#### How did you verify/test it?
By running sonic-mgmt tests that perform config reload and verifying that these errors do not cause loganalyzer to mark the tests as failed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
