### PR TITLE
DASH PL tests fixes

### DIFF
--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -86,6 +86,14 @@ def pytest_addoption(parser):
         help="Skip certificates cleanup after test"
     )
 
+    parser.addoption(
+        "--dpu_index",
+        action="store",
+        default=0,
+        type=int,
+        help="The default dpu used for the test"
+    )
+
 
 @pytest.fixture(scope="module")
 def config_only(request):
@@ -466,5 +474,5 @@ def acl_default_rule(localhost, duthost, ptfhost, dash_config_info):
 
 
 @pytest.fixture(scope="module")
-def dpu_index():
-    return 2
+def dpu_index(request):
+    return request.config.getoption("--dpu_index")

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -57,7 +57,6 @@ def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config):
         **pl.APPLIANCE_CONFIG,
         **pl.ROUTING_TYPE_PL_CONFIG,
         **pl.VNET_CONFIG,
-        **pl.PE_VNET_MAPPING_CONFIG,
         **pl.ROUTE_GROUP1_CONFIG,
         **pl.METER_POLICY_V4_CONFIG
     }
@@ -65,12 +64,13 @@ def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config):
 
     apply_messages(localhost, duthost, ptfhost, base_config_messages, dpu_index)
 
-    route_messages = {
+    route_and_mapping_messages = {
+        **pl.PE_VNET_MAPPING_CONFIG,
         **pl.PE_SUBNET_ROUTE_CONFIG,
         **pl.VM_SUBNET_ROUTE_CONFIG
     }
-    logger.info(route_messages)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpu_index)
+    logger.info(route_and_mapping_messages)
+    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpu_index)
 
     meter_rule_messages = {
         **pl.METER_RULE1_V4_CONFIG,
@@ -88,7 +88,9 @@ def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config):
     yield
 
     apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpu_index, False)
-    apply_messages(localhost, duthost, ptfhost, route_messages, dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, pl.ENI_CONFIG, dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpu_index, False)
     apply_messages(localhost, duthost, ptfhost, base_config_messages, dpu_index, False)
 
 

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -85,6 +85,12 @@ def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config):
     logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
     apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpu_index)
 
+    yield
+
+    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, route_messages, dpu_index, False)
+    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpu_index, False)
+
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])
 def test_privatelink_basic_transform(


### PR DESCRIPTION
 * Teardown configurations after the test
 * Make sure that vnet mapping is configured after routing_type is configured
 * Add an option to select the dpu to use for testing

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
To make sure that configuration applied during the test is cleaned up properly at the end of the test.
#### How did you do it?
By adding cleanup logic for PL tests.
#### How did you verify/test it?
By running sonic-mgmt test PL test and verifying that the DASH objects programmed during the test are cleaned up at the end.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
