### PR TITLE
[test_stress_route] Adding asic id in vtysh commands call - support for multi-asic

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -77,7 +77,7 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
 
     frr_demons_to_check = ['bgpd', 'zebra']
-    start_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check)
+    start_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, asichost.asic_index)
     logging.info(f"memory usage at start: {start_time_frr_daemon_memory}")
 
     while loop_times > 0:
@@ -94,7 +94,7 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv6 route used after is not equal to it used before")
 
-    end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check)
+    end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, asichost.asic_index)
     logging.info(f"memory usage at end: {end_time_frr_daemon_memory}")
     check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_daemon_memory,
                                    end_time_frr_daemon_memory)
@@ -122,12 +122,13 @@ def check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_
                       f"The increase memory should not exceed than {incr_frr_daemon_memory_threshold_dict[daemon]} MiB")
 
 
-def get_frr_daemon_memory_usage(duthost, daemon_list):
+def get_frr_daemon_memory_usage(duthost, daemon_list, asic_index):
     frr_daemon_memory_dict = {}
     for daemon in daemon_list:
-        frr_daemon_memory_output = duthost.shell(f'vtysh -c "show memory {daemon}"')["stdout"]
+        frr_daemon_memory_output = duthost.shell(f'vtysh -n {asic_index} -c "show memory {daemon}"')["stdout"]
         logging.info(f"{daemon} memory status: \n%s", frr_daemon_memory_output)
-        output = duthost.shell(f'vtysh -c "show memory {daemon}" | grep "Free ordinary blocks"')["stdout"]
+        output = duthost.shell(f'vtysh -n {asic_index} -c "show memory {daemon}" \
+                               | grep "Free ordinary blocks"')["stdout"]
         frr_daemon_memory = int(output.split()[-2])
         unit = output.split()[-1]
         if unit == "KiB":

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -75,9 +75,9 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     ipv4_route_used_before, ipv6_route_used_before = withdraw_and_announce_existing_routes
 
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
-
     frr_demons_to_check = ['bgpd', 'zebra']
-    start_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, asichost.asic_index)
+    start_time_frr_daemon_memory = get_frr_daemon_memory_usage(
+        duthost, frr_demons_to_check, enum_rand_one_frontend_asic_index)
     logging.info(f"memory usage at start: {start_time_frr_daemon_memory}")
 
     while loop_times > 0:
@@ -94,7 +94,8 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv6 route used after is not equal to it used before")
 
-    end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, asichost.asic_index)
+    end_time_frr_daemon_memory = get_frr_daemon_memory_usage(
+        duthost, frr_demons_to_check, enum_rand_one_frontend_asic_index)
     logging.info(f"memory usage at end: {end_time_frr_daemon_memory}")
     check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_daemon_memory,
                                    end_time_frr_daemon_memory)
@@ -124,10 +125,11 @@ def check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_
 
 def get_frr_daemon_memory_usage(duthost, daemon_list, asic_index):
     frr_daemon_memory_dict = {}
+    asic_prefix = f'-n {asic_index}' if asic_index is not None else ''
     for daemon in daemon_list:
-        frr_daemon_memory_output = duthost.shell(f'vtysh -n {asic_index} -c "show memory {daemon}"')["stdout"]
+        frr_daemon_memory_output = duthost.shell(f'vtysh {asic_prefix} -c "show memory {daemon}"')["stdout"]
         logging.info(f"{daemon} memory status: \n%s", frr_daemon_memory_output)
-        output = duthost.shell(f'vtysh -n {asic_index} -c "show memory {daemon}" \
+        output = duthost.shell(f'vtysh {asic_prefix} -c "show memory {daemon}" \
                                | grep "Free ordinary blocks"')["stdout"]
         frr_daemon_memory = int(output.split()[-2])
         unit = output.split()[-1]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Adapting vtysh commands to use asic namespace in case of multi-asic platform in suite test_stress_routes.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added prefix "-n {asic_index}" in vtysh calls.
In the case of a single-ASIC platform, the prefix is constructed and passed as an empty string for compatibility.

#### How did you verify/test it?
Ran test case in t2 and passed. 
Ran test case in kvm-t0 and passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
