### PR TITLE
pfcwd/test_pfcwd_cli.py Use Redis Config Facts for Lag Shutdown

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -304,7 +304,7 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         if self.ports[selected_port]['test_port_type'] != 'portchannel':
             return
 
-        config_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
+        config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
         portChannels = config_facts['PORTCHANNEL_MEMBER']
         portChannel = None
         portChannelMembers = None


### PR DESCRIPTION
Problem encountered using the config_db.json config information - PORTCHANNEL_MEMBER was indexed using the Ethernet alias name so the correct port channel could not be found.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/18318

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
