### PR TITLE
Modify thread.isAlive() to thread.is_alive() due to Python3.9

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/wr_arp.py
+++ b/ansible/roles/test/files/ptftests/py3/wr_arp.py
@@ -353,7 +353,7 @@ class ArpTest(BaseTest):
         self.warm_reboot()
 
         test_port_thr.join(timeout=self.how_long)
-        if test_port_thr.isAlive():
+        if test_port_thr.is_alive():
             self.log("Timed out waiting for traffic-sender (test_port_thr thread)")
             self.req_dut('quit')
             self.assertTrue(
@@ -436,7 +436,7 @@ class ArpTest(BaseTest):
             if wr_state is not False:
                 self.assertTrue(False, "CPA quit before warm reboot finished")
 
-            if test_non_broadcast_reply_thread.isAlive():
+            if test_non_broadcast_reply_thread.is_alive():
                 self.log("Timed out waiting for test_non_broadcast_reply_thread")
                 self.assertTrue(
                     False, "Timed out waiting for test_non_broadcast_reply_thread")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
test_wr_arp.py failed due to `thread.isAlive()` api, Python3.9 has changed this to `thread.is_alive()` Modified this api call in `wr_arp.py`
-->

Summary:
Fixes # (issue)
test_wr_arp.py failed due to `thread.isAlive()` api, Python3.9 has changed this to `thread.is_alive()` Modified this api call in `wr_arp.py`
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Nightly test failure
#### How did you do it?
Modify thread.isAlive() to thread.is_alive()
#### How did you verify/test it?
 https://elastictest.org/scheduler/testplan/68192059dec515a352da77f3?testcase=arp%2Ftest_wr_arp.py&type=console
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
