### PR TITLE
Increase timeout to 5 in verify_packet_any_port for background traffic

### DIFF
--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -92,7 +92,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         yield direction
 
     @pytest.fixture(scope='function', autouse=True)
-    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut):  # noqa F811
+    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut,  # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally):     # noqa F811
         stop_thread = threading.Event()
         src_port = EverflowIPv6Tests.rx_port_ptf_id
 
@@ -141,7 +142,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'dst')
                             exp_pkt.set_do_not_care_scapy(packet.Ether, 'src')
                             exp_pkt.set_do_not_care_packet(scapy.IPv6, "hlim")
-                            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptfadapter.ptf_port_set)
+                            testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptfadapter.ptf_port_set,
+                                                             timeout=5)
                     count += 1
 
             background_traffic(run_count=1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increase timeout to 5 in verify_packet_any_port for background traffic
Fixes [#522](https://github.com/aristanetworks/sonic-qual.msft/issues/522), [#496](https://github.com/aristanetworks/sonic-qual.msft/issues/496)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The test is giving us a false negative 

```
msg        = 'Did not receive expected packet on any of ports [7, 13, 17, 30, 27, 25, 5, 34, 21, 16, 24, 1, 33, 12, 4, 20, 2, 0, 11... 01  .............0..\n0050  00 AA BB CC DD EE                                ......\n==============================\n'
self       = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>

/usr/lib/python3.8/unittest/case.py:753: AssertionError
```

Although on a closer look we found that the DUTis forwarding the packet in a reasonable duration of time but for some reason `testutils.verify_packet_any_port` is taking longer to detect it.

There is also another issue which doesn't cause any failure but defeats the purpose of testing. In case of active-active dualtor we call `setup_standby_ports_on_rand_unselected_tor_unconditionally` to put the system in active-standby mode. If this is called after `background_traffic` then the background trafffic flows through the unselected ToR which is not desired. 

#### How did you do it?
Increase the timeout to 5s from system default for `testutils.verify_packet_any_port`

Make the order of fixture execution deterministic so that `setup_standby_ports_on_rand_unselected_tor_unconditionally` is called before `background_traffic`

#### How did you verify/test it?
Verified on Arista-7050CX3 with dualtor-aa topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
