### PR TITLE
added new topo 't1-48-lag' for cisco hwsku Cisco-8102-28FH-DPU-O8C40

### DIFF
--- a/ansible/roles/eos/templates/t1-48-lag-spine.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-spine.j2
@@ -1,0 +1,138 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+{% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+{% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ mtu 9214
+ no switchport
+ no shutdown
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 2
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/roles/eos/templates/t1-48-lag-tor.j2
+++ b/ansible/roles/eos/templates/t1-48-lag-tor.j2
@@ -1,0 +1,142 @@
+{% set host = configuration[hostname] %}
+{% set mgmt_ip = ansible_host %}
+{% set tornum = host['tornum'] %}
+{% if vm_type is defined and vm_type == "ceos" %}
+{% set mgmt_if_index = 0 %}
+{% else %}
+{% set mgmt_if_index = 1 %}
+{% endif %}
+no schedule tech-support
+!
+{% if vm_type is defined and vm_type == "ceos" %}
+agent LicenseManager shutdown
+agent PowerFuse shutdown
+agent PowerManager shutdown
+agent Thermostat shutdown
+agent LedPolicy shutdown
+agent StandbyCpld shutdown
+agent Bfd shutdown
+{% endif %}
+!
+hostname {{ hostname }}
+!
+vrf definition MGMT
+ rd 1:1
+!
+spanning-tree mode mstp
+!
+aaa root secret 0 123456
+!
+username admin privilege 15 role network-admin secret 0 123456
+!
+clock timezone UTC
+!
+lldp run
+lldp management-address Management{{ mgmt_if_index }}
+lldp management-address vrf MGMT
+!
+snmp-server community {{ snmp_rocommunity }} ro
+snmp-server vrf MGMT
+!
+ip routing
+ip routing vrf MGMT
+ipv6 unicast-routing
+!
+{% if vm_mgmt_gw is defined %}
+ip route vrf MGMT 0.0.0.0/0 {{ vm_mgmt_gw }}
+{% else %}
+ip route vrf MGMT 0.0.0.0/0 {{ mgmt_gw }}
+{% endif %}
+!
+interface Management {{ mgmt_if_index }}
+ description TO LAB MGMT SWITCH
+ {% if vm_type is defined and vm_type == "ceos" %}
+ vrf MGMT
+{% else %}
+ vrf forwarding MGMT
+ {% endif %}
+ ip address {{ mgmt_ip }}/{{ mgmt_prefixlen }}
+ no shutdown
+!
+{% for name, iface in host['interfaces'].items() %}
+interface {{ name }}
+{% if name.startswith('Loopback') %}
+ description LOOPBACK
+{% else %}
+ mtu 9214
+ no switchport
+ no shutdown
+{% endif %}
+{% if name.startswith('Port-Channel') %}
+ port-channel min-links 1
+{% endif %}
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ iface['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+{% if iface['lacp'] is defined %}
+ channel-group {{ iface['lacp'] }} mode active
+ lacp rate normal
+{% endif %}
+ no shutdown
+!
+{% endfor %}
+!
+interface {{ bp_ifname }}
+ description backplane
+ no switchport
+ no shutdown
+{% if host['bp_interface']['ipv4'] is defined %}
+ ip address {{ host['bp_interface']['ipv4'] }}
+{% endif %}
+{% if host['bp_interface']['ipv6'] is defined %}
+ ipv6 enable
+ ipv6 address {{ host['bp_interface']['ipv6'] }}
+ ipv6 nd ra suppress
+{% endif %}
+ no shutdown
+!
+router bgp {{ host['bgp']['asn'] }}
+ router-id {{ host['interfaces']['Loopback0']['ipv4'] |  ipaddr('address') }}
+ !
+ graceful-restart restart-time {{ bgp_gr_timer }}
+ graceful-restart
+ !
+{% for asn, remote_ips in host['bgp']['peers'].items() %}
+{% for remote_ip in remote_ips %}
+ neighbor {{ remote_ip }} remote-as {{ asn }}
+ neighbor {{ remote_ip }} description {{ asn }}
+{% if remote_ip | ipv6 %}
+ address-family ipv6
+  neighbor {{ remote_ip }} activate
+ exit
+{% endif %}
+{% endfor %}
+{% endfor %}
+ neighbor {{ props.nhipv4 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv4 }} description exabgp_v4
+ neighbor {{ props.nhipv6 }} remote-as {{ host['bgp']['asn'] }}
+ neighbor {{ props.nhipv6 }} description exabgp_v6
+ address-family ipv6
+  neighbor {{ props.nhipv6 }} activate
+ exit
+ !
+{% for name, iface in host['interfaces'].items() if name.startswith('Loopback') %}
+{% if iface['ipv4'] is defined %}
+ network {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ network {{ iface['ipv6'] }}
+{% endif %}
+{% endfor %}
+!
+management api http-commands
+ no protocol https
+ protocol http
+ no shutdown
+!
+end

--- a/ansible/vars/topo_t1-48-lag.yml
+++ b/ansible/vars/topo_t1-48-lag.yml
@@ -2,119 +2,119 @@ topology:
   VMs:
     ARISTA01T2:
       vlans:
-        - 0
-        - 1
+        - 24
+        - 25
       vm_offset: 0
     ARISTA03T2:
       vlans:
-        - 2
-        - 3
+        - 26
+        - 27
       vm_offset: 1
     ARISTA05T2:
       vlans:
-        - 4
-        - 5
+        - 28
+        - 29
       vm_offset: 2
     ARISTA07T2:
       vlans:
-        - 6
-        - 7
+        - 30
+        - 31
       vm_offset: 3
     ARISTA01T0:
       vlans:
-        - 8
+        - 0
       vm_offset: 4
     ARISTA02T0:
       vlans:
-        - 9
+        - 1
       vm_offset: 5
     ARISTA03T0:
       vlans:
-        - 10
+        - 2
       vm_offset: 6
     ARISTA04T0:
       vlans:
-        - 11
+        - 3
       vm_offset: 7
     ARISTA05T0:
       vlans:
-        - 12
+        - 4
       vm_offset: 8
     ARISTA06T0:
       vlans:
-        - 13
+        - 5
       vm_offset: 9
     ARISTA07T0:
       vlans:
-        - 14
+        - 6
       vm_offset: 10
     ARISTA08T0:
       vlans:
-        - 15
+        - 7
       vm_offset: 11
     ARISTA09T0:
       vlans:
-        - 16
+        - 8
       vm_offset: 12
     ARISTA10T0:
       vlans:
-        - 17
+        - 9
       vm_offset: 13
     ARISTA11T0:
       vlans:
-        - 18
+        - 10
       vm_offset: 14
     ARISTA12T0:
       vlans:
-        - 19
+        - 11
       vm_offset: 15
     ARISTA13T0:
       vlans:
-        - 20
+        - 12
       vm_offset: 16
     ARISTA14T0:
       vlans:
-        - 21
+        - 13
       vm_offset: 17
     ARISTA15T0:
       vlans:
-        - 22
+        - 14
       vm_offset: 18
     ARISTA16T0:
       vlans:
-        - 23
+        - 15
       vm_offset: 19
     ARISTA17T0:
       vlans:
-        - 24
+        - 16
       vm_offset: 20
     ARISTA18T0:
       vlans:
-        - 25
+        - 17
       vm_offset: 21
     ARISTA19T0:
       vlans:
-        - 26
+        - 18
       vm_offset: 22
     ARISTA20T0:
       vlans:
-        - 27
+        - 19
       vm_offset: 23
     ARISTA21T0:
       vlans:
-        - 28
+        - 20
       vm_offset: 24
     ARISTA22T0:
       vlans:
-        - 29
+        - 21
       vm_offset: 25
     ARISTA23T0:
       vlans:
-        - 30
+        - 22
       vm_offset: 26
     ARISTA24T0:
       vlans:
-        - 31
+        - 23
       vm_offset: 27
     ARISTA25T0:
       vlans:

--- a/ansible/vars/topo_t1-48-lag.yml
+++ b/ansible/vars/topo_t1-48-lag.yml
@@ -1,0 +1,1189 @@
+topology:
+  VMs:
+    ARISTA01T2:
+      vlans:
+        - 0
+        - 1
+      vm_offset: 0
+    ARISTA03T2:
+      vlans:
+        - 2
+        - 3
+      vm_offset: 1
+    ARISTA05T2:
+      vlans:
+        - 4
+        - 5
+      vm_offset: 2
+    ARISTA07T2:
+      vlans:
+        - 6
+        - 7
+      vm_offset: 3
+    ARISTA01T0:
+      vlans:
+        - 8
+      vm_offset: 4
+    ARISTA02T0:
+      vlans:
+        - 9
+      vm_offset: 5
+    ARISTA03T0:
+      vlans:
+        - 10
+      vm_offset: 6
+    ARISTA04T0:
+      vlans:
+        - 11
+      vm_offset: 7
+    ARISTA05T0:
+      vlans:
+        - 12
+      vm_offset: 8
+    ARISTA06T0:
+      vlans:
+        - 13
+      vm_offset: 9
+    ARISTA07T0:
+      vlans:
+        - 14
+      vm_offset: 10
+    ARISTA08T0:
+      vlans:
+        - 15
+      vm_offset: 11
+    ARISTA09T0:
+      vlans:
+        - 16
+      vm_offset: 12
+    ARISTA10T0:
+      vlans:
+        - 17
+      vm_offset: 13
+    ARISTA11T0:
+      vlans:
+        - 18
+      vm_offset: 14
+    ARISTA12T0:
+      vlans:
+        - 19
+      vm_offset: 15
+    ARISTA13T0:
+      vlans:
+        - 20
+      vm_offset: 16
+    ARISTA14T0:
+      vlans:
+        - 21
+      vm_offset: 17
+    ARISTA15T0:
+      vlans:
+        - 22
+      vm_offset: 18
+    ARISTA16T0:
+      vlans:
+        - 23
+      vm_offset: 19
+    ARISTA17T0:
+      vlans:
+        - 24
+      vm_offset: 20
+    ARISTA18T0:
+      vlans:
+        - 25
+      vm_offset: 21
+    ARISTA19T0:
+      vlans:
+        - 26
+      vm_offset: 22
+    ARISTA20T0:
+      vlans:
+        - 27
+      vm_offset: 23
+    ARISTA21T0:
+      vlans:
+        - 28
+      vm_offset: 24
+    ARISTA22T0:
+      vlans:
+        - 29
+      vm_offset: 25
+    ARISTA23T0:
+      vlans:
+        - 30
+      vm_offset: 26
+    ARISTA24T0:
+      vlans:
+        - 31
+      vm_offset: 27
+    ARISTA25T0:
+      vlans:
+        - 32
+      vm_offset: 28
+    ARISTA26T0:
+      vlans:
+        - 33
+      vm_offset: 29
+    ARISTA27T0:
+      vlans:
+        - 34
+      vm_offset: 30
+    ARISTA28T0:
+      vlans:
+        - 35
+      vm_offset: 31
+    ARISTA29T0:
+      vlans:
+        - 36
+      vm_offset: 32
+    ARISTA30T0:
+      vlans:
+        - 37
+      vm_offset: 33
+    ARISTA31T0:
+      vlans:
+        - 38
+      vm_offset: 34
+    ARISTA32T0:
+      vlans:
+        - 39
+      vm_offset: 35
+    ARISTA33T0:
+      vlans:
+        - 40
+      vm_offset: 36
+    ARISTA34T0:
+      vlans:
+        - 41
+      vm_offset: 37
+    ARISTA35T0:
+      vlans:
+        - 42
+      vm_offset: 38
+    ARISTA36T0:
+      vlans:
+        - 43
+      vm_offset: 39
+    ARISTA37T0:
+      vlans:
+        - 44
+      vm_offset: 40
+    ARISTA38T0:
+      vlans:
+        - 45
+      vm_offset: 41
+    ARISTA39T0:
+      vlans:
+        - 46
+      vm_offset: 42
+    ARISTA40T0:
+      vlans:
+        - 47
+      vm_offset: 43
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: LeafRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+    podset_number: 200
+    tor_number: 20
+    tor_subnet_number: 2
+    max_tor_subnet_number: 20
+    tor_subnet_size: 128
+  spine:
+    swrole: spine
+  tor:
+    swrole: tor
+
+configuration:
+  ARISTA01T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.0
+        - FC00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: fc00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+
+  ARISTA03T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.4
+        - FC00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: fc00::a/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::6/64
+
+  ARISTA05T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.8
+        - FC00::11
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: fc00::12/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::a/64
+
+  ARISTA07T2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+        - 10.0.0.12
+        - FC00::19
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: fc00::1a/126
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::e/64
+
+  ARISTA01T0:
+    properties:
+    - common
+    - tor
+    tornum: 1
+    bgp:
+      asn: 64001
+      peers:
+        65100:
+        - 10.0.0.32
+        - FC00::41
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::11/128
+      Ethernet1:
+        ipv4: 10.0.0.33/31
+        ipv6: fc00::42/126
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::22/64
+    vips:
+      ipv4:
+        prefixes:
+           - 200.0.1.0/26
+        asn: 64700
+
+  ARISTA02T0:
+    properties:
+    - common
+    - tor
+    tornum: 2
+    bgp:
+      asn: 64002
+      peers:
+        65100:
+        - 10.0.0.34
+        - FC00::45
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.18/32
+        ipv6: 2064:100::12/128
+      Ethernet1:
+        ipv4: 10.0.0.35/31
+        ipv6: fc00::46/126
+    bp_interface:
+      ipv4: 10.10.246.18/24
+      ipv6: fc0a::25/64
+
+  ARISTA03T0:
+    properties:
+    - common
+    - tor
+    tornum: 3
+    bgp:
+      asn: 64003
+      peers:
+        65100:
+        - 10.0.0.36
+        - FC00::49
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.19/32
+        ipv6: 2064:100::13/128
+      Ethernet1:
+        ipv4: 10.0.0.37/31
+        ipv6: fc00::4a/126
+    bp_interface:
+      ipv4: 10.10.246.19/24
+      ipv6: fc0a::26/64
+    vips:
+      ipv4:
+        prefixes:
+          - 200.0.1.0/26
+        asn: 64700
+
+  ARISTA04T0:
+    properties:
+    - common
+    - tor
+    tornum: 4
+    bgp:
+      asn: 64004
+      peers:
+        65100:
+        - 10.0.0.38
+        - FC00::4D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.20/32
+        ipv6: 2064:100::14/128
+      Ethernet1:
+        ipv4: 10.0.0.39/31
+        ipv6: fc00::4e/126
+    bp_interface:
+      ipv4: 10.10.246.20/24
+      ipv6: fc0a::29/64
+
+  ARISTA05T0:
+    properties:
+    - common
+    - tor
+    tornum: 5
+    bgp:
+      asn: 64005
+      peers:
+        65100:
+        - 10.0.0.40
+        - FC00::51
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.21/32
+        ipv6: 2064:100::15/128
+      Ethernet1:
+        ipv4: 10.0.0.41/31
+        ipv6: fc00::52/126
+    bp_interface:
+      ipv4: 10.10.246.21/24
+      ipv6: fc0a::2a/64
+
+  ARISTA06T0:
+    properties:
+    - common
+    - tor
+    tornum: 6
+    bgp:
+      asn: 64006
+      peers:
+        65100:
+        - 10.0.0.42
+        - FC00::55
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.22/32
+        ipv6: 2064:100::16/128
+      Ethernet1:
+        ipv4: 10.0.0.43/31
+        ipv6: fc00::56/126
+    bp_interface:
+      ipv4: 10.10.246.22/24
+      ipv6: fc0a::2d/64
+
+  ARISTA07T0:
+    properties:
+    - common
+    - tor
+    tornum: 7
+    bgp:
+      asn: 64007
+      peers:
+        65100:
+        - 10.0.0.44
+        - FC00::59
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.23/32
+        ipv6: 2064:100::17/128
+      Ethernet1:
+        ipv4: 10.0.0.45/31
+        ipv6: fc00::5a/126
+    bp_interface:
+      ipv4: 10.10.246.23/24
+      ipv6: fc0a::2e/64
+
+  ARISTA08T0:
+    properties:
+    - common
+    - tor
+    tornum: 8
+    bgp:
+      asn: 64008
+      peers:
+        65100:
+        - 10.0.0.46
+        - FC00::5D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.24/32
+        ipv6: 2064:100::18/128
+      Ethernet1:
+        ipv4: 10.0.0.47/31
+        ipv6: fc00::5e/126
+    bp_interface:
+      ipv4: 10.10.246.24/24
+      ipv6: fc0a::31/64
+
+  ARISTA09T0:
+    properties:
+    - common
+    - tor
+    tornum: 9
+    bgp:
+      asn: 64009
+      peers:
+        65100:
+        - 10.0.0.48
+        - FC00::61
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.25/32
+        ipv6: 2064:100::19/128
+      Ethernet1:
+        ipv4: 10.0.0.49/31
+        ipv6: fc00::62/126
+    bp_interface:
+      ipv4: 10.10.246.25/24
+      ipv6: fc0a::32/64
+
+  ARISTA10T0:
+    properties:
+    - common
+    - tor
+    tornum: 10
+    bgp:
+      asn: 64010
+      peers:
+        65100:
+        - 10.0.0.50
+        - FC00::65
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.26/32
+        ipv6: 2064:100::1a/128
+      Ethernet1:
+        ipv4: 10.0.0.51/31
+        ipv6: fc00::66/126
+    bp_interface:
+      ipv4: 10.10.246.26/24
+      ipv6: fc0a::35/64
+
+  ARISTA11T0:
+    properties:
+    - common
+    - tor
+    tornum: 11
+    bgp:
+      asn: 64011
+      peers:
+        65100:
+        - 10.0.0.52
+        - FC00::69
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.27/32
+        ipv6: 2064:100::1b/128
+      Ethernet1:
+        ipv4: 10.0.0.53/31
+        ipv6: fc00::6a/126
+    bp_interface:
+      ipv4: 10.10.246.27/24
+      ipv6: fc0a::36/64
+
+  ARISTA12T0:
+    properties:
+    - common
+    - tor
+    tornum: 12
+    bgp:
+      asn: 64012
+      peers:
+        65100:
+        - 10.0.0.54
+        - FC00::6D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.28/32
+        ipv6: 2064:100::1c/128
+      Ethernet1:
+        ipv4: 10.0.0.55/31
+        ipv6: fc00::6e/126
+    bp_interface:
+      ipv4: 10.10.246.28/24
+      ipv6: fc0a::39/64
+
+  ARISTA13T0:
+    properties:
+    - common
+    - tor
+    tornum: 13
+    bgp:
+      asn: 64013
+      peers:
+        65100:
+        - 10.0.0.56
+        - FC00::71
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.29/32
+        ipv6: 2064:100::1d/128
+      Ethernet1:
+        ipv4: 10.0.0.57/31
+        ipv6: fc00::72/126
+    bp_interface:
+      ipv4: 10.10.246.29/24
+      ipv6: fc0a::3a/64
+
+  ARISTA14T0:
+    properties:
+    - common
+    - tor
+    tornum: 14
+    bgp:
+      asn: 64014
+      peers:
+        65100:
+        - 10.0.0.58
+        - FC00::75
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.30/32
+        ipv6: 2064:100::1e/128
+      Ethernet1:
+        ipv4: 10.0.0.59/31
+        ipv6: fc00::76/126
+    bp_interface:
+      ipv4: 10.10.246.30/24
+      ipv6: fc0a::3d/64
+
+  ARISTA15T0:
+    properties:
+    - common
+    - tor
+    tornum: 15
+    bgp:
+      asn: 64015
+      peers:
+        65100:
+        - 10.0.0.60
+        - FC00::79
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.31/32
+        ipv6: 2064:100::1f/128
+      Ethernet1:
+        ipv4: 10.0.0.61/31
+        ipv6: fc00::7a/126
+    bp_interface:
+      ipv4: 10.10.246.31/24
+      ipv6: fc0a::3e/64
+
+  ARISTA16T0:
+    properties:
+    - common
+    - tor
+    tornum: 16
+    bgp:
+      asn: 64016
+      peers:
+        65100:
+        - 10.0.0.62
+        - FC00::7D
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.32/32
+        ipv6: 2064:100::20/128
+      Ethernet1:
+        ipv4: 10.0.0.63/31
+        ipv6: fc00::7e/126
+    bp_interface:
+      ipv4: 10.10.246.32/24
+      ipv6: fc0a::41/64
+
+  ARISTA17T0:
+    properties:
+    - common
+    - tor
+    tornum: 17
+    bgp:
+      asn: 64017
+      peers:
+        65100:
+        - 10.0.0.64
+        - FC00::81
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.33/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        ipv4: 10.0.0.65/31
+        ipv6: fc00::82/126
+    bp_interface:
+      ipv4: 10.10.246.33/24
+      ipv6: fc0a::42/64
+
+  ARISTA18T0:
+    properties:
+    - common
+    - tor
+    tornum: 18
+    bgp:
+      asn: 64018
+      peers:
+        65100:
+        - 10.0.0.66
+        - FC00::85
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.34/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        ipv4: 10.0.0.67/31
+        ipv6: fc00::86/126
+    bp_interface:
+      ipv4: 10.10.246.34/24
+      ipv6: fc0a::45/64
+
+  ARISTA19T0:
+    properties:
+    - common
+    - tor
+    tornum: 19
+    bgp:
+      asn: 64019
+      peers:
+        65100:
+        - 10.0.0.68
+        - FC00::89
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.35/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        ipv4: 10.0.0.69/31
+        ipv6: fc00::8a/126
+    bp_interface:
+      ipv4: 10.10.246.35/24
+      ipv6: fc0a::46/64
+
+  ARISTA20T0:
+    properties:
+    - common
+    - tor
+    tornum: 20
+    bgp:
+      asn: 64020
+      peers:
+        65100:
+        - 10.0.0.70
+        - FC00::8d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100::24/128
+      Ethernet1:
+        ipv4: 10.0.0.71/31
+        ipv6: fc00::8e/126
+    bp_interface:
+      ipv4: 10.10.246.36/24
+      ipv6: fc0a::49/64
+
+  ARISTA21T0:
+    properties:
+    - common
+    - tor
+    tornum: 21
+    bgp:
+      asn: 64021
+      peers:
+        65100:
+        - 10.0.0.72
+        - FC00::91
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.36/32
+        ipv6: 2064:100::21/128
+      Ethernet1:
+        ipv4: 10.0.0.73/31
+        ipv6: fc00::92/126
+    bp_interface:
+      ipv4: 10.10.246.36/24
+      ipv6: fc0a::49/64
+
+  ARISTA22T0:
+    properties:
+    - common
+    - tor
+    tornum: 22
+    bgp:
+      asn: 64022
+      peers:
+        65100:
+        - 10.0.0.74
+        - FC00::95
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.37/32
+        ipv6: 2064:100::22/128
+      Ethernet1:
+        ipv4: 10.0.0.75/31
+        ipv6: fc00::96/126
+    bp_interface:
+      ipv4: 10.10.246.37/24
+      ipv6: fc0a::50/64
+
+  ARISTA23T0:
+    properties:
+    - common
+    - tor
+    tornum: 23
+    bgp:
+      asn: 64023
+      peers:
+        65100:
+        - 10.0.0.76
+        - FC00::99
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.38/32
+        ipv6: 2064:100::23/128
+      Ethernet1:
+        ipv4: 10.0.0.77/31
+        ipv6: fc00::9a/126
+    bp_interface:
+      ipv4: 10.10.246.38/24
+      ipv6: fc0a::51/64
+
+  ARISTA24T0:
+    properties:
+    - common
+    - tor
+    tornum: 24
+    bgp:
+      asn: 64024
+      peers:
+        65100:
+        - 10.0.0.78
+        - FC00::9d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.39/32
+        ipv6: 2064:100::24/128
+      Ethernet1:
+        ipv4: 10.0.0.79/31
+        ipv6: fc00::9e/126
+    bp_interface:
+      ipv4: 10.10.246.39/24
+      ipv6: fc0a::52/64
+
+  ARISTA25T0:
+    properties:
+    - common
+    - tor
+    tornum: 25
+    bgp:
+      asn: 64025
+      peers:
+        65100:
+        - 10.0.0.80
+        - FC00::a1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.40/32
+        ipv6: 2064:100::25/128
+      Ethernet1:
+        ipv4: 10.0.0.81/31
+        ipv6: fc00::a2/126
+    bp_interface:
+      ipv4: 10.10.246.40/24
+      ipv6: fc0a::53/64
+
+  ARISTA26T0:
+    properties:
+    - common
+    - tor
+    tornum: 26
+    bgp:
+      asn: 64026
+      peers:
+        65100:
+        - 10.0.0.82
+        - FC00::a5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.41/32
+        ipv6: 2064:100::26/128
+      Ethernet1:
+        ipv4: 10.0.0.83/31
+        ipv6: fc00::a6/126
+    bp_interface:
+      ipv4: 10.10.246.41/24
+      ipv6: fc0a::54/64
+
+  ARISTA27T0:
+    properties:
+    - common
+    - tor
+    tornum: 27
+    bgp:
+      asn: 64027
+      peers:
+        65100:
+        - 10.0.0.84
+        - FC00::a9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.42/32
+        ipv6: 2064:100::27/128
+      Ethernet1:
+        ipv4: 10.0.0.85/31
+        ipv6: fc00::aa/126
+    bp_interface:
+      ipv4: 10.10.246.42/24
+      ipv6: fc0a::55/64
+
+  ARISTA28T0:
+    properties:
+    - common
+    - tor
+    tornum: 28
+    bgp:
+      asn: 64028
+      peers:
+        65100:
+        - 10.0.0.86
+        - FC00::ad
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.43/32
+        ipv6: 2064:100::28/128
+      Ethernet1:
+        ipv4: 10.0.0.87/31
+        ipv6: fc00::ae/126
+    bp_interface:
+      ipv4: 10.10.246.43/24
+      ipv6: fc0a::56/64
+
+  ARISTA29T0:
+    properties:
+    - common
+    - tor
+    tornum: 29
+    bgp:
+      asn: 64029
+      peers:
+        65100:
+        - 10.0.0.88
+        - FC00::b1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.44/32
+        ipv6: 2064:100::29/128
+      Ethernet1:
+        ipv4: 10.0.0.89/31
+        ipv6: fc00::b2/126
+    bp_interface:
+      ipv4: 10.10.246.44/24
+      ipv6: fc0a::57/64
+
+  ARISTA30T0:
+    properties:
+    - common
+    - tor
+    tornum: 30
+    bgp:
+      asn: 64030
+      peers:
+        65100:
+        - 10.0.0.90
+        - FC00::b5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.45/32
+        ipv6: 2064:100::30/128
+      Ethernet1:
+        ipv4: 10.0.0.91/31
+        ipv6: fc00::b6/126
+    bp_interface:
+      ipv4: 10.10.246.45/24
+      ipv6: fc0a::58/64
+
+  ARISTA31T0:
+    properties:
+    - common
+    - tor
+    tornum: 31
+    bgp:
+      asn: 64031
+      peers:
+        65100:
+        - 10.0.0.92
+        - FC00::b9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.46/32
+        ipv6: 2064:100::31/128
+      Ethernet1:
+        ipv4: 10.0.0.93/31
+        ipv6: fc00::ba/126
+    bp_interface:
+      ipv4: 10.10.246.46/24
+      ipv6: fc0a::59/64
+
+  ARISTA32T0:
+    properties:
+    - common
+    - tor
+    tornum: 32
+    bgp:
+      asn: 64032
+      peers:
+        65100:
+        - 10.0.0.94
+        - FC00::bd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.47/32
+        ipv6: 2064:100::32/128
+      Ethernet1:
+        ipv4: 10.0.0.95/31
+        ipv6: fc00::be/126
+    bp_interface:
+      ipv4: 10.10.246.47/24
+      ipv6: fc0a::60/64
+
+  ARISTA33T0:
+    properties:
+    - common
+    - tor
+    tornum: 33
+    bgp:
+      asn: 64033
+      peers:
+        65100:
+        - 10.0.0.96
+        - FC00::c1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.48/32
+        ipv6: 2064:100::33/128
+      Ethernet1:
+        ipv4: 10.0.0.97/31
+        ipv6: fc00::c2/126
+    bp_interface:
+      ipv4: 10.10.246.48/24
+      ipv6: fc0a::61/64
+
+  ARISTA34T0:
+    properties:
+    - common
+    - tor
+    tornum: 34
+    bgp:
+      asn: 64034
+      peers:
+        65100:
+        - 10.0.0.98
+        - FC00::c5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.49/32
+        ipv6: 2064:100::34/128
+      Ethernet1:
+        ipv4: 10.0.0.99/31
+        ipv6: fc00::c6/126
+    bp_interface:
+      ipv4: 10.10.246.49/24
+      ipv6: fc0a::62/64
+
+  ARISTA35T0:
+    properties:
+    - common
+    - tor
+    tornum: 35
+    bgp:
+      asn: 64035
+      peers:
+        65100:
+        - 10.0.0.100
+        - FC00::c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.50/32
+        ipv6: 2064:100::35/128
+      Ethernet1:
+        ipv4: 10.0.0.101/31
+        ipv6: fc00::ca/126
+    bp_interface:
+      ipv4: 10.10.246.50/24
+      ipv6: fc0a::63/64
+
+  ARISTA36T0:
+    properties:
+    - common
+    - tor
+    tornum: 36
+    bgp:
+      asn: 64036
+      peers:
+        65100:
+        - 10.0.0.102
+        - FC00::cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.51/32
+        ipv6: 2064:100::36/128
+      Ethernet1:
+        ipv4: 10.0.0.103/31
+        ipv6: fc00::ce/126
+    bp_interface:
+      ipv4: 10.10.246.51/24
+      ipv6: fc0a::64/64
+
+  ARISTA37T0:
+    properties:
+    - common
+    - tor
+    tornum: 37
+    bgp:
+      asn: 64037
+      peers:
+        65100:
+        - 10.0.0.104
+        - FC00::d1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.52/32
+        ipv6: 2064:100::37/128
+      Ethernet1:
+        ipv4: 10.0.0.105/31
+        ipv6: fc00::d2/126
+    bp_interface:
+      ipv4: 10.10.246.52/24
+      ipv6: fc0a::65/64
+
+  ARISTA38T0:
+    properties:
+    - common
+    - tor
+    tornum: 38
+    bgp:
+      asn: 64038
+      peers:
+        65100:
+        - 10.0.0.106
+        - FC00::d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.53/32
+        ipv6: 2064:100::38/128
+      Ethernet1:
+        ipv4: 10.0.0.107/31
+        ipv6: fc00::d6/126
+    bp_interface:
+      ipv4: 10.10.246.53/24
+      ipv6: fc0a::66/64
+
+  ARISTA39T0:
+    properties:
+    - common
+    - tor
+    tornum: 39
+    bgp:
+      asn: 64039
+      peers:
+        65100:
+        - 10.0.0.108
+        - FC00::d9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.54/32
+        ipv6: 2064:100::39/128
+      Ethernet1:
+        ipv4: 10.0.0.109/31
+        ipv6: fc00::da/126
+    bp_interface:
+      ipv4: 10.10.246.54/24
+      ipv6: fc0a::67/64
+
+  ARISTA40T0:
+    properties:
+    - common
+    - tor
+    tornum: 40
+    bgp:
+      asn: 64040
+      peers:
+        65100:
+        - 10.0.0.110
+        - FC00::dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.55/32
+        ipv6: 2064:100::40/128
+      Ethernet1:
+        ipv4: 10.0.0.111/31
+        ipv6: fc00::de/126
+    bp_interface:
+      ipv4: 10.10.246.55/24
+      ipv6: fc0a::68/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: added new topo t1-48-lag for cisco hwsku Cisco-8102-28FH-DPU-O8C40
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ X] 202405
- [X ] 202411

### Approach
#### What is the motivation for this PR?
Introduced new cisco hwsku Cisco-8102-28FH-DPU-O8C40 for T1 role which requires new topology
#### How did you do it?

#### How did you verify/test it?
deployed minigrapg and verified sanity 

#### Any platform specific information?
Cisco-8102-28FH-DPU-O8C40
#### Supported testbed topology if it's a new test case?
t1-48-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
