### PR TITLE
Fix for Everflow ACL Table Configuration Error

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -684,7 +684,9 @@ class BaseEverflowTest(object):
                 command += " --stage {}".format(self.acl_stage())
 
             if bind_ports_list:
-                command += " -p {}".format(",".join(bind_ports_list))
+                filtered_ports = [p for p in bind_ports_list if p and p != "Not Applicable"]
+                if filtered_ports:
+                    command += " -p {}".format(",".join(filtered_ports))
 
         elif config_method == CONFIG_MODE_CONFIGLET:
             pass


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix error when running everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_dscp_with_policer: 
```
E cmd = ['config', 'acl', 'add', 'table', 'EVERFLOW_DSCP', 'MIRROR_DSCP', '--stage', 'egress', '-p', 'Not', 'Applicable']
E Error: Got unexpected extra argument (Applicable)
```
The shell interpreter treats "Not Applicable" as two separate arguments instead of one value.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The shell interpreter treats "Not Applicable" as two separate arguments instead of one value, and causes error: RunAnsibleModuleFail: run module command failed

#### How did you do it?
By filtering out "Not Applicable" entries from the port list

#### How did you verify/test it?
Verified it in nightly test run:
```
-------------------------------- live log call ---------------------------------
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default] 
PASSED                                                                   [  5%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[erspan_ipv4-cli-upstream-default] 
PASSED                                                                   [ 30%]
```
#### Any platform specific information?
str4-sn5600-1

#### Supported testbed topology if it's a new test case?
t0-isolated-u16d16s1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
