### PR TITLE
[Test gap] Add coverage for IPv6 traffic to the PFCWD PTF test cases

### DIFF
--- a/ansible/library/get_ip_in_range.py
+++ b/ansible/library/get_ip_in_range.py
@@ -66,18 +66,17 @@ class IpRangeModule(object):
         prefix = IPNetwork(prefix)
         exclude_ips.append(prefix.broadcast)
         exclude_ips.append(prefix.network)
-        available_ips = list(prefix)
-
-        if len(available_ips) - len(exclude_ips) < num:
-            self.module.fail_json(msg="Don't have enough available ips in prefix, num=%d, prefix=%s, exclude_ips=%s." %
-                                  (num, prefix, exclude_ips))
         generated_ips = []
-        for available_ip in available_ips:
-            if available_ip not in exclude_ips:
-                generated_ips.append(str(available_ip) +
+        for ip in prefix:
+            if ip not in exclude_ips:
+                generated_ips.append(str(ip) +
                                      '/' + str(prefix.prefixlen))
             if len(generated_ips) == num:
                 break
+        else:
+            self.module.fail_json(msg="Don't have enough available ips in prefix, num=%d, prefix=%s, exclude_ips=%s." %
+                                  (num, prefix, exclude_ips))
+
         self.facts['generated_ips'] = generated_ips
         return
 

--- a/ansible/roles/test/files/ptftests/py3/pfc_wd.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd.py
@@ -9,7 +9,14 @@ import ptf.packet as scapy
 
 from ptf.base_tests import BaseTest
 from ptf.mask import Mask
-from ptf.testutils import test_params_get, simple_tcp_packet, send_packet, verify_no_packet_any, verify_packet_any_port
+from ptf.testutils import (
+    test_params_get,
+    simple_tcp_packet,
+    simple_tcpv6_packet,
+    send_packet,
+    verify_no_packet_any,
+    verify_packet_any_port
+)
 import macsec  # noqa F401
 
 
@@ -31,6 +38,7 @@ class PfcWdTest(BaseTest):
         self.wd_action = self.test_params.get('wd_action', 'drop')
         self.port_src_vlan_id = self.test_params.get('port_src_vlan_id')
         self.port_dst_vlan_id = self.test_params.get('port_dst_vlan_id')
+        self.ip_version = self.test_params.get('ip_version')
 
     def runTest(self):
         ecn = 1
@@ -51,99 +59,116 @@ class PfcWdTest(BaseTest):
             for x in range(0, self.pkt_count):
                 sport = random.randint(0, 65535)
                 dport = random.randint(0, 65535)
-                ip_src = socket.inet_ntoa(struct.pack(
-                    '>I', random.randint(1, 0xffffffff)))
-                ip_src = ipaddress.IPv4Address(ip_src)
-                if not isinstance(self.ip_dst, six.text_type):
-                    self.ip_dst = six.text_type(self.ip_dst, 'utf-8')
-                ip_dst = ipaddress.IPv4Address(self.ip_dst)
-                while ip_src == ip_dst or ip_src.is_multicast or ip_src.is_private or\
-                        ip_src.is_global or ip_src.is_reserved:
+                if self.ip_version == 'IPv4':
                     ip_src = socket.inet_ntoa(struct.pack(
                         '>I', random.randint(1, 0xffffffff)))
                     ip_src = ipaddress.IPv4Address(ip_src)
+                    if not isinstance(self.ip_dst, six.text_type):
+                        self.ip_dst = six.text_type(self.ip_dst, 'utf-8')
+                    ip_dst = ipaddress.IPv4Address(self.ip_dst)
+                    while ip_src == ip_dst or ip_src.is_multicast or ip_src.is_private or\
+                            ip_src.is_global or ip_src.is_reserved:
+                        ip_src = socket.inet_ntoa(struct.pack(
+                            '>I', random.randint(1, 0xffffffff)))
+                        ip_src = ipaddress.IPv4Address(ip_src)
+                else:
+                    if not isinstance(self.ip_dst, six.text_type):
+                        self.ip_dst = six.text_type(self.ip_dst, 'utf-8')
+                    ip_dst = ipaddress.IPv6Address(self.ip_dst)
+                    ip_src = ip_dst
+                    while ip_src == ip_dst:
+                        # pick randomly from safe range inside global unicast
+                        # [2003::, 3FFE:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF]
+                        ip_src = socket.inet_ntop(
+                            socket.AF_INET6,
+                            struct.pack(
+                                '>QQ',
+                                random.randint(0x2003000000000000, 0x3FFEFFFFFFFFFFFF),
+                                random.randint(0, 0xFFFFFFFFFFFFFFFF)
+                            )
+                        )
+                        ip_src = ipaddress.IPv6Address(ip_src)
 
                 ip_src = str(ip_src)
-                pkt_args = {
-                    'eth_dst': self.router_mac,
-                    'eth_src': src_mac,
-                    'ip_src': ip_src,
-                    'ip_dst': self.ip_dst,
-                    'ip_tos': tos,
-                    'tcp_sport': sport,
-                    'tcp_dport': dport,
-                    'ip_ttl': 64
-                }
-                if self.port_src_vlan_id is not None:
-                    pkt_args['dl_vlan_enable'] = True
-                    pkt_args['vlan_vid'] = int(self.port_src_vlan_id)
-                    pkt_args['vlan_pcp'] = self.queue_index
-                pkt = simple_tcp_packet(**pkt_args)
-                exp_pkt_args = {
-                    'eth_src': self.router_mac,
-                    'ip_src': ip_src,
-                    'ip_dst': self.ip_dst,
-                    'ip_tos': tos,
-                    'tcp_sport': sport,
-                    'tcp_dport': dport,
-                    'ip_ttl': 63
-                }
-                if self.port_dst_vlan_id is not None:
-                    exp_pkt_args['dl_vlan_enable'] = True
-                    exp_pkt_args['vlan_vid'] = int(self.port_dst_vlan_id)
-                    exp_pkt_args['vlan_pcp'] = self.queue_index
-                exp_pkt = simple_tcp_packet(**exp_pkt_args)
-                masked_exp_pkt = Mask(exp_pkt)
-                masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-                masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
-                masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
-                masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
-                masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
-
-                send_packet(self, self.port_src, pkt, 1)
+                masked_exp_pkt = self.create_and_send_pkt(self.router_mac, src_mac, sport, dport, ip_src, tos, 1)
         else:
             sport = random.randint(0, 65535)
             dport = random.randint(0, 65535)
-            ip_src = "1.1.1.1"
+            # Cloudflare’s public DNS resolver
+            ip_src = "1.1.1.1" if self.ip_version == "IPv4" else "2606:4700:4700::1111"
 
-            pkt_args = {
-                'eth_dst': self.vlan_mac,
-                'eth_src': src_mac,
-                'ip_src': ip_src,
-                'ip_dst': self.ip_dst,
-                'ip_tos': tos,
-                'tcp_sport': sport,
-                'tcp_dport': dport,
-                'ip_ttl': 64
-            }
-            if self.port_src_vlan_id is not None:
-                pkt_args['dl_vlan_enable'] = True
-                pkt_args['vlan_vid'] = int(self.port_src_vlan_id)
-                pkt_args['vlan_pcp'] = self.queue_index
-            pkt = simple_tcp_packet(**pkt_args)
-            exp_pkt_args = {
-                'eth_src': self.router_mac,
-                'ip_src': ip_src,
-                'ip_dst': self.ip_dst,
-                'ip_tos': tos,
-                'tcp_sport': sport,
-                'tcp_dport': dport,
-                'ip_ttl': 63
-            }
-            if self.port_dst_vlan_id is not None:
-                exp_pkt_args['dl_vlan_enable'] = True
-                exp_pkt_args['vlan_vid'] = int(self.port_dst_vlan_id)
-                exp_pkt_args['vlan_pcp'] = self.queue_index
-            exp_pkt = simple_tcp_packet(**exp_pkt_args)
-            masked_exp_pkt = Mask(exp_pkt)
-            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
-            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
+            masked_exp_pkt = self.create_and_send_pkt(self.vlan_mac, src_mac, sport, dport, ip_src, tos, self.pkt_count)
 
-            send_packet(self, self.port_src, pkt, self.pkt_count)
         if self.wd_action == 'drop':
             return verify_no_packet_any(self, masked_exp_pkt, dst_port_list)
         elif self.wd_action == 'forward':
             return verify_packet_any_port(self, masked_exp_pkt, dst_port_list)
+
+    def create_and_send_pkt(self, eth_dst, eth_src, sport, dport, ip_src, tos, pkt_count):
+        pkt_args = {
+            'eth_dst': eth_dst,
+            'eth_src': eth_src,
+            'tcp_sport': sport,
+            'tcp_dport': dport,
+        }
+
+        if self.port_src_vlan_id is not None:
+            pkt_args['dl_vlan_enable'] = True
+            pkt_args['vlan_vid'] = int(self.port_src_vlan_id)
+            pkt_args['vlan_pcp'] = self.queue_index
+
+        if self.ip_version == "IPv4":
+            pkt_args.update({
+                'ip_src': ip_src,
+                'ip_dst': self.ip_dst,
+                'ip_tos': tos,
+                'ip_ttl': 64
+            })
+            pkt = simple_tcp_packet(**pkt_args)
+        else:
+            pkt_args.update({
+                'ipv6_src': ip_src,
+                'ipv6_dst': self.ip_dst,
+                'ipv6_tc': tos,
+                'ipv6_hlim': 64
+            })
+            pkt = simple_tcpv6_packet(**pkt_args)
+
+        exp_pkt_args = {
+            'tcp_sport': sport,
+            'tcp_dport': dport,
+        }
+        if self.port_dst_vlan_id is not None:
+            exp_pkt_args['dl_vlan_enable'] = True
+            exp_pkt_args['vlan_vid'] = int(self.port_dst_vlan_id)
+            exp_pkt_args['vlan_pcp'] = self.queue_index
+
+        if self.ip_version == "IPv4":
+            exp_pkt_args.update({
+                'ip_src': ip_src,
+                'ip_dst': self.ip_dst,
+                'ip_tos': tos,
+                'ip_ttl': 63
+            })
+            exp_pkt = simple_tcp_packet(**exp_pkt_args)
+        else:
+            exp_pkt_args.update({
+                'ipv6_src': ip_src,
+                'ipv6_dst': self.ip_dst,
+                'ipv6_tc': tos,
+                'ipv6_hlim': 63
+            })
+            exp_pkt = simple_tcpv6_packet(**exp_pkt_args)
+
+        masked_exp_pkt = Mask(exp_pkt)
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+        if self.ip_version == "IPv4":
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "len")
+        else:
+            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+
+        send_packet(self, self.port_src, pkt, pkt_count)
+        return masked_exp_pkt

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class TrafficPorts(object):
     """ Generate a list of ports needed for the PFC Watchdog test"""
