### PR TITLE
Use a more robust way to cleanup previous ceos mount dir

### DIFF
--- a/ansible/roles/eos/tasks/ceos_config.yml
+++ b/ansible/roles/eos/tasks/ceos_config.yml
@@ -20,9 +20,7 @@
 
 - name: cleanup previous ceos mount dir
   become: yes
-  file:
-    path: "/{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}/"
-    state: absent
+  command: rm -rf /{{ ceos_image_mount_dir }}/ceos_{{ vm_set_name }}_{{ inventory_hostname }}
   delegate_to: "{{ VM_host[0] }}"
 
 - name: create directory for ceos config

--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -59,6 +59,7 @@
         become: true
 
       - name: Set routeCheck timeout to 600 seconds
+        become: true
         lineinfile:
           path: /etc/monit/conf.d/sonic-host
           regexp: '^check program routeCheck with path "/usr/local/bin/route_check.py"'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. The original usage of ansible file module failed sometimes. Change to use "rm -rf" to remove directories.
2. Add root privilege elevation when changing routeCheck timeout
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
