### PR TITLE
[show_techsupport] Remove asic dependency for show queue counters

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -210,7 +210,7 @@ misc_show_cmds = [
     "show interface transceiver eeprom --dom",
     "show ip interface",
     "show interface counters",
-    "{}show queue counters",
+    "show queue counters",
     "{}netstat -i",
     "{}ifconfig -a",
 ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PR [#3865](https://github.com/sonic-net/sonic-utilities/pull/3865) updated the `generate_dump` script to run the `show queue counters` command only in the host namespace, instead of for each ASIC namespace.

As a result, the test case in `show_techsupport/test_techsupport.py`, which was verifying that the command ran for each ASIC namespace failed.

This PR modifies the testcase to align with the new behavior.

Fixes [ #18364](https://github.com/sonic-net/sonic-mgmt/issues/18364)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Removed `{}` from `{} show queue counters` in `misc_show_cmds`, which is used to generate `commands_to_check`, to prevent per-ASIC expansion and check only the host namespace.
#### How did you verify/test it?
run `show_techsupport/test_techsupport.py`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
