### PR TITLE
Enhanced Ondatra's Build.bazel to trigger build for all test cases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ pr:
        - LICENSE
        - README.md
        - SECURITY.md
+       - sdn_tests/**
 trigger: none
 
 name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)

--- a/sdn_tests/pins_ondatra/BUILD.bazel
+++ b/sdn_tests/pins_ondatra/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//tests:ondatra_test.bzl", "ondatra_test", "ondatra_test_suite")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+
+#To run all the testcase
+filegroup(
+    name = "all_tests",
+    srcs = [
+        "//tests:ethcounter_sw_dual_switch_test",
+        "//tests:gnmi_long_stress_test",
+        "//tests:gnoi_file_test",
+        "//tests:lacp_timeout_test",
+        "//tests:link_event_damping_test",
+        "//tests:port_debug_data_test",
+        "//tests:platforms_hardware_component_test",
+        "//tests:module_reset_test",
+        "//tests:installation_test",
+        "//tests:inband_sw_interface_dual_switch_test",
+        "//tests:gnmi_get_modes_test",
+        "//tests:transceiver_test",
+        "//tests:inband_sw_interface_test",
+        "//tests:platforms_software_component_test",
+        "//tests:gnoi_reboot_test",
+        "//tests:cpu_sw_single_switch_test",
+        "//tests:ethcounter_sw_single_switch_test",
+        "//tests:gnmi_set_get_test",
+	"//tests:lacp_test",
+        "//tests:z_gnmi_stress_test",
+        "//tests:system_paths_test",
+        "//tests:gnmi_wildcard_subscription_test",
+    ],
+    testonly = 1,
+    visibility = ["//visibility:public"],
+)

--- a/sdn_tests/pins_ondatra/tests/BUILD.bazel
+++ b/sdn_tests/pins_ondatra/tests/BUILD.bazel
@@ -409,3 +409,32 @@ ondatra_test(
         "@org_golang_google_protobuf//encoding/prototext",
     ],
 )
+
+#To run all the testcase
+test_suite(
+    name = "all_tests",
+    tests = [
+        ":ethcounter_sw_dual_switch_test",
+        ":gnmi_long_stress_test",
+        ":gnoi_file_test",
+        ":lacp_timeout_test",
+        ":link_event_damping_test",
+        ":port_debug_data_test",
+        ":platforms_hardware_component_test",
+        ":module_reset_test",
+        ":installation_test",
+        ":inband_sw_interface_dual_switch_test",
+        ":gnmi_get_modes_test",
+        ":transceiver_test",
+        ":inband_sw_interface_test",
+        ":platforms_software_component_test",
+        ":gnoi_reboot_test",
+        ":cpu_sw_single_switch_test",
+        ":ethcounter_sw_single_switch_test",
+        ":gnmi_set_get_test",
+        ":lacp_test",
+        ":z_gnmi_stress_test",
+        ":system_paths_test",
+        ":gnmi_wildcard_subscription_test",
+    ],
+)


### PR DESCRIPTION
### Description of PR
Adding new BUILD.bazel file in /pins_ondatra  folder which helps to build All Ondatra Tests in single run using bazel commands below

Also modified pins_ondatra/tests/BUILD.bazel file to execute all the tests at a time

To Build All Tests:  bazel build ...
To Build and Execute all Tests : bazel test //tests:all_tests 


