### PR TITLE
[port error] Add the ability to run test on the testbed with partially connected optical cables

### DIFF
--- a/tests/layer1/test_port_error.py
+++ b/tests/layer1/test_port_error.py
@@ -5,6 +5,7 @@ import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
+from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
@@ -44,23 +45,29 @@ class TestMACFault(object):
     def get_interface_status(dut, interface):
         return dut.show_and_parse("show interfaces status {}".format(interface))[0].get("oper", "unknown")
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def select_random_interfaces(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         dut = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-        interfaces = list(dut.show_and_parse("show interfaces status"))
 
         sfp_presence = dut.command(cmd_sfp_presence)
         parsed_presence = {line.split()[0]: line.split()[1] for line in sfp_presence["stdout_lines"][2:]}
 
-        available_interfaces = [
-            intf["interface"] for intf in interfaces
-            if parsed_presence.get(intf["interface"]) == "Present"
-        ]
+        eeprom_infos = dut.command("sudo sfputil show eeprom -d")['stdout']
+        eeprom_infos = parse_sfp_eeprom_infos(eeprom_infos)
 
-        pytest_assert(available_interfaces, "No interfaces with SFP detected. Cannot proceed with tests.")
+        available_optical_interfaces = []
+        for port_name, eeprom_info in eeprom_infos.items():
+            if parsed_presence.get(port_name) == "Present" and \
+                    "SFP EEPROM detected" in eeprom_info[port_name] \
+                    and "COPPER" not in eeprom_info["Media Interface Code"].upper():
+                available_optical_interfaces.append(port_name)
+
+        pytest_assert(available_optical_interfaces, "No interfaces with SFP detected. Cannot proceed with tests.")
+        logging.info("Available Optical interfaces for tests: {}".format(available_optical_interfaces))
 
         # Select 5 random interfaces (or fewer if not enough available)
-        selected_interfaces = random.sample(available_interfaces, min(5, len(available_interfaces)))
+        selected_interfaces = random.sample(available_optical_interfaces, min(5, len(available_optical_interfaces)))
+        logging.info("Selected interfaces for tests: {}".format(selected_interfaces))
 
         return dut, selected_interfaces
 
@@ -77,19 +84,21 @@ class TestMACFault(object):
             dut.shell("sudo sfputil debug rx-output {} disable".format(interface))
             time.sleep(5)
             pytest_assert(self.get_interface_status(dut, interface) == "down",
-                          "Interface {} did not go down after disabling rx-output using sfputil".format(interface))
+                          "Interface {iface} did not go down after 'sudo sfputil debug rx-output {iface} disable'"
+                          .format(iface=interface))
 
             dut.shell("sudo sfputil debug rx-output {} enable".format(interface))
             time.sleep(20)
             pytest_assert(self.get_interface_status(dut, interface) == "up",
-                          "Interface {} did not come up after enabling rx-output using sfputil".format(interface))
+                          "Interface {iface} did not come up after 'sudo sfputil debug rx-output {iface} enable'"
+                          .format(iface=interface))
 
             local_fault_after = self.get_mac_fault_count(dut, interface, "mac local fault")
             logging.info("MAC local fault count after disabling/enabling rx-output using sfputil {}: {}".format(
                 interface, local_fault_after))
 
             pytest_assert(local_fault_after > local_fault_before,
-                          "MAC local fault count did not increment after disabling/enabling tx-output on the device")
+                          "MAC local fault count did not increment after disabling/enabling rx-output on the device")
 
     def test_mac_remote_fault_increment(self, select_random_interfaces):
         dut, interfaces = select_random_interfaces
@@ -104,16 +113,18 @@ class TestMACFault(object):
             dut.shell("sudo sfputil debug tx-output {} disable".format(interface))
             time.sleep(5)
             pytest_assert(self.get_interface_status(dut, interface) == "down",
-                          "Interface {} did not go down after disabling rx-output using sfputil".format(interface))
+                          "Interface {iface} did not go down after 'sudo sfputil debug tx-output {iface} disable'"
+                          .format(iface=interface))
 
             dut.shell("sudo sfputil debug tx-output {} enable".format(interface))
             time.sleep(20)
 
             pytest_assert(self.get_interface_status(dut, interface) == "up",
-                          "Interface {} did not come up after disabling tx-output using sfputil".format(interface))
+                          "Interface {iface} did not come up after 'sudo sfputil debug tx-output {iface} enable'"
+                          .format(iface=interface))
 
             remote_fault_after = self.get_mac_fault_count(dut, interface, "mac remote fault")
-            logging.info("MAC remote fault count after disabling/enabling rx-output using sfputil {}: {}".format(
+            logging.info("MAC remote fault count after disabling/enabling tx-output using sfputil {}: {}".format(
                 interface, remote_fault_after))
 
             pytest_assert(remote_fault_after > remote_fault_before,


### PR DESCRIPTION
… optic cables

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test changes:

- Before: Selected ports for tests can be with any cables.

- Now: Selected ports with optical cables



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add the ability to run the test on different testbeds


#### How did you verify/test it?
Test executed and passed


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
