### PR TITLE
test_upgrade_path: Fix ceos bgp cmd parse

### DIFF
--- a/ansible/roles/test/files/ptftests/arista.py
+++ b/ansible/roles/test/files/ptftests/arista.py
@@ -401,8 +401,8 @@ class Arista(host_device.HostDevice):
         is_gr_ipv6_enabled = False
         restart_time = None
         for line in output.split('\n'):
-            if '     Restart-time is' in line:
-                restart_time = int(line.replace('       Restart-time is ', ''))
+            if 'Restart-time is' in line:
+                restart_time = int(re.search(r'\d+', line).group())
                 continue
 
             if 'is enabled, Forwarding State is' in line:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Newer version of eos updates output of `show ip bgp neighbor`, which changes indentation. This breaks the parsing of restart_time.

#### How did you do it?
Regex match on integer and ignore indentation.

#### How did you verify/test it?
Tested on Arista testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
