### PR TITLE
[wol] increase acceptable error margin on time

### DIFF
--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -96,7 +96,7 @@ def verify_packet_any(ptfadapter, verifier, ports, count=1, interval=None, devic
             ts.extend(map(lambda result: result.time, results))
         ts = sorted(ts)
         ts_diff = [ts[i] - ts[i - 1] for i in range(1, len(ts))]
-        pytest_assert(all(map(lambda diff: abs(diff * 1000 - interval) < 5, ts_diff)),
+        pytest_assert(all(map(lambda diff: abs(diff * 1000 - interval) < 100, ts_diff)),
                       "Unexpected interval {}".format(ts_diff))
 
 

--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -19,7 +19,7 @@ DEFAULT_PORT = 9
 DEFAULT_IP = "255.255.255.255"
 VLAN_MEMBER_CHANGE_ERR = r".*Failed to get port by bridge port ID .*"
 TAC_CONNECTION_ERR = r".*audisp-tacplus: tac_connect_single: connection failed with .* is not connected"
-ERR_MARGIN = 100
+ERR_MARGIN = 100  # millisecond
 
 
 def p2b(password: str) -> bytes:

--- a/tests/wol/test_wol.py
+++ b/tests/wol/test_wol.py
@@ -19,6 +19,7 @@ DEFAULT_PORT = 9
 DEFAULT_IP = "255.255.255.255"
 VLAN_MEMBER_CHANGE_ERR = r".*Failed to get port by bridge port ID .*"
 TAC_CONNECTION_ERR = r".*audisp-tacplus: tac_connect_single: connection failed with .* is not connected"
+ERR_MARGIN = 100
 
 
 def p2b(password: str) -> bytes:
@@ -79,7 +80,7 @@ def verify_packets(ptfadapter, verifier, ports, count=1, interval=None, device_n
         for results in received_pkts.values():
             ts = list(map(lambda result: result.time, results))
             ts_diff = [ts[i] - ts[i - 1] for i in range(1, len(ts))]
-            pytest_assert(all(map(lambda diff: abs(diff * 1000 - interval) < 100, ts_diff)),
+            pytest_assert(all(map(lambda diff: abs(diff * 1000 - interval) < ERR_MARGIN, ts_diff)),
                           "Unexpected interval {}".format(ts_diff))
 
 
@@ -96,7 +97,7 @@ def verify_packet_any(ptfadapter, verifier, ports, count=1, interval=None, devic
             ts.extend(map(lambda result: result.time, results))
         ts = sorted(ts)
         ts_diff = [ts[i] - ts[i - 1] for i in range(1, len(ts))]
-        pytest_assert(all(map(lambda diff: abs(diff * 1000 - interval) < 100, ts_diff)),
+        pytest_assert(all(map(lambda diff: abs(diff * 1000 - interval) < ERR_MARGIN, ts_diff)),
                       "Unexpected interval {}".format(ts_diff))
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Currently test allows very little difference in the time to receive packets, which create many false errors. Increase the error margin to reduce those.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Current error margin is too small

#### How did you do it?
Increase error margin

#### How did you verify/test it?
Run wol test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
