### PR TITLE
Fix t1 testcases batch1: gcu/test_k8s_config, gcu/test_cacl

### DIFF
--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -416,11 +416,11 @@ def cacl_tc2_add_init_rule(duthost, protocol, ip_netns_namespace_prefix, namespa
         params_dict["table"] = "EXTERNAL_CLIENT_ACL"
         params_dict["IP_PROTOCOL"] = "6"
         params_dict["L4_DST_PORT"] = "8081"
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "add",
-            "path": "{}/ACL_RULE".format(json_namespace),
+            "path": "/ACL_RULE",
             "value": {
                 "{}|TEST_DROP".format(params_dict["table"]): {
                     "IP_PROTOCOL": "{}".format(params_dict["IP_PROTOCOL"]),
@@ -433,7 +433,8 @@ def cacl_tc2_add_init_rule(duthost, protocol, ip_netns_namespace_prefix, namespa
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -475,11 +476,11 @@ def cacl_tc2_add_duplicate_rule(duthost, protocol, namespace=None):
         params_dict["table"] = "EXTERNAL_CLIENT_ACL"
         params_dict["IP_PROTOCOL"] = "6"
         params_dict["L4_DST_PORT"] = "8081"
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "add",
-            "path": "{}/ACL_RULE".format(json_namespace),
+            "path": "/ACL_RULE",
             "value": {
                 "{}|TEST_DROP".format(params_dict["table"]): {
                     "IP_PROTOCOL": "{}".format(params_dict["IP_PROTOCOL"]),
@@ -492,7 +493,8 @@ def cacl_tc2_add_duplicate_rule(duthost, protocol, namespace=None):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -525,15 +527,16 @@ def cacl_tc2_replace_rule(duthost, protocol, ip_netns_namespace_prefix, namespac
         table = 'NTP_ACL'
     elif protocol == 'EXTERNAL_CLIENT':
         table = 'EXTERNAL_CLIENT_ACL'
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "replace",
-            "path": "{}/ACL_RULE/{}|TEST_DROP/SRC_IP".format(json_namespace, table),
+            "path": "/ACL_RULE/{}|TEST_DROP/SRC_IP".format(table),
             "value": "8.8.8.8/32"
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
 
@@ -563,11 +566,11 @@ def cacl_tc2_replace_rule(duthost, protocol, ip_netns_namespace_prefix, namespac
 def cacl_tc2_add_rule_to_unexisted_table(duthost, namespace=None):
     """ Add acl rule to unexisted table
     """
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "add",
-            "path": "{}/ACL_RULE/TEST_2|TEST_DROP".format(json_namespace),
+            "path": "/ACL_RULE/TEST_2|TEST_DROP",
             "value": {
                 "L4_DST_PORT": "22",
                 "IP_PROTOCOL": "6",
@@ -578,7 +581,8 @@ def cacl_tc2_add_rule_to_unexisted_table(duthost, namespace=None):
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -601,14 +605,15 @@ def cacl_tc2_remove_table_before_rule(duthost, protocol, namespace=None):
         table = 'NTP_ACL'
     elif protocol == 'EXTERNAL_CLIENT':
         table = 'EXTERNAL_CLIENT_ACL'
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "remove",
-            "path": "{}/ACL_TABLE/{}".format(json_namespace, table)
+            "path": "/ACL_TABLE/{}".format(table)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -631,14 +636,15 @@ def cacl_tc2_remove_unexist_rule(duthost, protocol, namespace=None):
         table = 'NTP_ACL'
     elif protocol == 'EXTERNAL_CLIENT':
         table = 'EXTERNAL_CLIENT_ACL'
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "remove",
-            "path": "{}/ACL_RULE/{}|TEST_DROP2".format(json_namespace, table)
+            "path": "/ACL_RULE/{}|TEST_DROP2".format(table)
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
     try:
@@ -651,14 +657,15 @@ def cacl_tc2_remove_unexist_rule(duthost, protocol, namespace=None):
 def cacl_tc2_remove_rule(duthost, ip_netns_namespace_prefix, namespace=None):
     """ Remove acl rule test
     """
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "remove",
-            "path": "{}/ACL_RULE".format(json_namespace)
+            "path": "/ACL_RULE".format()
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -685,11 +692,11 @@ def cacl_external_client_add_new_table(duthost, ip_netns_namespace_prefix, names
     ----------------------  ---------  ---------------  ----------------------------  -------  --------
     EXTERNAL_CLIENT_ACL     CTRLPLANE  EXTERNAL_CLIENT  EXTERNAL_CLIENT_ACL           ingress  Active
     """
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "add",
-            "path": "{}/ACL_TABLE/EXTERNAL_CLIENT_ACL".format(json_namespace),
+            "path": "/ACL_TABLE/EXTERNAL_CLIENT_ACL",
             "value": {
                 "policy_desc": "EXTERNAL_CLIENT_ACL",
                 "services": [
@@ -700,7 +707,8 @@ def cacl_external_client_add_new_table(duthost, ip_netns_namespace_prefix, names
             }
         }
     ]
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))
@@ -720,11 +728,11 @@ def cacl_external_client_add_new_table(duthost, ip_netns_namespace_prefix, names
 def cacl_tc3_acl_table_and_acl_rule(duthost, ip_netns_namespace_prefix, namespace=None):
     """ Add acl table and acl rule in single patch for test
     """
-    json_namespace = '' if namespace is None else '/' + namespace
+
     json_patch = [
         {
             "op": "add",
-            "path": "{}/ACL_TABLE/EXTERNAL_CLIENT_ACL".format(json_namespace),
+            "path": "/ACL_TABLE/EXTERNAL_CLIENT_ACL",
             "value": {
                 "type": "CTRLPLANE",
                 "stage": "ingress",
@@ -736,7 +744,7 @@ def cacl_tc3_acl_table_and_acl_rule(duthost, ip_netns_namespace_prefix, namespac
         },
         {
             "op": "add",
-            "path": "{}/ACL_RULE".format(json_namespace),
+            "path": "/ACL_RULE",
             "value": {
                 "EXTERNAL_CLIENT_ACL|RULE_1": {
                     "PRIORITY": "9999",
@@ -749,7 +757,8 @@ def cacl_tc3_acl_table_and_acl_rule(duthost, ip_netns_namespace_prefix, namespac
         }
     ]
 
-    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch, is_asic_specific=True)
+    json_patch = format_json_patch_for_multiasic(duthost=duthost, json_data=json_patch,
+                                                 is_asic_specific=True, asic_namespaces=[namespace])
 
     tmpfile = generate_tmpfile(duthost)
     logger.info("tmpfile {}".format(tmpfile))

--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -208,6 +208,13 @@ def setup_env(duthosts, rand_one_dut_hostname):
         delete_checkpoint(duthost)
 
 
+def compare_strings_ignore_whitespace(s1, s2):
+    # Remove all whitespace characters using regex
+    s1_clean = re.sub(r'\s+', '', s1)
+    s2_clean = re.sub(r'\s+', '', s2)
+    return s1_clean == s2_clean
+
+
 def get_k8s_runningconfig(duthost):
     """ Get k8s config from running config
     Sample output: K8SEMPTYCONFIG, K8SHALFCONFIG, K8SFULLCONFIG
@@ -278,7 +285,7 @@ def k8s_config_update(duthost, test_data):
 
             k8s_config = get_k8s_runningconfig(duthost)
             pytest_assert(
-                k8s_config == target_config,
+                compare_strings_ignore_whitespace(k8s_config[0], target_config[0]),
                 f"Failed to run num.{num+1} test case to update k8s config."
             )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: this is a part of the initiative that tries to fix existing T1 test cases that fail on multi-asic platforms.
This PR fixes two test cases:
1. generic_config_updater/test_kubernetes_config.py: it failed on multi-asic T1 because the output has different number of whitespaces
2. generic_config_updater/test_cacl.py: it failed on multi-asic T1 because previously the author of the test case did not format the GCU patches with namespace properly.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
