### PR TITLE
Fix route/test_static_route.py

### DIFF
--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -317,3 +317,10 @@ def set_pfc_timer_cisco_8000(duthost, asic_id, script, port):
     if asic_id:
         asic_arg = f"-n asic{asic_id}"
     duthost.shell(f"show platform npu script {asic_arg} -s {script_name}")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def cleanup(ptfhost):
+
+    yield
+    ptfhost.remove_ip_addresses()

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -9,6 +9,7 @@ import six
 from collections import defaultdict
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses, copy_arp_responder_py # noqa F811
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses # noqa F811
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import mux_server_url # noqa F811
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix route/test_static_route.py
Fixes [#521](https://github.com/aristanetworks/sonic-qual.msft/issues/521)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] msft-202412

### Approach
#### What is the motivation for this PR?
The test is flaky.
```
self = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>
msg = 'Received expected packet on port 5 for device 0, but it should have arrived on one of these ports: [1].\n========== R...65 2E  ute tests.route.\n0060  74 65 73 74                                      test\n==============================\n'

    def fail(self, msg=None):
        """Fail immediately, with the given message."""
>       raise self.failureException(msg)
E       AssertionError: Received expected packet on port 5 for device 0, but it should have arrived on one of these ports: [1].
E       ========== RECEIVED ==========
E       0000  EE 0E C9 56 A0 05 00 AA BB CC DD EE 08 00 45 00  ...V..........E.
E       0010  00 56 00 01 00 00 3F 06 77 9E 01 01 01 01 01 01  .V....?.w.......
E       0020  01 01 04 D2 10 E1 00 00 00 00 00 00 00 00 50 02  ..............P.
E       0030  20 00 5D 73 00 00 74 65 73 74 73 2E 72 6F 75 74   .]s..tests.rout
E       0040  65 2E 74 65 73 74 5F 73 74 61 74 69 63 5F 72 6F  e.test_static_ro
E       0050  75 74 65 20 74 65 73 74 73 2E 72 6F 75 74 65 2E  ute tests.route.
E       0060  74 65 73 74                                      test
E       ==============================

msg        = 'Received expected packet on port 5 for device 0, but it should have arrived on one of these ports: [1].\n========== R...65 2E  ute tests.route.\n0060  74 65 73 74                                      test\n==============================\n'
self       = <tests.common.plugins.ptfadapter.ptfadapter.PtfTestAdapter testMethod=runTest>
```

`pfcwd/test_pfcwd_warm_reboot.py` configures an IP on a PTF interface but doesn't clean that up.
`route/test_static_route.py` doesn't configures an IP but rather only sets up arp_responder for the IP.

If both tests pick up the same IP but map it to different MACs (either by assigning or setting up ARP responder)
then for the same ARP request the DUT can either receive reply from kernel or arp_responder. If the kernel responds the mismatch in ARP table can cause misforwarding.

#### How did you do it?
Proposed fix is to request `remove_ip_addresses` to clean up the IP addresses inside the PTF

#### How did you verify/test it?
Verified on `Arista-7050CX3` with dualtor topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
