### PR TITLE
Backport t0-118 test configs to 202411

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -12,7 +12,7 @@ broadcom_hwskus: [ "Force10-S6000", "Accton-AS7712-32X", "Celestica-DX010-C32", 
 broadcom_td2_hwskus: ['Force10-S6000', 'Force10-S6000-Q24S32', 'Arista-7050-QX32', 'Arista-7050-QX-32S', 'Arista-7050QX32S-Q32']
 broadcom_td3_hwskus: ['Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']
 broadcom_th_hwskus: ['Force10-S6100', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-C32-T1', 'Arista-7060CX-32S-D48C8', 'Celestica-DX010-C32', "Seastone-DX010" ]
-broadcom_th2_hwskus: ['Arista-7260CX3-D108C8',  'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
+broadcom_th2_hwskus: ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-C64', 'Arista-7260CX3-Q64']
 broadcom_th3_hwskus: ['DellEMC-Z9332f-M-O16C64',  'DellEMC-Z9332f-O32']
 broadcom_th4_hwskus: ['Arista-7060DX5-32', 'Arista-7060DX5-64S']
 broadcom_th5_hwskus: ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8']

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -245,8 +245,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             if hwsku == "Arista-7260CX3-D108C10":
                 # The first 2 ports are 100G
                 s100G_ports.extend([x for x in range(1, 3)])
-
-            if hwsku == "Arista-7260CX3-D108C8-AILAB":
+            elif hwsku == "Arista-7260CX3-D108C8-AILAB":
                 s100G_ports = [x for x in range(45, 53)]
             elif hwsku == "Arista-7260CX3-D108C8-CSI":
                 # Treat 40G port as 100G ports

--- a/ansible/roles/test/tasks/dir_bcast.yml
+++ b/ansible/roles/test/tasks/dir_bcast.yml
@@ -7,7 +7,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{testbed_type}} is invalid."
-  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type not in ['t0', 't0-16', 't0-56', 't0-64', 't0-64-32', 't0-116', 't0-118']
 
 - include_vars: "vars/topo_{{testbed_type}}.yml"
 

--- a/ansible/roles/test/tasks/fdb.yml
+++ b/ansible/roles/test/tasks/fdb.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-52']
+  when: testbed_type not in ['t0', 't0-64', 't0-116', 't0-118', 't0-52']
 
 - name: Gather minigraph facts about the device
   minigraph_facts: host={{inventory_hostname}}

--- a/ansible/roles/test/tasks/fdb_mac_expire.yml
+++ b/ansible/roles/test/tasks/fdb_mac_expire.yml
@@ -2,7 +2,7 @@
   when: testbed_type is not defined
 
 - fail: msg="testbed_type {{test_type}} is invalid"
-  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-52']
+  when: testbed_type not in ['t0', 't0-64', 't0-64-32', 't0-116', 't0-118', 't0-52']
 
 - name: set fdb_aging_time to default if no user input
   set_fact:

--- a/ansible/roles/test/tasks/pfc_wd/choose_test_port.yml
+++ b/ansible/roles/test/tasks/pfc_wd/choose_test_port.yml
@@ -23,27 +23,27 @@
 
 - set_fact:
     random_seed: "{{range(4) | list | shuffle}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_portchannel: "{{minigraph_portchannel_interfaces[0].attachto}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_rx_portchannel: "{%for p in minigraph_portchannel_interfaces if p['attachto']!=pfc_wd_test_portchannel %}{%if loop.first %}{{p['attachto']}}{%endif%}{%endfor%}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port: "{{minigraph_portchannels[pfc_wd_test_portchannel]['members'][0]}}"
     pfc_wd_rx_port: "{{minigraph_portchannels[pfc_wd_rx_portchannel]['members'][0]}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port_addr: "{%for p in minigraph_portchannel_interfaces%}{%if p['attachto']==pfc_wd_test_portchannel and p['addr']|ipv4%}{{p['addr']}}{%endif %}{%endfor%}"
     pfc_wd_rx_port_addr: "{%for p in minigraph_portchannel_interfaces%}{%if p['attachto']==pfc_wd_rx_portchannel and p['addr']|ipv4%}{{p['addr']}}{%endif %}{%endfor%}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]
 
 - set_fact:
     pfc_wd_test_port_id: "{{minigraph_port_indices[pfc_wd_test_port]}}"
     pfc_wd_rx_port_id: "{{minigraph_port_indices[pfc_wd_rx_port]}}"
-  when: testbed_type in ["t0", "t0-64", "t0-116"]
+  when: testbed_type in ["t0", "t0-64", "t0-116", "t0-118"]

--- a/ansible/roles/test/tasks/pfc_wd/iterate_portchannels.yml
+++ b/ansible/roles/test/tasks/pfc_wd/iterate_portchannels.yml
@@ -46,11 +46,11 @@
 
 - set_fact:
     p: "{{pfc_wd_test_port[1]}}"
-  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't1-lag']
+  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't0-118', 't1-lag']
 
 - set_fact:
     test_ports: "{{ test_ports | combine( {p:{'test_neighbor_addr':pfc_wd_test_neighbor_addr, 'rx_port':pfc_wd_rx_port, 'rx_neighbor_addr': pfc_wd_rx_neighbor_addr, 'peer_device':neighbors[p]['peerdevice'], 'test_port_id': minigraph_port_indices[p], 'rx_port_id': pfc_wd_rx_port_id.split(' ') | list, 'test_portchannel_members': pfc_wd_test_port_id.split(' ') | list, 'test_port_type':'portchannel' }})  }}"
-  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't1-lag']
+  when: rx_pc_port is defined and test_pc_port is defined and testbed_type in ['t0-64', 't0-116', 't0-118', 't1-lag']
 
 - set_fact:
     p: "{{pfc_wd_rx_port[0]}}"
