### PR TITLE
Add zellij layout support in ssh repo generation.

### DIFF
--- a/ansible/devutil/ssh_session_repo.py
+++ b/ansible/devutil/ssh_session_repo.py
@@ -419,11 +419,8 @@ class SshConfigSshSessionRepoGenerator(SshSessionRepoGenerator):
         self.ssh_config.write(self.target)
 
 
-class SshConfigTmuxinatorSessionRepoGenerator(SshSessionRepoGenerator):
-    """Tmuxinator session repo generator for tmuxinator configs.
-
-    It derives from SshSessionRepoGenerator and implements the generate method.
-    """
+class SshSessionLayoutRepoGenerator(SshSessionRepoGenerator):
+    """SSH session layout repo generator."""
 
     def __init__(self, target: str, ssh_config_params: Dict[str, str], console_ssh_config_params: Dict[str, str]):
         super().__init__(target, "")
@@ -440,6 +437,42 @@ class SshConfigTmuxinatorSessionRepoGenerator(SshSessionRepoGenerator):
 
         self.console_ssh_config_params = "".join([f" -o {k}={v}" for k, v in console_ssh_config_params.items()]
                                                  if console_ssh_config_params is not None else [])
+
+    def _load_template(self, template_file):
+        pass
+
+    def generate(self, repo_type: str, inv_name: str, testbed_name: str,
+                 device: DeviceInfo, ssh_info: DeviceSSHInfo):
+        config = self.testbeds.setdefault(testbed_name, {})
+        self._generate_tmuxinator_config_for_device(config, device, ssh_info.ip, ssh_info)
+
+    def _generate_tmuxinator_config_for_device(self, config: Dict[str, List[str]], device: DeviceInfo,
+                                               ssh_ip: str, ssh_info: DeviceSSHInfo):
+        device_type = self._get_device_type_short_name(device)
+        ssh_pass = f"sshpass -p {ssh_info.password} " if ssh_info.password else ""
+        ssh_common_params = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+
+        if device.device_type == "Console":
+            command = f"{ssh_pass}ssh {ssh_common_params}{self.console_ssh_config_params} -l {ssh_info.user} {ssh_ip}"
+        else:
+            command = f"{ssh_pass}ssh {ssh_common_params}{self.ssh_config_params} {ssh_info.user}@{ssh_ip}"
+
+        panes = config.setdefault(device_type, {})
+        panes[device.hostname] = command
+
+    def finish(self):
+        for testbed_name, config in self.testbeds.items():
+            self._generate_layout_file(testbed_name, config)
+
+    def _generate_layout_file(self, testbed_name: str, config: Dict[str, List[str]]):
+        pass
+
+
+class SshConfigTmuxinatorSessionRepoGenerator(SshSessionLayoutRepoGenerator):
+    """Tmuxinator session repo generator for tmuxinator configs."""
+
+    def __init__(self, target: str, ssh_config_params: Dict[str, str], console_ssh_config_params: Dict[str, str]):
+        super().__init__(target, ssh_config_params, console_ssh_config_params)
 
     def _load_template(self, template_file):
         """Load SSH session template file.
@@ -465,33 +498,52 @@ windows:
 """
         return jinja2.Template(template)
 