-    def __init__(self, mg_facts, neighbors, vlan_nw, topo, config_facts):
+    def __init__(self, mg_facts, neighbors, vlan_nw, topo, config_facts, ip_version):
         """
         Args:
             mg_facts (dict): parsed minigraph info
@@ -53,6 +53,7 @@ class TrafficPorts(object):
         self.pfc_wd_rx_port_id = None
         self.topo = topo
         self.config_facts = config_facts
+        self.ip_version = ip_version
 
     def build_port_list(self):
         """
@@ -85,7 +86,7 @@ class TrafficPorts(object):
         pfc_wd_test_port = None
         first_pair = False
         for intf in self.mg_facts['minigraph_interfaces']:
-            if ipaddress.ip_address(str(intf['addr'])).version != 4:
+            if ipaddress.ip_address(str(intf['addr'])).version != self.ip_version:
                 continue
             # first port
             if not self.pfc_wd_rx_port:
@@ -104,11 +105,12 @@ class TrafficPorts(object):
                 pfc_wd_test_neighbor_addr = None
 
                 for item in self.bgp_info:
-                    if ipaddress.ip_address(str(item['addr'])).version != 4:
+                    if ipaddress.ip_address(str(item['addr'])).version != self.ip_version:
                         continue
-                    if not self.pfc_wd_rx_neighbor_addr and item['peer_addr'] == self.pfc_wd_rx_port_addr:
+                    if not self.pfc_wd_rx_neighbor_addr and\
+                            str(item['peer_addr']).lower() == str(self.pfc_wd_rx_port_addr).lower():
                         self.pfc_wd_rx_neighbor_addr = item['addr']
