### PR TITLE
[dualtor-aa] Fix `test_arp_dualtor` on active-active dualtor

### DIFF
--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -184,7 +184,8 @@ def test_arp_update_for_failed_standby_neighbor(
 
 def test_standby_unsolicited_neigh_learning(
     config_dualtor_arp_responder, selected_mux_port, clear_neighbor_table,                      # noqa: F811
-    toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut     # noqa: F811
+    toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut,    # noqa: F811
+    setup_standby_ports_on_rand_unselected_tor                                                  # noqa: F811
 ):
     """
     Test the standby ToR's ability to perform unsolicited neighbor learning (GARP and unsolicited NA)

--- a/tests/arp/test_arp_dualtor.py
+++ b/tests/arp/test_arp_dualtor.py
@@ -63,17 +63,14 @@ def pause_arp_update(duthosts):
 
 
 @pytest.fixture(params=['IPv4', 'IPv6'])
-def neighbor_ip(request, mux_config):       # noqa: F811
-    """
-    Provide the neighbor IP used for testing
-
-    Randomly select an IP from the server IPs configured in the config DB MUX_CABLE table
-    """
+def selected_mux_port(request, mux_config):       # noqa: F811
+    """Randomly select a mux port for testing."""
     ip_version = request.param
     selected_intf = random.choice(list(mux_config.values()))
     neigh_ip = ip_interface(selected_intf["SERVER"][ip_version]).ip
+    cable_type = selected_intf["SERVER"].get("cable_type", "active-standby")
     logger.info("Using {} as neighbor IP".format(neigh_ip))
-    return neigh_ip
+    return selected_intf, neigh_ip, cable_type
 
 
 @pytest.fixture
@@ -135,7 +132,7 @@ def test_proxy_arp_for_standby_neighbor(proxy_arp_enabled, ip_and_intf_info, res
 
 
 def test_arp_update_for_failed_standby_neighbor(
-    config_dualtor_arp_responder, neighbor_ip, clear_neighbor_table,                            # noqa: F811
+    config_dualtor_arp_responder, selected_mux_port, clear_neighbor_table,                      # noqa: F811
     toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut     # noqa: F811
 ):
     """
@@ -149,6 +146,11 @@ def test_arp_update_for_failed_standby_neighbor(
     4. Run `arp_update` on the active ToR
     5. Verify the incomplete entry is now reachable
     """
+    _, neighbor_ip, cable_type = selected_mux_port
+
+    if cable_type == "active-active":
+        pytest.skip("Skip as the testcase is designed for active-standby mux port.")
+
     if ip_address(neighbor_ip).version == 6 and rand_unselected_dut.facts["asic_type"] == "vs":
         pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     # We only use ping to trigger an ARP request from the kernel, so exit early to save time
@@ -181,7 +183,7 @@ def test_arp_update_for_failed_standby_neighbor(
 
 
 def test_standby_unsolicited_neigh_learning(
-    config_dualtor_arp_responder, neighbor_ip, clear_neighbor_table,                            # noqa: F811
+    config_dualtor_arp_responder, selected_mux_port, clear_neighbor_table,                      # noqa: F811
     toggle_all_simulator_ports_to_rand_selected_tor, rand_selected_dut, rand_unselected_dut     # noqa: F811
 ):
     """
@@ -192,6 +194,7 @@ def test_standby_unsolicited_neigh_learning(
     2. Run arp_update on the active ToR
     3. Confirm that the standby ToR learned the entry and it is REACHABLE
     """
+    neighbor_ip = selected_mux_port[1]
     if ip_address(neighbor_ip).version == 6 and rand_unselected_dut.facts["asic_type"] == "vs":
         pytest.skip("Temporarily skipped to let the sonic-swss submodule be updated.")
     ping_cmd = "timeout 0.2 ping -c1 -W1 -i0.2 -n -q {}".format(neighbor_ip)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix `test_arp_dualtor` on active-active dualtor.
Two issues:
1.  `test_arp_update_for_failed_standby_neighbor` is failing on `active-active` dualtor.
The testcase is designed to validate the `FAILED` neighbor behavior on `active-standby` dualtor and the test steps are not working on `active-active` dualtor. 
The testcase is based on the fact that, on active-standby dualtor, the mux will drop downstream packets from the standby ToR, so any ARP probes from the standby ToR will be dropped by the mux -> no ARP replies -> `FAILED` neighbor on the standby ToR.
The mux forwarding behavior is different on active-active dualtor: the mux still forwards the ARP probes from the standby ToR -> ARP replies are generated -> `REACHABLE` neighbor on both ToRs.

2. `test_standby_unsolicited_neigh_learning` is not adapted to `active-active` dualtor.
The testcase is to validate the standby ToR could learn neighbors from unsolicited ARP replies, which needs one side to be standby.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. skip `test_arp_update_for_failed_standby_neighbor` on active-active dualtor.
2. add active-active toggle fixture to `test_standby_unsolicited_neigh_learning`.

#### How did you verify/test it?
```
arp/test_arp_dualtor.py::test_arp_update_for_failed_standby_neighbor[IPv4] SKIPPED (Skip as the testcase is designed for active-standby mux port.)                                                                                                                     [ 50%]
arp/test_arp_dualtor.py::test_arp_update_for_failed_standby_neighbor[IPv6] SKIPPED (Skip as the testcase is designed for active-standby mux port.)                                                                                                                     [100%]
arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning[IPv4] PASSED                                                                                                                                                                                          [ 50%]
arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning[IPv6] PASSED 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