@@ -62,11 +62,11 @@
 
 - set_fact:
     p: "{{pfc_wd_rx_port[1]}}"
-  when: first_pair and testbed_type in ['t0-64', 't0-116']
+  when: first_pair and testbed_type in ['t0-64', 't0-116', 't0-118']
 
 - set_fact:
     test_ports: "{{ test_ports | combine( {p:{'test_neighbor_addr':pfc_wd_rx_neighbor_addr, 'rx_port':pfc_wd_test_port, 'rx_neighbor_addr': pfc_wd_test_neighbor_addr, 'peer_device':neighbors[p]['peerdevice'], 'test_port_id': minigraph_port_indices[p], 'rx_port_id': pfc_wd_test_port_id.split(' ') | list , 'test_portchannel_members': pfc_wd_rx_port_id.split(' ') | list, 'test_port_type':'portchannel' }})  }}"
-  when: first_pair and testbed_type in ['t0-64', 't0-116']
+  when: first_pair and testbed_type in ['t0-64', 't0-116', 't0-118']
 
 - set_fact:
     used: false

--- a/ansible/roles/test/tasks/qos_sai.yml
+++ b/ansible/roles/test/tasks/qos_sai.yml
@@ -117,7 +117,7 @@
     - name: Init PTF base test parameters
       set_fact:
         ptf_base_params:
-        - router_mac={% if testbed_type not in ['t0', 't0-64', 't0-116'] %}'{{ansible_Ethernet0['macaddress']}}'{% else %}''{% endif %}
+        - router_mac={% if testbed_type not in ['t0', 't0-64', 't0-116', 't0-118'] %}'{{ansible_Ethernet0['macaddress']}}'{% else %}''{% endif %}
         - server='{{ansible_host}}'
         - port_map_file='/root/{{ptf_portmap | basename}}'
         - sonic_asic_type='{{sonic_asic_type}}'
