### PR TITLE
[TACACS] Add test case to verify per-command authorization send correct remote address to TACACS server.

### DIFF
--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -720,9 +720,9 @@ def test_send_remote_address(
         Verify TACACS+ send remote address to server.
     """
 
-    # per-command accounting message also send remote address
+    # Set accounting to local because per-command accounting TACACS request also send remote address
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
+    change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting local')
 
     # Clean tacacs log
     ptfhost.command(r'truncate -s 0  /var/log/tac_plus.log')

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -707,7 +707,7 @@ def test_tacacs_authorization_commands_during_login(
             logger.warning("Found {} commands during login, local accounting log: {}".format(count, res))
             pytest_assert(False, "Device execute {} commands during login,\
                            please check and remove unecessary login commands: {}".format(count, res))
-            
+
 
 def test_send_remote_address(
                             ptfhost,

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -715,7 +715,7 @@ def test_send_remote_address(
                             enum_rand_one_per_hwsku_hostname,
                             tacacs_creds,
                             check_tacacs,  # noqa: F811
-                            rw_user_client):
+                            remote_rw_user_client):
     """
         Verify TACACS+ send remote address to server.
     """
@@ -728,7 +728,7 @@ def test_send_remote_address(
     ptfhost.command(r'truncate -s 0  /var/log/tac_plus.log')
 
     # Send a authorization packet to TACACS server
-    ssh_run_command(rw_user_client, "show version")
+    ssh_run_command(remote_rw_user_client, "show version")
 
     # Remote address is first part of SSH_CONNECTION: '10.250.0.1 47462 10.250.0.101 22'
 

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -730,8 +730,10 @@ def test_send_remote_address(
     # Send a authorization packet to TACACS server
     ssh_run_command(remote_rw_user_client, "show version")
 
-    # Remote address is first part of SSH_CONNECTION: '10.250.0.1 47462 10.250.0.101 22'
+    exit_code, stdout_stream, stderr_stream = ssh_run_command(remote_rw_user_client, "echo $SSH_CONNECTION")
+    pytest_assert(exit_code == 0)
 
-    stdout = duthost.shell("echo $SSH_CONNECTION")["stdout"]
+    # Remote address is first part of SSH_CONNECTION: '10.250.0.1 47462 10.250.0.101 22'
+    stdout = stdout_stream.readlines()
     remote_address = stdout[0].split(" ")[0]
     check_server_received(ptfhost, remote_address)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -731,6 +731,7 @@ def test_send_remote_address(
     ssh_run_command(rw_user_client, "show version")
 
     # Remote address is first part of SSH_CONNECTION: '10.250.0.1 47462 10.250.0.101 22'
+
     stdout = duthost.shell("echo $SSH_CONNECTION")["stdout"]
     remote_address = stdout[0].split(" ")[0]
     check_server_received(ptfhost, remote_address)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -707,3 +707,30 @@ def test_tacacs_authorization_commands_during_login(
             logger.warning("Found {} commands during login, local accounting log: {}".format(count, res))
             pytest_assert(False, "Device execute {} commands during login,\
                            please check and remove unecessary login commands: {}".format(count, res))
+            
+
+def test_send_remote_address(
+                            ptfhost,
+                            duthosts,
+                            enum_rand_one_per_hwsku_hostname,
+                            tacacs_creds,
+                            check_tacacs,
+                            rw_user_client):
+    """
+        Verify TACACS+ send remote address to server.
+    """
+    
+    # per-command accounting message also send remote address
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
+    
+    # Clean tacacs log
+    ptfhost.command(r'truncate -s 0  /var/log/tac_plus.log')
+
+    exit_code, stdout_stream, stderr_stream = ssh_run_command(rw_user_client, "echo $SSH_CONNECTION")
+    pytest_assert(exit_code == 0)
+
+    # Remote address is first part of SSH_CONNECTION: '10.250.0.1 47462 10.250.0.101 22'
+    stdout = stdout_stream.readlines()
+    remote_address = stdout[0].split(" ")[0]
+    check_server_received(ptfhost, remote_address)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -727,10 +727,10 @@ def test_send_remote_address(
     # Clean tacacs log
     ptfhost.command(r'truncate -s 0  /var/log/tac_plus.log')
 
-    exit_code, stdout_stream, stderr_stream = ssh_run_command(rw_user_client, "echo $SSH_CONNECTION")
-    pytest_assert(exit_code == 0)
+    # Send a authorization packet to TACACS server
+    ssh_run_command(rw_user_client, "show version")
 
     # Remote address is first part of SSH_CONNECTION: '10.250.0.1 47462 10.250.0.101 22'
-    stdout = stdout_stream.readlines()
+    stdout = duthost.shell("echo $SSH_CONNECTION")["stdout"]
     remote_address = stdout[0].split(" ")[0]
     check_server_received(ptfhost, remote_address)

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -714,7 +714,7 @@ def test_send_remote_address(
                             duthosts,
                             enum_rand_one_per_hwsku_hostname,
                             tacacs_creds,
-                            check_tacacs,
+                            check_tacacs,  # noqa: F811
                             rw_user_client):
     """
         Verify TACACS+ send remote address to server.

--- a/tests/tacacs/test_authorization.py
+++ b/tests/tacacs/test_authorization.py
@@ -719,11 +719,11 @@ def test_send_remote_address(
     """
         Verify TACACS+ send remote address to server.
     """
-    
+
     # per-command accounting message also send remote address
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     change_and_wait_aaa_config_update(duthost, 'sudo config aaa accounting "tacacs+ local"')
-    
+
     # Clean tacacs log
     ptfhost.command(r'truncate -s 0  /var/log/tac_plus.log')
 


### PR DESCRIPTION
[TACACS] Add test case to verify per-command authorization send correct remote address to TACACS server.

#### Why I did it
Add test case for PR: https://github.com/sonic-net/sonic-buildimage/pull/22327#issuecomment-2811338514

##### Work item tracking
- Microsoft ADO: 32291587

#### How I did it
Add new PR to verify per-command authorization send correct remote address to TACACS server

#### How to verify it
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
[TACACS] Add test case to verify per-command authorization send correct remote address to TACACS server.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
