### PR TITLE
[dualtor][sniffer] Explicitly set listen ports

### DIFF
--- a/tests/scripts/dual_tor_sniffer.py
+++ b/tests/scripts/dual_tor_sniffer.py
@@ -1,11 +1,13 @@
 import argparse
 import logging
+import socket
 
 import scapy.all as scapyall
 
 
 class Sniffer(object):
     def __init__(self, filter=None, timeout=60):
+        self.ifaces = [iface for _, iface in socket.if_nameindex() if iface.startswith("eth")]
         self.filter = filter
         self.timeout = timeout
         self.packets = []
@@ -15,6 +17,7 @@ class Sniffer(object):
         logging.debug("scapy sniffer started: filter={}, timeout={}".format(
             self.filter, self.timeout))
         scapyall.sniff(
+            iface=self.ifaces,
             filter=self.filter,
             prn=self.process_pkt,
             timeout=self.timeout)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
On scapy with version v2.40 and under, the sniffer will capture packets on every interface if no interface is given.
On scapy with version v.2.50 and higher, the sniffer will capture packets on `conf.iface` if no interface is given; on the ptf, `conf.iface` is `mgmt`, so `dual_tor_sniffer` is not able to capture any meaningful dataplane packets.

https://github.com/secdev/scapy/pull/1420

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let `dual_tor_sniffer` explicitly sniff on dataplane ports (any ptf ports starting with `eth`)

#### How did you verify/test it?
Run dualtor I/O testcase.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
