### PR TITLE
Skip warm reboot related case on Arista-7050CX3-32S-C28S4

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -137,6 +137,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
         pytest.skip("Warm Reboot is not supported on isolated topology")
 
     duthost = duthosts[rand_one_dut_hostname]
+    hwsku = duthost.facts['hwsku']
+    if hwsku == "Arista-7050CX3-32S-C28S4":
+        pytest.skip("Warm reboot is not supported on Arista-7050CX3-32S-C28S4 with t0-d18u8s4 topology")
 
     # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot
     asic_type = duthost.facts['asic_type']

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -137,9 +137,6 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
         pytest.skip("Warm Reboot is not supported on isolated topology")
 
     duthost = duthosts[rand_one_dut_hostname]
-    hwsku = duthost.facts['hwsku']
-    if hwsku == "Arista-7050CX3-32S-C28S4":
-        pytest.skip("Warm reboot is not supported on Arista-7050CX3-32S-C28S4 with t0-d18u8s4 topology")
 
     # Skip the test on Virtual Switch due to fanout switch dependency and warm reboot
     asic_type = duthost.facts['asic_type']

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -193,6 +193,7 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
       - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
+      - "hwsku in ['Arista-7050CX3-32S-C28S4']"
 
 bgp/test_bgp_speaker.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1235,6 +1235,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
     conditions:
       - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
+      - "hwsku in ['Arista-7050CX3-32S-C28S4']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Skip following cases due to warm reboot is not supported on Arista-7050CX3-32S-C28S4 with t0-d18u8s4 topology:
- platform_tests/test_reboot.py::test_warm_reboot -> conditional mark
- bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot -> conditional mark

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