@@ -151,7 +151,7 @@
         - dst_port_3_ip='{{dst_port_3_ip}}'
         - src_port_id='{{src_port_id}}'
         - src_port_ip='{{src_port_ip}}'
-      when: testbed_type in ['t0', 't0-64', 't0-116'] or arp_entries.stdout.find('incomplete') == -1
+      when: testbed_type in ['t0', 't0-64', 't0-116', 't0-118'] or arp_entries.stdout.find('incomplete') == -1
 
     - include_tasks: qos_sai_ptf.yml
       vars:
@@ -268,7 +268,7 @@
         - pkts_num_hdrm_full={{qp_sc.hdrm_pool_size.pkts_num_hdrm_full}}
         - pkts_num_hdrm_partial={{qp_sc.hdrm_pool_size.pkts_num_hdrm_partial}}
       when: minigraph_hwsku is defined and
-            minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64']
+            minigraph_hwsku in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64']
 
     # Lossy queue
     - include_tasks: qos_sai_ptf.yml
@@ -348,11 +348,11 @@
         - packet_size='{{qp.wm_pg_shared_lossless.packet_size}}'
         - cell_size='{{qp.wm_pg_shared_lossless.cell_size}}'
       when: minigraph_hwsku is defined and
-            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10'])
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
-            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8'])
+            (minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10'])
 
     # Clear all watermarks before each watermark test
     # because of the clear on read polling mode
@@ -378,11 +378,11 @@
         - packet_size='{{qp.wm_pg_shared_lossy.packet_size}}'
         - cell_size='{{qp.wm_pg_shared_lossy.cell_size}}'
       when: minigraph_hwsku is defined and
-            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10']
     - debug:
         var: out.stdout_lines
       when: minigraph_hwsku is defined and
-            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8']
+            minigraph_hwsku not in ['Arista-7260CX3-Q64', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10']
 
     # Clear all watermarks before each watermark test
     # because of the clear on read polling mode

--- a/ansible/roles/test/tasks/shared-fib.yml
+++ b/ansible/roles/test/tasks/shared-fib.yml
@@ -18,7 +18,7 @@
 
 - name: Expand properties into props
   set_fact: props="{{configuration_properties['common']}}"
-  when: testbed_type in ['t0',  't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116']
+  when: testbed_type in ['t0',  't0-52', 't0-56', 't0-64', 't0-64-32', 't0-116', 't0-118']
 
 - name: Expand ToR properties into props
   set_fact: props_tor="{{configuration_properties['tor']}}"

--- a/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
+++ b/ansible/roles/test/tasks/warm-reboot-multi-sad.yml
@@ -12,7 +12,7 @@
 - name: Add all lag member down case
   set_fact:
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
-  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+  when: testbed_type in ['t0-64', 't0-116', 't0-118', 't0-64-32']
 
 - name: set default values vnet variables
   set_fact:

--- a/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
+++ b/ansible/roles/test/tasks/warm-reboot-sad-lag-member.yml
@@ -12,7 +12,7 @@
 - name: Add all lag member down case
   set_fact:
       pre_list: "{{ pre_list + ['dut_lag_member_down:2:{{ lag_memb_cnt }}', 'neigh_lag_member_down:3:{{ lag_memb_cnt }}']}}"
-  when: testbed_type in ['t0-64', 't0-116', 't0-64-32']
+  when: testbed_type in ['t0-64', 't0-116', 't0-118', 't0-64-32']
 
 - name: set default values vnet variables
   set_fact:

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -20,8 +20,8 @@
 0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
 ::/0 [24 25] [26 27] [28 29] [30 31]
 {% elif testbed_type == 't0-118' %}
-0.0.0.0/0 [0, 1] [22 23] [24 25] [26 27] [28 29]
-::/0 [0, 1] [22 23] [24 25] [26 27] [28 29]
+0.0.0.0/0 [22 23] [24 25] [26 27] [28 29]
+::/0 [22 23] [24 25] [26 27] [28 29]
 {% endif %}
 {#routes to uplink#}
 {#Limit the number of podsets and subnets to be covered to limit script execution time#}

--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -19,6 +19,9 @@
 {% elif testbed_type == 't0-116' %}
 0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
 ::/0 [24 25] [26 27] [28 29] [30 31]
+{% elif testbed_type == 't0-118' %}
+0.0.0.0/0 [0, 1] [22 23] [24 25] [26 27] [28 29]
+::/0 [0, 1] [22 23] [24 25] [26 27] [28 29]
 {% endif %}
 {#routes to uplink#}
 {#Limit the number of podsets and subnets to be covered to limit script execution time#}
@@ -61,7 +64,7 @@
 [{% for member in v.members %}{{ '%d' % minigraph_port_indices[member]}}{% if not loop.last %} {% endif %}{% endfor %}]{% if not loop.last %} {% endif %}{% endfor %}
 
 {% endif %}
-{% elif testbed_type == 't0-116' %}
+{% elif (testbed_type == 't0-116') or (testbed_type == 't0-118') %}
 {% set suffix = ( (podset * props.tor_number * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (tor * props.max_tor_subnet_number * props.tor_subnet_size) +
                   (subnet * props.tor_subnet_size) ) %}

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -26,7 +26,7 @@ testcases:
 
     bgp_fact:
       filename: bgp_fact.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     bgp_multipath_relax:
       filename: bgp_multipath_relax.yml
@@ -37,19 +37,19 @@ testcases:
 
     bgp_speaker:
       filename: bgp_speaker.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     config:
         filename: config.yml
-        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-120]
+        topologies: [t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-64, t0-116, t0-118, t0-120]
 
     continuous_reboot:
       filename: continuous_reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
+      topologies: [t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t1-28-lag]
 
     copp:
       filename: copp.yml
@@ -59,7 +59,7 @@ testcases:
 
     decap:
       filename: decap.yml
-      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
@@ -67,7 +67,7 @@ testcases:
 
     dhcp_relay:
       filename: dhcp_relay.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
@@ -85,7 +85,7 @@ testcases:
     fast-reboot:
       filename: fast-reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -93,7 +93,7 @@ testcases:
     warm-reboot:
       filename: warm-reboot.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -101,7 +101,7 @@ testcases:
     warm-reboot-sad:
       filename: warm-reboot-sad.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -109,14 +109,14 @@ testcases:
     warm-reboot-multi-sad:
       filename: warm-reboot-multi-sad.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           vm_hosts:
 
     warm-reboot-multi-sad-inboot:
       filename: warm-reboot-multi-sad-inboot.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -124,7 +124,7 @@ testcases:
     warm-reboot-sad-bgp:
       filename: warm-reboot-sad-bgp.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -132,7 +132,7 @@ testcases:
     warm-reboot-sad-lag:
       filename: warm-reboot-sad-lag.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -140,7 +140,7 @@ testcases:
     warm-reboot-sad-lag-member:
       filename: warm-reboot-sad-lag-member.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
@@ -148,21 +148,21 @@ testcases:
     warm-reboot-sad-vlan-port:
       filename: warm-reboot-sad-vlan-port.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-56]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-56]
       required_vars:
           ptf_host:
           vm_hosts:
 
     fib:
       filename: simple-fib.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     hash:
       filename: hash.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -170,21 +170,21 @@ testcases:
     warm-reboot-fib:
       filename: warm-reboot-fib.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     fdb:
       filename: fdb.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     fdb_mac_expire:
       filename: fdb_mac_expire.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t0-52]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t0-52]
       required_vars:
           fdb_aging_time:
           ptf_host:
@@ -192,31 +192,31 @@ testcases:
 
     dir_bcast:
       filename: dir_bcast.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     lag_2:
       filename: lag_2.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
 
     lldp:
       filename: lldp.yml
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120, t0-64-32, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     link_flap:
       filename: link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     continuous_link_flap:
       filename: continuous_link_flap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
 
     mtu:
       filename: mtu.yml
@@ -233,81 +233,81 @@ testcases:
 
     neighbour_mac_noptf:
       filename: neighbour-mac-noptf.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     ntp:
       filename: ntp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     pfc_wd:
       filename: pfc_wd.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     portstat:
       filename: portstat.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t0-120, t1]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t0-118, t0-120, t1]
 
     port_toggle:
       filename: port_toggle.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     qos_sai:
       filename: qos_sai.yml
