### PR TITLE
Static Route and Cisco ECN test changes

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -113,7 +113,7 @@ def __valid_ipv4_addr(ip):
         return False
 
 
-def __l3_intf_config(config, port_config_list, duthost, snappi_ports):
+def __l3_intf_config(config, port_config_list, duthost, snappi_ports, setup=True):
     """
     Generate Snappi configuration of layer 3 interfaces
     Args:
@@ -121,6 +121,7 @@ def __l3_intf_config(config, port_config_list, duthost, snappi_ports):
         port_config_list (list): list of Snappi port configuration information
         duthost (object): device under test
         snappi_ports (list): list of Snappi port information
+        setup (bool): Setting up or teardown? True or False
     Returns:
         True if we successfully generate configuration or False
     """
@@ -150,6 +151,8 @@ def __l3_intf_config(config, port_config_list, duthost, snappi_ports):
                     if snappi_port['peer_port'] == intf]
         if len(port_ids) != 1:
             return False
+
+        static_routes_cisco_8000(ip, duthost, intf, setup=setup)
 
         port_id = port_ids[0]
         mac = __gen_mac(port_id)
@@ -737,7 +740,8 @@ def setup_dut_ports(
             config_result = __l3_intf_config(config=config,
                                              port_config_list=port_config_list,
                                              duthost=duthost,
-                                             snappi_ports=snappi_ports)
+                                             snappi_ports=snappi_ports,
+                                             setup=setup)
             pytest_assert(config_result is True, 'Fail to configure L3 interfaces')
 
     return config, port_config_list, snappi_ports
