### PR TITLE
[gcu]: Fix test_pfcwd_status.py failure

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1862,6 +1862,8 @@ Totals               6450                 6449
             asic = "gb"
         elif "Mellanox Technologies" in output:
             asic = "spc"
+        elif "Marvell Technology" in output:
+            asic = "marvell-teralynx"
 
         logger.info("asic: {}".format(asic))
 

--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -454,8 +454,8 @@ def is_valid_platform_and_version(duthost, table, scenario, operation, field_val
             "validator_data"]["rdma_config_update_validator"][scenario]["platforms"][asic]     # noqa: E501
         if version_required == "":
             return False
-        # os_version is in format "20220531.04", version_required is in format "20220500"
-        return os_version[0:8] >= version_required[0:8]
+        # os_version can be in any of 202411.1, 20241100.1 formats and version_required is in format "20220500"
+        return os_version.split('.')[0].ljust(8, '0') >= version_required[0:8]
     except KeyError:
         return False
     except IndexError:


### PR DESCRIPTION
### Description of PR
Fix test_pfcwd_status.py failure
Fix verified on marvell-teralynx platform.

Summary:
Fixes #18456 

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach

#### What is the motivation for this PR?
#### How did you do it?
os_version format on DUT can be in any of 202411.1, 20241100.1
On DUT `gcu_field_operation_validators.conf.json` field validator version is in format of "20241100"

Because of the version comparison issue, test case is failing.
Also added marvell-teralynx asic_name in get_asic_name

#### How did you verify/test it?
Verified by running generic_config_updater/test_pfcwd_status.py test on marvell-teralynx platform.

```
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[single] PASSED    [25%]
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[all] PASSED       [50%]
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[single] PASSED   [75%]
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[all] PASSED      [100%]
```

[pfcwd_status_success_test.log](https://github.com/user-attachments/files/20242066/pfcwd_status_success_test.log)

#### Any platform specific information?
marvell-teralynx
#### Supported testbed topology if it's a new test case?

### Documentation
