### PR TITLE
Fix Skip tests if no portchannels are found in prepare_test_port fixture

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -114,6 +114,8 @@ def prepare_test_port(rand_selected_dut, tbinfo):
     if tbinfo["topo"]["type"] == "mx":
         dut_port = rand_selected_dut.acl_facts()["ansible_facts"]["ansible_acl_facts"]["DATAACL"]["ports"][0]
     else:
+        if not mg_facts['minigraph_portchannels']:
+            pytest.skip('No portchannels found')
         dut_port = list(mg_facts['minigraph_portchannels'].keys())[0]
     if not dut_port:
         pytest.skip('No portchannels found')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18291 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Fix bug, and let code run by design.

#### How did you do it?
Adjust the check condition for if there is portchannel.

#### How did you verify/test it?
Verified by running local test on testbed with no portchannel, and was erroring out before the fix.
![image](https://github.com/user-attachments/assets/8a81f43a-8066-4768-852b-1cffa0ebf7f1)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
