### PR TITLE
[platform_tests] Enable test_intf_fec.py test for Marvell

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -22,7 +22,7 @@ SUPPORTED_PLATFORMS = [
 ]
 
 SUPPORTED_SPEEDS = [
-    "100G", "200G", "400G", "800G", "1600G"
+    "50G", "100G", "200G", "400G", "800G", "1600G"
 ]
 
 
@@ -63,6 +63,9 @@ def test_verify_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     # Get interfaces that are operationally up and have supported speeds.
     interfaces = get_fec_eligible_interfaces(duthost, SUPPORTED_SPEEDS)
 
+    if not interfaces:
+        pytest.skip("Skipping this test as there is no fec eligible interface")
+
     for intf in interfaces:
         # Verify the FEC operational mode is valid
         fec = get_fec_oper_mode(duthost, intf)
@@ -82,6 +85,9 @@ def test_config_fec_oper_mode(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
 
     # Get interfaces that are operationally up and have supported speeds.
     interfaces = get_fec_eligible_interfaces(duthost, SUPPORTED_SPEEDS)
+
+    if not interfaces:
+        pytest.skip("Skipping this test as there is no fec eligible interface")
 
     for intf in interfaces:
         fec_mode = get_fec_oper_mode(duthost, intf)
@@ -123,6 +129,12 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
+    # Get operationally up and interfaces with supported speeds
+    interfaces = get_fec_eligible_interfaces(duthost, SUPPORTED_SPEEDS)
+
+    if not interfaces:
+        pytest.skip("Skipping this test as there is no fec eligible interface")
+
     logging.info("Get output of 'show interfaces counters fec-stats'")
     intf_status = duthost.show_and_parse("show interfaces counters fec-stats")
 
@@ -140,7 +152,9 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
     for intf in intf_status:
         intf_name = intf['iface']
         speed = duthost.get_speed(intf_name)
-        if speed not in SUPPORTED_SPEEDS:
+        # Convert the speed to gbps format
+        speed_gbps = f"{int(speed) // 1000}G"
+        if speed_gbps not in SUPPORTED_SPEEDS:
             continue
 
         # Removes commas from "show interfaces counters fec-stats" (i.e. 12,354 --> 12354) to allow int conversion
@@ -238,6 +252,9 @@ def test_verify_fec_histogram(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
 
     # Get operationally up and interfaces with supported speeds
     interfaces = get_fec_eligible_interfaces(duthost, SUPPORTED_SPEEDS)
+
+    if not interfaces:
+        pytest.skip("Skipping this test as there is no fec eligible interface")
 
     for intf_name in interfaces:
         for _ in range(3):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
Please provide following information to help code review process a bit easier:
-->
### Description of PR
- Enable test_intf_fec.py platform test for Marvell platform
- Adding 50G as supported fec capable speed
- Skipping the test case instead of returning success when DUT has no fec eligible interface.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To run the fec test for Marvell TL10 platform 
#### How did you do it?
Enabling the test case for marvell platform
#### How did you verify/test it?
Verified by running platform_tests/test_intf_fec.py test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
