### PR TITLE
Repave testing infra for virtual chassis

### DIFF
--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -64,6 +64,12 @@
           dest: /usr/bin/setup_vs_chassis.sh
         become: true
 
+      - name: Set routeCheck timeout to 600 seconds
+        lineinfile:
+          path: /etc/monit/conf.d/sonic-host
+          regexp: '^check program routeCheck with path "/usr/local/bin/route_check.py"'
+          line: "check program routeCheck with path \"/usr/local/bin/route_check.py\" timeout 600 seconds"
+
       - name: Execute setup_vs_chassis.sh to configure the DUT as a chassis device
         shell: bash /usr/bin/setup_vs_chassis.sh
         become: true

--- a/ansible/veos_vtb
+++ b/ansible/veos_vtb
@@ -262,7 +262,7 @@ all:
           ansible_user: admin
           card_type: supervisor
           slot_num: slot0
-          switch_type: fabric
+          switch_type: dummy-sup
         vlab-09:
           ansible_host: 10.250.0.115
           ansible_hostv6: fec0::ffff:afb:1

--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -496,7 +496,7 @@ class MultiAsicSonicHost(object):
         """
         services = [feature]
 
-        if (feature in self.sonichost.DEFAULT_ASIC_SERVICES):
+        if (feature in self.sonichost.DEFAULT_ASIC_SERVICES) or feature in ["bmp"]:
             services = []
             for asic in self.asics:
                 service_name = asic.get_docker_name(feature)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: there were some issues with the infrastructure found during testing with virtual chassis, as articulated below:
1. BMP feature is enabled on latest master image with multi-asic LCs. However, it is not marked as DEFAULT_ASIC_SERVICES so we need to manually check it when doing modify_syslog_rate_limit. 
2. The virtual chassis supervisor is not acting like a fabric card and it does not have fabric card's info so we should not mark its switch_type as fabric. I added a new switch_type called 'dummy-sup'.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
