### PR TITLE
Force eos default creds to be string

### DIFF
--- a/ansible/group_vars/all/creds.yml
+++ b/ansible/group_vars/all/creds.yml
@@ -1,9 +1,9 @@
 eos_default_login: "admin"
 eos_default_password: ""
 eos_login: admin
-eos_password: 123456
+eos_password: "123456"
 eos_root_user: root
-eos_root_password: 123456
+eos_root_password: "123456"
 
 junos_default_login: "root"
 junos_default_password:  ""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The eos default cred is all digits. It may be interpreted as an integer and raise below error during tests:
```
  File "/var/src/sonic-mgmt/tests/common/devices/eos.py", line 85, in shutdown
    out = self.eos_config(
  File "/var/src/sonic-mgmt/tests/common/devices/base.py", line 131, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
tests.common.errors.RunAnsibleModuleFail: run module eos_config failed, Ansible Results =>
failed = True
module_stdout = 
module_stderr = Expected unicode or bytes, got 123456
msg = MODULE FAILURE
See stdout/stderr for the exact error
_ansible_no_log = None
changed = False
stdout =
stderr =
```
#### How did you do it?
Add quote to the all digits default cred to force string type.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
