### PR TITLE
Skip macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp to unblock PR test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1549,6 +1549,12 @@ macsec/test_interop_protocol.py::TestInteropProtocol::test_port_channel:
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-buildimage/issues/22081"
 
+macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp:
+  skip:
+    reason: "Skip SNMP test for causing continuously failing in PR testing"
+    conditions:
+      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18273"
+
 #######################################
 #####           mclag             #####
 #######################################


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
`macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp` test has high failure rate and is blocking PR test
#### How did you do it?
Skip `macsec/test_interop_protocol.py::TestInteropProtocol::test_snmp` with https://github.com/sonic-net/sonic-mgmt/issues/18273 to unblock
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
