### PR TITLE
Use macsec_duthost fixture in test_restart_macsec_docker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1353,10 +1353,7 @@ def generate_params_frontend_hostname(request, macsec_only=False):
 def generate_params_hostname_rand_per_hwsku(request, frontend_only=False, macsec_only=False):
     hosts = get_specified_duts(request)
     if frontend_only:
-        if macsec_only:
-            hosts = generate_params_frontend_hostname(request, macsec_only=True)
-        else:
-            hosts = generate_params_frontend_hostname(request)
+        hosts = generate_params_frontend_hostname(request, macsec_only=macsec_only)
 
     hosts_per_hwsku = get_hosts_per_hwsku(request, hosts)
     return hosts_per_hwsku

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1338,12 +1338,18 @@ def generate_params_frontend_hostname(request):
 
 def generate_params_macsec_hostname(request):
     macsec_duts = []
-    tbname, _ = get_tbinfo(request)
+    tbname, tbinfo = get_tbinfo(request)
     duts = get_specified_duts(request)
     inv_files = get_inventory_files(request)
-    for dut in duts:
-        if is_macsec_capable_node(inv_files, dut):
-            macsec_duts.append(dut)
+
+    if 't2' in tbinfo['topo']['name']:
+        # currently in the T2 topo only the uplink linecard will have
+        # macsec enabled
+        for dut in duts:
+            if is_macsec_capable_node(inv_files, dut):
+                macsec_duts.append(dut)
+    else:
+        macsec_duts.append(duts[0])
     assert len(macsec_duts) > 0, \
         "Test selected require at-least one macsec node, " \
         "none of the DUTs '{}' in testbed '{}' are a macsec node".format(duts, tbname)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1350,20 +1350,6 @@ def generate_params_frontend_hostname(request, macsec_only=False):
     return frontend_duts
 
 
-def generate_params_macsec_hostname(request):
-    macsec_duts = []
-    tbname, _ = get_tbinfo(request)
-    duts = get_specified_duts(request)
-    inv_files = get_inventory_files(request)
-    for dut in duts:
-        if is_macsec_capable_node(inv_files, dut):
-            macsec_duts.append(dut)
-    assert len(macsec_duts) > 0, \
-        "Test selected require at-least one macsec node, " \
-        "none of the DUTs '{}' in testbed '{}' are a macsec node".format(duts, tbname)
-    return macsec_duts
-
-
 def generate_params_hostname_rand_per_hwsku(request, frontend_only=False, macsec_only=False):
     hosts = get_specified_duts(request)
     if frontend_only:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1350,6 +1350,20 @@ def generate_params_frontend_hostname(request, macsec_only=False):
     return frontend_duts
 
 
+def generate_params_macsec_hostname(request):
+    macsec_duts = []
+    tbname, _ = get_tbinfo(request)
+    duts = get_specified_duts(request)
+    inv_files = get_inventory_files(request)
+    for dut in duts:
+        if is_macsec_capable_node(inv_files, dut):
+            macsec_duts.append(dut)
+    assert len(macsec_duts) > 0, \
+        "Test selected require at-least one macsec node, " \
+        "none of the DUTs '{}' in testbed '{}' are a macsec node".format(duts, tbname)
+    return macsec_duts
+
+
 def generate_params_hostname_rand_per_hwsku(request, frontend_only=False, macsec_only=False):
     hosts = get_specified_duts(request)
     if frontend_only:

--- a/tests/macsec/test_docker_restart.py
+++ b/tests/macsec/test_docker_restart.py
@@ -13,8 +13,8 @@ pytestmark = [
 
 
 def test_restart_macsec_docker(duthosts, ctrl_links, policy, cipher_suite, send_sci,
-                               enum_rand_one_per_hwsku_frontend_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+                               enum_rand_one_per_hwsku_macsec_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_macsec_frontend_hostname]
 
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
     duthost.restart_service("macsec")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
test_docker_restart.py requires macsec docker containers to test container restart. This container is only available in macsec duthost and non-macsec duthosts will fail the test.

Therefore, we replace randomly choosing duthost to test with macsec_duthost fixture, so test will not fail on non-macsec duthosts
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_docker_restart.py failure in Cisco T2 8800 devices and potentially others.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Failure of test_docker_restart.py during macsec validation in Cisco T2 8800 devices
#### How did you do it?
Replace randomly choosing duthost with macsec_duthost fixture in test_restart_macsec_docker
#### How did you verify/test it?
tested in Cisco 8800 device
macsec/test_docker_restart.py::test_restart_macsec_docker[MACSEC_PROFILE] PASSED 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
