### PR TITLE
Validate BGP sessions are up | generic hash nexthop flap test

### DIFF
--- a/tests/hash/test_generic_hash.py
+++ b/tests/hash/test_generic_hash.py
@@ -325,9 +325,17 @@ def test_ecmp_and_lag_hash(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_f
         )
 
 
+def is_bgp_session_established(duthost, neighbor_ip):
+    """
+    Check if the BGP session is established.
+    """
+    bgp_neighbors = duthost.get_bgp_neighbors()
+    return bgp_neighbors.get(neighbor_ip, {}).get('state') == 'established'
+
+
 def test_nexthop_flap(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts, restore_interfaces,  # noqa:F811
                       restore_vxlan_port, global_hash_capabilities, get_supported_hash_algorithms,    # noqa:F811
-                      toggle_all_aa_ports_to_rand_selected_tor):                                      # noqa:F811
+                      toggle_all_aa_ports_to_rand_selected_tor, duthost):                             # noqa:F811
     """
     Test case to validate the ecmp hash when there is nexthop flapping.
     The hash field to test is randomly chosen from the supported hash fields.
@@ -402,8 +410,11 @@ def test_nexthop_flap(rand_selected_dut, tbinfo, ptfhost, fine_params, mg_facts,
     with allure.step('Startup the interface, and then flap it 3 more times'):
         startup_interface(rand_selected_dut, interface)
         flap_interfaces(rand_selected_dut, [interface], times=3)
-        pytest_assert(wait_until(10, 2, 0, check_default_route, rand_selected_dut, uplink_interfaces.keys()),
-                      'The default route is not restored after the flapping.')
+        ip_intfs = duthost.show_and_parse('show ip interface')
+        ip_intf = next((intf for intf in ip_intfs if intf['interface'] == interface), None)
+        neighbor_ip = ip_intf['neighbor ip']
+        pytest_assert(wait_until(60, 2, 0, is_bgp_session_established, duthost, neighbor_ip),
+                      "BGP session is not established on DUT after the flapping")
         ptf_params['expected_port_groups'] = origin_ptf_expected_port_groups
     with allure.step('Start the ptf test, send traffic and check the balancing'):
         ptf_runner(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Reapplying routes (including VXLAN routes) takes longer after an interface shutdown/startup. Since there is only one member in the ECMP group, there is no alternate path to the destination when the interface goes down. As a result, any traffic sent before the routes are fully restored will be lost. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Make a test stable with topos with 1 member in ECMP group
#### How did you do it?
Added 5 sec sleep after flap interface 3 times
#### How did you verify/test it?
Run test, test passed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
