### PR TITLE
Fix incompatible import of scapy and skip when no lldp neigh in test_srv6_dataplane.py

### DIFF
--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -3,10 +3,10 @@ import time
 import random
 import logging
 import string
-import scapy
 from scapy.all import Raw
 from scapy.layers.inet6 import IPv6, UDP
 from scapy.layers.l2 import Ether
+import ptf.packet as scapy
 import ptf.testutils as testutils
 from ptf.testutils import simple_ipv6_sr_packet, send_packet, verify_no_packet_any
 from ptf.mask import Mask
@@ -41,8 +41,7 @@ def get_ptf_src_port_and_dut_port_and_neighbor(dut, tbinfo):
         if intf in ports_map:
             return intf, ports_map[intf], entry[1]  # local intf, ptf_src_port, neighbor hostname
 
-    dut_port, ptf_src_port = random.choice(ports_map)
-    return dut_port, ptf_src_port, None
+    pytest.skip("No active LLDP neighbor found for {}".format(dut))
 
 
 def run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Previously I changed the import of scapy from ptf.packet to direct import, that broke the scapy header classes reference in the TestSRv6Base. Besides, when there is no LLDP neighbors, we should directly skip the test script.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
