### PR TITLE
Support multiple up/down neighbor types in topo

### DIFF
--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -11,7 +11,7 @@ import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
-from tests.common.utilities import get_upstream_neigh_type
+from tests.common.utilities import get_upstream_neigh_types
 from tests.common.utilities import get_neighbor_ptf_port_list
 
 logger = logging.getLogger(__name__)
@@ -286,8 +286,10 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
                     dst_port_indices.append(mg_facts_unselected_dut['minigraph_ptf_indices'][member])
     else:
         topo = tbinfo["topo"]["type"]
-        upstream_neigh_type = get_upstream_neigh_type(topo)
-        dst_port_indices = get_neighbor_ptf_port_list(rand_selected_dut, upstream_neigh_type, tbinfo)
+        upstream_neigh_types = get_upstream_neigh_types(topo)
+        dst_port_indices = []
+        for neigh_type in upstream_neigh_types:
+            dst_port_indices += get_neighbor_ptf_port_list(rand_selected_dut, neigh_type, tbinfo)
 
     test_pkts = build_testing_pkts(router_mac)
     for rule, pkt in list(test_pkts.items()):

--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -13,7 +13,7 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa: F40
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.utilities import get_upstream_neigh_type
+from tests.common.utilities import get_upstream_neigh_types
 from tests.common.utilities import get_neighbor_ptf_port_list
 from tests.common.utilities import get_neighbor_port_list
 
@@ -124,8 +124,10 @@ def create_acl_table(rand_selected_dut, tbinfo):
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
     if topo == "mx" or len(mg_facts["minigraph_portchannels"]) == 0:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
-        neighbor_ports = get_neighbor_port_list(rand_selected_dut, upstream_neigh_type)
+        upstream_neigh_types = get_upstream_neigh_types(topo)
+        neighbor_ports = []
+        for neigh_type in upstream_neigh_types:
+            neighbor_ports += get_neighbor_port_list(rand_selected_dut, upstream_neigh_types)
         ports = ",".join(neighbor_ports)
     else:
         # Get the list of LAGs
@@ -259,8 +261,10 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter,
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
     if topo == "mx" or len(mg_facts["minigraph_portchannels"]) == 0:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
-        ptf_interfaces = get_neighbor_ptf_port_list(rand_selected_dut, upstream_neigh_type, tbinfo)
+        upstream_neigh_types = get_upstream_neigh_types(topo)
+        ptf_interfaces = []
+        for neigh_type in upstream_neigh_types:
+            ptf_interfaces += get_neighbor_ptf_port_list(rand_selected_dut, neigh_type, tbinfo)
     else:
         portchannel_members = []
         for _, v in list(mg_facts["minigraph_portchannels"].items()):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -22,7 +22,7 @@ from tests.common.fixtures.ptfhost_utils import \
     copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa: F401
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr     # noqa: F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
-from tests.common.utilities import wait_until, get_upstream_neigh_type, get_downstream_neigh_type, check_msg_in_syslog
+from tests.common.utilities import wait_until, get_upstream_neigh_types, get_downstream_neigh_types, check_msg_in_syslog
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # noqa: F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
@@ -347,25 +347,26 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_unselected_dut, tbinfo, ptf
         downstream_port_id_to_router_mac_map = t2_info['downstream_port_id_to_router_mac_map']
         upstream_port_id_to_router_mac_map = t2_info['upstream_port_id_to_router_mac_map']
     else:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
-        downstream_neigh_type = get_downstream_neigh_type(topo)
-        pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
+        upstream_neigh_types = get_upstream_neigh_types(topo)
+        downstream_neigh_types = get_downstream_neigh_types(topo)
+        pytest_require(len(upstream_neigh_types) > 0 and len(downstream_neigh_types) > 0,
                        "Cannot get neighbor type for unsupported topo: {}".format(topo))
         mg_vlans = mg_facts["minigraph_vlans"]
         for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
             port_id = mg_facts["minigraph_ptf_indices"][interface]
-            if downstream_neigh_type in neighbor["name"].upper():
-                if topo in ["t0", "mx", "m0_vlan"]:
-                    if interface not in mg_vlans[vlan_name]["members"]:
-                        continue
-
-                downstream_ports[neighbor['namespace']].append(interface)
-                downstream_port_ids.append(port_id)
-                downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
-            elif upstream_neigh_type in neighbor["name"].upper():
-                upstream_ports[neighbor['namespace']].append(interface)
-                upstream_port_ids.append(port_id)
-                upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
+            for neigh_type in downstream_neigh_types:
+                if neigh_type in neighbor["name"].upper():
+                    if topo in ["t0", "mx", "m0_vlan"]:
+                        if interface not in mg_vlans[vlan_name]["members"]:
+                            continue
+                    downstream_ports[neighbor['namespace']].append(interface)
+                    downstream_port_ids.append(port_id)
+                    downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
+            for neigh_type in upstream_neigh_types:
+                if neigh_type in neighbor["name"].upper():
+                    upstream_ports[neighbor['namespace']].append(interface)
+                    upstream_port_ids.append(port_id)
+                    upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
 
     # stop garp service for single tor
     if 'dualtor' not in tbinfo['topo']['name']:

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -20,7 +20,7 @@ from abc import abstractmethod
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa: F401
 from tests.common.utilities import check_skip_release
 from tests.common.utilities import get_neighbor_ptf_port_list
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
+from tests.common.utilities import get_upstream_neigh_types
 
 logger = logging.getLogger(__name__)
 
