### PR TITLE
Use is_alive over isAlive for py3 threads

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1147,7 +1147,7 @@ class ReloadTest(BaseTest):
         self.fails['dut'].clear()
 
         # wait until sniffer and sender threads have started
-        while not (self.sniff_thr.isAlive() and self.sender_thr.isAlive()):
+        while not (self.sniff_thr.is_alive() and self.sender_thr.is_alive()):
             time.sleep(1)
 
         self.log("IO sender and sniffer threads have started, wait until completion")

--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -353,7 +353,7 @@ class ArpTest(BaseTest):
         self.warm_reboot()
 
         test_port_thr.join(timeout=self.how_long)
-        if test_port_thr.isAlive():
+        if test_port_thr.is_alive():
             self.log("Timed out waiting for traffic-sender (test_port_thr thread)")
             self.req_dut('quit')
             self.assertTrue(
@@ -436,7 +436,7 @@ class ArpTest(BaseTest):
             if wr_state is not False:
                 self.assertTrue(False, "CPA quit before warm reboot finished")
 
-            if test_non_broadcast_reply_thread.isAlive():
+            if test_non_broadcast_reply_thread.is_alive():
                 self.log("Timed out waiting for test_non_broadcast_reply_thread")
                 self.assertTrue(
                     False, "Timed out waiting for test_non_broadcast_reply_thread")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The python isAlive method for checking thread liveliness is for py2/earlier versions of py3. In py3.9 it is fully removed, and only is_alive is supported. Best to switch to is_alive for all versions of py3.

#### How did you do it?

#### How did you verify/test it?
Tested on Arista testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
