### PR TITLE
update ptf subnet to /22

### DIFF
--- a/ansible/group_vars/vm_host/main.yml
+++ b/ansible/group_vars/vm_host/main.yml
@@ -5,5 +5,5 @@ vm_console_base: 7000
 memory: 2097152
 max_fp_num: 4
 
-ptf_bp_ip: 10.10.246.254/24
+ptf_bp_ip: 10.10.246.254/22
 ptf_bp_ipv6: fc0a::ff/64

--- a/ansible/templates/topo_t0-isolated.j2
+++ b/ansible/templates/topo_t0-isolated.j2
@@ -65,6 +65,6 @@ configuration:
         ipv4: {{vm.pc_intf_ipv4}}/31
         ipv6: {{vm.pc_intf_ipv6}}/126
     bp_interface:
-      ipv4: {{vm.bp_ipv4}}/24
+      ipv4: {{vm.bp_ipv4}}/22
       ipv6: {{vm.bp_ipv6}}/64
 {%- endfor %}

--- a/ansible/templates/topo_t1-isolated.j2
+++ b/ansible/templates/topo_t1-isolated.j2
@@ -48,6 +48,6 @@ configuration:
         ipv4: {{vm.pc_intf_ipv4}}/31
         ipv6: {{vm.pc_intf_ipv6}}/126
     bp_interface:
-      ipv4: {{vm.bp_ipv4}}/24
+      ipv4: {{vm.bp_ipv4}}/22
       ipv6: {{vm.bp_ipv6}}/64
 {%- endfor %}

--- a/ansible/vars/topo_t0-isolated-d16u16s1.yml
+++ b/ansible/vars/topo_t0-isolated-d16u16s1.yml
@@ -156,7 +156,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64601
       peers:
         65100:
           - 10.0.0.64
@@ -169,13 +169,13 @@ configuration:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
     bp_interface:
-      ipv4: 10.10.246.34/24
+      ipv4: 10.10.246.34/22
       ipv6: fc0a::22/64
   ARISTA09T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64602
       peers:
         65100:
           - 10.0.0.80
@@ -188,13 +188,13 @@ configuration:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
     bp_interface:
-      ipv4: 10.10.246.42/24
+      ipv4: 10.10.246.42/22
       ipv6: fc0a::2a/64
   ARISTA17T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64603
       peers:
         65100:
           - 10.0.0.96
@@ -207,13 +207,13 @@ configuration:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
     bp_interface:
-      ipv4: 10.10.246.50/24
+      ipv4: 10.10.246.50/22
       ipv6: fc0a::32/64
   ARISTA25T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64604
       peers:
         65100:
           - 10.0.0.112
@@ -226,13 +226,13 @@ configuration:
         ipv4: 10.0.0.113/31
         ipv6: fc00::e2/126
     bp_interface:
-      ipv4: 10.10.246.58/24
+      ipv4: 10.10.246.58/22
       ipv6: fc0a::3a/64
   ARISTA33T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64605
       peers:
         65100:
           - 10.0.0.128
@@ -245,13 +245,13 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.246.66/24
+      ipv4: 10.10.246.66/22
       ipv6: fc0a::42/64
   ARISTA41T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64606
       peers:
         65100:
           - 10.0.0.144
@@ -264,13 +264,13 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.246.74/24
+      ipv4: 10.10.246.74/22
       ipv6: fc0a::4a/64
   ARISTA49T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64607
       peers:
         65100:
           - 10.0.0.160
@@ -283,13 +283,13 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.246.82/24
+      ipv4: 10.10.246.82/22
       ipv6: fc0a::52/64
   ARISTA57T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64608
       peers:
         65100:
           - 10.0.0.176
@@ -302,13 +302,13 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.246.90/24
+      ipv4: 10.10.246.90/22
       ipv6: fc0a::5a/64
   ARISTA65T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64609
       peers:
         65100:
           - 10.0.1.64
@@ -321,13 +321,13 @@ configuration:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
     bp_interface:
-      ipv4: 10.10.246.162/24
+      ipv4: 10.10.246.162/22
       ipv6: fc0a::a2/64
   ARISTA73T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64610
       peers:
         65100:
           - 10.0.1.80
@@ -340,13 +340,13 @@ configuration:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
     bp_interface:
-      ipv4: 10.10.246.170/24
+      ipv4: 10.10.246.170/22
       ipv6: fc0a::aa/64
   ARISTA81T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64611
       peers:
         65100:
           - 10.0.1.96
@@ -359,13 +359,13 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA89T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64612
       peers:
         65100:
           - 10.0.1.112
@@ -378,13 +378,13 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA97T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64613
       peers:
         65100:
           - 10.0.1.128
@@ -397,13 +397,13 @@ configuration:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
     bp_interface:
-      ipv4: 10.10.246.194/24
+      ipv4: 10.10.246.194/22
       ipv6: fc0a::c2/64
   ARISTA105T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64614
       peers:
         65100:
           - 10.0.1.144
@@ -416,13 +416,13 @@ configuration:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
     bp_interface:
-      ipv4: 10.10.246.202/24
+      ipv4: 10.10.246.202/22
       ipv6: fc0a::ca/64
   ARISTA113T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64615
       peers:
         65100:
           - 10.0.1.160
@@ -435,13 +435,13 @@ configuration:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
     bp_interface:
-      ipv4: 10.10.246.210/24
+      ipv4: 10.10.246.210/22
       ipv6: fc0a::d2/64
   ARISTA121T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64616
       peers:
         65100:
           - 10.0.1.176
@@ -454,13 +454,13 @@ configuration:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
     bp_interface:
-      ipv4: 10.10.246.218/24
+      ipv4: 10.10.246.218/22
       ipv6: fc0a::da/64
   ARISTA01PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65101
       peers:
         65100:
           - 10.0.2.0
