### PR TITLE
Updating the BGP convergence cases to latest Snappi Api Model instead of Snappi_convergence module

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -7,7 +7,6 @@ import logging
 import snappi
 import sys
 import random
-import snappi_convergence
 from tests.common.helpers.assertions import pytest_require
 from tests.common.errors import RunAnsibleModuleFail
 from ipaddress import ip_address, IPv4Address, IPv6Address
@@ -541,15 +540,6 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts):      # noqa: F811
         logger.info(snappi_ports)
 
     return snappi_ports
-
-
-@pytest.fixture(scope='module')
-def cvg_api(snappi_api_serv_ip,
-            snappi_api_serv_port):
-    api = snappi_convergence.api(location=snappi_api_serv_ip + ':' + str(snappi_api_serv_port), ext='ixnetwork')
-    yield api
-    if getattr(api, 'assistant', None) is not None:
-        api.assistant.Session.remove()
 
 
 def snappi_multi_base_config(duthost_list,

--- a/tests/gnmi/test_gnoi_system_grpc.py
+++ b/tests/gnmi/test_gnoi_system_grpc.py
@@ -7,7 +7,10 @@ import sys
 
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
-pytestmark = [pytest.mark.topology("any")]
+pytestmark = [
+    pytest.mark.topology("any"),
+    pytest.mark.disable_memory_utilization
+]
 
 
 """

--- a/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_convergence_helper.py
@@ -14,26 +14,24 @@ NG_LIST = []
 aspaths = [65002, 65003]
 
 
-def run_bgp_local_link_failover_test(cvg_api,
+def run_bgp_local_link_failover_test(snappi_api,
                                      duthost,
                                      tgen_ports,
                                      iteration,
                                      multipath,
                                      number_of_routes,
-                                     route_type,
-                                     port_speed,):
+                                     route_type,):
     """
     Run Local link failover test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         iteration: number of iterations for running convergence test on a port
         multipath: ecmp value for BGP config
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
 
@@ -44,17 +42,16 @@ def run_bgp_local_link_failover_test(cvg_api,
                        route_type,)
 
     """ Create bgp config on TGEN """
-    tgen_bgp_config = __tgen_bgp_config(cvg_api,
+    tgen_bgp_config = __tgen_bgp_config(snappi_api,
                                         port_count,
                                         number_of_routes,
-                                        route_type,
-                                        port_speed,)
+                                        route_type,)
 
     """
         Run the convergence test by flapping all the rx
         links one by one and calculate the convergence values
     """
-    get_convergence_for_local_link_failover(cvg_api,
+    get_convergence_for_local_link_failover(snappi_api,
                                             tgen_bgp_config,
                                             iteration,
                                             multipath,
@@ -65,25 +62,23 @@ def run_bgp_local_link_failover_test(cvg_api,
     cleanup_config(duthost)
 
 
-def run_bgp_remote_link_failover_test(cvg_api,
+def run_bgp_remote_link_failover_test(snappi_api,
                                       duthost,
                                       tgen_ports,
                                       iteration,
                                       multipath,
                                       number_of_routes,
-                                      route_type,
-                                      port_speed,):
+                                      route_type,):
     """
     Run Remote link failover test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         iteration: number of iterations for running convergence test on a port
         multipath: ecmp value for BGP config
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
     """ Create bgp config on dut """
@@ -93,17 +88,16 @@ def run_bgp_remote_link_failover_test(cvg_api,
                        route_type,)
 
     """ Create bgp config on TGEN """
-    tgen_bgp_config = __tgen_bgp_config(cvg_api,
+    tgen_bgp_config = __tgen_bgp_config(snappi_api,
                                         port_count,
                                         number_of_routes,
-                                        route_type,
-                                        port_speed,)
+                                        route_type,)
 
     """
         Run the convergence test by withdrawing all the route ranges
         one by one and calculate the convergence values
     """
-    get_convergence_for_remote_link_failover(cvg_api,
+    get_convergence_for_remote_link_failover(snappi_api,
                                              tgen_bgp_config,
                                              iteration,
                                              multipath,
@@ -114,26 +108,24 @@ def run_bgp_remote_link_failover_test(cvg_api,
     cleanup_config(duthost)
 
 
-def run_rib_in_convergence_test(cvg_api,
+def run_rib_in_convergence_test(snappi_api,
                                 duthost,
                                 tgen_ports,
                                 iteration,
                                 multipath,
                                 number_of_routes,
-                                route_type,
-                                port_speed,):
+                                route_type,):
     """
     Run RIB-IN Convergence test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         iteration: number of iterations for running convergence test on a port
         multipath: ecmp value for BGP config
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
 
@@ -144,17 +136,16 @@ def run_rib_in_convergence_test(cvg_api,
                        route_type,)
 
     """  Create bgp config on TGEN """
-    tgen_bgp_config = __tgen_bgp_config(cvg_api,
+    tgen_bgp_config = __tgen_bgp_config(snappi_api,
                                         port_count,
                                         number_of_routes,
-                                        route_type,
-                                        port_speed,)
+                                        route_type,)
 
     """
         Run the convergence test by withdrawing all routes at once and
         calculate the convergence values
     """
-    get_rib_in_convergence(cvg_api,
+    get_rib_in_convergence(snappi_api,
                            tgen_bgp_config,
                            iteration,
                            multipath,
@@ -165,26 +156,24 @@ def run_rib_in_convergence_test(cvg_api,
     cleanup_config(duthost)
 
 
-def run_RIB_IN_capacity_test(cvg_api,
+def run_RIB_IN_capacity_test(snappi_api,
                              duthost,
                              tgen_ports,
                              multipath,
                              start_value,
                              step_value,
-                             route_type,
-                             port_speed,):
+                             route_type,):
     """
     Run RIB-IN Capacity test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         multipath: ecmp value for BGP config
         start_value: start value of number of routes
         step_value: step value of routes to be incremented at every iteration
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     port_count = multipath+1
     """ Create bgp config on dut """
@@ -194,12 +183,11 @@ def run_RIB_IN_capacity_test(cvg_api,
                        route_type,)
 
     """ Run the RIB-IN capacity test by increasig the route count step by step """
-    get_RIB_IN_capacity(cvg_api,
+    get_RIB_IN_capacity(snappi_api,
                         multipath,
                         start_value,
                         step_value,
-                        route_type,
-                        port_speed,)
+                        route_type,)
 
     """ Cleanup the dut configs after getting the convergence numbers """
     cleanup_config(duthost)
@@ -291,24 +279,21 @@ def duthost_bgp_config(duthost,
             duthost.shell(bgp_config_neighbor)
 
 
-def __tgen_bgp_config(cvg_api,
+def __tgen_bgp_config(snappi_api,
                       port_count,
                       number_of_routes,
-                      route_type,
-                      port_speed,):
+                      route_type,):
     """
     Creating  BGP config on TGEN
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         port_count: multipath + 1
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     global NG_LIST
-    conv_config = cvg_api.convergence_config()
-    config = conv_config.config
+    config = snappi_api.config()
     for i in range(1, port_count+1):
         config.ports.port(name='Test_Port_%d' %
                           i, location=temp_tg_port[i-1]['location'])
@@ -329,14 +314,14 @@ def __tgen_bgp_config(cvg_api,
     layer1.name = 'port settings'
     layer1.port_names = [port.name for port in config.ports]
     layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = True
+    layer1.auto_negotiation.rs_fec = False
     layer1.auto_negotiation.link_training = False
-    layer1.speed = port_speed
+    layer1.speed = temp_tg_port[0]['speed']
     layer1.auto_negotiate = False
 
     def create_v4_topo():
         eth = config.devices[0].ethernets.add()
-        eth.port_name = config.lags[0].name
+        eth.connection.port_name = config.lags[0].name
         eth.name = 'Ethernet 1'
         eth.mac = "00:00:00:00:00:01"
         ipv4 = eth.ipv4_addresses.add()
@@ -353,7 +338,7 @@ def __tgen_bgp_config(cvg_api,
                 m = hex(i).split('0x')[1]
 
             ethernet_stack = config.devices[i-1].ethernets.add()
-            ethernet_stack.port_name = config.lags[i-1].name
+            ethernet_stack.connection.port_name = config.lags[i-1].name
             ethernet_stack.name = 'Ethernet %d' % i
             ethernet_stack.mac = "00:00:00:00:00:%s" % m
             ipv4_stack = ethernet_stack.ipv4_addresses.add()
@@ -382,7 +367,7 @@ def __tgen_bgp_config(cvg_api,
 
     def create_v6_topo():
         eth = config.devices[0].ethernets.add()
-        eth.port_name = config.lags[0].name
+        eth.connection.port_name = config.lags[0].name
         eth.name = 'Ethernet 1'
         eth.mac = "00:00:00:00:00:01"
         ipv6 = eth.ipv6_addresses.add()
@@ -398,7 +383,7 @@ def __tgen_bgp_config(cvg_api,
             else:
                 m = hex(i).split('0x')[1]
             ethernet_stack = config.devices[i-1].ethernets.add()
-            ethernet_stack.port_name = config.lags[i-1].name
+            ethernet_stack.connection.port_name = config.lags[i-1].name
             ethernet_stack.name = 'Ethernet %d' % i
             ethernet_stack.mac = "00:00:00:00:00:%s" % m
             ipv6_stack = ethernet_stack.ipv6_addresses.add()
@@ -439,20 +424,20 @@ def __tgen_bgp_config(cvg_api,
     flow.size.fixed = 1024
     flow.rate.percentage = 100
     flow.metrics.enable = True
-    return conv_config
+    return config
 
 
-def get_flow_stats(cvg_api):
+def get_flow_stats(snappi_api):
     """
     Args:
-        cvg_api (pytest fixture): Snappi API
+        snappi_api (pytest fixture): Snappi API
     """
-    request = cvg_api.convergence_request()
-    request.metrics.flow_names = []
-    return cvg_api.get_results(request).flow_metric
+    req = snappi_api.metrics_request()
+    req.flow.flow_names = []
+    return snappi_api.get_metrics(req).flow_metrics
 
 
-def get_convergence_for_local_link_failover(cvg_api,
+def get_convergence_for_local_link_failover(snappi_api,
                                             bgp_config,
                                             iteration,
                                             multipath,
@@ -460,7 +445,7 @@ def get_convergence_for_local_link_failover(cvg_api,
                                             route_type,):
     """
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         bgp_config: __tgen_bgp_config
         config: TGEN config
         iteration: number of iterations for running convergence test on a port
@@ -468,19 +453,21 @@ def get_convergence_for_local_link_failover(cvg_api,
         route_type: IPv4 or IPv6 routes
     """
     rx_port_names = []
-    for i in range(1, len(bgp_config.config.ports)):
-        rx_port_names.append(bgp_config.config.ports[i].name)
-    bgp_config.rx_rate_threshold = 90/(multipath-1)
-    cvg_api.set_config(bgp_config)
-
+    for i in range(1, len(bgp_config.ports)):
+        rx_port_names.append(bgp_config.ports[i].name)
+    bgp_config.events.cp_events.enable = True
+    bgp_config.events.dp_events.enable = True
+    bgp_config.events.dp_events.rx_rate_threshold = 90/(multipath-1)
+    snappi_api.set_config(bgp_config)
     """ Starting Protocols """
     logger.info("Starting all protocols ...")
-    cs = cvg_api.convergence_state()
-    cs.protocol.state = cs.protocol.START
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.protocol.all.state = cs.protocol.all.START
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT, "For Protocols To start")
 
     def get_avg_dpdp_convergence_time(port_name):
+
         """
         Args:
             port_name: Name of the port
@@ -493,21 +480,22 @@ def get_convergence_for_local_link_failover(cvg_api,
 
             """ Starting Traffic """
             logger.info('Starting Traffic')
-            cs = cvg_api.convergence_state()
-            cs.transmit.state = cs.transmit.START
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For Traffic To start")
-            flow_stats = get_flow_stats(cvg_api)
+            flow_stats = get_flow_stats(snappi_api)
             tx_frame_rate = flow_stats[0].frames_tx_rate
             assert tx_frame_rate != 0, "Traffic has not started"
             """ Flapping Link """
             logger.info('Simulating Link Failure on {} link'.format(port_name))
-            cs = cvg_api.convergence_state()
-            cs.link.port_names = [port_name]
-            cs.link.state = cs.link.DOWN
-            cvg_api.set_state(cs)
+            cs.choice = cs.PORT
+            cs.port.choice = cs.port.LINK
+            cs.port.link.port_names = [port_name]
+            cs.port.link.state = cs.port.link.DOWN
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For Link to go down")
-            flows = get_flow_stats(cvg_api)
+            flows = get_flow_stats(snappi_api)
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_rx_rate)
@@ -516,9 +504,9 @@ def get_convergence_for_local_link_failover(cvg_api,
                 .format(sum(tx_frate), sum(rx_frate))
             logger.info("Traffic has converged after link flap")
             """ Get control plane to data plane convergence value """
-            request = cvg_api.convergence_request()
+            request = snappi_api.metrics_request()
             request.convergence.flow_names = []
-            convergence_metrics = cvg_api.get_results(request).flow_convergence
+            convergence_metrics = snappi_api.get_metrics(request).convergence_metrics
             for metrics in convergence_metrics:
                 logger.info('CP/DP Convergence Time (ms): {}'.format(
                     metrics.control_plane_data_plane_convergence_us/1000))
@@ -528,13 +516,15 @@ def get_convergence_for_local_link_failover(cvg_api,
             """ Performing link up at the end of iteration """
             logger.info(
                 'Simulating Link Up on {} at the end of iteration {}'.format(port_name, i+1))
-            cs = cvg_api.convergence_state()
-            cs.link.port_names = [port_name]
-            cs.link.state = cs.link.UP
-            cvg_api.set_state(cs)
-            cs = cvg_api.convergence_state()
-            cs.transmit.state = cs.transmit.STOP
-            cvg_api.set_state(cs)
+            cs.choice = cs.PORT
+            cs.port.choice = cs.port.LINK
+            cs.port.link.port_names = [port_name]
+            cs.port.link.state = cs.port.link.UP
+            snappi_api.set_control_state(cs)
+            logger.info('Stopping Traffic')
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT-10, "For Traffic To Stop")
         table.append('%s Link Failure' % port_name)
         table.append(route_type)
@@ -552,7 +542,7 @@ def get_convergence_for_local_link_failover(cvg_api,
     logger.info("\n%s" % tabulate(table, headers=columns, tablefmt="psql"))
 
 
-def get_convergence_for_remote_link_failover(cvg_api,
+def get_convergence_for_remote_link_failover(snappi_api,
                                              bgp_config,
                                              iteration,
                                              multipath,
@@ -560,7 +550,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
                                              route_type,):
     """
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         bgp_config: __tgen_bgp_config
         config: TGEN config
         iteration: number of iterations for running convergence test on a port
@@ -568,8 +558,10 @@ def get_convergence_for_remote_link_failover(cvg_api,
         route_type: IPv4 or IPv6 routes
     """
     route_names = NG_LIST
-    bgp_config.rx_rate_threshold = 90/(multipath-1)
-    cvg_api.set_config(bgp_config)
+    bgp_config.events.cp_events.enable = True
+    bgp_config.events.dp_events.enable = True
+    bgp_config.events.dp_events.rx_rate_threshold = 90/(multipath-1)
+    snappi_api.set_config(bgp_config)
 
     def get_avg_cpdp_convergence_time(route_name):
         """
@@ -580,31 +572,31 @@ def get_convergence_for_remote_link_failover(cvg_api,
         table, avg, tx_frate, rx_frate, avg_delta = [], [], [], [], []
         """ Starting Protocols """
         logger.info("Starting all protocols ...")
-        cs = cvg_api.convergence_state()
-        cs.protocol.state = cs.protocol.START
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.protocol.all.state = cs.protocol.all.START
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT, "For Protocols To start")
         for i in range(0, iteration):
             logger.info(
                 '|---- {} Route Withdraw Iteration : {} ----|'.format(route_name, i+1))
             """ Starting Traffic """
             logger.info('Starting Traffic')
-            cs = cvg_api.convergence_state()
-            cs.transmit.state = cs.transmit.START
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For Traffic To start")
-            flow_stats = get_flow_stats(cvg_api)
+            flow_stats = get_flow_stats(snappi_api)
             tx_frame_rate = flow_stats[0].frames_tx_rate
             assert tx_frame_rate != 0, "Traffic has not started"
 
             """ Withdrawing routes from a BGP peer """
             logger.info('Withdrawing Routes from {}'.format(route_name))
-            cs = cvg_api.convergence_state()
-            cs.route.names = [route_name]
-            cs.route.state = cs.route.WITHDRAW
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.protocol.route.state = cs.protocol.route.WITHDRAW
+            cs.protocol.route.names = [route_name]
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For routes to be withdrawn")
-            flows = get_flow_stats(cvg_api)
+            flows = get_flow_stats(snappi_api)
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_rx_rate)
@@ -614,9 +606,9 @@ def get_convergence_for_remote_link_failover(cvg_api,
             logger.info("Traffic has converged after route withdraw")
 
             """ Get control plane to data plane convergence value """
-            request = cvg_api.convergence_request()
+            request = snappi_api.metrics_request()
             request.convergence.flow_names = []
-            convergence_metrics = cvg_api.get_results(request).flow_convergence
+            convergence_metrics = snappi_api.get_metrics(request).convergence_metrics
             for metrics in convergence_metrics:
                 logger.info('CP/DP Convergence Time (ms): {}'.format(
                     metrics.control_plane_data_plane_convergence_us/1000))
@@ -624,15 +616,16 @@ def get_convergence_for_remote_link_failover(cvg_api,
                 int(metrics.control_plane_data_plane_convergence_us/1000))
             avg_delta.append(int(flows[0].frames_tx)-int(flows[0].frames_rx))
             """ Advertise the routes back at the end of iteration """
-            cs = cvg_api.convergence_state()
-            cs.route.names = [route_name]
-            cs.route.state = cs.route.ADVERTISE
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.protocol.route.state = cs.protocol.route.ADVERTISE
+            cs.protocol.route.names = [route_name]
+            snappi_api.set_control_state(cs)
             logger.info('Readvertise {} routes back at the end of iteration {}'.format(
                 route_name, i+1))
-            cs = cvg_api.convergence_state()
-            cs.transmit.state = cs.transmit.STOP
-            cvg_api.set_state(cs)
+            logger.info('Stopping Traffic')
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For Traffic To Stop")
         table.append('%s route withdraw' % route_name)
         table.append(route_type)
@@ -651,7 +644,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
     logger.info("\n%s" % tabulate(table, headers=columns, tablefmt="psql"))
 
 
-def get_rib_in_convergence(cvg_api,
+def get_rib_in_convergence(snappi_api,
                            bgp_config,
                            iteration,
                            multipath,
@@ -659,7 +652,7 @@ def get_rib_in_convergence(cvg_api,
                            route_type,):
     """
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         bgp_config: __tgen_bgp_config
         config: TGEN config
         iteration: number of iterations for running convergence test on a port
@@ -667,32 +660,34 @@ def get_rib_in_convergence(cvg_api,
         route_type: IPv4 or IPv6 routes
     """
     route_names = NG_LIST
-    bgp_config.rx_rate_threshold = 90/(multipath)
-    cvg_api.set_config(bgp_config)
+    bgp_config.events.cp_events.enable = True
+    bgp_config.events.dp_events.enable = True
+    bgp_config.events.dp_events.rx_rate_threshold = 90/(multipath-1)
+    snappi_api.set_config(bgp_config)
     table, avg, tx_frate, rx_frate, avg_delta = [], [], [], [], []
     for i in range(0, iteration):
         logger.info(
             '|---- RIB-IN Convergence test, Iteration : {} ----|'.format(i+1))
         """ withdraw all routes before starting traffic """
         logger.info('Withdraw All Routes before starting traffic')
-        cs = cvg_api.convergence_state()
-        cs.route.names = route_names
-        cs.route.state = cs.route.WITHDRAW
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.protocol.route.names = route_names
+        cs.protocol.route.state = cs.protocol.route.WITHDRAW
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT-25, "For Routes to be withdrawn")
         """ Starting Protocols """
         logger.info("Starting all protocols ...")
-        cs = cvg_api.convergence_state()
-        cs.protocol.state = cs.protocol.START
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.protocol.all.state = cs.protocol.all.START
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT, "For Protocols To start")
         """ Start Traffic """
         logger.info('Starting Traffic')
-        cs = cvg_api.convergence_state()
-        cs.transmit.state = cs.transmit.START
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT, "For Traffic To start")
-        flow_stats = get_flow_stats(cvg_api)
+        flow_stats = get_flow_stats(snappi_api)
         tx_frame_rate = flow_stats[0].frames_tx_rate
         rx_frame_rate = flow_stats[0].frames_rx_rate
         assert tx_frame_rate != 0, "Traffic has not started"
@@ -700,12 +695,12 @@ def get_rib_in_convergence(cvg_api,
 
         """ Advertise All Routes """
         logger.info('Advertising all Routes from {}'.format(route_names))
-        cs = cvg_api.convergence_state()
-        cs.route.names = route_names
-        cs.route.state = cs.route.ADVERTISE
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.protocol.route.names = route_names
+        cs.protocol.route.state = cs.protocol.route.ADVERTISE
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT-25, "For all routes to be ADVERTISED")
-        flows = get_flow_stats(cvg_api)
+        flows = get_flow_stats(snappi_api)
         for flow in flows:
             tx_frate.append(flow.frames_tx_rate)
             rx_frate.append(flow.frames_rx_rate)
@@ -715,9 +710,9 @@ def get_rib_in_convergence(cvg_api,
         logger.info("Traffic has converged after route advertisement")
 
         """ Get RIB-IN convergence """
-        request = cvg_api.convergence_request()
+        request = snappi_api.metrics_request()
         request.convergence.flow_names = []
-        convergence_metrics = cvg_api.get_results(request).flow_convergence
+        convergence_metrics = snappi_api.get_metrics(request).convergence_metrics
         for metrics in convergence_metrics:
             logger.info('RIB-IN Convergence time (ms): {}'.format(
                 metrics.control_plane_data_plane_convergence_us/1000))
@@ -725,15 +720,15 @@ def get_rib_in_convergence(cvg_api,
         avg_delta.append(int(flows[0].frames_tx)-int(flows[0].frames_rx))
         """ Stop traffic at the end of iteration """
         logger.info('Stopping Traffic at the end of iteration{}'.format(i+1))
-        cs = cvg_api.convergence_state()
-        cs.transmit.state = cs.transmit.STOP
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT-20, "For Traffic To stop")
         """ Stopping Protocols """
         logger.info("Stopping all protocols ...")
-        cs = cvg_api.convergence_state()
-        cs.protocol.state = cs.protocol.STOP
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.protocol.all.state = cs.protocol.all.STOP
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT-20, "For Protocols To STOP")
     table.append('Advertise All BGP Routes')
     table.append(route_type)
@@ -746,25 +741,25 @@ def get_rib_in_convergence(cvg_api,
     logger.info("\n%s" % tabulate([table], headers=columns, tablefmt="psql"))
 
 
-def get_RIB_IN_capacity(cvg_api,
+def get_RIB_IN_capacity(snappi_api,
                         multipath,
                         start_value,
                         step_value,
-                        route_type,
-                        port_speed,):
+                        route_type,):
     """
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         temp_tg_port (pytest fixture): Ports mapping info of T0 testbed
         multipath: ecmp value for BGP config
         start_value:  Start value of the number of BGP routes
         step_value: Step value of the number of BGP routes to be incremented
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used in test
     """
     def tgen_capacity(routes):
-        conv_config = cvg_api.convergence_config()
-        config = conv_config.config
+        config = snappi_api.config()
+        config.events.cp_events.enable = True
+        config.events.dp_events.enable = True
+        config.events.dp_events.rx_rate_threshold = 90/(multipath-1)
         for i in range(1, 3):
             config.ports.port(name='Test_Port_%d' %
                               i, location=temp_tg_port[i-1]['location'])
@@ -785,14 +780,14 @@ def get_RIB_IN_capacity(cvg_api,
         layer1.name = 'port settings'
         layer1.port_names = [port.name for port in config.ports]
         layer1.ieee_media_defaults = False
-        layer1.auto_negotiation.rs_fec = True
+        layer1.auto_negotiation.rs_fec = False
         layer1.auto_negotiation.link_training = False
-        layer1.speed = port_speed
+        layer1.speed = temp_tg_port[0]['speed']
         layer1.auto_negotiate = False
 
         def create_v4_topo():
             eth = config.devices[0].ethernets.add()
-            eth.port_name = config.lags[0].name
+            eth.connection.port_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv4 = eth.ipv4_addresses.add()
@@ -807,7 +802,7 @@ def get_RIB_IN_capacity(cvg_api,
                 else:
                     m = hex(i).split('0x')[1]
                 ethernet_stack = config.devices[i-1].ethernets.add()
-                ethernet_stack.port_name = config.lags[i-1].name
+                ethernet_stack.connection.port_name = config.lags[i-1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv4_stack = ethernet_stack.ipv4_addresses.add()
@@ -837,7 +832,7 @@ def get_RIB_IN_capacity(cvg_api,
 
         def create_v6_topo():
             eth = config.devices[0].ethernets.add()
-            eth.port_name = config.lags[0].name
+            eth.connection.port_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv6 = eth.ipv6_addresses.add()
@@ -852,7 +847,7 @@ def get_RIB_IN_capacity(cvg_api,
                 else:
                     m = hex(i).split('0x')[1]
                 ethernet_stack = config.devices[i-1].ethernets.add()
-                ethernet_stack.port_name = config.lags[i-1].name
+                ethernet_stack.connection.port_name = config.lags[i-1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv6_stack = ethernet_stack.ipv6_addresses.add()
@@ -880,7 +875,6 @@ def get_RIB_IN_capacity(cvg_api,
                 as_path_segment.as_numbers = aspaths
                 rx_flow_name.append(route_range.name)
             return rx_flow_name
-        conv_config.rx_rate_threshold = 90/(multipath)
         if route_type == 'IPv4':
             rx_flows = create_v4_topo()
             flow = config.flows.flow(name='IPv4_Traffic_%d' % routes)[-1]
@@ -895,24 +889,24 @@ def get_RIB_IN_capacity(cvg_api,
         flow.rate.percentage = 100
         flow.metrics.enable = True
         flow.metrics.loss = True
-        return conv_config
+        return config
 
     def run_traffic(routes):
         logger.info(
             '|-------------------- RIB-IN Capacity test, No.of Routes : {} ----|'.format(routes))
         conv_config = tgen_capacity(routes)
-        cvg_api.set_config(conv_config)
+        snappi_api.set_config(conv_config)
         """ Starting Protocols """
         logger.info("Starting all protocols ...")
-        cs = cvg_api.convergence_state()
-        cs.protocol.state = cs.protocol.START
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.protocol.all.state = cs.protocol.all.START
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT, "For Protocols To start")
         """ Starting Traffic """
         logger.info('Starting Traffic')
-        cs = cvg_api.convergence_state()
-        cs.transmit.state = cs.transmit.START
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT, "For Traffic To start")
 
     try:
@@ -920,7 +914,7 @@ def get_RIB_IN_capacity(cvg_api,
             max_routes = start_value
             tx_frate, rx_frate = [], []
             run_traffic(j)
-            flow_stats = get_flow_stats(cvg_api)
+            flow_stats = get_flow_stats(snappi_api)
             logger.info('\n')
             logger.info('Loss% : {}'.format(flow_stats[0].loss))
             for flow in flow_stats:
@@ -937,15 +931,15 @@ def get_RIB_IN_capacity(cvg_api,
                 logger.info('Reducing the routes and running test')
                 b = j-step_value
                 logger.info('Stopping Traffic')
-                cs = cvg_api.convergence_state()
-                cs.transmit.state = cs.transmit.STOP
-                cvg_api.set_state(cs)
+                cs = snappi_api.control_state()
+                cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+                snappi_api.set_control_state(cs)
                 wait(TIMEOUT-20, "For Traffic To stop")
                 break
             logger.info('Stopping Traffic')
-            cs = cvg_api.convergence_state()
-            cs.transmit.state = cs.transmit.STOP
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT-20, "For Traffic To stop")
         routes = []
         routes.append(b+int(step_value/8))
@@ -955,7 +949,7 @@ def get_RIB_IN_capacity(cvg_api,
         routes.append(b+step_value-int(step_value/8))
         for i in range(0, len(routes)):
             run_traffic(routes[i])
-            flow_stats = get_flow_stats(cvg_api)
+            flow_stats = get_flow_stats(snappi_api)
             logger.info('Loss% : {}'.format(flow_stats[0].loss))
             if float(flow_stats[0].loss) <= 0.001:
                 max_routes = start_value
@@ -964,15 +958,15 @@ def get_RIB_IN_capacity(cvg_api,
                 max_routes = routes[i]-int(step_value/8)
                 break
             logger.info('Stopping Traffic')
-            cs = cvg_api.convergence_state()
-            cs.transmit.state = cs.transmit.STOP
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT-20, "For Traffic To stop")
             """ Stopping Protocols """
             logger.info("Stopping all protocols ...")
-            cs = cvg_api.convergence_state()
-            cs.protocol.state = cs.protocol.STOP
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.protocol.all.state = cs.protocol.all.START
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT-20, "For Protocols To STOP")
     except Exception as e:
         logger.info(e)

--- a/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_test_gap_helper.py
@@ -13,7 +13,7 @@ NG_LIST = []
 aspaths = [65002, 65003]
 
 
-def run_bgp_convergence_performance(cvg_api,
+def run_bgp_convergence_performance(snappi_api,
                                     duthost,
                                     tgen_ports,
                                     multipath,
@@ -25,7 +25,7 @@ def run_bgp_convergence_performance(cvg_api,
     Run Remote link failover test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         multipath: ecmp value for BGP config
@@ -44,7 +44,7 @@ def run_bgp_convergence_performance(cvg_api,
         Run the convergence test by withdrawing all the route ranges
         one by one and calculate the convergence values
     """
-    get_convergence_for_remote_link_failover(cvg_api,
+    get_convergence_for_remote_link_failover(snappi_api,
                                              multipath,
                                              start_routes,
                                              routes_step,
@@ -56,7 +56,7 @@ def run_bgp_convergence_performance(cvg_api,
     cleanup_config(duthost)
 
 
-def run_bgp_scalability_v4_v6(cvg_api,
+def run_bgp_scalability_v4_v6(snappi_api,
                               duthost,
                               localhost,
                               tgen_ports,
@@ -68,7 +68,7 @@ def run_bgp_scalability_v4_v6(cvg_api,
     Run Remote link failover test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of T0 testbed
         multipath: ecmp value for BGP config
@@ -86,21 +86,21 @@ def run_bgp_scalability_v4_v6(cvg_api,
     else:
         dual_stack_flag = 0
     """ Create bgp config on TGEN """
-    tgen_bgp_config = __tgen_bgp_config(cvg_api,
+    tgen_bgp_config = __tgen_bgp_config(snappi_api,
                                         port_count,
                                         ipv4_routes,
                                         ipv6_routes,
                                         ipv6_prefix,
                                         dual_stack_flag,)
 
-    if ipv4_routes + ipv6_routes > 20000:
+    if ipv4_routes + ipv6_routes > 125000:
         limit_flag = 1
     else:
         limit_flag = 0
     """
         Run the BGP Scalability test
     """
-    get_bgp_scalability_result(cvg_api, localhost, tgen_bgp_config, limit_flag, duthost)
+    get_bgp_scalability_result(snappi_api, localhost, tgen_bgp_config, limit_flag, duthost)
 
 
 def duthost_bgp_3port_config(duthost,
@@ -261,7 +261,7 @@ def duthost_bgp_scalability_config(duthost, tgen_ports, multipath):
         duthost.shell(bgp_config_neighbor)
 
 
-def __tgen_bgp_config(cvg_api,
+def __tgen_bgp_config(snappi_api,
                       port_count,
                       v4_routes,
                       v6_routes,
@@ -271,16 +271,15 @@ def __tgen_bgp_config(cvg_api,
     Creating  BGP config on TGEN
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         port_count: multipath + 1
         v4_routes: no of v4 routes
         v6_routes: no of v6 routes
         v6_prefix: IPv6 prefix value
         dual_stack_flag: notation for dual or single stack
     """
-    conv_config = cvg_api.convergence_config()
-    cvg_api.enable_scaling(True)
-    config = conv_config.config
+    config = snappi_api.config()
+    snappi_api.enable_scaling(True)
     p1, p2 = (
         config.ports.port(name="Source", location=temp_tg_port[0]['location'])
         .port(name="Destination", location=temp_tg_port[1]['location'])
@@ -303,7 +302,7 @@ def __tgen_bgp_config(cvg_api,
     layer1.name = 'port settings'
     layer1.port_names = [port.name for port in config.ports]
     layer1.ieee_media_defaults = False
-    layer1.auto_negotiation.rs_fec = True
+    layer1.auto_negotiation.rs_fec = False
     layer1.auto_negotiation.link_training = False
     layer1.speed = "speed_100_gbps"
     layer1.auto_negotiate = False
@@ -311,7 +310,7 @@ def __tgen_bgp_config(cvg_api,
     # Source
     config.devices.device(name='Tx')
     eth_1 = config.devices[0].ethernets.add()
-    eth_1.port_name = lag1.name
+    eth_1.connection.port_name = lag1.name
     eth_1.name = 'Ethernet 1'
     eth_1.mac = "00:14:0a:00:00:01"
     ipv4_1 = eth_1.ipv4_addresses.add()
@@ -327,7 +326,7 @@ def __tgen_bgp_config(cvg_api,
     # Destination
     config.devices.device(name="Rx")
     eth_2 = config.devices[1].ethernets.add()
-    eth_2.port_name = lag2.name
+    eth_2.connection.port_name = lag2.name
     eth_2.name = 'Ethernet 2'
     eth_2.mac = "00:14:01:00:00:01"
     ipv4_2 = eth_2.ipv4_addresses.add()
@@ -388,20 +387,20 @@ def __tgen_bgp_config(cvg_api,
             createTrafficItem("IPv6_1-IPv6_Routes", ipv6_1.name, route_range2.name, 10)
         elif v6_routes == 0:
             createTrafficItem("IPv4_1-IPv4_Routes", ipv4_1.name, route_range1.name, 10)
-    return conv_config
+    return config
 
 
-def get_flow_stats(cvg_api):
+def get_flow_stats(snappi_api):
     """
     Args:
-        cvg_api (pytest fixture): Snappi API
+        snappi_api (pytest fixture): Snappi API
     """
-    request = cvg_api.convergence_request()
-    request.metrics.flow_names = []
-    return cvg_api.get_results(request).flow_metric
+    req = snappi_api.metrics_request()
+    req.flow.flow_names = []
+    return snappi_api.get_metrics(req).flow_metrics
 
 
-def get_convergence_for_remote_link_failover(cvg_api,
+def get_convergence_for_remote_link_failover(snappi_api,
                                              multipath,
                                              start_routes,
                                              routes_step,
@@ -410,7 +409,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
                                              duthost):
     """
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         iteration: number of iterations for running convergence test on a port
         start_routes: starting value of no of routes
         routes_step: incremental step value for the routes
@@ -421,8 +420,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
     global NG_LIST
 
     def tgen_config(routes):
-        conv_config = cvg_api.convergence_config()
-        config = conv_config.config
+        config = snappi_api.config()
         for i in range(1, multipath + 2):
             config.ports.port(name='Test_Port_%d' % i, location=temp_tg_port[i - 1]['location'])
             c_lag = config.lags.lag(name="lag%d" % i)[-1]
@@ -442,14 +440,14 @@ def get_convergence_for_remote_link_failover(cvg_api,
         layer1.name = 'port settings'
         layer1.port_names = [port.name for port in config.ports]
         layer1.ieee_media_defaults = False
-        layer1.auto_negotiation.rs_fec = True
+        layer1.auto_negotiation.rs_fec = False
         layer1.auto_negotiation.link_training = False
         layer1.speed = "speed_100_gbps"
         layer1.auto_negotiate = False
 
         def create_v4_topo():
             eth = config.devices[0].ethernets.add()
-            eth.port_name = config.lags[0].name
+            eth.connection.port_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv4 = eth.ipv4_addresses.add()
@@ -466,7 +464,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
                     m = hex(i).split('0x')[1]
 
                 ethernet_stack = config.devices[i - 1].ethernets.add()
-                ethernet_stack.port_name = config.lags[i - 1].name
+                ethernet_stack.connection.port_name = config.lags[i - 1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv4_stack = ethernet_stack.ipv4_addresses.add()
@@ -494,7 +492,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
 
         def create_v6_topo():
             eth = config.devices[0].ethernets.add()
-            eth.port_name = config.lags[0].name
+            eth.connection.port_name = config.lags[0].name
             eth.name = 'Ethernet 1'
             eth.mac = "00:00:00:00:00:01"
             ipv6 = eth.ipv6_addresses.add()
@@ -510,7 +508,7 @@ def get_convergence_for_remote_link_failover(cvg_api,
                 else:
                     m = hex(i).split('0x')[1]
                 ethernet_stack = config.devices[i - 1].ethernets.add()
-                ethernet_stack.port_name = config.lags[i - 1].name
+                ethernet_stack.connection.port_name = config.lags[i - 1].name
                 ethernet_stack.name = 'Ethernet %d' % i
                 ethernet_stack.mac = "00:00:00:00:00:%s" % m
                 ipv6_stack = ethernet_stack.ipv6_addresses.add()
@@ -536,7 +534,9 @@ def get_convergence_for_remote_link_failover(cvg_api,
                 rx_flow_name.append(route_range.name)
             return rx_flow_name
 
-        conv_config.rx_rate_threshold = 90 / (multipath)
+        config.events.cp_events.enable = True
+        config.events.dp_events.enable = True
+        config.events.dp_events.rx_rate_threshold = 90/(multipath-1)
         if route_type == 'IPv4':
             rx_flows = create_v4_topo()
             flow = config.flows.flow(name='IPv4_Traffic_%d' % routes)[-1]
@@ -551,14 +551,16 @@ def get_convergence_for_remote_link_failover(cvg_api,
         flow.rate.percentage = 100
         flow.metrics.enable = True
         flow.metrics.loss = True
-        return conv_config
+        return config
 
     for j in range(start_routes, stop_routes, routes_step):
         logger.info('|--------------------CP/DP Test with No.of Routes : {} ----|'.format(j))
         bgp_config = tgen_config(j)
         route_name = NG_LIST[0]
-        bgp_config.rx_rate_threshold = 90 / (multipath - 1)
-        cvg_api.set_config(bgp_config)
+        bgp_config.events.cp_events.enable = True
+        bgp_config.events.dp_events.enable = True
+        bgp_config.events.dp_events.rx_rate_threshold = 90/(multipath-1)
+        snappi_api.set_config(bgp_config)
 
         def get_cpdp_convergence_time(route_name):
             """
@@ -567,18 +569,18 @@ def get_convergence_for_remote_link_failover(cvg_api,
 
             """
             table, tx_frate, rx_frate = [], [], []
-            run_traffic(cvg_api, duthost)
-            flow_stats = get_flow_stats(cvg_api)
+            run_traffic(snappi_api, duthost)
+            flow_stats = get_flow_stats(snappi_api)
             tx_frame_rate = flow_stats[0].frames_tx_rate
             assert tx_frame_rate != 0, "Traffic has not started"
             """ Withdrawing routes from a BGP peer """
             logger.info('Withdrawing Routes from {}'.format(route_name))
-            cs = cvg_api.convergence_state()
-            cs.route.names = [route_name]
-            cs.route.state = cs.route.WITHDRAW
-            cvg_api.set_state(cs)
+            cs = snappi_api.control_state()
+            cs.protocol.route.state = cs.protocol.route.WITHDRAW
+            cs.protocol.route.names = [route_name]
+            snappi_api.set_control_state(cs)
             wait(TIMEOUT, "For routes to be withdrawn")
-            flows = get_flow_stats(cvg_api)
+            flows = get_flow_stats(snappi_api)
             for flow in flows:
                 tx_frate.append(flow.frames_tx_rate)
                 rx_frate.append(flow.frames_rx_rate)
@@ -587,13 +589,13 @@ def get_convergence_for_remote_link_failover(cvg_api,
             logger.info("Traffic has converged after route withdraw")
 
             """ Get control plane to data plane convergence value """
-            request = cvg_api.convergence_request()
+            request = snappi_api.metrics_request()
             request.convergence.flow_names = []
-            convergence_metrics = cvg_api.get_results(request).flow_convergence
+            convergence_metrics = snappi_api.get_metrics(request).convergence_metrics
             for metrics in convergence_metrics:
                 logger.info('CP/DP Convergence Time (ms): \
                             {}'.format(metrics.control_plane_data_plane_convergence_us / 1000))
-            stop_traffic(cvg_api)
+            stop_traffic(snappi_api)
             table.append(route_type)
             table.append(j)
             table.append(int(metrics.control_plane_data_plane_convergence_us / 1000))
@@ -605,41 +607,41 @@ def get_convergence_for_remote_link_failover(cvg_api,
     logger.info("\n%s" % tabulate(table, headers=columns, tablefmt="psql"))
 
 
-def restart_traffic(cvg_api):
+def restart_traffic(snappi_api):
     """ Stopping Protocols """
     logger.info("L2/3 traffic apply failed,Restarting protocols and traffic")
-    cs = cvg_api.convergence_state()
-    cs.protocol.state = cs.protocol.STOP
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.protocol.all.state = cs.protocol.all.STOP
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT - 10, "For Protocols To stop")
-    cs = cvg_api.convergence_state()
-    cs.protocol.state = cs.protocol.START
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.protocol.all.state = cs.protocol.all.START
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT - 10, "For Protocols To start")
-    cs = cvg_api.convergence_state()
-    cs.transmit.state = cs.transmit.START
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT, "For Traffic To start and stabilize")
 
 
-def run_traffic(cvg_api, duthost):
+def run_traffic(snappi_api, duthost):
     warning = 0
     """ Starting Protocols """
     logger.info("Starting all protocols ...")
-    cs = cvg_api.convergence_state()
-    cs.protocol.state = cs.protocol.START
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.protocol.all.state = cs.protocol.all.START
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT - 10, "For Protocols To start")
     """ Starting Traffic """
     logger.info('Starting Traffic')
     try:
-        cs = cvg_api.convergence_state()
-        cs.transmit.state = cs.transmit.START
-        cvg_api.set_state(cs)
+        cs = snappi_api.control_state()
+        cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+        snappi_api.set_control_state(cs)
         wait(TIMEOUT + 10, "For Traffic To start and stabilize")
     except Exception as e:
         logger.info(e)
-        restart_traffic(cvg_api)
+        restart_traffic(snappi_api)
     finally:
         duthost.shell("sudo cp /var/log/syslog /host/scale_syslog.99")
         var = duthost.shell("sudo cat /host/scale_syslog.99 | grep 'ROUTE THRESHOLD_EXCEEDED' || true")['stdout']
@@ -652,43 +654,42 @@ def run_traffic(cvg_api, duthost):
     return warning
 
 
-def stop_traffic(cvg_api):
+def stop_traffic(snappi_api):
     logger.info('Stopping Traffic')
-    cs = cvg_api.convergence_state()
-    cs.transmit.state = cs.transmit.STOP
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT - 20, "For Traffic To stop")
     """ Stopping Protocols """
     logger.info("Stopping all protocols ...")
-    cs = cvg_api.convergence_state()
-    cs.protocol.state = cs.protocol.STOP
-    cvg_api.set_state(cs)
+    cs = snappi_api.control_state()
+    cs.protocol.all.state = cs.protocol.all.STOP
+    snappi_api.set_control_state(cs)
     wait(TIMEOUT - 20, "For Protocols To STOP")
 
 
-def get_bgp_scalability_result(cvg_api, localhost, bgp_config, flag, duthost):
+def get_bgp_scalability_result(snappi_api, localhost, bgp_config, flag, duthost):
     """
     Cleaning up dut config at the end of the test
 
     Args:
-        cvg_api (pytest fixture): snappi API
+        snappi_api (pytest fixture): snappi API
         bgp_config: tgen_bgp_config
     """
-    cvg_api.set_config(bgp_config)
-    restpy_session = cvg_api._api._assistant.Session
-    ixnet = restpy_session.Ixnetwork
+    snappi_api.set_config(bgp_config)
+    ixnet = snappi_api._ixnetwork
     if str(ixnet.Locations.find()[0].DeviceType) == 'Optixia XV':
         ixnet.Traffic.Statistics.CpdpConvergence.EnableDataPlaneEventsRateMonitor = False
-    warning = run_traffic(cvg_api, duthost)
+    warning = run_traffic(snappi_api, duthost)
     if warning == 1:
         msg = "THRESHOLD_EXCEEDED warning message observed in syslog"
     else:
         msg = "THRESHOLD_EXCEEDED warning message not observed in syslog"
-    flow_stats = get_flow_stats(cvg_api)
+    flow_stats = get_flow_stats(snappi_api)
     tx_frame_rate = flow_stats[0].frames_tx_rate
     assert tx_frame_rate != 0, "Traffic has not started"
-    stop_traffic(cvg_api)
-    flow_stats = get_flow_stats(cvg_api)
+    stop_traffic(snappi_api)
+    flow_stats = get_flow_stats(snappi_api)
     logger.info('|---- Tx Frame: {} ----|'.format(flow_stats[0].frames_tx))
     logger.info('|---- Rx Frame: {} ----|'.format(flow_stats[0].frames_rx))
     logger.info('|---- Loss % : {} ----|'.format(flow_stats[0].loss))

--- a/tests/snappi_tests/bgp/test_bgp_convergence_performance.py
+++ b/tests/snappi_tests/bgp/test_bgp_convergence_performance.py
@@ -1,5 +1,5 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
-    cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_test_gap_helper import run_bgp_convergence_performance
 from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
     conn_graph_facts, fanout_graph_facts)
@@ -9,11 +9,11 @@ pytestmark = [pytest.mark.topology('tgen')]
 
 
 @pytest.mark.parametrize('multipath', [2])
-@pytest.mark.parametrize('start_routes', [500])
-@pytest.mark.parametrize('routes_step', [500])
+@pytest.mark.parametrize('start_routes', [1000])
+@pytest.mark.parametrize('routes_step', [1000])
 @pytest.mark.parametrize('stop_routes', [16000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-def test_bgp_convergence_performance(cvg_api,               # noqa F811
+def test_bgp_convergence_performance(snappi_api,               # noqa F811
                                      duthost,
                                      tgen_ports,            # noqa F811
                                      multipath,
@@ -51,7 +51,7 @@ def test_bgp_convergence_performance(cvg_api,               # noqa F811
         stop_routes: ending route count value
         route_type: IPv4 or IPv6 routes
     """
-    run_bgp_convergence_performance(cvg_api,
+    run_bgp_convergence_performance(snappi_api,
                                     duthost,
                                     tgen_ports,
                                     multipath,

--- a/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_local_link_failover.py
@@ -1,5 +1,5 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
-    cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_bgp_local_link_failover_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
     conn_graph_facts, fanout_graph_facts)
@@ -12,8 +12,7 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('convergence_test_iterations', [1])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
-def test_bgp_convergence_for_local_link_failover(cvg_api,                   # noqa F811
+def test_bgp_convergence_for_local_link_failover(snappi_api,                   # noqa F811
                                                  duthost,
                                                  tgen_ports,                # noqa F811
                                                  conn_graph_facts,          # noqa F811
@@ -21,8 +20,7 @@ def test_bgp_convergence_for_local_link_failover(cvg_api,                   # no
                                                  multipath,
                                                  convergence_test_iterations,
                                                  number_of_routes,
-                                                 route_type,
-                                                 port_speed,):
+                                                 route_type,):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -42,7 +40,7 @@ def test_bgp_convergence_for_local_link_failover(cvg_api,                   # no
         Result: The traffic must be routed via rest of the ECMP paths
 
     Args:
-        cvg_api (pytest fixture): Snappi Convergence API
+        snappi_api (pytest fixture): Snappi Convergence API
         duthost (pytest fixture): duthost fixture
         tgen_ports (pytest fixture): Ports mapping info of testbed
         conn_graph_facts (pytest fixture): connection graph
@@ -51,15 +49,13 @@ def test_bgp_convergence_for_local_link_failover(cvg_api,                   # no
         convergence_test_iterations: number of iterations the link failure test has to be run for a port
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     # convergence_test_iterations, multipath, number_of_routes and
     # route_type parameters can be modified as per user preference
-    run_bgp_local_link_failover_test(cvg_api,
+    run_bgp_local_link_failover_test(snappi_api,
                                      duthost,
                                      tgen_ports,
                                      convergence_test_iterations,
                                      multipath,
                                      number_of_routes,
-                                     route_type,
-                                     port_speed,)
+                                     route_type,)

--- a/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
+++ b/tests/snappi_tests/bgp/test_bgp_remote_link_failover.py
@@ -1,5 +1,5 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
-    cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_bgp_remote_link_failover_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
     conn_graph_facts, fanout_graph_facts)
@@ -12,8 +12,7 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('convergence_test_iterations', [1])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
-def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # noqa F811
+def test_bgp_convergence_for_remote_link_failover(snappi_api,                  # noqa F811
                                                   duthost,
                                                   tgen_ports,               # noqa F811
                                                   conn_graph_facts,         # noqa F811
@@ -21,8 +20,7 @@ def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # no
                                                   multipath,
                                                   convergence_test_iterations,
                                                   number_of_routes,
-                                                  route_type,
-                                                  port_speed,):
+                                                  route_type,):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -51,15 +49,13 @@ def test_bgp_convergence_for_remote_link_failover(cvg_api,                  # no
         convergence_test_iterations: number of iterations the cp/dp convergence test has to be run for a port
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     # convergence_test_iterations, multipath, number_of_routes,
     # port_speed and route_type parameters can be modified as per user preference
-    run_bgp_remote_link_failover_test(cvg_api,
+    run_bgp_remote_link_failover_test(snappi_api,
                                       duthost,
                                       tgen_ports,
                                       convergence_test_iterations,
                                       multipath,
                                       number_of_routes,
-                                      route_type,
-                                      port_speed,)
+                                      route_type,)

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_capacity.py
@@ -1,5 +1,5 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
-    cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_RIB_IN_capacity_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
     conn_graph_facts, fanout_graph_facts)
@@ -9,11 +9,10 @@ pytestmark = [pytest.mark.topology('tgen')]
 
 
 @pytest.mark.parametrize('multipath', [2])
-@pytest.mark.parametrize('start_value', [1000])
-@pytest.mark.parametrize('step_value', [1000])
+@pytest.mark.parametrize('start_value', [5000])
+@pytest.mark.parametrize('step_value', [5000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
-def test_RIB_IN_capacity(cvg_api,                   # noqa F811
+def test_RIB_IN_capacity(snappi_api,                   # noqa F811
                          duthost,
                          tgen_ports,                # noqa F811
                          conn_graph_facts,          # noqa F811
@@ -21,8 +20,7 @@ def test_RIB_IN_capacity(cvg_api,                   # noqa F811
                          multipath,
                          start_value,
                          step_value,
-                         route_type,
-                         port_speed,):
+                         route_type,):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -51,14 +49,12 @@ def test_RIB_IN_capacity(cvg_api,                   # noqa F811
         start_value:  Start value of the number of BGP routes
         step_value: Step value of the number of BGP routes to be incremented
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     # multipath, start_value, step_value and route_type, port_speed parameters can be modified as per user preference
-    run_RIB_IN_capacity_test(cvg_api,
+    run_RIB_IN_capacity_test(snappi_api,
                              duthost,
                              tgen_ports,
                              multipath,
                              start_value,
                              step_value,
-                             route_type,
-                             port_speed,)
+                             route_type,)

--- a/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
+++ b/tests/snappi_tests/bgp/test_bgp_rib_in_convergence.py
@@ -1,5 +1,5 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
-    cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_convergence_helper import run_rib_in_convergence_test
 from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
     conn_graph_facts, fanout_graph_facts)
@@ -12,8 +12,7 @@ pytestmark = [pytest.mark.topology('tgen')]
 @pytest.mark.parametrize('convergence_test_iterations', [1])
 @pytest.mark.parametrize('number_of_routes', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])
-@pytest.mark.parametrize('port_speed', ['speed_100_gbps'])
-def test_rib_in_convergence(cvg_api,                    # noqa F811
+def test_rib_in_convergence(snappi_api,                    # noqa F811
                             duthost,
                             tgen_ports,                 # noqa F811
                             conn_graph_facts,           # noqa F811
@@ -21,8 +20,7 @@ def test_rib_in_convergence(cvg_api,                    # noqa F811
                             multipath,
                             convergence_test_iterations,
                             number_of_routes,
-                            route_type,
-                            port_speed,):
+                            route_type,):
     """
     Topo:
     TGEN1 --- DUT --- TGEN(2..N)
@@ -52,15 +50,13 @@ def test_rib_in_convergence(cvg_api,                    # noqa F811
         convergence_test_iterations: number of iterations the link failure test has to be run for a port
         number_of_routes:  Number of IPv4/IPv6 Routes
         route_type: IPv4 or IPv6 routes
-        port_speed: speed of the port used for test
     """
     # convergence_test_iterations, multipath, number_of_routes port_speed and
     # route_type parameters can be modified as per user preference
-    run_rib_in_convergence_test(cvg_api,
+    run_rib_in_convergence_test(snappi_api,
                                 duthost,
                                 tgen_ports,
                                 convergence_test_iterations,
                                 multipath,
                                 number_of_routes,
-                                route_type,
-                                port_speed,)
+                                route_type,)

--- a/tests/snappi_tests/bgp/test_bgp_scalability.py
+++ b/tests/snappi_tests/bgp/test_bgp_scalability.py
@@ -1,5 +1,5 @@
 from tests.common.snappi_tests.snappi_fixtures import (                           # noqa F401
-    cvg_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
+    snappi_api, snappi_api_serv_ip, snappi_api_serv_port, tgen_ports)
 from tests.snappi_tests.bgp.files.bgp_test_gap_helper import duthost_bgp_scalability_config, \
     run_bgp_scalability_v4_v6, cleanup_config
 from tests.common.fixtures.conn_graph_facts import (                        # noqa F401
@@ -18,7 +18,7 @@ def test_duthost_bgp_scalability_config(duthost, tgen_ports, multipath):        
 @pytest.mark.parametrize('ipv4_routes', [16000])
 @pytest.mark.parametrize('ipv6_routes', [1])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_16k_v4_routes(cvg_api,             # noqa F811
+def test_bgp_scalability_16k_v4_routes(snappi_api,             # noqa F811
                                        duthost,
                                        localhost,
                                        tgen_ports,          # noqa F811
@@ -27,7 +27,7 @@ def test_bgp_scalability_16k_v4_routes(cvg_api,             # noqa F811
                                        ipv6_routes,
                                        ipv6_prefix):
 
-    run_bgp_scalability_v4_v6(cvg_api,
+    run_bgp_scalability_v4_v6(snappi_api,
                               duthost,
                               localhost,
                               tgen_ports,
@@ -41,7 +41,7 @@ def test_bgp_scalability_16k_v4_routes(cvg_api,             # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [1])
 @pytest.mark.parametrize('ipv6_routes', [8000])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_8k_v6_routes(cvg_api,              # noqa F811
+def test_bgp_scalability_8k_v6_routes(snappi_api,              # noqa F811
                                       duthost,
                                       localhost,
                                       tgen_ports,           # noqa F811
@@ -50,7 +50,7 @@ def test_bgp_scalability_8k_v6_routes(cvg_api,              # noqa F811
                                       ipv6_routes,
                                       ipv6_prefix):
 
-    run_bgp_scalability_v4_v6(cvg_api,
+    run_bgp_scalability_v4_v6(snappi_api,
                               duthost,
                               localhost,
                               tgen_ports,
@@ -64,7 +64,7 @@ def test_bgp_scalability_8k_v6_routes(cvg_api,              # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [1])
 @pytest.mark.parametrize('ipv6_routes', [256])
 @pytest.mark.parametrize('ipv6_prefix', [128])
-def test_bgp_scalability_256_v6_routes(cvg_api,             # noqa F811
+def test_bgp_scalability_256_v6_routes(snappi_api,             # noqa F811
                                        duthost,
                                        localhost,
                                        tgen_ports,          # noqa F811
@@ -73,7 +73,7 @@ def test_bgp_scalability_256_v6_routes(cvg_api,             # noqa F811
                                        ipv6_routes,
                                        ipv6_prefix):
 
-    run_bgp_scalability_v4_v6(cvg_api,
+    run_bgp_scalability_v4_v6(snappi_api,
                               duthost,
                               localhost,
                               tgen_ports,
@@ -87,7 +87,7 @@ def test_bgp_scalability_256_v6_routes(cvg_api,             # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [8000])
 @pytest.mark.parametrize('ipv6_routes', [4000])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_8kv4_4kv6_routes(cvg_api,          # noqa F811
+def test_bgp_scalability_8kv4_4kv6_routes(snappi_api,          # noqa F811
                                           duthost,
                                           localhost,
                                           tgen_ports,       # noqa F811
@@ -96,7 +96,7 @@ def test_bgp_scalability_8kv4_4kv6_routes(cvg_api,          # noqa F811
                                           ipv6_routes,
                                           ipv6_prefix):
 
-    run_bgp_scalability_v4_v6(cvg_api,
+    run_bgp_scalability_v4_v6(snappi_api,
                               duthost,
                               localhost,
                               tgen_ports,
@@ -110,7 +110,7 @@ def test_bgp_scalability_8kv4_4kv6_routes(cvg_api,          # noqa F811
 @pytest.mark.parametrize('ipv4_routes', [100000])
 @pytest.mark.parametrize('ipv6_routes', [25000])
 @pytest.mark.parametrize('ipv6_prefix', [64])
-def test_bgp_scalability_100kv4_25kv6_routes(cvg_api,       # noqa F811
+def test_bgp_scalability_100kv4_25kv6_routes(snappi_api,       # noqa F811
                                              duthost,
                                              localhost,
                                              tgen_ports,    # noqa F811
@@ -119,7 +119,7 @@ def test_bgp_scalability_100kv4_25kv6_routes(cvg_api,       # noqa F811
                                              ipv6_routes,
                                              ipv6_prefix):
 
-    run_bgp_scalability_v4_v6(cvg_api,
+    run_bgp_scalability_v4_v6(snappi_api,
                               duthost,
                               localhost,
                               tgen_ports,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Updating the BGP convergence cases to accomodate latest Snappi Api Model
Fixes # (issue)

### Type of change
The snappi_convergence library has been replaced to snappi_api
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
To update the scripts for latest snappi models
#### How did you do it?
Removed snappi_convergence apis and replaced with snappi_api apis
#### How did you verify/test it?
Tested on Edgecore DUT
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
20:12:31 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet64
20:12:33 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet68
20:12:35 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet72
20:12:36 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet64 to PortChannel1 with IPs 20.1.1.0,2000:1::1
20:12:39 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet68 to PortChannel2 with IPs 20.1.1.2,2000:2::1
20:12:41 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet72 to PortChannel3 with IPs 20.1.1.4,2000:3::1
20:12:44 bgp_convergence_helper.duthost_bgp_confi L0262 INFO   | Configuring BGP v4 Neighbor 20.1.1.3
20:12:44 bgp_convergence_helper.duthost_bgp_confi L0262 INFO   | Configuring BGP v4 Neighbor 20.1.1.5
20:12:45 connection._warn                         L0246 WARNING| Verification of certificates is disabled
20:12:45 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.77.53 address...
20:12:45 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.77.53:11009.
20:12:45 connection._info                         L0243 INFO   | Connection established to `https://10.36.77.53:11009 on windows`
20:12:45 connection._info                         L0243 INFO   | Using IxNetwork api server version 10.20.2402.29
20:12:45 connection._info                         L0243 INFO   | User info IxNetwork/WIN-11RK5TNKNAN/8010
20:12:45 snappi_api.info                          L1419 INFO   | snappi-1.27.1
20:12:45 snappi_api.info                          L1419 INFO   | snappi_ixnetwork-1.27.1
20:12:45 snappi_api.info                          L1419 INFO   | ixnetwork_restpy-1.0.64
20:12:45 snappi_api.info                          L1419 INFO   | Config validation 0.011s
20:12:46 snappi_api.info                          L1419 INFO   | Ports configuration 0.057s
20:12:46 snappi_api.info                          L1419 INFO   | Captures configuration 0.032s
20:12:54 snappi_api.info                          L1419 INFO   | Location hosts ready [10.36.78.53] 2.059s
20:12:54 snappi_api.info                          L1419 INFO   | Speed conversion is not require for (port.name, speed) : [('Test_Port_1', 'novusHundredGigNonFanOut'), ('Test_Port_2', 'novusHundredGigNonFanOut'), ('Test_Port_3', 'novusHundredGigNonFanOut')]
20:12:54 snappi_api.info                          L1419 INFO   | Aggregation mode speed change 0.345s
20:12:54 snappi_api.info                          L1419 INFO   | Location configuration 8.625s
20:12:55 snappi_api.info                          L1419 INFO   | Layer1 configuration 0.886s
20:12:56 snappi_api.info                          L1419 INFO   | Lag Configuration 1.167s
20:12:57 snappi_api.info                          L1419 INFO   | Lag Ethernet Configuration 0.216s
20:12:58 snappi_api.info                          L1419 INFO   | Lag Protocol Configuration 0.998s
20:12:58 snappi_api.info                          L1419 INFO   | Convert device config : 0.127s
20:12:58 snappi_api.info                          L1419 INFO   | Create IxNetwork device config : 0.001s
20:12:59 snappi_api.info                          L1419 INFO   | Push IxNetwork device config : 0.987s
20:12:59 snappi_api.info                          L1419 INFO   | Devices configuration 1.125s
20:12:59 snappi_api.info                          L1419 INFO   | Flows configuration 0.668s
20:13:00 snappi_api.info                          L1419 INFO   | Start interfaces 0.508s
20:13:00 snappi_api.info                          L1419 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
20:13:00 snappi_api.info                          L1419 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
20:13:00 bgp_convergence_helper.get_convergence_f L0463 INFO   | Starting all protocols ...
20:13:17 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Protocols To start
20:13:47 bgp_convergence_helper.get_avg_dpdp_conv L0476 INFO   | |---- Test_Port_2 Link Flap Iteration : 1 ----|
20:13:47 bgp_convergence_helper.get_avg_dpdp_conv L0480 INFO   | Starting Traffic
20:13:50 snappi_api.info                          L1419 INFO   | Flows generate/apply 2.614s
20:14:03 snappi_api.info                          L1419 INFO   | Flows clear statistics 13.688s
20:14:03 snappi_api.info                          L1419 INFO   | Captures start 0.000s
20:14:06 snappi_api.info                          L1419 INFO   | Flows start 2.572s
20:14:06 snappi_api.info                          L1419 INFO   | IxNet - If ports in a lag are down, please enable Transmit Ignore Link Status port property in order to successfully start traffic or clear statistics.
20:14:06 snappi_api.info                          L1419 INFO   | IxNet - The Rate Monitoring Jitter Window Size was decreased to support the incoming frame rate
20:14:06 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To start
20:14:36 bgp_convergence_helper.get_avg_dpdp_conv L0489 INFO   | Simulating Link Failure on Test_Port_2 link
20:14:36 snappi_api.info                          L1419 INFO   | Link State operation 0.009s
20:14:36 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Link to go down
20:15:07 bgp_convergence_helper.get_avg_dpdp_conv L0503 INFO   | Traffic has converged after link flap
20:15:29 bgp_convergence_helper.get_avg_dpdp_conv L0509 INFO   | CP/DP Convergence Time (ms): 59.654
20:15:29 bgp_convergence_helper.get_avg_dpdp_conv L0515 INFO   | Simulating Link Up on Test_Port_2 at the end of iteration 1
20:15:29 snappi_api.info                          L1419 INFO   | Link State operation 0.009s
20:15:29 bgp_convergence_helper.get_avg_dpdp_conv L0522 INFO   | Stopping Traffic
20:15:34 snappi_api.info                          L1419 INFO   | Flows stop 5.351s
20:15:34 utilities.wait                           L0118 INFO   | Pause 20 seconds, reason: For Traffic To Stop
20:15:54 bgp_convergence_helper.get_avg_dpdp_conv L0476 INFO   | |---- Test_Port_3 Link Flap Iteration : 1 ----|
20:15:54 bgp_convergence_helper.get_avg_dpdp_conv L0480 INFO   | Starting Traffic
20:16:04 snappi_api.info                          L1419 INFO   | Flows clear statistics 9.147s
20:16:04 snappi_api.info                          L1419 INFO   | Captures start 0.000s
20:16:06 snappi_api.info                          L1419 INFO   | Flows start 2.666s
20:16:06 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To start
20:16:37 bgp_convergence_helper.get_avg_dpdp_conv L0489 INFO   | Simulating Link Failure on Test_Port_3 link
20:16:37 snappi_api.info                          L1419 INFO   | Link State operation 0.009s
20:16:37 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Link to go down
20:17:07 bgp_convergence_helper.get_avg_dpdp_conv L0503 INFO   | Traffic has converged after link flap
20:17:15 bgp_convergence_helper.get_avg_dpdp_conv L0509 INFO   | CP/DP Convergence Time (ms): 195.126
20:17:15 bgp_convergence_helper.get_avg_dpdp_conv L0515 INFO   | Simulating Link Up on Test_Port_3 at the end of iteration 1
20:17:15 snappi_api.info                          L1419 INFO   | Link State operation 0.010s
20:17:15 bgp_convergence_helper.get_avg_dpdp_conv L0522 INFO   | Stopping Traffic
20:17:21 snappi_api.info                          L1419 INFO   | Flows stop 5.809s
20:17:21 utilities.wait                           L0118 INFO   | Pause 20 seconds, reason: For Traffic To Stop
20:17:41 bgp_convergence_helper.get_convergence_f L0540 INFO   | 
+--------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------+
| Event Name               | Route Type   |   No. of Routes |   Iterations |   Delta Frames |   Avg Calculated Data Convergence Time (ms) |
|--------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------|
| Test_Port_2 Link Failure | IPv4         |            1000 |            1 |         317218 |                                          59 |
| Test_Port_3 Link Failure | IPv4         |            1000 |            1 |        1131648 |                                         195 |
+--------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------+
20:18:17 bgp_convergence_helper.cleanup_config    L0984 INFO   | Wait until all critical services are fully started
20:18:39 bgp_convergence_helper.cleanup_config    L0987 INFO   | Convergence Test Completed
PASSED       

------------------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------------------
16:29:09 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet64
16:29:11 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet68
16:29:12 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet72
16:29:14 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet64 to PortChannel1 with IPs 20.1.1.0,2000:1::1
16:29:16 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet68 to PortChannel2 with IPs 20.1.1.2,2000:2::1
16:29:19 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet72 to PortChannel3 with IPs 20.1.1.4,2000:3::1
16:29:21 bgp_convergence_helper.duthost_bgp_confi L0262 INFO   | Configuring BGP v4 Neighbor 20.1.1.3
16:29:22 bgp_convergence_helper.duthost_bgp_confi L0262 INFO   | Configuring BGP v4 Neighbor 20.1.1.5
16:29:22 connection._warn                         L0246 WARNING| Verification of certificates is disabled
16:29:22 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.77.53 address...
16:29:22 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.77.53:11009.
16:29:22 connection._info                         L0243 INFO   | Connection established to `https://10.36.77.53:11009 on windows`
16:29:22 connection._info                         L0243 INFO   | Using IxNetwork api server version 10.20.2402.29
16:29:22 connection._info                         L0243 INFO   | User info IxNetwork/WIN-11RK5TNKNAN/8010
16:29:23 snappi_api.info                          L1419 INFO   | snappi-1.27.1
16:29:23 snappi_api.info                          L1419 INFO   | snappi_ixnetwork-1.27.1
16:29:23 snappi_api.info                          L1419 INFO   | ixnetwork_restpy-1.0.64
16:29:23 snappi_api.info                          L1419 INFO   | Config validation 0.005s
16:29:24 snappi_api.info                          L1419 INFO   | Ports configuration 0.895s
16:29:24 snappi_api.info                          L1419 INFO   | Captures configuration 0.033s
16:29:26 snappi_api.info                          L1419 INFO   | Add location hosts [10.36.78.53] 2.127s
16:29:30 snappi_api.info                          L1419 INFO   | Location hosts ready [10.36.78.53] 4.077s
16:29:30 snappi_api.info                          L1419 INFO   | Speed conversion is not require for (port.name, speed) : [('Test_Port_1', 'novusHundredGigNonFanOut'), ('Test_Port_2', 'novusHundredGigNonFanOut'), ('Test_Port_3', 'novusHundredGigNonFanOut')]
16:29:30 snappi_api.info                          L1419 INFO   | Aggregation mode speed change 0.283s
16:29:36 snappi_api.info                          L1419 INFO   | Location preemption [10.36.78.53;4;5, 10.36.78.53;4;6, 10.36.78.53;4;7] 0.030s
16:29:59 snappi_api.info                          L1419 INFO   | Location connect [Test_Port_1, Test_Port_2, Test_Port_3] 23.081s
16:29:59 snappi_api.warning                       L1425 WARNING| Test_Port_1 connectedLinkDown
16:29:59 snappi_api.warning                       L1425 WARNING| Test_Port_2 connectedLinkDown
16:29:59 snappi_api.warning                       L1425 WARNING| Test_Port_3 connectedLinkDown
16:29:59 snappi_api.info                          L1419 INFO   | Location state check [Test_Port_1, Test_Port_2, Test_Port_3] 0.044s
16:29:59 snappi_api.info                          L1419 INFO   | Location configuration 35.924s
16:30:01 snappi_api.info                          L1419 INFO   | Layer1 configuration 1.439s
16:30:02 snappi_api.info                          L1419 INFO   | Lag Configuration 1.168s
16:30:02 snappi_api.info                          L1419 INFO   | Lag Ethernet Configuration 0.247s
16:30:03 snappi_api.info                          L1419 INFO   | Lag Protocol Configuration 0.889s
16:30:03 snappi_api.info                          L1419 INFO   | Convert device config : 0.125s
16:30:03 snappi_api.info                          L1419 INFO   | Create IxNetwork device config : 0.000s
16:30:04 snappi_api.info                          L1419 INFO   | Push IxNetwork device config : 0.981s
16:30:04 snappi_api.info                          L1419 INFO   | Devices configuration 1.115s
16:30:06 snappi_api.info                          L1419 INFO   | Flows configuration 1.193s
16:30:06 snappi_api.info                          L1419 INFO   | Start interfaces 0.717s
16:30:07 snappi_api.info                          L1419 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
16:30:07 snappi_api.info                          L1419 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
16:30:07 bgp_convergence_helper.get_rib_in_conver L0667 INFO   | |---- RIB-IN Convergence test, Iteration : 1 ----|
16:30:07 bgp_convergence_helper.get_rib_in_conver L0670 INFO   | Withdraw All Routes before starting traffic
16:30:07 snappi_api.info                          L1419 INFO   | Setting route state 0.088s
16:30:07 utilities.wait                           L0118 INFO   | Pause 5 seconds, reason: For Routes to be withdrawn
16:30:12 bgp_convergence_helper.get_rib_in_conver L0677 INFO   | Starting all protocols ...
16:30:43 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Protocols To start
16:31:13 bgp_convergence_helper.get_rib_in_conver L0683 INFO   | Starting Traffic
16:31:16 snappi_api.info                          L1419 INFO   | Flows generate/apply 2.965s
16:31:31 snappi_api.info                          L1419 INFO   | Flows clear statistics 15.604s
16:31:31 snappi_api.info                          L1419 INFO   | Captures start 0.000s
16:31:34 snappi_api.info                          L1419 INFO   | Flows start 2.951s
16:31:34 snappi_api.info                          L1419 INFO   | IxNet - If ports in a lag are down, please enable Transmit Ignore Link Status port property in order to successfully start traffic or clear statistics.
16:31:34 snappi_api.info                          L1419 INFO   | IxNet - The Rate Monitoring Jitter Window Size was decreased to support the incoming frame rate
16:31:34 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To start
16:32:05 bgp_convergence_helper.get_rib_in_conver L0695 INFO   | Advertising all Routes from ['Network_Group2', 'Network_Group3']
16:32:06 snappi_api.info                          L1419 INFO   | Setting route state 0.754s
16:32:06 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For all routes to be ADVERTISED
16:34:16 bgp_convergence_helper.get_rib_in_conver L0706 INFO   | Traffic has converged after route advertisement
16:34:22 bgp_convergence_helper.get_rib_in_conver L0706 INFO   | RIB-IN Convergence time (ms): 33358.574
16:34:22 bgp_convergence_helper.get_rib_in_conver L0706 INFO   | Stopping Traffic at the end of iteration1
16:34:28 snappi_api.info                          L1419 INFO   | Flows stop 5.410s
16:34:28 utilities.wait                           L0118 INFO   | Pause 10 seconds, reason: For Traffic To stop
16:34:38 bgp_convergence_helper.get_rib_in_conver L0706 INFO   | Stopping all protocols ...
16:34:38 utilities.wait                           L0118 INFO   | Pause 10 seconds, reason: For Protocols To STOP
16:34:48 bgp_convergence_helper.get_rib_in_conver L0706 INFO   | 
+--------------------------+--------------+-----------------+--------------+----------------+-----------------------------------+
| Event Name               | Route Type   |   No. of Routes |   Iterations |   Frames Delta |   Avg RIB-IN Convergence Time(ms) |
|--------------------------+--------------+-----------------+--------------+----------------+-----------------------------------|
| Advertise All BGP Routes | IPv4         |            1000 |            1 |      403386845 |                             33358 |
+--------------------------+--------------+-----------------+--------------+----------------+-----------------------------------+
16:35:23 bgp_convergence_helper.cleanup_config    L0988 INFO   | Wait until all critical services are fully started
16:35:45 bgp_convergence_helper.cleanup_config    L0991 INFO   | Convergence Test Completed
PASSED   


------------------------------------------------------------------------------------------------ live log call -------------------------------------------------------------------------------------------------
20:20:30 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet64
20:20:31 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet68
20:20:33 bgp_convergence_helper.duthost_bgp_confi L0222 INFO   | Removing configured IP and IPv6 Address from Ethernet72
20:20:35 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet64 to PortChannel1 with IPs 20.1.1.0,2000:1::1
20:20:37 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet68 to PortChannel2 with IPs 20.1.1.2,2000:2::1
20:20:39 bgp_convergence_helper.duthost_bgp_confi L0235 INFO   | Configuring Ethernet72 to PortChannel3 with IPs 20.1.1.4,2000:3::1
20:20:42 bgp_convergence_helper.duthost_bgp_confi L0262 INFO   | Configuring BGP v4 Neighbor 20.1.1.3
20:20:43 bgp_convergence_helper.duthost_bgp_confi L0262 INFO   | Configuring BGP v4 Neighbor 20.1.1.5
20:20:43 connection._warn                         L0246 WARNING| Verification of certificates is disabled
20:20:43 connection._info                         L0243 INFO   | Determining the platform and rest_port using the 10.36.77.53 address...
20:20:43 connection._warn                         L0246 WARNING| Unable to connect to http://10.36.77.53:11009.
20:20:43 connection._info                         L0243 INFO   | Connection established to `https://10.36.77.53:11009 on windows`
20:20:44 connection._info                         L0243 INFO   | Using IxNetwork api server version 10.20.2402.29
20:20:44 connection._info                         L0243 INFO   | User info IxNetwork/WIN-11RK5TNKNAN/8010
20:20:44 snappi_api.info                          L1419 INFO   | snappi-1.27.1
20:20:44 snappi_api.info                          L1419 INFO   | snappi_ixnetwork-1.27.1
20:20:44 snappi_api.info                          L1419 INFO   | ixnetwork_restpy-1.0.64
20:20:44 snappi_api.info                          L1419 INFO   | Config validation 0.005s
20:20:44 snappi_api.info                          L1419 INFO   | Ports configuration 0.066s
20:20:44 snappi_api.info                          L1419 INFO   | Captures configuration 0.031s
20:20:53 snappi_api.info                          L1419 INFO   | Location hosts ready [10.36.78.53] 2.058s
20:20:53 snappi_api.info                          L1419 INFO   | Speed conversion is not require for (port.name, speed) : [('Test_Port_1', 'novusHundredGigNonFanOut'), ('Test_Port_2', 'novusHundredGigNonFanOut'), ('Test_Port_3', 'novusHundredGigNonFanOut')]
20:20:53 snappi_api.info                          L1419 INFO   | Aggregation mode speed change 0.349s
20:20:53 snappi_api.info                          L1419 INFO   | Location configuration 8.623s
20:20:53 snappi_api.info                          L1419 INFO   | Layer1 configuration 0.056s
20:20:55 snappi_api.info                          L1419 INFO   | Lag Configuration 1.558s
20:20:55 snappi_api.info                          L1419 INFO   | Lag Ethernet Configuration 0.220s
20:20:56 snappi_api.info                          L1419 INFO   | Lag Protocol Configuration 0.924s
20:20:56 snappi_api.info                          L1419 INFO   | Convert device config : 0.129s
20:20:56 snappi_api.info                          L1419 INFO   | Create IxNetwork device config : 0.001s
20:20:57 snappi_api.info                          L1419 INFO   | Push IxNetwork device config : 1.051s
20:20:57 snappi_api.info                          L1419 INFO   | Devices configuration 1.191s
20:20:58 snappi_api.info                          L1419 INFO   | Flows configuration 0.615s
20:20:58 snappi_api.info                          L1419 INFO   | Start interfaces 0.515s
20:20:58 snappi_api.info                          L1419 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
20:20:58 snappi_api.info                          L1419 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
20:20:58 bgp_convergence_helper.get_avg_cpdp_conv L0572 INFO   | Starting all protocols ...
20:21:15 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Protocols To start
20:21:45 bgp_convergence_helper.get_avg_cpdp_conv L0578 INFO   | |---- Network_Group2 Route Withdraw Iteration : 1 ----|
20:21:45 bgp_convergence_helper.get_avg_cpdp_conv L0581 INFO   | Starting Traffic
20:21:51 snappi_api.info                          L1419 INFO   | Flows generate/apply 6.339s
20:22:05 snappi_api.info                          L1419 INFO   | Flows clear statistics 13.952s
20:22:05 snappi_api.info                          L1419 INFO   | Captures start 0.000s
20:22:08 snappi_api.info                          L1419 INFO   | Flows start 2.511s
20:22:08 snappi_api.info                          L1419 INFO   | IxNet - If ports in a lag are down, please enable Transmit Ignore Link Status port property in order to successfully start traffic or clear statistics.
20:22:08 snappi_api.info                          L1419 INFO   | IxNet - The Rate Monitoring Jitter Window Size was decreased to support the incoming frame rate
20:22:08 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To start
20:22:38 bgp_convergence_helper.get_avg_cpdp_conv L0591 INFO   | Withdrawing Routes from Network_Group2
20:22:39 snappi_api.info                          L1419 INFO   | Setting route state 0.742s
20:22:39 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For routes to be withdrawn
20:23:09 bgp_convergence_helper.get_avg_cpdp_conv L0604 INFO   | Traffic has converged after route withdraw
20:23:15 bgp_convergence_helper.get_avg_cpdp_conv L0611 INFO   | CP/DP Convergence Time (ms): 533.218
20:23:16 snappi_api.info                          L1419 INFO   | Setting route state 0.632s
20:23:16 bgp_convergence_helper.get_avg_cpdp_conv L0621 INFO   | Readvertise Network_Group2 routes back at the end of iteration 1
20:23:16 bgp_convergence_helper.get_avg_cpdp_conv L0623 INFO   | Stopping Traffic
20:23:21 snappi_api.info                          L1419 INFO   | Flows stop 5.371s
20:23:21 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To Stop
20:23:51 bgp_convergence_helper.get_avg_cpdp_conv L0572 INFO   | Starting all protocols ...
20:23:51 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Protocols To start
20:24:21 bgp_convergence_helper.get_avg_cpdp_conv L0578 INFO   | |---- Network_Group3 Route Withdraw Iteration : 1 ----|
20:24:21 bgp_convergence_helper.get_avg_cpdp_conv L0581 INFO   | Starting Traffic
20:24:33 snappi_api.info                          L1419 INFO   | Flows clear statistics 11.493s
20:24:33 snappi_api.info                          L1419 INFO   | Captures start 0.000s
20:24:36 snappi_api.info                          L1419 INFO   | Flows start 2.552s
20:24:36 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To start
20:25:06 bgp_convergence_helper.get_avg_cpdp_conv L0591 INFO   | Withdrawing Routes from Network_Group3
20:25:06 snappi_api.info                          L1419 INFO   | Setting route state 0.636s
20:25:07 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For routes to be withdrawn
20:25:37 bgp_convergence_helper.get_avg_cpdp_conv L0604 INFO   | Traffic has converged after route withdraw
20:25:43 bgp_convergence_helper.get_avg_cpdp_conv L0611 INFO   | CP/DP Convergence Time (ms): 547.448
20:25:44 snappi_api.info                          L1419 INFO   | Setting route state 0.651s
20:25:44 bgp_convergence_helper.get_avg_cpdp_conv L0621 INFO   | Readvertise Network_Group3 routes back at the end of iteration 1
20:25:44 bgp_convergence_helper.get_avg_cpdp_conv L0623 INFO   | Stopping Traffic
20:25:49 snappi_api.info                          L1419 INFO   | Flows stop 5.422s
20:25:49 utilities.wait                           L0118 INFO   | Pause 30 seconds, reason: For Traffic To Stop
20:26:19 bgp_convergence_helper.get_convergence_f L0642 INFO   | 
+-------------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------------+
| Event Name                    | Route Type   |   No. of Routes |   Iterations |   Frames Delta |   Avg Control to Data Plane Convergence Time (ms) |
|-------------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------------|
| Network_Group2 route withdraw | IPv4         |            1000 |            1 |             28 |                                               533 |
| Network_Group3 route withdraw | IPv4         |            1000 |            1 |             28 |                                               547 |
+-------------------------------+--------------+-----------------+--------------+----------------+---------------------------------------------------+
20:26:54 bgp_convergence_helper.cleanup_config    L0984 INFO   | Wait until all critical services are fully started
20:27:17 bgp_convergence_helper.cleanup_config    L0987 INFO   | Convergence Test Completed
PASSED    
17:46:04 bgp_convergence_helper.get_RIB_IN_capaci L0974 INFO   | 
+----------------------+-------------------------+
| Test Name            |   Maximum no. of Routes |
|----------------------+-------------------------|
| RIB-IN Capacity Test |                  125000 |
+----------------------+-------------------------+
17:46:39 bgp_convergence_helper.cleanup_config    L0988 INFO   | Wait until all critical services are fully started
17:47:01 bgp_convergence_helper.cleanup_config    L0991 INFO   | Convergence Test Completed
PASSED    
+--------------+-----------------+-----------------------------------------------+
| Route Type   |   No. of Routes |   Control to Data Plane Convergence Time (ms) |
|--------------+-----------------+-----------------------------------------------|
| IPv4         |            2000 |                                          1015 |
| IPv4         |            4000 |                                          1697 |
| IPv4         |            6000 |                                          2425 |
| IPv4         |            8000 |                                          3125 |
| IPv4         |           10000 |                                          3658 |
| IPv4         |           12000 |                                          4620 |
| IPv4         |           14000 |                                          5544 |
+--------------+-----------------+-----------------------------------------------+
18:32:43 bgp_test_gap_helper.cleanup_config       L0715 INFO   | Wait until all critical services are fully started
18:33:05 bgp_test_gap_helper.cleanup_config       L0718 INFO   | Convergence Test Completed
PASSED                                                                                                                                                                                                                                                                                              [100%]
-------------------------------------------------------------------------------------------------------------------------------------------- 