### PR TITLE
[Marvell] Change vendor id for marvell-teralynx platform

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -98,7 +98,7 @@ def tag_image(duthost, tag, image_name, image_version="latest"):
         image_version (str): The version of the image to tag.
     """
     vendor_id = _get_vendor_id(duthost)
-    if vendor_id in ['invm']:
+    if vendor_id in ['mrvl-teralynx']:
         image_name = "docker-syncd-{}-rpc".format(vendor_id)
 
     duthost.command("docker tag {}:{} {}".format(image_name, image_version, tag))
@@ -245,7 +245,7 @@ def _get_vendor_id(duthost):
     elif is_cisco_device(duthost):
         vendor_id = "cisco"
     elif is_marvell_teralynx_device(duthost):
-        vendor_id = "invm"
+        vendor_id = "mrvl-teralynx"
     else:
         error_message = '"{}" does not currently support swap_syncd'.format(duthost.facts["asic_type"])
         logger.error(error_message)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 
Renaming of vendor_id for Marvell Teralynx ASIC type.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
For Marvell's Teralynx asic, the name is changed from innovium to Marvell via varous PRs like 19829
This PR is to allign the vendor_id accordingly.

#### How did you do it?
Changed the 'vendor_id' from 'invm' to 'mrvl-teralynx'

#### How did you verify/test it?
Verify the vendor_id name in syncd image is correct.

#### Any platform specific information?
Applicable only for Marvell Teralynx ASIC.

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA