### PR TITLE
Fix PortChannel name matching in verify_attr_change to handle leading spaces

### DIFF
--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -264,7 +264,12 @@ def verify_attr_change(duthost, po_name, attr, value):
             ...
     """
     if attr == "mtu":
-        output = duthost.shell("show interfaces status | grep -w '^{}' | awk '{{print $4}}'".format(po_name))
+        cmd = (
+            "show interfaces status | "
+            "grep -w '^[[:space:]]*{}' | "
+            "awk '{{print $4}}'"
+        ).format(po_name)
+        output = duthost.shell(cmd)
 
         pytest_assert(output['stdout'] == value, "{} attribute {} failed to change to {}".format(po_name, attr, value))
     elif attr == "min_links":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
test_portchannel_interface_tc2_attributes failed with the following error:
```
        if attr == "mtu":
            output = duthost.shell("show interfaces status | grep -w '^{}' | awk '{{print $4}}'".format(po_name))
    
>           pytest_assert(output['stdout'] == value, "{} attribute {} failed to change to {}".format(po_name, attr, value))
E           Failed: PortChannel102 attribute mtu failed to change to 3324
```
This is due to cmd "show interfaces status | grep -w '^{}' | awk '{{print $4}}'" failed to filter out the correct PortChannel interface line when the PortChannel name is indented with spaces:
```
 PortChannel102              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
 PortChannel104              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
 PortChannel106              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
 PortChannel108              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
 PortChannel109              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel1010              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel1011              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel1012              N/A     100G   9100    N/A           N/A           routed      up       up              N/A         N/A
```
This PR updates the verify_attr_change function in test_portchannel_interface.py to correctly handle leading spaces in the PortChannel name when parsing interface status output.

#### How did you do it?
Modified the grep pattern from '^{}' to ^[[:space:]]*{} to match interface lines with leading spaces robustly.

#### How did you verify/test it?
Run generic_config_updater/test_portchannel_interface.py::test_portchannel_interface_tc2_attributes manually on DUT.
```
generic_config_updater/test_portchannel_interface.py::test_portchannel_interface_tc2_attributes PASSED                                                                                                 [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