@@ -473,5 +473,5 @@ configuration:
         ipv4: 10.0.2.1/31
         ipv6: fc00::402/126
     bp_interface:
-      ipv4: 10.10.247.2/24
+      ipv4: 10.10.247.2/22
       ipv6: fc0a::102/64

--- a/ansible/vars/topo_t0-isolated-d16u16s2.yml
+++ b/ansible/vars/topo_t0-isolated-d16u16s2.yml
@@ -160,7 +160,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64601
       peers:
         65100:
           - 10.0.0.64
@@ -173,13 +173,13 @@ configuration:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
     bp_interface:
-      ipv4: 10.10.246.34/24
+      ipv4: 10.10.246.34/22
       ipv6: fc0a::22/64
   ARISTA09T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64602
       peers:
         65100:
           - 10.0.0.80
@@ -192,13 +192,13 @@ configuration:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
     bp_interface:
-      ipv4: 10.10.246.42/24
+      ipv4: 10.10.246.42/22
       ipv6: fc0a::2a/64
   ARISTA17T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64603
       peers:
         65100:
           - 10.0.0.96
@@ -211,13 +211,13 @@ configuration:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
     bp_interface:
-      ipv4: 10.10.246.50/24
+      ipv4: 10.10.246.50/22
       ipv6: fc0a::32/64
   ARISTA25T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64604
       peers:
         65100:
           - 10.0.0.112
@@ -230,13 +230,13 @@ configuration:
         ipv4: 10.0.0.113/31
         ipv6: fc00::e2/126
     bp_interface:
-      ipv4: 10.10.246.58/24
+      ipv4: 10.10.246.58/22
       ipv6: fc0a::3a/64
   ARISTA33T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64605
       peers:
         65100:
           - 10.0.0.128
@@ -249,13 +249,13 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.246.66/24
+      ipv4: 10.10.246.66/22
       ipv6: fc0a::42/64
   ARISTA41T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64606
       peers:
         65100:
           - 10.0.0.144
@@ -268,13 +268,13 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.246.74/24
+      ipv4: 10.10.246.74/22
       ipv6: fc0a::4a/64
   ARISTA49T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64607
       peers:
         65100:
           - 10.0.0.160
@@ -287,13 +287,13 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.246.82/24
+      ipv4: 10.10.246.82/22
       ipv6: fc0a::52/64
   ARISTA57T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64608
       peers:
         65100:
           - 10.0.0.176
@@ -306,13 +306,13 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.246.90/24
+      ipv4: 10.10.246.90/22
       ipv6: fc0a::5a/64
   ARISTA65T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64609
       peers:
         65100:
           - 10.0.1.64
@@ -325,13 +325,13 @@ configuration:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
     bp_interface:
-      ipv4: 10.10.246.162/24
+      ipv4: 10.10.246.162/22
       ipv6: fc0a::a2/64
   ARISTA73T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64610
       peers:
         65100:
           - 10.0.1.80
@@ -344,13 +344,13 @@ configuration:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
     bp_interface:
-      ipv4: 10.10.246.170/24
+      ipv4: 10.10.246.170/22
       ipv6: fc0a::aa/64
   ARISTA81T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64611
       peers:
         65100:
           - 10.0.1.96
@@ -363,13 +363,13 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA89T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64612
       peers:
         65100:
           - 10.0.1.112
@@ -382,13 +382,13 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA97T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64613
       peers:
         65100:
           - 10.0.1.128
@@ -401,13 +401,13 @@ configuration:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
     bp_interface:
-      ipv4: 10.10.246.194/24
+      ipv4: 10.10.246.194/22
       ipv6: fc0a::c2/64
   ARISTA105T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64614
       peers:
         65100:
           - 10.0.1.144
@@ -420,13 +420,13 @@ configuration:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
     bp_interface:
-      ipv4: 10.10.246.202/24
+      ipv4: 10.10.246.202/22
       ipv6: fc0a::ca/64
   ARISTA113T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64615
       peers:
         65100:
           - 10.0.1.160
@@ -439,13 +439,13 @@ configuration:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
     bp_interface:
-      ipv4: 10.10.246.210/24
+      ipv4: 10.10.246.210/22
       ipv6: fc0a::d2/64
   ARISTA121T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 64616
       peers:
         65100:
           - 10.0.1.176
@@ -458,13 +458,13 @@ configuration:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
     bp_interface:
-      ipv4: 10.10.246.218/24
+      ipv4: 10.10.246.218/22
       ipv6: fc0a::da/64
   ARISTA01PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65101
       peers:
         65100:
           - 10.0.2.0
@@ -477,13 +477,13 @@ configuration:
         ipv4: 10.0.2.1/31
         ipv6: fc00::402/126
     bp_interface:
-      ipv4: 10.10.247.2/24
+      ipv4: 10.10.247.2/22
       ipv6: fc0a::102/64
   ARISTA02PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65102
       peers:
         65100:
           - 10.0.2.2
@@ -496,5 +496,5 @@ configuration:
         ipv4: 10.0.2.3/31
         ipv6: fc00::406/126
     bp_interface:
-      ipv4: 10.10.247.3/24
+      ipv4: 10.10.247.3/22
       ipv6: fc0a::103/64

--- a/ansible/vars/topo_t0-isolated-d32u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-d32u32s2.yml
@@ -253,7 +253,7 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.246.66/24
+      ipv4: 10.10.246.66/22
       ipv6: fc0a::42/64
   ARISTA09T1:
     properties:
@@ -272,7 +272,7 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.246.74/24
+      ipv4: 10.10.246.74/22
       ipv6: fc0a::4a/64
   ARISTA17T1:
     properties:
@@ -291,7 +291,7 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.246.82/24
+      ipv4: 10.10.246.82/22
       ipv6: fc0a::52/64
   ARISTA25T1:
     properties:
@@ -310,7 +310,7 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.246.90/24
+      ipv4: 10.10.246.90/22
       ipv6: fc0a::5a/64
   ARISTA33T1:
     properties:
@@ -329,7 +329,7 @@ configuration:
         ipv4: 10.0.0.193/31
         ipv6: fc00::182/126
     bp_interface:
-      ipv4: 10.10.246.98/24
+      ipv4: 10.10.246.98/22
       ipv6: fc0a::62/64
   ARISTA41T1:
     properties:
@@ -348,7 +348,7 @@ configuration:
         ipv4: 10.0.0.209/31
         ipv6: fc00::1a2/126
     bp_interface:
-      ipv4: 10.10.246.106/24
+      ipv4: 10.10.246.106/22
       ipv6: fc0a::6a/64
   ARISTA49T1:
     properties:
@@ -367,7 +367,7 @@ configuration:
         ipv4: 10.0.0.225/31
         ipv6: fc00::1c2/126
     bp_interface:
-      ipv4: 10.10.246.114/24
+      ipv4: 10.10.246.114/22
       ipv6: fc0a::72/64
   ARISTA57T1:
     properties:
@@ -386,7 +386,7 @@ configuration:
         ipv4: 10.0.0.241/31
         ipv6: fc00::1e2/126
     bp_interface:
-      ipv4: 10.10.246.122/24
+      ipv4: 10.10.246.122/22
       ipv6: fc0a::7a/64
   ARISTA65T1:
     properties:
@@ -405,7 +405,7 @@ configuration:
         ipv4: 10.0.1.1/31
         ipv6: fc00::202/126
     bp_interface:
-      ipv4: 10.10.246.130/24
+      ipv4: 10.10.246.130/22
       ipv6: fc0a::82/64
   ARISTA73T1:
     properties:
@@ -424,7 +424,7 @@ configuration:
         ipv4: 10.0.1.17/31
         ipv6: fc00::222/126
     bp_interface:
-      ipv4: 10.10.246.138/24
+      ipv4: 10.10.246.138/22
       ipv6: fc0a::8a/64
   ARISTA81T1:
     properties:
@@ -443,7 +443,7 @@ configuration:
         ipv4: 10.0.1.33/31
         ipv6: fc00::242/126
     bp_interface:
-      ipv4: 10.10.246.146/24
+      ipv4: 10.10.246.146/22
       ipv6: fc0a::92/64
   ARISTA89T1:
     properties:
@@ -462,7 +462,7 @@ configuration:
         ipv4: 10.0.1.49/31
         ipv6: fc00::262/126
     bp_interface:
-      ipv4: 10.10.246.154/24
+      ipv4: 10.10.246.154/22
       ipv6: fc0a::9a/64
   ARISTA97T1:
     properties:
@@ -481,7 +481,7 @@ configuration:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
     bp_interface:
-      ipv4: 10.10.246.162/24
+      ipv4: 10.10.246.162/22
       ipv6: fc0a::a2/64
   ARISTA105T1:
     properties:
@@ -500,7 +500,7 @@ configuration:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
     bp_interface:
-      ipv4: 10.10.246.170/24
+      ipv4: 10.10.246.170/22
       ipv6: fc0a::aa/64
   ARISTA113T1:
     properties:
@@ -519,7 +519,7 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA121T1:
     properties:
@@ -538,7 +538,7 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA129T1:
     properties:
@@ -557,7 +557,7 @@ configuration:
         ipv4: 10.0.2.129/31
         ipv6: fc00::502/126
     bp_interface:
-      ipv4: 10.10.247.66/24
+      ipv4: 10.10.247.66/22
       ipv6: fc0a::142/64
   ARISTA137T1:
     properties:
@@ -576,7 +576,7 @@ configuration:
         ipv4: 10.0.2.145/31
         ipv6: fc00::522/126
     bp_interface:
-      ipv4: 10.10.247.74/24
+      ipv4: 10.10.247.74/22
       ipv6: fc0a::14a/64
   ARISTA145T1:
     properties:
@@ -595,7 +595,7 @@ configuration:
         ipv4: 10.0.2.161/31
         ipv6: fc00::542/126
     bp_interface:
-      ipv4: 10.10.247.82/24
+      ipv4: 10.10.247.82/22
       ipv6: fc0a::152/64
   ARISTA153T1:
     properties:
@@ -614,7 +614,7 @@ configuration:
         ipv4: 10.0.2.177/31
         ipv6: fc00::562/126
     bp_interface:
-      ipv4: 10.10.247.90/24
+      ipv4: 10.10.247.90/22
       ipv6: fc0a::15a/64
   ARISTA161T1:
     properties:
@@ -633,7 +633,7 @@ configuration:
         ipv4: 10.0.2.193/31
         ipv6: fc00::582/126
     bp_interface:
-      ipv4: 10.10.247.98/24
+      ipv4: 10.10.247.98/22
       ipv6: fc0a::162/64
   ARISTA169T1:
     properties:
@@ -652,7 +652,7 @@ configuration:
         ipv4: 10.0.2.209/31
         ipv6: fc00::5a2/126
     bp_interface:
-      ipv4: 10.10.247.106/24
+      ipv4: 10.10.247.106/22
       ipv6: fc0a::16a/64
   ARISTA177T1:
     properties:
@@ -671,7 +671,7 @@ configuration:
         ipv4: 10.0.2.225/31
         ipv6: fc00::5c2/126
     bp_interface:
-      ipv4: 10.10.247.114/24
+      ipv4: 10.10.247.114/22
       ipv6: fc0a::172/64
   ARISTA185T1:
     properties:
@@ -690,7 +690,7 @@ configuration:
         ipv4: 10.0.2.241/31
         ipv6: fc00::5e2/126
     bp_interface:
-      ipv4: 10.10.247.122/24
+      ipv4: 10.10.247.122/22
       ipv6: fc0a::17a/64
   ARISTA193T1:
     properties:
@@ -709,7 +709,7 @@ configuration:
         ipv4: 10.0.3.1/31
         ipv6: fc00::602/126
     bp_interface:
-      ipv4: 10.10.247.130/24
+      ipv4: 10.10.247.130/22
       ipv6: fc0a::182/64
   ARISTA201T1:
     properties:
@@ -728,7 +728,7 @@ configuration:
         ipv4: 10.0.3.17/31
         ipv6: fc00::622/126
     bp_interface:
-      ipv4: 10.10.247.138/24
+      ipv4: 10.10.247.138/22
       ipv6: fc0a::18a/64
   ARISTA209T1:
     properties:
@@ -747,7 +747,7 @@ configuration:
         ipv4: 10.0.3.33/31
         ipv6: fc00::642/126
     bp_interface:
-      ipv4: 10.10.247.146/24
+      ipv4: 10.10.247.146/22
       ipv6: fc0a::192/64
   ARISTA217T1:
     properties:
@@ -766,7 +766,7 @@ configuration:
         ipv4: 10.0.3.49/31
         ipv6: fc00::662/126
     bp_interface:
-      ipv4: 10.10.247.154/24
+      ipv4: 10.10.247.154/22
       ipv6: fc0a::19a/64
   ARISTA225T1:
     properties:
@@ -785,7 +785,7 @@ configuration:
         ipv4: 10.0.3.65/31
         ipv6: fc00::682/126
     bp_interface:
-      ipv4: 10.10.247.162/24
+      ipv4: 10.10.247.162/22
       ipv6: fc0a::1a2/64
   ARISTA233T1:
     properties:
@@ -804,7 +804,7 @@ configuration:
         ipv4: 10.0.3.81/31
         ipv6: fc00::6a2/126
     bp_interface:
-      ipv4: 10.10.247.170/24
+      ipv4: 10.10.247.170/22
       ipv6: fc0a::1aa/64
   ARISTA241T1:
     properties:
@@ -823,7 +823,7 @@ configuration:
         ipv4: 10.0.3.97/31
         ipv6: fc00::6c2/126
     bp_interface:
-      ipv4: 10.10.247.178/24
+      ipv4: 10.10.247.178/22
       ipv6: fc0a::1b2/64
   ARISTA249T1:
     properties:
@@ -842,7 +842,7 @@ configuration:
         ipv4: 10.0.3.113/31
         ipv6: fc00::6e2/126
     bp_interface:
-      ipv4: 10.10.247.186/24
+      ipv4: 10.10.247.186/22
       ipv6: fc0a::1ba/64
   ARISTA01PT0:
     properties:
@@ -861,7 +861,7 @@ configuration:
         ipv4: 10.0.4.1/31
         ipv6: fc00::802/126
     bp_interface:
-      ipv4: 10.10.248.2/24
+      ipv4: 10.10.248.2/22
       ipv6: fc0a::202/64
   ARISTA02PT0:
     properties:
@@ -880,5 +880,5 @@ configuration:
         ipv4: 10.0.4.3/31
         ipv6: fc00::806/126
     bp_interface:
-      ipv4: 10.10.248.3/24
+      ipv4: 10.10.248.3/22
       ipv6: fc0a::203/64

--- a/ansible/vars/topo_t1-isolated-d28u1.yml
+++ b/ansible/vars/topo_t1-isolated-d28u1.yml
@@ -153,7 +153,7 @@ configuration:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
     bp_interface:
-      ipv4: 10.10.246.2/24
+      ipv4: 10.10.246.2/22
       ipv6: fc0a::2/64
   ARISTA09T0:
     properties:
@@ -174,7 +174,7 @@ configuration:
         ipv4: 10.0.0.17/31
         ipv6: fc00::22/126
     bp_interface:
-      ipv4: 10.10.246.10/24
+      ipv4: 10.10.246.10/22
       ipv6: fc0a::a/64
   ARISTA17T0:
     properties:
@@ -195,7 +195,7 @@ configuration:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
     bp_interface:
-      ipv4: 10.10.246.18/24
+      ipv4: 10.10.246.18/22
       ipv6: fc0a::12/64
   ARISTA25T0:
     properties:
@@ -216,7 +216,7 @@ configuration:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
     bp_interface:
-      ipv4: 10.10.246.26/24
+      ipv4: 10.10.246.26/22
       ipv6: fc0a::1a/64
   ARISTA33T0:
     properties:
@@ -237,7 +237,7 @@ configuration:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
     bp_interface:
-      ipv4: 10.10.246.34/24
+      ipv4: 10.10.246.34/22
       ipv6: fc0a::22/64
   ARISTA41T0:
     properties:
@@ -258,14 +258,14 @@ configuration:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
     bp_interface:
-      ipv4: 10.10.246.42/24
+      ipv4: 10.10.246.42/22
       ipv6: fc0a::2a/64
   ARISTA01T2:
     properties:
     - common
     - spine
     bgp:
-      asn: 65200
+      asn: 65201
       peers:
         65100:
           - 10.0.0.96
@@ -278,7 +278,7 @@ configuration:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
     bp_interface:
-      ipv4: 10.10.246.50/24
+      ipv4: 10.10.246.50/22
       ipv6: fc0a::32/64
   ARISTA49T0:
     properties:
@@ -299,7 +299,7 @@ configuration:
         ipv4: 10.0.0.101/31
         ipv6: fc00::ca/126
     bp_interface:
-      ipv4: 10.10.246.52/24
+      ipv4: 10.10.246.52/22
       ipv6: fc0a::34/64
   ARISTA57T0:
     properties:
@@ -320,7 +320,7 @@ configuration:
         ipv4: 10.0.0.121/31
         ipv6: fc00::f2/126
     bp_interface:
-      ipv4: 10.10.246.62/24
+      ipv4: 10.10.246.62/22
       ipv6: fc0a::3e/64
   ARISTA65T0:
     properties:
@@ -341,7 +341,7 @@ configuration:
         ipv4: 10.0.0.137/31
         ipv6: fc00::112/126
     bp_interface:
-      ipv4: 10.10.246.70/24
+      ipv4: 10.10.246.70/22
       ipv6: fc0a::46/64
   ARISTA73T0:
     properties:
@@ -362,7 +362,7 @@ configuration:
         ipv4: 10.0.0.153/31
         ipv6: fc00::132/126
     bp_interface:
-      ipv4: 10.10.246.78/24
+      ipv4: 10.10.246.78/22
       ipv6: fc0a::4e/64
   ARISTA81T0:
     properties:
@@ -383,7 +383,7 @@ configuration:
         ipv4: 10.0.0.169/31
         ipv6: fc00::152/126
     bp_interface:
-      ipv4: 10.10.246.86/24
+      ipv4: 10.10.246.86/22
       ipv6: fc0a::56/64
   ARISTA89T0:
     properties:
@@ -404,7 +404,7 @@ configuration:
         ipv4: 10.0.0.185/31
         ipv6: fc00::172/126
     bp_interface:
-      ipv4: 10.10.246.94/24
+      ipv4: 10.10.246.94/22
       ipv6: fc0a::5e/64
   ARISTA97T0:
     properties:
@@ -425,7 +425,7 @@ configuration:
         ipv4: 10.0.0.201/31
         ipv6: fc00::192/126
     bp_interface:
-      ipv4: 10.10.246.102/24
+      ipv4: 10.10.246.102/22
       ipv6: fc0a::66/64
   ARISTA105T0:
     properties:
@@ -446,7 +446,7 @@ configuration:
         ipv4: 10.0.0.217/31
         ipv6: fc00::1b2/126
     bp_interface:
-      ipv4: 10.10.246.110/24
+      ipv4: 10.10.246.110/22
       ipv6: fc0a::6e/64
   ARISTA113T0:
     properties:
@@ -467,7 +467,7 @@ configuration:
         ipv4: 10.0.0.233/31
         ipv6: fc00::1d2/126
     bp_interface:
-      ipv4: 10.10.246.118/24
+      ipv4: 10.10.246.118/22
       ipv6: fc0a::76/64
   ARISTA121T0:
     properties:
@@ -488,7 +488,7 @@ configuration:
         ipv4: 10.0.0.249/31
         ipv6: fc00::1f2/126
     bp_interface:
-      ipv4: 10.10.246.126/24
+      ipv4: 10.10.246.126/22
       ipv6: fc0a::7e/64
   ARISTA129T0:
     properties:
@@ -509,7 +509,7 @@ configuration:
         ipv4: 10.0.1.9/31
         ipv6: fc00::212/126
     bp_interface:
-      ipv4: 10.10.246.134/24
+      ipv4: 10.10.246.134/22
       ipv6: fc0a::86/64
   ARISTA137T0:
     properties:
@@ -530,7 +530,7 @@ configuration:
         ipv4: 10.0.1.25/31
         ipv6: fc00::232/126
     bp_interface:
-      ipv4: 10.10.246.142/24
+      ipv4: 10.10.246.142/22
       ipv6: fc0a::8e/64
   ARISTA145T0:
     properties:
@@ -551,7 +551,7 @@ configuration:
         ipv4: 10.0.1.41/31
         ipv6: fc00::252/126
     bp_interface:
-      ipv4: 10.10.246.150/24
+      ipv4: 10.10.246.150/22
       ipv6: fc0a::96/64
   ARISTA153T0:
     properties:
@@ -572,7 +572,7 @@ configuration:
         ipv4: 10.0.1.57/31
         ipv6: fc00::272/126
     bp_interface:
-      ipv4: 10.10.246.158/24
+      ipv4: 10.10.246.158/22
       ipv6: fc0a::9e/64
   ARISTA161T0:
     properties:
@@ -593,7 +593,7 @@ configuration:
         ipv4: 10.0.1.77/31
         ipv6: fc00::29a/126
     bp_interface:
-      ipv4: 10.10.246.168/24
+      ipv4: 10.10.246.168/22
       ipv6: fc0a::a8/64
   ARISTA169T0:
     properties:
@@ -614,7 +614,7 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA177T0:
     properties:
@@ -635,7 +635,7 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA185T0:
     properties:
@@ -656,7 +656,7 @@ configuration:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
     bp_interface:
-      ipv4: 10.10.246.194/24
+      ipv4: 10.10.246.194/22
       ipv6: fc0a::c2/64
   ARISTA193T0:
     properties:
@@ -677,7 +677,7 @@ configuration:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
     bp_interface:
-      ipv4: 10.10.246.202/24
+      ipv4: 10.10.246.202/22
       ipv6: fc0a::ca/64
   ARISTA201T0:
     properties:
@@ -698,7 +698,7 @@ configuration:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
     bp_interface:
-      ipv4: 10.10.246.210/24
+      ipv4: 10.10.246.210/22
       ipv6: fc0a::d2/64
   ARISTA209T0:
     properties:
@@ -719,7 +719,7 @@ configuration:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
     bp_interface:
-      ipv4: 10.10.246.218/24
+      ipv4: 10.10.246.218/22
       ipv6: fc0a::da/64
   ARISTA217T0:
     properties:
@@ -740,5 +740,5 @@ configuration:
         ipv4: 10.0.1.193/31
         ipv6: fc00::382/126
     bp_interface:
-      ipv4: 10.10.246.226/24
+      ipv4: 10.10.246.226/22
       ipv6: fc0a::e2/64

--- a/ansible/vars/topo_t1-isolated-d56u2.yml
+++ b/ansible/vars/topo_t1-isolated-d56u2.yml
@@ -269,7 +269,7 @@ configuration:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
     bp_interface:
-      ipv4: 10.10.246.2/24
+      ipv4: 10.10.246.2/22
       ipv6: fc0a::2/64
   ARISTA09T0:
     properties:
@@ -290,7 +290,7 @@ configuration:
         ipv4: 10.0.0.17/31
         ipv6: fc00::22/126
     bp_interface:
-      ipv4: 10.10.246.10/24
+      ipv4: 10.10.246.10/22
       ipv6: fc0a::a/64
   ARISTA17T0:
     properties:
@@ -311,7 +311,7 @@ configuration:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
     bp_interface:
-      ipv4: 10.10.246.18/24
+      ipv4: 10.10.246.18/22
       ipv6: fc0a::12/64
   ARISTA25T0:
     properties:
@@ -332,7 +332,7 @@ configuration:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
     bp_interface:
-      ipv4: 10.10.246.26/24
+      ipv4: 10.10.246.26/22
       ipv6: fc0a::1a/64
   ARISTA33T0:
     properties:
@@ -353,7 +353,7 @@ configuration:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
     bp_interface:
-      ipv4: 10.10.246.34/24
+      ipv4: 10.10.246.34/22
       ipv6: fc0a::22/64
   ARISTA41T0:
     properties:
@@ -374,7 +374,7 @@ configuration:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
     bp_interface:
-      ipv4: 10.10.246.42/24
+      ipv4: 10.10.246.42/22
       ipv6: fc0a::2a/64
   ARISTA49T0:
     properties:
@@ -395,7 +395,7 @@ configuration:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
     bp_interface:
-      ipv4: 10.10.246.50/24
+      ipv4: 10.10.246.50/22
       ipv6: fc0a::32/64
   ARISTA57T0:
     properties:
@@ -416,7 +416,7 @@ configuration:
         ipv4: 10.0.0.113/31
         ipv6: fc00::e2/126
     bp_interface:
-      ipv4: 10.10.246.58/24
+      ipv4: 10.10.246.58/22
       ipv6: fc0a::3a/64
   ARISTA65T0:
     properties:
@@ -437,7 +437,7 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.246.66/24
+      ipv4: 10.10.246.66/22
       ipv6: fc0a::42/64
   ARISTA73T0:
     properties:
@@ -458,7 +458,7 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.246.74/24
+      ipv4: 10.10.246.74/22
       ipv6: fc0a::4a/64
   ARISTA81T0:
     properties:
@@ -479,7 +479,7 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.246.82/24
+      ipv4: 10.10.246.82/22
       ipv6: fc0a::52/64
   ARISTA89T0:
     properties:
@@ -500,7 +500,7 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.246.90/24
+      ipv4: 10.10.246.90/22
       ipv6: fc0a::5a/64
   ARISTA01T2:
     properties:
@@ -520,7 +520,7 @@ configuration:
         ipv4: 10.0.0.193/31
         ipv6: fc00::182/126
     bp_interface:
-      ipv4: 10.10.246.98/24
+      ipv4: 10.10.246.98/22
       ipv6: fc0a::62/64
   ARISTA03T2:
     properties:
@@ -540,7 +540,7 @@ configuration:
         ipv4: 10.0.0.197/31
         ipv6: fc00::18a/126
     bp_interface:
-      ipv4: 10.10.246.100/24
+      ipv4: 10.10.246.100/22
       ipv6: fc0a::64/64
   ARISTA97T0:
     properties:
@@ -561,7 +561,7 @@ configuration:
         ipv4: 10.0.0.201/31
         ipv6: fc00::192/126
     bp_interface:
-      ipv4: 10.10.246.102/24
+      ipv4: 10.10.246.102/22
       ipv6: fc0a::66/64
   ARISTA105T0:
     properties:
@@ -582,7 +582,7 @@ configuration:
         ipv4: 10.0.0.217/31
         ipv6: fc00::1b2/126
     bp_interface:
-      ipv4: 10.10.246.110/24
+      ipv4: 10.10.246.110/22
       ipv6: fc0a::6e/64
   ARISTA113T0:
     properties:
@@ -603,7 +603,7 @@ configuration:
         ipv4: 10.0.0.241/31
         ipv6: fc00::1e2/126
     bp_interface:
-      ipv4: 10.10.246.122/24
+      ipv4: 10.10.246.122/22
       ipv6: fc0a::7a/64
   ARISTA121T0:
     properties:
@@ -624,7 +624,7 @@ configuration:
         ipv4: 10.0.1.1/31
         ipv6: fc00::202/126
     bp_interface:
-      ipv4: 10.10.246.130/24
+      ipv4: 10.10.246.130/22
       ipv6: fc0a::82/64
   ARISTA129T0:
     properties:
@@ -645,7 +645,7 @@ configuration:
         ipv4: 10.0.1.17/31
         ipv6: fc00::222/126
     bp_interface:
-      ipv4: 10.10.246.138/24
+      ipv4: 10.10.246.138/22
       ipv6: fc0a::8a/64
   ARISTA137T0:
     properties:
@@ -666,7 +666,7 @@ configuration:
         ipv4: 10.0.1.33/31
         ipv6: fc00::242/126
     bp_interface:
-      ipv4: 10.10.246.146/24
+      ipv4: 10.10.246.146/22
       ipv6: fc0a::92/64
   ARISTA145T0:
     properties:
@@ -687,7 +687,7 @@ configuration:
         ipv4: 10.0.1.49/31
         ipv6: fc00::262/126
     bp_interface:
-      ipv4: 10.10.246.154/24
+      ipv4: 10.10.246.154/22
       ipv6: fc0a::9a/64
   ARISTA153T0:
     properties:
@@ -708,7 +708,7 @@ configuration:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
     bp_interface:
-      ipv4: 10.10.246.162/24
+      ipv4: 10.10.246.162/22
       ipv6: fc0a::a2/64
   ARISTA161T0:
     properties:
@@ -729,7 +729,7 @@ configuration:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
     bp_interface:
-      ipv4: 10.10.246.170/24
+      ipv4: 10.10.246.170/22
       ipv6: fc0a::aa/64
   ARISTA169T0:
     properties:
@@ -750,7 +750,7 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA177T0:
     properties:
@@ -771,7 +771,7 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA185T0:
     properties:
@@ -792,7 +792,7 @@ configuration:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
     bp_interface:
-      ipv4: 10.10.246.194/24
+      ipv4: 10.10.246.194/22
       ipv6: fc0a::c2/64
   ARISTA193T0:
     properties:
@@ -813,7 +813,7 @@ configuration:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
     bp_interface:
-      ipv4: 10.10.246.202/24
+      ipv4: 10.10.246.202/22
       ipv6: fc0a::ca/64
   ARISTA201T0:
     properties:
@@ -834,7 +834,7 @@ configuration:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
     bp_interface:
-      ipv4: 10.10.246.210/24
+      ipv4: 10.10.246.210/22
       ipv6: fc0a::d2/64
   ARISTA209T0:
     properties:
@@ -855,7 +855,7 @@ configuration:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
     bp_interface:
-      ipv4: 10.10.246.218/24
+      ipv4: 10.10.246.218/22
       ipv6: fc0a::da/64
   ARISTA217T0:
     properties:
@@ -876,7 +876,7 @@ configuration:
         ipv4: 10.0.1.193/31
         ipv6: fc00::382/126
     bp_interface:
-      ipv4: 10.10.246.226/24
+      ipv4: 10.10.246.226/22
       ipv6: fc0a::e2/64
   ARISTA225T0:
     properties:
@@ -897,7 +897,7 @@ configuration:
         ipv4: 10.0.1.209/31
         ipv6: fc00::3a2/126
     bp_interface:
-      ipv4: 10.10.246.234/24
+      ipv4: 10.10.246.234/22
       ipv6: fc0a::ea/64
   ARISTA233T0:
     properties:
@@ -918,7 +918,7 @@ configuration:
         ipv4: 10.0.1.225/31
         ipv6: fc00::3c2/126
     bp_interface:
-      ipv4: 10.10.246.242/24
+      ipv4: 10.10.246.242/22
       ipv6: fc0a::f2/64
   ARISTA241T0:
     properties:
@@ -939,7 +939,7 @@ configuration:
         ipv4: 10.0.1.241/31
         ipv6: fc00::3e2/126
     bp_interface:
-      ipv4: 10.10.246.250/24
+      ipv4: 10.10.246.250/22
       ipv6: fc0a::fa/64
   ARISTA249T0:
     properties:
@@ -960,7 +960,7 @@ configuration:
         ipv4: 10.0.2.1/31
         ipv6: fc00::402/126
     bp_interface:
-      ipv4: 10.10.247.2/24
+      ipv4: 10.10.247.2/22
       ipv6: fc0a::102/64
   ARISTA257T0:
     properties:
@@ -981,7 +981,7 @@ configuration:
         ipv4: 10.0.2.17/31
         ipv6: fc00::422/126
     bp_interface:
-      ipv4: 10.10.247.10/24
+      ipv4: 10.10.247.10/22
       ipv6: fc0a::10a/64
   ARISTA265T0:
     properties:
@@ -1002,7 +1002,7 @@ configuration:
         ipv4: 10.0.2.33/31
         ipv6: fc00::442/126
     bp_interface:
-      ipv4: 10.10.247.18/24
+      ipv4: 10.10.247.18/22
       ipv6: fc0a::112/64
   ARISTA273T0:
     properties:
@@ -1023,7 +1023,7 @@ configuration:
         ipv4: 10.0.2.49/31
         ipv6: fc00::462/126
     bp_interface:
-      ipv4: 10.10.247.26/24
+      ipv4: 10.10.247.26/22
       ipv6: fc0a::11a/64
   ARISTA281T0:
     properties:
@@ -1044,7 +1044,7 @@ configuration:
         ipv4: 10.0.2.65/31
         ipv6: fc00::482/126
     bp_interface:
-      ipv4: 10.10.247.34/24
+      ipv4: 10.10.247.34/22
       ipv6: fc0a::122/64
   ARISTA289T0:
     properties:
@@ -1065,7 +1065,7 @@ configuration:
         ipv4: 10.0.2.81/31
         ipv6: fc00::4a2/126
     bp_interface:
-      ipv4: 10.10.247.42/24
+      ipv4: 10.10.247.42/22
       ipv6: fc0a::12a/64
   ARISTA297T0:
     properties:
@@ -1086,7 +1086,7 @@ configuration:
         ipv4: 10.0.2.97/31
         ipv6: fc00::4c2/126
     bp_interface:
-      ipv4: 10.10.247.50/24
+      ipv4: 10.10.247.50/22
       ipv6: fc0a::132/64
   ARISTA305T0:
     properties:
@@ -1107,7 +1107,7 @@ configuration:
         ipv4: 10.0.2.113/31
         ipv6: fc00::4e2/126
     bp_interface:
-      ipv4: 10.10.247.58/24
+      ipv4: 10.10.247.58/22
       ipv6: fc0a::13a/64
   ARISTA313T0:
     properties:
