### PR TITLE
skip vlan member config if no vlan is defined in fanout.yml deployment

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -54,11 +54,13 @@
     {% for port_name in port_config %}
     {% if port_name in device_port_vlans[inventory_hostname] %}
     {% if device_port_vlans[inventory_hostname][port_name]['mode'].lower() == 'access' %}
+    {% if device_port_vlans[inventory_hostname][port_name]['vlanids'] != '' %}
     {% if ns.firstPrinted %},{% endif %}
         "Vlan{{ device_port_vlans[inventory_hostname][port_name]['vlanids'] }}|{{ fanout_port_config[port_name]['name'] }}": {
             "tagging_mode" : "untagged"
         }
     {% if ns.update({'firstPrinted': True}) %} {% endif %}
+    {% endif %}
     {% elif device_port_vlans[inventory_hostname][port_name]['mode'].lower() == 'trunk' %}
     {% for vlanid in device_port_vlans[inventory_hostname][port_name]['vlanlist'] %}
     {% if ns.firstPrinted %},{% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When vlanids are not provided in the links.csv, need to skip generating vlan member configuration.
When links.csv is defined as following where no VLAN id is provided.  This is a use case where in minimised isolated-xx topology, VLANs are not needed for some links to save VLAN id resource
```
dut1,Ethernet0,fanout1,Ethernet0,100000,,Access,off
```
fanout.yaml will generate the following incorrect config, and cause vlanmgr crash.
```
         "Vlan|Ethernet0": {
             "tagging_mode": "untagged"
         },
```
The format vlanmgr expects is following:
```
         "Vlan2900|Ethernet0": {
             "tagging_mode": "untagged"
         },
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Skip generating wrong vlan member configuration in fanout.yml

#### How did you do it?

#### How did you verify/test it?
manually verified on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
