### PR TITLE
Check different counters on different ASIC platforms for SRv6 blackhole test case

### DIFF
--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -472,7 +472,6 @@ def test_srv6_dataplane_after_reboot(setup_uN, ptfadapter, ptfhost, localhost, w
     run_srv6_traffic_test(duthost, dut_mac, ptf_src_port, neighbor_ip, ptfadapter, ptfhost, with_srh)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("with_srh", [True, False])
 def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
     duthost = setup_uN['duthost']

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -482,8 +482,11 @@ def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
     neighbor_ip = setup_uN['neighbor_ip']
     ptf_port_ids = setup_uN['ptf_port_ids']
 
-    # get the RX_DROP counter before traffic test
-    before_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
+    # get the drop counter before traffic test
+    if duthost.facts["asic_type"] == "broadcom":
+        before_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
+    elif duthost.facts["asic_type"] == "mellanox":
+        before_count = duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0]
 
     # inject a number of packets with random payload
     pkt_count = 100
@@ -516,5 +519,9 @@ def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
         verify_no_packet_any(ptfadapter, expected_pkt, ptf_port_ids, 0, 1)
 
     # verify that the RX_DROP counter is incremented
-    after_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
-    assert after_count >= (before_count + pkt_count), "RX_DROP counter is not incremented as expected"
+    if duthost.facts["asic_type"] == "broadcom":
+        after_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
+        assert after_count >= (before_count + pkt_count), "RX_DRP counter is not incremented as expected"
+    elif duthost.facts["asic_type"] == "mellanox":
+        after_count = duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0]
+        assert after_count >= (before_count + pkt_count), "RIF RX_ERR counter is not incremented as expected"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: We found that on broadcom and Mellanox platforms, the packets dropped by blackhole routes were counted in different ways. So, we need to check different counters depending on the asic_type in the test case.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
