### PR TITLE
Avoid config reload in test_lldp_neighbor_post_orchagent_reboot to save ~4m of test execution time

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -180,3 +180,4 @@ def test_lldp_neighbor_post_orchagent_reboot(duthosts, enum_rand_one_per_hwsku_f
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,
                         enum_frontend_asic_index, tbinfo, request)
+    duthost.shell("sudo config feature autorestart swss enabled")


### PR DESCRIPTION
### Description of PR
Avoid config reload at the end of test_lldp_neighbor_post_orchagent_reboot tc to save ~4m of test execution time

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
We disable the auto_restart of swss as part of test_lldp_neighbor_post_orchagent_reboot and do not revert it. That causes running config mismatch and a config reload is issued with the pre test running config. This config reload adds ~4m to the test execution time.

**Test log excerpts**
```
13/05/2025 **10:37:06** conftest.core_dump_and_config_check      L2555 WARNING| Core dump or config check failed for lldp/test_lldp.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"mathilda-01": []}}, "config_db_check": {"failed": true, "pre_only_config": {"mathilda-01": {"null": {}}}, "cur_only_config": {"mathilda-01": {"null": {}}}, "inconsistent_config": {"mathilda-01": {"null": {"FEATURE": {"pre_value": {"bgp": {"auto_restart": "enabled", "check_up_status": "false", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "database": {"auto_restart": "always_enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "always_enabled", "support_syslog_rate_limit": "true"}, "dhcp_relay": {"auto_restart": "enabled", "check_up_status": "False", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "set_owner": "local", "state": "enabled", "support_syslog_rate_limit": "True"}, "eventd": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "gnmi": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "lldp": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "macsec": {"auto_restart": "enabled", "check_up_status": "False", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "set_owner": "local", "state": "disabled", "support_syslog_rate_limit": "True"}, "mgmt-framework": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "mux": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "always_disabled", "support_syslog_rate_limit": "true"}, "nat": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "disabled", "support_syslog_rate_limit": "true"}, "pmon": {"auto_restart": "enabled", "check_up_status": "false", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "radv": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "sflow": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "disabled", "support_syslog_rate_limit": "true"}, "snmp": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "swss": {"auto_restart": "enabled", "check_up_status": "false", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "syncd": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "teamd": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "telemetry": {"delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "state": "disabled"}}, "cur_value": {"bgp": {"auto_restart": "enabled", "check_up_status": "false", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "database": {"auto_restart": "always_enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "always_enabled", "support_syslog_rate_limit": "true"}, "dhcp_relay": {"auto_restart": "enabled", "check_up_status": "False", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "set_owner": "local", "state": "enabled", "support_syslog_rate_limit": "True"}, "eventd": {"auto_restart": "enabled", "delayed": "False", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "gnmi": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "lldp": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_limit": "true"}, "macsec": {"auto_restart": "enabled", "check_up_status": "False", "delayed": "False", "has_global_scope": "False", "has_per_asic_scope": "True", "high_mem_alert": "disabled", "set_owner": "local", "state": "disabled", "support_syslog_rate_limit": "True"}, "mgmt-framework": {"auto_restart": "enabled", "delayed": "True", "has_global_scope": "True", "has_per_asic_scope": "False", "high_mem_alert": "disabled", "state": "enabled", "support_syslog_rate_li
13/05/2025 10:37:06 conftest.restore_config_db_and_config_re L2245 INFO   | dut reload called on mathilda-01
…
13/05/2025 **10:41:15** __init__.sanity_check_full               L0335 INFO   | No post-test check is required. Done post-test sanity check
```

#### How did you do it?
Revert the config changes done by the test at the end of the test to avoid config reload

#### How did you verify/test it?
Executed the test with this changes and verified that the test passed and there was no confog reload issued at the end of the test
```
---------- generated xml file: /data/tests/logs/lldp/test_lldp.py::test_lldp_neighbor_post_orchagent_reboot_2025-05-13-10-44-15.xml -----------
INFO:root:Can not get Allure report URL. Please check logs
----------------------------------------------------------- live log sessionfinish ------------------------------------------------------------
10:47:51 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================== 1 passed, 3 warnings in 214.62s (0:03:34) ==================================================

```
**Test log excerpts:**
```
13/05/2025 **10:47:51** conftest.core_dump_and_config_check      L2560 INFO   | Core dump and config check passed for lldp/test_lldp.py
13/05/2025 **10:47:51** __init__.sanity_check_full               L0335 INFO   | No post-test check is required. Done post-test sanity check
```

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA
