### PR TITLE
[T2][ACL-test] Allow upstream and downstream rifs in the same namespace

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -238,7 +238,7 @@ def get_t2_info(duthosts, tbinfo):
                         acl_table_ports[''].append(port)
                     else:
                         acl_table_ports[namespace].append(port)
-            else:
+            if len(downstream_rifs):
                 for port in downstream_rifs:
                     # This code is commented due to a bug which restricts rif interfaces to
                     # be added to global acl table - https://github.com/sonic-net/sonic-utilities/issues/2185


### PR DESCRIPTION
If we have a T2 topology with ports in the same namespace connecting to both upstream and downstream ports we'll end up excluding them from the ACL.
E.G.
```
> show acl table
Name                    Type       Binding          Description             Stage    Status
----------------------  ---------  ---------------  ----------------------  -------  --------
DATA_INGRESS_IPV4_TEST  L3         Ethernet32       DATA_INGRESS_IPV4_TEST  ingress  Active
                                   PortChannel2001
                                   PortChannel2003
                                   PortChannel2004
```

But we can see it excluded Ethernet248 (which is connected to a downstream port):
```
  Interface                            Lanes    Speed    MTU    FEC         Alias             Vlan    Oper    Admin
-----------  -------------------------------  -------  -----  -----  ------------  ---------------  ------  -------
 Ethernet16          48,49,50,51,52,53,54,55     800G   9100     rs   Ethernet3/1  PortChannel2001      up       up
 Ethernet32  120,121,122,123,124,125,126,127     800G   9100     rs   Ethernet5/1           routed      up       up
 Ethernet48  104,105,106,107,108,109,110,111     800G   9100     rs   Ethernet7/1  PortChannel2003      up       up
Ethernet160  248,249,250,251,252,253,254,255     800G   9100     rs  Ethernet21/1  PortChannel2004      up       up
Ethernet184  224,225,226,227,228,229,230,231     800G   9100     rs  Ethernet24/1  PortChannel2004      up       up
Ethernet248  128,129,130,131,132,133,134,135     800G   9100     rs  Ethernet32/1           routed      up       up
```

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202503
