### PR TITLE
[bgp-peer-scale-test] BGP peer scale test that makes uses of existing t0/t1 topologies

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -331,6 +331,7 @@ t0-2vlans:
 
 t0-sonic:
   - bgp/test_bgp_fact.py
+  - bgp/test_bgp_peer_scale.py
   - bmp/test_frr_bmp_sanity.py
   - macsec/test_controlplane.py
   - macsec/test_dataplane.py
@@ -799,6 +800,8 @@ specific_param:
   t0-sonic:
   - name: bgp/test_bgp_fact.py
     param: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"
+  - name: bgp/test_bgp_peer_scale.py
+    param: "--neighbor_type=sonic"
 #  all the test modules under macsec directory
   - name: macsec
     param: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"

--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -331,7 +331,6 @@ t0-2vlans:
 
 t0-sonic:
   - bgp/test_bgp_fact.py
-  - bgp/test_bgp_peer_scale.py
   - bmp/test_frr_bmp_sanity.py
   - macsec/test_controlplane.py
   - macsec/test_dataplane.py
@@ -800,8 +799,6 @@ specific_param:
   t0-sonic:
   - name: bgp/test_bgp_fact.py
     param: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"
-  - name: bgp/test_bgp_peer_scale.py
-    param: "--neighbor_type=sonic"
 #  all the test modules under macsec directory
   - name: macsec
     param: "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -714,6 +714,13 @@ def pytest_addoption(parser):
         default=None,
         help="Max flap neighbor number, default is None"
     )
