### PR TITLE
[202405] Restore config after vxlan_crm from vxlan_ecmp. (#17767)

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -61,6 +61,8 @@ import copy
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils \
     import copy_ptftests_directory     # noqa: F401
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
+from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.vxlan.vxlan_ecmp_utils import Ecmp_Utils
@@ -141,7 +143,8 @@ def fixture_setUp(duthosts,
                   rand_one_dut_hostname,
                   minigraph_facts,
                   tbinfo,
-                  encap_type):
+                  encap_type,
+                  backup_and_restore_config_db_on_duts):        # noqa F811
     '''
         Setup for the entire script.
         The basic steps in VxLAN configs are:
@@ -338,6 +341,14 @@ def fixture_setUp(duthosts,
         ecmp_utils.stop_bfd_responder(data['ptfhost'])
 
     setup_crm_interval(data['duthost'], int(data['original_crm_interval']))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_config_by_config_reload(duthosts, rand_one_dut_hostname, localhost):
+    yield
+    duthost = duthosts[rand_one_dut_hostname]
+
+    config_reload(duthost, safe_reload=True)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
What is the motivation for this PR?
Cherry pick #17767

test_vxlan_crm.py was recently enabled for smartswitch, which uses the same setup fixture as test_vxlan_ecmp.py. However, the tests in test_vxlan_ecmp.py have additional cleanup code to handle these BFD entries which is missing in test_vxlan_crm.py.

How did you do it?
Added a config restore fixture, same as in #17046, to test_vxlan_ecmp.py which is re-used by test_vxlan_crm.py

How did you verify/test it?
Ran test_cacl_application.py after running test_vxlan_crm.py and it's now passing with the fix in place. Also checked that iptable is cleaned up after running test_vxlan_crm.py.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
