### PR TITLE
added xfail in test_generic_hash.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1424,6 +1424,24 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IN_PORT:
     conditions:
     - "asic_type in ['broadcom', 'mellanox']"
 
+hash/test_generic_hash.py::test_lag_member_flap[CRC-IP_PROTOCOL:
+  xfail:
+    reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
+    conditions:
+    - "asic_type in ['cisco-8000']"
+
+hash/test_generic_hash.py::test_lag_member_remove_add[CRC_CCITT-IP_PROTOCOL:
+  xfail:
+    reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+hash/test_generic_hash.py::test_reboot[CRC-IP_PROTOCOL:
+  xfail:
+    reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 #######################################
 #####           http              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
adding these 3 TCs in hash/test_generic_hash.py as xfail in test_condition_mark.yaml
hash/test_generic_hash.py::test_lag_member_flap[CRC-IP_PROTOCOL-ipv4-None-None]
hash/test_generic_hash.py::test_lag_member_remove_add[CRC_CCITT-IP_PROTOCOL-ipv4-None-None]
hash/test_generic_hash.py::test_reboot[CRC-IP_PROTOCOL-ipv4-None-None-cold]

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
to xfail mentioned testcases in hash/test_generic_hash.py

#### How did you do it?
adding xfail reasons and conditions for three TCs in test_conditional_mark.yaml file

#### How did you verify/test it?
via UT

#### Any platform specific information?
for cisco-8000

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
