### PR TITLE
Skip T2 tests not applicable to disaggregated chassis

### DIFF
--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -73,12 +73,9 @@ def dut_nbrs(duthost, nbrhosts):
     return nbrs_to_dut
 
 
-# Get one random downlink linecard in a T2 chassis
+# Check if DUT has downlink T1 connections. Return one random downlink linecard in a T2 chassis 
 @pytest.fixture(scope="module")
 def rand_one_downlink_duthost(duthosts, tbinfo):
-    if tbinfo['topo']['type'] != 't2':
-        return []
-
     dl_duthosts = []
     for dut in duthosts.frontend_nodes:
         minigraph_facts = dut.get_extended_minigraph_facts(tbinfo)
@@ -87,10 +84,11 @@ def rand_one_downlink_duthost(duthosts, tbinfo):
             if 'T1' in value['name']:
                 dl_duthosts.append(dut)
                 break
+    if len(dl_duthosts) == 0:
+        pytest.skip("No downlink T1 connections found")
     dut = random.sample(dl_duthosts, 1)
     if dut:
         return dut[0]
-    pytest.skip("Skipping test - No downlink linecards found")
 
 
 def test_idf_isolated_no_export(rand_one_downlink_duthost,

--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -73,7 +73,7 @@ def dut_nbrs(duthost, nbrhosts):
     return nbrs_to_dut
 
 
-# Check if DUT has downlink T1 connections. Return one random downlink linecard in a T2 chassis 
+# Check if DUT has downlink T1 connections. Return one random downlink linecard in a T2 chassis
 @pytest.fixture(scope="module")
 def rand_one_downlink_duthost(duthosts, tbinfo):
     dl_duthosts = []

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -218,12 +218,11 @@ bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
   skip:
     reason: "Not applicable for passive bgpmon_v6"
 
-bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
+bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_abnormal_reboot:
   skip:
-    reason: "Test is flaky and causing PR test to fail unnecessarily"
+    reason: "Not supported on T2 single node topology"
     conditions:
-      - "asic_type in ['vs']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/6471
+      - "'t2_single_node' in topo_name"
 
 bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_cold_reboot:
   skip:
@@ -231,7 +230,7 @@ bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_cold_r
     conditions:
       - "'t2_single_node' in topo_name"
 
-bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_abnormal_reboot:
+bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_tsa_on_sup:
   skip:
     reason: "Not supported on T2 single node topology"
     conditions:
@@ -243,11 +242,13 @@ bgp/test_startup_tsa_tsb_service.py::test_user_init_tsb_on_sup_while_service_run
     conditions:
       - "'t2_single_node' in topo_name"
 
-bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_tsa_on_sup:
+bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
   skip:
-    reason: "Not supported on T2 single node topology"
+    reason: "Test is flaky and causing PR test to fail unnecessarily"
     conditions:
-      - "'t2_single_node' in topo_name"
+      - "asic_type in ['vs']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/6471
+
 #######################################
 #####            cacl             #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -225,6 +225,29 @@ bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
       - "asic_type in ['vs']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6471
 
+bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_cold_reboot:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_supervisor_abnormal_reboot:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+bgp/test_startup_tsa_tsb_service.py::test_user_init_tsb_on_sup_while_service_run_on_dut:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+bgp/test_startup_tsa_tsb_service.py::test_tsa_tsb_service_with_tsa_on_sup:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
 #######################################
 #####            cacl             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR skips modular chassis specific tests on disaggregated chassis

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Modular chassis specific tests that involve triggers on supervisor are not applicable to disaggregated chassis.

#### How did you do it?
Add skip conditions for BGP tsa-tsb-services tests that are specific to modular chassis with a supervisor

#### How did you verify/test it?
Verified that the tests are skipped on disaggregated chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
