### PR TITLE
Revert "[dualtor] Refine `fdb_mac_learning_test.py`"

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/fdb_mac_learning_test.py
+++ b/ansible/roles/test/files/ptftests/py3/fdb_mac_learning_test.py
@@ -1,6 +1,6 @@
 import ptf
 from ptf.base_tests import BaseTest
-from ptf.testutils import send, simple_arp_packet, test_params_get
+from ptf.testutils import send, simple_eth_packet, test_params_get
 
 
 class FdbMacLearningTest(BaseTest):
@@ -20,9 +20,10 @@ class FdbMacLearningTest(BaseTest):
     def populateFdbForInterface(self):
         for dut_port, ptf_port in self.dut_ptf_ports:
             mac = self.dummy_mac_prefix + ":" + "{:02X}".format(ptf_port)
-            pkt = simple_arp_packet(eth_dst=self.router_mac,        # noqa: F405
-                                    eth_src=mac)
-            send(self, ptf_port, pkt, count=10)
+            pkt = simple_eth_packet(eth_dst=self.router_mac,        # noqa: F405
+                                    eth_src=mac,
+                                    eth_type=0x1234)
+            send(self, ptf_port, pkt)
             self.mac_table.append((ptf_port, mac))
 
     # --------------------------------------------------------------------------

--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -1,12 +1,14 @@
 import logging
 import pytest
 import time
+from tests.common import config_reload
 from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.ptf_runner import ptf_runner
 from .utils import fdb_table_has_dummy_mac_for_interface
+from tests.common.helpers.ptf_tests_helper import upstream_links    # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 
 
@@ -34,6 +36,8 @@ class TestFdbMacLearning:
     """
     TestFdbMacLearning verifies that stale MAC entries are not present in MAC table after doing sonic-clear fdb all
     -shut down all ports
+    -config save
+    -config reload
     -bring up 1 port. populate fdb
     -bring up 3 more ports. populate fdb.
     -shut down 3 ports added in last step
@@ -119,7 +123,7 @@ class TestFdbMacLearning:
         """
             Select DUT ports which will be used for the testcase
             Get a mapping of selected DUT ports and ptf ports
-            shut down all DUT ports
+            shut down all DUT ports, congit save and config reload the DUT before starting the testcases
 
             Args:
                 duthosts: Devices under test
@@ -169,24 +173,9 @@ class TestFdbMacLearning:
         logging.info("shutdown all interfaces on DUT")
         for port in dut_ports:
             duthost.shell("sudo config interface shutdown {}".format(port))
-
+        duthost.command('sudo config save -y')
+        config_reload(duthost, config_source='config_db', safe_reload=True)
         yield target_ports_to_ptf_mapping, ptf_ports_available_in_topo, conf_facts
-
-        logging.info("startup all interfaces on DUT")
-        for port in dut_ports:
-            duthost.shell("sudo config interface startup {}".format(port))
-
-    @pytest.fixture(autouse=True)
-    def cleanup_arp_fdb(self, duthosts, rand_one_dut_hostname):
-        """Cleanup fdb and arp on the selected target DUT."""
-        duthost = duthosts[rand_one_dut_hostname]
-        duthost.shell("sonic-clear arp")
-        duthost.shell("sonic-clear fdb all")
-
-        yield
-
-        duthost.shell("sonic-clear arp")
-        duthost.shell("sonic-clear fdb all")
 
     def dynamic_fdb_oper(self, duthost, tbinfo, ptfhost, dut_ptf_ports):
         """function to populate fdb for given dut/ptf ports"""
@@ -216,13 +205,44 @@ class TestFdbMacLearning:
         """
         Make sure interfaces are ready for sending traffic.
         """
-        time.sleep(30)
+        if "dualtor-aa" in tbinfo['topo']['name']:
+            pytest_assert(wait_until(300, 5, 0, self.check_mux_status_consistency, duthost, ports))
+        else:
+            time.sleep(30)
+
+    def bringup_uplink_ports(self, duthost, upstream_links): # noqa F811
+        """
+        For active-active dualtor NIC simulator doesn't install OVS flows for downlink ports until the link status
+        becomes consistent which can happen in this case only if upstream connectivity is restored.
+        """
+        # Get one upstream port
+        uplink_intf = list(upstream_links.keys())[0]
+        # Check if it's a LAG member
+        config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+        portChannels = config_facts['PORTCHANNEL_MEMBER']
+        portChannel = None
+        members = None
+        for intf in portChannels:
+            if uplink_intf in portChannels[intf]:
+                portChannel = intf
+                members = list(portChannels[intf].keys())
+                break
+        if portChannel:
+            min_links = int(config_facts['PORTCHANNEL'][portChannel]['min_links'])
+            # Bringup minimum ports for this port channel to be up
+            for i in range(min_links):
+                duthost.shell("sudo config interface startup {}".format(members[i]))
+        else:
+            duthost.shell("sudo config interface startup {}".format(uplink_intf))
 
     def testFdbMacLearning(self, ptfadapter, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request, prepare_test,
+                           upstream_links, setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
                            toggle_all_simulator_ports_to_rand_selected_tor_m):                                          # noqa F811
         """
             TestFdbMacLearning verifies stale MAC entries are not present in MAC table after doing sonic-clear fdb all
             -shut down all ports
+            -config save
+            -config reload
             -bring up 1 port. populate fdb
             -bring up 3 more ports. populate fdb.
             -shut down 3 ports added in last step
@@ -240,7 +260,10 @@ class TestFdbMacLearning:
             res = ptfhost.shell('cat /sys/class/net/{}/address'.format(ptf_port))
             ptf_interfaces_mac_addresses.append(res['stdout'].upper())
 
+        # Bringup uplink connectivity for muxcable status consistency to happen.
         duthost = duthosts[rand_one_dut_hostname]
+        if "dualtor-aa" in tbinfo['topo']['name']:
+            self.bringup_uplink_ports(duthost, upstream_links)
 
         # unshut 1 port and populate fdb for that port. make sure fdb entry is populated in mac table
         target_ports = [target_ports_to_ptf_mapping[0][0]]
@@ -307,13 +330,9 @@ class TestFdbMacLearning:
         try:
             self.configureInterfaceIp(duthost, dut_interface, action="add")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="add")
-            time.sleep(2)
             ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP), module_ignore_errors=True)
 
         finally:
-            int_ip_found = any((dut_interface in line and self.DUT_INTF_IP in line)
-                               for line in duthost.command("show ip interface")["stdout_lines"])
-            pytest_assert(int_ip_found, "%s is not configured on %s" % (self.DUT_INTF_IP, dut_interface))
             show_arp = duthost.command('show arp')
             arp_found = False
             for arp_entry in show_arp['stdout_lines']:


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#18092, as it doesn't have the full fix.