### PR TITLE
Disable voq watchdog in qos_sai script

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2747,9 +2747,22 @@ class QosSaiBase(QosBase):
                         "Changing lacp timer multiplier to default for %s in %s" % (neighbor_lag_member, vm_host))
                     vm_host.no_lacp_time_multiplier(neighbor_lag_member)
 
-    def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
+    def copy_dshell_script_cisco_8000(self, dut, asic, dshell_script, script_name):
         if dut.facts['asic_type'] != "cisco-8000":
             raise RuntimeError("This function should have been called only for cisco-8000.")
+
+        script_path = "/tmp/{}".format(script_name)
+        dut.copy(content=dshell_script, dest=script_path)
+        if dut.sonichost.is_multi_asic:
+            dest = f"syncd{asic}"
+        else:
+            dest = "syncd"
+        dut.docker_copy_to_all_asics(
+            container_name=dest,
+            src=script_path,
+            dst="/")
+
+    def copy_set_cir_script_cisco_8000(self, dut, ports, asic="", speed="10000000"):
         dshell_script = '''
 from common import *
 from sai_utils import *
@@ -2765,16 +2778,7 @@ def set_port_cir(interface, rate):
         for intf in ports:
             dshell_script += f'\nset_port_cir("{intf}", {speed})'
 
-        script_path = "/tmp/set_scheduler.py"
-        dut.copy(content=dshell_script, dest=script_path)
-        if dut.sonichost.is_multi_asic:
-            dest = f"syncd{asic}"
-        else:
-            dest = "syncd"
-        dut.docker_copy_to_all_asics(
-            container_name=dest,
-            src=script_path,
-            dst="/")
+        self.copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_scheduler.py")
 
     @pytest.fixture(scope="function", autouse=False)
     def set_cir_change(self, get_src_dst_asic_and_duts, dutConfig):
@@ -2809,25 +2813,13 @@ def set_port_cir(interface, rate):
         return
 
     def copy_set_voq_watchdog_script_cisco_8000(self, dut, asic="", enable=True):
-        if dut.facts['asic_type'] != "cisco-8000":
-            raise RuntimeError("This function should have been called only for cisco-8000.")
         dshell_script = '''
 def set_voq_watchdog(enable):
     d0.set_bool_property(sdk.la_device_property_e_VOQ_WATCHDOG_ENABLED, enable)
+set_voq_watchdog({})
+'''.format(enable)
 
-'''
-        dshell_script += f'set_voq_watchdog({enable})\n'
-
-        script_path = "/tmp/set_voq_watchdog.py"
-        dut.copy(content=dshell_script, dest=script_path)
-        if dut.sonichost.is_multi_asic:
-            dest = f"syncd{asic}"
-        else:
-            dest = "syncd"
-        dut.docker_copy_to_all_asics(
-            container_name=dest,
-            src=script_path,
-            dst="/")
+        self.copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_voq_watchdog.py")
 
     @pytest.fixture(scope='class', autouse=True)
     def disable_voq_watchdog(self, get_src_dst_asic_and_duts, dutConfig):

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2814,6 +2814,7 @@ def set_port_cir(interface, rate):
 
     def copy_set_voq_watchdog_script_cisco_8000(self, dut, asic="", enable=True):
         dshell_script = '''
+from common import d0
 def set_voq_watchdog(enable):
     d0.set_bool_property(sdk.la_device_property_e_VOQ_WATCHDOG_ENABLED, enable)
 set_voq_watchdog({})

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2822,19 +2822,22 @@ set_voq_watchdog({})
         self.copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_voq_watchdog.py")
 
     @pytest.fixture(scope='class', autouse=True)
-    def disable_voq_watchdog(self, get_src_dst_asic_and_duts, dutConfig):
+    def disable_voq_watchdog(self, duthosts, get_src_dst_asic_and_duts, dutConfig):
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
         dst_asic = get_src_dst_asic_and_duts['dst_asic']
-        dst_index = dst_asic.asic_index
         dut_list = [dst_dut]
-        asic_index_list = [dst_index]
+        asic_index_list = [dst_asic.asic_index]
 
         if not get_src_dst_asic_and_duts["single_asic_test"]:
             src_dut = get_src_dst_asic_and_duts['src_dut']
             src_asic = get_src_dst_asic_and_duts['src_asic']
-            src_index = src_asic.asic_index
             dut_list.append(src_dut)
-            asic_index_list.append(src_index)
+            asic_index_list.append(src_asic.asic_index)
+            # fabric card asics
+            for rp_dut in duthosts.supervisor_nodes:
+                for asic in rp_dut.asics:
+                    dut_list.append(rp_dut)
+                    asic_index_list.append(asic.asic_index)
 
         if dst_dut.facts['asic_type'] != "cisco-8000" or not dst_dut.sonichost.is_multi_asic:
             yield

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2826,29 +2826,42 @@ set_voq_watchdog({})
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
         dst_asic = get_src_dst_asic_and_duts['dst_asic']
         dst_index = dst_asic.asic_index
+        dut_list = [dst_dut]
+        asic_index_list = [dst_index]
+
+        if not get_src_dst_asic_and_duts["single_asic_test"]:
+            src_dut = get_src_dst_asic_and_duts['src_dut']
+            src_asic = get_src_dst_asic_and_duts['src_asic']
+            src_index = src_asic.asic_index
+            dut_list.append(src_dut)
+            asic_index_list.append(src_index)
 
         if dst_dut.facts['asic_type'] != "cisco-8000" or not dst_dut.sonichost.is_multi_asic:
             yield
             return
 
         # Disable voq watchdog.
-        self.copy_set_voq_watchdog_script_cisco_8000(
-            dut=dst_dut,
-            asic=dst_index,
-            enable=False)
-
-        cmd_opt = "-n asic{}".format(dst_index)
-        if not dst_dut.sonichost.is_multi_asic:
-            cmd_opt = ""
-        dst_dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
+        for (dut, asic_index) in zip(dut_list, asic_index_list):
+            self.copy_set_voq_watchdog_script_cisco_8000(
+                dut=dut,
+                asic=asic_index,
+                enable=False)
+            cmd_opt = "-n asic{}".format(asic_index)
+            if not dst_dut.sonichost.is_multi_asic:
+                cmd_opt = ""
+            dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
 
         yield
 
         # Enable voq watchdog.
-        self.copy_set_voq_watchdog_script_cisco_8000(
-            dut=dst_dut,
-            asic=dst_index,
-            enable=True)
-        dst_dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
+        for (dut, asic_index) in zip(dut_list, asic_index_list):
+            self.copy_set_voq_watchdog_script_cisco_8000(
+                dut=dut,
+                asic=asic_index,
+                enable=True)
+            cmd_opt = "-n asic{}".format(asic_index)
+            if not dst_dut.sonichost.is_multi_asic:
+                cmd_opt = ""
+            dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
 
         return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
VOQ watchdog will be enabled on T2, tx disable for 60 seconds will trigger soft reset.
Disable VOQ watchdog when running qos_sai script.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Avoid soft reset caused by tx disable.

#### How did you do it?
Disable voq watchdog.

#### How did you verify/test it?
Enable voq watchdog on T2 testbed and run qos-sai regression.

#### Any platform specific information?
T2.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
