### PR TITLE
Use ip link instead of ifconfig to speed up

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -493,12 +493,14 @@ class VMTopology(object):
     def get_vm_bridges(self, vmname):
         brs = []
         vm_bridge_regx = OVS_FP_BRIDGE_REGEX % vmname
+        # Use ip link instead of ifconfig to speed up
         out = VMTopology.cmd(
-            'ifconfig -a', grep_cmd='grep -E %s' % vm_bridge_regx, retry=3)
+            'ip link', grep_cmd='grep -E %s' % vm_bridge_regx, retry=3)
         for row in out.split('\n'):
             fields = row.split(':')
-            if len(fields) > 0:
-                brs.append(fields[0])
+            logging.info('=== Found bridge %s ===' % fields)
+            if len(fields) >= 2:
+                brs.append(fields[1].strip())
 
         return brs
 

--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -498,7 +498,6 @@ class VMTopology(object):
             'ip link', grep_cmd='grep -E %s' % vm_bridge_regx, retry=3)
         for row in out.split('\n'):
             fields = row.split(':')
-            logging.info('=== Found bridge %s ===' % fields)
             if len(fields) >= 2:
                 brs.append(fields[1].strip())
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to use `ip link` instead of `ifconfig -a` to speed up `add-topo`.

**Time cost of `ifconfig -a`** - Around 10 seconds
```
$ /usr/bin/time ifconfig -a | grep -E br-VM41177-[0-9]+ 
br-VM41177-0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
br-VM41177-1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
br-VM41177-2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
br-VM41177-3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
3.52user 6.17system 0:09.77elapsed 99%CPU (0avgtext+0avgdata 6100maxresident)k
0inputs+0outputs (0major+1028minor)pagefaults 0swaps
```

**Time cost of `ip link`** - Less than 1 second
```
/usr/bin/time ip link | grep -E br-VM41177-[0-9]+
74966: br-VM41177-0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9216 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
74967: br-VM41177-1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9216 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
74968: br-VM41177-2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9216 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
74969: br-VM41177-3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9216 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
0.01user 0.06system 0:00.07elapsed 98%CPU (0avgtext+0avgdata 6500maxresident)k
0inputs+0outputs (0major+1062minor)pagefaults 0swaps
```
The change can also address the issue below
```
TASK [vm_set : Bind topology ft2-64 to VMs. base vm = VM41160] ****************************************************************************************************************************************************************
Monday 05 May 2025  22:21:19 +0000 (0:17:55.457)       0:32:56.259 ************ 
^Hfatal: [STR4-ACS-SERV-71]: FAILED! => {"changed": false, "msg": "ret_code=1, error message=\"\". cmd=\"ifconfig -a | grep -E br-VM41200-[0-9]+\""}
``` 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to use `ip link` instead of `ifconfig -a` to speed up `add-topo`.

#### How did you do it?
Change command `ifconfig -a` to `ip link`.

#### How did you verify/test it?
Verified by deploying a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
