### PR TITLE
argparse conflicting option string

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,13 @@ def pytest_addoption(parser):
     # FWUtil options
     parser.addoption('--fw-pkg', action='store', help='Firmware package file')
 
+    #####################################
+    # dash, vxlan, route shared options #
+    #####################################
+    parser.addoption("--skip_cleanup", action="store_true", help="Skip config cleanup after test (tests: dash, vxlan)")
+    parser.addoption("--num_routes", action="store", default=None, type=int,
+                     help="Number of routes (tests: route, vxlan)")
+
     ############################
     # pfc_asym options         #
     ############################

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -63,12 +63,6 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--skip_cleanup",
-        action="store_true",
-        help="Skip config cleanup after test"
-    )
-
-    parser.addoption(
         "--skip_dataplane_checking",
         action="store_true",
         help="Skip dataplane checking"

--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -8,9 +8,6 @@ def pytest_addoption(parser):
 
     route_group = parser.getgroup("Route test suite options")
 
-    route_group.addoption("--num_routes", action="store", default=None, type=int,
-                          help="Number of routes for add/delete")
-
     route_group.addoption("--max_scale", action="store_true",
                           help="Test with maximum possible route scale")
 

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -60,14 +60,6 @@ def pytest_addoption(parser):
     )
 
     vxlan_group.addoption(
-        "--num_routes",
-        action="store",
-        default=16000,
-        type=int,
-        help="number of routes for VNET VxLAN test"
-    )
-
-    vxlan_group.addoption(
         "--num_endpoints",
         action="store",
         default=4000,
@@ -121,12 +113,6 @@ def pytest_addoption(parser):
         type=str2bool,
         default=True,
         help="Test IPV6 in IPv6"
-    )
-
-    vxlan_group.addoption(
-        "--skip_cleanup",
-        action="store_true",
-        help="Do not cleanup after VNET VxLAN test"
     )
 
     vxlan_group.addoption(
@@ -259,6 +245,8 @@ def scaled_vnet_params(request):
     params = {}
     params[NUM_VNET_KEY] = request.config.option.num_vnet
     params[NUM_ROUTES_KEY] = request.config.option.num_routes
+    if params[NUM_ROUTES_KEY] is None:
+        params[NUM_ROUTES_KEY] = 16000
     params[NUM_ENDPOINTS_KEY] = request.config.option.num_endpoints
     return params
 


### PR DESCRIPTION
### Description of PR
Two option strings, `--num_routes` and `--skip_cleanup` conflict between a couple of test suites.  This causes `./run_tests.sh` when executing test cases simultaneously (such as when running the full suite) to exit with an error of something like:
```
argparse.ArgumentError: argument --num_routes: conflicting option string(s): --num_routes
```

Move these arguments into the global scope from their conflicting locations.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/5526

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

Make running all tests pass

#### How did you do it?

Move conflicting options to global scope.

#### How did you verify/test it?
```
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -f vtestbed.yaml -i ../ansible/veos_vtb -e "--neighbor_type=sonic" -t t0,any
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
