### PR TITLE
Fix parsing error and speedup testing in test_srv6_no_sid_blackhole

### DIFF
--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -330,42 +330,42 @@ def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
     if duthost.facts["asic_type"] == "broadcom":
         before_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
     elif duthost.facts["asic_type"] == "mellanox":
-        before_count = duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0]
+        before_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
 
     # inject a number of packets with random payload
     pkt_count = 100
-    for i in range(pkt_count):
-        payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
-        if with_srh:
-            injected_pkt = simple_ipv6_sr_packet(
-                eth_dst=dut_mac,
-                eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
-                ipv6_src=ptfhost.mgmt_ipv6,
-                ipv6_dst="fcbb:bbbb:3:2::",
-                srh_seg_left=1,
-                srh_nh=41,
-                inner_frame=IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6) / UDP(dport=4791) / Raw(load=payload)
-            )
-        else:
-            injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
-                / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:3:2::") \
-                / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6) / UDP(dport=4791) / Raw(load=payload)
+    random.seed(time.time())
+    payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
+    if with_srh:
+        injected_pkt = simple_ipv6_sr_packet(
+            eth_dst=dut_mac,
+            eth_src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode(),
+            ipv6_src=ptfhost.mgmt_ipv6,
+            ipv6_dst="fcbb:bbbb:3:2::",
+            srh_seg_left=1,
+            srh_nh=41,
+            inner_frame=IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6) / UDP(dport=4791) / Raw(load=payload)
+        )
+    else:
+        injected_pkt = Ether(dst=dut_mac, src=ptfadapter.dataplane.get_mac(0, ptf_src_port).decode()) \
+            / IPv6(src=ptfhost.mgmt_ipv6, dst="fcbb:bbbb:3:2::") \
+            / IPv6(dst=neighbor_ip, src=ptfhost.mgmt_ipv6) / UDP(dport=4791) / Raw(load=payload)
 
-        expected_pkt = injected_pkt.copy()
-        expected_pkt['IPv6'].dst = "fcbb:bbbb:3:2::"
-        expected_pkt['IPv6'].hlim -= 1
-        logger.debug("Expected packet #{}: {}".format(i, expected_pkt.summary()))
+    expected_pkt = injected_pkt.copy()
+    expected_pkt['IPv6'].dst = "fcbb:bbbb:3:2::"
+    expected_pkt['IPv6'].hlim -= 1
+    logger.debug("Expected packet: {}".format(expected_pkt.summary()))
 
-        expected_pkt = Mask(expected_pkt)
-        expected_pkt.set_do_not_care_packet(Ether, "dst")
-        expected_pkt.set_do_not_care_packet(Ether, "src")
-        send_packet(ptfadapter, ptf_src_port, injected_pkt, 1)
-        verify_no_packet_any(ptfadapter, expected_pkt, ptf_port_ids, 0, 1)
+    expected_pkt = Mask(expected_pkt)
+    expected_pkt.set_do_not_care_packet(Ether, "dst")
+    expected_pkt.set_do_not_care_packet(Ether, "src")
+    send_packet(ptfadapter, ptf_src_port, injected_pkt, count=pkt_count)
+    verify_no_packet_any(ptfadapter, expected_pkt, ptf_port_ids, 0, 1)
 
     # verify that the RX_DROP counter is incremented
     if duthost.facts["asic_type"] == "broadcom":
         after_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
         assert after_count >= (before_count + pkt_count), "RX_DRP counter is not incremented as expected"
     elif duthost.facts["asic_type"] == "mellanox":
-        after_count = duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0]
+        after_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
         assert after_count >= (before_count + pkt_count), "RIF RX_ERR counter is not incremented as expected"

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -335,7 +335,6 @@ def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
 
     # inject a number of packets with random payload
     pkt_count = 100
-    random.seed(time.time())
     payload = ''.join(random.choices(string.ascii_letters + string.digits, k=20))
     if with_srh:
         injected_pkt = simple_ipv6_sr_packet(

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -328,7 +328,8 @@ def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
 
     # get the drop counter before traffic test
     if duthost.facts["asic_type"] == "broadcom":
-        before_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
+        portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
+        before_count = int(portstat[dut_port]['rx_drp'])
     elif duthost.facts["asic_type"] == "mellanox":
         before_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])
 
@@ -364,7 +365,8 @@ def test_srv6_no_sid_blackhole(setup_uN, ptfadapter, ptfhost, with_srh):
 
     # verify that the RX_DROP counter is incremented
     if duthost.facts["asic_type"] == "broadcom":
-        after_count = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])[dut_port]['RX_DRP']
+        portstat = parse_portstat(duthost.command(f'portstat -i {dut_port}')['stdout_lines'])
+        after_count = int(portstat[dut_port]['rx_drp'])
         assert after_count >= (before_count + pkt_count), "RX_DRP counter is not incremented as expected"
     elif duthost.facts["asic_type"] == "mellanox":
         after_count = int(duthost.command(f"show interfaces counters rif {dut_port}")['stdout_lines'][6].split()[0])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Previously, the test case verified the dropping of 100 packets one-by-one, which was very slow. Now, we changed it to send 100 packets in a single batch and then verified the no-receiving behavior. Besides, there was a parsing error regarding the counter value when the platform is a mellanox device. I forgot to convert str to int before calculating the counter values.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
