### PR TITLE
remove cisco 8122 from ComputeAI list

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -219,7 +219,7 @@
 
   - name: gather hwsku that supports ComputeAI deployment
     set_fact:
-      hwsku_list_compute_ai: "['Cisco-8111-O64', 'Cisco-8111-O32', 'Cisco-8122-O64', 'Cisco-8122-O64S2', 'Cisco-8122-O128']"
+      hwsku_list_compute_ai: "['Cisco-8111-O64', 'Cisco-8111-O32']"
 
   - name: enable ComputeAI deployment
     set_fact:


### PR DESCRIPTION
**What is the motivation for this PR?**
This PR removed Cisco 8122 platform from ComputeAI list as it is not fully supported

**How did you do it?**
Removed Cisco 8122 hwskus from ComputeAI list in file config_sonic_basedon_testbed.yml

**Type of change** 
-Test modification

**Back port request** 
-202405
-202411

**How did you verify/test it?**
Made sure that once 8122 hwskus are removed from file config_sonic_basedon_testbed.yml, after doing deploy-mg, the device-type did not get changed to ‘BackEndToRRouter’.