### PR TITLE
Changes to setup NTP before executing gnmi suite

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -49,10 +49,12 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
 
     if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
         logger.info("check_system_time_sync is skipped for this platform, so skip ntp setup")
+        yield
         return
 
     if check_ntp_sync_status(duthost) is True:
         logger.info("DUT is already in sycn with NTP server, so skip ntp setup")
+        yield
         return
 
     with setup_ntp_context(ptfhost, duthost, False):

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -13,6 +13,7 @@ from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_co
 from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
+from tests.common.helpers.ntp_helper import setup_ntp_context
 
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,15 @@ def download_gnmi_client(duthosts, rand_one_dut_hostname, localhost):
         shutil.copyfile(gnmi_bin, "gnmi/%s" % file)
         localhost.shell("sudo chmod +x gnmi/%s" % file)
 
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
+    """Auto-setup NTP for all gNMI tests using existing helper."""
+    duthost = duthosts[rand_one_dut_hostname]
+
+    if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
+       with setup_ntp_context(ptfhost, duthost, False):
+            yield
 
 def create_revoked_cert_and_crl(localhost, ptfhost):
     # Create client key

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -9,8 +9,8 @@ from grpc_tools import protoc
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, create_ca_conf, check_ntp_sync_status
-from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME
+from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, create_ca_conf
+from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.helpers.ntp_helper import setup_ntp_context

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -47,9 +47,11 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
     """Auto-setup NTP for all gNMI tests using existing helper."""
     duthost = duthosts[rand_one_dut_hostname]
 
-    if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
-        with setup_ntp_context(ptfhost, duthost, False):
-            yield
+    if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        pytest.skip("check_system_time_sync is skipped for this platform, so skip ntp setup")
+
+    with setup_ntp_context(ptfhost, duthost, False):
+        yield
 
 
 def create_revoked_cert_and_crl(localhost, ptfhost):

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -9,8 +9,8 @@ from grpc_tools import protoc
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, create_ca_conf
-from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
+from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, create_ca_conf, check_ntp_sync_status
+from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.helpers.ntp_helper import setup_ntp_context

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -51,7 +51,7 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
         logger.info("check_system_time_sync is skipped for this platform, so skip ntp setup")
         return
 
-    if check_ntp_sync_status(duthost) == True:
+    if check_ntp_sync_status(duthost) is True:
         logger.info("DUT is already in sycn with NTP server, so skip ntp setup")
         return
 

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -48,8 +48,9 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     if duthost.facts['platform'] != 'x86_64-kvm_x86_64-r0':
-       with setup_ntp_context(ptfhost, duthost, False):
+        with setup_ntp_context(ptfhost, duthost, False):
             yield
+
 
 def create_revoked_cert_and_crl(localhost, ptfhost):
     # Create client key

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -10,7 +10,7 @@ from grpc_tools import protoc
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
 from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config, create_ext_conf, create_ca_conf
-from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME
+from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.helpers.ntp_helper import setup_ntp_context
@@ -48,7 +48,12 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     if duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
-        pytest.skip("check_system_time_sync is skipped for this platform, so skip ntp setup")
+        logger.info("check_system_time_sync is skipped for this platform, so skip ntp setup")
+        return
+
+    if check_ntp_sync_status(duthost) == True:
+        logger.info("DUT is already in sycn with NTP server, so skip ntp setup")
+        return
 
     with setup_ntp_context(ptfhost, duthost, False):
         yield

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -146,20 +146,17 @@ def recover_cert_config(duthost):
     assert wait_until(300, 3, 0, check_gnmi_status, duthost), "GNMI service failed to start"
 
 
-def check_system_time_sync(duthost):
+def check_ntp_sync_status(duthost):
     """
     Checks if the DUT's time is synchronized with the NTP server.
-    If not synchronized, it attempts to restart the NTP service.
     """
 
     ntp_daemon = get_ntp_daemon_in_use(duthost)
 
     if ntp_daemon == NtpDaemon.CHRONY:
         ntp_status_cmd = "chronyc -c tracking"
-        restart_ntp_cmd = "sudo systemctl restart chrony"
     else:
         ntp_status_cmd = "ntpstat"
-        restart_ntp_cmd = "sudo systemctl restart ntp"
 
     ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
     if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
@@ -167,18 +164,38 @@ def check_system_time_sync(duthost):
         logger.info("DUT %s is synchronized with NTP server.", duthost)
         return True
     else:
-        logger.info("DUT %s is NOT synchronized. Restarting NTP service...", duthost)
-        duthost.command(restart_ntp_cmd)
-        time.sleep(5)
-        # Rechecking status after restarting NTP
-        ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
-        if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
-                (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
-            logger.info("DUT %s is now synchronized with NTP server.", duthost)
-            return True
-        else:
-            logger.error("DUT %s: NTP synchronization failed. Please check manually.", duthost)
-            return False
+        logger.info("DUT %s is NOT synchronized.", duthost)
+        return False
+
+
+def check_system_time_sync(duthost):
+    """
+    Checks if the DUT's time is synchronized with the NTP server.
+    If not synchronized, it attempts to restart the NTP service.
+    """
+
+    if check_ntp_sync_status(duthost) == True:
+        return True
+
+    ntp_daemon = get_ntp_daemon_in_use(duthost)
+
+    if ntp_daemon == NtpDaemon.CHRONY:
+        restart_ntp_cmd = "sudo systemctl restart chrony"
+    else:
+        restart_ntp_cmd = "sudo systemctl restart ntp"
+
+    logger.info("DUT %s is NOT synchronized. Restarting NTP service...", duthost)
+    duthost.command(restart_ntp_cmd)
+    time.sleep(5)
+    # Rechecking status after restarting NTP
+    ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
+    if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
+        (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
+        logger.info("DUT %s is now synchronized with NTP server.", duthost)
+        return True
+    else:
+        logger.error("DUT %s: NTP synchronization failed. Please check manually.", duthost)
+        return False
 
 
 def gnmi_capabilities(duthost, localhost):

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -174,7 +174,7 @@ def check_system_time_sync(duthost):
     If not synchronized, it attempts to restart the NTP service.
     """
 
-    if check_ntp_sync_status(duthost) == True:
+    if check_ntp_sync_status(duthost) is True:
         return True
 
     ntp_daemon = get_ntp_daemon_in_use(duthost)
@@ -188,9 +188,8 @@ def check_system_time_sync(duthost):
     duthost.command(restart_ntp_cmd)
     time.sleep(5)
     # Rechecking status after restarting NTP
-    ntp_status = duthost.command(ntp_status_cmd, module_ignore_errors=True)
-    if (ntp_daemon == NtpDaemon.CHRONY and "Not synchronised" not in ntp_status["stdout"]) or \
-        (ntp_daemon != NtpDaemon.CHRONY and "synchronized" in ntp_status["stdout"]):
+    ntp_status = check_ntp_sync_status(duthost)
+    if ntp_status is True:
         logger.info("DUT %s is now synchronized with NTP server.", duthost)
         return True
     else:


### PR DESCRIPTION
### Description of PR
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/18203

Issue : GNMI test cases fails if NTP is not configured prior to running suite

Root cause : GNMI suite has dependency on NTP, but it doesn't setup ntp before running gnmi cases

Fix : Ensure NTP client & server configuration are done for gnmi cases

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
GNMI test cases fails if NTP is not configured prior to running suite

#### How did you do it?
Ensure NTP client & server configuration are done for gnmi cases

#### How did you verify/test it?
Run all GNMI & NTP test cases

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA
