### PR TITLE
Add PTF test parameter for ceos neighbor lacp multiplier

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -180,6 +180,7 @@ class ReloadTest(BaseTest):
         self.check_param('asic_type', '', required=False)
         self.check_param('logfile_suffix', None, required=False)
         self.check_param('neighbor_type', 'eos', required=False)
+        self.check_param('ceos_neighbor_lacp_multiplier', 3, required=False)
         self.check_param('port_channel_intf_idx', [], required=False)
         if not self.test_params['preboot_oper'] or self.test_params['preboot_oper'] == 'None':
             self.test_params['preboot_oper'] = None
@@ -1405,9 +1406,9 @@ class ReloadTest(BaseTest):
         self.assertTrue(is_good, errors)
 
     def runTest(self):
-        # Set LACP timer multiplier to 5 for cEOS peers
-        if self.test_params['neighbor_type'] == "eos":
-            self.ceos_set_lacp_all_neighs(5)
+        # Set LACP timer multiplier for cEOS peers when it is not default (3)
+        if self.test_params['neighbor_type'] == "eos" and self.test_params['ceos_neighbor_lacp_multiplier'] != 3:
+            self.ceos_set_lacp_all_neighs(self.test_params['ceos_neighbor_lacp_multiplier'])
 
         self.pre_reboot_test_setup()
         try:
@@ -1463,7 +1464,7 @@ class ReloadTest(BaseTest):
             self.fails['dut'].add(traceback_msg)
         finally:
             # Restore cEOS LACP timer multiplier to default (3)
-            if self.test_params['neighbor_type'] == "eos":
+            if self.test_params['neighbor_type'] == "eos" and self.test_params['ceos_neighbor_lacp_multiplier'] != 3:
                 self.ceos_set_lacp_all_neighs(3)
 
             self.handle_post_reboot_test_reports()

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -133,6 +133,7 @@ class AdvancedReboot:
         self.bgpV4V6TimeDiff = self.request.config.getoption("--bgp_v4_v6_time_diff")
         self.new_docker_image = self.request.config.getoption("--new_docker_image")
         self.neighborType = self.request.config.getoption("--neighbor_type")
+        self.ceosNeighLacpMultiplier = self.request.config.getoption("--ceos_neighbor_lacp_multiplier")
 
         # Set default reboot limit if it is not given
         if self.rebootLimit is None:
@@ -912,6 +913,7 @@ class AdvancedReboot:
             "service_data": None if self.rebootType != 'service-warm-restart' else self.service_data,
             "neighbor_type": self.neighborType,
             "kvm_support": True,
+            "ceos_neighbor_lacp_multiplier": self.ceosNeighLacpMultiplier,
         }
 
         if self.dual_tor_mode:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,10 @@ def pytest_addoption(parser):
     parser.addoption("--neighbor_type", action="store", default="eos", type=str, choices=["eos", "sonic", "cisco"],
                      help="Neighbor devices type")
 
+    # ceos neighbor lacp multiplier
+    parser.addoption("--ceos_neighbor_lacp_multiplier", action="store", default=3, type=int,
+                     help="LACP multiplier for ceos neighbors")
+
     # FWUtil options
     parser.addoption('--fw-pkg', action='store', help='Firmware package file')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add an argument for the advanced_reboot PTF test to set the LACP multiplier for ceos neighbors.

Can be set when running `run.sh` via `-e` (extra parameters).
i.e.:
```
-e "--ceos_neighbor_lacp_multiplier=5"
```

Requested here:
https://github.com/sonic-net/sonic-mgmt/pull/17964#issuecomment-2837412391

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To be able to have different LACP multipliers when running tests on different platforms.

#### How did you do it?
Mirror `--neighbor_type` param changes.

#### How did you verify/test it?
Tested with a Arista 7050-CX3 with and without the parameter. Can observe that the LACP multiplier is properly set on the ceos neighbors when parameter is given, and see that there are no changes when the parameter is not set.

Tested wtih:
```
sudo ./run_tests.sh -n ardut -u -x -c 'upgrade_path/test_upgrade_path.py::test_upgrade_path' -e "--base_image_list LINK-TO-20240510 --target_image_list LINK-TO-20241110 --ceos_neighbor_lacp_multiplier=5"
```

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
