### PR TITLE
Recovery for inconsistent mux state issue

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -710,12 +710,15 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
 
         check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
 
-        def _verify_mux_simulator_status_passed():
-            nonlocal check_passed, err_msg, duts_mux_status
-            check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
-            return check_passed
-        duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
-        wait_until(30, 5, 0, _verify_mux_simulator_status_passed)
+        if not check_passed:
+            def _verify_mux_simulator_status_passed():
+                nonlocal check_passed, err_msg, duts_mux_status
+                check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
+                return check_passed
+
+            logger.warning('Mux state check failed, trying to recover via linkmgrd restart')
+            duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
+            wait_until(30, 5, 0, _verify_mux_simulator_status_passed)
 
         if not check_passed:
             logger.warning(err_msg)

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -710,6 +710,10 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
 
         check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
         if not check_passed:
+            duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
+            check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
+
+        if not check_passed:
             logger.warning(err_msg)
             results['failed'] = True
             results['failed_reason'] = err_msg

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -709,9 +709,13 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
         reason = ''
 
         check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
-        if not check_passed:
-            duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
+
+        def _verify_mux_simulator_status_passed():
+            nonlocal check_passed, err_msg, duts_mux_status
             check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
+            return check_passed
+        duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
+        wait_until(30, 5, 0,_verify_mux_simulator_status_passed)
 
         if not check_passed:
             logger.warning(err_msg)

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -715,7 +715,7 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
             check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
             return check_passed
         duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
-        wait_until(30, 5, 0,_verify_mux_simulator_status_passed)
+        wait_until(30, 5, 0, _verify_mux_simulator_status_passed)
 
         if not check_passed:
             logger.warning(err_msg)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To improve the speed of mux state recovery by restarting the linkmgrd process directly, reducing the time taken to recover from an inconsistent mux state.

#### How did you do it?
Added a linkmgrd restart command to save time for inconsistent mux state.

#### How did you verify/test it?
Ran the pre-test and confirmed that it can recover the inconsistent mux state.

Before:
![image](https://github.com/user-attachments/assets/84d3875b-6f91-4d6a-8855-ed1e72fe7e6a)

After:
![image](https://github.com/user-attachments/assets/ab8c4431-85dc-43d3-a6db-f454904404d8)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
