### PR TITLE
Extend LACP time multiplier for advanced-reboot tests with cEOS peers

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1754,9 +1754,7 @@ class ReloadTest(BaseTest):
 
         # in the list of all LACPDUs received by T1, find the largest time gap between two consecutive LACPDUs
         max_lacp_session_wait = None
-        max_allowed_lacp_session_wait = 90
-        if self.test_params['neighbor_type'] == "sonic":
-            max_allowed_lacp_session_wait = 150
+        max_allowed_lacp_session_wait = 150
         if lacp_pdu_all_times and len(lacp_pdu_all_times) > 1:
             lacp_pdu_all_times.sort()
             max_lacp_session_wait = 0

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1402,21 +1402,7 @@ class ReloadTest(BaseTest):
     def runTest(self):
         # Set LACP timer multiplier to 5 for cEOS peers
         if self.test_params['neighbor_type'] == "eos":
-            for neigh in self.ssh_targets:
-                self.neigh_handle = HostDevice.getHostDeviceInstance(
-                      self.test_params['neighbor_type'], neigh, None, self.test_params)
-                self.neigh_handle.connect()
-
-                raw_json = self.neigh_handle.do_cmd("show lacp interface | json")
-                neigh_int_json = json.loads(raw_json[raw_json.find("{"):raw_json.rfind("}")+1])
-
-                self.neigh_handle.do_cmd("config")
-                for lag in neigh_int_json["portChannels"]:
-                    for neigh_int in neigh_int_json["portChannels"][lag]['interfaces']:
-                        self.neigh_handle.do_cmd(f"interface {neigh_int}")
-                        self.neigh_handle.do_cmd("lacp timer multiplier 5")
-
-                self.neigh_handle.disconnect()
+            self.ceos_set_lacp_all_neighs(5)
 
         self.pre_reboot_test_setup()
         try:
@@ -1471,26 +1457,28 @@ class ReloadTest(BaseTest):
             traceback_msg = traceback.format_exc()
             self.fails['dut'].add(traceback_msg)
         finally:
-            # Restore cEOS LACP timer multiplier changes
+            # Restore cEOS LACP timer multiplier to default (3)
             if self.test_params['neighbor_type'] == "eos":
-                for neigh in self.ssh_targets:
-                    self.neigh_handle = HostDevice.getHostDeviceInstance(
-                                            self.test_params['neighbor_type'], neigh, None, self.test_params)
-                    self.neigh_handle.connect()
-
-                    raw_json = self.neigh_handle.do_cmd("show lacp interface | json")
-                    neigh_int_json = json.loads(raw_json[raw_json.find("{"):raw_json.rfind("}")+1])
-
-                    self.neigh_handle.do_cmd("config")
-                    for lag in neigh_int_json["portChannels"]:
-                        for neigh_int in neigh_int_json["portChannels"][lag]['interfaces']:
-                            self.neigh_handle.do_cmd(f"interface {neigh_int}")
-                            # Restore lacp timer multiplier to default (3)
-                            self.neigh_handle.do_cmd("lacp timer multiplier 3")
-
-                    self.neigh_handle.disconnect()
+                self.ceos_set_lacp_all_neighs(3)
 
             self.handle_post_reboot_test_reports()
+
+    def ceos_set_lacp_all_neighs(self, multiplier):
+        for neigh in self.ssh_targets:
+            self.neigh_handle = HostDevice.getHostDeviceInstance(
+                                    self.test_params['neighbor_type'], neigh, None, self.test_params)
+            self.neigh_handle.connect()
+
+            raw_json = self.neigh_handle.do_cmd("show lacp interface | json")
+            neigh_int_json = json.loads(raw_json[raw_json.find("{"):raw_json.rfind("}")+1])
+
+            self.neigh_handle.do_cmd("config")
+            for lag in neigh_int_json["portChannels"]:
+                for neigh_int in neigh_int_json["portChannels"][lag]['interfaces']:
+                    self.neigh_handle.do_cmd(f"interface {neigh_int}")
+                    self.neigh_handle.do_cmd(f"lacp timer multiplier {multiplier}")
+
+            self.neigh_handle.disconnect()
 
     def neigh_lag_status_check(self):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Extend LACP timeout for cEOS peers by setting LACP timer multiplier to `5` during advanced-reboot PTF test, and restore the value to the default `3` after the test completes.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Transitioning from using vSonic peers to cEOS peers for some tests. Requested by Microsoft.

#### How did you do it?
Adding cli commands for each cEOS peers at the start and end of the PTF test `advanced-reboot.py`.

#### How did you verify/test it?
Tested with `test_upgrade_path.py::test_upgrade_path` on a `Arista-7050CX3-32S-C32`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
