### PR TITLE
[dhcp_relay] Optimize log for test_dhcp_relay

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -256,7 +256,9 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                "uplink_mac": str(dhcp_relay['uplink_mac']),
                                "testing_mode": testing_mode,
                                "kvm_support": True},
-                       log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
+                       log_file=("/tmp/dhcp_relay_test.DHCPTest.default.{}.log"
+                                 .format(dhcp_relay["downlink_vlan_iface"]["name"])),
+                       is_python3=True)
             if not skip_dhcpmon:
                 time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
                 loganalyzer.analyze(marker)
@@ -346,7 +348,9 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
                                "testing_mode": testing_mode,
                                "enable_source_port_ip_in_relay": True,
                                "kvm_support": True},
-                       log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
+                       log_file=("/tmp/dhcp_relay_test.DHCPTest.src_ip.{}.log"
+                                 .format(dhcp_relay["downlink_vlan_iface"]["name"])),
+                       is_python3=True)
             if not skip_dhcpmon:
                 time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
                 loganalyzer.analyze(marker)
@@ -408,7 +412,9 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testing_mode": testing_mode,
                            "kvm_support": True},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
+                   log_file=("/tmp/dhcp_relay_test.DHCPTest.link_flap.{}.log"
+                             .format(dhcp_relay["downlink_vlan_iface"]["name"])),
+                   is_python3=True)
 
 
 def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
@@ -465,7 +471,9 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testing_mode": testing_mode,
                            "kvm_support": True},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
+                   log_file=("/tmp/dhcp_relay_test.DHCPTest.uplinks_down.{}.log"
+                             .format(dhcp_relay["downlink_vlan_iface"]["name"])),
+                   is_python3=True)
 
 
 def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -501,7 +509,9 @@ def test_dhcp_relay_unicast_mac(ptfhost, dut_dhcp_relay_data, validate_dut_route
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testing_mode": testing_mode,
                            "kvm_support": True},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
+                   log_file=("/tmp/dhcp_relay_test.DHCPTest.unicast_mac.{}.log"
+                             .format(dhcp_relay["downlink_vlan_iface"]["name"])),
+                   is_python3=True)
 
 
 def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -536,7 +546,9 @@ def test_dhcp_relay_random_sport(ptfhost, dut_dhcp_relay_data, validate_dut_rout
                            "uplink_mac": str(dhcp_relay['uplink_mac']),
                            "testing_mode": testing_mode,
                            "kvm_support": True},
-                   log_file="/tmp/dhcp_relay_test.DHCPTest.log", is_python3=True)
+                   log_file=("/tmp/dhcp_relay_test.DHCPTest.random_sport.{}.log"
+                             .format(dhcp_relay["downlink_vlan_iface"]["name"])),
+                   is_python3=True)
 
 
 def get_dhcp_relay_counter(duthost, ifname, type, dir):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add log for test_dhcp_relay for triaging issue

#### How did you do it?
Add log for test_dhcp_relay for triaging issue

#### How did you verify/test it?
Run test and find below log files
```
/tmp/dhcp_relay_test.DHCPTest.default.Vlan1000.log               /tmp/dhcp_relay_test.DHCPTest.src_ip.Vlan1000.log
/tmp/dhcp_relay_test.DHCPTest.default.Vlan1000.pcap              /tmp/dhcp_relay_test.DHCPTest.src_ip.Vlan1000.pcap
/tmp/dhcp_relay_test.DHCPTest.default.Vlan1000.pcap.tar.gz       /tmp/dhcp_relay_test.DHCPTest.src_ip.Vlan1000.pcap.tar.gz
/tmp/dhcp_relay_test.DHCPTest.link_flap.Vlan1000.log             /tmp/dhcp_relay_test.DHCPTest.unicast_mac.Vlan1000.log
/tmp/dhcp_relay_test.DHCPTest.link_flap.Vlan1000.pcap            /tmp/dhcp_relay_test.DHCPTest.unicast_mac.Vlan1000.pcap
/tmp/dhcp_relay_test.DHCPTest.link_flap.Vlan1000.pcap.tar.gz     /tmp/dhcp_relay_test.DHCPTest.unicast_mac.Vlan1000.pcap.tar.gz
/tmp/dhcp_relay_test.DHCPTest.random_sport.Vlan1000.log          /tmp/dhcp_relay_test.DHCPTest.uplinks_down.Vlan1000.log
/tmp/dhcp_relay_test.DHCPTest.random_sport.Vlan1000.pcap         /tmp/dhcp_relay_test.DHCPTest.uplinks_down.Vlan1000.pcap
/tmp/dhcp_relay_test.DHCPTest.random_sport.Vlan1000.pcap.tar.gz  /tmp/dhcp_relay_test.DHCPTest.uplinks_down.Vlan1000.pcap.tar.gz
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
