### PR TITLE
vSonic peer ipv6 loopback routes need to be /128

### DIFF
--- a/ansible/roles/sonic/tasks/vsonic.yml
+++ b/ansible/roles/sonic/tasks/vsonic.yml
@@ -31,6 +31,7 @@
             | jq '.DEVICE_METADATA.localhost.hostname="{{ hostname }}"'
             | jq '.DEVICE_METADATA.localhost.bgp_asn="{{ configuration[hostname]['bgp']['asn'] }}"'
             | jq '.DEVICE_METADATA.localhost.deployment_id="1"'
+            | jq '.DEVICE_METADATA.localhost.bgp_adv_lo_prefix_as_128="true"'
             > config-metadata.json
     when: '"hwsku" in configuration[hostname]'
 
@@ -40,6 +41,7 @@
             | jq '.DEVICE_METADATA.localhost.hostname="{{ hostname }}"'
             | jq '.DEVICE_METADATA.localhost.bgp_asn="{{ configuration[hostname]['bgp']['asn'] }}"'
             | jq '.DEVICE_METADATA.localhost.deployment_id="1"'
+            | jq '.DEVICE_METADATA.localhost.bgp_adv_lo_prefix_as_128="true"'
             > config-metadata.json
     when: '"hwsku" not in configuration[hostname]'
 


### PR DESCRIPTION
### Description of PR
cEOS peers advertises loopback routes as /128, so vSonic should as well when used as the peer.  This was causing test failures in things such as snmp/test_snmp_loopback.py when using a vSonic peer instead of cEOS.  It was instead receiving multiple /64 routes since each peer has a loopback address using a /128 that is technically in the same /64 range, so there was no guarantee the packets would be shipped off to the right peer.

The DUT is unchanged.

Summary: vSonic peer ipv6 loopback routes need to be /128 to mimic cEOS
Fixes https://github.com/sonic-net/sonic-mgmt/issues/18102

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Failures when using vSonic instead of cEOS for the peers

#### How did you do it?

Added `bgp_adv_lo_prefix_as_128=true` to the vsonic peer configuration.

#### How did you verify/test it?

By running `snmp/test_snmp_loopback.py` and observing the ipv6 tests now pass.

#### Any platform specific information?

vsonic instead of peer instead of cEOS

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

