### PR TITLE
Fix loganalyzer error handling inconsistency and Improve error handling in parallel processes execution

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -162,6 +162,15 @@ def parallel_run(
             len(gone), len(alive)
         ))
 
+        # todo: Sometimes process run to the end but still alive, causing exception hidden.
+        #       Explicitly check the process exception to prevent exception miss.
+        #       Remove this temp fix once resolve the process alive problem.
+        for worker in alive:
+            if worker.exception is not None:
+                failed_processes[worker.name] = {}
+                failed_processes[worker.name]['exit_code'] = worker.exitcode
+                failed_processes[worker.name]['exception'] = worker.exception
+
         if len(gone) == 0:
             logger.debug("all processes have timedout")
             tasks_running -= len(workers)

--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -177,7 +177,7 @@ def parallel_run(
         # check if we have any processes that failed - have exitcode non-zero or exception not none
         for worker in gone + alive:
             worker_exception = worker.exception  # Force-read to prevent pipe hangs
-            if worker.exitcode != 0 or worker_exception is not None:
+            if worker_exception is not None:
                 failed_processes[worker.name] = {
                     'exit_code': worker.exitcode,
                     'exception': worker_exception


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
**Problem**
When running tasks via parallel_run, completed subprocesses sometimes remain alive (is_alive() == True), causing failure to capture exceptions.

**​​Potential Root Cause​​:**
Sending large data over a pipe can block the child process, even after it has logically "finished". 
- ​​details: Child processes hang on send() if parent doesn't read from the pipe.
​​The pipe buffer size is limited​​. The operating system allocates a fixed-size memory buffer for the pipe. When the child process sends data through send():
Data volume < buffer​​: The write succeeds immediately, and the child process continues to execute subsequent code (close the pipe, exit).
Data volume > buffer​​: The child process will be blocked in send() until the parent process reads and releases the buffer space.

So that sometimes the child process run to the end but hang on send().

**Solution:**
- Force-read exceptions from ​​all​​ workers (including alives).
If a parallel run function throws an exception, it will sent via Pipe. Therefore, after a timeout, we force-read exceptions from all processes(even alive ones). If any process encountered a failure (exception is not None), we record the error.

In addition, make some improvements:
- Close pipe connections immediately after sending/receiving data.
- Track read status to prevent multiple reads.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Fix loganalyzer error hidden and Improve error handling in parallel processes execution

#### How did you do it?

Force-read exceptions from ​​all​​ workers (including alives).

#### How did you verify/test it?

Run manual tests and catched error as expected whether it is a larger error or a smaller error.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
