### PR TITLE
Enable platform api watchdog  tests for dpu

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -18,6 +18,8 @@ from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.platform.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, \
     OFFSET_ITEMS, TIME_SPAN_ITEMS, REQUIRED_PATTERNS
+from tests.common.devices.duthosts import DutHosts
+from tests.common.plugins.ansible_fixtures import ansible_adhoc
 
 """
 Helper script for fanout switch operations
@@ -1131,3 +1133,60 @@ def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform
         yield conn
     finally:
         conn.close()
+
+
+@pytest.fixture(scope='module')
+def add_platform_api_server_port_nat_for_dpu(ansible_adhoc, tbinfo, request, duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    if duthost.is_dpu():
+        ip_interface_status = duthost.show_and_parse('show ip interface')
+        for item in ip_interface_status:
+            if item['interface'] == "eth0-midplane":
+                dpu_ip = item['ipv4 address/mask'].split('/')[0]
+                logger.info(f'Found DPU IP {dpu_ip} for {duthost.hostname}')
+                break
+        npu_host = create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost)
+        npu_host.command(
+            f'sudo iptables -t nat -A PREROUTING -i eth0 -p tcp --dport \
+            {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')
+
+    yield
+
+    if duthost.is_dpu():
+        npu_host.command(
+            f'sudo iptables -t nat -D PREROUTING -i eth0 -p tcp --dport \
+                {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')
+
+
+def get_ansible_ssh_port(duthost, ansible_adhoc):
+    host = ansible_adhoc(become=True, args=[], kwargs={})[duthost.hostname]
+    vm = host.options["inventory_manager"].get_host(duthost.hostname).vars
+    ansible_ssh_port = vm.get("ansible_ssh_port", None)
+    logger.info(f'ansible_ssh_port for {duthost.hostname} is {ansible_ssh_port}')
+    return ansible_ssh_port
+
+
+def create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost):
+    '''
+    Create a NPU host object based on DPU info
+    E.g
+    when one smartswitch setup has following devices:
+    smartswitch-01
+    smartswitch-01-dpu-0
+    smartswitch-01-dpu-1
+    smartswitch-01-dpu-2
+    smartswitch-01-dpu-3
+    when we want run the platform api test on dpu, we pass smartswitch-01-dpu-0 to host-pattern,
+    then we can find the NPU host smartswitch-01 from the setup info,
+    and then create a NPU host object based on the info
+    '''
+    for dut in tbinfo['duts']:
+        npu_host_name = None
+        if 'dpu' not in dut and dut in duthost.hostname:
+            npu_host_name = dut
+            logger.info(f'Found NPU hostname {npu_host_name} for {duthost.hostname}')
+            break
+    if npu_host_name is None:
+        pytest.fail('No NPU host found in testbed')
+    npu_host = DutHosts(ansible_adhoc, tbinfo, request, npu_host_name)[0]
+    return npu_host

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -19,7 +19,7 @@ from tests.common.mellanox_data import is_mellanox_device
 from tests.common.platform.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, \
     OFFSET_ITEMS, TIME_SPAN_ITEMS, REQUIRED_PATTERNS
 from tests.common.devices.duthosts import DutHosts
-from tests.common.plugins.ansible_fixtures import ansible_adhoc
+from tests.common.plugins.ansible_fixtures import ansible_adhoc  # noqa F401
 
 """
 Helper script for fanout switch operations
@@ -1136,7 +1136,8 @@ def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform
 
 
 @pytest.fixture(scope='module')
