### PR TITLE
Disable memory utilization check due to buggy monit

### DIFF
--- a/tests/gnmi/test_gnoi_system_grpc.py
+++ b/tests/gnmi/test_gnoi_system_grpc.py
@@ -4,7 +4,10 @@ import time
 
 from tests.gnmi.grpc_utils import get_gnoi_system_stubs
 
-pytestmark = [pytest.mark.topology("any")]
+pytestmark = [
+    pytest.mark.topology("any"),
+    pytest.mark.disable_memory_utilization
+]
 
 
 """


### PR DESCRIPTION
This test triggers monit segfault which is irrelevant to gnoi. See https://elastictest.org/scheduler/testplan/6812d311dec515a352da73cb?testcase=gnmi%2Ftest_gnoi_system_grpc.py%7C%7C%7C1&type=console

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
Disable memory utilization

#### What is the motivation for this PR?
Reduces flakes like https://elastictest.org/scheduler/testplan/6812d311dec515a352da73cb?testcase=gnmi%2Ftest_gnoi_system_grpc.py%7C%7C%7C1&type=console

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
