### PR TITLE
Fix dependency issue in test_vxlan_crm.py

### DIFF
--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -4,6 +4,7 @@ import ipaddress
 from functools import reduce
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #17995: test_vxlan_crm setup failed due to missing backup_and_restore_config_db_on_duts fixture

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix issue https://github.com/sonic-net/sonic-mgmt/issues/17995
#### How did you do it?
Import backup_and_restore_config_db_on_duts
#### How did you verify/test it?
Reran test_vxlan_crm.py and all tests passed.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
