### PR TITLE
Stop/start correct BGP agent for model on cEOSLab peers

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -212,12 +212,19 @@ class EosHost(AnsibleHostBase):
             logging.info("Set interface [%s] lacp rate to [%s]" % (interface_name, mode))
         return out
 
+    def is_multiagent(self):
+        out = self.eos_command(commands=["show ip route summary | json"])
+        model = out["stdout"][0]["protoModelStatus"]["operatingProtoModel"]
+        return model == "multi-agent"
+
     def kill_bgpd(self):
-        out = self.eos_config(lines=['agent Rib shutdown'])
+        agent = 'Bgp' if self.is_multiagent() else 'Rib'
+        out = self.eos_config(lines=['agent {} shutdown'.format(agent)])
         return out
 
     def start_bgpd(self):
-        out = self.eos_config(lines=['no agent Rib shutdown'])
+        agent = 'Bgp' if self.is_multiagent() else 'Rib'
+        out = self.eos_config(lines=['no agent {} shutdown'.format(agent)])
         return out
 
     def no_shutdown_bgp(self, asn):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Depending on the version of cEOSLab being run, the docker peer devices to the SONiC DUT may be running in "multi-agent" mode.  This means that the agent referred to as "bgpd" in testing may differ based on the mode.  When running in "multi-agent" mode, the "Bgp" agent needs to be stopped, instead of "Rib".    The mode is determined based on the output of a CLI show-command run on the cEOSLab docker peer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Addressing this bug means that the test bgp/test_bgp_gr_helper.py will restart the correct "bgpd" agent and pass irrespective of the version of cEOSLab being run on the docker peers.

#### How did you do it?
The test runs the command "show ip route summary | json" on the cEOSLab peer instance and parses the output to identify whether or not the instance is running in "multi-agent" mode.  This information is then used to start/stop either the "Bgp" or "Rib" processes.

#### How did you verify/test it?
Verified by running the same bgp/test_bgp_gr_helper.py with and without the fix.  With the fix the correct "bgpd" agent is restarted by the test.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
No new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
