### PR TITLE
Increase KVM testbed memory from 4G to 6G

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -29,17 +29,9 @@
     <model fallback='forbid'/>
     <topology sockets='1' dies='1' cores='5' threads='2'/>
   </cpu>
-{% elif "dualtor" in topo %}
+{% else %}
   <memory unit='GiB'>6</memory>
   <currentMemory unit='GiB'>6</currentMemory>
-  <vcpu placement='static'>4</vcpu>
-  <cpu mode='host-model'>
-    <model fallback='forbid'/>
-    <topology sockets='1' dies='1' cores='2' threads='2'/>
-  </cpu>
-{% else %}
-  <memory unit='GiB'>4</memory>
-  <currentMemory unit='GiB'>4</currentMemory>
   <vcpu placement='static'>4</vcpu>
   <cpu mode='host-model'>
     <model fallback='forbid'/>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
KVM testbed have a chance to fail for memory exhaustion:
```
>       pytest.fail(message)
E       Failed: [ALARM]: monit:memory_usage, Previous memory usage 90.2 exceeds high threshold 90.0
```
#### How did you do it?
Increase KVM testbed memory from 4G to 6G
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
