### PR TITLE
[test_cont_link_flap] Fix get_frr_daemon_memory_usage

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import time
 import math
+import re
 
 from collections import defaultdict
 
@@ -45,9 +46,12 @@ class TestContLinkFlap(object):
                 frr_daemon_memory_output
             )
 
-            frr_daemon_memory = asic.run_vtysh(
-                f'-c "show memory {daemon}" | grep "Used ordinary blocks"'
-            )["stdout"].split()[-2]
+            frr_str = asic.run_vtysh(f'-c "show memory {daemon}"')["stdout"]
+            frr_daemon_memory = ''
+            for line in frr_str.splitlines():
+                if re.search("Used ordinary blocks", line):
+                    frr_daemon_memory = line.split()[-2]
+                    break
 
             frr_daemon_memory_per_asics[asic.asic_index] = frr_daemon_memory
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18337 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Fix get_frr_daemon_memory_usage() to getting the proper memory usage of daemons.
Existing implementation fails to read proper memory usage as grep in vtysh shell is a unsupported command.

```
sonic# show memory bgpd | grep "Used ordinary blocks"
% Unknown action 'grep'
sonic# 
```

#### How did you do it?

#### How did you verify/test it?
Run test_cont_link_flap.py tests to verify test.log

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