-      topologies: [ptf32, ptf64, t1, t1-lag, t0, t0-64, t0-116, t0-120]
+      topologies: [ptf32, ptf64, t1, t1-lag, t0, t0-64, t0-116, t0-118, t0-120]
 
     reboot:
       filename: reboot.yml
-      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss:
       filename: run_config_cleanup.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_swss_service:
       filename: restart_swss.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     restart_syncd:
       filename: restart_syncd.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     sensors:
       filename: sensors_check.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     service_acl:
       filename: service_acl.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     snmp:
       filename: snmp.yml
-      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     syslog:
       filename: syslog.yml
-      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     vlan:
       filename: vlantb.yml
-      topologies: [t0, t0-16, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
           testbed_type:
 
     crm:
       filename: crm.yml
-      topologies: [t1, t1-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-120]
+      topologies: [t1, t1-lag, t0, t0-52, t0-56, t0-64, t0-116, t0-118, t0-120]
 
     dip_sip:
       filename: dip_sip.yml
-      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
+      topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag]
       required_vars:
           ptf_host:
           testbed_type:
@@ -315,27 +315,27 @@ testcases:
     vxlan_decap:
       filename: vxlan-decap.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     wr_arp:
       filename: wr_arp.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     vnet_vxlan:
       filename: vnet_vxlan.yml
       vtestbed_compatible: no
