### PR TITLE
[M1] Update everflow testcase to support M1 topo

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -354,11 +354,11 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     """
     duthost = None
     topo = tbinfo['topo']['name']
-    if 't1' in topo or 't0' in topo or 'm0' in topo or 'mx' in topo or 'dualtor' in topo:
-        downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
-    elif 't2' in topo:
+    if 't2' in topo:
         pytest_assert(len(duthosts) > 1, "Test must run on whole chassis")
         downstream_duthost, upstream_duthost = get_t2_duthost(duthosts, tbinfo)
+    else:
+        downstream_duthost = upstream_duthost = duthost = duthosts[rand_one_dut_hostname]
 
     setup_information = gen_setup_information(duthost, downstream_duthost, upstream_duthost, tbinfo, topo_scenario)
 

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -44,6 +44,8 @@ def build_candidate_ports(duthost, tbinfo, ns):
         candidate_neigh_name = 'MX'
     elif tbinfo['topo']['type'] == 't1':
         candidate_neigh_name = 'T0'
+    elif tbinfo['topo']['type'] == 'm1':
+        candidate_neigh_name = 'M0'
     else:
         candidate_neigh_name = 'T1'
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update everflow testcase to support M1 topo

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Update everflow testcase to support M1 topo

#### How did you do it?
Update common functions

#### How did you verify/test it?
Verified by run everflow testcases on Arista-7050CX3 M1-48 testbed.

```
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[erspan_ipv4-cli-downstream-default] PASSED [  1%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[erspan_ipv4-cli-downstream-default] PASSED [  2%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_unused_ecmp_next_hop[erspan_ipv4-cli-downstream-default] PASSED [  3%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_remove_used_ecmp_next_hop[erspan_ipv4-cli-downstream-default] PASSED [  4%]
everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default] PASSED [  5%]
...
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_src_ipv6_mirroring[erspan_ipv4-cli-default] PASSED         [  2%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_dst_ipv6_mirroring[erspan_ipv4-cli-default] PASSED         [  5%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_next_header_mirroring[erspan_ipv4-cli-default] PASSED      [  7%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_src_port_mirroring[erspan_ipv4-cli-default] PASSED      [ 10%]
everflow/test_everflow_ipv6.py::TestIngressEverflowIPv6::test_l4_dst_port_mirroring[erspan_ipv4-cli-default] PASSED      [ 12%]
...
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv4-default] PASSED                    [ 12%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv4-default] PASSED                    [ 25%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv4-default] PASSED                    [ 37%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv4-default] PASSED                    [ 50%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv6-default] PASSED                    [ 62%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv6-default] PASSED                    [ 75%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv6-default] PASSED                    [ 87%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv6-default] PASSED                    [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
