### PR TITLE
decrease max system date const in sonic clock test

### DIFF
--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -51,7 +51,7 @@ class ClockConsts:
     TIME_ZONE = "Time zone"
 
     MIN_SYSTEM_DATE = "1970-01-01"
-    MAX_SYSTEM_DATE = "2231-12-31"
+    MAX_SYSTEM_DATE = "2106-02-06"
 
     # ntp
     CMD_SHOW_NTP = "show ntp"


### PR DESCRIPTION
Due to gzip fails to handle timestamps after 2106-02-07, decreased the MAX_SYSTEM_DATE const so the test would randomize time-dates in a shorter (but wide enough) range.

This change fixes an issue with log rotation.

https://www.gnu.org/software/gzip/manual/gzip.html#Overview-1

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
