### PR TITLE
Handle multi-asic systems in `get_frr_daemon_memory_usage`

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -77,7 +77,7 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     loop_times = LOOP_TIMES_LEVEL_MAP[normalized_level]
 
     frr_demons_to_check = ['bgpd', 'zebra']
-    start_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check)
+    start_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, namespace)
     logging.info(f"memory usage at start: {start_time_frr_daemon_memory}")
 
     while loop_times > 0:
@@ -94,7 +94,7 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
                   "ipv6 route used after is not equal to it used before")
 
-    end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check)
+    end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, namespace)
     logging.info(f"memory usage at end: {end_time_frr_daemon_memory}")
     check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_daemon_memory,
                                    end_time_frr_daemon_memory)
@@ -122,12 +122,14 @@ def check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_
                       f"The increase memory should not exceed than {incr_frr_daemon_memory_threshold_dict[daemon]} MiB")
 
 
-def get_frr_daemon_memory_usage(duthost, daemon_list):
+def get_frr_daemon_memory_usage(duthost, daemon_list, namespace):
     frr_daemon_memory_dict = {}
     for daemon in daemon_list:
-        frr_daemon_memory_output = duthost.shell(f'vtysh -c "show memory {daemon}"')["stdout"]
+        frr_daemon_memory_output = duthost.shell(duthost.get_vtysh_cmd_for_namespace(
+           f'vtysh -c "show memory {daemon}"', namespace))["stdout"]
         logging.info(f"{daemon} memory status: \n%s", frr_daemon_memory_output)
-        output = duthost.shell(f'vtysh -c "show memory {daemon}" | grep "Free ordinary blocks"')["stdout"]
+        output = duthost.shell(duthost.get_vtysh_cmd_for_namespace(
+           f'vtysh -c "show memory {daemon}" | grep "Free ordinary blocks"', namespace))["stdout"]
         frr_daemon_memory = int(output.split()[-2])
         unit = output.split()[-1]
         if unit == "KiB":


### PR DESCRIPTION
Without this change `stress/test_stress_routes.py` will fail on multi-asic systems with:
```
 E           tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
 E           failed = True
 E           changed = True
 E           rc = 1
 E           cmd = vtysh -c "show memory bgpd"
 E           start = 2025-04-27 06:02:20.869391
 E           end = 2025-04-27 06:02:20.882943
 E           delta = 0:00:00.013552
 E           msg = non-zero return code
 E           invocation = {'module_args': {'_raw_params': 'vtysh -c "show memory bgpd"', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
 E           _ansible_no_log = None
 E           stdout =
 E           stderr =
 E           Usage: /usr/bin/vtysh -n [0 to 1] [OPTION]...
```

Summary:
Fixes #18270 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202503