### PR TITLE
Issue #17885: Add SET-REPLACE full config test to gnmi/test_gnmi_configdb.py

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -228,7 +228,14 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
     else:
         cmd += '-pkey /root/gnmiclient.key '
         cmd += '-cchain /root/gnmiclient.crt '
-    cmd += '-m set-update '
+    if len(replace_list) >= 1:
+        cmd += '-m set-replace '
+    elif len(update_list) >= 1:
+        cmd += '-m set-update '
+    elif len(delete_list) >= 1:
+        cmd += '-m set-delete '
+    else:
+        raise Exception("SET operation must have at least one entry to modify")
     xpath = ''
     xvalue = ''
     for path in delete_list:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # 17885

Add a test case to gnmi/test_gnmi_configdb.py to test sending a full configuration file using SET-REPLACE in order to trigger a call to GCU's 'config replace' on the device.

This tests the codepath introduced [here](https://github.com/sonic-net/sonic-gnmi/pull/369).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [ ] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

To support the changes to sonic-gnmi proposed [here](https://github.com/sonic-net/sonic-gnmi/pull/369)

#### How did you do it?

Add a new test case following the existing testcase that tests a full config reload (test_gnmi_configdb_full_01).

#### How did you verify/test it?

With the changes made to sonic-gnmi to use ConfigReplace for a full config update, the current test fails. This version passes with those changes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

Supports all testbeds supported by the test as a whole.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