@@ -787,8 +787,10 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
         cfg['dst_mac'] = duthost.facts['router_mac']    # MAC address should be router_mac rather than ptf mac
         # We will inject packet with vlan from portchannel. The packet will egress from the
         # interface we setup
-        upstream_neightbor_name = UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]]
-        ptf_src_ports = get_neighbor_ptf_port_list(duthost, upstream_neightbor_name, tbinfo)
+        upstream_neigh_types = get_upstream_neigh_types([tbinfo["topo"]["type"]])
+        ptf_src_ports = []
+        for neigh_type in upstream_neigh_types:
+            ptf_src_ports += get_neighbor_ptf_port_list(duthost, neigh_type, tbinfo)
         cfg['src_port'] = [ptf_src_ports[-1]]
         if TYPE_TAGGED == tagged_mode:
             cfg['dst_port'] = vlan_setup[100]['tagged_ports'][1]

--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -787,7 +787,7 @@ class TestAclVlanOuter_Egress(AclVlanOuterTest_Base):
         cfg['dst_mac'] = duthost.facts['router_mac']    # MAC address should be router_mac rather than ptf mac
         # We will inject packet with vlan from portchannel. The packet will egress from the
         # interface we setup
-        upstream_neigh_types = get_upstream_neigh_types([tbinfo["topo"]["type"]])
+        upstream_neigh_types = get_upstream_neigh_types(tbinfo["topo"]["type"])
         ptf_src_ports = []
         for neigh_type in upstream_neigh_types:
             ptf_src_ports += get_neighbor_ptf_port_list(duthost, neigh_type, tbinfo)

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -11,21 +11,23 @@ DUT_CHECK_NAMESPACE = "dut_check_result"
 
 # Describe upstream neighbor of dut in different topos
 UPSTREAM_NEIGHBOR_MAP = {
-    "t0": "t1",
-    "t1": "t2",
-    "m0": "m1",
-    "mx": "m0",
-    "t2": "t3",
-    "m0_vlan": "m1",
-    "m0_l3": "m1"
+    "t0": ["t1"],
+    "t1": ["t2"],
+    "m1": ["m2"],
+    "m0": ["m1"],
+    "mx": ["m0"],
+    "t2": ["t3"],
+    "m0_vlan": ["m1"],
+    "m0_l3": ["m1"],
 }
 # Describe downstream neighbor of dut in different topos
 DOWNSTREAM_NEIGHBOR_MAP = {
-    "t0": "server",
-    "t1": "t0",
-    "m0": "mx",
-    "mx": "server",
-    "t2": "t1",
-    "m0_vlan": "server",
-    "m0_l3": "mx"
+    "t0": ["server"],
+    "t1": ["t0"],
+    "m1": ["m0", "c0"],
+    "m0": ["mx"],
+    "mx": ["server"],
+    "t2": ["t1"],
+    "m0_vlan": ["server"],
+    "m0_l3": ["mx"],
 }

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -866,7 +866,7 @@ def get_image_type(duthost):
     return "public"
 
 
-def find_duthost_on_role(duthosts, role, tbinfo):
+def find_duthost_on_roles(duthosts, roles, tbinfo):
     role_set = False
     role_host = None
     for duthost in duthosts:
@@ -877,10 +877,11 @@ def find_duthost_on_role(duthosts, role, tbinfo):
 
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
-            if role in neighbor["name"]:
-                role_host = duthost
-                role_set = True
-    pytest_assert(role_host, "Could not find {} duthost".format(role))
+            for role in roles:
+                if role in neighbor["name"]:
+                    role_host = duthost
+                    role_set = True
+    pytest_assert(role_host, "Could not find {} duthost".format(roles))
     return role_host
 
 
@@ -919,32 +920,30 @@ def get_neighbor_ptf_port_list(duthost, neighbor_name, tbinfo):
     return ptf_port_list
 
 
-def get_upstream_neigh_type(topo_type, is_upper=True):
+def get_upstream_neigh_types(topo_type, is_upper=True):
     """
     @summary: Get neighbor type by topo type
     @param topo_type: topo type
     @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
-    @return a str
-        Sample output: "mx"
+    @return a list
+        Sample output: ["mx"]
     """
