### PR TITLE
Update test_caclmgrd_syslog case to make it work at dualtor setup

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -2,6 +2,7 @@ import ipaddress
 import json
 import logging
 import pytest
+import re
 
 from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
@@ -1307,5 +1308,6 @@ def test_caclmgrd_syslog(duthosts, enum_rand_one_per_hwsku_hostname,):
     pytest_assert("iptables -P INPUT ACCEPT" in syslog_output,
                   "Syslog does not contain 'iptables -P INPUT ACCEPT' after restarting caclmgrd")
     systemctl_output = duthost.command("sudo systemctl status caclmgrd")["stdout"]
-    pytest_assert("iptables -A INPUT" in systemctl_output,
-                  "iptables rules are not applied after restarting caclmgrd")
+    match = re.search(r'(caclmgrd.*?iptables)', systemctl_output)
+    mux_match = re.search(r'(caclmgrd.*?mux)', systemctl_output)
+    pytest_assert(match or mux_match, "iptables rules are not applied after restarting caclmgrd")


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update test_caclmgrd_syslog case to make it work at dualtor setup 
At dualtor setup there would be "iptables -t nat -A POSTROUTING" instead of "iptables -A INPUT"

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Make the case test_caclmgrd_syslog pass at dualtor setup
#### How did you do it?
Enhance the cacl match pattern
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