-def add_platform_api_server_port_nat_for_dpu(ansible_adhoc, tbinfo, request, duthosts, enum_rand_one_per_hwsku_hostname):
+def add_platform_api_server_port_nat_for_dpu(
+        ansible_adhoc, tbinfo, request, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     if duthost.is_dpu():
         ip_interface_status = duthost.show_and_parse('show ip interface')
@@ -1158,7 +1159,7 @@ def add_platform_api_server_port_nat_for_dpu(ansible_adhoc, tbinfo, request, dut
                 {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')
 
 
-def get_ansible_ssh_port(duthost, ansible_adhoc):
+def get_ansible_ssh_port(duthost, ansible_adhoc):  # noqa F811
     host = ansible_adhoc(become=True, args=[], kwargs={})[duthost.hostname]
     vm = host.options["inventory_manager"].get_host(duthost.hostname).vars
     ansible_ssh_port = vm.get("ansible_ssh_port", None)
@@ -1166,7 +1167,7 @@ def get_ansible_ssh_port(duthost, ansible_adhoc):
     return ansible_ssh_port
 
 
-def create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost):
+def create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost): # noqa F811
     '''
     Create a NPU host object based on DPU info
     E.g

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1138,6 +1138,12 @@ def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform
 @pytest.fixture(scope='module')
 def add_platform_api_server_port_nat_for_dpu(
         ansible_adhoc, tbinfo, request, duthosts, enum_rand_one_per_hwsku_hostname):  # noqa F811
+    '''
+    This fixture is used to add a NAT rule to the DPU's eth0-midplane interface
+    to forward traffic from NPU to the platform API server on DPU.
+    It is used to test the platform API test on DPU of the Smartswitch.
+    The NAT rule is added before the test and removed after the test.
+    '''
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     if duthost.is_dpu():
         ip_interface_status = duthost.show_and_parse('show ip interface')

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -6,8 +6,10 @@ import yaml
 import pytest
 from tests.common.helpers.platform_api import watchdog
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service    # noqa F401
+from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service, \
+      add_platform_api_server_port_nat_for_dpu, get_ansible_ssh_port    # noqa F401
 from .platform_api_test_base import PlatformApiTestBase
+from tests.common.plugins.ansible_fixtures import ansible_adhoc
 
 from collections import OrderedDict
 
@@ -62,7 +64,7 @@ class TestWatchdogApi(PlatformApiTestBase):
                 duthost.shell("systemctl start cpu_wdt.service")
 
     @pytest.fixture(scope='module')
-    def conf(self, request, duthosts, enum_rand_one_per_hwsku_hostname):
+    def conf(self, request, duthosts, enum_rand_one_per_hwsku_hostname, add_platform_api_server_port_nat_for_dpu):
         ''' Reads the watchdog test configuration file @TEST_CONFIG_FILE and
         results in a dictionary which holds parameters for test '''
 
@@ -94,7 +96,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
     @pytest.mark.dependency()
     def test_arm_disarm_states(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                               platform_api_conn, conf):  # noqa F811
+                               platform_api_conn, conf, ansible_adhoc):  # noqa F811
         ''' arm watchdog with a valid timeout value, verify it is in armed state,
         disarm watchdog and verify it is in disarmed state
         '''
@@ -134,7 +136,8 @@ class TestWatchdogApi(PlatformApiTestBase):
             self.expect(remaining_time is -1,
                         "Watchdog remaining_time {} seconds is wrong for disarmed state".format(remaining_time))
 
-        res = localhost.wait_for(host=duthost.mgmt_ip, port=22, state="stopped", delay=5,
+        ansible_ssh_port = get_ansible_ssh_port(duthost, ansible_adhoc) if duthost.is_dpu() else 22
+        res = localhost.wait_for(host=duthost.mgmt_ip, port=ansible_ssh_port, state="stopped", delay=5,
                                  timeout=watchdog_timeout + TIMEOUT_DEVIATION, module_ignore_errors=True)
 
         self.expect('Timeout' in res.get('msg', ''), "unexpected disconnection from dut")

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -9,7 +9,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service, \
       add_platform_api_server_port_nat_for_dpu, get_ansible_ssh_port    # noqa F401
 from .platform_api_test_base import PlatformApiTestBase
-from tests.common.plugins.ansible_fixtures import ansible_adhoc
+from tests.common.plugins.ansible_fixtures import ansible_adhoc  # noqa F401
 
 from collections import OrderedDict
 
@@ -64,7 +64,7 @@ class TestWatchdogApi(PlatformApiTestBase):
                 duthost.shell("systemctl start cpu_wdt.service")
 
     @pytest.fixture(scope='module')
-    def conf(self, request, duthosts, enum_rand_one_per_hwsku_hostname, add_platform_api_server_port_nat_for_dpu):
+    def conf(self, request, duthosts, enum_rand_one_per_hwsku_hostname, add_platform_api_server_port_nat_for_dpu):  # noqa F811
         ''' Reads the watchdog test configuration file @TEST_CONFIG_FILE and
         results in a dictionary which holds parameters for test '''
 

--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -67,6 +67,12 @@ x86_64-nvidia_sn4280-r0:
     greater_timeout: 100
     too_big_timeout: 66000
 
+arm64-nvda_bf-bf3comdpu:
+  default:
+    valid_timeout: 45
+    greater_timeout: 100
+    too_big_timeout: 66000
+
 # Dell watchdog
 x86_64-dell.*:
   default:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable platform api watchdog tests for dpu. Since platform api tests need to run a http server on the dut, so when dut is dpu, we need to add a nat config for the specific api service port for the tested dpu.

The relevant PRs:

- https://github.com/sonic-net/sonic-buildimage/pull/22046
- https://github.com/sonic-net/sonic-buildimage/pull/22587

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Enable platform api watchdog tests for dpu.

#### How did you do it?
Add a nat config for the specific api service port for the tested dpu.

#### How did you verify/test it?
Run the platform api watchdog tests on dpu

#### Any platform specific information?
dpu

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