-                    if item['peer_addr'] == pfc_wd_test_port_addr:
+                    if str(item['peer_addr']).lower() == str(pfc_wd_test_port_addr).lower():
                         pfc_wd_test_neighbor_addr = item['addr']
 
                 self.test_ports[pfc_wd_test_port] = {
@@ -149,7 +151,7 @@ class TrafficPorts(object):
         pfc_wd_test_port = None
         first_pair = False
         for item in self.mg_facts['minigraph_portchannel_interfaces']:
-            if ipaddress.ip_address(str(item['addr'])).version != 4:
+            if ipaddress.ip_address(str(item['addr'])).version != self.ip_version:
                 continue
             pc = item['attachto']
             # first port
@@ -170,11 +172,12 @@ class TrafficPorts(object):
                 pfc_wd_test_neighbor_addr = None
 
                 for bgp_item in self.bgp_info:
-                    if ipaddress.ip_address(str(bgp_item['addr'])).version != 4:
+                    if ipaddress.ip_address(str(bgp_item['addr'])).version != self.ip_version:
                         continue
-                    if not self.pfc_wd_rx_neighbor_addr and bgp_item['peer_addr'] == self.pfc_wd_rx_port_addr:
+                    if not self.pfc_wd_rx_neighbor_addr and\
+                            str(bgp_item['peer_addr']).lower() == str(self.pfc_wd_rx_port_addr).lower():
                         self.pfc_wd_rx_neighbor_addr = bgp_item['addr']
-                    if bgp_item['peer_addr'] == pfc_wd_test_port_addr:
+                    if str(bgp_item['peer_addr']).lower() == str(pfc_wd_test_port_addr).lower():
                         pfc_wd_test_neighbor_addr = bgp_item['addr']
 
                 for port in pfc_wd_test_port:
@@ -228,7 +231,7 @@ class TrafficPorts(object):
         rx_port_id = self.pfc_wd_rx_port_id if isinstance(self.pfc_wd_rx_port_id, list) else [self.pfc_wd_rx_port_id]
         for item in vlan_members:
             ip_addr = self.vlan_nw if 'dualtor' not in self.topo else \
-                      self.config_facts['MUX_CABLE'][item]['server_ipv4'].split('/')[0]
+                      self.config_facts['MUX_CABLE'][item][f'server_ipv{self.ip_version}'].split('/')[0]
             temp_ports[item] = {'test_neighbor_addr': ip_addr,
                                 'rx_port': rx_port,
                                 'rx_neighbor_addr': self.pfc_wd_rx_neighbor_addr,
@@ -249,7 +252,7 @@ class TrafficPorts(object):
         pfc_wd_test_port = None
         first_pair = False
         for sub_intf in self.mg_facts['minigraph_vlan_sub_interfaces']:
-            if ipaddress.ip_address(str(sub_intf['addr'])).version != 4:
+            if ipaddress.ip_address(str(sub_intf['addr'])).version != self.ip_version:
                 continue
             intf_name, vlan_id = sub_intf['attachto'].split(constants.VLAN_SUB_INTERFACE_SEPARATOR)
             # first port
@@ -270,11 +273,12 @@ class TrafficPorts(object):
                 pfc_wd_test_neighbor_addr = None
 
                 for item in self.bgp_info:
-                    if ipaddress.ip_address(str(item['addr'])).version != 4:
+                    if ipaddress.ip_address(str(item['addr'])).version != self.ip_version:
                         continue
-                    if not self.pfc_wd_rx_neighbor_addr and item['peer_addr'] == self.pfc_wd_rx_port_addr:
+                    if not self.pfc_wd_rx_neighbor_addr and\
+                            str(item['peer_addr']).lower() == str(self.pfc_wd_rx_port_addr).lower():
                         self.pfc_wd_rx_neighbor_addr = item['addr']
-                    if item['peer_addr'] == pfc_wd_test_port_addr:
+                    if str(item['peer_addr']).lower() == str(pfc_wd_test_port_addr).lower():
                         pfc_wd_test_neighbor_addr = item['addr']
 
                 self.test_ports[pfc_wd_test_port] = {

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2163,7 +2163,18 @@ pfcwd/test_pfcwd_warm_reboot.py:
         - "release in ['202412']"
         - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/8400"
 
-pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
+pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[IPv4-async_storm:
+   skip:
+     reason: "Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on M* testbed. / Currently async_storm test is not supported on VS platform / Warm reboot is not required for 202412"
+     conditions_logical_operator: or
+     conditions:
+        - "'t2' in topo_name"
+        - "'standalone' in topo_name"
+        - "topo_type in ['m0', 'mx', 'm1']"
+        - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17803"
+        - "release in ['202412']"
+
+pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[IPv6-async_storm:
    skip:
      reason: "Warm Reboot is not supported in T2 or in standalone topos. / Pfcwd tests skipped on M* testbed. / Currently async_storm test is not supported on VS platform / Warm reboot is not required for 202412"
      conditions_logical_operator: or

--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -10,7 +10,7 @@ from tests.common.helpers.pfcwd_helper import start_wd_on_ports, start_backgroun
 
 from tests.common.plugins.loganalyzer import DisableLogrotateCronContext
 from tests.common.helpers.pfcwd_helper import send_background_traffic
-
+from tests.common import config_reload
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -26,24 +26,6 @@ def pfc_queue_idx(pfcwd_timer_setup_restore):
     # This is used by the common code, this needs to be defined
     # before using start_background_traffic() fixture.
     yield pfcwd_timer_setup_restore['storm_handle'].pfc_queue_idx
-
-
-@pytest.fixture(scope='module')
-def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname, core_dump_and_config_check):
-    """
-    Fixture that stops PFC Watchdog before each test run
-
-    Args:
-        duthost (AnsibleHost): DUT instance
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    logger.info("--- Stop Pfcwd --")
-    duthost.command("pfcwd stop")
-
-    yield
-
-    logger.info("--- Start Pfcwd --")
-    duthost.command("pfcwd start_default")
 
 
 @pytest.fixture(autouse=True)
@@ -69,7 +51,7 @@ def ignore_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_hostname, log
 
 @pytest.fixture(scope='module', autouse=True)
 def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,        # noqa: F811
-                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts, stop_pfcwd):
+                              enum_rand_one_per_hwsku_frontend_hostname, fanouthosts):
     """
     Fixture that inits the test vars, start PFCwd on ports and cleans up after the test run
 
@@ -118,6 +100,8 @@ def pfcwd_timer_setup_restore(setup_pfc_test, enum_fanout_graph_facts, duthosts,
            }
 
     logger.info("--- Pfcwd timer test cleanup ---")
+    # clear pfcwd stats and reset to default for next run
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
     dut.iptables(table="nat", flush="yes")
     dut.sysctl(name="net.ipv4.conf.eth0.route_localnet", value=0, sysctl_set=True)
     storm_handle.stop_storm()

--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -16,10 +16,12 @@ from tests.common.reboot import DUT_ACTIVE
 from tests.common.utilities import InterruptableThread
 from tests.common.utilities import join_all
 from tests.ptf_runner import ptf_runner
+from tests.common import constants
 from tests.common.helpers.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, pfcwd_show_status
 from tests.common.helpers.pfcwd_helper import send_background_traffic
 from tests.common.helpers.pfcwd_helper import has_neighbor_device
 from tests.common.utilities import wait_until
+from tests.common import config_reload
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "templates")
 TESTCASE_INFO = {'no_storm': {'test_sequence': ["detect", "restore", "warm-reboot", "detect", "restore"],
@@ -111,7 +113,7 @@ class PfcCmd(object):
 
 class SetupPfcwdFunc(object):
     """ Test setup per port """
-    def setup_test_params(self, port, vlan, idx):
+    def setup_test_params(self, port, vlan, idx, ip_version="IPv4"):
         """
         Sets up test parameters associated with a DUT port
 
@@ -121,7 +123,7 @@ class SetupPfcwdFunc(object):
         """
         logger.info("--- Setting up test params for port {} ---".format(port))
         self.setup_port_params(port, idx)
-        self.resolve_arp(vlan)
+        self.resolve_arp(vlan, ip_version=ip_version)
 
     def setup_port_params(self, port, idx):
         """
@@ -150,9 +152,11 @@ class SetupPfcwdFunc(object):
             self.pfc_wd['test_port_ids'] = self.ports[port]['test_portchannel_members']
         elif self.pfc_wd['port_type'] in ["vlan", "interface"]:
             self.pfc_wd['test_port_ids'] = [self.pfc_wd['test_port_id']]
+        self.pfc_wd['test_port_vlan_id'] = self.ports[port].get('test_port_vlan_id')
+        self.pfc_wd['rx_port_vlan_id'] = self.ports[port].get('rx_port_vlan_id')
         self.pfc_wd['fake_storm'] = self.fake_storm
 
-    def resolve_arp(self, vlan):
+    def resolve_arp(self, vlan, ip_version="IPv4"):
         """
         Populate ARP info for the DUT vlan port
 
@@ -161,10 +165,23 @@ class SetupPfcwdFunc(object):
         """
         if self.pfc_wd['port_type'] == "vlan":
             self.ptf.script("./scripts/remove_ip.sh")
-            self.ptf.command("ifconfig eth{} {}".format(self.pfc_wd['test_port_id'],
-                                                        self.pfc_wd['test_neighbor_addr']))
-            self.ptf.command("ping {} -c 10".format(vlan['addr']))
-            self.dut.command("docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']))
+            ptf_port = 'eth%s' % self.pfc_wd['test_port_id']
+            if self.pfc_wd['test_port_vlan_id'] is not None:
+                ptf_port += (constants.VLAN_SUB_INTERFACE_SEPARATOR + self.pfc_wd['test_port_vlan_id'])
+            self.ptf.command("ip neigh flush all")
+            self.ptf.command("ip -6 neigh flush all")
+            self.dut.command("ip neigh flush all")
+            self.dut.command("ip -6 neigh flush all")
+            if ip_version == "IPv4":
+                self.ptf.command("ifconfig {} {}".format(ptf_port, self.pfc_wd['test_neighbor_addr']))
+                self.ptf.command("ping {} -c 10".format(vlan['addr']))
+                self.dut.command(
+                    "docker exec -i swss arping {} -c 5".format(self.pfc_wd['test_neighbor_addr']))  # noqa: E501
+            else:
+                self.ptf.command(
+                    "ip -6 addr add {}/{} dev {}".format(self.pfc_wd['test_neighbor_addr'], vlan['prefix'], ptf_port))
+                self.ptf.command("ping {} -6 -c 10".format(vlan['addr']))
+                self.dut.command("docker exec -i swss ping -6 -c 5 {}".format(self.pfc_wd['test_neighbor_addr']))
 
     def storm_defer_setup(self):
         """
@@ -217,7 +234,7 @@ class SetupPfcwdFunc(object):
 
 class SendVerifyTraffic(object):
     """ PTF test """
-    def __init__(self, ptf, router_mac, pfc_params, queue):
+    def __init__(self, ptf, router_mac, pfc_params, queue, ip_version='IPv4'):
         """
         Args:
             ptf(AnsibleHost) : ptf instance
@@ -236,6 +253,7 @@ class SendVerifyTraffic(object):
         self.pfc_wd_rx_neighbor_addr = pfc_params['rx_neighbor_addr']
         self.port_type = pfc_params['port_type']
         self.queue = queue
+        self.ip_version = ip_version
 
     def verify_tx_egress(self, wd_action):
         """
@@ -256,7 +274,8 @@ class SendVerifyTraffic(object):
                       'port_dst': dst_port,
                       'ip_dst': self.pfc_wd_test_neighbor_addr,
                       'port_type': self.port_type,
-                      'wd_action': wd_action}
+                      'wd_action': wd_action,
+                      'ip_version': self.ip_version}
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
@@ -282,7 +301,8 @@ class SendVerifyTraffic(object):
                       'port_dst': dst_port,
                       'ip_dst': self.pfc_wd_rx_neighbor_addr,
                       'port_type': self.port_type,
-                      'wd_action': wd_action}
+                      'wd_action': wd_action,
+                      'ip_version': self.ip_version}
         log_format = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
         log_file = "/tmp/pfc_wd.PfcWdTest.{}.log".format(log_format)
         ptf_runner(self.ptf, "ptftests", "pfc_wd.PfcWdTest", "ptftests", params=ptf_params,
@@ -479,6 +499,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
         time.sleep(5)
         logger.info("--- Stop PFC WD ---")
         self.dut.command("pfcwd stop")
+        config_reload(self.dut, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
     def stop_all_storm(self):
         """
@@ -511,6 +532,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
             fanouthosts(AnsibleHost): fanout instance
         """
         setup_info = setup_pfc_test
+        ip_version = setup_info["ip_version"]
         self.fanout_info = enum_fanout_graph_facts
         self.ptf = ptfhost
         self.dut = duthost
@@ -571,7 +593,7 @@ class TestPfcwdWb(SetupPfcwdFunc):
                     send_pfc_frame_interval = calculate_send_pfc_frame_interval(duthost, port)
                 else:
                     send_pfc_frame_interval = 0
-                self.setup_test_params(port, setup_info['vlan'], p_idx)
+                self.setup_test_params(port, setup_info['vlan'], p_idx, ip_version=ip_version)
                 for q_idx, queue in enumerate(self.pfc_wd['queue_indices']):
                     logger.info("pfcwd wr: --- Testing on queue {} ---".format(queue))
                     if not t_idx or storm_deferred:
@@ -590,7 +612,9 @@ class TestPfcwdWb(SetupPfcwdFunc):
                         else:
                             self.oid_map[(port, queue)] = PfcCmd.get_queue_oid(self.dut, port, queue)
 
-                    self.traffic_inst = SendVerifyTraffic(self.ptf, dut_facts['router_mac'], self.pfc_wd, queue)
+                    self.traffic_inst = SendVerifyTraffic(
+                        self.ptf, dut_facts['router_mac'], self.pfc_wd, queue, ip_version
+                    )
                     try:
                         pfcwd_show_status(
                             self.dut,


### PR DESCRIPTION
Add IPv6 test coverage for PFCWD.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/10959

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-buildimage/issues/17446 
This issue was raised regarding PFCWD not dropping IPv6 traffic during storm. It revealed the need for test coverage.

#### How did you do it?
- I added a parametrized ip_version fixture [*tests/conftest.py*]
- This fixture is used in the setup_pfc_test fixture [*tests/conftest.py*]
- All the tests that use setup_pfc_test to initialize the TrafficPorts will create them using once with IPv4 and once with IPv6
- TrafficPorts [*tests/common/helpers/pfcwd_helper.py*] uses the ip version to determine the test interfaces' and neighbour's ip addresses
- The ip_version is used explicitly in tests with a SendVerifyTraffic class [*tests/pfcwd/test_pfcwd_cli.py*, *tests/pfcwd/test_pfcwd_warm_reboot.py*, *tests/pfcwd/test_pfcwd_function.py*] that calls the ptf_runner with PfcWdTest [*ansible/roles/test/files/ptftests/py3/pfc_wd.py*]
  - We use the IP version to properly generate addresses and to properly create tcp packets in PfcWdTest
- I updated pfcwd timer accuracy test cleanup [*tests/pfcwd/test_pfcwd_timer_accuracy.py*] to perform a config reload, this was required to clear the `show pfcwd stats` in between the IPv4 and IPv6 runs
  - it also removed the need for `stop_pfcwd` fixture as the pfcwd is already stopped by setup_pfc_test, the `stop_pfcwd` fixture additionally restarted the wd (https://github.com/sonic-net/sonic-mgmt/pull/15025) but this is now unnecessary due to the config reload.
- Changes for VLAN compatibility:
  - resolve_arp [*tests/pfcwd/test_pfcwd_cli.py*, *tests/pfcwd/test_pfcwd_warm_reboot.py*, *tests/pfcwd/test_pfcwd_function.py*] required IPv6 compatible bash commands
  - get_ip_in_range [*ansible/library/get_ip_in_range.py*] required refactoring to allow for lazy loading of large address spaces (i.e. IPv6 spaces)

#### How did you verify/test it?
Ran all pfcwd sonic mgmt tests across T0, T1, and T2 topologies all with successful results.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
