### PR TITLE
Add restore_image fixture to test_multi_hop_upgrade_path

### DIFF
--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -17,4 +17,5 @@ def upgrade_path_lists(request):
     from_list = request.config.getoption('base_image_list')
     to_list = request.config.getoption('target_image_list')
     restore_to_image = request.config.getoption('restore_to_image')
-    return upgrade_type, from_list, to_list, restore_to_image
+    enable_cpa = request.config.getoption('enable_cpa')
+    return upgrade_type, from_list, to_list, restore_to_image, enable_cpa

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -9,7 +9,7 @@ from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import check_neighbors, \
     multihop_advanceboot_loganalyzer_factory, verify_dut_health, advanceboot_neighbor_restore           # noqa F401
 from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, check_copp_config, check_reboot_cause, \
-    check_services, install_sonic, multi_hop_warm_upgrade_test_helper
+    check_services, install_sonic, multi_hop_warm_upgrade_test_helper, restore_image                    # noqa F401
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db                            # noqa F401
 from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa F401
@@ -40,7 +40,7 @@ def pytest_generate_tests(metafunc):
 
 def test_multi_hop_upgrade_path(localhost, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, request,
                                 get_advanced_reboot, multihop_advanceboot_loganalyzer_factory,  # noqa F811
-                                verify_dut_health, consistency_checker_provider):               # noqa F811
+                                verify_dut_health, consistency_checker_provider, restore_image):               # noqa F811
     duthost = duthosts[rand_one_dut_hostname]
     multi_hop_upgrade_path = request.config.getoption('multi_hop_upgrade_path')
     upgrade_type = request.config.getoption('upgrade_type')
@@ -96,7 +96,7 @@ def test_multi_hop_warm_upgrade_sad_path(localhost, duthosts, rand_one_dut_hostn
                                          get_advanced_reboot, multihop_advanceboot_loganalyzer_factory, # noqa F811
                                          verify_dut_health, nbrhosts, fanouthosts, vmhost,              # noqa F811
                                          backup_and_restore_config_db, advanceboot_neighbor_restore,    # noqa F811
-                                         sad_case_type):
+                                         sad_case_type, restore_image):                                 # noqa F811
 
     duthost = duthosts[rand_one_dut_hostname]
     multi_hop_upgrade_path = request.config.getoption('multi_hop_upgrade_path')


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
test_multi_hop_upgrade_path should be consistent with test_upgrade_path in allowing for test to restore device back to a given image.

#### How did you do it?

#### How did you verify/test it?
Tested on arista testbed: device is restored back to given image after test completes

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
