### PR TITLE
Remove docker-ptf py3only tag based pilot rollout code

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -55,7 +55,7 @@ parameters:
 
   - name: PTF_IMAGE_TAG
     type: string
-    default: ""
+    default: "latest"
 
   - name: IMAGE_URL
     type: string

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,35 +83,13 @@ stages:
     steps:
       - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml
 
-  - job: choose_between_mixed_and_py3_ptf_image
-    displayName: "Choose between latest (mixed type) and py3 ptf image"
-    timeoutInMinutes: 10
-    continueOnError: false
-    pool: sonic-ubuntu-1c
-    steps:
-      - script: |
-          python - <<EOF
-          import random
-          tag = 'latest'
-          if random.random() < 0.7:
-            tag = 'py3only'
-          print(f"##vso[task.setvariable variable=tag_value;isOutput=true]{tag}")
-          EOF
-        name: ptf_image_tag
-        displayName: "Selecting PTF_IMAGE_TAG"
-      - script: |
-            echo "Chosen PTF_IMAGE_TAG: $(ptf_image_tag.tag_value)"
-        displayName: "PTF_IMAGE_TAG value"
-
   - job: impacted_area_t0_elastictest
     displayName: "impacted-area-kvmtest-t0 by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -124,7 +102,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t0
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -135,11 +112,9 @@ stages:
     displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -152,7 +127,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t0
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -164,11 +138,9 @@ stages:
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -183,7 +155,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-lag
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -194,11 +165,9 @@ stages:
     displayName: "impacted-area-kvmtest-dualtor by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -213,7 +182,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: dualtor
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -225,11 +193,9 @@ stages:
     displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1-multi-asic_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -242,7 +208,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-8-lag
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -254,11 +219,9 @@ stages:
     displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -272,7 +235,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t0-64-32
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -289,11 +251,9 @@ stages:
     displayName: "impacted-area-kvmtest-dpu by Elastictest"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -306,7 +266,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: dpu
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -321,11 +280,9 @@ stages:
     displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest - optional"
     dependsOn:
     - get_impacted_area
-    - choose_between_mixed_and_py3_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      set_ptf_image_tag: $[ dependencies.choose_between_mixed_and_py3_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: true
     pool: sonic-ubuntu-1c
@@ -338,7 +295,6 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-8-lag
-          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           STOP_ON_FAILURE: "False"
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)


### PR DESCRIPTION
### Description of PR

The PR removes pipeline job that was introduced to run pilot rollout of Python 3 only docker-ptf image as the rollout is now complete.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The docker-ptf:latest now uses Python 3 only image. The code that was used to test pilot rollout of this feature is no longer needed.

#### How did you do it?

Remove job and related references from the pipeline.

#### How did you verify/test it?

N/A

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A