### PR TITLE
Fixing multiple issues in test_vrf.py

### DIFF
--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -23,29 +23,25 @@
     },
 {%     elif k == 'BGP_PEER_RANGE' %}
     "BGP_PEER_RANGE": {
-        "BGPSLBPassive": {
-            "vrf_name": "Vrf1",
+        "Vrf1|BGPSLBPassive": {
             "ip_range": [
                 "10.255.0.0/25"
             ],
             "name": "BGPSLBPassive"
         },
-        "BGPVac": {
-            "vrf_name": "Vrf1",
+        "Vrf1|BGPVac": {
             "ip_range": [
                 "192.168.0.0/21"
             ],
             "name": "BGPVac"
         },
-        "BGPSLBPassive2": {
-            "vrf_name": "Vrf2",
+        "Vrf2|BGPSLBPassive2": {
             "ip_range": [
                 "10.255.0.0/25"
             ],
             "name": "BGPSLBPassive2"
         },
-        "BGPVac2": {
-            "vrf_name": "Vrf2",
+        "Vrf2|BGPVac2": {
             "ip_range": [
                 "192.168.0.0/21"
             ],

--- a/tests/vrf/vrf_neigh.j2
+++ b/tests/vrf/vrf_neigh.j2
@@ -7,9 +7,9 @@
 {% endif -%}
 {%- endmacro %}
 
-{% for intf, ip_facts in intf_ips.iteritems() -%}
+{% for intf, ip_facts in intf_ips.items() -%}
 {% if 'Loopback' not in intf -%}
-{% for ver, ips in ip_facts.iteritems() -%}
+{% for ver, ips in ip_facts.items() -%}
 {% for ip in ips -%}
 {{ ip.ip + 1 }} {{ gen_dst_ports(intf) }}
 {% endfor -%}


### PR DESCRIPTION
fixes: https://github.com/sonic-net/sonic-mgmt/issues/18355

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix multiple issues in test_vrf.py:
- 1. Use integer division for python 3 compatibility
- 2. Use items instead of iteritems in vrf_neigh.j2 for python 3 compabibility
- 3. Wait for interface to be bound to vrf, instead of immediately asserting
- 4. In Python 3, tempfile.NamedTemporaryFile() defaults to binary mode (mode='w+b'), whereas the test is opening it in text mode. Opening it explicitly in text mode for python3 compatibility using
`with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8', delete=False)`
- 5. Test is using a hack to configure a bgp router so that bgp port can be opened. However in most cases bgp router config is already present, which causes the config to fail. Get the bgp asn from tbinfo and use that in the hack instead of a random asn config (which would fail if asn is configured as per tbinfo).
- 6. Cleanup the links created in ptf container during teardown
- 7. peer-groups to be configured in VRF should follow the syntax of `<VRF|group>`

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
