### PR TITLE
Only print the matched syslog in loganalzyer teardown check, no traceback info printed

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -214,7 +214,7 @@ def parallel_run(
             # For analyzed matched syslog, don't need to log the traceback
             if "analyze_logs" in process_name and "Match Messages" in str(p_exception):
                 failure_message = 'Got matched syslog in processes "{}" exit code:"{}"\n{}'.format(
-                    list(failed_processes.keys()), p_exitcode, p_exception
+                    process_name, p_exitcode, p_exception
                 )
             else:
                 failure_message = 'Processes "{}" failed with exit code "{}"\nException:\n{}\nTraceback:\n{}'.format(

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -211,12 +211,15 @@ def parallel_run(
                 p_exception = process['exception'][0]
                 p_traceback = process['exception'][1]
                 p_exitcode = process['exit_code']
-            pt_assert(
-                False,
-                'Processes "{}" failed with exit code "{}"\nException:\n{}\nTraceback:\n{}'.format(
-                    list(failed_processes.keys()), p_exitcode, p_exception, p_traceback
+            # For analyzed matched syslog, don't need to log the traceback
+            if "analyze_logs" in process_name and "Match Messages" in str(p_exception):
+                failure_message = 'Got matched syslog in processes "{}" exit code:"{}"\n{}'.format(
+                    list(failed_processes.keys()), p_exitcode, p_exception
                 )
-            )
+            else:
+                failure_message = 'Processes "{}" failed with exit code "{}"\nException:\n{}\nTraceback:\n{}'.format(
+                    list(failed_processes.keys()), p_exitcode, p_exception, p_traceback)
+            pt_assert(False, failure_message)
 
     logger.info(
         'Completed running processes for target "{}" in {} seconds'.format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To make the failed summary of teardown loganalyzer shorter and clearer. It can make the summary easy to understand and downstream failure analyzer can do analysis based on clean summaries.

The summary when a case failed in loganalzyer teardown phase:
Before change:
```
E               Failed: Processes "['analyze_logs--<MultiAsicSonicHost str-msn4700-02>']" failed with exit code "1"
E               Exception:
E               match: 1
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2025 Apr  9 02:42:13.609855 str-msn4700-02 ERR kernel: [ 1820.284908] sxd_kernel: [error] Failed to bind BFD socket to local_addr (ip:104.0.0.74 ,port:49282) (err:-98).
        
E               Traceback:
E               Traceback (most recent call last):
E                 File "/var/src/sonic-mgmt_vms11-t1-4700-6_6670b1f1e72b94cbabbdfe65/tests/common/helpers/parallel.py", line 35, in run
E                   Process.run(self)
E                 File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
E                   self._target(*self._args, **self._kwargs)
E                 File "/var/src/sonic-mgmt_vms11-t1-4700-6_6670b1f1e72b94cbabbdfe65/tests/common/helpers/parallel.py", line 245, in wrapper
E                   target(*args, **kwargs)
E                 File "/var/src/sonic-mgmt_vms11-t1-4700-6_6670b1f1e72b94cbabbdfe65/tests/common/plugins/loganalyzer/__init__.py", line 45, in analyze_logs
E                   dut_analyzer.analyze(markers[node.hostname], fail_test, store_la_logs=store_la_logs)
E                 File "/var/src/sonic-mgmt_vms11-t1-4700-6_6670b1f1e72b94cbabbdfe65/tests/common/plugins/loganalyzer/loganalyzer.py", line 409, in analyze
E                   self._verify_log(analyzer_summary)
E                 File "/var/src/sonic-mgmt_vms11-t1-4700-6_6670b1f1e72b94cbabbdfe65/tests/common/plugins/loganalyzer/loganalyzer.py", line 140, in _verify_log
E                   raise LogAnalyzerError(result_str)
E               tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzerError: match: 1
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_bfd_multihop[ipv6]>
INFO:root:Can not get Allure report URL. Please check logs
E               2025 Apr  9 02:42:13.609855 str-msn4700-02 ERR kernel: [ 1820.284908] sxd_kernel: [error] Failed to bind BFD socket to local_addr (ip:104.0.0.74 ,port:49282) (err:-98).
```

After change:
```
E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost bjw2-can-7260-10>" exit code:"1"
E               match: 1
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2025 Apr 10 08:21:06.808698 bjw2-can-7260-10 ERR admin: [ 1820.284908] sxd_kernel: [error] Failed to bind BFD socket to local_addr (ip:104.0.0.74 ,port:49282) (err:-98)
```

#### How did you do it?
Check if the failed process is analyze_log and if there is Matched Messages in the exception, if so, just print the exception. Don't need to print the traceback, it ensures the summary is shorter and clearer.

#### How did you verify/test it?
Run a case failed in loganalyzer teardown phase, check the summary of the failed case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
