### PR TITLE
Bug: hash/test_generic_hash.py "Failed: The global hash configuration is not as expected:"

### DIFF
--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -674,8 +674,8 @@ def test_reboot(rand_selected_dut, tbinfo, ptfhost, localhost, fine_params, mg_f
         )
 
     with allure.step(f'Randomly choose a reboot type: {reboot_type}, and reboot'):
-        # Save config if reboot type is config reload or cold reboot
-        if reboot_type in ['cold', 'reload', 'warm']:
+        # Save config if reboot type is config reload, cold, fast, warm reboot
+        if reboot_type in ['cold', 'reload', 'warm', 'fast']:
             rand_selected_dut.shell('config save -y')
         # Reload/Reboot the dut
         if reboot_type == 'reload':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During the run of `test_reboot` we are randomly generating `reboot_type` which can be one of following values `'cold', 'warm', 'fast', 'reload'` and in the test we are checking if `reboot_type ` is one of that values

`if reboot_type in ['cold', 'reload', 'warm']:`

But there are missing check for 'fast'` 

And as a result we are not saving config  before reboot if reboot type is `fast ` and because of that 
`ecmp hash fields` and `lag hash fields` are empty

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Failed test hash/test_generic_hash.py
#### How did you do it?
Added 'fast' reboot type check in order to save config for this type of reboot
#### How did you verify/test it?
Run test in testbed
