### PR TITLE
Skip test_virtualdb_table_streaming due to github issue and #22201

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2489,6 +2489,18 @@ telemetry/test_telemetry.py::test_telemetry_queue_buffer_cnt:
       - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-mgmt/issues/15393"
 
+telemetry/test_telemetry.py::test_virtualdb_table_streaming:
+  skip:
+    reason: "Skip due to community issue https://github.com/sonic-net/sonic-buildimage/issues/22201"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/22201
+
+telemetry/test_telemetry_cert_rotation.py:
+  skip:
+    reason: "Skip due to community issue https://github.com/sonic-net/sonic-buildimage/issues/22201"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/22201
+
 #######################################
 #####         pktgen              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip telemetry test_virtualdb_table_streaming and test_telemetry_cert_rotation tests due to https://github.com/sonic-net/sonic-buildimage/issues/22201

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Skip test_virtualdb_table_streaming due to known issues
#### How did you do it?
Skip telemetry test_virtualdb_table_streaming and test_telemetry_cert_rotation tests due to https://github.com/sonic-net/sonic-buildimage/issues/22201
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
