### PR TITLE
BGP testcases failure having sonic as neighbor device

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -23,7 +23,8 @@ from tests.common.utilities import wait_until, delete_running_config
 from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
-
+from tests.common.devices.sonic import SonicHost
+from tests.common.devices.eos import EosHost
 
 pytestmark = [
     pytest.mark.topology('t1', 't1-multi-asic'),
@@ -195,6 +196,8 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
+    nhipv4 = tbinfo['topo']['properties']['configuration_properties']['common']['nhipv4']
+    nhipv6 = tbinfo['topo']['properties']['configuration_properties']['common']['nhipv6']
     tor_neighbors = natsorted([neighbor for neighbor in list(nbrhosts.keys()) if neighbor.endswith('T0')])
     tor1 = tor_neighbors[0]
 
@@ -232,12 +235,18 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
     aspath_dual_dut_asn = '{} {} {} {}'.format(dut_asn, DUMMY_ASN1, dut_asn, DUMMY_ASN2)
 
     Route = namedtuple('Route', ['prefix', 'nexthop', 'aspath'])
+    '''
+    tor1's peer_addr is nothing but DUT's interface IP. Sending with DUT's IP as nexthop
+    will be treated as martian route and it will be dropped.  Even if we use
+    allow-martian-nexthop feature, it will be received by DUT, but it will  not
+    be installed in FIB and advertised to other neighbors.  This will lead both DUT check
+    and other_vms check to fail. Hence, exabgp ip is used as nexthop.
+    '''
+    bbr_route = Route(BBR_PREFIX, nhipv4, aspath)
+    bbr_route_v6 = Route(BBR_PREFIX_V6, nhipv6, aspath)
 
-    bbr_route = Route(BBR_PREFIX, neigh_peer_map[tor1]['peer_addr'], aspath)
-    bbr_route_v6 = Route(BBR_PREFIX_V6, neigh_peer_map[tor1]['peer_addr_v6'], aspath)
-
-    bbr_route_dual_dut_asn = Route(BBR_PREFIX, neigh_peer_map[tor1]['peer_addr'], aspath_dual_dut_asn)
-    bbr_route_v6_dual_dut_asn = Route(BBR_PREFIX_V6, neigh_peer_map[tor1]['peer_addr_v6'], aspath_dual_dut_asn)
+    bbr_route_dual_dut_asn = Route(BBR_PREFIX, nhipv4, aspath_dual_dut_asn)
+    bbr_route_v6_dual_dut_asn = Route(BBR_PREFIX_V6, nhipv6, aspath_dual_dut_asn)
 
     setup_info = {
         'bbr_default_state': bbr_default_state,
@@ -312,16 +321,28 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
         # Check route on tor1
         logger.info('Check route for prefix {} on {}'.format(route.prefix, tor1))
         tor1_route = nbrhosts[tor1]['host'].get_route(route.prefix)
-        if route.prefix not in list(tor1_route['vrfs']['default']['bgpRouteEntries'].keys()):
-            logging.warning('No route for {} found on {}'.format(route.prefix, tor1))
-            return False
-        tor1_route_aspath = tor1_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
-            ['asPathEntry']['asPath']   # noqa:E211
-        if not tor1_route_aspath == route.aspath:
-            logging.warning(
-                'On {} expected aspath: {}, actual aspath: {}'.format(tor1, route.aspath, tor1_route_aspath)
-            )
 
+        if isinstance(nbrhosts[tor1]['host'], EosHost):
+            if route.prefix not in list(tor1_route['vrfs']['default']['bgpRouteEntries'].keys()):
+                logging.warn('No route for {} found on {}'.format(route.prefix, tor1))
+                return False
+            tor1_route_aspath = tor1_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
+                ['asPathEntry']['asPath']   # noqa E211
+            if not tor1_route_aspath == route.aspath:
+                logging.warn('On {} expected aspath: {}, actual aspath: {}'.format(
+                    tor1, route.aspath, tor1_route_aspath))
+                return False
+        elif isinstance(nbrhosts[tor1]['host'], SonicHost):
+            if not tor1_route:
+                logging.warn('No route for {} found on {}'.format(route.prefix, tor1))
+                return False
+            tor1_route_aspath = tor1_route['paths'][0]['aspath']['string']
+            if not tor1_route_aspath == route.aspath:
+                logging.warn('On {} expected aspath: {}, actual aspath: {}'.format(
+                    tor1, route.aspath, tor1_route_aspath))
+                return False
+        else:
+            logging.error('Unknown host type {} for {}'.format(type(nbrhosts[tor1]['host']), tor1))
             return False
         return True
 
@@ -360,8 +381,8 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
                     logging.warning("DUT didn't advertise route to neighbor %s" % vm)
                     return False
         else:
-            if dut_route:
-                logging.warning('Prefix {} should not be accepted by DUT'.format(route.prefix))
+            if dut_route and 'paths' in dut_route:
+                logging.warn('Prefix {} should not be accepted by DUT'.format(route.prefix))
         return True
 
     # Check route on other VMs
@@ -378,23 +399,45 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
         vm_route['failed'] = False
         vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
         if accepted:
-            if route.prefix not in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
-                vm_route['failed'] = True
-                vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
-            else:
-                tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
-                    ['asPathEntry']['asPath']   # noqa:E211
-                # Route path from other VMs: -> DUT(T1) -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
-                tor_route_aspath_expected = '{} {} {}'.format(dut_asn, tor1_asn, route.aspath)
-                if tor_route_aspath != tor_route_aspath_expected:
+            tor_route_aspath = None
+            if isinstance(nbrhosts[node]['host'], EosHost):
+                if route.prefix not in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
                     vm_route['failed'] = True
-                    vm_route['message'] = 'On {} expected aspath: {}, actual aspath: {}'\
-                        .format(node, tor_route_aspath_expected, tor_route_aspath)
-        else:
-            if route.prefix in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
+                    vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
+                else:
+                    tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
+                    ['asPathEntry']['asPath']   # noqa E211
+            elif isinstance(nbrhosts[node]['host'], SonicHost):
+                if vm_route and 'paths' in vm_route:
+                    tor_route_aspath = vm_route['paths'][0]['aspath']['string']
+                else:
+                    vm_route['failed'] = True
+                    vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
+            else:
                 vm_route['failed'] = True
-                vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
-        results[node] = vm_route
+                logging.error('Unknown host type {} for {}'.format(type(nbrhosts[node]['host']), node))
+                return
+
+            # Route path from other VMs: -> DUT(T1) -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
+            tor_route_aspath_expected = '{} {} {}'.format(dut_asn, tor1_asn, route.aspath)
+            if tor_route_aspath != tor_route_aspath_expected:
+                vm_route['failed'] = True
+                vm_route['message'] = 'On {} expected aspath: {}, actual aspath: {}'\
+                    .format(node, tor_route_aspath_expected, tor_route_aspath)
+        else:
+            if isinstance(nbrhosts[node]['host'], EosHost):
+                if route.prefix in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
+                    vm_route['failed'] = True
+                    vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+            elif isinstance(nbrhosts[node]['host'], SonicHost):
+                if vm_route and 'paths' in vm_route:
+                    vm_route['failed'] = True
+                    vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+            else:
+                vm_route['failed'] = True
+                logging.error('Unknown host type {} for {}'.format(type(nbrhosts[node]['host']), node))
+                return
+        return vm_route
 
     other_vms = setup['other_vms']
     bgp_neighbors = json.loads(duthost.shell("sonic-cfggen -d --var-json 'BGP_NEIGHBOR'")['stdout'])

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -211,7 +211,7 @@ def test_bgp_peer_shutdown(
             if not announced_route_on_dut_before_shutdown:
                 pytest.fail("announce route %s from n0 to dut failed" % announced_route["prefix"])
 
-            timestamp_before_teardown = time.time()
+            timestamp_before_teardown = float(duthost.shell("date +%s.%6N")['stdout'])
             # tear down BGP session on n0
             bgp_pcap = BGP_DOWN_LOG_TMPL
             with capture_bgp_packages_to_file(duthost, "any", bgp_pcap, n0.namespace):

--- a/tests/bgp/test_bgp_route_neigh_learning.py
+++ b/tests/bgp/test_bgp_route_neigh_learning.py
@@ -2,6 +2,9 @@ import json
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert as py_assert
+from tests.common.devices.eos import EosHost
+from tests.common.devices.sonic import SonicHost
+from tests.common.utilities import wait_until
 pytestmark = [
     pytest.mark.topology('t0'),
     pytest.mark.device_type('vs')
@@ -47,17 +50,44 @@ def fixture_setUp(nbrhosts, duthosts, enum_frontend_dut_hostname):
 
     Logger.info("Performing cleanup")
     for name in data['T1']:
+        nbrhost = data['nbr'][name]['host']
         bgp_as_num = data['bgp'][name]
         # remove the route in the neighbor T1 eos device
-        cmds = ["configure",
-                "router bgp {}".format(bgp_as_num),
-                "address-family ipv4",
-                "no network {}/{}".format(V4_PREFIX, V4_MASK),
-                "no interface loopback 1",
-                "exit"
-                ]
-        Logger.info("Route, IP and Loopback 1 removed from %s", name)
-        data['nbr'][name]['host'].run_command_list(cmds)
+        if isinstance(nbrhost, EosHost):
+            cmds = ["configure",
+                    "router bgp {}".format(bgp_as_num),
+                    "address-family ipv4",
+                    "no network {}/{}".format(V4_PREFIX, V4_MASK),
+                    "no interface loopback 1",
+                    "exit"
+                    ]
+            Logger.info("Route, IP and Loopback 1 removed from %s", name)
+            nbrhost.run_command_list(cmds)
+        elif isinstance(nbrhost, SonicHost):
+            cmd = "sudo vtysh -c 'configure terminal' " \
+                  f"-c 'router bgp {bgp_as_num}' " \
+                  "-c 'address-family ipv4 unicast' " \
+                  f"-c 'no network {V4_PREFIX}/{V4_MASK}' " \
+                  "-c 'exit-address-family'"
+            result = nbrhost.shell(cmd)
+            py_assert(result['rc'] == 0, "BGP network not removed")
+            cmd = f"sudo config interface ip remove Loopback1 {V4_PREFIX}/{V4_MASK}"
+            result = nbrhost.shell(cmd)
+            py_assert(result['rc'] == 0, "loopback interface not removed")
+        else:
+            raise ValueError("Unsupported neighbor type")
+
+
+def _check_route_propagation(duthost, data):
+    cmd = "redis-cli -n 0 hget \"ROUTE_TABLE:{}\" 'nexthop'".format(V4_PREFIX)
+    result = duthost.shell(cmd)
+    if result['stdout'] == "":
+        return None
+    Logger.info("Route table nexthops are %s", result)
+    nexthops = result['stdout'].split(",")
+    if len(nexthops) != len(data['T1']):
+        return False
+    return True
 
 
 def run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, data):
@@ -66,28 +96,40 @@ def run_bgp_neighbor_route_learning(duthosts, enum_frontend_dut_hostname, data):
 
     for name in data['T1']:
         bgp_as_num = data['bgp'][name]
+        nbrhost = data['nbr'][name]['host']
+        cmds = []
         # add a route in the neighbor T1 eos device
-        cmds = ["configure",
-                "interface loopback 1",
-                "ip address {}/{}".format(V4_PREFIX, V4_MASK),
-                "exit",
-                "router bgp {}".format(bgp_as_num),
-                "address-family ipv4",
-                "network {}/{}".format(V4_PREFIX, V4_MASK),
-                "exit"
-                ]
-        data['nbr'][name]['host'].run_command_list(cmds)
-        Logger.info("Route %s added to :%s", V4_PREFIX, name)
+        if isinstance(nbrhost, EosHost):
+            cmds = ["configure",
+                    "interface loopback 1",
+                    "ip address {}/{}".format(V4_PREFIX, V4_MASK),
+                    "exit",
+                    "router bgp {}".format(bgp_as_num),
+                    "address-family ipv4",
+                    "network {}/{}".format(V4_PREFIX, V4_MASK),
+                    "exit"
+                    ]
+            nbrhost.run_command_list(cmds)
+        elif isinstance(nbrhost, SonicHost):
+            # Create and configure loopback interface
+            cmd = f"sudo config interface ip add Loopback1 {V4_PREFIX}/{V4_MASK}"
+            result = nbrhost.shell(cmd)
+            py_assert(result['rc'] == 0, "Failed to configure loopback interface")
+            # Configure BGP network
+            cmd = "sudo vtysh -c 'configure terminal' " \
+                  f"-c 'router bgp {bgp_as_num}' " \
+                  "-c 'address-family ipv4 unicast' " \
+                  f"-c 'network {V4_PREFIX}/{V4_MASK}' " \
+                  "-c 'exit-address-family'"
+            result = nbrhost.shell(cmd)
+            py_assert(result['rc'] == 0, "Failed to configure BGP network")
+        else:
+            raise ValueError("Unsupported neighbor type")
 
     duthost = duthosts[enum_frontend_dut_hostname]
-    #  redis-cli -n 0  hget "ROUTE_TABLE:99.99.99.99" 'nexthop'
     Logger.info("checking  DUT for route %s", V4_PREFIX)
-    cmd = "redis-cli -n 0  hget \"ROUTE_TABLE:{}\" 'nexthop'".format(V4_PREFIX)
-    result = duthost.shell(cmd)
-    result = result['stdout']
-    Logger.info("Route table nexthops are %s", result)
-    py_assert(result != "", "The route has not propagated to the DUT")
-    py_assert(len(result.split(",")) == len(data['T1']), "Some Neighbor did not propagated route to the DUT")
+    is_route_propagated = wait_until(10, 2, 0, lambda: _check_route_propagation(duthost, data))
+    py_assert(is_route_propagated, "Route did not propagate to the DUT")
 
 
 def test_bgp_neighbor_route_learnning(duthosts, enum_frontend_dut_hostname, setUp):

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -575,3 +575,6 @@ class EosHost(AnsibleHostBase):
             parents=['interface {}'.format(interface_name)])
         logging.info('Reset lacp timer to default for interface [%s]' % interface_name)
         return out
+
+    def config(self, lines=None, parents=None, module_ignore_errors=False):
+        return self.eos_config(lines=lines, parents=parents)

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -21,8 +21,7 @@ pytestmark = [
 
 def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
     logger.info("announce ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/",
-                              log_path="logs")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="announce", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "outq") is True)
 
@@ -31,8 +30,7 @@ def announce_withdraw_routes(duthost, namespace, localhost, ptf_ip, topo_name):
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)
 
     logger.info("withdraw ipv4 and ipv6 routes")
-    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/",
-                              log_path="logs")
+    localhost.announce_routes(topo_name=topo_name, ptf_ip=ptf_ip, action="withdraw", path="../ansible/")
 
     wait_until(MAX_WAIT_TIME, CRM_POLLING_INTERVAL, 0, lambda: check_queue_status(duthost, "inq") is True)
     sleep_to_wait(CRM_POLLING_INTERVAL * 5)


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-buildimage/issues/22578

The following are a set of testcase which fail when we use sonic as neighbor device.  This set of testcases use EOS as neighbor device.

List of test cases:
/tests/bgp/test_bgp_peer_shutdown.py
/tests/bgp/test_bgp_route_neigh_learning.py
/tests/bgp/test_bgp_bbr.py


The changes include some of the common and helper function update to support sonic related configuration and validaton and using these in these test cases.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