-      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-16, t0-52, t0-56, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
     warm_reboot_vnet:
       filename: warm-reboot-vnet.yml
-      topologies: [t0, t0-64, t0-64-32, t0-116, t0-120]
+      topologies: [t0, t0-64, t0-64-32, t0-116, t0-118, t0-120]
       required_vars:
           ptf_host:
 
@@ -345,7 +345,7 @@ testcases:
 
     iface_mode:
       filename: iface_naming_mode.yml
-      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-120, t1, ptf32, ptf64]
+      topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, ptf32, ptf64]
       required_vars:
           testbed_type:
 

--- a/ansible/testbed-new.yaml
+++ b/ansible/testbed-new.yaml
@@ -230,7 +230,7 @@ veos_groups:
     servers:
         children: [server_1, server_2]                      # source: sonic-mgmt/veos
         vars:
-            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116']  # source: sonic-mgmt/veos
+            topologies: ['t1', 't1-lag', 't1-64-lag', 't1-64-lag-clet', 't1-56-lag', 't0', 't0-56', 't0-52', 'ptf32', 'ptf64', 't0-64', 't0-64-32', 't0-116', 't0-118']  # source: sonic-mgmt/veos
     server_1:
         children: [vm_host_1, vms_1]                        # source: sonic-mgmt/veos
         vars:

--- a/tests/common/platform/warmboot_sad_cases.py
+++ b/tests/common/platform/warmboot_sad_cases.py
@@ -59,7 +59,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
                 # (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
                                    PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-64-32'] else []),
