### PR TITLE
added a retry of sending traffic in ptf test_fib in case packet wasn't correctly sent to the DUT

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -385,8 +385,20 @@ class FibTest(BaseTest):
 
         dst_ports = list(itertools.chain(*dst_port_lists))
         if self.pkt_action == self.ACTION_FWD:
-            rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-                self, masked_exp_pkt, dst_ports, timeout=1)
+            try:
+                rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                    self, masked_exp_pkt, dst_ports, timeout=1)
+            except AssertionError:
+                logging.error("Traffic wasn't sent successfully, trying again")
+                send_packet(self, src_port, pkt, count=5)
+
+                logging.info('Sent Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={}) on port {}'
+                             .format(pkt.src, pkt.dst, pkt['IP'].src, pkt['IP'].dst, sport, dport, src_port))
+                logging.info('Expect Ether(src={}, dst={})/IP(src={}, dst={})/TCP(sport={}, dport={})'
+                             .format('any', 'any', ip_src, ip_dst, sport, dport))
+
+                rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                    self, masked_exp_pkt, dst_ports, timeout=1)
             rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(
@@ -480,8 +492,21 @@ class FibTest(BaseTest):
 
         dst_ports = list(itertools.chain(*dst_port_lists))
         if self.pkt_action == self.ACTION_FWD:
-            rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-                self, masked_exp_pkt, dst_ports, timeout=1)
+            try:
+                rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                    self, masked_exp_pkt, dst_ports, timeout=1)
+            except AssertionError:
+                logging.error("Traffic wasn't sent successfully, trying again")
+                send_packet(self, src_port, pkt, count=5)
+
+                logging.info('Sent Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={}) on port {}'
+                             .format(pkt.src, pkt.dst, pkt['IPv6'].src, pkt['IPv6'].dst, sport, dport, src_port))
+                logging.info('Expect Ether(src={}, dst={})/IPv6(src={}, dst={})/TCP(sport={}, dport={})'
+                             .format('any', 'any', ip_src, ip_dst, sport, dport))
+
+                rcvd_port_index, rcvd_pkt = verify_packet_any_port(
+                    self, masked_exp_pkt, dst_ports, timeout=1)
+
             rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

In case of a weak nic, when a packet is not received, resend the packet
Related PR: https://github.com/sonic-net/sonic-mgmt/pull/14139

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Avoid failing the test in case of a packet wasn't received because of a weak NIC

#### How did you do it?
Add a retry sending traffic in case a packet wasn't received

#### How did you verify/test it?
Ran test in a loop to ensure its stability

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
