### PR TITLE
Enable test_vlan_tc7_tagged_qinq_switch_on_outer_tag for marvell teralynx platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2570,7 +2570,7 @@ vlan/test_vlan.py::test_vlan_tc7_tagged_qinq_switch_on_outer_tag:
   skip:
     reason: "Unsupported platform."
     conditions:
-      - "asic_type not in ['mellanox', 'barefoot', 'cisco-8000']"
+        - "asic_type not in ['mellanox', 'barefoot', 'cisco-8000', 'marvell-teralynx']"
 
 vlan/test_vlan_ping.py:
   skip:


### PR DESCRIPTION
**Description of PR**
Enable test_vlan_tc7_tagged_qinq_switch_on_outer_tag for marvell-teralynx platform

**Summary**
This test was being skipped for the marvell-teralynx platform. This fix enables the test to run for the same.

**Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
- [x] Enable test case for new platform


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To enable test case execution for marvell-teralynx device

#### How did you do it?
Updated the platform check

#### How did you verify/test it?
Yes, executed the test-case on device.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

