### PR TITLE
Regex correction for bgp commands in show_tech_cmds.py

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -115,10 +115,10 @@ bgp_cmds = [
     "vtysh{} -c 'show bgp ipv4 labeled-unicast'",
     "vtysh{} -c 'show bgp ipv6 labeled-unicast'",
     "vtysh{} -c 'show bgp mac hash'",
-    re.compile(r"vtysh(\s+-Ec 'show bgp ipv4 neighbors .* advertised-routes' "
-               "-Ec 'show bgp ipv4 neighbors .* routes')+"),
-    re.compile(r"vtysh(\s+-Ec 'show bgp ipv6 neighbors .* advertised-routes' "
-               "-Ec 'show bgp ipv6 neighbors .* routes')+"),
+    re.compile(r"vtysh(?:\s+-n\s+0)?(\s+-Ec 'show bgp ipv4 neighbors .* advertised-routes'(?:\s+-n\s+0)?\s+-Ec"
+               r" 'show bgp ipv4 neighbors .* routes')+"),
+    re.compile(r"vtysh(?:\s+-n\s+0)?(\s+-Ec 'show bgp ipv6 neighbors .* advertised-routes'(?:\s+-n\s+0)?\s+-Ec"
+               r" 'show bgp ipv6 neighbors .* routes')+"),
 
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The regex is enhanced to capture the logs correctly.
Test failed with error  - 
 "_Failed: Commands not found for 'bgp_cmds': vtysh(\s+-Ec 'show bgp ipv4 neighbors .* advertised-routes' -Ec 'show bgp ipv4 neighbors .* routes')+; vtysh(\s+-Ec 'show bgp ipv6 neighbors .* advertised-routes' -Ec 'show bgp ipv6 neighbors .* routes')+_ "
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test failed with error  - 
 "_Failed: Commands not found for 'bgp_cmds': vtysh(\s+-Ec 'show bgp ipv4 neighbors .* advertised-routes' -Ec 'show bgp ipv4 neighbors .* routes')+; vtysh(\s+-Ec 'show bgp ipv6 neighbors .* advertised-routes' -Ec 'show bgp ipv6 neighbors .* routes')+_ "
#### How did you do it?

#### How did you verify/test it?
Executed test suite and verfiy
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
