### PR TITLE
T2 add IXIA test to validate the count of voqs evicted to HBM and unevicted from HBM

### DIFF
--- a/tests/snappi_tests/ecn/files/helper.py
+++ b/tests/snappi_tests/ecn/files/helper.py
@@ -1219,14 +1219,14 @@ def run_voq_eviction_to_hbm(
     run_voq_eviction_test(
         pause_prio_list=[test_prio_list[0]],
         expected_voq_count=1,
-        err_msg="VoQ eviction to HBM expected for TC : {}".format(test_prio_list[1])
+        err_msg="VoQ eviction to HBM expected for TC : {}".format(test_prio_list[0])
     )
 
     # Test with only the second priority
     run_voq_eviction_test(
         pause_prio_list=[test_prio_list[1]],
         expected_voq_count=1,
-        err_msg="VoQ eviction to HBM expected for TC : {}".format(test_prio_list[0])
+        err_msg="VoQ eviction to HBM expected for TC : {}".format(test_prio_list[1])
     )
 
     # Test case 4: no pause priorities

--- a/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
@@ -15,6 +15,7 @@ from tests.snappi_tests.ecn.files.helper import run_ecn_marking_test, \
     run_ecn_marking_port_toggle_test, run_ecn_marking_ect_marked_pkts, \
     run_voq_eviction_to_hbm
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.common.cisco_data import is_cisco_device
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
@@ -163,7 +164,6 @@ def test_ecn_marking_lossless_prio(
     """
     Verify ECN marking on lossless prio with same DWRR weight
     Args:
-        request (pytest fixture): pytest request object
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts (pytest fixture): fanout graph
@@ -195,8 +195,8 @@ def test_ecn_marking_lossless_prio(
                             prio_dscp_map=prio_dscp_map,
                             test_flow_percent=test_flow_percent,
                             number_of_streams=10,
-                            input_port_same_asic=info.input_port_same_asic,
-                            input_port_same_dut=info.input_port_same_dut,
+                            input_port_same_asic=info.input_ports_same_asic,
+                            input_port_same_dut=info.input_ports_same_dut,
                             single_dut=info.single_dut,
                             snappi_extra_params=snappi_extra_params)
 
@@ -265,23 +265,24 @@ def test_voq_eviction_to_hbm(
                                 setup_ports_and_dut,     # noqa: F811
                                 prio_dscp_map):                    # noqa: F811
     """
-    Verify ECN marking for ECT marked pkts
+    Verify VoQ eviction to HBM on congestion
     Args:
-        request (pytest fixture): pytest request object
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
         lossless_prio_list (pytest fixture): list of all the lossless priorities
-        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
-        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
-        tbinfo (pytest fixture): fixture provides information about testbed
         get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+        tbinfo (pytest fixture): fixture provides information about testbed
+        disable_pfcwd: Disables the PFCWD on all the duthosts
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
     Returns:
         N/A
     """
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+
+    pytest_require(is_cisco_device(snappi_ports[0]['duthost']), "This test is for Cisco 8000 only")
 
     info = snappi_port_dut_info(snappi_ports)
 

--- a/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_ecn_marking_with_snappi.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 from tabulate import tabulate # noqa F401
+from collections import namedtuple
 from tests.common.helpers.assertions import pytest_assert, pytest_require     # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut         # noqa: F401
@@ -11,11 +12,18 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
     lossless_prio_list, disable_pfcwd   # noqa F401
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut, enable_debug_shell  # noqa: F401
 from tests.snappi_tests.ecn.files.helper import run_ecn_marking_test, \
-    run_ecn_marking_port_toggle_test, run_ecn_marking_ect_marked_pkts
+    run_ecn_marking_port_toggle_test, run_ecn_marking_ect_marked_pkts, \
+    run_voq_eviction_to_hbm
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.common.cisco_data import is_cisco_device
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
+
+
+PortDutInfo = namedtuple(
+    "PortDutInfo",
+    ["input_ports_same_asic", "input_ports_same_dut", "single_dut",
+     "is_bp_fabric_ecn_check_required", "egress_port_short_link", "input_ports_long_link"]
+)
 
 
 def snappi_port_dut_info(snappi_ports):
@@ -64,57 +72,19 @@ def snappi_port_dut_info(snappi_ports):
     ingress_ports_1_short_link = check_dut_short_link(tx_asic_1, tx_dut_1, tx_peer_port_1)
     ingress_ports_2_short_link = check_dut_short_link(tx_asic_2, tx_dut_2, tx_peer_port_2)
 
+    input_ports_long_link = [
+        not ingress_ports_1_short_link,
+        not ingress_ports_2_short_link
+    ]
+
     # ECN mark check on bp or fabric port only when both ingress are on short and egress is on long link
     is_bp_fabric_ecn_check_required = ingress_ports_1_short_link and ingress_ports_2_short_link \
         and not egress_port_short_link
 
-    return input_ports_same_asic, input_ports_same_dut, single_dut, \
-        is_bp_fabric_ecn_check_required, egress_port_short_link
-
-
-def validate_snappi_ports(snappi_ports):
-
-    if not is_cisco_device(snappi_ports[0]['duthost']):
-        return True
-
-    '''
-        One ingress port and the egress port should be on the same DUT and asic.
-        The second ingress port can be on diff asic or DUT.
-        This is needed to avoid tail drops caused by use of default voq in case
-        both the BP ports of egress port are on the same slice
-
-        All ingress and egress port on the same DUT and asic is fine.
-    '''
-
-    # Extract duthost and peer_port values for rx_dut and tx_dut configurations
-    rx_dut = snappi_ports[0]['duthost']
-    rx_peer_port = snappi_ports[0]['peer_port']
-    tx_dut_1 = snappi_ports[1]['duthost']
-    tx_peer_port_1 = snappi_ports[1]['peer_port']
-    tx_dut_2 = snappi_ports[2]['duthost']
-    tx_peer_port_2 = snappi_ports[2]['peer_port']
-
-    # get the ASIC namespace for a given duthost and peer_port
-    def get_asic(duthost, peer_port):
-        return duthost.get_port_asic_instance(peer_port).namespace
-
-    # Retrieve ASIC namespace
-    rx_asic = get_asic(rx_dut, rx_peer_port)
-    tx_asic_1 = get_asic(tx_dut_1, tx_peer_port_1)
-    tx_asic_2 = get_asic(tx_dut_2, tx_peer_port_2)
-
-    # Check if all duthosts and their ASICs are the same
-    if (rx_dut == tx_dut_1 == tx_dut_2) and (rx_asic == tx_asic_1 == tx_asic_2):
-        return True
-
-    # Check if rx_dut and its ASIC matches either of the tx_dut and their ASIC
-    if (tx_asic_1 == tx_asic_2):
-        return True
-
-    if (tx_dut_1 == tx_dut_2) and (rx_dut != tx_dut_1):
-        return True
-
-    return False
+    return PortDutInfo(
+        input_ports_same_asic, input_ports_same_dut, single_dut,
+        is_bp_fabric_ecn_check_required, egress_port_short_link, input_ports_long_link
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -152,10 +122,10 @@ def test_ecn_marking_port_toggle(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    _, _, _, is_bp_fabric_ecn_check_required, _ = snappi_port_dut_info(snappi_ports)
+    info = snappi_port_dut_info(snappi_ports)
 
     supervisor_dut = None
-    if is_bp_fabric_ecn_check_required:
+    if info.is_bp_fabric_ecn_check_required:
         supervisor_dut = next((duthost for duthost in duthosts if duthost.is_supervisor_node()), None)
 
     logger.info("Snappi Ports : {}".format(snappi_ports))
@@ -170,7 +140,7 @@ def test_ecn_marking_port_toggle(
                             test_prio_list=lossless_prio_list,
                             prio_dscp_map=prio_dscp_map,
                             supervisor_dut=supervisor_dut,
-                            is_bp_fabric_ecn_check_required=is_bp_fabric_ecn_check_required,
+                            is_bp_fabric_ecn_check_required=info.is_bp_fabric_ecn_check_required,
                             snappi_extra_params=snappi_extra_params)
 
 
@@ -209,9 +179,8 @@ def test_ecn_marking_lossless_prio(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    input_port_same_asic, input_port_same_dut, single_dut, _, \
-        egress_port_short_link = snappi_port_dut_info(snappi_ports)
-    pytest_require(egress_port_short_link, "Egress port must be on short link")
+    info = snappi_port_dut_info(snappi_ports)
+    pytest_require(info.egress_port_short_link, "Egress port must be on short link")
 
     logger.info("Snappi Ports : {}".format(snappi_ports))
     snappi_extra_params = SnappiTestParams()
@@ -226,9 +195,9 @@ def test_ecn_marking_lossless_prio(
                             prio_dscp_map=prio_dscp_map,
                             test_flow_percent=test_flow_percent,
                             number_of_streams=10,
-                            input_port_same_asic=input_port_same_asic,
-                            input_port_same_dut=input_port_same_dut,
-                            single_dut=single_dut,
+                            input_port_same_asic=info.input_port_same_asic,
+                            input_port_same_dut=info.input_port_same_dut,
+                            single_dut=info.single_dut,
                             snappi_extra_params=snappi_extra_params)
 
 
@@ -262,10 +231,10 @@ def test_ecn_marking_ect_marked_pkts(
 
     testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
 
-    _, _, _, is_bp_fabric_ecn_check_required, _ = snappi_port_dut_info(snappi_ports)
+    info = snappi_port_dut_info(snappi_ports)
 
     supervisor_dut = None
-    if is_bp_fabric_ecn_check_required:
+    if info.is_bp_fabric_ecn_check_required:
         supervisor_dut = next((duthost for duthost in duthosts if duthost.is_supervisor_node()), None)
 
     logger.info("Snappi Ports : {}".format(snappi_ports))
@@ -280,5 +249,57 @@ def test_ecn_marking_ect_marked_pkts(
                             test_prio_list=lossless_prio_list,
                             prio_dscp_map=prio_dscp_map,
                             supervisor_dut=supervisor_dut,
-                            is_bp_fabric_ecn_check_required=is_bp_fabric_ecn_check_required,
+                            is_bp_fabric_ecn_check_required=info.is_bp_fabric_ecn_check_required,
                             snappi_extra_params=snappi_extra_params)
+
+
+def test_voq_eviction_to_hbm(
+                                snappi_api,                       # noqa: F811
+                                conn_graph_facts,                 # noqa: F811
+                                fanout_graph_facts_multidut,               # noqa: F811
+                                duthosts,
+                                lossless_prio_list,     # noqa: F811
+                                get_snappi_ports,     # noqa: F811
+                                tbinfo,      # noqa: F811
+                                disable_pfcwd,  # noqa: F811
+                                setup_ports_and_dut,     # noqa: F811
+                                prio_dscp_map):                    # noqa: F811
+    """
+    Verify ECN marking for ECT marked pkts
+    Args:
+        request (pytest fixture): pytest request object
+        snappi_api (pytest fixture): SNAPPI session
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        tbinfo (pytest fixture): fixture provides information about testbed
+        get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+    Returns:
+        N/A
+    """
+
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+
+    info = snappi_port_dut_info(snappi_ports)
+
+    pytest_require(any(info.input_ports_long_link),
+                   "At least one ingress port must be on a long link")
+
+    logger.info("Snappi Ports : {}".format(snappi_ports))
+    snappi_extra_params = SnappiTestParams()
+    snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
+
+    # send the index of the long-link tx port (1 or 2)
+    for idx, is_long in enumerate(info.input_ports_long_link, start=1):
+        if is_long:
+            run_voq_eviction_to_hbm(
+                                    api=snappi_api,
+                                    testbed_config=testbed_config,
+                                    port_config_list=port_config_list,
+                                    test_prio_list=lossless_prio_list,
+                                    prio_dscp_map=prio_dscp_map,
+                                    tx_port_index=idx,
+                                    snappi_extra_params=snappi_extra_params)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Add snappi test to validate the count of voqs evicted to HBM

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Verify voq eviction to HBM on congestion

#### How did you do it?

Traffic from port A -> port B
PAUSE frame injected to Port B.
Congestion and eviction verified on port A

#### How did you verify/test it?

With snappi based test on T2 ixia

```
-------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------
15:20:09 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================= short test summary info ==================================================================================================
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info0]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_port_toggle[multidut_port_info1]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent0]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent1]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent2]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent3]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent4]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent5]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent6]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent7]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_ect_marked_pkts[multidut_port_info0]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_ecn_marking_ect_marked_pkts[multidut_port_info1]
PASSED snappi_tests/ecn/test_ecn_marking_with_snappi.py::test_voq_eviction_to_hbm[multidut_port_info0]
SKIPPED [8] common/helpers/assertions.py:16: Egress port must be on short link
SKIPPED [1] common/helpers/assertions.py:16: At least one ingress port must be on a long link
================================================================================= 13 passed, 9 skipped, 17 warnings in 5966.15s (1:39:26) ==================================================================================
```

#### Any platform specific information?

T2 Cisco platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
