### PR TITLE
Minor correction in tsa/tsb command output verification in test_ro_disk.py

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -261,10 +261,12 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
         # Verify after monit fix login issue ,remote user can run TSA/TSB command.
         res = ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo TSA")
         logger.debug("TSA res={}".format(res))
-        assert "System Mode: Normal -> Maintenance" in res["stdout_lines"], "Failed to TSA"
+        assert res["rc"] == 0, "failed to TSA"
+        assert "System Mode: Normal -> Maintenance" in res["stdout_lines"][0], "Failed to TSA"
         res = ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo TSB")
         logger.debug("TSB res={}".format(res))
-        assert "System Mode: Maintenance -> Normal" in res["stdout_lines"], "Failed to TSB"
+        assert res["rc"] == 0, "failed to TSB"
+        assert "System Mode: Maintenance -> Normal" in res["stdout_lines"][0], "Failed to TSB"
 
         if not os.path.exists(DATA_DIR):
             os.makedirs(DATA_DIR)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The command output of sudo/ TSA/TSB stored in 'stdout_lines' is a list of string. Hence enhancing the check for correct verification in tests/tacacs/test_ro_disk.py
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Test Failure
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
