### PR TITLE
PY3 upgrade in everflow policer test for marvell-teralynx specific ERSPAN Header Format

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -274,7 +274,7 @@ class EverflowPolicerTest(BaseTest):
             elif self.asic_type in ["marvell-teralynx"] or \
                     self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx", "Nokia-7215-A1"]:
                 pkt = scapy.Ether(pkt)[scapy.GRE].payload
-                pkt = scapy.Ether(pkt[8:])
+                pkt = scapy.Ether(bytes(pkt)[8:])
             elif self.asic_type == "barefoot":
                 pkt = scapy.Ether(pkt).load
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
Fixed a pattern matching issue in case of everflow policer tests as part of checkMirroredFlow fixture, py3 upgrade is added for marvell-teralynx specific ERSPAN Header format.
-->

Summary:
Fix applicable for specific platform vendor.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
py3 migration for vendor specific packet format to validate the test on marvell-teralynx platform.

#### How did you do it?
Added byte conversion.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
-->
