### PR TITLE
Changes from 202405 - Fixes for duplicate entry of admin user in tacacs config

### DIFF
--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -170,9 +170,12 @@ def setup_tacacs_server(ptfhost, tacacs_creds, duthost):
     if 'ansible_ssh_user' in dut_options and 'ansible_ssh_pass' in dut_options:
         duthost_ssh_user = dut_options['ansible_ssh_user']
         duthost_ssh_passwd = dut_options['ansible_ssh_pass']
-        logger.debug("setup_tacacs_server: update extra_vars with ansible_ssh_user and ansible_ssh_pass.")
-        extra_vars['duthost_ssh_user'] = duthost_ssh_user
-        extra_vars['duthost_ssh_passwd'] = crypt.crypt(duthost_ssh_passwd, 'abc')
+        if not duthost_ssh_user == extra_vars['duthost_admin_user']:
+            logger.debug("setup_tacacs_server: update extra_vars with ansible_ssh_user and ansible_ssh_pass.")
+            extra_vars['duthost_ssh_user'] = duthost_ssh_user
+            extra_vars['duthost_ssh_passwd'] = crypt.crypt(duthost_ssh_passwd, 'abc')
+        else:
+            logger.debug("setup_tacacs_server: duthost_admin_user and ansible_ssh_user are the same.")
     else:
         logger.debug("setup_tacacs_server: duthost options does not contains config for ansible_ssh_user.")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR just includes the changes of [PR 14424](https://github.com/sonic-net/sonic-mgmt/pull/14424) which was for `202405`. Changes made are same in `202405` & `202411`, but the files in which the changes were made are different, as `202411` doesn't have `setup_tacacs_server` fn in `tacacs/utils.py` & its in `common/helpers/tacacs/tacacs_helper.py`

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
