### PR TITLE
[Cisco chassis] Add extra sleep after reboot to fix the flakiness failure

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1401,6 +1401,14 @@ class TestAclWithReboot(TestBasicAcl):
         # Delay 10 seconds for route convergence
         time.sleep(10)
 
+        # todo: remove the extra sleep on chassis device after bgp suppress fib pending feature is enabled
+        # We observe flakiness failure on chassis devices
+        # Suspect it's because the route is not programmed into hardware
+        # Add external sleep to make sure route is in hardware
+        if dut.get_facts().get("modular_chassis") and dut.facts["asic_type"] == "cisco-8000":
+            logger.info("Sleep 180s on Cisco chassis")
+            time.sleep(180)
+
         populate_vlan_arp_entries()
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_acl.py has a high chance to fail on Cisco chassis.
It's a flakiness failure, add extra sleeping time to wait for the routes to be programmed.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
test_acl.py has a high chance to fail on Cisco chassis.
It's a flakiness failure, add extra sleeping time to wait for the routes to be programmed.
#### How did you do it?
Add extra sleeping time to wait for the routes to be programmed.
#### How did you verify/test it?
Test on physical testbeds and it stables passes.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
