### PR TITLE
chore: fix parameterise mixed speed

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
+++ b/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
@@ -71,7 +71,7 @@ def test_mixed_speed_diff_dist_over(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in MIXED_SPEED_PORT_INFO[MULTIDUT_TESTBED].items():
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = port_map[0]
         rx_port_count = port_map[2]
         snappi_port_list = get_snappi_ports
@@ -208,7 +208,7 @@ def test_mixed_speed_uni_dist_over(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in MIXED_SPEED_PORT_INFO[MULTIDUT_TESTBED].items():
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = port_map[0]
         rx_port_count = port_map[2]
         snappi_port_list = get_snappi_ports
@@ -341,7 +341,7 @@ def test_mixed_speed_no_congestion(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in MIXED_SPEED_PORT_INFO[MULTIDUT_TESTBED].items():
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = port_map[0]
         rx_port_count = port_map[2]
         snappi_port_list = get_snappi_ports

--- a/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
@@ -71,7 +71,7 @@ def test_mixed_speed_pfcwd_enable(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in MIXED_SPEED_PORT_INFO[MULTIDUT_TESTBED].items():
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = port_map[0]
         rx_port_count = port_map[2]
         snappi_port_list = get_snappi_ports
@@ -205,7 +205,7 @@ def test_mixed_speed_pfcwd_disable(snappi_api,                   # noqa: F811
     # With imix flag set, the traffic_generation.py uses IMIX profile.
     pkt_size = 1024
 
-    for testbed_subtype, rdma_ports in MIXED_SPEED_PORT_INFO[MULTIDUT_TESTBED].items():
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
         tx_port_count = port_map[0]
         rx_port_count = port_map[2]
         snappi_port_list = get_snappi_ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some of the mixed speed test should use multidut_port_info, otherwise it will not be parameterised properly

Fixes # (issue) 32678097

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
