### PR TITLE
[202411] Restore disable packet aging fixture 202411

### DIFF
--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -29,7 +29,7 @@ from .tunnel_qos_remap_base import build_testing_packet, check_queue_counter,\
     dut_config, qos_config, tunnel_qos_maps, run_ptf_test, toggle_mux_to_host,\
     setup_module, update_docker_services, swap_syncd, counter_poll_config                               # noqa F401
 from .tunnel_qos_remap_base import leaf_fanout_peer_info, start_pfc_storm, \
-    stop_pfc_storm, get_queue_counter, get_queue_watermark                                              # noqa F401
+    stop_pfc_storm, get_queue_counter, get_queue_watermark, disable_packet_aging                        # noqa F401
 from ptf import testutils
 from ptf.testutils import simple_tcp_packet
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts     # noqa F401


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to cherry-pick #17800 to 202411 branch and address an issue as well.
This PR is to fix an issue introduced by https://github.com/sonic-net/sonic-mgmt/pull/17728

The auto-used PR is still required for the test cases in [tests/qos/test_tunnel_qos_remap.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:restore_disable_packet_aging_fixture?expand=1#diff-0bc1dc320b693a545a1dd0b09c307b3f13faf79f79650fc7a1fe4fb78e3c8480) because fixture `update_docker_services` is only called for several test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix an issue introduced by https://github.com/sonic-net/sonic-mgmt/pull/17728

#### How did you do it?
Add the fixture back.

#### How did you verify/test it?
Verified on a physical SN4700 dualtor testbed.

```
collected 4 items                                                                                                                                                                                                             

qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_1] PASSED                                                                                                                                                    [ 25%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_2] PASSED                                                                                                                                                    [ 50%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_3] PASSED                                                                                                                                                    [ 75%]
qos/test_tunnel_qos_remap.py::test_xoff_for_pcbb[pcbb_xoff_4] PASSED                                                                                                                                                    [100%]

collected 1 item                                                                                                                                                                                                              

qos/test_tunnel_qos_remap.py::test_tunnel_decap_dscp_to_pg_mapping  ^H ^H ^HPASSED                                                                                                                                               [100%] ^H
```
#### Any platform specific information?
Mellanox platform specific.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
