### PR TITLE
Read memory threshold from monit config to improve memory_checker test

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -157,6 +157,12 @@ def parse_monit_output(lines):
             continue
         if service is None:
             continue
+
+        # Ignore line continuations that start with more than 2 whitespace
+        # characters.  We don't need the data at all.
+        if len(line) - len(line.lstrip()) > 2:
+            continue
+
         if line.startswith('  '):
             key, value = line.lstrip().split('  ', 1)
             service[key.replace(' ', '_')] = value.lstrip()

--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -548,7 +548,7 @@ def consumes_memory_and_checks_container_restart(duthost, container):
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix=marker_prefix)
     loganalyzer.expect_regex = container.get_restart_expected_logre()
     with loganalyzer:
-        timeout_monit_fail = 360  # fails happens after timeout wait
+        timeout_monit_fail = 1200  # fails happens after timeout wait
         container.start_consume_memory()
         container.wait_monit_mem_failed(timeout_monit_fail)
         logger.info("Container %s should now be restarting", container.name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
memory_checker test uses fixed memory threshold for gnmi and telemetry container.
We will increase memory threshold for gnmi container, and then this threshold will be wrong.

#### How did you do it?
Read monit config file to get memory threshold.

#### How did you verify/test it?
Run memory_checker test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
