### PR TITLE
Check bgp status for gnmi test

### DIFF
--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -66,6 +66,16 @@ def get_sonic_cfggen_output(duthost, namespace=None):
     return (json.loads(output["stdout"]))
 
 
+def wait_bgp_neighbor(duthost):
+    '''
+    Wait for BGP neighbor to be up
+    '''
+    config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+    bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
+    pytest_assert(wait_until(60, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
+                  "Not all BGP sessions are established on DUT")
+
+
 def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     '''
     Verify GNMI native write, incremental config for configDB
@@ -103,6 +113,8 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     assert status == "up", "Incremental config failed to toggle interface %s status" % interface
     msg_list = gnmi_get(duthost, ptfhost, path_list)
     assert msg_list[0] == "\"up\"", msg_list[0]
+    # Wait for BGP neighbor to be up
+    wait_bgp_neighbor(duthost)
 
 
 def test_gnmi_configdb_incremental_02(duthosts, rand_one_dut_hostname, ptfhost):
@@ -336,6 +348,8 @@ def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost)
     # Startup interface
     duthost.shell("config interface startup %s" % interface)
     duthost.shell("config save -y")
+    # Wait for BGP neighbor to be up
+    wait_bgp_neighbor(duthost)
 
 
 def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost):

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -297,6 +297,8 @@ def test_gnmi_configdb_full_01(duthosts, rand_one_dut_hostname, ptfhost):
     assert status == "down", "Full config failed to toggle interface %s status" % interface
     # Startup interface
     duthost.shell("config interface startup %s" % interface)
+    # Wait for BGP neighbor to be up
+    wait_bgp_neighbor(duthost)
 
 
 def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 32456075

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
The BGP sessions are idle after test_gnmi_configdb, and then bgp related test failed.

#### How did you do it?
Check bgp status after test_gnmi_configdb to make sure bgp sessions are recovered.

#### How did you verify/test it?
Run gnmi end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
