### PR TITLE
Try to fix/make more reliable test_lag_traffic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1608,12 +1608,6 @@ pc/test_lag_member.py:
     conditions:
         - "'dualtor' in topo_name or 't0-backend' in topo_name"
 
-pc/test_lag_member.py::test_lag_member_traffic:
-  skip:
-    reason: "Have an issue on kvm t0"
-    conditions:
-        - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/13898"
-
 pc/test_lag_member_forwarding.py:
   xfail:
     reason: "Not supported on BRCM before SDK 13.x"

--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -402,7 +402,7 @@ def most_common_port_speed(duthost):
 
 
 def check_arp(duthost, port_name, ip_address):
-    res = duthost.shell("show arp", module_ignore_errors=True)
+    res = duthost.command("show arp", module_ignore_errors=True)
     if res["rc"] != 0:
         return False
     output_lines = res["stdout_lines"]
@@ -476,17 +476,18 @@ def test_lag_member_traffic(common_setup_teardown, duthost, ptf_dut_setup_and_te
     """
     ptfhost = common_setup_teardown
     dut_ports, ptf_ports, vlan = ptf_dut_setup_and_teardown
-    ping_format = "timeout 2 ping -c 2 -w 2 -I {} {}"
+    ping_format = "ping -c 5 -w 2 -l 5 -I {} {}"
 
     vlan_ip = vlan["ip"].split("/")[0]
     not_behind_lag_ping_cmd = ping_format.format(ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"], vlan_ip)
-    behind_lag_ping_cmd = " & ".join([ping_format.format(port, vlan_ip) for port in ptf_ports[ATTR_PORT_BEHIND_LAG]
-                                      .values()])
+
     # ping dut from port not behind lag, port not behind lag and lag interface to refresh arp table in dut.
-    ptfhost.shell((not_behind_lag_ping_cmd + " & " + behind_lag_ping_cmd + "&" +
-                  ping_format.format(PTF_LAG_NAME, vlan_ip)), module_ignore_errors=True)
-    pytest_assert(wait_until(10, 1, 0, check_arp, duthost, DUT_LAG_NAME, ptf_ports["ip"]["lag"].split("/")[0]),
-                  "Arp info for portchannel is not correct")
+    ptfhost.command(not_behind_lag_ping_cmd, module_ignore_errors=True)
+    ptfhost.command(ping_format.format(PTF_LAG_NAME, vlan_ip), module_ignore_errors=True)
+
+    if duthost.facts["asic_type"] != "vs":
+        pytest_assert(wait_until(10, 1, 0, check_arp, duthost, DUT_LAG_NAME, ptf_ports["ip"]["lag"].split("/")[0]),
+                      "Arp info for portchannel is not correct")
     pytest_assert(wait_until(10, 1, 0, check_arp, duthost, dut_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"],
                              ptf_ports["ip"][ATTR_PORT_NOT_BEHIND_LAG].split("/")[0]),
                   "Arp info for port not behind lag is not correct")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #13898

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

I'm suspecting that something in the ping code and the timeouts is causing random intermittent failures in test_lag_traffic, in the form of the ARP entry not getting populated.

#### How did you do it?

Try to make it more reliable by getting rid of the `timeout` wrapper around the call and let ping's `-w` flag effectively act as a timeout. Also, send 5 ping packets at once, just to avoid potential missed packets.

Also, enable this test case on VS/KVM by commenting out the ARP check for the portchannel interface entry.

#### How did you verify/test it?

Tested on KVM and physical device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
