### PR TITLE
Snappi: Add the correct queue to select for test_snappi

### DIFF
--- a/tests/snappi_tests/test_snappi.py
+++ b/tests/snappi_tests/test_snappi.py
@@ -9,6 +9,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa F401
+from tests.common.snappi_tests.variables import pfcQueueValueDict
 
 SNAPPI_POLL_DELAY_SEC = 2
 
@@ -60,7 +61,7 @@ def __gen_all_to_all_traffic(testbed_config,
             eth, ipv4 = flow.packet.ethernet().ipv4()
             eth.src.value = tx_mac
             eth.dst.value = rx_mac
-            eth.pfc_queue.value = priority
+            eth.pfc_queue.value = pfcQueueValueDict[priority]
 
             ipv4.src.value = tx_port_config.ip
             ipv4.dst.value = rx_port_config.ip


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
tests/snappi_tests/test_snappi.py is failing when we use the non-default queue mapping in variables.py. This is because it uses the priority as the queue id.
In this PR we change the code to use the correct queue_id from the variables.py.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
The failure of test_snappi.py for non default queue mapping.

#### How did you do it?
Pls see description.

#### How did you verify/test it?
Ran it in T2 testbed:
