### PR TITLE
[testbed-cli opt] skip snmp_facts when ceos container doesn't exist to save time

### DIFF
--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -1,14 +1,24 @@
-- snmp_facts: host={{ ansible_host }} version=v2c is_eos=true community={{ snmp_rocommunity }}
-  delegate_to: localhost
-  register: snmp_data
-  ignore_errors: true
+- name: Get ceos container info
+  docker_container_info:
+    name: ceos_{{ vm_set_name }}_{{ inventory_hostname }}
+  register: ctninfo
+  delegate_to: "{{ VM_host[0] }}"
+  become: yes
 
 - name: set force_restart=yes for ceos container
   set_fact: force_restart=yes
 
-- name: set force_restart=no for ceos container
-  set_fact: force_restart=no
-  when: snmp_data.ansible_facts.ansible_sysname is defined
+- name: Check if ceos container responses to snmp
+  when: ctninfo.exists
+  block:
+  - snmp_facts: host={{ ansible_host }} version=v2c is_eos=true community={{ snmp_rocommunity }}
+    delegate_to: localhost
+    register: snmp_data
+    ignore_errors: true
+
+  - name: set force_restart=no for ceos container
+    set_fact: force_restart=no
+    when: snmp_data.ansible_facts.ansible_sysname is defined
 
 - include_tasks: ceos_config.yml
 - include_vars: group_vars/vm_host/ceos.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When adding topology with batch size 30, the task snmp_facts may take hours due to there is no ceos container responding.
We need to skip this task when there is no ceos container to save time.

![image](https://github.com/user-attachments/assets/5f344f62-604a-41b1-843a-6fa1bf0315d1)

#### How did you do it?
Check if ceos container exsit, if no, skip snmp_facts task
#### How did you verify/test it?
Tested on testbed with add-topo after remove-topo
from the pic, we can see that, due to ceos container was deleted when remove-topo, so when add-topo, there is no ceos container, and the snmp_facts task was skipped.
![image](https://github.com/user-attachments/assets/e31c3435-6873-4fe2-93e1-9b06261b8575)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
