### PR TITLE
Fix packets_aging.py not found issue

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -402,6 +402,8 @@ def update_docker_services(rand_selected_dut, swap_syncd, disable_container_auto
 
     asic = rand_selected_dut.get_asic_name()
     if 'spc' in asic:
+        # Disable Mellanox packet aging. We don't need to cleanup as there is an autoused fixture
+        # disable_packet_aging to handle this.
         logger.info("Disable Mellanox packet aging")
         rand_selected_dut.copy(src="qos/files/mellanox/packets_aging.py", dest="/tmp")
         rand_selected_dut.command("docker cp /tmp/packets_aging.py syncd:/")
@@ -413,11 +415,6 @@ def update_docker_services(rand_selected_dut, swap_syncd, disable_container_auto
         rand_selected_dut, testcase="test_tunnel_qos_remap", feature_list=feature_list)
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="start", **service)
-
-    if 'spc' in asic:
-        logger.info("Enable Mellanox packet aging")
-        rand_selected_dut.command("docker exec syncd python /packets_aging.py enable")
-        rand_selected_dut.command("docker exec syncd rm -rf /packets_aging.py")
 
 
 def _update_mux_feature(duthost, state):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix an issue caused by PR #17800
`python: can't open file '/packets_aging.py': [Errno 2] No such file or directory`

Root cause:
If `swap_syncd` fixture is executed, the file copied to `syncd` container will be removed. 

This PR addressed the issue by ignoring the errors for running the script or removing the script.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix an issue caused by PR #17800
```
python: can't open file '/packets_aging.py': [Errno 2] No such file or directory
```
#### How did you do it?
Ignore the error.

#### How did you verify/test it?
The change is verified by running `test_tunnel_decap_dscp_to_pg_mapping` on a dualtor testbed with `swap_syncd` enabled.
```
collected 1 item                                                                                                                                                                                                              

qos/test_tunnel_qos_remap.py::test_tunnel_decap_dscp_to_pg_mapping  ^H ^H ^HPASSED                                                                                                                                               [100%] ^H
```
#### Any platform specific information?
Mellanox platform only.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
