### PR TITLE
[TACACS] Fix auditd TACACS config re-init check failed issue.

### DIFF
--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -4,7 +4,7 @@ import pytest
 from tests.common.devices.ptf import PTFHost
 from tests.common.helpers.tacacs.tacacs_helper import stop_tacacs_server, start_tacacs_server, \
     per_command_accounting_skip_versions, remove_all_tacacs_server, check_tacacs  # noqa: F401
-from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_line_count, \
+from .utils import check_server_received, change_and_wait_aaa_config_update, get_auditd_config_reload_timestamp, \
     ensure_tacacs_server_running_after_ut, ssh_connect_remote_retry, ssh_run_command, cleanup_tacacs_log  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import skip_release
@@ -251,7 +251,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
     # when tacacs config change multiple time in short time
     # auditd service may been request reload during reloading
     # when this happen, auditd will ignore request and only reload once
-    last_line_count = get_auditd_config_reload_line_count(duthost)
+    last_timestamp = get_auditd_config_reload_timestamp(duthost)
 
     duthost.shell("sudo config tacacs timeout 1")
     remove_all_tacacs_server(duthost)
@@ -259,7 +259,7 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
     duthost.shell("sudo config tacacs add %s --port 59" % tacacs_server_ip)
     change_and_wait_aaa_config_update(duthost,
                                       "sudo config aaa accounting tacacs+",
-                                      last_line_count)
+                                      last_timestamp)
 
     cleanup_tacacs_log(ptfhost, rw_user_client)
 

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -80,7 +80,7 @@ def change_and_wait_aaa_config_update(duthost, command, last_timestamp=None, tim
     if not last_timestamp:
         last_timestamp = get_auditd_config_reload_timestamp(duthost)
 
-    # Wait 2 seconds to make sure auditd config re-init time stamp dupe with last timestamp:
+    # Wait 2 seconds to make sure auditd config re-init time stamp not dupe with last timestamp:
     #     https://github.com/sonic-net/sonic-mgmt/issues/16709
     time.sleep(2)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[TACACS] Fix auditd TACACS config re-init check failed issue.

##### Work item tracking
- Microsoft ADO: 32621325

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [] 202411

### Approach
#### What is the motivation for this PR?
TACACS test case failed because change_and_wait_aaa_config_update failed

The issue introduced by [this PR](https://github.com/sonic-net/sonic-mgmt/pull/16723/files) when fix bug https://github.com/sonic-net/sonic-mgmt/issues/16709

The code in PR #16723 check timestamp count, however there is a case some older log will lost in the "sudo journalctl -u auditd --boot --no-pager" command, which will cause older log count bigger than newer log count.

#### How did you do it?
Add a 2seconds delay before change AAA config, so the latest config re-init timestamp will not have same timestamp with last one.

#### How did you verify/test it?
Pass all test case

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
