### PR TITLE
Test_decap: Inner packet construction enhanced to handle Uniform DSCP mode

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -270,7 +270,7 @@ class DecapPacketTest(BaseTest):
         if "pipe" == self.dscp_mode:
             exp_tc = exp_tos = tc_in
         elif "uniform" == self.dscp_mode:
-            exp_tc = exp_tos = tc_out
+            exp_tc = exp_tos = tc_out = tos_in
         else:
             print("ERROR: no dscp is configured")
             exit()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This PR fixes the Inner packet construction to handle the incoming tos value as per uniform mode.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Assert error observed due to mismatch in the received packet and the expected packet.
Root Cause:
Test constructs IPinIP packets and verifies the DUT's decapsulation functionality, In current script, Inner packet that is sent from PTF docker is not updated with the correct incoming tos value that is suitable for uniform DSCP model. 
This PR fixes the Inner packet construction to handle the incoming tos value as per uniform mode.

#### How did you verify/test it?
Test Cases
with this the following 2 cases from test_decap is successful now,
1.decap.test_decap -> test_decap[ttl=pipe, dscp=uniform, vxlan=disable] :: SUCCESS
2.decap.test_decap -> test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset] :: SUCCESS

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
