### PR TITLE
Ensure iptables is restored to original state in kubesonic test

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -277,6 +277,10 @@ def clean_configdb_k8s_table(duthost):
 
 @pytest.fixture()
 def setup_and_teardown(duthost, vmhost, creds):
+    # Capture initial iptables
+    duthost.shell("sudo iptables-save > /tmp/iptables_rules_before")
+    duthost.shell("sudo ip6tables-save > /tmp/ip6tables_rules_before")
+
     check_image_type_supported(duthost)
     check_dut_k8s_version_supported(duthost)
     logger.info("Start to setup test environment")
@@ -345,6 +349,12 @@ def setup_and_teardown(duthost, vmhost, creds):
         # Clean up the current env
         remove_k8s_master(vmhost)
         remove_minikube(vmhost)
+
+    # Restore original iptables and cleanup
+    duthost.shell("sudo iptables-restore < /tmp/iptables_rules_before")
+    duthost.shell("sudo ip6tables-restore < /tmp/ip6tables_rules_before")
+    duthost.shell("rm -f /tmp/iptables_rules_before")
+    duthost.shell("rm -f /tmp/ip6tables_rules_before")
 
 
 def trigger_join_and_check(duthost, vmhost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18277

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We noticed `kubesonic/test_k8s_join_disjoin.py` was causing failures in `cacl/test_cacl_application.py` as teardown didn't set `iptables`/`ip6tables` to original state.
#### How did you do it?
Save `iptables`/`ip6tables` config before the test, then restore it after the test
#### How did you verify/test it?
Ensure that `iptables`/`ip6tables` was the same before and after test, and it doesn't cause failures in `cacl/test_cacl_application.py` when run after
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
