### PR TITLE
Fix t0-118 fib.j2 test configs

### DIFF
--- a/ansible/roles/test/templates/fib.j2
+++ b/ansible/roles/test/templates/fib.j2
@@ -20,8 +20,8 @@
 0.0.0.0/0 [24 25] [26 27] [28 29] [30 31]
 ::/0 [24 25] [26 27] [28 29] [30 31]
 {% elif testbed_type == 't0-118' %}
-0.0.0.0/0 [0, 1] [22 23] [24 25] [26 27] [28 29]
-::/0 [0, 1] [22 23] [24 25] [26 27] [28 29]
+0.0.0.0/0 [22 23] [24 25] [26 27] [28 29]
+::/0 [22 23] [24 25] [26 27] [28 29]
 {% endif %}
 {#routes to uplink#}
 {#Limit the number of podsets and subnets to be covered to limit script execution time#}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Remove interfaces 0, 1 from fib.j2 for t0-118 as they are not uplinks

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
