### PR TITLE
[smartswitch] Make DPU workflow auto rotate password

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -774,8 +774,8 @@
       - name: Load DPU config in smartswitch
         load_extra_dpu_config:
           hwsku: "{{ hwsku }}"
-          host_username: "{{ dpu_username | default('admin') }}"
-          host_password: "{{ dpu_password | default('password') }}"
+          host_username: "{{ sonic_login }}"
+          host_passwords: "{{ sonic_default_passwords }}"
         become: true
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
 

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -600,6 +600,7 @@
         copy: src=golden_config_db/smartswitch_t1.json
               dest=/tmp/smartswitch.json
         become: true
+        # t1-28-lag is smartswitch topo only
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
 
       - name: Create dns config
@@ -769,6 +770,7 @@
         copy: src=golden_config_db/smartswitch_dpu_extra.json
               dest=/tmp/dpu_extra.json
         become: true
+        # t1-28-lag is smartswitch topo only
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
 
       - name: Load DPU config in smartswitch
@@ -777,6 +779,7 @@
           host_username: "{{ sonic_login }}"
           host_passwords: "{{ sonic_default_passwords }}"
         become: true
+        # t1-28-lag is smartswitch topo only
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
 
       - name: Configure TACACS

--- a/ansible/library/load_extra_dpu_config.py
+++ b/ansible/library/load_extra_dpu_config.py
@@ -25,15 +25,15 @@ class LoadExtraDpuConfigModule(object):
         self.module = AnsibleModule(
             argument_spec=dict(
                 hwsku=dict(type='str', required=True),
-                host_username=dict(type='str', required=False, default='admin'),
-                host_password=dict(type='str', required=False, default='password', no_log=True)
+                host_username=dict(type='str', required=True),
+                host_passwords=dict(type='list', elements='str', required=True, no_log=True)
             ),
             supports_check_mode=False
         )
 
         self.hwsku = self.module.params['hwsku']
         self.host_username = self.module.params['host_username']
-        self.host_password = self.module.params['host_password']
+        self.host_passwords = self.module.params['host_passwords']
 
         try:
             self.hwsku_config = smartswitch_hwsku_config[self.hwsku]
@@ -48,17 +48,21 @@ class LoadExtraDpuConfigModule(object):
         """Establish an SSH connection to the DPU with retry"""
         retry_count = 0
         last_exception = None
+
         while retry_count < MAX_RETRIES:
-            try:
-                ssh = paramiko.SSHClient()
-                ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-                ssh.connect(dpu_ip, username=self.host_username, password=self.host_password, timeout=30)
-                return ssh
-            except Exception as e:
-                retry_count += 1
-                last_exception = e
-                if retry_count < MAX_RETRIES:
-                    time.sleep(RETRY_DELAY)
+            for password in self.host_passwords:
+                try:
+                    ssh = paramiko.SSHClient()
+                    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                    ssh.connect(dpu_ip, username=self.host_username, password=password, timeout=30)
+                    return ssh
+                except Exception as e:
+                    last_exception = e
+                    continue
+
+            retry_count += 1
+            if retry_count < MAX_RETRIES:
+                time.sleep(RETRY_DELAY)
 
         self.module.fail_json(msg="Failed to connect to DPU {} after {} retries: {}".format(
             dpu_ip, MAX_RETRIES, str(last_exception)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Make DPU workflow rotate password instead of hardcode
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/17773

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
1. Make rotate password instead of hardcode; 2. Add comment for smartswitch topo.
#### How did you do it?
Try preset creds info.
#### How did you verify/test it?
E2E test with non hardcode password.
```
PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************
TESTBED            : ok=100  changed=34   unreachable=0    failed=0    skipped=69   rescued=0    ignored=1   

Monday 21 April 2025  02:27:15 +0000 (0:00:00.449)       0:03:37.697 ********** 
=============================================================================== 
Wait 60s for docker containers to restart -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 60.09s
Load DPU config in smartswitch ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 57.30s
restart docker service, let docker proxy takes effect -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 27.65s
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
