### PR TITLE
chore: increase vm threshold

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -221,6 +221,43 @@
     sysctl_set: yes
   become: yes
 
+- name: Increase neighbor gc_thresh1
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "8192"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh1
+    - net.ipv6.neigh.default.gc_thresh1
+
+- name: Increase neighbor gc_thresh2
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "16384"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh2
+    - net.ipv6.neigh.default.gc_thresh2
+
+- name: Increase neighbor gc_thresh3
+  sysctl:
+    sysctl_set: yes
+    name: "{{ item }}"
+    value: "32768"
+  become: yes
+  with_items:
+    - net.ipv4.neigh.default.gc_thresh3
+    - net.ipv6.neigh.default.gc_thresh3
+
+- name: increase kernel pid max
+  sysctl:
+    name: "kernel.pid_max"
+    value: "4194304"
+    sysctl_set: yes
+  become: yes
+
 - name: Setup external front port
   include_tasks: external_port.yml
   when: external_port is defined


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Increase our VM threshold to support deploy large scale vms.

Fixes # (issue) 32767670

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Without this change, ceos VM will abnormally terminate ProcMgr.service which led to BGP down. During this time I noticed dmesg

```
[4351605.348948] neighbour: ndisc_cache: neighbor table overflow!
[4352518.918103] neighbour: ndisc_cache: neighbor table overflow!
[4353433.024687] neighbour: ndisc_cache: neighbor table overflow!
[4353433.024717] neighbour: ndisc_cache: neighbor table overflow!
[4353737.315904] neighbour: ndisc_cache: neighbor table overflow!
```

Which indicate the neighbor arp cache table be out of entry. Adjusting here make the VM more stable on large scale.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
