### PR TITLE
Revert "Disable all bmp table after bmp test to avoid potential impact to other test cases"

### DIFF
--- a/tests/bmp/test_bmp_configdb.py
+++ b/tests/bmp/test_bmp_configdb.py
@@ -89,8 +89,3 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     table_name = 'bgp_rib_out_table'
     status = check_table_status(output, table_name)
     assert (status == 'true')
-
-    # disable all table to avoid further impact to other test cases
-    disable_bmp_neighbor_table(duthost)
-    disable_bmp_rib_in_table(duthost)
-    disable_bmp_rib_out_table(duthost)

--- a/tests/bmp/test_bmp_statedb.py
+++ b/tests/bmp/test_bmp_statedb.py
@@ -3,7 +3,6 @@ import pytest
 import time
 import re
 from bmp.helper import enable_bmp_neighbor_table, enable_bmp_rib_in_table, enable_bmp_rib_out_table
-from bmp.helper import disable_bmp_neighbor_table, disable_bmp_rib_in_table, disable_bmp_rib_out_table
 
 logger = logging.getLogger(__name__)
 
@@ -126,8 +125,3 @@ def test_bmp_population(duthosts, rand_one_dut_hostname, localhost):
     enable_bmp_rib_out_table(duthost)
     for idx, neighbor_v6addr in enumerate(neighbor_v6addrs):
         check_dut_bmp_rib_out_status(duthost, neighbor_v6addr)
-
-    # disable all table to avoid further impact to other test cases
-    disable_bmp_neighbor_table(duthost)
-    disable_bmp_rib_in_table(duthost)
-    disable_bmp_rib_out_table(duthost)


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#17910