### PR TITLE
chore: change portchannel naming

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -109,7 +109,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
 {% set port_channel_intf=';'.join(intf_names[vms[index]])  %}
         <PortChannel>
-          <Name>PortChannel{{ '10' + ((index+1)|string) }}</Name>
+          <Name>PortChannel{{ ('10' if num_asics > 1 else '') + ((index+1)|string) }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
@@ -191,7 +191,7 @@
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int][intf_index]|lower %}
-          <AttachTo>PortChannel{{ '10' + ((index+1) |string) }}</AttachTo>
+          <AttachTo>PortChannel{{('10' if num_asics > 1 else '') + ((index+1) |string) }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -202,7 +202,7 @@
         <IPInterface>
           <Name i:Name="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int][intf_index]|lower %}
-          <AttachTo>PortChannel{{ '10' + ((index+1) |string) }}</AttachTo>
+          <AttachTo>PortChannel{{ ('10' if num_asics > 1 else '') + ((index+1) |string) }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -293,7 +293,7 @@
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-{% set a_intf = 'PortChannel' + '10' + ((index+1) |string) %}
+{% set a_intf = 'PortChannel' + ('10' if num_asics > 1 else '') + ((index+1) |string) %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endfor %}

--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -109,7 +109,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
 {% set port_channel_intf=';'.join(intf_names[vms[index]])  %}
         <PortChannel>
-          <Name>PortChannel{{ ('10' if num_asics > 1 else '') + ((index+1)|string) }}</Name>
+          <Name>PortChannel{{ (100 + index + 1)|string }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
@@ -191,7 +191,7 @@
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int][intf_index]|lower %}
-          <AttachTo>PortChannel{{('10' if num_asics > 1 else '') + ((index+1) |string) }}</AttachTo>
+          <AttachTo>PortChannel{{ (100 + index + 1)|string }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -202,7 +202,7 @@
         <IPInterface>
           <Name i:Name="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int][intf_index]|lower %}
-          <AttachTo>PortChannel{{ ('10' if num_asics > 1 else '') + ((index+1) |string) }}</AttachTo>
+          <AttachTo>PortChannel{{ (100 + index + 1)|string }}</AttachTo>
 {% else %}
           <AttachTo>{{ port_alias[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -293,7 +293,7 @@
 {%- set acl_intfs = [] -%}
 {%- for index in range(vms_number) %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
-{% set a_intf = 'PortChannel' + ('10' if num_asics > 1 else '') + ((index+1) |string) %}
+{% set a_intf = 'PortChannel' ~ (100 + index + 1)|string %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Change the current logic for portchannel naming to only apply for multi-asics. For topology that requires more than 100 lags, if we use `PortChannel10x` as the prefix we will get more than 16 characters which will violate the linux interface naming convention (only less than 15 characters)

Fixes # (issue) 32562998

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Described above

#### How did you do it?
Only apply `PortChannel10` if num_asics > 1, otherwise we stick with standard `PortChannel` to restrict the change to multi-asics
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
