### PR TITLE
Fix ACL tests for t1-isolated-d28/128

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -358,20 +358,34 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
         pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
                        "Cannot get neighbor type for unsupported topo: {}".format(topo))
         mg_vlans = mg_facts["minigraph_vlans"]
-        for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
-            port_id = mg_facts["minigraph_ptf_indices"][interface]
-            if downstream_neigh_type in neighbor["name"].upper():
-                if topo in ["t0", "mx", "m0_vlan"]:
-                    if interface not in mg_vlans[vlan_name]["members"]:
-                        continue
+        if tbinfo["topo"]["name"] in ("t1-isolated-d28", "t1-isolated-d128"):
+            count = 0
+            for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
+                port_id = mg_facts["minigraph_ptf_indices"][interface]
+                if count % 2 == 0:
+                    downstream_ports[neighbor['namespace']].append(interface)
+                    downstream_port_ids.append(port_id)
+                    downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
+                else:
+                    upstream_ports[neighbor['namespace']].append(interface)
+                    upstream_port_ids.append(port_id)
+                    upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
+                count += 1
+        else:
+            for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
+                port_id = mg_facts["minigraph_ptf_indices"][interface]
+                if downstream_neigh_type in neighbor["name"].upper():
+                    if topo in ["t0", "mx", "m0_vlan"]:
+                        if interface not in mg_vlans[vlan_name]["members"]:
+                            continue
 
-                downstream_ports[neighbor['namespace']].append(interface)
-                downstream_port_ids.append(port_id)
-                downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
-            elif upstream_neigh_type in neighbor["name"].upper():
-                upstream_ports[neighbor['namespace']].append(interface)
-                upstream_port_ids.append(port_id)
-                upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
+                    downstream_ports[neighbor['namespace']].append(interface)
+                    downstream_port_ids.append(port_id)
+                    downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
+                elif upstream_neigh_type in neighbor["name"].upper():
+                    upstream_ports[neighbor['namespace']].append(interface)
+                    upstream_port_ids.append(port_id)
+                    upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
 
     # stop garp service for single tor
     if 'dualtor' not in tbinfo['topo']['name']:
@@ -399,7 +413,8 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
     acl_table_ports = defaultdict(list)
 
     if topo in ["t0", "mx", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag",
-                                                                              "t1-isolated-d28u1"):
+                                                                              "t1-isolated-d28u1", "t1-isolated-d28",
+                                                                              "t1-isolated-d128"):
         for namespace, port in list(downstream_ports.items()):
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.
@@ -890,6 +905,9 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
 
     def get_dst_ports(self, setup, direction):
         """Get the set of possible destination ports for the current test."""
+        if setup["topo_name"] in ("t1-isolated-d28", "t1-isolated-d128"):
+            return setup["upstream_port_ids"] + setup["downstream_port_ids"] if direction == "downlink->uplink" \
+                    else setup["downstream_port_ids"]
         return setup["upstream_port_ids"] if direction == "downlink->uplink" else setup["downstream_port_ids"]
 
     def get_dst_ip(self, direction, ip_version):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18320 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?
Fix all tests in `acl/test_acl.py` for t1-isolated-d28/128.

#### How did you do it?
We modify the ACL test configuration by splitting the downlinks into two groups (odd and even port indices) and run the ACL tests between these two groups.

#### How did you verify/test it?
Tested on t1-isolated-d28 and t1-isolated-d128

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
