### PR TITLE
Adjust port selection in testQosSaiXonHysteresis for Cisco-8101-O32

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -854,11 +854,11 @@ class QosParamCisco(object):
                 sq_occupancies_mb = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4]
                 params_1 = {"packet_size": packet_size,
                             "ecn": 1,
-                            "dscps":  [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "pgs":    [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "queues": [3, 4, 3, 4, 3, 4, 3, 4, 3, 3, 3],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 5, 6],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "dscps":      [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "pgs":        [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "queues":     [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_1", params_1)
 
@@ -869,8 +869,8 @@ class QosParamCisco(object):
                             "dscps":      [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_2", params_2)
 
@@ -885,8 +885,8 @@ class QosParamCisco(object):
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  9,  9],
+                            "dst_port_i": [7, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_3", params_3)
 
@@ -901,8 +901,8 @@ class QosParamCisco(object):
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [3, 0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4],
                             "queues":     [3, 1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8],
+                            "src_port_i": [0, 0, 1, 1, 2, 2, 3,  3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10, 11, 11],
+                            "dst_port_i": [7, 8, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_4", params_4)
 
@@ -916,9 +916,10 @@ class QosParamCisco(object):
                                            self.dscp_queue1, self.dscp_queue0,
                                            self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "pgs":        [0, 0, 0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4,  3,  4],
-                            "queues":     [1, 0, 1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8],
+                            "queues":     [1, 0, 1, 0, 1, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4],
+                            "src_port_i": [0, 0, 1, 1, 2, 2, 2, 3, 3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10, 11, 11],
+                            "dst_port_i": [7, 8, 12, 12, 13, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17,
+                                           18, 18, 19, 19, 20, 20],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_5", params_5)
 
@@ -932,8 +933,8 @@ class QosParamCisco(object):
                                            4, 3, 4, 3, 4],
                             "pgs":        [3, 4, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
                             "queues":     [3, 4, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+                            "src_port_i": [0, 0, 1, 1, 1, 2,  2,  3,  3,  4,  4,  5,  5,  6,  6],
+                            "dst_port_i": [7, 8, 9, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_6", params_6)
 
@@ -945,7 +946,8 @@ class QosParamCisco(object):
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12, 12],
-                            "dst_port_i": [7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8,  8],
+                            "dst_port_i": [7, 7, 8, 8, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18,
+                                           18, 19, 19, 20, 20, 21, 21],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_7", params_7)
 
@@ -957,7 +959,8 @@ class QosParamCisco(object):
                             "pgs":        [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "queues":     [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4,  3,  4,  3,  4,  3,  4],
                             "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11, 11, 12, 12],
-                            "dst_port_i": [7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8,  8,  8,  8],
+                            "dst_port_i": [7, 8, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19,
+                                           19, 20, 20, 21, 21, 22, 22],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_8", params_8)
 
@@ -972,8 +975,8 @@ class QosParamCisco(object):
                                            3, 4, 3, 4, 3, 4],
                             "pgs":        [0, 0, 0, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4],
                             "queues":     [1, 0, 1, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3,  4,  3,  4],
-                            "src_port_i": [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 9, 9, 10, 10, 11],
-                            "dst_port_i": [7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,  8,  8,  8],
+                            "src_port_i": [0, 0, 1,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  9,  9,  10, 10],
+                            "dst_port_i": [7, 8, 11, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18],
                             "pkt_counts": mb_to_pkt_count(sq_occupancies_mb)}
                 self.write_params("xon_hysteresis_9", params_9)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://migsonic.atlassian.net/browse/MIGSMSFT-848
qos.test_qos_sai.TestQosSai.testQosSaiXonHysteresis failed on hwsku Cisco-8101-O32 T1 setup.
VOQ tail drop since connected routes use default voq. Multi src_ports → same dst_port using same voq, caused voq tail drop happen before PFC triggered.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix testQosSaiXonHysteresis failures for Cisco-8101-O32.

#### How did you do it?
Adjust port selection to avoid multiple flows using same voq.

#### How did you verify/test it?
Verified on Cisco-8101-O8C48 T1 testbed.
SONiC Software Version: SONiC.azure_cisco_202411.23036-dirty-20250402.193037
sdk-version: 24.11.3000.24
```
-------------- generated xml file: /tmp/qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis_2025-04-25-23-19-16.xml --------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
23:32:17 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_3]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_4]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_5]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_6]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_7]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_8]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis[single_asic-xon_hysteresis_9]
SKIPPED [9] qos/test_qos_sai.py:2499: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [27] qos/test_qos_sai.py:2499: multi-dut is not supported on T1 topologies
======================================== 9 passed, 36 skipped, 1 warning in 780.42s (0:13:00) =========================================
sonic@sonic-ucs-m6-26:/data/tests$ 
```

#### Any platform specific information?
For HwSKU: Cisco-8101-

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
