### PR TITLE
Dualtor-AA/AS test_qos_sai.py setup revision

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1699,7 +1699,7 @@ def validate_active_active_dualtor_setup(
     return
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def config_active_active_dualtor_active_standby(duthosts, active_active_ports, tbinfo):     # noqa: F811
     """Config the active-active dualtor that one ToR as active and the other as standby."""
     if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
@@ -1906,7 +1906,7 @@ def setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m(
     return
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def setup_standby_ports_on_rand_unselected_tor_unconditionally(
     active_active_ports,                                                   # noqa: F811
     rand_selected_dut,

--- a/tests/common/dualtor/mux_simulator_control.py
+++ b/tests/common/dualtor/mux_simulator_control.py
@@ -37,6 +37,7 @@ __all__ = [
     'toggle_all_simulator_ports_to_lower_tor',
     'toggle_all_simulator_ports_to_another_side',
     'toggle_all_simulator_ports_to_random_side',
+    'toggle_all_simulator_ports_to_rand_selected_tor_m',
     'toggle_simulator_port_to_upper_tor',
     'toggle_simulator_port_to_lower_tor',
     'toggle_all_simulator_ports',
@@ -662,7 +663,7 @@ def toggle_all_simulator_ports_to_another_side(mux_server_url, tbinfo):
     _toggle_all_simulator_ports(mux_server_url, TOGGLE, tbinfo)
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def toggle_all_simulator_ports_to_rand_selected_tor_m(duthosts, mux_server_url,
                                                       tbinfo, rand_one_dut_hostname,
                                                       active_standby_ports):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
- Uplift scope from default "function" to "class" for some common dualtor fixtures. 
- Revise test_qos_sai.py to use these fixtures at class scope instead of the pre-existing AS method for putting just the lower tor in Active state
- Enable QOS SAI to use a randomly selected tor rather than the hardcoded lower tor
- Remove unnecessary references to the lower tor fixture. 

CC @lolyu for design review. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

- [x] Validate test_qos_sai.py had expected results on dualtor-aa topo on cisco-8000.
- [ ] Validate dualtor-as topo if needed
- [ ] Validate any other tests that may be impacted by the fixture scope uplift


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
