### PR TITLE
Changes to accommodate Mixed mode testing

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1194,14 +1194,6 @@ def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
         snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts_multidut)
         snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
         snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
-        port_speed = None
-        for i in range(len(snappi_ports)):
-            if port_speed is None:
-                port_speed = int(snappi_ports[i]['speed'])
-
-            elif port_speed != int(snappi_ports[i]['speed']):
-                """ All the ports should have the same bandwidth """
-                return None
 
         for port in snappi_ports:
             port['intf_config_changed'] = False


### PR DESCRIPTION
### Description of PR

For mixed mode testing we need Ixia ports in different speed connected to DUT. Like 100G and 400G. In snappi fixture there was a check which was making sure all snappi ports are of same speed which was bailing out mixed mode tests.

Removing the check to have same speed Ixia ports to accommodate mixed speed testing


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
All mixed speed tests were failing with below error:

`12/05/2025 16:59:05 __init__._log_sep_line                   L0170 INFO   | ==================== snappi_tests/pfc/test_pfc_mixed_speed.py::test_mixed_speed_no_congestion[multi-dut-long-400g-short-100g-port_map0] call ==================== 12/05/2025 16:59:05 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last): File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest self.ihook.pytest_pyfunc_call(pyfuncitem=self) File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__ return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult) File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec return self._inner_hookexec(hook_name, methods, kwargs, firstresult) File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall raise exception.with_traceback(exception.__traceback__) File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall res = hook_impl.function(*args) File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call result = testfunction(**testargs) File "/data/tests/snappi_tests/pfc/test_pfc_mixed_speed.py", line 350, in test_mixed_speed_no_congestion pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count, TypeError: object of type 'NoneType' has no len()`

#### How did you do it?
Removed the check for same speed ixia ports

#### How did you verify/test it?
Verified teh change by running the Mixed speed tests

#### Any platform specific information?
No


