### PR TITLE
Shutdown BGP for PCBB tests instead of stopping processes

### DIFF
--- a/tests/qos/tunnel_qos_remap_base.py
+++ b/tests/qos/tunnel_qos_remap_base.py
@@ -395,12 +395,12 @@ def update_docker_services(rand_selected_dut, swap_syncd, disable_container_auto
 
     SERVICES = [
         {"docker": "lldp", "service": "lldp-syncd"},
-        {"docker": "lldp", "service": "lldpd"},
-        {"docker": "bgp",  "service": "bgpd"},
-        {"docker": "bgp",  "service": "bgpmon"}
+        {"docker": "lldp", "service": "lldpd"}
     ]
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="stop", **service)
+
+    rand_selected_dut.shell("sudo config bgp shutdown all")
 
     asic = rand_selected_dut.get_asic_name()
     if 'spc' in asic:
@@ -413,6 +413,9 @@ def update_docker_services(rand_selected_dut, swap_syncd, disable_container_auto
 
     enable_container_autorestart(
         rand_selected_dut, testcase="test_tunnel_qos_remap", feature_list=feature_list)
+
+    rand_selected_dut.shell("sudo config bgp start all")
+
     for service in SERVICES:
         _update_docker_service(rand_selected_dut, action="start", **service)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

When running test_tunnel_qos_remap.py, the BGP bgpmon and bgpd service stop and start hacking does not correctly bring BGP back up on Cisco-8000 devices. Modify shutdown/startup to match QOS SAI's test fixtures, as revised by PR #15108.

Note that this only causes issues with BGP if the syncd swap is not performed (i.e. it's already loaded and --qos_swap_syncd is set to False). If the swap is performed, then the entire config is reloaded, which masks the fact that BGP didn't come back up correctly. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Validated on dualtor-aa Cisco-8000 that BGP comes back up after running test_tunnel_qos_remap.py xoff test cases. 
Ran without doing dynamic syncd container swap, per above note about this masking the BGP issue. 
Output after test pass shown here as sessions are up for 39 seconds. 
```
root@tor-dut-1:/home/cisco# show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.33, local AS number 65100 vrf-id 0
BGP table version 32014
RIB entries 12809, using 1639552 bytes of memory
Peers 4, using 82368 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.1.57      4  64600       6501       6502     32014      0       0  00:00:39             6402  ARISTA01T1
10.0.1.59      4  64600       6501       6503     32014      0       0  00:00:39             6402  ARISTA02T1
10.0.1.61      4  64600       6501       6503     32014      0       0  00:00:39             6402  ARISTA03T1
10.0.1.63      4  64600       6501       6503     32014      0       0  00:00:39             6402  ARISTA04T1

Total number of neighbors 4
```

#### Any platform specific information?

Test on Cisco-8000, but affects code-path for all vendors. Now matches procedure in qos_sai_base.py. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
