### PR TITLE
[ondatra] Improve ConfigRestorer with config convergence verification and port polling fix.

### DIFF
--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/config_convergence.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/config_convergence.go
@@ -277,18 +277,25 @@ func WaitForAllPortsUp(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice
 
 	allInterfaces, err := ygnmi.GetAll(ctx, yc, gnmi.OC().InterfaceAny().Name().Config())
 	if err != nil {
-		return fmt.Errorf("ygnmi.GetAll for /interfaces/interface/config/name failed, err: %v", err)
+		return fmt.Errorf("ygnmi.GetAll for /interfaces/interface/config failed, err: %v", err)
 	}
 
 	numPorts := 0
 	b := ygnmi.NewWildcardBatch(gnmi.OC().InterfaceAny().OperStatus().State())
 	// Create a batch query of all the interfaces of the format: EthernetX/Y/Z
 	// to check if they are up.
-	for _, i := range allInterfaces {
-		if !inEthernetPortChannelLaneFormat(i) {
+	for _, intf := range allInterfaces {
+		if !inEthernetPortChannelLaneFormat(intf) {
 			continue
 		}
-		b.AddPaths(gnmi.OC().Interface(i).OperStatus().State())
+		enabled, err := ygnmi.Get(ctx, yc, gnmi.OC().Interface(intf).Enabled().Config())
+		if err != nil {
+			return fmt.Errorf("ygnmi.Get for /interfaces/interface(name=%v)/enabled/config failed, err: %v", intf, err)
+		}
+		if !enabled {
+			continue
+		}
+		b.AddPaths(gnmi.OC().Interface(intf).OperStatus().State())
 		numPorts++
 	}
 
@@ -363,19 +370,19 @@ func WaitForSwitchState(ctx context.Context, t *testing.T, dut *ondatra.DUTDevic
 		switch s := switchState; s {
 		case down:
 			if err := GNOIAble(t, dut); err != nil {
-				log.InfoContextf(ctx, "GNOIAble(dut=%v) failed", dutName)
+				log.InfoContextf(ctx, "GNOIAble(dut=%v) failed, err: %v", dutName, err)
 				return false
 			}
 			switchState++
 		case gnoiAble:
 			if err := GNMIAble(t, dut); err != nil {
-				log.InfoContextf(ctx, "GNMIAble(dut=%v) failed", dutName)
+				log.InfoContextf(ctx, "GNMIAble(dut=%v) failed, err: %v", dutName, err)
 				return false
 			}
 			switchState++
 		case gnmiAble:
 			if err := WaitForAllPortsUp(ctx, t, dut); err != nil {
-				log.InfoContextf(ctx, "WaitForAllPortsUp(dut=%v) failed", dutName)
+				log.InfoContextf(ctx, "WaitForAllPortsUp(dut=%v) failed, err: %v", dutName, err)
 				return false
 			}
 			switchState++

--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/platform_components.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/platform_components.go
@@ -39,6 +39,7 @@ func (c CPUInfo) GetMaxAverageUsage() uint8 {
 
 // RebootTimeForDevice returns the maximum time that the device might take to reboot.
 func RebootTimeForDevice(t *testing.T, d *ondatra.DUTDevice) (time.Duration, error) {
+
 	info, err := platformInfoForDevice(t, d)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to fetch platform specific information")


### PR DESCRIPTION
Keyword Check:
/sonic-mgmt/sdn_tests/pins_ondatra$ ~/tools/keyword_checks.sh .
Keyword check Passed.



Build Result:
sonic-mgmt/sdn_tests/pins_ondatra$ bazel build ...
Starting local Bazel server and connecting to it...
INFO: Analyzed 19 targets (507 packages loaded, 30100 targets configured).
INFO: Found 19 targets...
INFO: Elapsed time: 267.900s, Critical Path: 101.99s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions


Test Result:
/sonic-mgmt/sdn_tests/pins_ondatra$ bazel test ...
INFO: Analyzed 20 targets (0 packages loaded, 0 targets configured).
INFO: Found 18 targets and 2 test targets...
INFO: Elapsed time: 62.176s, Critical Path: 44.12s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
//infrastructure/thinkit:ondatra_params_test (cached) PASSED in 1.1s
//infrastructure/thinkit:ondatra_generic_testbed_fixture_test PASSED in 43.4s

Executed 1 out of 2 tests: 2 tests pass.

Individual Build Results:
/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:cthinkit
INFO: Analyzed target //infrastructure/thinkit:cthinkit (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:cthinkit up-to-date:
bazel-bin/infrastructure/thinkit/libcthinkit.a
bazel-bin/infrastructure/thinkit/libcthinkit.so
INFO: Elapsed time: 6.749s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_generic_testbed
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed up-to-date (nothing to build)
INFO: Elapsed time: 2.087s, Critical Path: 0.04s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_generic_testbed_fixture
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture up-to-date:
bazel-bin/infrastructure/thinkit/libondatra_generic_testbed_fixture.a
bazel-bin/infrastructure/thinkit/libondatra_generic_testbed_fixture.so
INFO: Elapsed time: 0.604s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_generic_testbed_fixture_test
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test up-to-date:
bazel-bin/infrastructure/thinkit/ondatra_generic_testbed_fixture_test
INFO: Elapsed time: 2.235s, Critical Path: 0.07s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_mirror_testbed
INFO: Analyzed target //infrastructure/thinkit:ondatra_mirror_testbed (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_mirror_testbed up-to-date (nothing to build)
INFO: Elapsed time: 1.042s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_mirror_testbed_fixture
INFO: Analyzed target //infrastructure/thinkit:ondatra_mirror_testbed_fixture (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_mirror_testbed_fixture up-to-date:
bazel-bin/infrastructure/thinkit/libondatra_mirror_testbed_fixture.a
bazel-bin/infrastructure/thinkit/libondatra_mirror_testbed_fixture.so
INFO: Elapsed time: 2.078s, Critical Path: 0.08s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_params
INFO: Analyzed target //infrastructure/thinkit:ondatra_params (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_params up-to-date:
bazel-bin/infrastructure/thinkit/libondatra_params.a
bazel-bin/infrastructure/thinkit/libondatra_params.so
INFO: Elapsed time: 3.471s, Critical Path: 0.12s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_params_test
INFO: Analyzed target //infrastructure/thinkit:ondatra_params_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_params_test up-to-date:
bazel-bin/infrastructure/thinkit/ondatra_params_test
INFO: Elapsed time: 0.560s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:random_blackbox_events_test
INFO: Analyzed target //tests/thinkit:random_blackbox_events_test (9 packages loaded, 2916 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:random_blackbox_events_test up-to-date:
bazel-bin/tests/thinkit/random_blackbox_events_test
INFO: Elapsed time: 64.318s, Critical Path: 59.07s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:arbitration_test
INFO: Analyzed target //tests/thinkit:arbitration_test (0 packages loaded, 8 targets configured).
INFO: Found 1 target...
INFO: From Compiling tests/thinkit/arbitration_test.cc:
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:30,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h: In member function 'absl::lts_20230802::Status pins::ArbitrationTestFixture::NormalizeSwitchState(pdpi::P4RuntimeSession*)':
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:96:27: warning: 'absl::lts_20230802::Status pdpi::ClearTableEntries(pdpi::P4RuntimeSession*)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
96 | RETURN_IF_ERROR(pdpi::ClearTableEntries(p4rt_session));
| ^~~~~~~~~~~~~~~~~
external/com_github_sonic_net_sonic_pins/gutil/status.h:275:30: note: in definition of macro 'RETURN_IF_ERROR'
275 | for (absl::Status status = expr; !status.ok();)
| ^~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:34,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/p4_pdpi/p4_runtime_session.h:392:14: note: declared here
392 | absl::Status ClearTableEntries(P4RuntimeSession session);
| ^~~~~~~~~~~~~~~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:30,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:96:57: warning: 'absl::lts_20230802::Status pdpi::ClearTableEntries(pdpi::P4RuntimeSession)' is deprecated: Use ClearEntities instead. [-Wdeprecated-declarations]
96 | RETURN_IF_ERROR(pdpi::ClearTableEntries(p4rt_session));
| ^
external/com_github_sonic_net_sonic_pins/gutil/status.h:275:30: note: in definition of macro 'RETURN_IF_ERROR'
275 | for (absl::Status status = expr; !status.ok();)
| ^~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:34,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/p4_pdpi/p4_runtime_session.h:392:14: note: declared here
392 | absl::Status ClearTableEntries(P4RuntimeSession session);
| ^~~~~~~~~~~~~~~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:30,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:98:42: warning: 'absl::lts_20230802::StatusOr<std::vectorp4::v1::TableEntry > pdpi::ReadPiTableEntries(pdpi::P4RuntimeSession)' is deprecated: Prefer ReadPiEntities instead. [-Wdeprecated-declarations]
98 | ASSIGN_OR_RETURN(auto entries, pdpi::ReadPiTableEntries(p4rt_session));
| ^~~~~~~~~~~~~~~~~~
external/com_github_sonic_net_sonic_pins/gutil/status.h:286:43: note: in definition of macro '__ASSIGN_OR_RETURN'
286 | auto __ASSIGN_OR_RETURN_VAL(LINE) = expr;
| ^~~~
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:98:5: note: in expansion of macro 'ASSIGN_OR_RETURN'
98 | ASSIGN_OR_RETURN(auto entries, pdpi::ReadPiTableEntries(p4rt_session));
| ^~~~~~~~~~~~~~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:34,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/p4_pdpi/p4_runtime_session.h:363:1: note: declared here
363 | ReadPiTableEntries(P4RuntimeSession session);
| ^~~~~~~~~~~~~~~~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:30,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:98:73: warning: 'absl::lts_20230802::StatusOr<std::vectorp4::v1::TableEntry > pdpi::ReadPiTableEntries(pdpi::P4RuntimeSession)' is deprecated: Prefer ReadPiEntities instead. [-Wdeprecated-declarations]
98 | ASSIGN_OR_RETURN(auto entries, pdpi::ReadPiTableEntries(p4rt_session));
| ^
external/com_github_sonic_net_sonic_pins/gutil/status.h:286:43: note: in definition of macro '__ASSIGN_OR_RETURN'
286 | auto __ASSIGN_OR_RETURN_VAL(LINE) = expr;
| ^~~~
external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:98:5: note: in expansion of macro 'ASSIGN_OR_RETURN'
98 | ASSIGN_OR_RETURN(auto entries, pdpi::ReadPiTableEntries(p4rt_session));
| ^~~~~~~~~~~~~~~~
In file included from external/com_github_sonic_net_sonic_pins/tests/forwarding/arbitration_test.h:34,
from tests/thinkit/arbitration_test.cc:1:
external/com_github_sonic_net_sonic_pins/p4_pdpi/p4_runtime_session.h:363:1: note: declared here
363 | ReadPiTableEntries(P4RuntimeSession *session);
| ^~~~~~~~~~~~~~~~~~
Target //tests/thinkit:arbitration_test up-to-date:
bazel-bin/tests/thinkit/arbitration_test
INFO: Elapsed time: 30.402s, Critical Path: 28.06s
INFO: 4 processes: 2 internal, 2 linux-sandbox.
INFO: Build completed successfully, 4 total actions

/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:configure_mirror_testbed_test
INFO: Analyzed target //tests/thinkit:configure_mirror_testbed_test (0 packages loaded, 5 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:configure_mirror_testbed_test up-to-date:
bazel-bin/tests/thinkit/configure_mirror_testbed_test
INFO: Elapsed time: 9.353s, Critical Path: 7.87s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:arriba_test
INFO: Analyzed target //tests/thinkit:arriba_test (2 packages loaded, 44 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:arriba_test up-to-date:
bazel-bin/tests/thinkit/arriba_test
INFO: Elapsed time: 7.371s, Critical Path: 6.43s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions


Individual test Results:
For infrastructure/thinkit:ondatra_generic_testbed_fixture_test

sonic-mgmt/sdn_tests/pins_ondatra$ bazel test //infrastructure/thinkit:ondatra_generic_testbed_fixture_test
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test up-to-date:
bazel-bin/infrastructure/thinkit/ondatra_generic_testbed_fixture_test
INFO: Elapsed time: 2.007s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//infrastructure/thinkit:ondatra_generic_testbed_fixture_test (cached) PASSED in 2.3s

Executed 0 out of 1 test: 1 test passes.

For infrastructure/thinkit:ondatra_params_test

sonic-mgmt/sdn_tests/pins_ondatra$ bazel test //infrastructure/thinkit:ondatra_params_test
INFO: Analyzed target //infrastructure/thinkit:ondatra_params_test (3 packages loaded, 17 targets configured).
INFO: Found 1 test target...
Target //infrastructure/thinkit:ondatra_params_test up-to-date:
bazel-bin/infrastructure/thinkit/ondatra_params_test
INFO: Elapsed time: 17.701s, Critical Path: 16.73s
INFO: 11 processes: 5 internal, 6 linux-sandbox.
INFO: Build completed successfully, 11 total actions
//infrastructure/thinkit:ondatra_params_test PASSED in 0.1s

Executed 1 out of 1 test: 1 test passes.


sonic-mgmt/sdn_tests/pins_ondatra$ ~/tools/sdn_build.sh .
==========[Building test: ethcounter_sw_dual_switch_test]==========
INFO: Analyzed target //tests:ethcounter_sw_dual_switch_test (4 packages loaded, 127 targets configured).
INFO: Found 1 target...
Target //tests:ethcounter_sw_dual_switch_test up-to-date:
bazel-bin/tests/ethcounter_sw_dual_switch_test_/ethcounter_sw_dual_switch_test
INFO: Elapsed time: 98.809s, Critical Path: 97.37s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: ethcounter_sw_dual_switch_test]==========
==========[Building test: gnmi_long_stress_test]==========
INFO: Analyzed target //tests:gnmi_long_stress_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_long_stress_test up-to-date:
bazel-bin/tests/gnmi_long_stress_test_/gnmi_long_stress_test
INFO: Elapsed time: 15.145s, Critical Path: 14.53s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnmi_long_stress_test]==========
==========[Building test: gnmi_stress_helper]==========
INFO: Analyzed target //tests:gnmi_stress_helper (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_stress_helper up-to-date:
bazel-bin/tests/gnmi_stress_helper.a
INFO: Elapsed time: 0.615s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_stress_helper]==========
==========[Building test: gnoi_file_test]==========
INFO: Analyzed target //tests:gnoi_file_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_file_test up-to-date:
bazel-bin/tests/gnoi_file_test_/gnoi_file_test
INFO: Elapsed time: 7.877s, Critical Path: 7.46s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnoi_file_test]==========
==========[Building test: lacp_timeout_test]==========
INFO: Analyzed target //tests:lacp_timeout_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:lacp_timeout_test up-to-date:
bazel-bin/tests/lacp_timeout_test_/lacp_timeout_test
INFO: Elapsed time: 18.078s, Critical Path: 17.56s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: lacp_timeout_test]==========
==========[Building test: link_event_damping_test]==========
INFO: Analyzed target //tests:link_event_damping_test (0 packages loaded, 3 targets configured).
INFO: Found 1 target...
Target //tests:link_event_damping_test up-to-date:
bazel-bin/tests/link_event_damping_test_/link_event_damping_test
INFO: Elapsed time: 19.054s, Critical Path: 17.98s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: link_event_damping_test]==========
==========[Building test: port_debug_data_test]==========
INFO: Analyzed target //tests:port_debug_data_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:port_debug_data_test up-to-date:
bazel-bin/tests/port_debug_data_test_/port_debug_data_test
INFO: Elapsed time: 21.941s, Critical Path: 21.43s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: port_debug_data_test]==========
==========[Building test: platforms_hardware_component_test]==========
INFO: Analyzed target //tests:platforms_hardware_component_test (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //tests:platforms_hardware_component_test up-to-date:
bazel-bin/tests/platforms_hardware_component_test_/platforms_hardware_component_test
INFO: Elapsed time: 20.473s, Critical Path: 19.46s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: platforms_hardware_component_test]==========
==========[Building test: module_reset_test]==========
INFO: Analyzed target //tests:module_reset_test_dualnode (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:module_reset_test_dualnode up-to-date:
bazel-bin/tests/module_reset_test_dualnode_/module_reset_test_dualnode
INFO: Elapsed time: 15.018s, Critical Path: 14.38s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: module_reset_test]==========
==========[Building test: installation_test]==========
INFO: Analyzed target //tests:installation_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:installation_test up-to-date:
bazel-bin/tests/installation_test_/installation_test
INFO: Elapsed time: 13.884s, Critical Path: 12.90s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: installation_test]==========
==========[Building test: inband_sw_interface_dual_switch_test]==========
INFO: Analyzed target //tests:inband_sw_interface_dual_switch_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:inband_sw_interface_dual_switch_test up-to-date:
bazel-bin/tests/inband_sw_interface_dual_switch_test_/inband_sw_interface_dual_switch_test
INFO: Elapsed time: 19.356s, Critical Path: 18.76s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: inband_sw_interface_dual_switch_test]==========
==========[Building test: gnmi_get_modes_test]==========
INFO: Analyzed target //tests:gnmi_get_modes_test (2 packages loaded, 14 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_get_modes_test up-to-date:
bazel-bin/tests/gnmi_get_modes_test_/gnmi_get_modes_test
INFO: Elapsed time: 83.157s, Critical Path: 82.38s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnmi_get_modes_test]==========
==========[Building test: transceiver_test]==========
INFO: Analyzed target //tests:transceiver_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:transceiver_test up-to-date:
bazel-bin/tests/transceiver_test_/transceiver_test
INFO: Elapsed time: 46.466s, Critical Path: 35.79s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: transceiver_test]==========
==========[Building test: inband_sw_interface_test]==========
INFO: Analyzed target //tests:inband_sw_interface_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:inband_sw_interface_test up-to-date:
bazel-bin/tests/inband_sw_interface_test_/inband_sw_interface_test
INFO: Elapsed time: 33.579s, Critical Path: 32.34s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: inband_sw_interface_test]==========
==========[Building test: platforms_software_component_test]==========
INFO: Analyzed target //tests:platforms_software_component_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:platforms_software_component_test up-to-date:
bazel-bin/tests/platforms_software_component_test_/platforms_software_component_test
INFO: Elapsed time: 22.369s, Critical Path: 21.70s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: platforms_software_component_test]==========
==========[Building test: gnoi_reboot_test]==========
INFO: Analyzed target //tests:gnoi_reboot_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_reboot_test up-to-date:
bazel-bin/tests/gnoi_reboot_test_/gnoi_reboot_test
INFO: Elapsed time: 17.526s, Critical Path: 16.84s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnoi_reboot_test]==========
==========[Building test: cpu_sw_single_switch_test]==========
INFO: Analyzed target //tests:cpu_sw_single_switch_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:cpu_sw_single_switch_test up-to-date:
bazel-bin/tests/cpu_sw_single_switch_test_/cpu_sw_single_switch_test
INFO: Elapsed time: 16.744s, Critical Path: 16.01s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: cpu_sw_single_switch_test]==========
==========[Building test: ethcounter_sw_single_switch_test]==========
INFO: Analyzed target //tests:ethcounter_sw_single_switch_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:ethcounter_sw_single_switch_test up-to-date:
bazel-bin/tests/ethcounter_sw_single_switch_test_/ethcounter_sw_single_switch_test
INFO: Elapsed time: 18.187s, Critical Path: 17.46s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: ethcounter_sw_single_switch_test]==========
==========[Building test: gnmi_set_get_test]==========
INFO: Analyzed target //tests:gnmi_set_get_test (1 packages loaded, 6 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_set_get_test up-to-date:
bazel-bin/tests/gnmi_set_get_test_/gnmi_set_get_test
INFO: Elapsed time: 16.443s, Critical Path: 15.35s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnmi_set_get_test]==========
==========[Building test: lacp_test]==========
INFO: Analyzed target //tests:lacp_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:lacp_test up-to-date:
bazel-bin/tests/lacp_test_/lacp_test
INFO: Elapsed time: 16.217s, Critical Path: 15.54s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: lacp_test]==========
==========[Building test: z_gnmi_stress_test]==========
INFO: Analyzed target //tests:z_gnmi_stress_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:z_gnmi_stress_test up-to-date:
bazel-bin/tests/z_gnmi_stress_test_/z_gnmi_stress_test
INFO: Elapsed time: 14.839s, Critical Path: 14.22s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: z_gnmi_stress_test]==========
==========[Building test: system_paths_test]==========
INFO: Analyzed target //tests:system_paths_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:system_paths_test up-to-date:
bazel-bin/tests/system_paths_test_/system_paths_test
INFO: Elapsed time: 17.858s, Critical Path: 16.13s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: system_paths_test]==========
==========[Building test: gnmi_wildcard_subscription_test]==========
INFO: Analyzed target //tests:gnmi_wildcard_subscription_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_wildcard_subscription_test up-to-date:
bazel-bin/tests/gnmi_wildcard_subscription_test_/gnmi_wildcard_subscription_test
INFO: Elapsed time: 15.277s, Critical Path: 14.73s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnmi_wildcard_subscription_test]==========
==========[Building test: mgmt_interface_test]==========
INFO: Analyzed target //tests:mgmt_interface_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:mgmt_interface_test up-to-date:
bazel-bin/tests/mgmt_interface_test_/mgmt_interface_test
INFO: Elapsed time: 19.595s, Critical Path: 19.01s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: mgmt_interface_test]==========
==========[Building test: gnmi_subscribe_modes_test]==========
INFO: Analyzed target //tests:gnmi_subscribe_modes_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_subscribe_modes_test up-to-date:
bazel-bin/tests/gnmi_subscribe_modes_test_/gnmi_subscribe_modes_test
INFO: Elapsed time: 16.032s, Critical Path: 15.49s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnmi_subscribe_modes_test]==========