### PR TITLE
Fix t0-isolated-v6 topo errors

### DIFF
--- a/ansible/roles/eos/templates/t0-isolated-v6-d128u128s1-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d128u128s1-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-isolated-v6-d128u128s2-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d128u128s2-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-isolated-v6-d16u16s1-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d16u16s1-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-isolated-v6-d16u16s2-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d16u16s2-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-isolated-v6-d256u256s2-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d256u256s2-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-isolated-v6-d32u32s2-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d32u32s2-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-isolated-v6-d96u32s2-leaf.j2
+++ b/ansible/roles/eos/templates/t0-isolated-v6-d96u32s2-leaf.j2
@@ -1,1 +1,1 @@
-t0-leaf.j2
+t0-v6-leaf.j2

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -113,8 +113,10 @@ router bgp {{ host['bgp']['asn'] }}
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% if props.nhipv4 is defined %}
  neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv4 }} description exabgp_v4
+{% endif %}
  neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
  neighbor {{ props.nhipv6 }} description exabgp_v6
  address-family ipv6

--- a/ansible/roles/eos/templates/t0-v6-leaf.j2
+++ b/ansible/roles/eos/templates/t0-v6-leaf.j2
@@ -1,0 +1,138 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ mtu 9214
+ no switchport
+ no shutdown
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['bgp']['router-id'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/templates/topo_t0-isolated-v6.j2
+++ b/ansible/templates/topo_t0-isolated-v6.j2
@@ -43,6 +43,9 @@ configuration_properties:
     tor_asn_start: 4200000000
     failure_rate: 0
     nhipv6: FC0A::FF
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
+    enable_ipv4_routes_generation: false
+    enable_ipv6_routes_generation: true
 
 configuration:
 {%- for vm in vm_list %}
@@ -50,7 +53,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: {{vm.loopback_ipv4}}
+      router-id: {{vm.loopback_ipv4}}
       asn: {{vm.asn_v6}}
       peers:
         {{vm.peer_asn_v6}}:

--- a/ansible/templates/topo_t1-isolated-v6.j2
+++ b/ansible/templates/topo_t1-isolated-v6.j2
@@ -17,7 +17,7 @@ configuration_properties:
     max_tor_subnet_number: 16
     tor_subnet_size: 128
     nhipv6: FC0A::FF
-    ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
   spine:

--- a/ansible/vars/topo_t0-isolated-v6-d16u16s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d16u16s2.yml
@@ -146,13 +146,16 @@ configuration_properties:
     tor_asn_start: 4200000000
     failure_rate: 0
     nhipv6: FC0A::FF
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
+    enable_ipv4_routes_generation: false
+    enable_ipv6_routes_generation: true
 
 configuration:
   ARISTA01T1:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.33
+      router-id: 100.1.0.33
       asn: 4200100000
       peers:
         4200000000:
@@ -168,7 +171,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.41
+      router-id: 100.1.0.41
       asn: 4200100000
       peers:
         4200000000:
@@ -184,7 +187,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.49
+      router-id: 100.1.0.49
       asn: 4200100000
       peers:
         4200000000:
@@ -200,7 +203,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.57
+      router-id: 100.1.0.57
       asn: 4200100000
       peers:
         4200000000:
@@ -216,7 +219,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.65
+      router-id: 100.1.0.65
       asn: 4200100000
       peers:
         4200000000:
@@ -232,7 +235,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.73
+      router-id: 100.1.0.73
       asn: 4200100000
       peers:
         4200000000:
@@ -248,7 +251,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.81
+      router-id: 100.1.0.81
       asn: 4200100000
       peers:
         4200000000:
@@ -264,7 +267,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.89
+      router-id: 100.1.0.89
       asn: 4200100000
       peers:
         4200000000:
@@ -280,7 +283,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.161
+      router-id: 100.1.0.161
       asn: 4200100000
       peers:
         4200000000:
@@ -296,7 +299,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.169
+      router-id: 100.1.0.169
       asn: 4200100000
       peers:
         4200000000:
@@ -312,7 +315,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.177
+      router-id: 100.1.0.177
       asn: 4200100000
       peers:
         4200000000:
@@ -328,7 +331,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.185
+      router-id: 100.1.0.185
       asn: 4200100000
       peers:
         4200000000:
@@ -344,7 +347,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.193
+      router-id: 100.1.0.193
       asn: 4200100000
       peers:
         4200000000:
@@ -360,7 +363,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.201
+      router-id: 100.1.0.201
       asn: 4200100000
       peers:
         4200000000:
@@ -376,7 +379,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.209
+      router-id: 100.1.0.209
       asn: 4200100000
       peers:
         4200000000:
@@ -392,7 +395,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.217
+      router-id: 100.1.0.217
       asn: 4200100000
       peers:
         4200000000:
@@ -408,7 +411,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.1
+      router-id: 100.1.1.1
       asn: 4200000000
       peers:
         4200000000:
@@ -424,7 +427,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.2
+      router-id: 100.1.1.2
       asn: 4200000000
       peers:
         4200000000:

--- a/ansible/vars/topo_t0-isolated-v6-d256u256s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d256u256s2.yml
@@ -1346,13 +1346,16 @@ configuration_properties:
     tor_asn_start: 4200000000
     failure_rate: 0
     nhipv6: FC0A::FF
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
+    enable_ipv4_routes_generation: false
+    enable_ipv6_routes_generation: true
 
 configuration:
   ARISTA01T1:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.65
+      router-id: 100.1.0.65
       asn: 4200100000
       peers:
         4200000000:
@@ -1368,7 +1371,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.66
+      router-id: 100.1.0.66
       asn: 4200100000
       peers:
         4200000000:
@@ -1384,7 +1387,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.67
+      router-id: 100.1.0.67
       asn: 4200100000
       peers:
         4200000000:
@@ -1400,7 +1403,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.68
+      router-id: 100.1.0.68
       asn: 4200100000
       peers:
         4200000000:
@@ -1416,7 +1419,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.69
+      router-id: 100.1.0.69
       asn: 4200100000
       peers:
         4200000000:
@@ -1432,7 +1435,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.70
+      router-id: 100.1.0.70
       asn: 4200100000
       peers:
         4200000000:
@@ -1448,7 +1451,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.71
+      router-id: 100.1.0.71
       asn: 4200100000
       peers:
         4200000000:
@@ -1464,7 +1467,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.72
+      router-id: 100.1.0.72
       asn: 4200100000
       peers:
         4200000000:
@@ -1480,7 +1483,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.73
+      router-id: 100.1.0.73
       asn: 4200100000
       peers:
         4200000000:
@@ -1496,7 +1499,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.74
+      router-id: 100.1.0.74
       asn: 4200100000
       peers:
         4200000000:
@@ -1512,7 +1515,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.75
+      router-id: 100.1.0.75
       asn: 4200100000
       peers:
         4200000000:
@@ -1528,7 +1531,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.76
+      router-id: 100.1.0.76
       asn: 4200100000
       peers:
         4200000000:
@@ -1544,7 +1547,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.77
+      router-id: 100.1.0.77
       asn: 4200100000
       peers:
         4200000000:
@@ -1560,7 +1563,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.78
+      router-id: 100.1.0.78
       asn: 4200100000
       peers:
         4200000000:
@@ -1576,7 +1579,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.79
+      router-id: 100.1.0.79
       asn: 4200100000
       peers:
         4200000000:
@@ -1592,7 +1595,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.80
+      router-id: 100.1.0.80
       asn: 4200100000
       peers:
         4200000000:
@@ -1608,7 +1611,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.81
+      router-id: 100.1.0.81
       asn: 4200100000
       peers:
         4200000000:
@@ -1624,7 +1627,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.82
+      router-id: 100.1.0.82
       asn: 4200100000
       peers:
         4200000000:
@@ -1640,7 +1643,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.83
+      router-id: 100.1.0.83
       asn: 4200100000
       peers:
         4200000000:
@@ -1656,7 +1659,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.84
+      router-id: 100.1.0.84
       asn: 4200100000
       peers:
         4200000000:
@@ -1672,7 +1675,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.85
+      router-id: 100.1.0.85
       asn: 4200100000
       peers:
         4200000000:
@@ -1688,7 +1691,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.86
+      router-id: 100.1.0.86
       asn: 4200100000
       peers:
         4200000000:
@@ -1704,7 +1707,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.87
+      router-id: 100.1.0.87
       asn: 4200100000
       peers:
         4200000000:
@@ -1720,7 +1723,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.88
+      router-id: 100.1.0.88
       asn: 4200100000
       peers:
         4200000000:
@@ -1736,7 +1739,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.89
+      router-id: 100.1.0.89
       asn: 4200100000
       peers:
         4200000000:
@@ -1752,7 +1755,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.90
+      router-id: 100.1.0.90
       asn: 4200100000
       peers:
         4200000000:
@@ -1768,7 +1771,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.91
+      router-id: 100.1.0.91
       asn: 4200100000
       peers:
         4200000000:
@@ -1784,7 +1787,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.92
+      router-id: 100.1.0.92
       asn: 4200100000
       peers:
         4200000000:
@@ -1800,7 +1803,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.93
+      router-id: 100.1.0.93
       asn: 4200100000
       peers:
         4200000000:
@@ -1816,7 +1819,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.94
+      router-id: 100.1.0.94
       asn: 4200100000
       peers:
         4200000000:
@@ -1832,7 +1835,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.95
+      router-id: 100.1.0.95
       asn: 4200100000
       peers:
         4200000000:
@@ -1848,7 +1851,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.96
+      router-id: 100.1.0.96
       asn: 4200100000
       peers:
         4200000000:
@@ -1864,7 +1867,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.97
+      router-id: 100.1.0.97
       asn: 4200100000
       peers:
         4200000000:
@@ -1880,7 +1883,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.98
+      router-id: 100.1.0.98
       asn: 4200100000
       peers:
         4200000000:
@@ -1896,7 +1899,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.99
+      router-id: 100.1.0.99
       asn: 4200100000
       peers:
         4200000000:
@@ -1912,7 +1915,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.100
+      router-id: 100.1.0.100
       asn: 4200100000
       peers:
         4200000000:
@@ -1928,7 +1931,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.101
+      router-id: 100.1.0.101
       asn: 4200100000
       peers:
         4200000000:
@@ -1944,7 +1947,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.102
+      router-id: 100.1.0.102
       asn: 4200100000
       peers:
         4200000000:
@@ -1960,7 +1963,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.103
+      router-id: 100.1.0.103
       asn: 4200100000
       peers:
         4200000000:
@@ -1976,7 +1979,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.104
+      router-id: 100.1.0.104
       asn: 4200100000
       peers:
         4200000000:
@@ -1992,7 +1995,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.105
+      router-id: 100.1.0.105
       asn: 4200100000
       peers:
         4200000000:
@@ -2008,7 +2011,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.106
+      router-id: 100.1.0.106
       asn: 4200100000
       peers:
         4200000000:
@@ -2024,7 +2027,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.107
+      router-id: 100.1.0.107
       asn: 4200100000
       peers:
         4200000000:
@@ -2040,7 +2043,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.108
+      router-id: 100.1.0.108
       asn: 4200100000
       peers:
         4200000000:
@@ -2056,7 +2059,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.109
+      router-id: 100.1.0.109
       asn: 4200100000
       peers:
         4200000000:
@@ -2072,7 +2075,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.110
+      router-id: 100.1.0.110
       asn: 4200100000
       peers:
         4200000000:
@@ -2088,7 +2091,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.111
+      router-id: 100.1.0.111
       asn: 4200100000
       peers:
         4200000000:
@@ -2104,7 +2107,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.112
+      router-id: 100.1.0.112
       asn: 4200100000
       peers:
         4200000000:
@@ -2120,7 +2123,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.113
+      router-id: 100.1.0.113
       asn: 4200100000
       peers:
         4200000000:
@@ -2136,7 +2139,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.114
+      router-id: 100.1.0.114
       asn: 4200100000
       peers:
         4200000000:
@@ -2152,7 +2155,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.115
+      router-id: 100.1.0.115
       asn: 4200100000
       peers:
         4200000000:
@@ -2168,7 +2171,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.116
+      router-id: 100.1.0.116
       asn: 4200100000
       peers:
         4200000000:
@@ -2184,7 +2187,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.117
+      router-id: 100.1.0.117
       asn: 4200100000
       peers:
         4200000000:
@@ -2200,7 +2203,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.118
+      router-id: 100.1.0.118
       asn: 4200100000
       peers:
         4200000000:
@@ -2216,7 +2219,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.119
+      router-id: 100.1.0.119
       asn: 4200100000
       peers:
         4200000000:
@@ -2232,7 +2235,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.120
+      router-id: 100.1.0.120
       asn: 4200100000
       peers:
         4200000000:
@@ -2248,7 +2251,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.121
+      router-id: 100.1.0.121
       asn: 4200100000
       peers:
         4200000000:
@@ -2264,7 +2267,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.122
+      router-id: 100.1.0.122
       asn: 4200100000
       peers:
         4200000000:
@@ -2280,7 +2283,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.123
+      router-id: 100.1.0.123
       asn: 4200100000
       peers:
         4200000000:
@@ -2296,7 +2299,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.124
+      router-id: 100.1.0.124
       asn: 4200100000
       peers:
         4200000000:
@@ -2312,7 +2315,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.125
+      router-id: 100.1.0.125
       asn: 4200100000
       peers:
         4200000000:
@@ -2328,7 +2331,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.126
+      router-id: 100.1.0.126
       asn: 4200100000
       peers:
         4200000000:
@@ -2344,7 +2347,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.127
+      router-id: 100.1.0.127
       asn: 4200100000
       peers:
         4200000000:
@@ -2360,7 +2363,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.128
+      router-id: 100.1.0.128
       asn: 4200100000
       peers:
         4200000000:
@@ -2376,7 +2379,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.129
+      router-id: 100.1.0.129
       asn: 4200100000
       peers:
         4200000000:
@@ -2392,7 +2395,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.130
+      router-id: 100.1.0.130
       asn: 4200100000
       peers:
         4200000000:
@@ -2408,7 +2411,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.131
+      router-id: 100.1.0.131
       asn: 4200100000
       peers:
         4200000000:
@@ -2424,7 +2427,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.132
+      router-id: 100.1.0.132
       asn: 4200100000
       peers:
         4200000000:
@@ -2440,7 +2443,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.133
+      router-id: 100.1.0.133
       asn: 4200100000
       peers:
         4200000000:
@@ -2456,7 +2459,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.134
+      router-id: 100.1.0.134
       asn: 4200100000
       peers:
         4200000000:
@@ -2472,7 +2475,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.135
+      router-id: 100.1.0.135
       asn: 4200100000
       peers:
         4200000000:
@@ -2488,7 +2491,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.136
+      router-id: 100.1.0.136
       asn: 4200100000
       peers:
         4200000000:
@@ -2504,7 +2507,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.137
+      router-id: 100.1.0.137
       asn: 4200100000
       peers:
         4200000000:
@@ -2520,7 +2523,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.138
+      router-id: 100.1.0.138
       asn: 4200100000
       peers:
         4200000000:
@@ -2536,7 +2539,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.139
+      router-id: 100.1.0.139
       asn: 4200100000
       peers:
         4200000000:
@@ -2552,7 +2555,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.140
+      router-id: 100.1.0.140
       asn: 4200100000
       peers:
         4200000000:
@@ -2568,7 +2571,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.141
+      router-id: 100.1.0.141
       asn: 4200100000
       peers:
         4200000000:
@@ -2584,7 +2587,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.142
+      router-id: 100.1.0.142
       asn: 4200100000
       peers:
         4200000000:
@@ -2600,7 +2603,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.143
+      router-id: 100.1.0.143
       asn: 4200100000
       peers:
         4200000000:
@@ -2616,7 +2619,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.144
+      router-id: 100.1.0.144
       asn: 4200100000
       peers:
         4200000000:
@@ -2632,7 +2635,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.145
+      router-id: 100.1.0.145
       asn: 4200100000
       peers:
         4200000000:
@@ -2648,7 +2651,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.146
+      router-id: 100.1.0.146
       asn: 4200100000
       peers:
         4200000000:
@@ -2664,7 +2667,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.147
+      router-id: 100.1.0.147
       asn: 4200100000
       peers:
         4200000000:
@@ -2680,7 +2683,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.148
+      router-id: 100.1.0.148
       asn: 4200100000
       peers:
         4200000000:
@@ -2696,7 +2699,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.149
+      router-id: 100.1.0.149
       asn: 4200100000
       peers:
         4200000000:
@@ -2712,7 +2715,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.150
+      router-id: 100.1.0.150
       asn: 4200100000
       peers:
         4200000000:
@@ -2728,7 +2731,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.151
+      router-id: 100.1.0.151
       asn: 4200100000
       peers:
         4200000000:
@@ -2744,7 +2747,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.152
+      router-id: 100.1.0.152
       asn: 4200100000
       peers:
         4200000000:
@@ -2760,7 +2763,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.153
+      router-id: 100.1.0.153
       asn: 4200100000
       peers:
         4200000000:
@@ -2776,7 +2779,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.154
+      router-id: 100.1.0.154
       asn: 4200100000
       peers:
         4200000000:
@@ -2792,7 +2795,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.155
+      router-id: 100.1.0.155
       asn: 4200100000
       peers:
         4200000000:
@@ -2808,7 +2811,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.156
+      router-id: 100.1.0.156
       asn: 4200100000
       peers:
         4200000000:
@@ -2824,7 +2827,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.157
+      router-id: 100.1.0.157
       asn: 4200100000
       peers:
         4200000000:
@@ -2840,7 +2843,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.158
+      router-id: 100.1.0.158
       asn: 4200100000
       peers:
         4200000000:
@@ -2856,7 +2859,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.159
+      router-id: 100.1.0.159
       asn: 4200100000
       peers:
         4200000000:
@@ -2872,7 +2875,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.160
+      router-id: 100.1.0.160
       asn: 4200100000
       peers:
         4200000000:
@@ -2888,7 +2891,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.161
+      router-id: 100.1.0.161
       asn: 4200100000
       peers:
         4200000000:
@@ -2904,7 +2907,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.162
+      router-id: 100.1.0.162
       asn: 4200100000
       peers:
         4200000000:
@@ -2920,7 +2923,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.163
+      router-id: 100.1.0.163
       asn: 4200100000
       peers:
         4200000000:
@@ -2936,7 +2939,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.164
+      router-id: 100.1.0.164
       asn: 4200100000
       peers:
         4200000000:
@@ -2952,7 +2955,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.165
+      router-id: 100.1.0.165
       asn: 4200100000
       peers:
         4200000000:
@@ -2968,7 +2971,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.166
+      router-id: 100.1.0.166
       asn: 4200100000
       peers:
         4200000000:
@@ -2984,7 +2987,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.167
+      router-id: 100.1.0.167
       asn: 4200100000
       peers:
         4200000000:
@@ -3000,7 +3003,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.168
+      router-id: 100.1.0.168
       asn: 4200100000
       peers:
         4200000000:
@@ -3016,7 +3019,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.169
+      router-id: 100.1.0.169
       asn: 4200100000
       peers:
         4200000000:
@@ -3032,7 +3035,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.170
+      router-id: 100.1.0.170
       asn: 4200100000
       peers:
         4200000000:
@@ -3048,7 +3051,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.171
+      router-id: 100.1.0.171
       asn: 4200100000
       peers:
         4200000000:
@@ -3064,7 +3067,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.172
+      router-id: 100.1.0.172
       asn: 4200100000
       peers:
         4200000000:
@@ -3080,7 +3083,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.173
+      router-id: 100.1.0.173
       asn: 4200100000
       peers:
         4200000000:
@@ -3096,7 +3099,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.174
+      router-id: 100.1.0.174
       asn: 4200100000
       peers:
         4200000000:
@@ -3112,7 +3115,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.175
+      router-id: 100.1.0.175
       asn: 4200100000
       peers:
         4200000000:
@@ -3128,7 +3131,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.176
+      router-id: 100.1.0.176
       asn: 4200100000
       peers:
         4200000000:
@@ -3144,7 +3147,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.177
+      router-id: 100.1.0.177
       asn: 4200100000
       peers:
         4200000000:
@@ -3160,7 +3163,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.178
+      router-id: 100.1.0.178
       asn: 4200100000
       peers:
         4200000000:
@@ -3176,7 +3179,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.179
+      router-id: 100.1.0.179
       asn: 4200100000
       peers:
         4200000000:
@@ -3192,7 +3195,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.180
+      router-id: 100.1.0.180
       asn: 4200100000
       peers:
         4200000000:
@@ -3208,7 +3211,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.181
+      router-id: 100.1.0.181
       asn: 4200100000
       peers:
         4200000000:
@@ -3224,7 +3227,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.182
+      router-id: 100.1.0.182
       asn: 4200100000
       peers:
         4200000000:
@@ -3240,7 +3243,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.183
+      router-id: 100.1.0.183
       asn: 4200100000
       peers:
         4200000000:
@@ -3256,7 +3259,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.184
+      router-id: 100.1.0.184
       asn: 4200100000
       peers:
         4200000000:
@@ -3272,7 +3275,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.185
+      router-id: 100.1.0.185
       asn: 4200100000
       peers:
         4200000000:
@@ -3288,7 +3291,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.186
+      router-id: 100.1.0.186
       asn: 4200100000
       peers:
         4200000000:
@@ -3304,7 +3307,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.187
+      router-id: 100.1.0.187
       asn: 4200100000
       peers:
         4200000000:
@@ -3320,7 +3323,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.188
+      router-id: 100.1.0.188
       asn: 4200100000
       peers:
         4200000000:
@@ -3336,7 +3339,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.189
+      router-id: 100.1.0.189
       asn: 4200100000
       peers:
         4200000000:
@@ -3352,7 +3355,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.190
+      router-id: 100.1.0.190
       asn: 4200100000
       peers:
         4200000000:
@@ -3368,7 +3371,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.191
+      router-id: 100.1.0.191
       asn: 4200100000
       peers:
         4200000000:
@@ -3384,7 +3387,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.192
+      router-id: 100.1.0.192
       asn: 4200100000
       peers:
         4200000000:
@@ -3400,7 +3403,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.65
+      router-id: 100.1.1.65
       asn: 4200100000
       peers:
         4200000000:
@@ -3416,7 +3419,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.66
+      router-id: 100.1.1.66
       asn: 4200100000
       peers:
         4200000000:
@@ -3432,7 +3435,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.67
+      router-id: 100.1.1.67
       asn: 4200100000
       peers:
         4200000000:
@@ -3448,7 +3451,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.68
+      router-id: 100.1.1.68
       asn: 4200100000
       peers:
         4200000000:
@@ -3464,7 +3467,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.69
+      router-id: 100.1.1.69
       asn: 4200100000
       peers:
         4200000000:
@@ -3480,7 +3483,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.70
+      router-id: 100.1.1.70
       asn: 4200100000
       peers:
         4200000000:
@@ -3496,7 +3499,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.71
+      router-id: 100.1.1.71
       asn: 4200100000
       peers:
         4200000000:
@@ -3512,7 +3515,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.72
+      router-id: 100.1.1.72
       asn: 4200100000
       peers:
         4200000000:
@@ -3528,7 +3531,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.73
+      router-id: 100.1.1.73
       asn: 4200100000
       peers:
         4200000000:
@@ -3544,7 +3547,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.74
+      router-id: 100.1.1.74
       asn: 4200100000
       peers:
         4200000000:
@@ -3560,7 +3563,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.75
+      router-id: 100.1.1.75
       asn: 4200100000
       peers:
         4200000000:
@@ -3576,7 +3579,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.76
+      router-id: 100.1.1.76
       asn: 4200100000
       peers:
         4200000000:
@@ -3592,7 +3595,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.77
+      router-id: 100.1.1.77
       asn: 4200100000
       peers:
         4200000000:
@@ -3608,7 +3611,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.78
+      router-id: 100.1.1.78
       asn: 4200100000
       peers:
         4200000000:
@@ -3624,7 +3627,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.79
+      router-id: 100.1.1.79
       asn: 4200100000
       peers:
         4200000000:
@@ -3640,7 +3643,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.80
+      router-id: 100.1.1.80
       asn: 4200100000
       peers:
         4200000000:
@@ -3656,7 +3659,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.81
+      router-id: 100.1.1.81
       asn: 4200100000
       peers:
         4200000000:
@@ -3672,7 +3675,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.82
+      router-id: 100.1.1.82
       asn: 4200100000
       peers:
         4200000000:
@@ -3688,7 +3691,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.83
+      router-id: 100.1.1.83
       asn: 4200100000
       peers:
         4200000000:
@@ -3704,7 +3707,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.84
+      router-id: 100.1.1.84
       asn: 4200100000
       peers:
         4200000000:
@@ -3720,7 +3723,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.85
+      router-id: 100.1.1.85
       asn: 4200100000
       peers:
         4200000000:
@@ -3736,7 +3739,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.86
+      router-id: 100.1.1.86
       asn: 4200100000
       peers:
         4200000000:
@@ -3752,7 +3755,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.87
+      router-id: 100.1.1.87
       asn: 4200100000
       peers:
         4200000000:
@@ -3768,7 +3771,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.88
+      router-id: 100.1.1.88
       asn: 4200100000
       peers:
         4200000000:
@@ -3784,7 +3787,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.89
+      router-id: 100.1.1.89
       asn: 4200100000
       peers:
         4200000000:
@@ -3800,7 +3803,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.90
+      router-id: 100.1.1.90
       asn: 4200100000
       peers:
         4200000000:
@@ -3816,7 +3819,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.91
+      router-id: 100.1.1.91
       asn: 4200100000
       peers:
         4200000000:
@@ -3832,7 +3835,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.92
+      router-id: 100.1.1.92
       asn: 4200100000
       peers:
         4200000000:
@@ -3848,7 +3851,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.93
+      router-id: 100.1.1.93
       asn: 4200100000
       peers:
         4200000000:
@@ -3864,7 +3867,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.94
+      router-id: 100.1.1.94
       asn: 4200100000
       peers:
         4200000000:
@@ -3880,7 +3883,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.95
+      router-id: 100.1.1.95
       asn: 4200100000
       peers:
         4200000000:
@@ -3896,7 +3899,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.96
+      router-id: 100.1.1.96
       asn: 4200100000
       peers:
         4200000000:
@@ -3912,7 +3915,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.97
+      router-id: 100.1.1.97
       asn: 4200100000
       peers:
         4200000000:
@@ -3928,7 +3931,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.98
+      router-id: 100.1.1.98
       asn: 4200100000
       peers:
         4200000000:
@@ -3944,7 +3947,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.99
+      router-id: 100.1.1.99
       asn: 4200100000
       peers:
         4200000000:
@@ -3960,7 +3963,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.100
+      router-id: 100.1.1.100
       asn: 4200100000
       peers:
         4200000000:
@@ -3976,7 +3979,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.101
+      router-id: 100.1.1.101
       asn: 4200100000
       peers:
         4200000000:
@@ -3992,7 +3995,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.102
+      router-id: 100.1.1.102
       asn: 4200100000
       peers:
         4200000000:
@@ -4008,7 +4011,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.103
+      router-id: 100.1.1.103
       asn: 4200100000
       peers:
         4200000000:
@@ -4024,7 +4027,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.104
+      router-id: 100.1.1.104
       asn: 4200100000
       peers:
         4200000000:
@@ -4040,7 +4043,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.105
+      router-id: 100.1.1.105
       asn: 4200100000
       peers:
         4200000000:
@@ -4056,7 +4059,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.106
+      router-id: 100.1.1.106
       asn: 4200100000
       peers:
         4200000000:
@@ -4072,7 +4075,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.107
+      router-id: 100.1.1.107
       asn: 4200100000
       peers:
         4200000000:
@@ -4088,7 +4091,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.108
+      router-id: 100.1.1.108
       asn: 4200100000
       peers:
         4200000000:
@@ -4104,7 +4107,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.109
+      router-id: 100.1.1.109
       asn: 4200100000
       peers:
         4200000000:
@@ -4120,7 +4123,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.110
+      router-id: 100.1.1.110
       asn: 4200100000
       peers:
         4200000000:
@@ -4136,7 +4139,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.111
+      router-id: 100.1.1.111
       asn: 4200100000
       peers:
         4200000000:
@@ -4152,7 +4155,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.112
+      router-id: 100.1.1.112
       asn: 4200100000
       peers:
         4200000000:
@@ -4168,7 +4171,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.113
+      router-id: 100.1.1.113
       asn: 4200100000
       peers:
         4200000000:
@@ -4184,7 +4187,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.114
+      router-id: 100.1.1.114
       asn: 4200100000
       peers:
         4200000000:
@@ -4200,7 +4203,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.115
+      router-id: 100.1.1.115
       asn: 4200100000
       peers:
         4200000000:
@@ -4216,7 +4219,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.116
+      router-id: 100.1.1.116
       asn: 4200100000
       peers:
         4200000000:
@@ -4232,7 +4235,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.117
+      router-id: 100.1.1.117
       asn: 4200100000
       peers:
         4200000000:
@@ -4248,7 +4251,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.118
+      router-id: 100.1.1.118
       asn: 4200100000
       peers:
         4200000000:
@@ -4264,7 +4267,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.119
+      router-id: 100.1.1.119
       asn: 4200100000
       peers:
         4200000000:
@@ -4280,7 +4283,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.120
+      router-id: 100.1.1.120
       asn: 4200100000
       peers:
         4200000000:
@@ -4296,7 +4299,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.121
+      router-id: 100.1.1.121
       asn: 4200100000
       peers:
         4200000000:
@@ -4312,7 +4315,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.122
+      router-id: 100.1.1.122
       asn: 4200100000
       peers:
         4200000000:
@@ -4328,7 +4331,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.123
+      router-id: 100.1.1.123
       asn: 4200100000
       peers:
         4200000000:
@@ -4344,7 +4347,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.124
+      router-id: 100.1.1.124
       asn: 4200100000
       peers:
         4200000000:
@@ -4360,7 +4363,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.125
+      router-id: 100.1.1.125
       asn: 4200100000
       peers:
         4200000000:
@@ -4376,7 +4379,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.126
+      router-id: 100.1.1.126
       asn: 4200100000
       peers:
         4200000000:
@@ -4392,7 +4395,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.127
+      router-id: 100.1.1.127
       asn: 4200100000
       peers:
         4200000000:
@@ -4408,7 +4411,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.128
+      router-id: 100.1.1.128
       asn: 4200100000
       peers:
         4200000000:
@@ -4424,7 +4427,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.129
+      router-id: 100.1.1.129
       asn: 4200100000
       peers:
         4200000000:
@@ -4440,7 +4443,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.130
+      router-id: 100.1.1.130
       asn: 4200100000
       peers:
         4200000000:
@@ -4456,7 +4459,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.131
+      router-id: 100.1.1.131
       asn: 4200100000
       peers:
         4200000000:
@@ -4472,7 +4475,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.132
+      router-id: 100.1.1.132
       asn: 4200100000
       peers:
         4200000000:
@@ -4488,7 +4491,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.133
+      router-id: 100.1.1.133
       asn: 4200100000
       peers:
         4200000000:
@@ -4504,7 +4507,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.134
+      router-id: 100.1.1.134
       asn: 4200100000
       peers:
         4200000000:
@@ -4520,7 +4523,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.135
+      router-id: 100.1.1.135
       asn: 4200100000
       peers:
         4200000000:
@@ -4536,7 +4539,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.136
+      router-id: 100.1.1.136
       asn: 4200100000
       peers:
         4200000000:
@@ -4552,7 +4555,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.137
+      router-id: 100.1.1.137
       asn: 4200100000
       peers:
         4200000000:
@@ -4568,7 +4571,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.138
+      router-id: 100.1.1.138
       asn: 4200100000
       peers:
         4200000000:
@@ -4584,7 +4587,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.139
+      router-id: 100.1.1.139
       asn: 4200100000
       peers:
         4200000000:
@@ -4600,7 +4603,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.140
+      router-id: 100.1.1.140
       asn: 4200100000
       peers:
         4200000000:
@@ -4616,7 +4619,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.141
+      router-id: 100.1.1.141
       asn: 4200100000
       peers:
         4200000000:
@@ -4632,7 +4635,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.142
+      router-id: 100.1.1.142
       asn: 4200100000
       peers:
         4200000000:
@@ -4648,7 +4651,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.143
+      router-id: 100.1.1.143
       asn: 4200100000
       peers:
         4200000000:
@@ -4664,7 +4667,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.144
+      router-id: 100.1.1.144
       asn: 4200100000
       peers:
         4200000000:
@@ -4680,7 +4683,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.145
+      router-id: 100.1.1.145
       asn: 4200100000
       peers:
         4200000000:
@@ -4696,7 +4699,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.146
+      router-id: 100.1.1.146
       asn: 4200100000
       peers:
         4200000000:
@@ -4712,7 +4715,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.147
+      router-id: 100.1.1.147
       asn: 4200100000
       peers:
         4200000000:
@@ -4728,7 +4731,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.148
+      router-id: 100.1.1.148
       asn: 4200100000
       peers:
         4200000000:
@@ -4744,7 +4747,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.149
+      router-id: 100.1.1.149
       asn: 4200100000
       peers:
         4200000000:
@@ -4760,7 +4763,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.150
+      router-id: 100.1.1.150
       asn: 4200100000
       peers:
         4200000000:
@@ -4776,7 +4779,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.151
+      router-id: 100.1.1.151
       asn: 4200100000
       peers:
         4200000000:
@@ -4792,7 +4795,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.152
+      router-id: 100.1.1.152
       asn: 4200100000
       peers:
         4200000000:
@@ -4808,7 +4811,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.153
+      router-id: 100.1.1.153
       asn: 4200100000
       peers:
         4200000000:
@@ -4824,7 +4827,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.154
+      router-id: 100.1.1.154
       asn: 4200100000
       peers:
         4200000000:
@@ -4840,7 +4843,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.155
+      router-id: 100.1.1.155
       asn: 4200100000
       peers:
         4200000000:
@@ -4856,7 +4859,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.156
+      router-id: 100.1.1.156
       asn: 4200100000
       peers:
         4200000000:
@@ -4872,7 +4875,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.157
+      router-id: 100.1.1.157
       asn: 4200100000
       peers:
         4200000000:
@@ -4888,7 +4891,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.158
+      router-id: 100.1.1.158
       asn: 4200100000
       peers:
         4200000000:
@@ -4904,7 +4907,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.159
+      router-id: 100.1.1.159
       asn: 4200100000
       peers:
         4200000000:
@@ -4920,7 +4923,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.160
+      router-id: 100.1.1.160
       asn: 4200100000
       peers:
         4200000000:
@@ -4936,7 +4939,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.161
+      router-id: 100.1.1.161
       asn: 4200100000
       peers:
         4200000000:
@@ -4952,7 +4955,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.162
+      router-id: 100.1.1.162
       asn: 4200100000
       peers:
         4200000000:
@@ -4968,7 +4971,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.163
+      router-id: 100.1.1.163
       asn: 4200100000
       peers:
         4200000000:
@@ -4984,7 +4987,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.164
+      router-id: 100.1.1.164
       asn: 4200100000
       peers:
         4200000000:
@@ -5000,7 +5003,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.165
+      router-id: 100.1.1.165
       asn: 4200100000
       peers:
         4200000000:
@@ -5016,7 +5019,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.166
+      router-id: 100.1.1.166
       asn: 4200100000
       peers:
         4200000000:
@@ -5032,7 +5035,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.167
+      router-id: 100.1.1.167
       asn: 4200100000
       peers:
         4200000000:
@@ -5048,7 +5051,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.168
+      router-id: 100.1.1.168
       asn: 4200100000
       peers:
         4200000000:
@@ -5064,7 +5067,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.169
+      router-id: 100.1.1.169
       asn: 4200100000
       peers:
         4200000000:
@@ -5080,7 +5083,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.170
+      router-id: 100.1.1.170
       asn: 4200100000
       peers:
         4200000000:
@@ -5096,7 +5099,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.171
+      router-id: 100.1.1.171
       asn: 4200100000
       peers:
         4200000000:
@@ -5112,7 +5115,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.172
+      router-id: 100.1.1.172
       asn: 4200100000
       peers:
         4200000000:
@@ -5128,7 +5131,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.173
+      router-id: 100.1.1.173
       asn: 4200100000
       peers:
         4200000000:
@@ -5144,7 +5147,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.174
+      router-id: 100.1.1.174
       asn: 4200100000
       peers:
         4200000000:
@@ -5160,7 +5163,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.175
+      router-id: 100.1.1.175
       asn: 4200100000
       peers:
         4200000000:
@@ -5176,7 +5179,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.176
+      router-id: 100.1.1.176
       asn: 4200100000
       peers:
         4200000000:
@@ -5192,7 +5195,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.177
+      router-id: 100.1.1.177
       asn: 4200100000
       peers:
         4200000000:
@@ -5208,7 +5211,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.178
+      router-id: 100.1.1.178
       asn: 4200100000
       peers:
         4200000000:
@@ -5224,7 +5227,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.179
+      router-id: 100.1.1.179
       asn: 4200100000
       peers:
         4200000000:
@@ -5240,7 +5243,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.180
+      router-id: 100.1.1.180
       asn: 4200100000
       peers:
         4200000000:
@@ -5256,7 +5259,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.181
+      router-id: 100.1.1.181
       asn: 4200100000
       peers:
         4200000000:
@@ -5272,7 +5275,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.182
+      router-id: 100.1.1.182
       asn: 4200100000
       peers:
         4200000000:
@@ -5288,7 +5291,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.183
+      router-id: 100.1.1.183
       asn: 4200100000
       peers:
         4200000000:
@@ -5304,7 +5307,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.184
+      router-id: 100.1.1.184
       asn: 4200100000
       peers:
         4200000000:
@@ -5320,7 +5323,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.185
+      router-id: 100.1.1.185
       asn: 4200100000
       peers:
         4200000000:
@@ -5336,7 +5339,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.186
+      router-id: 100.1.1.186
       asn: 4200100000
       peers:
         4200000000:
@@ -5352,7 +5355,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.187
+      router-id: 100.1.1.187
       asn: 4200100000
       peers:
         4200000000:
@@ -5368,7 +5371,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.188
+      router-id: 100.1.1.188
       asn: 4200100000
       peers:
         4200000000:
@@ -5384,7 +5387,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.189
+      router-id: 100.1.1.189
       asn: 4200100000
       peers:
         4200000000:
@@ -5400,7 +5403,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.190
+      router-id: 100.1.1.190
       asn: 4200100000
       peers:
         4200000000:
@@ -5416,7 +5419,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.191
+      router-id: 100.1.1.191
       asn: 4200100000
       peers:
         4200000000:
@@ -5432,7 +5435,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.192
+      router-id: 100.1.1.192
       asn: 4200100000
       peers:
         4200000000:
@@ -5448,7 +5451,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.2.1
+      router-id: 100.1.2.1
       asn: 4200000000
       peers:
         4200000000:
@@ -5464,7 +5467,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.2.2
+      router-id: 100.1.2.2
       asn: 4200000000
       peers:
         4200000000:

--- a/ansible/vars/topo_t0-isolated-v6-d32u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d32u32s2.yml
@@ -226,13 +226,16 @@ configuration_properties:
     tor_asn_start: 4200000000
     failure_rate: 0
     nhipv6: FC0A::FF
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
+    enable_ipv4_routes_generation: false
+    enable_ipv6_routes_generation: true
 
 configuration:
   ARISTA01T1:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.65
+      router-id: 100.1.0.65
       asn: 4200100000
       peers:
         4200000000:
@@ -248,7 +251,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.73
+      router-id: 100.1.0.73
       asn: 4200100000
       peers:
         4200000000:
@@ -264,7 +267,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.81
+      router-id: 100.1.0.81
       asn: 4200100000
       peers:
         4200000000:
@@ -280,7 +283,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.89
+      router-id: 100.1.0.89
       asn: 4200100000
       peers:
         4200000000:
@@ -296,7 +299,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.97
+      router-id: 100.1.0.97
       asn: 4200100000
       peers:
         4200000000:
@@ -312,7 +315,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.105
+      router-id: 100.1.0.105
       asn: 4200100000
       peers:
         4200000000:
@@ -328,7 +331,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.113
+      router-id: 100.1.0.113
       asn: 4200100000
       peers:
         4200000000:
@@ -344,7 +347,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.121
+      router-id: 100.1.0.121
       asn: 4200100000
       peers:
         4200000000:
@@ -360,7 +363,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.129
+      router-id: 100.1.0.129
       asn: 4200100000
       peers:
         4200000000:
@@ -376,7 +379,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.137
+      router-id: 100.1.0.137
       asn: 4200100000
       peers:
         4200000000:
@@ -392,7 +395,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.145
+      router-id: 100.1.0.145
       asn: 4200100000
       peers:
         4200000000:
@@ -408,7 +411,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.153
+      router-id: 100.1.0.153
       asn: 4200100000
       peers:
         4200000000:
@@ -424,7 +427,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.161
+      router-id: 100.1.0.161
       asn: 4200100000
       peers:
         4200000000:
@@ -440,7 +443,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.169
+      router-id: 100.1.0.169
       asn: 4200100000
       peers:
         4200000000:
@@ -456,7 +459,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.177
+      router-id: 100.1.0.177
       asn: 4200100000
       peers:
         4200000000:
@@ -472,7 +475,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.185
+      router-id: 100.1.0.185
       asn: 4200100000
       peers:
         4200000000:
@@ -488,7 +491,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.65
+      router-id: 100.1.1.65
       asn: 4200100000
       peers:
         4200000000:
@@ -504,7 +507,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.73
+      router-id: 100.1.1.73
       asn: 4200100000
       peers:
         4200000000:
@@ -520,7 +523,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.81
+      router-id: 100.1.1.81
       asn: 4200100000
       peers:
         4200000000:
@@ -536,7 +539,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.89
+      router-id: 100.1.1.89
       asn: 4200100000
       peers:
         4200000000:
@@ -552,7 +555,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.97
+      router-id: 100.1.1.97
       asn: 4200100000
       peers:
         4200000000:
@@ -568,7 +571,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.105
+      router-id: 100.1.1.105
       asn: 4200100000
       peers:
         4200000000:
@@ -584,7 +587,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.113
+      router-id: 100.1.1.113
       asn: 4200100000
       peers:
         4200000000:
@@ -600,7 +603,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.121
+      router-id: 100.1.1.121
       asn: 4200100000
       peers:
         4200000000:
@@ -616,7 +619,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.129
+      router-id: 100.1.1.129
       asn: 4200100000
       peers:
         4200000000:
@@ -632,7 +635,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.137
+      router-id: 100.1.1.137
       asn: 4200100000
       peers:
         4200000000:
@@ -648,7 +651,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.145
+      router-id: 100.1.1.145
       asn: 4200100000
       peers:
         4200000000:
@@ -664,7 +667,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.153
+      router-id: 100.1.1.153
       asn: 4200100000
       peers:
         4200000000:
@@ -680,7 +683,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.161
+      router-id: 100.1.1.161
       asn: 4200100000
       peers:
         4200000000:
@@ -696,7 +699,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.169
+      router-id: 100.1.1.169
       asn: 4200100000
       peers:
         4200000000:
@@ -712,7 +715,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.177
+      router-id: 100.1.1.177
       asn: 4200100000
       peers:
         4200000000:
@@ -728,7 +731,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.1.185
+      router-id: 100.1.1.185
       asn: 4200100000
       peers:
         4200000000:
@@ -744,7 +747,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.2.1
+      router-id: 100.1.2.1
       asn: 4200000000
       peers:
         4200000000:
@@ -760,7 +763,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.2.2
+      router-id: 100.1.2.2
       asn: 4200000000
       peers:
         4200000000:

--- a/ansible/vars/topo_t1-isolated-v6-d28u1.yml
+++ b/ansible/vars/topo_t1-isolated-v6-d28u1.yml
@@ -127,7 +127,7 @@ configuration_properties:
     max_tor_subnet_number: 16
     tor_subnet_size: 128
     nhipv6: FC0A::FF
-    ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
   spine:

--- a/ansible/vars/topo_t1-isolated-v6-d448u16.yml
+++ b/ansible/vars/topo_t1-isolated-v6-d448u16.yml
@@ -1867,7 +1867,7 @@ configuration_properties:
     max_tor_subnet_number: 16
     tor_subnet_size: 128
     nhipv6: FC0A::FF
-    ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
   spine:

--- a/ansible/vars/topo_t1-isolated-v6-d56u2.yml
+++ b/ansible/vars/topo_t1-isolated-v6-d56u2.yml
@@ -243,7 +243,7 @@ configuration_properties:
     max_tor_subnet_number: 16
     tor_subnet_size: 128
     nhipv6: FC0A::FF
-    ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
   spine:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes issues in isolated v6 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix the following error
- ipv6 address pattern
- 'route-id' typo
-  remove template dependencies for `nhipv4` and `host['interfaces']['Loopback0']['ipv4']`

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
