### PR TITLE
fix the prefix_to_ipv4 to return decimal format address

### DIFF
--- a/tests/dash/proto_utils.py
+++ b/tests/dash/proto_utils.py
@@ -154,15 +154,22 @@ def get_message_from_table_name(table_name):
 
 
 def prefix_to_ipv4(prefix_length):
+    if int(prefix_length) > 32:
+        return ""
     mask = 2**32 - 2**(32-int(prefix_length))
     s = str(hex(mask))
     s = s[2:]
     hex_groups = [s[i:i+2] for i in range(0, len(s), 2)]
-    ipv4_address_str = '.'.join(hex_groups)
+    decimal_groups = []
+    for hex_string in hex_groups:
+        decimal_groups.append(str(int(hex_string, 16)))
+    ipv4_address_str = '.'.join(decimal_groups)
     return ipv4_address_str
 
 
 def prefix_to_ipv6(prefix_length):
+    if int(prefix_length) > 128:
+        return ""
     mask = 2**128 - 2**(128-int(prefix_length))
     s = str(hex(mask))
     s = s[2:]


### PR DESCRIPTION
### Description of PR
Fix the prefix_to_ipv4 to return a prefix made of decimal values and not hex values

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
