### PR TITLE
[test_bgp_stress_link_flap] update completeness_level for bgp link flap case

### DIFF
--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -23,9 +23,9 @@ neighbor_flap_count = 0
 
 LOOP_TIMES_LEVEL_MAP = {
     'debug': 60,
-    'basic': 300,
-    'confident': 3600,
-    'thorough': 21600
+    'basic': 3600,
+    'confident': 21600,
+    'thorough': 432000
 }
 
 
@@ -205,6 +205,26 @@ async def flap_neighbor_interface(neighbor, neighbor_port, sleep_duration, test_
             break
 
 
+async def monitor_system_resources(duthost, test_run_duration, interval=60):
+    logger.info("Monitoring system resources for {} seconds, interval {} seconds".format(test_run_duration, interval))
+    start_time = time.time()
+
+    monitor_count = 0
+
+    while not stop_tasks and time.time() - start_time < test_run_duration:
+        logger.info("Memory usage:")
+        cmd = "free -m"
+        cmd_response = duthost.shell(cmd, module_ignore_errors=True)
+        logger.info("loop {} cmd {} rsp {}".format(monitor_count, cmd, cmd_response.get('stdout', None)))
+        monitor_count += 1
+
+        await asyncio.sleep(interval)
+
+        if stop_tasks:
+            logger.info("Stop monitor task, breaking monitor system resources monitor_count {} ".format(monitor_count))
+            break
+
+
 @pytest.mark.parametrize("test_type", ["dut", "fanout", "neighbor", "all"])
 def test_bgp_stress_link_flap(duthosts, rand_one_dut_hostname, setup, nbrhosts, fanouthosts, test_type,
                               get_function_completeness_level):
@@ -271,6 +291,12 @@ def test_bgp_stress_link_flap(duthosts, rand_one_dut_hostname, setup, nbrhosts, 
             logger.info("Start flap fanout {} dut {} ".format(fanouthosts, duthost))
             flap_tasks.append(task)
 
+        if normalized_level == 'thorough':
+            task = asyncio.create_task(
+                monitor_system_resources(duthost, TEST_RUN_DURATION, interval=1800))
+            logger.info("Start monitor system resources {}".format(duthost))
+            flap_tasks.append(task)
+
         logger.info("flap_tasks {} ".format(flap_tasks))
         start_time = time.time()
 
@@ -291,4 +317,8 @@ def test_bgp_stress_link_flap(duthosts, rand_one_dut_hostname, setup, nbrhosts, 
         flap_tasks.clear()
 
     asyncio.run(flap_interfaces())
+
+    logger.info("Test Completed, waiting for 60 seconds to stabilize the system")
+    time.sleep(60)
+
     return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
32454304

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
We plan to use this case test_bgp_stress_link_flap for the longevity test, current thorough run time is not meet the requirement, need enlarge the run time value for thorough level.

#### How did you do it?
update completeness_level for test_bgp_stress_link_flap.py
Enlarge the runtime for the case and add the memory monitor during test in thorough level.

#### How did you verify/test it?
Run the pipeline

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
