### PR TITLE
[platform_tests][api] Set fan speed target value to a default value per platform

### DIFF
--- a/tests/platform_tests/api/test_chassis_fans.py
+++ b/tests/platform_tests/api/test_chassis_fans.py
@@ -193,7 +193,7 @@ class TestChassisFans(PlatformApiTestBase):
         fans_skipped = 0
 
         for i in range(self.num_fans):
-            speed_target_val = 25
+            speed_target_val = self.get_fan_facts(duthost, i, 25, "speed", "default")
             speed_controllable = self.get_fan_facts(duthost, i, True, "speed", "controllable")
             if not speed_controllable:
                 logger.info("test_get_fans_target_speed: Skipping chassis fan {} (speed not controllable)"

--- a/tests/platform_tests/api/test_fan_drawer_fans.py
+++ b/tests/platform_tests/api/test_fan_drawer_fans.py
@@ -250,7 +250,7 @@ class TestFanDrawerFans(PlatformApiTestBase):
             fans_skipped = 0
 
             for i in range(num_fans):
-                speed_target_val = 25
+                speed_target_val = self.get_fan_facts(duthost, j, i, 25, "speed", "default")
                 speed_controllable = self.get_fan_facts(duthost, j, i, True, "speed", "controllable")
                 if not speed_controllable:
                     logger.info("test_get_fans_target_speed: Skipping fandrawer {} fan {} (speed not controllable)"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In all `test_get_fans_target_speed` testcases, `speed_target_val` is being arbitrarily set to `25`. However, there are fans/platforms that do not support operational speed in that range according the HW specs. 

This PR, is an enhancement that allows vendors to configure a default target speed (rather than using the hardcoded `25` value). This configuration (`default` attribute), should be provided in the `platform.json` file (similar to what is currently being supported with respect to the `minimum` and the `maximum` values).
```
"name": "Fan1",
"speed": {
	"controllable": true,
	"minimum": 20,
	"default": 50
}
```
If `default` field is not provided, then the test functionality falls back to the existing one, i.e., there is no any functional change/impact.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
- [x] Test case improvement


### Back port request
- [x] 202505

### Approach
#### What is the motivation for this PR?
Enhancement 

#### How did you verify/test it?
Verified using the testcases
- platform_tests/api/test_chassis_fans.py::TestChassisFans::test_get_fans_target_speed
- platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_get_fans_target_speed

#### Any platform specific information?
Generic

```
   ***       
  ** **
 **   **
 **   **         **** 
 **   **       **   ****
 **  **       *   **   **
  **  *      *  **  ***  **
   **  *    *  **     **  *
    ** **  ** **        **
    **   **  **
   *           *
  *             *
 *    0     0    *
 *   /   @   \   *
 *   \__/ \__/   *
   *     W     *
     **     **   
       *****
```