### PR TITLE
Skip test cases where packets have SRH for broadcom platform

### DIFF
--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -163,6 +163,11 @@ class SRv6Base():
 
         ptf_src_mac = ptfadapter.dataplane.get_mac(0, self.params['ptf_downlink_port']).decode('utf-8')
         for srv6_packet in self.params['srv6_packets']:
+            if duthost.facts["asic_type"] == "broadcom" and \
+               (srv6_packet['srh_seg_left'] or srv6_packet['srh_seg_list']):
+                logger.info("Skip the test for Broadcom ASIC with SRH")
+                continue
+
             logger.info('-------------------------------------------------------------------------')
             logger.info(f'SRv6 tunnel decapsulation mode: {dscp_mode}')
             logger.info(f'Send {self.params["packet_num"]} SRv6 packets with action: {srv6_packet["action"]}')


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Broadcom hardware cannot process SRv6 packets with SRH properly at this time. We need to skip testing those packets on Broadcom hardware.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
