### PR TITLE
Make "autoneg" in connection graph optional

### DIFF
--- a/ansible/roles/fanout/templates/arista_7060_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7060_deploy.j2
@@ -36,8 +36,7 @@ interface defaults
 {% for intf in device_port_vlans[inventory_hostname] %}
 interface {{ intf }}
    description {{ device_conn[inventory_hostname][intf]['peerdevice'] }}-{{ device_conn[inventory_hostname][intf]['peerport'] }}
-# TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
-{%     if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
+{%     if device_conn[inventory_hostname][intf].get('autoneg', '')|lower == "on" %}
    speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
 {%   else %}
    speed force {{ device_conn[inventory_hostname][intf]['speed'] }}full
@@ -48,8 +47,7 @@ interface {{ intf }}
 {%   else %}
    switchport mode dot1q-tunnel
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
-# TODO: Add an additional var/check in fanout devices if autoneg is enabled with the below check
-{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf]['autoneg']|lower == "off" %}
+{%     if device_conn[inventory_hostname][intf]['speed'] == "100000" and device_conn[inventory_hostname][intf].get('autoneg', '')|lower == "off" %}
    error-correction encoding reed-solomon
 {%     else %}
    no error-correction encoding

--- a/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
+++ b/ansible/roles/fanout/templates/arista_7260cx3_deploy.j2
@@ -39,7 +39,7 @@ vrf definition management
    switchport access vlan {{ device_port_vlans[inventory_hostname][intf]['vlanids'] }}
    switchport mode dot1q-tunnel
    spanning-tree portfast
-{% if device_conn[inventory_hostname][intf]['autoneg']|lower == "on" %}
+{% if device_conn[inventory_hostname][intf].get('autoneg', '')|lower == "on" %}
    speed auto {{ device_conn[inventory_hostname][intf]['speed'] }}full
    no error-correction encoding
 {%     else %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
PR #15004 enhanced the connection graph csv files to support "AutoNeg". After this change, deploy fanout switch using connection graph csv files missing this field would fail.

#### How did you do it?
This change updated the fanout deploy template to best effort getting value of "autoneg" for links. With this change, the field "AutoNeg" in csv file would be optional and default to "off" or on according to context.

#### How did you verify/test it?
Verified deployment on physical fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
