### PR TITLE
Skip modular chassis specific tests on disaggregated chassis

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1835,17 +1835,6 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
 #######################################
 #####     platform_tests          #####
 #######################################
-platform_tests/cli/test_show_chassis_module.py:
-  skip:
-    reason: "Skip modular chassis specific commands on disaggregated chassis"
-    conditions:
-      - "'t2_single_node' in topo_name"
-
-platform_tests/test_chassis_reboot.py:
-  skip:
-    reason: "Skip modular chassis specific test on disaggregated chassis"
-    conditions:
-      - "'t2_single_node' in topo_name"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1835,6 +1835,18 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
 #######################################
 #####     platform_tests          #####
 #######################################
+platform_tests/cli/test_show_chassis_module.py:
+  skip:
+    reason: "Skip modular chassis specific commands on disaggregated chassis"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+platform_tests/test_chassis_reboot.py:
+  skip:
+    reason: "Skip modular chassis specific test on disaggregated chassis"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:
     reason: "Skip test_reload_configuration_checks on Cisco platform due to unstable results"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1835,7 +1835,6 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
 #######################################
 #####     platform_tests          #####
 #######################################
-
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:
     reason: "Skip test_reload_configuration_checks on Cisco platform due to unstable results"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1085,6 +1085,15 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
       - "release in ['202412']"
 
 #######################################
+#####   test_chassis_reboot.py  #####
+#######################################
+platform_tests/test_chassis_reboot.py:
+  skip:
+    reason: "Skip modular chassis specific test on disaggregated chassis"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+#######################################
 #####   test_cont_warm_reboot.py  #####
 #######################################
 platform_tests/test_cont_warm_reboot.py:
@@ -1193,12 +1202,6 @@ platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus:
 #######################################
 #####        test_reboot.py       #####
 #######################################
-platform_tests/test_chassis_reboot.py:
-  skip:
-    reason: "Skip modular chassis specific test on disaggregated chassis"
-    conditions:
-      - "'t2_single_node' in topo_name"
-
 platform_tests/test_power_off_reboot.py:
   skip:
     reason: "Skip power off reboot test for Wistron/Nokia-7215"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -869,7 +869,7 @@ platform_tests/api/test_watchdog.py:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['barefoot'] and hwsku in ['newport', 'montara'] or ('sw_to3200k' in hwsku)"
-      - "platform in ['x86_64-nokia_ixr7250e_sup-r0', 'x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-dell_s6000_s1220-r0']"
+      - "platform in ['x86_64-nokia_ixr7250e_sup-r0', 'x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-nokia_ixr7250_x3b-r0', 'x86_64-dell_s6000_s1220-r0']"
       - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
@@ -890,6 +890,12 @@ platform_tests/broadcom/test_ser.py:
 #######################################
 #####  cli/test_show_platform.py  #####
 #######################################
+platform_tests/cli/test_show_chassis_module.py:
+  skip:
+    reason: "Skip modular chassis specific commands on disaggregated chassis"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
 platform_tests/cli/test_show_platform.py::test_show_platform_fan:
   skip:
     reason: "Unsupported platform API"
@@ -1187,6 +1193,12 @@ platform_tests/test_platform_info.py::test_turn_on_off_psu_and_check_psustatus:
 #######################################
 #####        test_reboot.py       #####
 #######################################
+platform_tests/test_chassis_reboot.py:
+  skip:
+    reason: "Skip modular chassis specific test on disaggregated chassis"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
 platform_tests/test_power_off_reboot.py:
   skip:
     reason: "Skip power off reboot test for Wistron/Nokia-7215"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Skip modular chassis tests on disaggregated chassis

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Tests specific for modular chassis are not applicable for disaggregated chassis. These are skipped in the PR

#### How did you do it?
Check topo name to identify disaggregated chassis and skip the tests

#### How did you verify/test it?
Ran both tests on disaggregated chassis to confirm skip

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
