### PR TITLE
Set PR tests to use py3only PTF image tag to 70%

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
           python - <<EOF
           import random
           tag = 'latest'
-          if random.random() < 0.3:
+          if random.random() < 0.7:
             tag = 'py3only'
           print(f"##vso[task.setvariable variable=tag_value;isOutput=true]{tag}")
           EOF


### PR DESCRIPTION
### Description of PR

Modify PR tests pipeline to increase the usage of `py3only` docker-ptf tag to 70% of the PRs.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Modify PR tests pipeline to increase the usage of `py3only` docker-ptf tag to 70% of the PRs. More testing of `py3only` tag before full rollout.

#### How did you do it?

NA

#### How did you verify/test it?

NA

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA