### PR TITLE
fixing FixtureLookUp Error

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
+++ b/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
@@ -1,10 +1,12 @@
 import pytest
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts          # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, cleanup_config, get_snappi_ports_for_rdma, snappi_multi_base_config, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters      # noqa: F401
+    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports_single_dut      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
 from tests.snappi_tests.variables import MIXED_SPEED_PORT_INFO, MULTIDUT_TESTBED

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -1,10 +1,12 @@
 import pytest
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                           # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut    # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts    # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, cleanup_config, get_snappi_ports_for_rdma, snappi_multi_base_config, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters      # noqa: F401
+    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports_single_dut      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                   # noqa: F401
 from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -1,10 +1,12 @@
 import pytest
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                            # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_multi_base_config, cleanup_config, get_snappi_ports_for_rdma, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters       # noqa: F401
+    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports_single_dut       # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list, disable_pfcwd                                                     # noqa: F401
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED

--- a/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
@@ -2,10 +2,12 @@ import pytest
 import logging
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts   # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_multi_base_config, cleanup_config, get_snappi_ports_for_rdma, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters      # noqa: F401
+    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports_single_dut      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list                                                                  # noqa: F401
 from tests.common.snappi_tests.common_helpers import get_pfcwd_stats

--- a/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
@@ -1,10 +1,12 @@
 import pytest
 import random
 from tests.common.helpers.assertions import pytest_require, pytest_assert                   # noqa: F401
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut     # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, cleanup_config, get_snappi_ports_for_rdma, snappi_multi_base_config, \
-    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters      # noqa: F401
+    get_snappi_ports, get_snappi_ports_multi_dut, clear_fabric_counters, check_fabric_counters, \
+    get_snappi_ports_single_dut     # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list, \
     lossy_prio_list, all_prio_list                                                                  # noqa: F401
 from tests.snappi_tests.variables import MIXED_SPEED_PORT_INFO, MULTIDUT_TESTBED

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -3,10 +3,11 @@ import pytest
 import random
 import logging
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut      # noqa: F401
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
+    fanout_graph_facts      # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, snappi_api, \
     snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
-    get_snappi_ports_multi_dut       # noqa: F401
+    get_snappi_ports_multi_dut, get_snappi_ports_single_dut       # noqa: F401
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp


### PR DESCRIPTION
### Description of PR
These tests were failing with FixureLookUpError

snappi_tests.pfc.test_pfc_no_congestion_throughput#test_single_lossless_prio
snappi_tests.pfc.test_pfc_no_congestion_throughput#test_multiple_prio_uni_dist
snappi_tests.pfc.test_pfc_no_congestion_throughput#test_multiple_prio_diff_dist
snappi_tests.pfc.test_pfc_mixed_speed#test_mixed_speed_no_congestion
snappi_tests.pfc.test_pfc_mixed_speed#test_mixed_speed_uni_dist_over
snappi_tests.pfc.test_pfc_mixed_speed#test_mixed_speed_diff_dist_over
snappi_tests.pfcwd.test_pfcwd_mixed_speed#test_mixed_speed_pfcwd_disable
snappi_tests.pfcwd.test_pfcwd_mixed_speed#test_mixed_speed_pfcwd_enable
snappi_tests.pfcwd.test_pfcwd_actions.py (all tests)
snappi_tests.test_multidut_snappi#test_snappi

file /data/tests/snappi_tests/pfc/test_pfc_mixed_speed.py, line 24
@pytest.mark.parametrize('port_map', port_map)
@pytest.mark.parametrize("multidut_port_info", MIXED_SPEED_PORT_INFO[MULTIDUT_TESTBED])
def test_mixed_speed_diff_dist_over(snappi_api, # noqa: F811
file /data/tests/common/snappi_tests/snappi_fixtures.py, line 1215
@pytest.fixture(scope="module")
def get_snappi_ports(duthosts, request):
E fixture 'get_snappi_ports_single_dut' not found



Summary:
Fixes Fixture LookUp error seen while running these tests

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X ] 202411

#### How did you do it?
Added the required imports for the Fixture

#### How did you verify/test it?
Manually tested the tests

#### Any platform specific information?
No

