### PR TITLE
Update test_config_interface_state in iface_namingmode

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -840,8 +840,9 @@ class TestConfigInterface():
             line = show_intf_status['stdout'].strip()
             if regex_int.match(line) and interface == regex_int.match(line).group(1):
                 admin_state = regex_int.match(line).group(7)
+                oper_state = regex_int.match(line).group(6)
 
-            return admin_state == expected_state
+            return admin_state == expected_state and oper_state == expected_state
 
         def _lldp_exists(expected=True):
             show_lldp_neighbor = dutHostGuest.shell(
@@ -864,7 +865,7 @@ class TestConfigInterface():
         if out['rc'] != 0:
             pytest.fail()
         pytest_assert(wait_until(PORT_TOGGLE_TIMEOUT, 2, 0, _port_status, 'up'),
-                      "Interface {} should be admin up".format(test_intf))
+                      "Interface {} should be admin and oper up".format(test_intf))
 
         # Make sure LLDP neighbor is repopulated
         pytest_assert(wait_until(PORT_TOGGLE_TIMEOUT, 2, 0, _lldp_exists, True),


### PR DESCRIPTION
Check both admin and oper port states after a port toggle 
We need to ensure port is up and can receive packets before verifying its lldp neighbors

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
