### PR TITLE
Considering voq inband routes in local route count for  testNeighborMacNoPtf

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -47,7 +47,7 @@ class TestNeighborMacNoPtf:
         # these routes are present only on multi asic device, on single asic platform they will be zero
         internal = self.count_routes(asichost, "8.") + self.count_routes(asichost, "2603")
         if asichost.sonichost.facts['switch_type'] == 'voq':
-            #voq inband_ip's
+            # voq inband_ip's
             internal += self.count_routes(asichost, "3")
         allroutes = self.count_routes(asichost, "")
         logger.info("asic[{}] localv4 routes {} localv6 routes {} internalv4 {} allroutes {}"

--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -46,6 +46,9 @@ class TestNeighborMacNoPtf:
         localv4 = self.count_routes(asichost, "10.") + self.count_routes(asichost, "192.")
         # these routes are present only on multi asic device, on single asic platform they will be zero
         internal = self.count_routes(asichost, "8.") + self.count_routes(asichost, "2603")
+        if asichost.sonichost.facts['switch_type'] == 'voq':
+            #voq inband_ip's
+            internal += self.count_routes(asichost, "3")
         allroutes = self.count_routes(asichost, "")
         logger.info("asic[{}] localv4 routes {} localv6 routes {} internalv4 {} allroutes {}"
                     .format(asichost.asic_index, localv4, localv6, internal, allroutes))

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -782,6 +782,12 @@ dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect:
     conditions:
       - "asic_type in ['vs'] or 'arista_7800' in platform"
 
+dut_console/test_console_chassis_conn.py::test_console_availability_serial_ports:
+  skip:
+    reason: "Skipping test because test is not supported on this hwsku"
+    conditions:
+      - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-nokia_ixr7250_x3b-r0']"
+
 #######################################
 #####             ecmp            #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In testNeighborMacNoPtf test the bgp is disabled and checks that there are no routes installed by BGP in ASIC_DB
 by filtering out all local routes installed on testbed. For voq chassis, this collection of local routes was not including voq inband routes which mislead the correct summation of local routes on voq chassis.

Summary:
Fixes # (issue)
Added the voq inband ip routes in summation of all local routes
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test case failure for  single_dut_multi_asic chasiss
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