@@ -1128,7 +1128,7 @@ configuration:
         ipv4: 10.0.2.129/31
         ipv6: fc00::502/126
     bp_interface:
-      ipv4: 10.10.247.66/24
+      ipv4: 10.10.247.66/22
       ipv6: fc0a::142/64
   ARISTA321T0:
     properties:
@@ -1149,7 +1149,7 @@ configuration:
         ipv4: 10.0.2.153/31
         ipv6: fc00::532/126
     bp_interface:
-      ipv4: 10.10.247.78/24
+      ipv4: 10.10.247.78/22
       ipv6: fc0a::14e/64
   ARISTA329T0:
     properties:
@@ -1170,7 +1170,7 @@ configuration:
         ipv4: 10.0.2.169/31
         ipv6: fc00::552/126
     bp_interface:
-      ipv4: 10.10.247.86/24
+      ipv4: 10.10.247.86/22
       ipv6: fc0a::156/64
   ARISTA337T0:
     properties:
@@ -1191,7 +1191,7 @@ configuration:
         ipv4: 10.0.2.193/31
         ipv6: fc00::582/126
     bp_interface:
-      ipv4: 10.10.247.98/24
+      ipv4: 10.10.247.98/22
       ipv6: fc0a::162/64
   ARISTA345T0:
     properties:
@@ -1212,7 +1212,7 @@ configuration:
         ipv4: 10.0.2.209/31
         ipv6: fc00::5a2/126
     bp_interface:
-      ipv4: 10.10.247.106/24
+      ipv4: 10.10.247.106/22
       ipv6: fc0a::16a/64
   ARISTA353T0:
     properties:
@@ -1233,7 +1233,7 @@ configuration:
         ipv4: 10.0.2.225/31
         ipv6: fc00::5c2/126
     bp_interface:
-      ipv4: 10.10.247.114/24
+      ipv4: 10.10.247.114/22
       ipv6: fc0a::172/64
   ARISTA361T0:
     properties:
@@ -1254,7 +1254,7 @@ configuration:
         ipv4: 10.0.2.241/31
         ipv6: fc00::5e2/126
     bp_interface:
-      ipv4: 10.10.247.122/24
+      ipv4: 10.10.247.122/22
       ipv6: fc0a::17a/64
   ARISTA369T0:
     properties:
@@ -1275,7 +1275,7 @@ configuration:
         ipv4: 10.0.3.1/31
         ipv6: fc00::602/126
     bp_interface:
-      ipv4: 10.10.247.130/24
+      ipv4: 10.10.247.130/22
       ipv6: fc0a::182/64
   ARISTA377T0:
     properties:
@@ -1296,7 +1296,7 @@ configuration:
         ipv4: 10.0.3.17/31
         ipv6: fc00::622/126
     bp_interface:
-      ipv4: 10.10.247.138/24
+      ipv4: 10.10.247.138/22
       ipv6: fc0a::18a/64
   ARISTA385T0:
     properties:
@@ -1317,7 +1317,7 @@ configuration:
         ipv4: 10.0.3.33/31
         ipv6: fc00::642/126
     bp_interface:
-      ipv4: 10.10.247.146/24
+      ipv4: 10.10.247.146/22
       ipv6: fc0a::192/64
   ARISTA393T0:
     properties:
@@ -1338,7 +1338,7 @@ configuration:
         ipv4: 10.0.3.49/31
         ipv6: fc00::662/126
     bp_interface:
-      ipv4: 10.10.247.154/24
+      ipv4: 10.10.247.154/22
       ipv6: fc0a::19a/64
   ARISTA401T0:
     properties:
@@ -1359,7 +1359,7 @@ configuration:
         ipv4: 10.0.3.65/31
         ipv6: fc00::682/126
     bp_interface:
-      ipv4: 10.10.247.162/24
+      ipv4: 10.10.247.162/22
       ipv6: fc0a::1a2/64
   ARISTA409T0:
     properties:
@@ -1380,7 +1380,7 @@ configuration:
         ipv4: 10.0.3.81/31
         ipv6: fc00::6a2/126
     bp_interface:
-      ipv4: 10.10.247.170/24
+      ipv4: 10.10.247.170/22
       ipv6: fc0a::1aa/64
   ARISTA417T0:
     properties:
@@ -1401,7 +1401,7 @@ configuration:
         ipv4: 10.0.3.97/31
         ipv6: fc00::6c2/126
     bp_interface:
-      ipv4: 10.10.247.178/24
+      ipv4: 10.10.247.178/22
       ipv6: fc0a::1b2/64
   ARISTA425T0:
     properties:
@@ -1422,7 +1422,7 @@ configuration:
         ipv4: 10.0.3.113/31
         ipv6: fc00::6e2/126
     bp_interface:
-      ipv4: 10.10.247.186/24
+      ipv4: 10.10.247.186/22
       ipv6: fc0a::1ba/64
   ARISTA433T0:
     properties:
@@ -1443,7 +1443,7 @@ configuration:
         ipv4: 10.0.3.129/31
         ipv6: fc00::702/126
     bp_interface:
-      ipv4: 10.10.247.194/24
+      ipv4: 10.10.247.194/22
       ipv6: fc0a::1c2/64
   ARISTA441T0:
     properties:
@@ -1464,5 +1464,5 @@ configuration:
         ipv4: 10.0.3.145/31
         ipv6: fc00::722/126
     bp_interface:
-      ipv4: 10.10.247.202/24
+      ipv4: 10.10.247.202/22
       ipv6: fc0a::1ca/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18056 by expanding the ptf subnet from /24 to /22 to accommodate up to 1024 exabgp neighbor IPs

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested in physical testbed with existing t0 topo.  https://elastictest.org/scheduler/testplan/681c5af9750afedc7f448247

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
