### PR TITLE
[M1] Add M1 up/down stream neighbor type

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -13,6 +13,7 @@ DUT_CHECK_NAMESPACE = "dut_check_result"
 UPSTREAM_NEIGHBOR_MAP = {
     "t0": "t1",
     "t1": "t2",
+    "m1": "m2",
     "m0": "m1",
     "mx": "m0",
     "t2": "t3",
@@ -23,6 +24,7 @@ UPSTREAM_NEIGHBOR_MAP = {
 DOWNSTREAM_NEIGHBOR_MAP = {
     "t0": "server",
     "t1": "t0",
+    "m1": "m0",
     "m0": "mx",
     "mx": "server",
     "t2": "t1",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add M1 up/down stream neighbor type.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add M1 up/down stream neighbor type.

#### How did you do it?
Add M1 up/down stream neighbor type.

#### How did you verify/test it?
Verified by testcase `route/test_default_route.py`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
