### PR TITLE
Fix saithrift installation failure

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -394,8 +394,15 @@ def test_update_saithrift_ptf(request, ptfhost):
     PY_PATH = "/usr/lib/python3/dist-packages/"
     SRC_PATH = PY_PATH + "saithrift-0.9-py3.11.egg/switch_sai_thrift"
     DST_PATH = PY_PATH + "switch_sai_thrift"
-    if ptfhost.stat(path=SRC_PATH)['stat']['exists'] and not ptfhost.stat(path=DST_PATH)['stat']['exists']:
+    # Always remove the destination path if it exist
+    if ptfhost.stat(path=DST_PATH)['stat']['exists']:
+        ptfhost.shell("rm -rf {}".format(DST_PATH))
+
+    # Copy SRC_PATH to DST_PATH regardless of its current state
+    if ptfhost.stat(path=SRC_PATH)['stat']['exists']:
         ptfhost.copy(src=SRC_PATH, dest=PY_PATH, remote_src=True)
+    else:
+        pytest.skip("Python saithrift package installation failed")
     logging.info("Python saithrift package installed successfully")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) #18283 
The issue reported is fixed by always deleting the 'DST_PATH' if it exists and copy the SRC_PATH to DST_PATH

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Ensure Python saithrift package installation always succeeds, irrespective of previous failed test run terminations.

#### How did you do it?
Always delete 'DST_PATH' if it exists and copy the 'SRC_PATH'

#### How did you verify/test it?
Create a empty 'DST_PATH' in the ptf docker and run test_pretest.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
