### PR TITLE
Higher timeout for vs chassis

### DIFF
--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -65,13 +65,6 @@
           regexp: '^check program routeCheck with path "/usr/local/bin/route_check.py"'
           line: "check program routeCheck with path \"/usr/local/bin/route_check.py\" timeout 600 seconds"
 
-      - name: Set routeCheck timeout to 600 seconds
-        become: true
-        lineinfile:
-          path: /usr/local/bin/route_check.py
-          regexp: '^TIMEOUT_SECONDS ='
-          line: "TIMEOUT_SECONDS = 600"
-
       - name: Execute setup_vs_chassis.sh to configure the DUT as a chassis device
         shell: bash /usr/bin/setup_vs_chassis.sh
         become: true

--- a/ansible/testbed_config_vchassis.yml
+++ b/ansible/testbed_config_vchassis.yml
@@ -58,12 +58,19 @@
           dest: /usr/bin/setup_vs_chassis.sh
         become: true
 
-      - name: Set routeCheck timeout to 600 seconds
+      - name: Set routeCheck timeout to 600 seconds in monit
         become: true
         lineinfile:
           path: /etc/monit/conf.d/sonic-host
           regexp: '^check program routeCheck with path "/usr/local/bin/route_check.py"'
           line: "check program routeCheck with path \"/usr/local/bin/route_check.py\" timeout 600 seconds"
+
+      - name: Set routeCheck timeout to 600 seconds
+        become: true
+        lineinfile:
+          path: /usr/local/bin/route_check.py
+          regexp: '^TIMEOUT_SECONDS ='
+          line: "TIMEOUT_SECONDS = 600"
 
       - name: Execute setup_vs_chassis.sh to configure the DUT as a chassis device
         shell: bash /usr/bin/setup_vs_chassis.sh

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -749,7 +749,7 @@ class SonicHost(AnsibleHostBase):
         for service in self.critical_services:
             cmd = 'docker exec {} supervisorctl status'.format(service)
             cmds.append(cmd)
-        results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=30)['results']
+        results = self.shell_cmds(cmds=cmds, continue_on_fail=True, module_ignore_errors=True, timeout=60)['results']
 
         # Extract service name of each command result, transform results list to a dict keyed by service name
         service_results = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The execution time of critical process check and routeCheck.py on virtual chassis becomes very high on elastictest backend so we need to increase the timeout value.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
