### PR TITLE
Update default COPP swap syncd value to True

### DIFF
--- a/tests/copp/conftest.py
+++ b/tests/copp/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from tests.common import constants
+from tests.common.utilities import str2bool
 
 """
     Pytest configuration used by the COPP tests.
@@ -13,7 +14,8 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--copp_swap_syncd",
-        action="store_true",
+        action="store",
+        type=str2bool,
         default=True,
         help="Swap syncd container with syncd-rpc container",
     )

--- a/tests/copp/conftest.py
+++ b/tests/copp/conftest.py
@@ -14,7 +14,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--copp_swap_syncd",
         action="store_true",
-        default=False,
+        default=True,
         help="Swap syncd container with syncd-rpc container",
     )
     parser.addoption(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The QOS “--qos_swap_syncd” action defaults to True and uses a str2bool parser: https://github.com/sonic-net/sonic-mgmt/blob/19c4ff080d2dc8383774496f86da1f86509e0010/tests/conftest.py#L114
Change --copp_swap_syncd to have the same usage. 

Test cases pass internally on Cisco-8000 dualtor-aa only if the COPP flag defaults to true. While the flag could also be explicitly provided, running the tests in a group results in an undefined flag error for non-copp since it is only locally defined. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
- Validated all COPP tests pass on dualtor-aa with no flags passed. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