+    parser.addoption(
+        "--peers-per-dut",
+        action="store",
+        type=int,
+        default=10,
+        help="Number of additional BGP peers to configure per DUT for BGP peer scale test (default: 10)"
+    )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/bgp/test_bgp_peer_scale.py
+++ b/tests/bgp/test_bgp_peer_scale.py
@@ -1,0 +1,542 @@
+"""
+Test BGP peer scaling by adding multiple BGP peers using loopback interfaces on SONiC DUTs.
+"""
+import logging
+import pytest
+from tests.bgp.bgp_helpers import configure_bgp_peer
+from tests.common.helpers.ip_helpers import (
+    configure_loopback,
+    unconfigure_loopback,
+    configure_static_route,
+    unconfigure_static_route,
+)
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("t0-sonic"),
+]
+
+# Constants for BGP peer scaling
+BASE_LOOPBACK_ID = 1  # Starting Loopback ID
+PEERS_PER_DUT = 32  # Number of additional peers to configure per DUT
+MAX_PEERS_PER_DUT = 256  # Maximum number of peers per DUT (used for loopback ID calculation)
+
+# Multipliers for loopback ID calculation
+# These ensure that each peer gets a unique loopback ID
+# DUT_ID_MULTIPLIER must be large enough to avoid overlap between different DUTs
+# NEIGHBOR_ID_MULTIPLIER must be >= MAX_PEERS_PER_DUT to avoid overlap between different neighbors
+DUT_ID_MULTIPLIER = 10000  # Multiplier for DUT index in loopback ID calculation
+NEIGHBOR_ID_MULTIPLIER = MAX_PEERS_PER_DUT  # Multiplier for neighbor index in loopback ID calculation
+
+
+# Define regex patterns to ignore harmless loopback interface errors
+LOOPBACK_IGNORE_REGEX = [
+    # Ignore errors about adding IPv4 addresses to loopback interfaces that already exist
+    r".*ERR swss#intfmgrd: :- setIntfIp: Command '/sbin/ip address \"add\" \".*\"" \
+    r" dev \"Loopback.*\"' failed with rc 2.*",
+    # Ignore errors about adding IPv6 addresses to loopback interfaces that already exist
+    r".*ERR swss#intfmgrd: :- setIntfIp: Command '/sbin/ip -6 address \"add\" \".*\"" \
+    r" dev \"Loopback.*\"' failed with rc 2.*",
+    # Ignore RTNETLINK answers: File exists errors
+    r".*swss#supervisord: intfmgrd RTNETLINK answers: File exists.*"
+]
+
+
+def get_neighbor_ip_pairs(duthost, nbrhost, tbinfo, addr_family="ipv4"):
+    """Get the IP address pairs between DUT and neighbor host.
+
+    Args:
+        duthost: DUT host object
+        nbrhost: Neighbor host object
+        tbinfo: Testbed info fixture
+        addr_family: Address family ("ipv4" or "ipv6")
+
+    Returns:
+        tuple: (dut_nbr_ip, nbr_dut_ip) - IP addresses on DUT and neighbor sides
+    """
+    try:
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+
+        # Get the VM base number (e.g., 100 from VM0100)
+        current_vm = int(nbrhost.hostname[2:])  # Extract number from VMxxxx
+
+        # Find the topology name for this neighbor
+        topo_name = None
+        for _, neigh in mg_facts['minigraph_neighbors'].items():
+            vm_offset = tbinfo['topo']['properties']['topology']['VMs'][neigh['name']]['vm_offset']
+            base_vm = current_vm - vm_offset  # Calculate what the base VM should be
+            # Check if this neighbor's base VM matches
+            if base_vm == int(tbinfo['vm_base'][2:]):  # Compare with actual base VM number
+                topo_name = neigh['name']
+                break
+
+        if not topo_name:
+            logger.error(f"Could not find topology name for VM {nbrhost.hostname}")
+            return None, None
+
+        # Find BGP neighbor information
+        for bgp_peer in mg_facts['minigraph_bgp']:
+            if bgp_peer['name'] == topo_name:
+                # Check if it's the right address family
+                if addr_family == "ipv4" and '.' in bgp_peer['addr']:
+                    return bgp_peer['addr'], bgp_peer['peer_addr']
+                elif addr_family == "ipv6" and ':' in bgp_peer['addr']:
+                    return bgp_peer['addr'], bgp_peer['peer_addr']
+
+        logger.error(f"No {addr_family} BGP connection found between {duthost.hostname} and {topo_name}")
+        return None, None
+
+    except Exception as e:
+        logger.warning(f"Failed to get neighbor IP pairs: {str(e)}")
+        return None, None
+
+
+def calculate_loopback_id(dut_index, neighbor_index, peer_index):
+    """Get a unique loopback ID based on DUT, neighbor, and peer indices.
+
+    Args:
+        dut_index (int): Index of the DUT
+        neighbor_index (int): Index of the neighbor
+        peer_index (int): Index of the peer
+
+    Returns:
+        int: A unique loopback ID
+    """
+    # Calculate a unique loopback ID that ensures no overlap
+    # Use a formula that can handle up to MAX_PEERS_PER_DUT peers per neighbor
+    # Each DUT gets a range of DUT_ID_MULTIPLIER IDs
+    # Each neighbor within a DUT gets a range of NEIGHBOR_ID_MULTIPLIER IDs
+    return BASE_LOOPBACK_ID + (dut_index * DUT_ID_MULTIPLIER) + (neighbor_index * NEIGHBOR_ID_MULTIPLIER) + peer_index
+
+
+def get_loopback_ip_pair(loopback_id):
+    """Get a pair of non-overlapping IP addresses for local and neighbor loopback use."""
+    # Use loopback ID directly in the third octet to ensure each loopback gets a unique subnet
+    # For example:
+    # Loopback 1 -> 172.16.1.1/32 and 172.16.1.2/32
+    # Loopback 2 -> 172.16.2.1/32 and 172.16.2.2/32
+    # This supports up to 254 unique loopback IDs
+
+    # Ensure loopback ID doesn't exceed 254 (reserve 255 for future use)
+    if loopback_id > 254:
+        # For loopback IDs > 254, use a different second octet
+        # This extends support to 254 * 255 = 64,770 unique loopback IDs
+        second_octet = 16 + (loopback_id // 255)
+        third_octet = loopback_id % 255
+        if third_octet == 0:  # Avoid 0 in third octet
+            third_octet = 255
+            second_octet -= 1
+
+        # Ensure second octet doesn't exceed 254
+        if second_octet > 254:
+            logger.warning(f"Loopback ID {loopback_id} exceeds maximum supported value (64,770)")
+            second_octet = 254
+            third_octet = loopback_id % 255  # Use modulo to get a unique third octet
+            if third_octet == 0:  # Avoid 0 in third octet
+                third_octet = 255
+
+        # Create IP addresses
+        local_ip = f"172.{second_octet}.{third_octet}.1"
+        neighbor_ip = f"172.{second_octet}.{third_octet}.2"
+    else:
+        # For loopback IDs <= 254, use the original scheme
+        local_ip = f"172.16.{loopback_id}.1"
+        neighbor_ip = f"172.16.{loopback_id}.2"
+
+    return local_ip, neighbor_ip
+
+
+def get_loopback_ipv6_pair(loopback_id):
+    """Get a pair of non-overlapping IPv6 addresses for local and neighbor loopback use."""
+    # Use loopback ID directly in the IPv6 address to ensure each loopback gets a unique subnet
+    # For example:
+    # Loopback 1 -> fc00:1::1/128 and fc00:1::2/128
+    # Loopback 2 -> fc00:2::1/128 and fc00:2::2/128
+    # This supports up to 65,535 unique loopback IDs
+
+    # Ensure loopback_id is within valid range for IPv6 hex notation
+    if loopback_id > 65535:
+        # For larger loopback IDs, use multiple segments
+        first_segment = loopback_id // 65536
+        second_segment = loopback_id % 65536
+
+        # Create IPv6 addresses
+        local_ip = f"fc00:{first_segment:x}:{second_segment:x}::1"
+        neighbor_ip = f"fc00:{first_segment:x}:{second_segment:x}::2"
+    else:
+        # For smaller loopback IDs, use a single segment
+        local_ip = f"fc00:{loopback_id:x}::1"
+        neighbor_ip = f"fc00:{loopback_id:x}::2"
+
+    return local_ip, neighbor_ip
+
+
+def get_asn_values(duthost):
+    """Get the local and remote ASN values from existing BGP neighbors or config.
+    Returns tuple of (local_asn, remote_asn)
+    """
+    try:
+        # Use vtysh to get BGP summary in JSON format for both IPv4 and IPv6
+        result = duthost.shell("vtysh -c 'show bgp summary json'", module_ignore_errors=True)
+
+        if result['rc'] == 0:
+            try:
+                # Parse the JSON output
+                import json
+                bgp_summary = json.loads(result['stdout'])
+                logger.debug(f"BGP summary JSON: {bgp_summary}")
+
+                # Get the local ASN from either IPv4 or IPv6 unicast
+                local_asn = None
+                if 'ipv4Unicast' in bgp_summary and bgp_summary['ipv4Unicast'].get('as') is not None:
+                    local_asn = bgp_summary['ipv4Unicast'].get('as')
+                    logger.info(f"Found BGP already running with ASN {local_asn} from IPv4 unicast")
+                elif 'ipv6Unicast' in bgp_summary and bgp_summary['ipv6Unicast'].get('as') is not None:
+                    local_asn = bgp_summary['ipv6Unicast'].get('as')
+                    logger.info(f"Found BGP already running with ASN {local_asn} from IPv6 unicast")
+
+                if local_asn is None:
+                    logger.warning("Could not find local ASN in BGP summary")
+                    return None, None
+
+                # Look for a peer with a different ASN in either IPv4 or IPv6 unicast
+                remote_asn = None
+
+                # Check IPv4 peers first
+                if 'ipv4Unicast' in bgp_summary:
+                    peers = bgp_summary['ipv4Unicast'].get('peers', {})
+                    for peer_ip, peer_data in peers.items():
+                        peer_remote_asn = peer_data.get('remoteAs')
+                        if peer_remote_asn is not None and peer_remote_asn != local_asn:
+                            remote_asn = peer_remote_asn
+                            logger.info(f"Found remote ASN {remote_asn} for IPv4 peer {peer_ip}")
+                            return local_asn, remote_asn
+
+                # If no IPv4 peer with different ASN, check IPv6 peers
+                if 'ipv6Unicast' in bgp_summary:
+                    peers = bgp_summary['ipv6Unicast'].get('peers', {})
+                    for peer_ip, peer_data in peers.items():
+                        peer_remote_asn = peer_data.get('remoteAs')
+                        if peer_remote_asn is not None and peer_remote_asn != local_asn:
+                            remote_asn = peer_remote_asn
+                            logger.info(f"Found remote ASN {remote_asn} for IPv6 peer {peer_ip}")
+                            return local_asn, remote_asn
+
+                logger.warning("Could not find a peer with a different ASN in BGP summary")
+                return None, None
+            except json.JSONDecodeError as e:
+                logger.warning(f"Failed to parse JSON output: {str(e)}")
+            except Exception as e:
+                logger.warning(f"Error processing BGP summary JSON: {str(e)}")
+    except Exception as e:
+        logger.warning(f"Failed to get ASN values from BGP summary: {str(e)}")
+
+    # If vtysh method fails, try config facts
+    try:
+        # Try to get from config facts
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        local_asn = config_facts.get('DEVICE_METADATA', {}).get('localhost', {}).get('bgp_asn')
+
+        if local_asn is None:
+            logger.error("Could not determine local ASN from config facts")
+            return None, None
+
+        # Try to get remote ASN from existing BGP neighbors
+        bgp_config = config_facts.get('BGP_NEIGHBOR', {})
+        for peer_data in bgp_config.values():
+            if 'asn' in peer_data and peer_data['asn'] != local_asn:
+                return local_asn, peer_data['asn']
+
+        logger.error("Could not determine remote ASN from BGP neighbors")
+        return None, None
+
+    except Exception as e:
+        logger.error(f"Failed to get ASN values from config: {str(e)}")
+        return None, None
+
+
+def run_bgp_peer_scale(duthosts, _, nbrhosts, tbinfo, addr_family="ipv4"):
+    """
+    Common helper function to run BGP peer scale tests for IPv4 or IPv6.
+
+    Args:
+        duthosts: DUT host objects
+        enum_rand_one_per_hwsku_hostname: Test fixture
+        nbrhosts: Neighbor host objects
+        tbinfo: Testbed information dictionary containing topology details
+        addr_family: Address family ("ipv4" or "ipv6")
+    """
+    # Check if PEERS_PER_DUT is set to a valid value
+    if PEERS_PER_DUT > MAX_PEERS_PER_DUT:
+        error_msg = f"PEERS_PER_DUT ({PEERS_PER_DUT}) exceeds MAX_PEERS_PER_DUT ({MAX_PEERS_PER_DUT})"
+        logger.error(error_msg)
+        pytest.fail(error_msg)
+
+    configs = []
+    try:
+        for dut_index, duthost in enumerate(duthosts):
+            # Get local and remote asn values for the DUT
+            dut_local_asn, dut_remote_asn = get_asn_values(duthost)
+
+            if dut_local_asn is None or dut_remote_asn is None:
+                pytest.fail(f"Could not determine ASN values for DUT {duthost.hostname}")
+
+            logger.info(f"DUT {duthost.hostname} has local ASN {dut_local_asn} and remote ASN {dut_remote_asn}")
+
+            # Get all current BGP neighbors for this DUT
+            current_neighbors = [nbr["host"] for nbr in nbrhosts.values()]
+
+            if not current_neighbors:
+                pytest.fail(f"No existing BGP neighbors found for DUT {duthost.hostname}")
+
+            # Get port connections between DUT and neighbors
+            for neighbor_index, nbrhost in enumerate(current_neighbors):
+                # Get neighbor IPs for connectivity
+                dut_nbr_ip, nbr_dut_ip = get_neighbor_ip_pairs(duthost, nbrhost, tbinfo, addr_family=addr_family)
+
+                if not dut_nbr_ip or not nbr_dut_ip:
+                    pytest.fail(f"Failed to get neighbor IP addresses for {duthost.hostname} and {nbrhost.hostname}")
+
+                # Get ASN values for the neighbor
+                nbr_local_asn, nbr_remote_asn = get_asn_values(nbrhost)
+
+                if nbr_local_asn is None or nbr_remote_asn is None:
+                    pytest.fail(f"Could not determine ASN values for neighbor {nbrhost.hostname}")
+
+                logger.info(f"Neighbor {nbrhost.hostname} has local ASN {nbr_local_asn}, remote ASN {nbr_remote_asn}")
+
+                # Configure additional peers for this neighbor
+                for peer_index in range(PEERS_PER_DUT):
+                    # Calculate a unique loopback ID
+                    loopback_id = calculate_loopback_id(dut_index, neighbor_index, peer_index)
+
+                    if addr_family == "ipv4":
+                        local_ip, neighbor_ip = get_loopback_ip_pair(loopback_id)
+                    else:
+                        local_ip, neighbor_ip = get_loopback_ipv6_pair(loopback_id)
+
+                    # Configure loopback interfaces on DUT and neighbor
+                    # Be little paranoid and verify that the IP addresses are different
+                    if local_ip == neighbor_ip:
+                        pytest.fail(f"IP conflict detected: Both DUT and neighbor would use {local_ip}")
+
+                    logger.info(f"Configuring loopback {loopback_id} with IP {local_ip} on {duthost.hostname}")
+                    if not configure_loopback(duthost, loopback_id, local_ip):
+                        pytest.fail(
+                            f"Failed to configure loopback {loopback_id} with IP {local_ip} on {duthost.hostname}"
+                        )
+
+                    logger.info(f"Configuring loopback {loopback_id} with IP {neighbor_ip} on {nbrhost.hostname}")
+                    if not configure_loopback(nbrhost, loopback_id, neighbor_ip):
+                        pytest.fail(
+                            f"Failed to configure loopback {loopback_id} with IP {neighbor_ip} on {nbrhost.hostname}"
+                        )
+
+                    logger.info(
+                        f"Successfully configured loopback {loopback_id} with IP {local_ip} on {duthost.hostname}"
+                    )
+                    logger.info(
+                        f"Successfully configured loopback {loopback_id} with IP {neighbor_ip} on {nbrhost.hostname}"
+                    )
+
+                    # Configure routes to reach each other's loopbacks
+                    prefix_len = '128' if addr_family == "ipv6" else '32'
+                    if not configure_static_route(duthost, f"{neighbor_ip}/{prefix_len}", dut_nbr_ip):
+                        pytest.fail(f"Failed to configure route to peer loopback on {duthost.hostname}")
+                    if not configure_static_route(nbrhost, f"{local_ip}/{prefix_len}", nbr_dut_ip):
+                        pytest.fail(f"Failed to configure route to peer loopback on {nbrhost.hostname}")
+                    logger.info(
+                        f"Configured static route on {duthost.hostname} to reach {neighbor_ip} via {dut_nbr_ip}"
+                    )
+                    logger.info(
+                        f"Configured static route on {nbrhost.hostname} to reach {local_ip} via {nbr_dut_ip}"
+                    )
+
+                    # Configure eBGP peers
+                    loopback_name = f"Loopback{loopback_id}"
+
+                    # Configure BGP peer on DUT using DUT's ASN values
+                    # DUT peers with neighbor's IP
+                    logger.info(
+                        f"Configuring BGP peer on {duthost.hostname} to peer with {neighbor_ip} "
+                        f"(using loopback {loopback_name})"
+                    )
+                    if not configure_bgp_peer(duthost, neighbor_ip, dut_local_asn,
+                                              nbr_local_asn, afi=addr_family,
+                                              update_source_intf=loopback_name):
+                        pytest.fail(
+                            f"Failed to configure BGP peer on {duthost.hostname} to peer with {neighbor_ip}"
+                        )
+                    logger.info(
+                        f"Successfully configured BGP peer on {duthost.hostname} to peer with {neighbor_ip}"
+                    )
+
+                    # Configure BGP peer on neighbor using neighbor's ASN values
+                    # Neighbor peers with DUT's IP
+                    logger.info(
+                        f"Configuring BGP peer on {nbrhost.hostname} to peer with {local_ip} "
+                        f"(using loopback {loopback_name})"
+                    )
+                    if not configure_bgp_peer(nbrhost, local_ip, nbr_local_asn,
+                                              dut_local_asn, afi=addr_family,
+                                              update_source_intf=loopback_name):
+                        pytest.fail(
+                            f"Failed to configure {addr_family} BGP peer on {nbrhost.hostname} to peer with {local_ip}"
+                        )
+                    logger.info(
+                        f"Successfully configured BGP peer on {nbrhost.hostname} to peer with {local_ip}"
+                    )
+
+                    configs.append({
+                        'duthost': duthost,
+                        'nbrhost': nbrhost,
+                        'loopback_id': loopback_id,
+                        'local_ip': local_ip,
+                        'neighbor_ip': neighbor_ip,
+                        'dut_local_asn': dut_local_asn,
+                        'nbr_local_asn': nbr_local_asn,
+                        'addr_family': addr_family
+                    })
+
+        # Verify BGP peer configuration and status
+        verify_bgp_peer_scale(duthosts, configs, addr_family=addr_family)
+    finally:
+        # Clean up configurations
+        for config in configs:
+            duthost = config['duthost']
+            nbrhost = config['nbrhost']
+            loopback_id = config['loopback_id']
+            local_ip = config['local_ip']
+            neighbor_ip = config['neighbor_ip']
+            addr_family = config['addr_family']
+
+            # Remove BGP neighbors added by this test
+            duthost.shell(
+                f"vtysh -c 'configure terminal' "
+                f"-c 'router bgp {config['dut_local_asn']}' "
+                f"-c 'no neighbor {neighbor_ip}'",
+                module_ignore_errors=True
+            )
+            nbrhost.shell(
+                f"vtysh -c 'configure terminal' "
+                f"-c 'router bgp {config['nbr_local_asn']}' "
+                f"-c 'no neighbor {local_ip}'",
+                module_ignore_errors=True
+            )
+
+            # Delete routes to peer loopbacks
+            prefix_len = '128' if addr_family == "ipv6" else '32'
+            if not unconfigure_static_route(duthost, f"{neighbor_ip}/{prefix_len}"):
+                logger.error(f"Failed to delete route to peer loopback on {duthost.hostname}")
+            if not unconfigure_static_route(nbrhost, f"{local_ip}/{prefix_len}"):
+                logger.error(f"Failed to delete route to peer loopback on {nbrhost.hostname}")
+
+            # Remove loopback interfaces
+            if not unconfigure_loopback(duthost, loopback_id):
+                logger.error(f"Failed to unconfigure loopback {loopback_id} on {duthost.hostname}")
+            if not unconfigure_loopback(nbrhost, loopback_id):
+                logger.error(f"Failed to unconfigure loopback {loopback_id} on {nbrhost.hostname}")
+
+
+def test_bgp_peer_scale_v4(duthosts, enum_rand_one_per_hwsku_hostname, nbrhosts, tbinfo, loganalyzer):
+    # Configure loganalyzer to ignore loopback interface errors
+    for duthost in duthosts:
+        if duthost.hostname in loganalyzer:
+            loganalyzer[duthost.hostname].ignore_regex.extend(LOOPBACK_IGNORE_REGEX)
+    """
+    Verify BGP IPv4 peer scaling by checking:
+    1. All VLAN interfaces are properly configured and up
+    2. All BGP peers are configured
+    3. All BGP sessions are established
+    """
+    run_bgp_peer_scale(duthosts, enum_rand_one_per_hwsku_hostname, nbrhosts, tbinfo, addr_family="ipv4")
+
+
+def test_bgp_peer_scale_v6(duthosts, enum_rand_one_per_hwsku_hostname, nbrhosts, tbinfo, loganalyzer):
+    # Configure loganalyzer to ignore loopback interface errors
+    for duthost in duthosts:
+        if duthost.hostname in loganalyzer:
+            loganalyzer[duthost.hostname].ignore_regex.extend(LOOPBACK_IGNORE_REGEX)
+    """
+    Verify BGP IPv6 peer scaling by checking:
+    1. All VLAN interfaces are properly configured and up
+    2. All BGP peers are configured
+    3. All BGP sessions are established
+    """
+    run_bgp_peer_scale(duthosts, enum_rand_one_per_hwsku_hostname, nbrhosts, tbinfo, addr_family="ipv6")
+
+
+def verify_bgp_peer_scale(duthosts, configs, addr_family="ipv4"):
+    """
+    Verify BGP peer scale configuration and status for all DUTs
+
+    Args:
+        duthosts: List of DUT host objects
+        configs: List of configuration dictionaries containing neighbor information
+        addr_family: Address family ("ipv4" or "ipv6")
+    """
+    if not configs:
+        return
+
+    ipcmd = 'ipv6' if addr_family == "ipv6" else 'ip'
+
+    # Verify configuration for each DUT
+    for duthost in duthosts:
+        # Get DUT-specific configs
+        dut_configs = [config for config in configs if config['duthost'] == duthost]
+        if not dut_configs:
+            continue
+
+        # Get interface info once per DUT
+        output = duthost.shell(f"show {ipcmd} interfaces")["stdout"]
+
+        # Get BGP facts once per DUT
+        bgp_facts = duthost.bgp_facts()['ansible_facts']
+
+        # Verify all loopback interfaces for this DUT
+        neighbor_ips = []
+        for config in dut_configs:
+            loopback_name = f"Loopback{config['loopback_id']}"
+            interface_found = False
+            ip_configured = False
+            status_up = False
+
+            for line in output.split('\n'):
+                if loopback_name in line:
+                    interface_found = True
+                    ip_configured = config['local_ip'] in line
+                    status_up = 'up/up' in line.lower()
+                    break
+
+            pytest_assert(
+                interface_found,
+                f"Loopback interface {loopback_name} not found in show ip interfaces output on {duthost.hostname}"
+            )
+
+            pytest_assert(
+                ip_configured,
+                f"Incorrect IP address configured on {loopback_name}. Expected {config['local_ip']}"
+            )
+
+            pytest_assert(
+                status_up,
+                f"Interface {loopback_name} is not up on {duthost.hostname}"
+            )
+
+            # Verify BGP peer configuration
+            pytest_assert(
+                config['neighbor_ip'] in bgp_facts['bgp_neighbors'],
+                f"BGP peer {config['neighbor_ip']} not found in BGP neighbors on {duthost.hostname}"
+            )
+
+            neighbor_ips.append(config['neighbor_ip'])
+
+        # Check all BGP sessions
+        timeout = 120
+        pytest_assert(
+            wait_until(timeout, 5, 0, duthost.check_bgp_session_state, neighbor_ips),
+            f"Not all BGP sessions are established after {timeout} seconds on {duthost.hostname}"
+        )

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2565,13 +2565,17 @@ Totals               6450                 6449
         """
         self.command("config interface ip remove {} {}".format(port, ip))
 
-    def add_ip_addr_to_port(self, port, ip, gwaddr):
+    def add_ip_addr_to_port(self, port, ip, gwaddr=None):
         """
         Add ip addr on the port.
         :param port: port name
         :param ip: IP address
+        :param gwaddr: (Optional) Gateway address
         """
-        self.command("config interface ip add {} {} {}".format(port, ip, gwaddr))
+        cmd = "config interface ip add {} {}".format(port, ip)
+        if gwaddr:
+            cmd += " {}".format(gwaddr)
+        self.command(cmd)
 
     def remove_ip_addr_from_vlan(self, vlan, ip):
         """

--- a/tests/common/helpers/ip_helpers.py
+++ b/tests/common/helpers/ip_helpers.py
@@ -1,107 +1,203 @@
 import logging
+from tests.common.devices.eos import EosHost
 
 # Initialize logger
 logger = logging.getLogger(__name__)
 
 
-def configure_loopback(duthost, loopback_id, ip_addr):
+def configure_loopback(host, loopback_id, ip_addr):
     """Configure a loopback interface with the given IP.
 
     Args:
-        duthost: DUT host object
+        host: DUT host object (SONiC or EOS)
         loopback_id: Loopback interface ID
         ip_addr: IP address (IPv4 or IPv6) to configure
     """
-    try:
-        loopback_name = f"Loopback{loopback_id}"
-        is_ipv6 = ':' in ip_addr
-        prefix_len = '128' if is_ipv6 else '32'
+    if isinstance(host, EosHost):
+        # For cEOS, use Arista EOS configuration commands
+        try:
+            loopback_name = f"Loopback{loopback_id}"
+            is_ipv6 = ':' in ip_addr
+            prefix_len = '128' if is_ipv6 else '32'
 
-        # Configure loopback interface - try to add it and handle the case if it already exists
-        result = duthost.shell(f"config loopback add {loopback_name}", module_ignore_errors=True)
-        if result['rc'] != 0 and "already exists" not in result.get('stderr', ''):
-            logger.error(f"Failed to add loopback: {result.get('stderr', '')}")
+            if is_ipv6:
+                ip_cmd = f"ipv6 address {ip_addr}/{prefix_len}"
+            else:
+                ip_cmd = f"ip address {ip_addr}/{prefix_len}"
+
+            interface_commands = [
+                ip_cmd,
+                "no shutdown"
+            ]
+
+            result = host.eos_config(
+                lines=interface_commands,
+                parents=[f"interface {loopback_name}"]
+            )
+            if result.get('failed', False):  # type: ignore
+                logger.error(f"Failed to configure EOS loopback: {result}")
+                return False
+
+            logger.info(f"Successfully configured loopback {loopback_name} with IP {ip_addr} on EOS host")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error configuring EOS loopback: {str(e)}")
             return False
-        elif result['rc'] != 0 and "already exists" in result.get('stderr', ''):
-            logger.info(f"Loopback {loopback_name} already exists, continuing with configuration")
+    else:
+        try:
+            loopback_name = f"Loopback{loopback_id}"
+            is_ipv6 = ':' in ip_addr
+            prefix_len = '128' if is_ipv6 else '32'
 
-        # Configure IP address
-        duthost.add_ip_addr_to_port(loopback_name, f"{ip_addr}/{prefix_len}")
+            # Configure loopback interface - try to add it and handle the case if it already exists
+            result = host.shell(f"config loopback add {loopback_name}", module_ignore_errors=True)
+            if result['rc'] != 0 and "already exists" not in result.get('stderr', ''):
+                logger.error(f"Failed to add loopback: {result.get('stderr', '')}")
+                return False
+            elif result['rc'] != 0 and "already exists" in result.get('stderr', ''):
+                logger.info(f"Loopback {loopback_name} already exists, continuing with configuration")
 
-        return True
+            # Configure IP address
+            host.add_ip_addr_to_port(loopback_name, f"{ip_addr}/{prefix_len}")
 
-    except Exception as e:
-        logger.error(f"Error configuring loopback: {str(e)}")
-        return False
+            return True
+
+        except Exception as e:
+            logger.error(f"Error configuring loopback: {str(e)}")
+            return False
 
 
-def unconfigure_loopback(duthost, loopback_id):
+def unconfigure_loopback(host, loopback_id):
     """Unconfigure a loopback interface and its route.
 
     Args:
-        duthost: DUT host object
+        host: DUT host object (SONiC or EOS)
         loopback_id: Loopback interface ID
-        ip_addr: IP address (IPv4 or IPv6) configured on the loopback
     """
-    try:
-        loopback_name = f"Loopback{loopback_id}"
+    if isinstance(host, EosHost):
+        # For cEOS, use Arista EOS configuration commands
+        try:
+            loopback_name = f"Loopback{loopback_id}"
+            commands = [f"no interface {loopback_name}"]
 
-        # Remove loopback interface
-        result = duthost.shell(f"config loopback del {loopback_name}", module_ignore_errors=True)
-        if result['rc'] != 0 and "does not exist" not in result.get('stderr', ''):
-            logger.error(f"Failed to remove loopback: {result['stderr']}")
+            result = host.eos_config(lines=commands)
+            if result.get('failed', False):  # type: ignore
+                logger.error(f"Failed to unconfigure EOS loopback: {result}")
+                return False
+
+            logger.info(f"Successfully unconfigured loopback {loopback_id} on EOS host")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error unconfiguring EOS loopback: {str(e)}")
+            return False
+    else:
+        try:
+            loopback_name = f"Loopback{loopback_id}"
+
+            # Remove loopback interface
+            result = host.shell(f"config loopback del {loopback_name}", module_ignore_errors=True)
+            if result['rc'] != 0 and "does not exist" not in result.get('stderr', ''):
+                logger.error(f"Failed to remove loopback: {result['stderr']}")
+                return False
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Error unconfiguring loopback: {str(e)}")
             return False
 
-        return True
 
-    except Exception as e:
-        logger.error(f"Error unconfiguring loopback: {str(e)}")
-        return False
-
-
-def configure_static_route(duthost, prefix, next_hop_ip):
+def configure_static_route(host, prefix, next_hop_ip):
     """Configure static route.
 
     Args:
-        duthost: DUT host object
+        host: DUT host object (SONiC or EOS)
         prefix: Network prefix in CIDR notation (e.g. '192.168.1.0/24' or '2001:db8::/64')
         next_hop_ip: Next hop IP for reaching the prefix
     """
-    try:
-        is_ipv6 = ':' in prefix
-        ip_route_cmd = 'ip -6 route' if is_ipv6 else 'ip route'
+    if isinstance(host, EosHost):
+        # For cEOS, use Arista EOS configuration commands
+        try:
+            is_ipv6 = ':' in prefix
 
-        route_cmd = f"{ip_route_cmd} add {prefix} via {next_hop_ip}"
-        result = duthost.shell(route_cmd, module_ignore_errors=True)
-        if result['rc'] != 0 and "File exists" not in result.get('stderr', ''):
-            logger.error(f"Failed to configure route. Error: {result['stderr']}")
+            # EOS configuration commands (note: EOS uses different syntax than Linux)
+            # EOS format: "ip route <prefix> <next_hop>" (no "via" keyword)
+            if is_ipv6:
+                route_cmd = f"ipv6 route {prefix} {next_hop_ip}"
+            else:
+                route_cmd = f"ip route {prefix} {next_hop_ip}"
+
+            result = host.eos_config(lines=[route_cmd])
+            if result.get('failed', False):  # type: ignore
+                logger.error(f"Failed to configure EOS static route: {result}")
+                return False
+
+            logger.info(f"Successfully configured static route {prefix} via {next_hop_ip} on EOS host")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error configuring EOS static route: {str(e)}")
+            return False
+    else:
+        try:
+            is_ipv6 = ':' in prefix
+            ip_route_cmd = 'ip -6 route' if is_ipv6 else 'ip route'
+
+            route_cmd = f"{ip_route_cmd} add {prefix} via {next_hop_ip}"
+            result = host.shell(route_cmd, module_ignore_errors=True)
+            if result['rc'] != 0 and "File exists" not in result.get('stderr', ''):
+                logger.error(f"Failed to configure route. Error: {result['stderr']}")
+                return False
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Error configuring route: {str(e)}")
             return False
 
-        return True
 
-    except Exception as e:
-        logger.error(f"Error configuring route: {str(e)}")
-        return False
-
-
-def unconfigure_static_route(duthost, prefix):
+def unconfigure_static_route(host, prefix):
     """Unconfigure static route.
 
     Args:
-        duthost: DUT host object
+        host: DUT host object (SONiC or EOS)
         prefix: Network prefix in CIDR notation (e.g. '192.168.1.0/24' or '2001:db8::/64')
     """
-    try:
-        is_ipv6 = ':' in prefix
-        ip_route_cmd = 'ip -6 route' if is_ipv6 else 'ip route'
+    if isinstance(host, EosHost):
+        # For cEOS, use Arista EOS configuration commands
+        try:
+            is_ipv6 = ':' in prefix
 
-        route_cmd = f"{ip_route_cmd} del {prefix}"
-        result = duthost.shell(route_cmd, module_ignore_errors=True)
-        if result['rc'] != 0 and "No such process" not in result.get('stderr', ''):
-            logger.error(f"Failed to unconfigure route. Error: {result['stderr']}")
+            if is_ipv6:
+                route_cmd = f"no ipv6 route {prefix}"
+            else:
+                route_cmd = f"no ip route {prefix}"
+
+            result = host.eos_config(lines=[route_cmd])
+            if result.get('failed', False):  # type: ignore
+                logger.error(f"Failed to unconfigure EOS static route: {result}")
+                return False
+
+            logger.info(f"Successfully unconfigured static route {prefix} on EOS host")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error unconfiguring EOS static route: {str(e)}")
             return False
-        return True
+    else:
+        try:
+            is_ipv6 = ':' in prefix
+            ip_route_cmd = 'ip -6 route' if is_ipv6 else 'ip route'
 
-    except Exception as e:
-        logger.error(f"Error unconfiguring route: {str(e)}")
-        return False
+            route_cmd = f"{ip_route_cmd} del {prefix}"
+            result = host.shell(route_cmd, module_ignore_errors=True)
+            if result['rc'] != 0 and "No such process" not in result.get('stderr', ''):
+                logger.error(f"Failed to unconfigure route. Error: {result['stderr']}")
+                return False
+            return True
+
+        except Exception as e:
+            logger.error(f"Error unconfiguring route: {str(e)}")
+            return False

--- a/tests/common/helpers/ip_helpers.py
+++ b/tests/common/helpers/ip_helpers.py
@@ -1,0 +1,107 @@
+import logging
+
+# Initialize logger
+logger = logging.getLogger(__name__)
+
+
+def configure_loopback(duthost, loopback_id, ip_addr):
+    """Configure a loopback interface with the given IP.
+
+    Args:
+        duthost: DUT host object
+        loopback_id: Loopback interface ID
+        ip_addr: IP address (IPv4 or IPv6) to configure
+    """
+    try:
+        loopback_name = f"Loopback{loopback_id}"
+        is_ipv6 = ':' in ip_addr
+        prefix_len = '128' if is_ipv6 else '32'
+
+        # Configure loopback interface - try to add it and handle the case if it already exists
+        result = duthost.shell(f"config loopback add {loopback_name}", module_ignore_errors=True)
+        if result['rc'] != 0 and "already exists" not in result.get('stderr', ''):
+            logger.error(f"Failed to add loopback: {result.get('stderr', '')}")
+            return False
+        elif result['rc'] != 0 and "already exists" in result.get('stderr', ''):
+            logger.info(f"Loopback {loopback_name} already exists, continuing with configuration")
+
+        # Configure IP address
+        duthost.add_ip_addr_to_port(loopback_name, f"{ip_addr}/{prefix_len}")
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Error configuring loopback: {str(e)}")
+        return False
+
+
+def unconfigure_loopback(duthost, loopback_id):
+    """Unconfigure a loopback interface and its route.
+
+    Args:
+        duthost: DUT host object
+        loopback_id: Loopback interface ID
+        ip_addr: IP address (IPv4 or IPv6) configured on the loopback
+    """
+    try:
+        loopback_name = f"Loopback{loopback_id}"
+
+        # Remove loopback interface
+        result = duthost.shell(f"config loopback del {loopback_name}", module_ignore_errors=True)
+        if result['rc'] != 0 and "does not exist" not in result.get('stderr', ''):
+            logger.error(f"Failed to remove loopback: {result['stderr']}")
+            return False
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Error unconfiguring loopback: {str(e)}")
+        return False
+
+
+def configure_static_route(duthost, prefix, next_hop_ip):
+    """Configure static route.
+
+    Args:
+        duthost: DUT host object
+        prefix: Network prefix in CIDR notation (e.g. '192.168.1.0/24' or '2001:db8::/64')
+        next_hop_ip: Next hop IP for reaching the prefix
+    """
+    try:
+        is_ipv6 = ':' in prefix
+        ip_route_cmd = 'ip -6 route' if is_ipv6 else 'ip route'
+
+        route_cmd = f"{ip_route_cmd} add {prefix} via {next_hop_ip}"
+        result = duthost.shell(route_cmd, module_ignore_errors=True)
+        if result['rc'] != 0 and "File exists" not in result.get('stderr', ''):
+            logger.error(f"Failed to configure route. Error: {result['stderr']}")
+            return False
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Error configuring route: {str(e)}")
+        return False
+
+
+def unconfigure_static_route(duthost, prefix):
+    """Unconfigure static route.
+
+    Args:
+        duthost: DUT host object
+        prefix: Network prefix in CIDR notation (e.g. '192.168.1.0/24' or '2001:db8::/64')
+    """
+    try:
+        is_ipv6 = ':' in prefix
+        ip_route_cmd = 'ip -6 route' if is_ipv6 else 'ip route'
+
+        route_cmd = f"{ip_route_cmd} del {prefix}"
+        result = duthost.shell(route_cmd, module_ignore_errors=True)
+        if result['rc'] != 0 and "No such process" not in result.get('stderr', ''):
+            logger.error(f"Failed to unconfigure route. Error: {result['stderr']}")
+            return False
+        return True
+
+    except Exception as e:
+        logger.error(f"Error unconfiguring route: {str(e)}")
+        return False


### PR DESCRIPTION
Fixes: https://github.com/sonic-net/sonic-mgmt/issues/18527

The BGP peer scale test that works by configuring multiple bgp peers on neighboring devices on existing t0/t1 topologies. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
BGP peer scale test that configures multiple bgp peers on same set of neighboring devices.

- In sonic-mgmt, currently all the topologies are built where one VM would only act as a single BGP peer. We don't have any topology with multiple peers between two same devices.
- This test runs on existing t0 or t1 topology (but can potentially work on any topology where we have two devices connected to each other), and configures multiple BGP peers between same two devices using loopback interfaces.
- Since all BGP peers on same VM end up advertising the same prefix (with different nexthop), on the main DUT we have the same default route scale, but we end up with n-way ECMP for those routes, where n is the total number of BGP peer on a neighbor VM.
- Currently testcase just verifies that the BGP peers are established without doing any other testing. This can be extended in future e.g. to do link flap testing for convergence etc.
- The peer count is currently controlled using PEER_PER_DUT constant, currently set to 10, but we can pass any value through cmd line argument `--peers-per-dut`. This means on a virtual t0 testbed with 4 peer duts and main vsonic dut with 8G RAM, we have verified (by passing different values to test) that we were able to successfully sustain 200 BGP peers on the same setup.

```
IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 1823204
RIB entries 12807, using 1639296 bytes of memory
Peers 132, using 2718144 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       4539       4289   1822993      0       0  00:53:46             6402  ARISTA01T1
10.0.0.59      4  64600       8064       7495   1822993      0       0  00:43:02             6402  ARISTA02T1
10.0.0.61      4  64600       4283       4288   1822993      0       0  00:53:52             6402  ARISTA03T1
10.0.0.63      4  64600       4282       4285   1822993      0       0  00:53:52             6402  ARISTA04T1
172.16.1.2     4  64600       3450       3451   1822993      0       0  00:12:17             6400
172.16.2.2     4  64600       3449       3450   1822993      0       0  00:12:13             6400
172.16.3.2     4  64600       3447       3448   1822993      0       0  00:12:07             6400
172.16.4.2     4  64600       3446       3446   1822993      0       0  00:12:03             6400
172.16.5.2     4  64600       3443       3444   1822993      0       0  00:11:55             6400
172.16.6.2     4  64600       3441       3442   1822993      0       0  00:11:50             6400
172.16.7.2     4  64600       3439       3441   1822993      0       0  00:11:45             6400
172.16.8.2     4  64600       3438       3438   1822993      0       0  00:11:40             6400
172.16.9.2     4  64600       3436       3437   1822993      0       0  00:11:33             6400
172.16.10.2    4  64600       3433       3435   1822993      0       0  00:11:26             6400
172.16.11.2    4  64600       3432       3433   1822993      0       0  00:11:21             6400
172.16.12.2    4  64600       3430       3431   1822993      0       0  00:11:16             6400
172.16.13.2    4  64600       3428       3429   1822993      0       0  00:11:10             6400
172.16.14.2    4  64600       3427       3428   1822993      0       0  00:11:06             6400
...
...
172.19.25.2    4  64600       3220       3221   1813736      0       0  00:00:48             6400
172.19.26.2    4  64600       3218       3219   1813736      0       0  00:00:42             6400
172.19.27.2    4  64600       3217       3218   1813736      0       0  00:00:37             6400
172.19.28.2    4  64600       3215       3216   1813736      0       0  00:00:31             6400
172.19.29.2    4  64600       2698       2058   1813736      0       0  00:00:26             5372
172.19.30.2    4  64600       1480       2484   1813736      0       0  00:00:18             2940
172.19.31.2    4  64600        581       2520   1813736      0       0  00:00:11             1148
172.19.32.2    4  64600        132          5         0      0       0  00:00:06              252
172.19.33.2    4  64600          2          2         0      0       0  00:00:01                0

Total number of neighbors 130
admin@vlab-01:~$

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 1824382
RIB entries 12801, using 1638528 bytes of memory
Peers 130, using 2676960 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
fc00:1::2      4  64600       3467       6675   1824382      0       0  00:13:11   6400
fc00:1a::2     4  64600       3415       6622   1824382      0       0  00:10:34   6400
fc00:1b::2     4  64600       3413       6620   1824382      0       0  00:10:29   6400
fc00:1c::2     4  64600       3411       6618   1824382      0       0  00:10:24   6400
fc00:1d::2     4  64600       3409       6616   1824382      0       0  00:10:17   6400
fc00:1e::2     4  64600       3407       6613   1824382      0       0  00:10:10   6400
fc00:1f::2     4  64600       3405       6612   1824382      0       0  00:10:04   6400
fc00:2::2      4  64600       3466       6672   1824382      0       0  00:13:06   6400
fc00:3::2      4  64600       3463       6670   1824382      0       0  00:12:59   6400
fc00:4::2      4  64600       3461       6669   1824382      0       0  00:12:53   6400
...
fc00:313::2    4  64600       3226       3226   1819769      0       0  00:01:04             6400
fc00:314::2    4  64600       3223       3224   1819769      0       0  00:00:56             6400
fc00:315::2    4  64600       3221       3222   1819769      0       0  00:00:50             6400
fc00:316::2    4  64600       3219       3219   1819769      0       0  00:00:44             6400
fc00:317::2    4  64600       3216       3217   1819769      0       0  00:00:36             6400
fc00:318::2    4  64600       3214       3215   1819769      0       0  00:00:29             6400
fc00:319::2    4  64600       2249       3213   1819769      0       0  00:00:23             4478
fc00::7a       4  64600       4745       7953   1819769      0       0  01:17:06             6400  ARISTA03T1
fc00::7e       4  64600       4747       7953   1819769      0       0  01:17:06             6400  ARISTA04T1
fc00::72       4  64600       8207       7956   1819769      0       0  00:01:17             6402  ARISTA01T1
fc00::76       4  64600       5132       7956   1819769      0       0  01:17:00             6402  ARISTA02T1
fc00:a::2      4  64600       3446       6653   1819769      0       0  00:12:09             6400
fc00:b::2      4  64600       3444       6651   1819769      0       0  00:12:02             6400
fc00:c::2      4  64600       3442       6649   1819769      0       0  00:11:55             6400
fc00:d::2      4  64600       3440       6647   1819769      0       0  00:11:50             6400
fc00:e::2      4  64600       3438       6645   1819769      0       0  00:11:44             6400
fc00:f::2      4  64600       3436       6643   1819769      0       0  00:11:36             6400

Total number of neighbors 128
admin@vlab-01:~$
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
```
azureuser@sonic-mgmt-vm:/data/sonic-mgmt/tests$ ./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c bgp/test_bgp_peer_scale.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--neighbor_type=sonic" -u run
=== Running tests in groups ===
Running: python3 -m pytest bgp/test_bgp_peer_scale.py --inventory ../ansible/veos_vtb --host-pattern vlab-01 --dpu-pattern None --testbed vms-kvm-t0 --testbed_file vtestbed.yaml --log-cli-level warning --log-file-level debug --kube_master unset --showlocals --assert plain --show-capture no -rav --allow_recover --ignore=ptftests --ignore=acstests --ignore=saitests --ignore=scripts --ignore=k8s --ignore=sai_qualify --junit-xml=logs/tr.xml --log-file=logs/test.log --neighbor_type=sonic
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /data/sonic-mgmt/tests
configfile: pytest.ini
plugins: stress-1.0.1, allure-pytest-2.8.22, html-4.1.1, repeat-0.9.3, ansible-4.0.0, forked-1.6.0, xdist-1.28.0, metadata-3.1.1
collecting ...
----------------------------------------------------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------------------------------------------------
20:57:55 testbed.get_testbed_type                 L0263 WARNING| Unsupported testbed type - force10-7nodes
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
collecting 0 items                                                                                                                                                                                                                                                             20:58:06 testbed.get_testbed_type                 L0263 WARNING| Unsupported testbed type - force10-7nodes
collected 2 items

bgp/test_bgp_peer_scale.py::test_bgp_peer_scale_v4[vlab-01] PASSED                                                                                                                                                                                                       [ 50%]
bgp/test_bgp_peer_scale.py::test_bgp_peer_scale_v6[vlab-01] PASSED                                                                                                                                                                                                       [100%]

=============================================================================================================================== warnings summary ===============================================================================================================================
../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

common/plugins/loganalyzer/system_msg_handler.py:1
  /data/sonic-mgmt/tests/common/plugins/loganalyzer/system_msg_handler.py:1: DeprecationWarning: invalid escape sequence \
    '''

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------------------------------------------------------------------------------------ generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ------------------------------------------------------------------------------------------------------------
================================================================================================================== 2 passed, 2 warnings in 3087.39s (0:51:27) ==================================================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_bgp_peer_scale_v6[vlab-01]>
INFO:root:Can not get Allure report URL. Please check logs
azureuser@sonic-mgmt-vm:/data/sonic-mgmt/tests$
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
