### PR TITLE
update d18u8s4 PT0 ASN to 4 bytes

### DIFF
--- a/ansible/vars/topo_t0-d18u8s4.yml
+++ b/ansible/vars/topo_t0-d18u8s4.yml
@@ -318,7 +318,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 4200000000
       peers:
         65100:
         - 10.0.0.156
@@ -338,7 +338,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 4200000001
       peers:
         65100:
         - 10.0.0.158
@@ -358,7 +358,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 4200000002
       peers:
         65100:
         - 10.0.0.160
@@ -378,7 +378,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 4200000003
       peers:
         65100:
         - 10.0.0.162


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes same issue in [#22022](https://github.com/sonic-net/sonic-buildimage/pull/22022) by updating the peer T0's ASN to 4 bytes ASN number.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix topo error.

#### How did you do it?

#### How did you verify/test it?

```
admin@sonic:~$ show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 2
RIB entries 3, using 672 bytes of memory
Peers 12, using 8903712 KiB of memory
Peer groups 5, using 320 bytes of memory


Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4       64600          0          0         0      0       0  never      Active          ARISTA01T1
10.0.0.59      4       64600          0          0         0      0       0  never      Active          ARISTA02T1
10.0.0.61      4       64600          0          0         0      0       0  never      Active          ARISTA03T1
10.0.0.63      4       64600          0          0         0      0       0  never      Active          ARISTA04T1
10.0.0.65      4       64600          0          0         0      0       0  never      Active          ARISTA05T1
10.0.0.67      4       64600          0          0         0      0       0  never      Active          ARISTA06T1
10.0.0.69      4       64600          0          0         0      0       0  never      Active          ARISTA07T1
10.0.0.71      4       64600          0          0         0      0       0  never      Active          ARISTA08T1
10.0.0.157     4  4200000000          0          0         0      0       0  never      Active          ARISTA01PT0
10.0.0.159     4  4200000001          0          0         0      0       0  never      Active          ARISTA02PT0
10.0.0.161     4  4200000002          0          0         0      0       0  never      Active          ARISTA03PT0
10.0.0.163     4  4200000003          0          0         0      0       0  never      Active          ARISTA04PT0

Total number of neighbors 12
admin@sonic:~$ show ipv6 bgp summary

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 2
RIB entries 3, using 672 bytes of memory
Peers 12, using 8903712 KiB of memory
Peer groups 5, using 320 bytes of memory


Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
fc00::7a       4       64600          0          0         0      0       0  never      Active          ARISTA03T1
fc00::7e       4       64600          0          0         0      0       0  never      Active          ARISTA04T1
fc00::8a       4       64600          0          0         0      0       0  never      Active          ARISTA07T1
fc00::8e       4       64600          0          0         0      0       0  never      Active          ARISTA08T1
fc00::17a      4  4200000002          0          0         0      0       0  never      Active          ARISTA03PT0
fc00::17e      4  4200000003          0          0         0      0       0  never      Active          ARISTA04PT0
fc00::72       4       64600          0          0         0      0       0  never      Active          ARISTA01T1
fc00::76       4       64600          0          0         0      0       0  never      Active          ARISTA02T1
fc00::82       4       64600          0          0         0      0       0  never      Active          ARISTA05T1
fc00::86       4       64600          0          0         0      0       0  never      Active          ARISTA06T1
fc00::172      4  4200000000          0          0         0      0       0  never      Active          ARISTA01PT0
fc00::176      4  4200000001          0          0         0      0       0  never      Active          ARISTA02PT0

Total number of neighbors 12
admin@sonic:~$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
