### PR TITLE
decouple bug handler logic from log analyzer

### DIFF
--- a/tests/common/plugins/loganalyzer/bug_handler_helper.py
+++ b/tests/common/plugins/loganalyzer/bug_handler_helper.py
@@ -1,16 +1,7 @@
 
-def skip_loganalyzer_bug_handler(duthost, request):
+def bug_handler_wrapper(analyzers, duthosts, la_results):
     """
-    return True if the bug handler will be skipped.
-    User could implement their own logic here.
-    """
-    return True
-
-
-def log_analyzer_bug_handler(duthost, request):
-    """
-    If the not skip bug handler after the loganalyzer, run this function to handle the err msg detected in the
-    loganalyzer.
+    Further processing of loganalyzer results.
     User could implement their own logic here.
     """
     pass


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This PR decouples bug handler processing from log analyzer by removing the post processing coupled in log analyzer.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Avoid coupling of bug handling processing in log analyzer. Each vendor can implement their own logic of bug handling processing independently based on the results of log analyzer. 

e.g. Each vendor can set up their own timeout settings for bug handler processing independently of the timeout setting for log analyzer

#### How did you do it?
Removing _post_err_msg_handler from log analyzer and pass log analyzer results to bug handler for further processing

#### How did you verify/test it?

Ran 2 tests, one with and one without matched error message from log analyzer result

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
