### PR TITLE
[docker-ptf] Enable pilot rollout of Debian bookworm-based image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,13 +83,35 @@ stages:
     steps:
       - template: .azure-pipelines/impacted_area_testing/get-impacted-area.yml
 
+  - job: choose_between_py3_bullseye_vs_bookworm_ptf_image
+    displayName: "Choose between latest py3 ptf image bullseye vs bookworm"
+    timeoutInMinutes: 10
+    continueOnError: false
+    pool: sonic-ubuntu-1c
+    steps:
+      - script: |
+          python - <<EOF
+          import random
+          tag = 'latest'
+          if random.random() < 0.7:
+            tag = 'bookworm'
+          print(f"##vso[task.setvariable variable=tag_value;isOutput=true]{tag}")
+          EOF
+        name: ptf_image_tag
+        displayName: "Selecting PTF_IMAGE_TAG"
+      - script: |
+            echo "Chosen PTF_IMAGE_TAG: $(ptf_image_tag.tag_value)"
+        displayName: "PTF_IMAGE_TAG value"
+
   - job: impacted_area_t0_elastictest
     displayName: "impacted-area-kvmtest-t0 by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -102,6 +124,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t0
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -112,9 +135,11 @@ stages:
     displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -127,6 +152,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t0
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -138,9 +164,11 @@ stages:
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -155,6 +183,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-lag
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -165,9 +194,11 @@ stages:
     displayName: "impacted-area-kvmtest-dualtor by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -182,6 +213,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: dualtor
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -193,9 +225,11 @@ stages:
     displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1-multi-asic_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -208,6 +242,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-8-lag
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -219,9 +254,11 @@ stages:
     displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -235,6 +272,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t0-64-32
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -251,9 +289,11 @@ stages:
     displayName: "impacted-area-kvmtest-dpu by Elastictest"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: false
     pool: sonic-ubuntu-1c
@@ -266,6 +306,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: dpu
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)
           MAX_WORKER: $(INSTANCE_NUMBER)
@@ -280,9 +321,11 @@ stages:
     displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest - optional"
     dependsOn:
     - get_impacted_area
+    - choose_between_py3_bullseye_vs_bookworm_ptf_image
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      set_ptf_image_tag: $[ dependencies.choose_between_py3_bullseye_vs_bookworm_ptf_image.outputs['ptf_image_tag.tag_value'] ]
     timeoutInMinutes: 240
     continueOnError: true
     pool: sonic-ubuntu-1c
@@ -295,6 +338,7 @@ stages:
       - template: .azure-pipelines/run-test-elastictest-template.yml
         parameters:
           TOPOLOGY: t1-8-lag
+          PTF_IMAGE_TAG: $(set_ptf_image_tag)
           STOP_ON_FAILURE: "False"
           SCRIPTS: $(SCRIPTS)
           MIN_WORKER: $(INSTANCE_NUMBER)


### PR DESCRIPTION
### Description of PR

This PR uses a custom tag (`:bookworm`) and enables a pilot rollout of the Debian bookworm-based image for 30% of the PRs.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

The Python 3 only image is based on Bullseye. This update is to Bookworm as part of security requirements.

#### How did you do it?

Modified buildimage.

#### How did you verify/test it?

TBD

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA