### PR TITLE
[config_sonic_basedon_testbed.yaml] Adjust SOC properties during deploy-mg so fabric cards start up

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -631,6 +631,42 @@
                   dest=/tmp/dns_config.json
         become: true
 
+      - name: Adjust BCM DNX soc properties to set STAN_ALN mode correctly
+        block:
+          - name: Get active fabric links
+            block:
+            - name: Get online fabric cards
+              shell: show chassis module status | grep "FABRIC-CARD" | grep "Online" | wc -l
+              register: active_fabric_cards
+
+            - name: Set fabric links based on active fabric cards
+              set_fact:
+                fabric_links: "{{ active_fabric_cards.stdout | int * 24 }}"
+
+            when: inventory_hostname == sup_dut
+
+          - name: Adjust SOC properties if appl_param_active_links_thr_high is greater than fabric links
+            block:
+              - name: Set SOC properties locations
+                set_fact:
+                  device_config_path: "/usr/share/sonic/device/{{ sonic_hw_platform }}/{{ hwsku }}/*"
+
+              - name: Get appl_param_active_links_thr_high
+                shell: grep -ir appl_param_active_links_thr_high {{ device_config_path }} | sed -n 's/.*appl_param_active_links_thr_high=\([0-9]*\).*/\1/p'
+                register: high_active_links_grep
+
+              - name: Get highest appl_param_active_links_thr_high value"
+                set_fact:
+                  high_active_links: "{{ high_active_links_grep.stdout_lines | map('int') | max }}"
+
+              - name: Adjust appl_param_active_links_thr_high to match active fabric links
+                shell: grep -rl appl_param_active_links_thr_high {{ device_config_path }} | xargs sudo sed -i 's/appl_param_active_links_thr_high=.*/appl_param_active_links_thr_high={{ hostvars[sup_dut]['fabric_links'] }}/g'
+                when: high_active_links | int > hostvars[sup_dut]['fabric_links'] | int
+                # Needs to be followed by config reload to take affect
+
+            when: inventory_hostname != sup_dut
+        when: ("t2" in topo) and (switch_type is defined and (switch_type == "voq" or switch_type == "fabric"))
+
       - name: Generate golden_config_db.json
         generate_golden_config_db:
           topo_name: "{{ topo }}"

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -666,6 +666,8 @@
 
             when: inventory_hostname != sup_dut
         when: ("t2" in topo) and (switch_type is defined and (switch_type == "voq" or switch_type == "fabric"))
+        rescue:
+          - debug: msg="SOC properties may not be defined in the device config file. Skipping adjustment of SOC properties."
 
       - name: Generate golden_config_db.json
         generate_golden_config_db:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18183

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Allow iBGP and fabric cards to come up properly when fabric card slots are not fully populated and active fabric links are less than `appl_param_active_links_thr_high`
#### How did you do it?
Compare `appl_param_active_links_thr_high` and active fabric links and adjust as needed
#### How did you verify/test it?
Tested on images with `appl_param_active_links_thr_high` defined above the threshold, below the threshold, and not defined.
#### Any platform specific information?
Only applicable to BRCM DNX Chassis
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