+            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
 
         "sad_bgp": [
                 'neigh_bgp_down:2',     # Shutdown single BGP session on 2 remote devices (VMs) before reboot DUT
@@ -81,7 +81,7 @@ def get_sad_case_list(duthost, nbrhosts, fanouthosts, vmhost, tbinfo, sad_case_t
                 # (1 each)
                 NeighLagMemberDown(duthost, nbrhosts, fanouthosts, DatetimeSelector(3),
                                    PhyPropsPortSelector(duthost, lagMemberCnt)),
-            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-64-32'] else []),
+            ] if tbinfo['topo']['name'] in ['t0-64', 't0-116', 't0-118', 't0-64-32'] else []),
 
         "sad_lag": [
                 'dut_lag_down:2',               # Shutdown 2 LAG sessions on DUT brefore rebooting it

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -247,7 +247,7 @@ copp/test_copp.py:
   skip:
     reason: "Topology not supported by COPP tests"
     conditions:
-      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_add_new_trap:
   skip:
@@ -255,7 +255,7 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
@@ -263,7 +263,7 @@ copp/test_copp.py::TestCOPP::test_remove_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:
@@ -273,14 +273,14 @@ copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
       - "is_multi_asic==True"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) == 20220531 and int(build_version.split('.')[1]) > 27 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) > 20220531 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_neighbor_miss:
   skip:
     reason: "Copp test_trap_neighbor_miss is not supported on broadcom platforms or non-TOR topologies"
     conditions_logical_operator: or
     conditions:
-      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116'])"
+      - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116', 't0-118'])"
       - "(asic_type in ['broadcom'] and release in ['202411'])"
 
 #######################################
@@ -914,7 +914,7 @@ generic_config_updater/test_eth_interface.py::test_replace_fec:
              / generic_config_updater is not a supported feature for T2'
     conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
+      - "hwsku in ['Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7260CX3-Q64', 'Mellanox-SN3800-D112C8'] and https://github.com/sonic-net/sonic-mgmt/issues/11237"
       - "'t2' in topo_name"
 
 generic_config_updater/test_eth_interface.py::test_toggle_pfc_asym:
@@ -1640,7 +1640,7 @@ qos/test_qos_sai.py::TestQosSai:
     reason: "Unsupported testbed type. / M0/MX topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "topo_type in ['m0', 'mx']"
 
 qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
@@ -1651,7 +1651,7 @@ qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
   skip:
@@ -1660,7 +1660,7 @@ qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
     conditions:
       - "asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
   skip:
@@ -1669,7 +1669,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc','x86_64-arista_7800r3ak_36dm2_lc']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
   skip:
@@ -1678,7 +1678,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
     conditions:
       - "'backend' not in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
   skip:
@@ -1687,7 +1687,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
     conditions:
       - "'backend' not in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
   skip:
@@ -1696,7 +1696,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
   skip:
@@ -1705,7 +1705,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
     conditions:
       - "'backend' in topo_name"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
   skip:
@@ -1714,7 +1714,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
     conditions:
       - "asic_type in ['mellanox']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
   skip:
@@ -1723,7 +1723,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
     conditions:
       - "asic_type not in ['cisco-8000'] or topo_name not in ['ptf64']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
   skip:
@@ -1731,10 +1731,10 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100']
-      and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
+      and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "'t2' in topo_name and asic_subtype in ['broadcom-dnx']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
@@ -1746,11 +1746,11 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:
@@ -1759,7 +1759,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
   skip:
@@ -1768,7 +1768,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
   skip:
@@ -1777,7 +1777,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
   skip:
@@ -1786,7 +1786,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
   skip:
@@ -1795,7 +1795,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
     conditions:
       - "asic_type in ['cisco-8000'] and not platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_lossy]:
   xfail:
@@ -1810,7 +1810,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
     conditions:
       - "asic_type not in ['cisco-8000']"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
   skip:
@@ -1819,7 +1819,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx']"
-      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
+      - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 't0-80', 't0-backend', 't1-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "asic_type in ['vs']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1269,7 +1269,7 @@ platform_tests/test_sensors.py::test_sensors:
   xfail:
     reason: "Case failed and waiting for fix on Arista platform"
     conditions:
