### PR TITLE
[Mellanox] Ignore the expected errors in bfd test

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -377,6 +377,25 @@ def verify_bfd_queue_counters(duthost, dut_intf):
         pytest.fail('Queue 7 packet count is zero, no BFD traffic')
 
 
+@pytest.fixture(autouse=True)
+def ignore_syslog_errors(rand_selected_dut, loganalyzer):
+    """Ignore expected error logs during test execution."""
+    if loganalyzer:
+        loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(
+            [
+                '.*ERR kernel:.*Failed to bind BFD socket to local_addr.*',
+                '.*ERR kernel:.*Failed to create TX socket for session.*',
+                '.*ERR kernel:.*Parsing BFD command.*failed.*',
+                '.*ERR syncd#SDK:.*BFD.ERR.*ioctl failed, error description: Input.output error',
+                '.*ERR syncd#SDK:.*CORE_API.ERR.*Failed in bfd_offload_set().* error:.*',
+                '.*ERR syncd#SDK:.*SAI_BFD.ERR.*.*mlnx_sai_bfd.c.*mlnx_set_offload_bfd_tx_session.*: Error create TX BFD session.*',  # noqa: E501
+                '.*ERR syncd#SDK: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_FAILURE',  # noqa: E501
+                '.*ERR syncd#SDK: :- processQuadEvent: attr: SAI_BFD_SESSION_ATTR_.*',
+                '.*ERR swss#orchagent: :- create: create status: SAI_STATUS_FAILURE.*'
+            ]
+        )
+
+
 @pytest.mark.parametrize('dut_init_first', [True, False], ids=['dut_init_first', 'ptf_init_first'])
 @pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
 def test_bfd_basic(request, rand_selected_dut, ptfhost, tbinfo, ipv6, dut_init_first):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Nvidia paltforms, while running this test BFD session creation can fail sometime resulting in some syslog errors.
THe syncd retries in such a case and is able to create the BFD session subsequently. So these errors can be ignored.

There is already a PR handling the same errors in tests/vxlan/test_vxlan_ecmp.py: https://github.com/sonic-net/sonic-mgmt/pull/14025

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
Tested on Nvidia plarforms, errors can be ignored.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
