### PR TITLE
Remove unused arguments when calling testbed_config_vchassis playbook.

### DIFF
--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -332,8 +332,7 @@ function add_topo
     fi
 
     if [[ $topo == *"t2"* ]]; then
-      ansible-playbook -i ${inv_name} testbed_config_vchassis.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$testbed_name" \
-      -e topo="$topo" -e testbed_file=$tbfile -e vm_file=$vmfile  -e server="$server" $@
+      ansible-playbook -i ${inv_name} testbed_config_vchassis.yml --vault-password-file="$passfile" -l "$duts" -e topo="$topo"
     fi
 
     # Delete the obsoleted arp entry for the PTF IP
@@ -828,8 +827,7 @@ function config_vs_chassis
 
   read_file $testbed_name
 
-  ansible-playbook -i "$inventory" testbed_config_vchassis.yml --vault-password-file="$passfile" -l "$duts" -e testbed_name="$testbed_name" \
-  -e topo="$topo" -e testbed_file=$tbfile -e vm_file=$vmfile -e deploy=true $@
+  ansible-playbook -i "$inventory" testbed_config_vchassis.yml --vault-password-file="$passfile" -l "$duts" -e topo="$topo"
 
   echo Done
 }

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -332,7 +332,7 @@ function add_topo
     fi
 
     if [[ $topo == *"t2"* ]]; then
-      ansible-playbook -i ${inv_name} testbed_config_vchassis.yml --vault-password-file="$passfile" -l "$duts" -e topo="$topo"
+      ansible-playbook -i ${inv_name} testbed_config_vchassis.yml -l "$duts" -e topo="$topo"
     fi
 
     # Delete the obsoleted arp entry for the PTF IP

--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -10,12 +10,6 @@
     meta: end_play
     when: is_vs_chassis is not defined or is_vs_chassis == false
 
-  - name: Check that variable testbed_name is defined
-    fail: msg="Define testbed_name variable with -e testbed_name=something"
-    when: testbed_name is not defined
-
-  - debug: msg="testbed_name = {{ testbed_name }}"
-
   - name: Check that variable topo is defined
     fail: msg="Define topo variable with -e topo=something"
     when: topo is not defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Previously, the testbed_config_vchassis.yml playbook was called with some unnecessary arguments which may cause failures for certain users depending on the user input. Now, we remove the unnecessary arguments to reduce the possibility caused by misinput.
Fixes #17922  (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
