### PR TITLE
Update baseline test plan max execution time and test job timeout

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.template.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.template.yml
@@ -71,7 +71,7 @@ jobs:
       COMMON_EXTRA_PARAMS: ""
       DEPLOY_MG_EXTRA_PARAMS: ""
       SPECIFIC_PARAM: "[]"
-    timeoutInMinutes: 240
+    timeoutInMinutes: 300
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
@@ -98,3 +98,4 @@ jobs:
           NUM_ASIC: $(NUM_ASIC)
           VM_TYPE: $(VM_TYPE)
           SPECIFIC_PARAM: $(SPECIFIC_PARAM)
+          MAX_RUN_TEST_MINUTES: 240


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We were using Azure DevOps pipeline job timeout to set max execution time in baseline test jobs, so once baseline test exceed timeout, test plans will be cancelled by Azure DevOps pipeline and we will get the error code "TEST_PLAN_CANCELLED", and we won't be able to distinguish whether the test plan is cancelled by timeout or other reasons.
#### How did you do it?
Use Elastictest timeout MAX_RUN_TEST_MINUTES to set max execution time in baseline test plans, and update test job timeout longer than Elastictest timeout, so once baseline test exceed timeout, test plans will be cancelled by Elastictest and we will get different error code.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
