### PR TITLE
[testARPCompleted] Cleanup ptf ip after test failure

### DIFF
--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import time
+from tests.common import config_reload
 from tests.common.utilities import wait_until
 
 from tests.common.helpers.assertions import pytest_assert
@@ -172,9 +173,8 @@ class TestFdbMacLearning:
 
         yield target_ports_to_ptf_mapping, ptf_ports_available_in_topo, conf_facts
 
-        logging.info("startup all interfaces on DUT")
-        for port in dut_ports:
-            duthost.shell("sudo config interface startup {}".format(port))
+        logging.info("reload device %s to recover", duthost.hostname)
+        config_reload(duthost, config_source='running_golden_config', safe_reload=True)
 
     @pytest.fixture(autouse=True)
     def cleanup_arp_fdb(self, duthosts, rand_one_dut_hostname):
@@ -309,10 +309,8 @@ class TestFdbMacLearning:
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="add")
             time.sleep(2)
             ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP), module_ignore_errors=True)
-
-        finally:
             int_ip_found = any((dut_interface in line and self.DUT_INTF_IP in line)
-                               for line in duthost.command("show ip interface")["stdout_lines"])
+                    for line in duthost.command("show ip interface")["stdout_lines"])
             pytest_assert(int_ip_found, "%s is not configured on %s" % (self.DUT_INTF_IP, dut_interface))
             show_arp = duthost.command('show arp')
             arp_found = False
@@ -323,5 +321,6 @@ class TestFdbMacLearning:
                     pytest_assert(items[2] == dut_interface, "ARP entry for ip address {}"
                                   " is incomplete. Interface is missing".format(self.PTF_HOST_IP))
             pytest_assert(arp_found, "ARP entry not found for ip address {}".format(self.PTF_HOST_IP))
+        finally:
             self.configureInterfaceIp(duthost, dut_interface, action="remove")
             self.configureNeighborIp(ptfhost, ptf_ports_available_in_topo[ptf_port_index], action="del")

--- a/tests/fdb/test_fdb_mac_learning.py
+++ b/tests/fdb/test_fdb_mac_learning.py
@@ -310,7 +310,7 @@ class TestFdbMacLearning:
             time.sleep(2)
             ptfhost.shell("ping {} -c 3 -I {}".format(self.DUT_INTF_IP, self.PTF_HOST_IP), module_ignore_errors=True)
             int_ip_found = any((dut_interface in line and self.DUT_INTF_IP in line)
-                    for line in duthost.command("show ip interface")["stdout_lines"])
+                               for line in duthost.command("show ip interface")["stdout_lines"])
             pytest_assert(int_ip_found, "%s is not configured on %s" % (self.DUT_INTF_IP, dut_interface))
             show_arp = duthost.command('show arp')
             arp_found = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

Two improvements:
1. ensure the `testARPCompleted` cleanup the ptf/dut ip if the test fails.
2. use `reload` to restore the DUT.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
Run on dualtor/t0 testbed and pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