-    if topo_type in UPSTREAM_NEIGHBOR_MAP:
-        return UPSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else UPSTREAM_NEIGHBOR_MAP[topo_type]
+    if is_upper:
+        return [neigh.upper() for neigh in UPSTREAM_NEIGHBOR_MAP.get(topo_type, [])]
+    return UPSTREAM_NEIGHBOR_MAP.get(topo_type, [])
 
-    return None
 
-
-def get_downstream_neigh_type(topo_type, is_upper=True):
+def get_downstream_neigh_types(topo_type, is_upper=True):
     """
     @summary: Get neighbor type by topo type
     @param topo_type: topo type
     @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
-    @return a str
-        Sample output: "mx"
+    @return a list
+        Sample output: ["mx"]
     """
-    if topo_type in DOWNSTREAM_NEIGHBOR_MAP:
-        return DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else DOWNSTREAM_NEIGHBOR_MAP[topo_type]
-
-    return None
+    if is_upper:
+        return [neigh.upper() for neigh in DOWNSTREAM_NEIGHBOR_MAP.get(topo_type, [])]
+    return DOWNSTREAM_NEIGHBOR_MAP.get(topo_type, [])
 
 
 def run_until(interval, delay, retry, condition, function, *args, **kwargs):

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -35,8 +35,8 @@ from tests.common.reboot import reboot
 from tests.common.utilities import skip_release
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import find_duthost_on_role
-from tests.common.utilities import get_upstream_neigh_type
+from tests.common.utilities import find_duthost_on_roles
+from tests.common.utilities import get_upstream_neigh_types
 
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
@@ -261,7 +261,7 @@ def copp_testbed(
         # There is no upstream neighbor in T1 backend topology. Test is skipped on T0 backend.
         # For Non T2 topologies, setting upStreamDuthost as duthost to cover dualTOR and MLAG scenarios.
         if 't2' in tbinfo["topo"]["name"]:
-            upStreamDuthost = find_duthost_on_role(duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+            upStreamDuthost = find_duthost_on_roles(duthosts, get_upstream_neigh_types(tbinfo['topo']['type']), tbinfo)
         else:
             upStreamDuthost = duthost
 

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -90,12 +90,12 @@ def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, t
         for dut_port, neigh in list(mg_facts["minigraph_neighbors"].items()):
             pytest_assert(topo_type in UPSTREAM_NEIGHBOR_MAP and
                           topo_type in DOWNSTREAM_NEIGHBOR_MAP, "Unsupported topo")
-            if UPSTREAM_NEIGHBOR_MAP[topo_type] in neigh["name"].lower():
+            if any(t in neigh["name"].lower() for t in UPSTREAM_NEIGHBOR_MAP[topo_type]):
                 upstream_ports_namespace_map[neigh['namespace']].append(dut_port)
                 upstream_ports_namespace.add(neigh['namespace'])
                 upstream_neigh_namespace_map[neigh['namespace']].add(neigh["name"])
 
-            elif DOWNSTREAM_NEIGHBOR_MAP[topo_type] in neigh["name"].lower():
+            elif any(t in neigh["name"].lower() for t in DOWNSTREAM_NEIGHBOR_MAP[topo_type]):
                 downstream_ports_namespace_map[neigh['namespace']].append(dut_port)
                 downstream_ports_namespace.add(neigh['namespace'])
                 downstream_neigh_namespace_map[neigh['namespace']].add(neigh["name"])

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -16,8 +16,7 @@ import ptf.packet as packet
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import find_duthost_on_roles
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+from tests.common.utilities import find_duthost_on_roles, get_upstream_neigh_types, get_downstream_neigh_types
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 import json
 
@@ -88,14 +87,14 @@ def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, t
     # Get the list of T0/T2 ports
     for mg_facts in mg_facts_list:
         for dut_port, neigh in list(mg_facts["minigraph_neighbors"].items()):
-            pytest_assert(topo_type in UPSTREAM_NEIGHBOR_MAP and
-                          topo_type in DOWNSTREAM_NEIGHBOR_MAP, "Unsupported topo")
-            if any(t in neigh["name"].lower() for t in UPSTREAM_NEIGHBOR_MAP[topo_type]):
+            upstream_neigh_types = get_upstream_neigh_types(topo_type)
+            downstream_neigh_types = get_downstream_neigh_types(topo_type)
+            pytest_assert(len(upstream_neigh_types) > 0 and len(downstream_neigh_types) > 0, "Unsupported topo")
+            if any(t in neigh["name"].lower() for t in upstream_neigh_types):
                 upstream_ports_namespace_map[neigh['namespace']].append(dut_port)
                 upstream_ports_namespace.add(neigh['namespace'])
                 upstream_neigh_namespace_map[neigh['namespace']].add(neigh["name"])
-
-            elif any(t in neigh["name"].lower() for t in DOWNSTREAM_NEIGHBOR_MAP[topo_type]):
+            elif any(t in neigh["name"].lower() for t in downstream_neigh_types):
                 downstream_ports_namespace_map[neigh['namespace']].append(dut_port)
                 downstream_ports_namespace.add(neigh['namespace'])
                 downstream_neigh_namespace_map[neigh['namespace']].add(neigh["name"])

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -16,7 +16,7 @@ import ptf.packet as packet
 from abc import abstractmethod
 from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import find_duthost_on_role
+from tests.common.utilities import find_duthost_on_roles
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 import json
@@ -326,8 +326,8 @@ def get_t2_duthost(duthosts, tbinfo):
     """
     Generate setup information dictionary for T2 topologies.
     """
-    t3_duthost = find_duthost_on_role(duthosts, "T3", tbinfo)
-    t1_duthost = find_duthost_on_role(duthosts, "T1", tbinfo)
+    t3_duthost = find_duthost_on_roles(duthosts, ["T3"], tbinfo)
+    t1_duthost = find_duthost_on_roles(duthosts, ["T1"], tbinfo)
     return t1_duthost, t3_duthost
 
 

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -34,7 +34,7 @@ from tests.common.gu_utils import expect_acl_table_match_multiple_bindings
 from tests.generic_config_updater.gu_utils import format_and_apply_template, load_and_apply_json_patch
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.dualtor.dual_tor_utils import setup_standby_ports_on_rand_unselected_tor # noqa F401
-from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type, \
+from tests.common.utilities import get_upstream_neigh_types, get_downstream_neigh_types, \
     increment_ipv4_addr, increment_ipv6_addr
 
 pytestmark = [
@@ -160,18 +160,20 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
     )
 
     if topo == "m0_l3" or tbinfo['topo']['name'] in topos_no_portchannels:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
-        downstream_neigh_type = get_downstream_neigh_type(topo)
-        pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
+        upstream_neigh_types = get_upstream_neigh_types(topo)
+        downstream_neigh_types = get_downstream_neigh_types(topo)
+        pytest_require(len(upstream_neigh_types) > 0 and len(downstream_neigh_types) > 0,
                        "Cannot get neighbor type for unsupported topo: {}".format(topo))
         for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
             port_id = mg_facts["minigraph_ptf_indices"][interface]
-            if downstream_neigh_type in neighbor["name"].upper():
-                downstream_ports.append(interface)
-                downstream_port_ids.append(port_id)
-            elif upstream_neigh_type in neighbor["name"].upper():
-                upstream_ports.append(interface)
-                upstream_port_ids.append(port_id)
+            for neigh_type in downstream_neigh_types:
+                if neigh_type in neighbor["name"].upper():
+                    downstream_ports.append(interface)
+                    downstream_port_ids.append(port_id)
+            for neigh_type in upstream_neigh_types:
+                if neigh_type in neighbor["name"].upper():
+                    upstream_ports.append(interface)
+                    upstream_port_ids.append(port_id)
     else:
         downstream_ports = list(mg_facts["minigraph_vlans"][vlan_name]["members"])
         # Put all portchannel members into dst_ports

--- a/tests/ipfwd/test_dir_bcast.py
+++ b/tests/ipfwd/test_dir_bcast.py
@@ -6,8 +6,8 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.ptf_runner import ptf_runner
 from datetime import datetime
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.utilities import get_neighbor_ptf_port_list
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
+from tests.common.utilities import get_neighbor_ptf_port_list, get_upstream_neigh_types
+
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx')
 ]
@@ -19,8 +19,10 @@ PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 
 def get_ptf_src_ports(tbinfo, duthost):
     # Source ports are upstream ports
-    upstream_neightbor_name = UPSTREAM_NEIGHBOR_MAP[tbinfo["topo"]["type"]]
-    ptf_src_ports = get_neighbor_ptf_port_list(duthost, upstream_neightbor_name, tbinfo)
+    upstream_neigh_types = get_upstream_neigh_types(tbinfo["topo"]["type"])
+    ptf_src_ports = []
+    for neigh_type in upstream_neigh_types:
+        ptf_src_ports += get_neighbor_ptf_port_list(duthost, neigh_type, tbinfo)
     return ptf_src_ports
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The M1/M2/M3 topologies have multiple upstream neighbor types and multiple downstream neighbor types. This PR enhance some common functions to support that.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The M1/M2/M3 topologies have multiple upstream neighbor types and multiple downstream neighbor types. This PR enhance some common functions to support that.

#### How did you do it?

Update few common functions.

#### How did you verify/test it?

Verified by PR test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