@@ -1309,15 +1313,13 @@ def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=Tr
         Return a static route-d IP address for the given IP gateway(Ixia port address).
         Also configure the same in the DUT.
     '''
-    global DEST_TO_GATEWAY_MAP
     if dut is None:
         if addr not in DEST_TO_GATEWAY_MAP:
             logger.warn(f"Request for dest addr: {addr} without setting it in advance.")
             return addr
         return DEST_TO_GATEWAY_MAP[addr]['dest']
 
-    if (dut.facts['asic_type'] != "cisco-8000" or
-            not dut.get_facts().get("modular_chassis", None)):
+    if dut.facts['asic_type'] != "cisco-8000":
         DEST_TO_GATEWAY_MAP[addr] = {}
         DEST_TO_GATEWAY_MAP[addr]['dest'] = addr
         return addr

--- a/tests/snappi_tests/ecn/files/ecnhelper.py
+++ b/tests/snappi_tests/ecn/files/ecnhelper.py
@@ -4,7 +4,6 @@ import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401
-from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
     get_lossless_buffer_size, get_pg_dropped_packets,\
     stop_pfcwd, disable_packet_aging, sec_to_nanosec,\
@@ -69,7 +68,8 @@ def run_ecn_test_cisco8000(api,
                            dut_port,
                            test_prio_list,
                            prio_dscp_map,
-                           snappi_extra_params=None):
+                           snappi_extra_params=None,
+                           snappi_ports=None):
     """
     Run a PFC test
     Args:
@@ -101,10 +101,10 @@ def run_ecn_test_cisco8000(api,
     init_ctr_4 = get_npu_voq_queue_counters(duthost, dut_port, test_prio_list[1])
 
     # Get the ID of the port to test
-    port_id = get_dut_port_id(dut_hostname=duthost.hostname,
-                              dut_port=dut_port,
-                              conn_data=conn_data,
-                              fanout_data=fanout_data)
+    for i in range(len(snappi_ports)):
+        if snappi_ports[i]['peer_port'] == dut_port:
+            port_id = snappi_ports[i]['port_id']
+            break
 
     pytest_assert(port_id is not None,
                   'Fail to get ID for port {}'.format(dut_port))

--- a/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_dequeue_ecn_with_snappi.py
@@ -52,6 +52,7 @@ def test_dequeue_ecn(request,
         N/A
     """
 
+    skip_ecn_tests(duthosts[0])
     for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = 1
         rx_port_count = 1
@@ -79,8 +80,6 @@ def test_dequeue_ecn(request,
                                                                                 snappi_api)
 
     lossless_prio = random.sample(lossless_prio_list, 1)
-    skip_ecn_tests(snappi_ports[0]['duthost'])
-    skip_ecn_tests(snappi_ports[1]['duthost'])
     lossless_prio = int(lossless_prio[0])
     snappi_extra_params = SnappiTestParams()
 

--- a/tests/snappi_tests/ecn/test_ecn_marking_cisco8000.py
+++ b/tests/snappi_tests/ecn/test_ecn_marking_cisco8000.py
@@ -2,13 +2,16 @@ import logging
 import pytest
 
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
-    snappi_api, snappi_testbed_config, is_snappi_multidut # noqa F401
+    snappi_api, snappi_testbed_config, is_snappi_multidut, get_snappi_ports, \
+    get_snappi_ports_single_dut, get_snappi_ports_multi_dut, get_snappi_ports_for_rdma, \
+    snappi_dut_base_config # noqa F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
     fanout_graph_facts # noqa F401
 from tests.common.helpers.assertions import pytest_require
 from tests.snappi_tests.ecn.files.ecnhelper import run_ecn_test_cisco8000
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list # noqa F401
 from tests.common.cisco_data import is_cisco_device
+from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info # noqa F401
 
 
 logger = logging.getLogger(__name__)
@@ -20,14 +23,19 @@ pytestmark = [pytest.mark.topology('tgen')]
 # second stream from second tx port is for TC 3 and 4
 # line rate percent/2 for TC 3, 4 from tx two ports
 
+
+@pytest.fixture(autouse=True)
+def number_of_tx_rx_ports():
+    yield (2, 1)
+
 def test_ecn_multi_lossless_prio(snappi_api, # noqa F811
-                                 snappi_testbed_config, # noqa F811
                                  conn_graph_facts, # noqa F811
                                  fanout_graph_facts, # noqa F811
                                  duthosts,
                                  rand_one_dut_hostname,
                                  rand_one_dut_portname_oper_up,
                                  lossless_prio_list, # noqa F811
+                                 setup_ports_and_dut, # noqa F811
                                  prio_dscp_map, # noqa F811
                                  ):
 
@@ -54,7 +62,7 @@ def test_ecn_multi_lossless_prio(snappi_api, # noqa F811
     pytest_require(rand_one_dut_hostname == dut_hostname,
                    "Port is not mapped to the expected DUT")
 
-    testbed_config, port_config_list = snappi_testbed_config
+    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
     duthost = duthosts[rand_one_dut_hostname]
     if not is_cisco_device(duthost):
         pytest.skip("Test is supported on Cisco device only")
@@ -72,4 +80,5 @@ def test_ecn_multi_lossless_prio(snappi_api, # noqa F811
                            duthost=duthost,
                            dut_port=dut_port,
                            test_prio_list=test_prio_list,
-                           prio_dscp_map=prio_dscp_map)
+                           prio_dscp_map=prio_dscp_map,
+                           snappi_ports=snappi_ports)

--- a/tests/snappi_tests/ecn/test_red_accuracy_with_snappi.py
+++ b/tests/snappi_tests/ecn/test_red_accuracy_with_snappi.py
@@ -55,6 +55,7 @@ def test_red_accuracy(request,
     # if disable_test:
     #     pytest.skip("test_red_accuracy is disabled")
 
+    skip_ecn_tests(duthosts[0])
     for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = 1
         rx_port_count = 1
@@ -81,7 +82,6 @@ def test_red_accuracy(request,
                                                                                 snappi_ports,
                                                                                 snappi_api)
 
-    skip_ecn_tests(snappi_ports[0]['duthost']) or skip_ecn_tests(snappi_ports[1]['duthost'])
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
 


### PR DESCRIPTION
Static route changes for single asic DUT and Cisco specific ECN test changes

### Description of PR
For ECN tests static routes were added recently for multi DUT in this PR https://github.com/sonic-net/sonic-mgmt/pull/17012, 
this PR enables the same for Single ASIC DUT's and Cisco specific ECN test changes.

### Type of change
- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X ] 202411

### Approach
#### What is the motivation for this PR?
Hitting failures in multiple tests due to traffic taking default voq (due to the connected routes).

#### How did you do it?
Adding static route in case of Sinlge DUT as well.

#### How did you verify/test it?
Tested all ECN tests on M64 platform.

==================================== PASSES ====================================
[32m[1m______________ test_ecn_multi_lossless_prio[multidut_port_info0] _______________[0m
[32m[1m_ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config0] _[0m
[32m[1m_ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config1] _[0m
[32m[1m_ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config2] _[0m
[32m[1m_ test_ecn_marking_with_pfc_quanta_variance[multidut_port_info0-test_ecn_config3] _[0m
[32m[1m______________ test_ecn_marking_port_toggle[multidut_port_info0] _______________[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent0] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent1] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent2] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent3] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent4] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent5] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent6] ____[0m
[32m[1m____ test_ecn_marking_lossless_prio[multidut_port_info0-test_flow_percent7] ____[0m
[32m[1m____________ test_ecn_marking_ect_marked_pkts[multidut_port_info0] _____________[0m

#### Any platform specific information?
Only for cisco-8000.

