### PR TITLE
[syslog]: test_syslog_source_ip.py fix IPv6 address case issue

### DIFF
--- a/tests/syslog/test_syslog_source_ip.py
+++ b/tests/syslog/test_syslog_source_ip.py
@@ -375,8 +375,8 @@ class TestSSIP:
         """
         syslog_config_list = self.duthost.show_syslog()
         for syslog_config in syslog_config_list:
-            if all([syslog_config["server ip"] == syslog_server_ip,
-                    syslog_config["source ip"] == source,
+            if all([syslog_config["server ip"].lower() == syslog_server_ip.lower(),
+                    syslog_config["source ip"].lower() == source.lower(),
                     syslog_config["vrf"] == vrf,
                     syslog_config["port"] == port]):
                 return True


### PR DESCRIPTION
### Description of PR
Ignore case when validating IPv6 address in syslog CLI output
`show syslog` CLI output shows IPv6 address in lower case.
But PTF ansible's can have IPv6 configuration in any case. This leads to test failure 

Sample Sonic PTF ansible IPv6 config:
```
ansible_hostv6 : FC00:2::32
```
Sonic DUT CLI output:
```
root@str-marvell-01:/home/admin# show syslog
SERVER IP      SOURCE IP      PORT    VRF
-------------  -------------  ------  --------
10.28.60.1     10.28.60.9     800     mgmt
100.100.100.1  100.100.100.2  800     default
200.200.200.1  200.200.200.2  800     Vrf-data
2221::1111     2221::1112     800     Vrf-data
2222::1111     2222::1112     800     default
fc00:2::1      fc00:2::32     800     mgmt      <===
```

Summary:
Fixes #18438 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
Change CLI validation code in test_syslog_source_ip.py to perform IPv6 validation in lower case.
#### What is the motivation for this PR?

#### How did you do it?
Changed logic to perform IP format verification in lower case.

#### How did you verify/test it?
By running Syslog PTF testcases:
```
syslog/test_syslog_source_ip.py::TestSSIP::test_basic_syslog_config[str-marvell-01-None-vrf_set_source_set_None] PASSED                                                             [100%]
```

[master_syslog_success_test.log](https://github.com/user-attachments/files/20231411/master_syslog_success_test.log)

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?

### Documentation


