### PR TITLE
Fix ZMQ test case because python version changes in ptf image (#17316)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2501,3 +2501,4 @@ zmq/test_gnmi_zmq.py:
     reason: "Test is for smartswitch"
     conditions:
       - "'arista' in platform"
+


### PR DESCRIPTION
Fix conflict: https://github.com/sonic-net/sonic-mgmt/pull/17316

Fix ZMQ test case because python version changes in ptf image

Why I did it
py_gnmicli.py report warning message with python3, these warning should be ignored:

    if output['stderr']:
      raise Exception("error:" + output['stderr'])
E Exception: error:/root/gnxi/gnmi_cli_py/py_gnmicli.py:508: SyntaxWarning: "is not" with a literal. Did you mean "!="? E if filter_event_regex is not "":
E /root/gnxi/gnmi_cli_py/py_gnmicli.py:510: SyntaxWarning: "is not" with a literal. Did you mean "!="? E if len(match) is not 0:

How I did it
Change code to not throw exception when stderr is not empty, the change is copy from GNMI test case.

How to verify it
Pass all test case.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
