### PR TITLE
[Fix for Issue #17413] Modified the Tx Rx port id list selection for …

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -75,14 +75,19 @@ def run_pfcwd_multi_node_test(api,
     pfcwd_to_be_configured = set()
 
     rx_port = snappi_extra_params.multi_dut_params.multi_dut_ports[0]
-    rx_port_id_list = [rx_port["port_id"]]
     egress_duthost = rx_port['duthost']
     # Add the port to the set of ports to be configured for PFC
     pfcwd_to_be_configured.add((egress_duthost, rx_port['asic_value']))
 
     tx_port = [snappi_extra_params.multi_dut_params.multi_dut_ports[1],
                snappi_extra_params.multi_dut_params.multi_dut_ports[2]]
-    tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
+    if pattern == 'all to all':
+        tx_port_id_list = [rx_port["port_id"], tx_port[0]["port_id"], tx_port[1]["port_id"]]
+        rx_port_id_list = [rx_port["port_id"], tx_port[0]["port_id"], tx_port[1]["port_id"]]
+        pfcwd_to_be_configured.add((rx_port['duthost'], rx_port['asic_value']))
+    elif pattern == 'many to one':
+        tx_port_id_list = [tx_port[0]["port_id"], tx_port[1]["port_id"]]
+        rx_port_id_list = [rx_port["port_id"]]
     # add ingress DUT into the set
     pfcwd_to_be_configured.add((tx_port[0]['duthost'], tx_port[0]['asic_value']))
     pfcwd_to_be_configured.add((tx_port[1]['duthost'], tx_port[1]['asic_value']))


### PR DESCRIPTION
…all to all scenario

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix for [snappi] test_multidut_pfcwd_all_to_all is not working as expected as in test plan #17413
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/17413
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added and if else condition to use separate tx rx port id list for all to all pattern scenario
#### How did you verify/test it?
 Tested on Edgecore dut
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-False] 
--------------------------------------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------------------------------------
18:09:50 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
18:09:50 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
18:09:50 conftest.enhance_inventory               L0285 INFO   | Inventory file: ['../ansible/snappi-sonic']
18:09:52 ptfhost_utils.run_icmp_responder_session L0310 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
18:09:52 __init__._sanity_check                   L0428 INFO   | Skip sanity check according to command line argument
18:09:52 conftest.collect_before_test             L2457 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
18:09:53 conftest.collect_before_test             L2461 INFO   | Collecting core dumps before test on sonic-s6100-dut1
18:09:53 conftest.collect_before_test             L2470 INFO   | Collecting running config before test on sonic-s6100-dut1
18:09:55 conftest.temporarily_disable_route_check L2736 INFO   | Skipping temporarily_disable_route_check fixture
18:09:55 conftest.generate_params_dut_hostname    L1395 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
18:09:55 conftest.set_rand_one_dut_hostname       L0561 INFO   | Randomly select dut sonic-s6100-dut1 for testing
18:09:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
18:09:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
18:09:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
18:09:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
18:09:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
18:09:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
18:09:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
18:09:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
18:09:55 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
18:09:55 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
18:09:55 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
18:09:55 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
18:09:55 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
18:09:55 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
18:09:56 conftest.rand_one_dut_front_end_hostname L0597 INFO   | Randomly select dut sonic-s6100-dut1 for testing
18:09:56 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossless_prio_list setup starts --------------------
18:09:57 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossless_prio_list setup ends --------------------
18:09:57 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
18:09:57 conftest.generate_port_lists             L1464 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68', 'sonic-s6100-dut1|Ethernet72', 'sonic-s6100-dut1|Ethernet76']}
18:09:57 conftest.generate_port_lists             L1487 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68', 'sonic-s6100-dut1|Ethernet72', 'sonic-s6100-dut1|Ethernet76']
18:09:57 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
18:09:57 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
18:09:57 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
18:09:57 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture prio_dscp_map setup starts --------------------
18:09:58 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture prio_dscp_map setup ends --------------------
18:09:58 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture all_prio_list setup starts --------------------
18:09:58 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture all_prio_list setup ends --------------------
18:09:58 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossy_prio_list setup starts --------------------
18:09:58 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossy_prio_list setup ends --------------------
18:09:58 __init__.loganalyzer                     L0074 INFO   | Log analyzer is disabled
18:09:58 __init__.memory_utilization              L0108 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Accton-AS7726-32X, Platform: x86_64-accton_as7726_32x-r0
18:09:58 __init__.store_fixture_values            L0020 INFO   | store memory_utilization test_multidut_pfcwd_all_to_all[multidut_port_info0-False]
18:09:58 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture ignore_route_check_for_cisco_8000 setup starts --------------------
18:09:58 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture ignore_route_check_for_cisco_8000 setup ends --------------------
18:09:58 __init__.pytest_runtest_setup            L0034 INFO   | collect memory before test test_multidut_pfcwd_all_to_all[multidut_port_info0-False]
18:09:58 __init__.pytest_runtest_setup            L0054 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 22.7}}}, 'after_test': {'sonic-s6100-dut1': {}}}
---------------------------------------------------------------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------------------------------------------------------------
18:09:58 test_pfcwd_a2a_with_snappi.test_multidut L0068 INFO   | Running test for testbed subtype: single-dut-single-asic
18:09:58 snappi_fixtures.__intf_config_multidut   L0853 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet72 with IP 20.1.1.0/31
18:10:00 snappi_fixtures.__intf_config_multidut   L0853 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet64 with IP 20.1.1.2/31
18:10:01 snappi_fixtures.__intf_config_multidut   L0853 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet68 with IP 20.1.1.4/31
18:10:02 snappi_fixtures.__intf_config_multidut   L0853 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet76 with IP 20.1.1.6/31
18:13:52 connection._warn                         L0246 WARNING| Verification of certificates is disabled
18:13:52 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.77.53 address...
18:13:52 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.77.53:11009.
18:13:52 connection._info                         L0243 INFO   | Connection established to `https://10.36.77.53:11009 on windows`
18:13:52 connection._info                         L0243 INFO   | Using IxNetwork api server version 10.20.2402.29
18:13:52 connection._info                         L0243 INFO   | User info IxNetwork/WIN-11RK5TNKNAN/8010
18:13:52 snappi_api.info                          L1132 INFO   | snappi-0.9.1
18:13:52 snappi_api.info                          L1132 INFO   | snappi_ixnetwork-0.9.1
18:13:52 snappi_api.info                          L1132 INFO   | ixnetwork_restpy-1.0.64
18:13:53 snappi_api.info                          L1132 INFO   | Config validation 0.084s
18:13:53 snappi_api.info                          L1132 INFO   | Ports configuration 0.059s
18:13:53 snappi_api.info                          L1132 INFO   | Captures configuration 0.032s
18:14:03 snappi_api.info                          L1132 INFO   | Location hosts ready [10.36.78.53] 2.057s
18:14:03 snappi_api.info                          L1132 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'novusHundredGigNonFanOut'), ('Port 1', 'novusHundredGigNonFanOut'), ('Port 2', 'novusHundredGigNonFanOut'), ('Port 3', 'novusHundredGigNonFanOut')]
18:14:03 snappi_api.info                          L1132 INFO   | Aggregation mode speed change 0.286s
18:14:10 snappi_api.info                          L1132 INFO   | Location preemption [10.36.78.53;6;7, 10.36.78.53;6;5, 10.36.78.53;6;6] 0.020s
18:14:56 snappi_api.info                          L1132 INFO   | Location connect [Port 0, Port 1, Port 2] 46.208s
18:14:56 snappi_api.info                          L1132 INFO   | Location state check [Port 0, Port 1, Port 2] 0.040s
18:14:56 snappi_api.info                          L1132 INFO   | Location configuration 63.066s
18:15:06 snappi_api.info                          L1132 INFO   | Layer1 configuration 10.092s
18:15:06 snappi_api.info                          L1132 INFO   | Lag Configuration 0.008s
18:15:06 snappi_api.info                          L1132 INFO   | Convert device config : 0.093s
18:15:06 snappi_api.info                          L1132 INFO   | Create IxNetwork device config : 0.000s
18:15:06 snappi_api.info                          L1132 INFO   | Push IxNetwork device config : 0.360s
18:15:06 snappi_api.info                          L1132 INFO   | Devices configuration 0.462s
18:15:23 snappi_api.info                          L1132 INFO   | Flows configuration 16.625s
18:15:29 snappi_api.info                          L1132 INFO   | Start interfaces 6.336s
18:15:30 snappi_api.info                          L1132 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
18:15:30 pfcwd_multi_node_helper_new.__run_traffi L0550 INFO   | Wait for Arp to Resolve ...
18:15:30 pfcwd_multi_node_helper_new.__run_traffi L0553 INFO   | Starting transmit on all flows ...
18:15:32 snappi_api.info                          L1132 INFO   | Flows generate/apply 2.049s
18:15:45 snappi_api.info                          L1132 INFO   | Flows clear statistics 12.532s
18:15:45 snappi_api.info                          L1132 INFO   | Captures start 0.000s
18:15:49 snappi_api.info                          L1132 INFO   | Flows start 4.009s
18:15:59 pfcwd_multi_node_helper_new.__run_traffi L0586 INFO   | Stop transmit on all flows ...
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Warm Up Traffic 0 -> 1 Prio 3 , Tx Frames : 1795977, Rx Frames : 1795977
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Warm Up Traffic 0 -> 2 Prio 3 , Tx Frames : 1795977, Rx Frames : 1795977
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Warm Up Traffic 1 -> 0 Prio 3 , Tx Frames : 1795977, Rx Frames : 1795977
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Warm Up Traffic 1 -> 2 Prio 3 , Tx Frames : 1795977, Rx Frames : 1795977
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Warm Up Traffic 2 -> 0 Prio 3 , Tx Frames : 1795977, Rx Frames : 1795977
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Warm Up Traffic 2 -> 1 Prio 3 , Tx Frames : 1795977, Rx Frames : 1795977
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Pause Storm , Tx Frames : 596, Rx Frames : 0
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0642 INFO   | PFC pause storm expected to be dropped
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Test Flow 0 -> 1 Prio 3 , Tx Frames : 3591954, Rx Frames : 3591954
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Test Flow 0 -> 2 Prio 3 , Tx Frames : 3591954, Rx Frames : 3591954
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Test Flow 1 -> 0 Prio 3 , Tx Frames : 3591954, Rx Frames : 3591954
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0680 INFO   | This test flow is delayed by PFC storm
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0681 INFO   | Tx and Rx should not have any dropped packet
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Test Flow 1 -> 2 Prio 3 , Tx Frames : 3591954, Rx Frames : 3591954
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Test Flow 2 -> 0 Prio 3 , Tx Frames : 3591954, Rx Frames : 3591954
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0680 INFO   | This test flow is delayed by PFC storm
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0681 INFO   | Tx and Rx should not have any dropped packet
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Test Flow 2 -> 1 Prio 3 , Tx Frames : 3591954, Rx Frames : 3591954
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 1 Prio 1 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 1 Prio 5 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 1 Prio 6 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 1 Prio 2 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 1 Prio 0 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 2 Prio 1 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 2 Prio 5 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 2 Prio 6 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 2 Prio 2 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 0 -> 2 Prio 0 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 0 Prio 1 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 0 Prio 5 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 0 Prio 6 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 0 Prio 2 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 0 Prio 0 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 2 Prio 1 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 2 Prio 5 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 2 Prio 6 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 2 Prio 2 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 1 -> 2 Prio 0 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 0 Prio 1 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 0 Prio 5 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 0 Prio 6 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 0 Prio 2 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 0 Prio 0 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 1 Prio 1 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 1 Prio 5 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 1 Prio 6 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 1 Prio 2 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0638 INFO   | Flow Name : Background Flow 2 -> 1 Prio 0 , Tx Frames : 718390, Rx Frames : 718390
18:15:59 pfcwd_multi_node_helper_new.__verify_res L0648 INFO   | Background flows expected not to have any dropped packets
18:15:59 snappi_fixtures.cleanup_config           L0943 INFO   | Removing Configuration on Dut: sonic-s6100-dut1 with port Ethernet72 with ip :20.1.1.0/31
18:16:00 snappi_fixtures.cleanup_config           L0943 INFO   | Removing Configuration on Dut: sonic-s6100-dut1 with port Ethernet64 with ip :20.1.1.2/31
18:16:02 snappi_fixtures.cleanup_config           L0943 INFO   | Removing Configuration on Dut: sonic-s6100-dut1 with port Ethernet68 with ip :20.1.1.4/31
18:16:03 snappi_fixtures.cleanup_config           L0943 INFO   | Removing Configuration on Dut: sonic-s6100-dut1 with port Ethernet76 with ip :20.1.1.6/31
PASSED                                                                                                                                                                                                                                                                      [100%]
-------------------------------------------------------------------------------------------------------------------------------- live log teardown --------------------------------------------------------------------------------------------------------------------------------
18:16:04 __init__.pytest_runtest_teardown         L0066 INFO   | collect memory after test test_multidut_pfcwd_all_to_all[multidut_port_info0-False]
18:16:04 __init__.pytest_runtest_teardown         L0089 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 22.7}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 23.2}}}}
18:16:04 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture ignore_route_check_for_cisco_8000 teardown starts --------------------
18:16:04 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture ignore_route_check_for_cisco_8000 teardown ends --------------------
18:16:04 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
18:16:04 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
18:16:04 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
18:16:05 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
18:16:05 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
18:16:05 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
18:16:05 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
18:16:05 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
18:16:05 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
18:16:05 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
18:16:05 conftest.temporarily_disable_route_check L2738 INFO   | Skipping temporarily_disable_route_check fixture
18:16:05 conftest.collect_after_test              L2525 INFO   | Dumping Disk and Memory Space information after test on sonic-s6100-dut1
18:16:06 conftest.collect_after_test              L2529 INFO   | Collecting core dumps after test on sonic-s6100-dut1
18:16:06 conftest.collect_after_test              L2540 INFO   | Collecting running config after test on sonic-s6100-dut1
18:16:07 conftest.core_dump_and_config_check      L2681 WARNING| Core dump or config check failed for test_pfcwd_a2a_with_snappi.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"sonic-s6100-dut1": []}}, "config_db_check": {"failed": true, "pre_only_config": {"sonic-s6100-dut1": {"null": {"VLAN_MEMBER": {"Vlan2|Ethernet64": {"tagging_mode": "untagged"}, "Vlan2|Ethernet68": {"tagging_mode": "untagged"}, "Vlan2|Ethernet72": {"tagging_mode": "untagged"}, "Vlan2|Ethernet76": {"tagging_mode": "untagged"}}}}}, "cur_only_config": {"sonic-s6100-dut1": {"null": {}}}, "inconsistent_config": {"sonic-s6100-dut1": {"null": {}}}}}
18:16:07 conftest.restore_config_db_and_config_re L2359 INFO   | dut reload called on sonic-s6100-dut1
18:16:08 config_reload.config_reload              L0147 INFO   | reloading config_db