### PR TITLE
Fix dpu reload test issues

### DIFF
--- a/tests/smartswitch/common/reboot.py
+++ b/tests/smartswitch/common/reboot.py
@@ -26,7 +26,7 @@ def log_and_perform_reboot(duthost, reboot_type, dpu_name):
         if duthost.is_smartswitch():
             if dpu_name is None:
                 logger.info("Sync reboot cause history queue with DUT reboot cause history queue")
-                sync_reboot_history_queue_with_dut(hostname)
+                sync_reboot_history_queue_with_dut(duthost)
 
                 logger.info("Rebooting the switch {} with type {}".format(hostname, reboot_type))
                 return duthost.command("sudo reboot")

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -6,11 +6,11 @@ import logging
 import pytest
 import re
 from tests.common.platform.processes_utils import wait_critical_processes
-from tests.common.reboot import reboot, REBOOT_TYPE_COLD
+from tests.common.reboot import reboot, REBOOT_TYPE_COLD, SONIC_SSH_PORT, SONIC_SSH_REGEX
 from tests.common.helpers.platform_api import module
 from tests.smartswitch.common.device_utils_dpu import check_dpu_link_and_status,\
     pre_test_check, post_test_switch_check, post_test_dpus_check,\
-    num_dpu_modules  # noqa: F401
+    num_dpu_modules, check_dpus_are_not_pingable  # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 from tests.smartswitch.common.reboot import perform_reboot
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
@@ -21,6 +21,8 @@ pytestmark = [
 
 kernel_panic_cmd = "sudo nohup bash -c 'sleep 5 && echo c > /proc/sysrq-trigger' &"
 memory_exhaustion_cmd = "sudo nohup bash -c 'sleep 5 && tail /dev/zero' &"
+DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
+DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 100
 
 
 def test_dpu_status_post_switch_reboot(duthosts,
@@ -99,6 +101,15 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts,
                   a large process...")
     duthost.shell(memory_exhaustion_cmd, executable="/bin/bash")
 
+    logging.info("Waiting for ssh to drop on {}".format(duthost.hostname))
+    localhost.wait_for(host=duthost.mgmt_ip,
+                       port=SONIC_SSH_PORT,
+                       state='absent',
+                       search_regex=SONIC_SSH_REGEX,
+                       delay=10,
+                       timeout=DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION,
+                       module_ignore_errors=True)
+
     logging.info("Executing post test check")
     post_test_switch_check(duthost, localhost,
                            dpu_on_list, dpu_off_list,
@@ -127,6 +138,15 @@ def test_dpu_status_post_switch_kernel_panic(duthosts,
     logging.info("Triggering kernel panic on NPU...")
     duthost.shell(kernel_panic_cmd, executable="/bin/bash")
 
+    logging.info("Waiting for ssh to drop on {}".format(duthost.hostname))
+    localhost.wait_for(host=duthost.mgmt_ip,
+                       port=SONIC_SSH_PORT,
+                       state='absent',
+                       search_regex=SONIC_SSH_REGEX,
+                       delay=10,
+                       timeout=DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC,
+                       module_ignore_errors=True)
+
     logging.info("Executing post test check")
     post_test_switch_check(duthost, localhost,
                            dpu_on_list, dpu_off_list,
@@ -154,6 +174,9 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
         dpu_id = int(re.search(r'\d+', dpu_on).group())
         dpuhosts[dpu_id].shell(kernel_panic_cmd, executable="/bin/bash")
 
+    logging.info("Checking DPUs are not pingable")
+    check_dpus_are_not_pingable(duthost, ip_address_list)
+
     logging.info("Executing post test dpu check")
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules, "Non-Hardware")
 
@@ -180,6 +203,9 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
         dpu_on = dpu_on_list[index]
         dpu_id = int(re.search(r'\d+', dpu_on).group())
         dpuhosts[dpu_id].shell(memory_exhaustion_cmd, executable="/bin/bash")
+
+    logging.info("Checking DPUs are not pingable")
+    check_dpus_are_not_pingable(duthost, ip_address_list)
 
     logging.info("Executing post test dpu check")
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

1. When dpu or npu restart by kernel panic or mem_exhaustion, we need check the connection is lost before the post checker
2. duthost should be passed to the sync_reboot_history_queue_with_dut not hostname

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix test_reload_dpu.py case issues

#### How did you do it?
1. When dpu or npu restart by kernel panic or mem_exhaustion, we need check the connection is lost before the post checker
2. duthost should be passed to the sync_reboot_history_queue_with_dut not hostname

#### How did you verify/test it?
Run the tests on smartswitch

#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
