### PR TITLE
Skip reboot-cause history fetching on 202012

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -319,7 +319,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     logger.info('DUT {} create a file /dev/shm/test_reboot before rebooting'.format(hostname))
     duthost.command('sudo touch /dev/shm/test_reboot')
     # Get reboot-cause history before reboot
-    prev_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
+    logger.info('DUT OS Version: {}'.format(duthost.os_version))
+    prev_reboot_cause_history = None
+    # prev_reboot_cause_history is only used for T2 device.
+    if duthost.get_facts().get("modular_chassis") and reboot_type == REBOOT_TYPE_POWEROFF:
+        logger.info('Fetching reboot cause history before rebooting')
+        prev_reboot_cause_history = duthost.show_and_parse("show reboot-cause history")
 
     wait_conlsole_connection = 5
     console_thread_res = pool.apply_async(


### PR DESCRIPTION
### Description of PR

Enhance reboot function to conditionally fetch reboot cause history based on OS version. It will be skipped for versions "202012"

This is required due to:
When the upgrade_path test starts with the device on 202012, boot_into_base_image fails due to running:
```
admin@str2-7050cx3-acs-12:~$ show reboot-cause history 
Reboot-cause history is not yet available in StateDB 
admin@str2-7050cx3-acs-12:~$

```
which returns rc=1 and fails the test.
This change is the cause of the problem: https://github.com/sonic-net/sonic-mgmt/pull/16348/files


Summary:
Fixes # [(17793)](https://github.com/sonic-net/sonic-mgmt/issues/17793)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When the device is on 202012 before the test starts, boot_into_base_image fails and aborts the upgrade_path tests

#### How did you do it?
Avoid performing reboot cause history on OS versions starting with "202012"

#### How did you verify/test it?
Installed version 202012 on the device
Started the `tests/upgrade_path/test_upgrade_path.py` test with and base/target version
Made sure it was successful


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
