### PR TITLE
[fib] Handle VOQ systems which don't have inband ports

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -49,7 +49,8 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts, testname=None):
         for asic_cfg_facts in cfg_facts:
             if duthost.facts['switch_type'] == "voq":
                 switch_type = "voq"
-                dut_inband_intfs.setdefault(duthost.hostname, []).extend(asic_cfg_facts[1]['VOQ_INBAND_INTERFACE'])
+                if 'VOQ_INBAND_INTERFACE' in asic_cfg_facts[1]:
+                    dut_inband_intfs.setdefault(duthost.hostname, []).extend(asic_cfg_facts[1]['VOQ_INBAND_INTERFACE'])
             dut_port_channels.setdefault(duthost.hostname, {}).update(asic_cfg_facts[1].get('PORTCHANNEL_MEMBER', {}))
     sys_neigh = {}
     if switch_type == "voq":


### PR DESCRIPTION
On new single-asic fixed VOQ systems we don't need a inband port nor do we have one, this causes test_fib.py to fail with:
```
        # Collect system neighbors, inband intf and port channel info to resolve ptf ports
        # for system neigh or lags.
        dut_inband_intfs = {}
        dut_port_channels = {}
        switch_type = ''
        for duthost in duthosts.frontend_nodes:
            cfg_facts = duts_cfg_facts[duthost.hostname]
            for asic_cfg_facts in cfg_facts:
                if duthost.facts['switch_type'] == "voq":
                    switch_type = "voq"
&gt;                   dut_inband_intfs.setdefault(duthost.hostname, []).extend(asic_cfg_facts[1]['VOQ_INBAND_INTERFACE'])
E                   KeyError: 'VOQ_INBAND_INTERFACE'
```

We can skip adding this if there is no `VOQ_INBAND_INTERFACE` as `dut_inband_intfs` is only used to skip internal ports later in the function:
```
# Skip route for inband neighbors.
if remote_neigh_intf in dut_inband_intfs[remote_duthost_name]:
    skip = True
    continue
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
