### PR TITLE
[dualtor-aa] Fix testbed deploy error

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -593,9 +593,10 @@ class VMTopology(object):
             VMTopology._generate_fingerprint(ext_if, MAX_INTF_LEN-len(int_if))
         logging.info('=== For veth pair, add %s to bridge %s, set %s to netns, tmp intf %s' % (
             ext_if, bridge, int_if, tmp_int_if))
-        if VMTopology.intf_not_exists(ext_if):
-            VMTopology.cmd("ip link add %s type veth peer name %s" %
-                           (ext_if, tmp_int_if))
+        if VMTopology.intf_exists(ext_if):
+            VMTopology.cmd("ip link del dev %s" % ext_if)
+        VMTopology.cmd("ip link add %s type veth peer name %s" %
+                        (ext_if, tmp_int_if))
 
         _, if_to_br = VMTopology.brctl_show(bridge)
         if ext_if not in if_to_br:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix the testebd deploy error in add-topo:
```
TASK [vm_set : Bind topology dualtor-aa-64-breakout to VMs. base vm = VM18024] ***********************************************************************************************************************************************************************************************
Friday 18 April 2025  03:12:34 +0000 (0:00:19.030)       0:02:28.049 **********
fatal: [STR2-ACS-SERV-18]: FAILED! => {"changed": false, "msg": "ret_code=1, error message=\"Cannot find device \"mgmt\"\n\". cmd=\"ip netns exec ns-vms18-3 ip link set mgmt up\""}
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Let's remove if 


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
