### PR TITLE
[dhcp_relay] Add dhcpmon checking in enable source ip test

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -84,12 +84,14 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo):
 
         def dhcp_ready(enable_source_port_ip_in_relay):
             dhcp_relay_running = duthost.is_service_fully_started("dhcp_relay")
-            dhcp_relay_process = duthost.shell("ps -ef |grep dhcrelay|grep -v grep",
-                                               module_ignore_errors=True)["stdout"]
+            dhcp_processes = duthost.shell("ps -ef |grep -E 'dhcrelay|dhcpmon' | grep -v grep",
+                                           module_ignore_errors=True)["stdout"]
             if enable_source_port_ip_in_relay:
-                dhcp_relay_process_ready = "-si" in dhcp_relay_process and "dhcrelay" in dhcp_relay_process
+                dhcp_relay_process_ready = ("-si" in dhcp_processes and "dhcrelay" in dhcp_processes and
+                                            "dhcpmon" in dhcp_processes)
             else:
-                dhcp_relay_process_ready = "-si" not in dhcp_relay_process and "dhcrelay" in dhcp_relay_process
+                dhcp_relay_process_ready = ("-si" not in dhcp_processes and "dhcrelay" in dhcp_processes and
+                                            "dhcpmon" in dhcp_processes)
             return dhcp_relay_running and dhcp_relay_process_ready
         pytest_assert(wait_until(60, 2, 0, dhcp_ready, True), "Source port ip in relay is not enabled!")
         yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
