### PR TITLE
Added DPC role support for SmartSwitch.

### DIFF
--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -14,6 +14,9 @@
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>
           <Priority>0</Priority>
+{% if subtype == 'SmartSwitch' and index > 27 %}
+          <role>Dpc</role>
+{% endif %}
 {% if port_speed[port_alias[index]] is defined %}
           <Speed>{{ port_speed[port_alias[index]] }}</Speed>
 {% elif (breakout_speed is defined) and (hwsku in breakout_speed) and (port_alias[index] in breakout_speed[hwsku].keys()) %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:added support for subtype for smartswicth
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405
- [ X] 202411

### Approach
#### What is the motivation for this PR?
The SmartSwitch platform introduced new backplane interfaces that require role configuration.

#### How did you do it?
added new config in device specific template.
ansible/templates/minigraph_device.j2
#### How did you verify/test it?
Deployed the minigraph and confirmed that the DPU configuration is present for all backplane interfaces.
#### Any platform specific information?
HwSKU: Cisco-8102-28FH-DPU-O
#### Supported testbed topology if it's a new test case?
t1-28-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
