### PR TITLE
Fixing the error seen while generating Snappi configuration for L3 interfaces and Vlan interfaces

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -149,7 +149,7 @@ def __l3_intf_config(config, port_config_list, duthost, snappi_ports):
         port_ids = [id for id, snappi_port in enumerate(snappi_ports)
                     if snappi_port['peer_port'] == intf]
         if len(port_ids) != 1:
-            return False
+            continue
 
         port_id = port_ids[0]
         mac = __gen_mac(port_id)
@@ -178,6 +178,9 @@ def __l3_intf_config(config, port_config_list, duthost, snappi_ports):
                                        peer_port=intf)
 
         port_config_list.append(port_config)
+
+    if len(port_config_list) != len(snappi_ports):
+        return False
 
     return True
 
@@ -230,7 +233,7 @@ def __vlan_intf_config(config, port_config_list, duthost, snappi_ports):
             port_ids = [id for id, snappi_port in enumerate(snappi_ports)
                         if snappi_port['peer_port'] == phy_intf]
             if len(port_ids) != 1:
-                return False
+                continue
 
             port_id = port_ids[0]
             mac = __gen_mac(port_id)
@@ -258,6 +261,9 @@ def __vlan_intf_config(config, port_config_list, duthost, snappi_ports):
                                            peer_port=phy_intf)
 
             port_config_list.append(port_config)
+
+        if len(port_config_list) != len(snappi_ports):
+            return False
 
     return True
 


### PR DESCRIPTION

### Description of PR
When the number if snappi ports used in the test and number of l3 interfaces or number of Vlan members configured on DUT are not same it was failing to generate the snappi configuration and was failing in

https://wwwin-github.cisco.com/whitebox/sonic-test/blob/343dc8e4dfb9d6137e6ff09cc9a9a1b516e76daf/sonic-mgmt/tests/common/snappi_tests/snappi_fixtures.py#L152

OR

https://wwwin-github.cisco.com/whitebox/sonic-test/blob/343dc8e4dfb9d6137e6ff09cc9a9a1b516e76daf/sonic-mgmt/tests/common/snappi_tests/snappi_fixtures.py#L233


Summary:
Fixes the error seen and generates the Snappi configuration accordingly.

### Type of change
- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X ] 202411

### Approach
#### What is the motivation for this PR?
Tests were failing 

#### How did you do it?
Added the fix to handle the scenario

#### How did you verify/test it?
Manually ran the test with changes and verified it passes

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
No
