### PR TITLE
Add certain error signatures to loganalyzer ignore list

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -342,3 +342,6 @@ r, ".* ERR swss#orchagent:.*queryAttributeEnumValuesCapability:.*returned value 
 
 # https://github.com/sonic-net/sonic-buildimage/issues/22346
 r, ".* ERR hostcfgd: \['sonic-kdump-config'[^]]*\] - failed.*"
+
+# https://github.com/sonic-net/sonic-buildimage/issues/22348
+r, ".* ERR pmon#chassis_db_init: Failed to load chassis due to ModuleNotFoundError.*"

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -339,3 +339,6 @@ r, ".*ERR swss\d*#orchagent:.*handlePortStatusChangeNotification: Failed to get 
 
 # Ignore SAI_NEXT_HOP_GROUP_ATTR_TYPE unsupported
 r, ".* ERR swss#orchagent:.*queryAttributeEnumValuesCapability:.*returned value \d+ is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE"
+
+# https://github.com/sonic-net/sonic-buildimage/issues/22346
+r, ".* ERR hostcfgd: \['sonic-kdump-config'[^]]*\] - failed.*"


### PR DESCRIPTION
 * These errors are temporarily ignored until the issues referenced below are fixed: 
    https://github.com/sonic-net/sonic-buildimage/issues/22346
    https://github.com/sonic-net/sonic-buildimage/issues/22348

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The PR ignores the following errors seen on kvm test runs on master branch:

E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost vlab-01>" exit code:"1"
E               match: 7
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2025 Apr 16 19:34:25.031707 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--disable'] - failed: return code - 1, output:#012None
E               
E               2025 Apr 16 19:34:25.714266 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M'] - failed: return code - 1, output:#012None
E               
E               2025 Apr 16 19:34:26.830424 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--num_dumps', '3'] - failed: return code - 1, output:#012None
E               
E               2025 Apr 16 19:34:27.988539 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--remote', 'false'] - failed: return code - 2, output:#012None
E               
E               2025 Apr 16 19:34:29.771931 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--ssh_string', 'user@localhost'] - failed: return code - 1, output:#012None
E               
E               2025 Apr 16 19:34:30.948038 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--ssh_path', '/a/b/c'] - failed: return code - 1, output:#012None
E               
E               2025 Apr 16 19:34:59.698716 vlab-01 ERR pmon#chassis_db_init: Failed to load chassis due to ModuleNotFoundError("No module named 'sonic_platform'")

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
To unblock features/PRs blocked by these errors

#### How did you do it?
By adding the error regex to loganalyzer ignore list.

#### How did you verify/test it?
By running the relevant tests on kvm testbeds

#### Any platform specific information?
kvm

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
