### PR TITLE
Update PSU testcases to align with new format

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -88,14 +88,14 @@ def get_dut_psu_line_pattern(dut):
         w+ cannot match following examples properly:
 
         example 1:
-            PSU 1  PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
-            PSU 2  PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
+            psu1   PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
+            psu2   PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
         example 2:
-            PSU 1  N/A      N/A               12.05           3.38        40.62  OK        green
-            PSU 2  N/A      N/A               12.01           4.12        49.50  OK        green
+            psutray0.psu0  N/A      N/A               12.05           3.38        40.62  OK        green
+            psutray0.psu1  N/A      N/A               12.01           4.12        49.50  OK        green
 
         """
-        psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
+        psu_line_pattern = re.compile(r"^(\S+)\s+.*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
     return psu_line_pattern
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
https://github.com/sonic-net/sonic-utilities/pull/3208 updated the first column format of `show platform psustatus`. My PR update the testcase to align with the new format.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
update the PSU testcase to align with the new format in latest image change.

#### How did you do it?
Update the regex to match new format.

#### How did you verify/test it?
1. Verified by PR test.
2. Verified on Arista-7050CX3 physical testbed:

```
platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus[bjw2-can-7050-7-ignore_particular_error_log0] PASSED [100%]
========================================= 1 passed, 1 warning in 214.63s (0:03:34) ==========================================
platform_tests/cli/test_show_platform.py::test_show_platform_psustatus[bjw2-can-7050-7] PASSED                        [100%]
========================================== 1 passed, 1 warning in 93.90s (0:01:33) ==========================================
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
