### PR TITLE
Add subtype field to the duthost facts

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -206,11 +206,12 @@ class SonicHost(AnsibleHostBase):
                 lambda: self._get_modular_chassis(facts["asic_type"]),
                 self._get_mgmt_interface,
                 self._get_switch_type,
+                self._get_subtype,
                 self._get_router_type,
                 self.get_asics_present_from_inventory,
                 lambda: self._get_platform_asic(facts["platform"])
             ],
-            timeout=180,
+            timeout=120,
             thread_count=5
         )
 
@@ -219,12 +220,13 @@ class SonicHost(AnsibleHostBase):
         facts["modular_chassis"] = str2bool(results[2])
         facts["mgmt_interface"] = results[3]
         facts["switch_type"] = results[4]
-        facts["router_type"] = results[5]
+        facts["subtype"] = results[5]
+        facts["router_type"] = results[6]
 
-        facts["asics_present"] = results[6] if len(results[6]) != 0 else list(range(facts["num_asic"]))
+        facts["asics_present"] = results[7] if len(results[7]) != 0 else list(range(facts["num_asic"]))
 
-        if results[7]:
-            facts["platform_asic"] = results[7]
+        if results[8]:
+            facts["platform_asic"] = results[8]
 
         logging.debug("Gathered SonicHost facts: %s" % json.dumps(facts))
         return facts
@@ -301,6 +303,13 @@ class SonicHost(AnsibleHostBase):
     def _get_switch_type(self):
         try:
             return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.switch_type'")["stdout_lines"][0]\
+                .encode().decode("utf-8").lower()
+        except Exception:
+            return ''
+
+    def _get_subtype(self):
+        try:
+            return self.command("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.subtype'")["stdout_lines"][0]\
                 .encode().decode("utf-8").lower()
         except Exception:
             return ''

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -211,7 +211,7 @@ class SonicHost(AnsibleHostBase):
                 self.get_asics_present_from_inventory,
                 lambda: self._get_platform_asic(facts["platform"])
             ],
-            timeout=120,
+            timeout=180,
             thread_count=5
         )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add subtype to the duthost facts
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

This field is useful to discriminate for a smartswitch cisco-8000 device as it will be set to "smartswitch". 

#### How did you do it?

Updated common sonic.py file to include subtype in the same way the other fields are extracted.

#### How did you verify/test it?

Tested test_neighbor_mac_noptf.py and used the subtype field to only run specific IP filters for "smartswitch" devices.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
