### PR TITLE
[Smartswitch] Disable loganalyzer for the some dpu reload cases

### DIFF
--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -76,6 +76,7 @@ def test_dpu_status_post_switch_config_reload(duthosts,
                               dpu_off_list, ip_address_list)
 
 
+@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_mem_exhaustion(duthosts,
                                                enum_rand_one_per_hwsku_hostname,  # noqa: E501
                                                localhost,
@@ -105,6 +106,7 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts,
                            ip_address_list)
 
 
+@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_switch_kernel_panic(duthosts,
                                              enum_rand_one_per_hwsku_hostname,
                                              localhost,
@@ -133,6 +135,7 @@ def test_dpu_status_post_switch_kernel_panic(duthosts,
                            ip_address_list)
 
 
+@pytest.mark.disable_loganalyzer
 def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
                                           enum_rand_one_per_hwsku_hostname,
                                           platform_api_conn, num_dpu_modules):  # noqa: F811, E501
@@ -158,6 +161,7 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules, "Non-Hardware")
 
 
+@pytest.mark.disable_loganalyzer
 def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
                                            enum_rand_one_per_hwsku_hostname,
                                            platform_api_conn, num_dpu_modules):  # noqa: F811, E501


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
During the memory exhaustion and kernel panic cases in [test_reload_dpu.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/smartswitch/platform_tests/test_reload_dpu.py) some errors are expected. Loganalyzer should be disabled in those cases.
For example, on SN4280 we see mlx5 driver errors because the driver is communicating between NPU and DPU, when either side is not responding due to kernel panic or memory exhaustion, the driver throws errors like:
```
ERR kernel: [ 1428.871135] mlx5_core 0000:08:00.0: poll_health:824:(pid 0): Fatal error 3 detected
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Disable loganalyzer in the following cases:
test_dpu_status_post_switch_mem_exhaustion
test_dpu_status_post_switch_kernel_panic
test_dpu_status_post_dpu_kernel_panic
test_dpu_check_post_dpu_mem_exhaustion

#### How did you verify/test it?
Run the test on SN4280.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