-    def generate(self, repo_type: str, inv_name: str, testbed_name: str,
-                 device: DeviceInfo, ssh_info: DeviceSSHInfo):
-        config = self.testbeds.setdefault(testbed_name, {})
-        self._generate_tmuxinator_config_for_device(config, device, ssh_info.ip, ssh_info)
-
-    def _generate_tmuxinator_config_for_device(self, config: Dict[str, List[str]], device: DeviceInfo,
-                                               ssh_ip: str, ssh_info: DeviceSSHInfo):
-        device_type = self._get_device_type_short_name(device)
-        ssh_pass = f"sshpass -p {ssh_info.password} " if ssh_info.password else ""
-        ssh_common_params = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-
-        if device.device_type == "Console":
-            command = f"{ssh_pass}ssh {ssh_common_params}{self.console_ssh_config_params} -l {ssh_info.user} {ssh_ip}"
-        else:
-            command = f"{ssh_pass}ssh {ssh_common_params}{self.ssh_config_params} {ssh_info.user}@{ssh_ip}"
-
-        panes = config.setdefault(device_type, {})
-        panes[device.hostname] = command
-
-    def finish(self):
-        for testbed_name, config in self.testbeds.items():
-            self._generate_tmuxinator_session_file(testbed_name, config)
-
-    def _generate_tmuxinator_session_file(self, testbed_name: str, config: Dict[str, List[str]]):
+    def _generate_layout_file(self, testbed_name: str, config: Dict[str, List[str]]):
         tmux_config_file_path = os.path.join(self.target, testbed_name + ".yml")
 
         config_file_content = self.template.render(testbed_name=testbed_name,
+                                                   config=config)
+
+        with open(tmux_config_file_path, "w") as f:
+            f.write(config_file_content)
+
+
+class ZellijLayoutRepoGenerator(SshSessionLayoutRepoGenerator):
+    """Zillij layout repo generator."""
+
+    def __init__(self, target: str, ssh_config_params: Dict[str, str], console_ssh_config_params: Dict[str, str]):
+        super().__init__(target, ssh_config_params, console_ssh_config_params)
+        self.shell = os.environ.get("SHELL", "/bin/bash")
+
+    def _load_template(self, template_file):
+        """Load zillij layout template file."""
+
+        template = """layout {
+    cwd "."
+    {%- for device_type, panes in config.items() %}
+    tab name="{{ device_type }}" {
+        pane stacked=true {
+            {%- for title, command in panes.items() %}
+            pane name="{{ title }}" command="{{ shell }}" {
+                args "-c" "{{ command }}"
+            }
+            {%- endfor %}
+        }
+        pane size=1 borderless=true {
+            plugin location="compact-bar"
+        }
+    }
+    {%- endfor %}
+}
+"""
+
+        return jinja2.Template(template)
+
+    def _generate_layout_file(self, testbed_name: str, config: Dict[str, List[str]]):
+        tmux_config_file_path = os.path.join(self.target, testbed_name + ".kdl")
+
+        config_file_content = self.template.render(testbed_name=testbed_name,
+                                                   shell=self.shell,
                                                    config=config)
 
         with open(tmux_config_file_path, "w") as f:

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -16,6 +16,7 @@ from devutil.ssh_session_repo import (
     SecureCRTSshSessionRepoGenerator,
     SshConfigSshSessionRepoGenerator,
     SshConfigTmuxinatorSessionRepoGenerator,
+    ZellijLayoutRepoGenerator,
     SshSessionRepoGenerator,
 )
 
@@ -302,6 +303,13 @@ def main(args):
         # SSH config doesn't support hierarchical structure well, so we only generate the flattened SSH config for now.
         create_testbed_repo = True
         create_device_repo = False
+    elif args.format == "zellij":
+        repo_generator = ZellijLayoutRepoGenerator(
+            args.target, args.ssh_config_params, args.console_ssh_config_params
+        )
+        # SSH config doesn't support hierarchical structure well, so we only generate the flattened SSH config for now.
+        create_testbed_repo = True
+        create_device_repo = False
     else:
         print("Unsupported output format: {}".format(args.format))
         return
@@ -442,7 +450,7 @@ the `secrets.json` file and use the alternative credentials.
         "--format",
         type=str,
         dest="format",
-        choices=["securecrt", "ssh", "tmuxinator"],
+        choices=["securecrt", "ssh", "tmuxinator", "zellij"],
         default="securecrt",
         help="Output target format, currently supports securecrt or ssh.",
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Add zellij layout support in ssh repo generation.

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

This helps generates the zellij layout, which simplifies the way to connect to all related devices to a single testbed.

#### How did you do it?

Updated SSH session generator.

#### How did you verify/test it?

Tested on local machine.

![image](https://github.com/user-attachments/assets/b4d34988-89c7-4dc5-8913-f3b31dac005e)


#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
