### PR TITLE
Add default routes to t1 isolated

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -341,9 +341,10 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
                     nexthop_v6, tor_subnet_size, max_tor_subnet_number, topo,
                     router_type="leaf", tor_index=None, set_num=None,
                     no_default_route=False, core_ra_asn=CORE_RA_ASN,
-                    ipv6_address_pattern=IPV6_ADDRESS_PATTERN_DEFAULT_VALUE):
+                    ipv6_address_pattern=IPV6_ADDRESS_PATTERN_DEFAULT_VALUE,
+                    tor_default_route=False):
     routes = []
-    if not no_default_route and router_type != "tor":
+    if not no_default_route and (router_type != "tor" or tor_default_route):
         default_route_as_path = get_uplink_router_as_path(
             router_type, spine_asn)
 
@@ -511,7 +512,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
             change_routes(action, ptf_ip, port6, routes_v6)
 
 
-def fib_t1_lag(topo, ptf_ip, no_default_route=False, action="announce"):
+def fib_t1_lag(topo, ptf_ip, no_default_route=False, action="announce", tor_default_route=False):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -562,7 +563,7 @@ def fib_t1_lag(topo, ptf_ip, no_default_route=False, action="announce"):
                                             None, leaf_asn_start, tor_asn_start,
                                             nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t1",
                                             router_type=router_type, tor_index=tor_index,
-                                            no_default_route=no_default_route)
+                                            no_default_route=no_default_route, tor_default_route=tor_default_route)
                 if aggregate_routes_v4:
                     filterout_subnet_ipv4(aggregate_routes, routes_v4)
                     routes_v4.extend(aggregate_routes_v4)
@@ -573,7 +574,8 @@ def fib_t1_lag(topo, ptf_ip, no_default_route=False, action="announce"):
                                             nhipv4, nhipv6, tor_subnet_size, max_tor_subnet_number, "t1",
                                             router_type=router_type, tor_index=tor_index,
                                             no_default_route=no_default_route,
-                                            ipv6_address_pattern=ipv6_address_pattern)
+                                            ipv6_address_pattern=ipv6_address_pattern,
+                                            tor_default_route=tor_default_route)
                 if aggregate_routes_v6:
                     filterout_subnet_ipv6(aggregate_routes, routes_v6)
                     routes_v6.extend(aggregate_routes_v6)
@@ -1352,6 +1354,7 @@ def main():
                 topo['configuration'].pop(vm_name)
 
     is_storage_backend = "backend" in topo_name
+    tor_default_route = topo_name in ["t1-isolated-d128"]
 
     topo_type = get_topo_type(topo_name)
 
@@ -1361,7 +1364,7 @@ def main():
             module.exit_json(changed=True)
         elif topo_type == "t1" or topo_type == "smartswitch-t1":
             fib_t1_lag(
-                topo, ptf_ip, no_default_route=is_storage_backend, action=action)
+                topo, ptf_ip, no_default_route=is_storage_backend, action=action, tor_default_route=tor_default_route)
             module.exit_json(changed=True)
         elif topo_type == "t2":
             fib_t2_lag(topo, ptf_ip, action=action)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Add default routes to t1-isolated-d128 through it's t0 peers. This specific topo does not have t2 peers, which will normally provide the default route through BGP, so we need to propagate it this way for this specific topology.

#### How did you do it?

Update the announce-routes module

#### How did you verify/test it?

Tested minimised topology and checked that ipv4 and ipv6 default routes were added on DUT  

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