-      - "hwsku in ['Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7260CX3-D108C8', 'Arista-7060CX-32S-C32', 'Arista-7260CX3-C64']"
+      - "hwsku in ['Arista-7050QX32S-Q32', 'Arista-7060CX-32S-D48C8', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Arista-7060CX-32S-C32', 'Arista-7260CX3-C64']"
       - "release in ['202205']"
       - https://github.com/sonic-net/sonic-mgmt/issues/8437
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -57,7 +57,7 @@ def get_dummay_mac_count(tbinfo, duthosts, rand_one_dut_hostname):
 
     # t0-116 will take 90m with DUMMY_MAC_COUNT, so use DUMMY_MAC_COUNT_SLIM for t0-116 to reduce running time
     # Use DUMMY_MAC_COUNT_SLIM on dualtor-64 to reduce running time
-    REQUIRED_TOPO = ["t0-116", "dualtor-64", "dualtor-120",
+    REQUIRED_TOPO = ["t0-116", "t0-118", "dualtor-64", "dualtor-120",
                      "t0-standalone-64", "t0-standalone-128", "t0-standalone-256", "t0-standalone-512"]
     if tbinfo["topo"]["name"] in REQUIRED_TOPO:
         # To reduce the case running time

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -41,10 +41,10 @@ class QosBase:
     """
     Common APIs
     """
-    SUPPORTED_T0_TOPOS = ["t0", "t0-56", "t0-56-po2vlan", "t0-64", "t0-116", "t0-35", "dualtor-56", "dualtor-64",
-                          "dualtor-120", "dualtor", "dualtor-64-breakout", "t0-120", "t0-80", "t0-backend",
-                          "t0-56-o8v48", "t0-8-lag", "t0-standalone-32", "t0-standalone-64", "t0-standalone-128",
-                          "t0-standalone-256", "t0-28"]
+    SUPPORTED_T0_TOPOS = ["t0", "t0-56", "t0-56-po2vlan", "t0-64", "t0-116", "t0-118", "t0-35", "dualtor-56",
+                          "dualtor-64", "dualtor-120", "dualtor", "dualtor-64-breakout", "t0-120", "t0-80",
+                          "t0-backend", "t0-56-o8v48", "t0-8-lag", "t0-standalone-32", "t0-standalone-64",
+                          "t0-standalone-128", "t0-standalone-256", "t0-28"]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -180,6 +180,7 @@ class TestQosSai(QosSaiBase):
         'Arista-7060CX-32S-C32',
         'Celestica-DX010-C32',
         'Arista-7260CX3-D108C8',
+        'Arista-7260CX3-D108C10',
         'Force10-S6100',
         'Arista-7260CX3-Q64',
         'Arista-7050CX3-32S-C32',

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2925,7 +2925,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.src_port_macs = [self.dataplane.get_mac(
             0, ptid) for ptid in self.src_port_ids]
 
-        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-120']:
+        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-118', 't0-120']:
             # populate ARP
             # sender's MAC address is corresponding PTF port's MAC address
             # sender's IP address is caculated in tests/qos/qos_sai_base.py::QosSaiBase::__assignTestPortIps()
@@ -3163,6 +3163,7 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
 
             upper_bound = 2 * margin + 1
             if (hwsku == 'Arista-7260CX3-D108C8' and self.testbed_type in ('t0-116', 'dualtor-120')) \
+                    or (hwsku == 'Arista-7260CX3-D108C10' and self.testbed_type in ('t0-118')) \
                     or (hwsku == 'Arista-7260CX3-C64' and self.testbed_type in ('dualtor-aa-56', 't1-64-lag')):
                 upper_bound = 2 * margin + self.pgs_num
             if self.wm_multiplier:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Manually backport t0-118 test configs (https://github.com/sonic-net/sonic-mgmt/pull/16659) to 202411

#### How did you do it?

#### How did you verify/test it?
Ran test suite on t0-118 supported DUT

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
