### PR TITLE
Update get_transceiver_bulk_status to match the new SFP API naming.

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -71,7 +71,7 @@ def get_transceiver_info_firmware_versions(conn, index):
 
 
 def get_transceiver_bulk_status(conn, index):
-    return sfp_api(conn, index, 'get_transceiver_bulk_status')
+    return sfp_api(conn, index, 'get_transceiver_dom_real_value')
 
 
 def get_transceiver_threshold_info(conn, index):


### PR DESCRIPTION
Update get_transceiver_bulk_status to match the new SFP API naming.
In sfp.py call get_transceiver_dom_real_value instead of get_transceiver_bulk_status. The change is according to
https://github.com/sonic-net/sonic-platform-common/pull/556/files

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Update in the SFP API of renaming the get_transceiver_bulk_status function to get_transceiver_dom_real_value.

#### How did you do it?
Update get_transceiver_bulk_status in sfp.py file to call the new function name.

#### How did you verify/test it?
Rerun successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
