### PR TITLE
monit service parsing needs to handle multi-line data

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -157,6 +157,12 @@ def parse_monit_output(lines):
             continue
         if service is None:
             continue
+
+        # Ignore line continuations that start with more than 2 whitespace
+        # characters.  We don't need the data at all.
+        if len(line) - len(line.lstrip()) > 2:
+            continue
+
         if line.startswith('  '):
             key, value = line.lstrip().split('  ', 1)
             service[key.replace(' ', '_')] = value.lstrip()


### PR DESCRIPTION
### Description of PR

This patch adds handling for concatenating multi-line output to the prior service's last value.

Summary: memory_checker/test_memory_checker.py fix reading monit status
Fixes https://github.com/sonic-net/sonic-mgmt/issues/18101

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

In some circumstances monit can return multiline data for a value for a service, such as:

```
Program 'routeCheck'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              255
  last output                  Some routes are not set offloaded in FRR                           but all routes in APPL_DB and ASIC_DB are in sync
                               Failure results: {{
                                   "": {
                                       "missed_FRR_routes": [
                                           {
                                               "destSelected": true,
                                               "distance": 1,
...
```

This results in a parser error like
```
File "/var/AzDevOps/sonic-mgmt/tests/common/utilities.py", line 146, in wait_until
    check_result = condition(*args, **kwargs)
  File "/var/AzDevOps/sonic-mgmt/tests/memory_checker/test_memory_checker.py", line 434, in is_monit_mem_ok
    status = self.get_monit_mem_status()
  File "/var/AzDevOps/sonic-mgmt/tests/memory_checker/test_memory_checker.py", line 431, in get_monit_mem_status
    return get_monit_service_status(self.duthost, self.memory_service_name)
  File "/var/AzDevOps/sonic-mgmt/tests/memory_checker/test_memory_checker.py", line 180, in get_monit_service_status
    services = parse_monit_output(result["stdout_lines"])
  File "/var/AzDevOps/sonic-mgmt/tests/memory_checker/test_memory_checker.py", line 161, in parse_monit_output
    key, value = line.lstrip().split('  ', 1)
ValueError: not enough values to unpack (expected 2, got 1)
, error:not enough values to unpack (expected 2, got 1)
```

This can happen in memory_checker/test_memory_checker.py::test_monit_reset_counter_failure as it will forcibly kill containers that have exceeded the specified memory limits.  This can leave things in a bad state when daemons are killed hard, such as in this case, not all routes are synced.  But recovery of said daemons is not the purpose for this test, so can be ignored.

#### How did you do it?

Ignore mutli-line continuations for monit service values.

#### How did you verify/test it?

memory_checker/test_memory_checker.py::test_monit_reset_counter_failure now passes

#### Any platform specific information?

Seen in T1 topology on physical hardware

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
