### PR TITLE
T2:Qos-Sai:Pg shared wm lossless

### DIFF
--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -213,7 +213,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 14723
+                    pkts_num_trig_pfc: 14721
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 8156
@@ -707,7 +707,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 14723
+                    pkts_num_trig_pfc: 14721
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 8156

--- a/tests/qos/files/qos_params.gb.yaml
+++ b/tests/qos/files/qos_params.gb.yaml
@@ -213,7 +213,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 14721
+                    pkts_num_trig_pfc: 14723
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 8156
@@ -707,7 +707,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 14721
+                    pkts_num_trig_pfc: 14723
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
                     packet_size: 8156


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the failure of qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark for long->short.
Recently a change went into the cisco-8000 platform that reduces the PFC threshold for long links. We need to reduce the values in qos parameters for this combination as well.

In rx cgm profile, SQ drop if SQ occupancy > 115MB (PFC pause threshold 25MB + headroom size 90MB).

Before change:
Headroom drop is triggered at 14724 packets. There is 2 buffers padding in PFC pause threshold, and 2 buffers padding in headroom drop threshold. The number of packets to trigger rx drop is:
```
>>> 115*1024**2/8192+2+2
14724.0 
```
After change:
SQ drop is triggered at 14722 packets. There is 2 buffers padding in SQ drop threshold. The number of packets to trigger rx drop is:
```
>>> 115*1024**2/8192+2
14722.0 
```
The meaning of pkts_num_trig_pfc in wm_pg_shared_lossless: the maximum packets reside in queue.
So, need to decrease its value from 14723 to 14721.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Failure of qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark
#### How did you do it?
Its a simple change of parameters.

#### How did you verify/test it?
Ran it on T2 TB:
```
====================================================================================================================== warnings summary ======================================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================== PASSES ===========================================================================================================================
_________________________________________________________________________________________ TestQosSai.testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] __________________________________________________________________________________________
___________________________________________________________________________________________ TestQosSai.testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] ___________________________________________________________________________________________
____________________________________________________________________________________ TestQosSai.testQosSaiPgSharedWatermark[single_dut_multi_asic-wm_pg_shared_lossless] _____________________________________________________________________________________
_______________________________________________________________________________ TestQosSai.testQosSaiPgSharedWatermark[multi_dut_longlink_to_shortlink-wm_pg_shared_lossless] ________________________________________________________________________________
_______________________________________________________________________________ TestQosSai.testQosSaiPgSharedWatermark[multi_dut_shortlink_to_longlink-wm_pg_shared_lossless] ________________________________________________________________________________
------------------------------------------------------ generated xml file: /run_logs/pfcwd-set/2025-04-29-00-09-47/qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark_2025-04-29-21-50-21.xml ------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------------
22:43:37 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_dut_multi_asic-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_longlink_to_shortlink-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_shortlink_to_longlink-wm_pg_shared_lossless]
SKIPPED [3] qos/test_qos_sai.py:1678: The lossy test is not valid for multiAsic configuration.
SKIPPED [2] qos/test_qos_sai.py:1640: Don't have 2 shortlink frontend nodes - so can't run multi_dut_shortlink_to_shortlinktests
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost xx37-rp>']" failed with exit code "1"
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost xx37-rp>']" failed with exit code "1"
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_dut_multi_asic-wm_pg_shared_lossless] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost xx37-rp>']" failed with exit code "1"
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_longlink_to_shortlink-wm_pg_shared_lossless] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost xx37-rp>']" failed with exit code "1"
ERROR qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_shortlink_to_longlink-wm_pg_shared_lossless] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost xx37-rp>']" failed with exit code "1"
=============================================================================================== 5 passed, 5 skipped, 1 warning, 5 errors in 3194.02s (0:53:14) ===============================================================================================
sonic@sonic-mgmt-DNT-msft-202405:/data/tests$ 
```
The errors are from Log analyzer from a BGP container in RP, not related to this PR.

#### Any platform specific information?
Cisco-8000