### PR TITLE
[Snappi] Skip warm and fast reboots for Nokia devices.

### DIFF
--- a/tests/common/nokia_data.py
+++ b/tests/common/nokia_data.py
@@ -1,0 +1,2 @@
+def is_nokia_device(dut):
+    return ('nokia' in dut.facts["hwsku"].lower())

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -6,6 +6,7 @@ from itertools import cycle
 from tests.common.broadcom_data import is_broadcom_device
 from tests.common.helpers.assertions import pytest_require
 from tests.common.cisco_data import is_cisco_device
+from tests.common.nokia_data import is_nokia_device
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.common.config_reload import config_reload
 from tests.common.reboot import reboot
@@ -33,6 +34,8 @@ def skip_warm_reboot(duthost, reboot_type):
     asic_type = duthost.get_asic_name()
     reboot_case_supported = True
     if (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
+        reboot_case_supported = False
+    elif (reboot_type == "warm" or reboot_type == "fast") and is_nokia_device(duthost):
         reboot_case_supported = False
     elif is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type:
         reboot_case_supported = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18180 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Nokia platforms do not support warm and fast reboots. The warm and fast reboots are part of two testcases:
tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py

These testcases have warm, cold and fast reboots parameterized. However, Nokia platforms do not support warm and fast reboots and hence need to skipped.

@vmittal-msft, @rawal01 , @sdszhang for viz

#### How did you do it?
Create a file called nokia_data.py which looks for hardware SKU contains NOKIA or not.

In snappi_tests/files/helper.py, the function skip_warm_reboot, then calls this function. If reboot_type is either warm or fast, and hardware SKU contains Nokia, then reboot_type is skipped.

#### How did you verify/test it?
T0/T1 verification:
```
AzDevOps@sonic_mgmt_nokia_202411:/data/sonic-mgmt/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern ixr-aaa-14 --testbed ixr-aaa-14-t2 --testbed_file ../ansible/testbed.csv --log-cli-level info --log-file-level info --kube_master unset --showlocals -ra --show-capture stdout --junit-xml=/tmp/p.xml --skip_sanity --log-file=/tmp/p.log --cache-clear --topology tgen snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py -k reboot
Fri May  2 19:02:59 UTC 2025
---------- curtailed output ----------------
19:03:37 helper.skip_warm_reboot                  L0048 INFO   | Reboot type warm is not supported on broadcom switches
SKIPPED (Reboot type warm is not supported on broadcom switches) 
---------- curtailed output ----------------
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-ixr-aaa-14|3] 
--------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------
19:10:28 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture reboot_duts_and_disable_wd setup ends --------------------
19:10:28 __init__.pytest_runtest_setup            L0034 INFO   | collect memory before test test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-ixr-aaa-14|3]
19:10:28 __init__.pytest_runtest_setup            L0054 INFO   | Before test: collected memory_values {'before_test': {}, 'after_test': {}}
---------- curtailed output ----------------
PASSED                                                                                                                                                                                                          [ 16%]
-------------------------------------------------------------------------------------------------- live log teardown --------------------------------------------------------------------------------------------------
19:16:15 __init__.pytest_runtest_teardown         L0066 INFO   | collect memory after test test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-ixr-aaa-14|3]
19:16:15 __init__.pytest_runtest_teardown         L0089 INFO   | After test: collected memory_values {'before_test': {}, 'after_test': {}}
19:16:15 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture reboot_duts_and_disable_wd teardown starts --------------------
19:16:22 config_reload.config_reload              L0145 INFO   | reloading config_db
19:20:47 processes_utils.wait_critical_processes  L0078 INFO   | Wait until all critical processes are healthy in 600 sec
19:20:47 processes_utils._all_critical_processes_ L0045 INFO   | Check critical processes status
19:20:55 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture reboot_duts_and_disable_wd teardown ends --------------------
19:20:55 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture setup_ports_and_dut teardown starts --------------------
19:20:56 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture setup_ports_and_dut teardown ends --------------------
19:20:56 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture number_of_tx_rx_ports teardown starts --------------------
19:20:56 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture number_of_tx_rx_ports teardown ends --------------------
19:20:56 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture multidut_port_info teardown starts --------------------
19:20:56 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture multidut_port_info teardown ends --------------------
19:20:56 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture ignore_route_check_for_cisco_8000 teardown starts --------------------
19:20:56 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture ignore_route_check_for_cisco_8000 teardown ends --------------------

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-fast-ixr-aaa-14|3] 
--------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------
19:20:58 helper.skip_warm_reboot                  L0048 INFO   | Reboot type fast is not supported on broadcom switches
SKIPPED (Reboot type fast is not supported on broadcom switches)                                                                                                            
---------- curtailed output ----------------
=============================================================================================== short test summary info ===============================================================================================
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:202: Reboot type warm is not supported on broadcom switches
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:202: Reboot type fast is not supported on broadcom switches
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:261: Reboot type warm is not supported on broadcom switches
SKIPPED [2] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:261: Reboot type fast is not supported on broadcom switches
======================================================================== 4 passed, 8 skipped, 10 deselected, 12 warnings in 3941.64s (1:05:41) ========================================================================
AzDevOps@sonic_mgmt_nokia_202411:/data/sonic-mgmt/tests$ 
```

T2 verification:
```
AzDevOps@7c3002ea4994:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern board73,board74 --testbed chassis17-t2 --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --junit-xml=/tmp/pfc/p.xml --skip_sanity --log-file=/tmp/pfc/p.log snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py -k reboot --pdb
Sat May  3 15:06:45 UTC 2025
---------- curtailed output ----------------
15:07:41 helper.skip_warm_reboot                  L0052 INFO   | Reboot type warm is not supported on broadcom switches
SKIPPED (Reboot type warm is not supported on broadcom switches)                                                                                              
---------- curtailed output ----------------
15:29:57 helper.skip_warm_reboot                  L0052 INFO   | Reboot type fast is not supported on broadcom switches
SKIPPED (Reboot type fast is not supported on broadcom switches) 

---------- curtailed output ----------------
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info1-cold-board71|4] 
--------------------------------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------------------------------
15:30:13 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
15:30:13 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
15:30:13 __init__.loganalyzer                     L0067 INFO   | Log analyzer is disabled
---------- curtailed output ----------------
15:30:19 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture setup_ports_and_dut setup ends --------------------
15:30:19 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture reboot_duts_and_disable_wd setup starts --------------------
15:30:19 sonic.get_asic_name                      L1778 INFO   | asic: unknown
15:30:19 helper.skip_warm_reboot                  L0052 INFO   | Reboot type cold is  supported on broadcom switches
15:30:20 sonic.get_asic_name                      L1778 INFO   | asic: unknown
15:30:20 helper.skip_warm_reboot                  L0052 INFO   | Reboot type cold is  supported on broadcom switches
15:30:22 helper.save_config_and_reboot            L0411 INFO   | Issuing a cold reboot on the dut board73
15:30:22 helper.save_config_and_reboot            L0411 INFO   | Issuing a cold reboot on the dut board74
---------- curtailed output ----------------
=============================================================================================== short test summary info ===============================================================================================
SKIPPED [4] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:203: Reboot type warm is not supported on broadcom switches
SKIPPED [4] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:203: Reboot type fast is not supported on broadcom switches
SKIPPED [4] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:262: Reboot type warm is not supported on broadcom switches
SKIPPED [4] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:262: Reboot type fast is not supported on broadcom switches
======================================================================= 8 passed, 16 skipped, 20 deselected, 71 warnings in 10050.95s (2:47:30) =======================================================================
INFO:root:Can not get Allure report URL. Please check logs
```

#### Any platform specific information?
Only Nokia platform specific changes.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
