### PR TITLE
[setup_vrf_cfg] Fix TypeError issue

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -273,9 +273,10 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
 
     # get members from Vlan1000, and move half of them to Vlan2000 in vrf basic cfg
     ports = get_vlan_members('Vlan1000', cfg_facts)
+    ports_halfway = len(ports) // 2
 
-    vlan_ports = {'Vlan1000': ports[:len(ports)/2],
-                  'Vlan2000': ports[len(ports)/2:]}
+    vlan_ports = {'Vlan1000': ports[:ports_halfway],
+                  'Vlan2000': ports[ports_halfway:]}
 
     extra_vars = {'cfg_t0': cfg_t0,
                   'vlan_ports': vlan_ports}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The `setup_vfr_cfg` function would fail on testbeds with an odd number of interfaces for Vlan1000, as a slice would attempt to be taken using a float instead of an integer. This float would always end in `.5` (due to there being an odd number), causing the `TypeError` to be raised, as coercion to an integer would fail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Issue would occur when there is an odd number of ports, causing the `len(ports) / 2` operation to return a float that could not be coerced into an int.

#### How did you do it?
Calculate `len(ports) // 2` instead, as the result of a floor division always returns an int.

#### How did you verify/test it?
Previously failed on 7050cx3 testbeds:
```
01:00:00 test_vrf.setup_vrf                       L0519 ERROR  | Exception raised in setup: TypeError('slice indices must be integers or None or have an __index__ method')
01:00:00 test_vrf.setup_vrf                       L0520 ERROR  | [
  "Traceback (most recent call last):\n",
  "  File \"/var/src/sonic-mgmt-int/tests/vrf/test_vrf.py\", line 492, in setup_vrf\n    setup_vrf_cfg(duthost, localhost, cfg_t0)\n",
  "  File \"/var/src/sonic-mgmt-int/tests/vrf/test_vrf.py\", line 277, in setup_vrf_cfg\n    vlan_ports = {'Vlan1000': ports[:len(ports)/2],\n",
  "TypeError: slice indices must be integers or None or have an __index__ method\n"
]
```
With the change, now passes:
TODO

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
