### PR TITLE
[platform_tests/sfp]: Skip getting sfp info for supervisor

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -215,6 +215,8 @@ def port_list_with_flat_memory(duthosts):
 def passive_cable_ports(duthosts):
     passive_cable_ports = {}
     for dut in duthosts:
+        if dut.is_supervisor_node():
+            continue
         passive_cable_ports.update({dut.hostname: get_passive_cable_port_list(dut)})
     logging.info(f"passive_cable_ports: {passive_cable_ports}")
     return passive_cable_ports
@@ -224,6 +226,8 @@ def passive_cable_ports(duthosts):
 def cmis_cable_ports_and_ver(duthosts):
     cmis_cable_ports_and_ver = {}
     for dut in duthosts:
+        if dut.is_supervisor_node():
+            continue
         cmis_cable_ports_and_ver.update({dut.hostname: get_cmis_cable_ports_and_ver(dut)})
     logging.info(f"cmis_cable_ports_and_ver: {cmis_cable_ports_and_ver}")
     return cmis_cable_ports_and_ver


### PR DESCRIPTION
PR #16573 added some fixtures for getting port information for sfp tests, however when these fixtures run on supervisor nodes, it fails as sfputil is not valid for supervisors.
Add a check in these fixtures to skip supervisor nodes

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405
- [ x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on nokia 7250 chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
