### PR TITLE
Initialize two variables to prevent unbound variable error in upstream_links fixture

### DIFF
--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -59,6 +59,8 @@ def upstream_links(rand_selected_dut, tbinfo, nbrhosts):
     def filter(interface, neighbor, mg_facts, tbinfo):
         if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"])
                 or (tbinfo["topo"]["type"] == "t1" and "T2" in neighbor["name"])):
+            local_ipv4_addr = None
+            peer_ipv4_addr = None
             for item in mg_facts["minigraph_bgp"]:
                 if item["name"] == neighbor["name"]:
                     if isinstance(ip_address(item["addr"]), IPv4Address):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The upstream_links fixture assumes that BGP neighbors are always using IPv4 addresses which is false for IPv6 only topology. This PR initializes two variables to prevent unbound variable error in the upstream_links fixture setup.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
