### PR TITLE
Fix for lag port selection in test_bgp_update_timer.py

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -346,7 +346,6 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                         if not ipv4_interfaces:
                             ipv4_interfaces.append(intf["attachto"])
                             asic_idx = intf_asic_idx
-                            used_subnets.add(ipaddress.ip_network(intf["subnet"]))
                         else:
                             if intf_asic_idx != asic_idx:
                                 continue
@@ -359,21 +358,21 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 for pt in mg_facts["minigraph_portchannel_interfaces"]:
                     if _is_ipv4_address(pt["addr"]):
                         pt_members = mg_facts["minigraph_portchannels"][pt["attachto"]]["members"]
+                        pc_asic_idx = duthost.get_asic_index_for_portchannel(pt["attachto"])
                         # Only use LAG with 1 member for bgpmon session between PTF,
                         # It's because exabgp on PTF is bind to single interface
                         if len(pt_members) == 1:
                             # If first time, we record the asic index
-                            if not ipv4_lag_interfaces:
+                            if not ipv4_interfaces and not ipv4_lag_interfaces:
+                                asic_idx = pc_asic_idx
                                 ipv4_lag_interfaces.append(pt["attachto"])
-                                asic_idx = duthost.get_asic_index_for_portchannel(pt["attachto"])
-                            # Not first time, only append the portchannel that belongs to the same asic in current list
+                            # Not first time, only append the port-channel that belongs to the same asic in current list
                             else:
-                                asic = duthost.get_asic_index_for_portchannel(pt["attachto"])
-                                if asic != asic_idx:
+                                if pc_asic_idx != asic_idx:
                                     continue
                                 else:
                                     ipv4_lag_interfaces.append(pt["attachto"])
-                        used_subnets.add(ipaddress.ip_network(pt["subnet"]))
+                            used_subnets.add(ipaddress.ip_network(pt["subnet"]))
 
             vlan_sub_interfaces = []
             if is_backend_topo:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The test_bgp_update_timer.py selects the ports via random port selection in setup. The fixture 'common_setup_teardown' fails the test if the ports belong to different asics for mutli-asic chassis.
Hence updated the function '_setup_interfaces_t1_or_t2' to apply random selection on the set of interfaces belonging to same asic.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test failure due to selected ports belonging to different asics
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
