### PR TITLE
Snappi: T0/T1/T2: Convert all traffic to static routed destinations in snappi scripts.

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -152,7 +152,7 @@ def __l3_intf_config(config, port_config_list, duthost, snappi_ports, setup=True
         if len(port_ids) != 1:
             continue
 
-        static_routes_cisco_8000(ip, duthost, intf, setup=setup)
+        gen_data_flow_dest_ip(ip, duthost, intf, setup=setup)
 
         port_id = port_ids[0]
         mac = __gen_mac(port_id)
@@ -860,7 +860,7 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports, setu
         else:
             cmd = "remove"
         if not setup:
-            static_routes_cisco_8000(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
+            gen_data_flow_dest_ip(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
 
         if port['asic_value'] is None:
             duthost.command('sudo config interface ip {} {} {}/{} \n' .format(
@@ -876,7 +876,7 @@ def __intf_config_multidut(config, port_config_list, duthost, snappi_ports, setu
                                                                                     dutIp,
                                                                                     prefix_length))
         if setup:
-            static_routes_cisco_8000(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
+            gen_data_flow_dest_ip(tgenIp, duthost, port['peer_port'], port['asic_value'], setup)
         if setup is False:
             continue
         port['intf_config_changed'] = True
@@ -939,7 +939,7 @@ def cleanup_config(duthost_list, snappi_ports):
         global DEST_TO_GATEWAY_MAP
         copy_DEST_TO_GATEWAY_MAP = copy(DEST_TO_GATEWAY_MAP)
         for addr in copy_DEST_TO_GATEWAY_MAP:
-            static_routes_cisco_8000(
+            gen_data_flow_dest_ip(
                 addr,
                 dut=DEST_TO_GATEWAY_MAP[addr]['dut'],
                 intf=None,
@@ -1024,8 +1024,8 @@ def pre_configure_dut_interface(duthost, snappi_ports):
                                                                                 port['peer_port'],
                                                                                 dutv6Ips[port_id],
                                                                                 v6_prefix_length))
-            static_routes_cisco_8000(tgenIps[port_id], duthost, port['peer_port'], port['asic_value'], setup=True)
-            static_routes_cisco_8000(tgenv6Ips[port_id], duthost, port['peer_port'], port['asic_value'], setup=True)
+            gen_data_flow_dest_ip(tgenIps[port_id], duthost, port['peer_port'], port['asic_value'], setup=True)
+            gen_data_flow_dest_ip(tgenv6Ips[port_id], duthost, port['peer_port'], port['asic_value'], setup=True)
         except Exception:
             pytest_assert(False, "Unable to configure ip on the interface {}".format(port['peer_port']))
     return snappi_ports_dut
@@ -1328,7 +1328,7 @@ DEST_TO_GATEWAY_MAP = {}
 
 
 # Add static routes using CLI WAY.
-def static_routes_cisco_8000(addr, dut=None, intf=None, namespace=None, setup=True):
+def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True):
     '''
         Return a static route-d IP address for the given IP gateway(Ixia port address).
         Also configure the same in the DUT.

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -549,7 +549,9 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts):      # noqa: F811
         snappi_ports = pre_configure_dut_interface(duthost, snappi_ports)
         logger.info(snappi_ports)
 
-    return snappi_ports
+    yield snappi_ports
+
+    remove_static_route_cisco_8000([duthost])
 
 
 def snappi_multi_base_config(duthost_list,
@@ -932,7 +934,7 @@ def create_ip_list(value, count, mask=32, incr=0):
     return ip_list
 
 
-def cleanup_config(duthost_list, snappi_ports):
+def remove_static_route_cisco_8000(duthost_list):
     if (duthost_list[0].facts['asic_type'] == "cisco-8000" and
             duthost_list[0].get_facts().get("modular_chassis", None)):
         global DEST_TO_GATEWAY_MAP
@@ -946,6 +948,12 @@ def cleanup_config(duthost_list, snappi_ports):
                 setup=False)
 
         time.sleep(4)
+
+
+def cleanup_config(duthost_list, snappi_ports):
+
+    remove_static_route_cisco_8000(duthost_list)
+
     for index, duthost in enumerate(duthost_list):
         port_count = len(snappi_ports)
         dutIps = create_ip_list(dut_ip_start, port_count, mask=prefix_length)

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -997,13 +997,18 @@ def pre_configure_dut_interface(duthost, snappi_ports):
         port['peer_ipv6'] = dutv6Ips[port_id]
         port['ipv6_prefix'] = v6_prefix_length
         port['ipv6'] = tgenv6Ips[port_id]
+        port['asic_value'] = duthost.get_port_asic_instance(port['peer_port'])
+        asic_cmd = ""
+        if port['asic_value'] is not None:
+            asic_cmd = " -n {} ".format(port['asic_value'])
         try:
             logger.info('Pre-Configuring Dut: {} with port {} with IP {}/{}'.format(
                                                                                 duthost.hostname,
                                                                                 port['peer_port'],
                                                                                 dutIps[port_id],
                                                                                 prefix_length))
-            duthost.command('sudo config interface ip add {} {}/{} \n' .format(
+            duthost.command('sudo config interface {} ip add {} {}/{} \n' .format(
+                                                                                asic_cmd,
                                                                                 port['peer_port'],
                                                                                 dutIps[port_id],
                                                                                 prefix_length))
@@ -1012,10 +1017,13 @@ def pre_configure_dut_interface(duthost, snappi_ports):
                                                                                 port['peer_port'],
                                                                                 dutv6Ips[port_id],
                                                                                 v6_prefix_length))
-            duthost.command('sudo config interface ip add {} {}/{} \n' .format(
+            duthost.command('sudo config interface {} ip add {} {}/{} \n' .format(
+                                                                                asic_cmd,
                                                                                 port['peer_port'],
                                                                                 dutv6Ips[port_id],
                                                                                 v6_prefix_length))
+            static_routes_cisco_8000(tgenIps[port_id], duthost, port['peer_port'], port['asic_value'], setup=True)
+            static_routes_cisco_8000(tgenv6Ips[port_id], duthost, port['peer_port'], port['asic_value'], setup=True)
         except Exception:
             pytest_assert(False, "Unable to configure ip on the interface {}".format(port['peer_port']))
     return snappi_ports_dut

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -549,9 +549,7 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts):      # noqa: F811
         snappi_ports = pre_configure_dut_interface(duthost, snappi_ports)
         logger.info(snappi_ports)
 
-    yield snappi_ports
-
-    remove_static_route_cisco_8000([duthost])
+    return snappi_ports
 
 
 def snappi_multi_base_config(duthost_list,
@@ -934,7 +932,8 @@ def create_ip_list(value, count, mask=32, incr=0):
     return ip_list
 
 
-def remove_static_route_cisco_8000(duthost_list):
+def cleanup_config(duthost_list, snappi_ports):
+
     if (duthost_list[0].facts['asic_type'] == "cisco-8000" and
             duthost_list[0].get_facts().get("modular_chassis", None)):
         global DEST_TO_GATEWAY_MAP
@@ -948,11 +947,6 @@ def remove_static_route_cisco_8000(duthost_list):
                 setup=False)
 
         time.sleep(4)
-
-
-def cleanup_config(duthost_list, snappi_ports):
-
-    remove_static_route_cisco_8000(duthost_list)
 
     for index, duthost in enumerate(duthost_list):
         port_count = len(snappi_ports)

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -15,7 +15,7 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
 from .variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 from tests.common.cisco_data import is_cisco_device
 from tests.common.reboot import reboot
 
@@ -166,7 +166,7 @@ def generate_test_flows(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[prio]
 
         ipv4.src.value = base_flow_config["tx_port_config"].ip
-        ipv4.dst.value = static_routes_cisco_8000(base_flow_config["rx_port_config"].ip)
+        ipv4.dst.value = gen_data_flow_dest_ip(base_flow_config["rx_port_config"].ip)
         ipv4.priority.choice = ipv4.priority.DSCP
         ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
         ipv4.priority.dscp.ecn.value = (ipv4.priority.dscp.ecn.CONGESTION_ENCOUNTERED if congested else
@@ -252,7 +252,7 @@ def generate_background_flows(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[prio]
 
         ipv4.src.value = base_flow_config["tx_port_config"].ip
-        ipv4.dst.value = static_routes_cisco_8000(base_flow_config["rx_port_config"].ip)
+        ipv4.dst.value = gen_data_flow_dest_ip(base_flow_config["rx_port_config"].ip)
         ipv4.priority.choice = ipv4.priority.DSCP
         ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
         ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -15,7 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                 # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
 TEST_FLOW_NAME = 'Test Flow'
@@ -370,7 +370,7 @@ def __gen_data_flow(testbed_config,
                 eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
         ipv4.src.value = tx_port_config.ip
-        ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+        ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
         ipv4.priority.choice = ipv4.priority.DSCP
 
         if 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_external_pause_storms_helper.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                 # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 logger = logging.getLogger(__name__)
 
 TEST_FLOW_NAME = 'Test Flow'
@@ -369,7 +370,7 @@ def __gen_data_flow(testbed_config,
                 eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
         ipv4.src.value = tx_port_config.ip
-        ipv4.dst.value = rx_port_config.ip
+        ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
         ipv4.priority.choice = ipv4.priority.DSCP
 
         if 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -16,6 +16,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                      # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -378,7 +379,7 @@ def __gen_data_flow(testbed_config,
                 eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
         ipv4.src.value = tx_port_config.ip
-        ipv4.dst.value = rx_port_config.ip
+        ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
         ipv4.priority.choice = ipv4.priority.DSCP
         if 'Background Flow 1 -> 0' in flow.name:
             ipv4.priority.dscp.phb.values = [

--- a/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
+++ b/tests/snappi_tests/pfc/files/lossless_response_to_throttling_pause_storms_helper.py
@@ -16,7 +16,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, verify_pause_flow, \
      setup_base_traffic_config                                      # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +379,7 @@ def __gen_data_flow(testbed_config,
                 eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
         ipv4.src.value = tx_port_config.ip
-        ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+        ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
         ipv4.priority.choice = ipv4.priority.DSCP
         if 'Background Flow 1 -> 0' in flow.name:
             ipv4.priority.dscp.phb.values = [

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -9,6 +9,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config          # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
@@ -369,7 +370,7 @@ def __gen_data_flow(testbed_config,
     udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = rx_port_config.ip
+    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
     if '1 Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -9,7 +9,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config          # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
@@ -370,7 +370,7 @@ def __gen_data_flow(testbed_config,
     udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+    ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
     if '1 Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -15,7 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                         # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
@@ -335,7 +335,7 @@ def __gen_data_flow(testbed_config,
     udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+    ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
     flow_prio_dscp_list = []

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                         # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
@@ -334,7 +335,7 @@ def __gen_data_flow(testbed_config,
     udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = rx_port_config.ip
+    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
     flow_prio_dscp_list = []

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -16,7 +16,7 @@ from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config                      # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
 from tests.common.portstat_utilities import parse_portstat                              # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
 
@@ -355,7 +355,7 @@ def __gen_data_flow(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+    ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
     if 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -16,6 +16,7 @@ from tests.common.snappi_tests.traffic_generation import run_traffic, \
      setup_base_traffic_config                      # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
 from tests.common.portstat_utilities import parse_portstat                              # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -354,7 +355,7 @@ def __gen_data_flow(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = rx_port_config.ip
+    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
     if 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -15,6 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                               # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
@@ -368,7 +369,7 @@ def __gen_data_flow(testbed_config,
     udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = rx_port_config.ip
+    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
     flow.duration.fixed_seconds.delay.nanoseconds = 0
     if 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -15,7 +15,7 @@ from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.traffic_generation import setup_base_traffic_config, \
      run_traffic                                               # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 
 PAUSE_FLOW_NAME = 'Pause Storm'
@@ -369,7 +369,7 @@ def __gen_data_flow(testbed_config,
     udp.src_port.increment.count = no_of_streams
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+    ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
     flow.duration.fixed_seconds.delay.nanoseconds = 0
     if 'Background Flow 1 -> 0' in flow.name:

--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -329,7 +330,7 @@ def __gen_traffic(testbed_config,
             udp.src_port.increment.count = number_of_streams
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = rx_port_config.ip
+            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -12,7 +12,7 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
 
@@ -330,7 +330,7 @@ def __gen_traffic(testbed_config,
             udp.src_port.increment.count = number_of_streams
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+            ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
@@ -11,7 +11,7 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,7 @@ def __gen_traffic(testbed_config,
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+            ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_burst_storm_helper.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +196,7 @@ def __gen_traffic(testbed_config,
                 eth.pfc_queue.value = pfcQueueValueDict[prio]
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = rx_port_config.ip
+            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -12,7 +12,7 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
 
@@ -444,7 +444,7 @@ def __gen_data_flow(testbed_config,
         eth.pfc_queue.value = pfcQueueValueDict[flow_prio]
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+    ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
     ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio]
     ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_multi_node_helper.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.port import select_ports                         
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp                                 # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -443,7 +444,7 @@ def __gen_data_flow(testbed_config,
         eth.pfc_queue.value = pfcQueueValueDict[flow_prio]
 
     ipv4.src.value = tx_port_config.ip
-    ipv4.dst.value = rx_port_config.ip
+    ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
     ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio]
     ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_runtime_traffic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_runtime_traffic_helper.py
@@ -8,7 +8,7 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port       # 
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 
 DATA_FLOW_NAME = "Data Flow"
@@ -178,7 +178,7 @@ def __gen_traffic(testbed_config,
             udp.src_port.increment.count = 1
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+            ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/files/pfcwd_runtime_traffic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_runtime_traffic_helper.py
@@ -8,6 +8,8 @@ from tests.common.snappi_tests.port import select_ports, select_tx_port       # 
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+
 
 DATA_FLOW_NAME = "Data Flow"
 WARM_UP_TRAFFIC_NAME = "Warm Up Traffic"
@@ -176,7 +178,7 @@ def __gen_traffic(testbed_config,
             udp.src_port.increment.count = 1
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = rx_port_config.ip
+            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[prio]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
@@ -192,6 +192,7 @@ def test_pfcwd_drop_90_10(snappi_api,                  # noqa: F811
             check_fabric_counters(dut)
 
     finally:
+        cleanup_config(duthosts, snappi_ports)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)
 
@@ -360,6 +361,7 @@ def test_pfcwd_drop_uni(snappi_api,                  # noqa: F811
             check_fabric_counters(dut)
 
     finally:
+        cleanup_config(duthosts, snappi_ports)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)
 
@@ -531,6 +533,7 @@ def test_pfcwd_frwd_90_10(snappi_api,                  # noqa: F811
             check_fabric_counters(dut)
 
     finally:
+        cleanup_config(duthosts, snappi_ports)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)
 
@@ -703,6 +706,7 @@ def test_pfcwd_drop_over_subs_40_09(snappi_api,                  # noqa: F811
             check_fabric_counters(dut)
 
     finally:
+        cleanup_config(duthosts, snappi_ports)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)
 
@@ -875,6 +879,7 @@ def test_pfcwd_frwd_over_subs_40_09(snappi_api,                  # noqa: F811
             check_fabric_counters(dut)
 
     finally:
+        cleanup_config(duthosts, snappi_ports)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)
 
@@ -1015,5 +1020,6 @@ def test_pfcwd_disable_pause_cngtn(snappi_api,                  # noqa: F811
             check_fabric_counters(dut)
 
     finally:
+        cleanup_config(duthosts, snappi_ports)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)

--- a/tests/snappi_tests/qos/files/packet_reorder_helper.py
+++ b/tests/snappi_tests/qos/files/packet_reorder_helper.py
@@ -5,7 +5,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +166,7 @@ def __gen_traffic(testbed_config,
 
         # Configure outer IPv4 header
         outer_ipv4.src.value = tx_port_config.ip
-        outer_ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+        outer_ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
         outer_ipv4.identification.choice = "increment"
         outer_ipv4.identification.increment.start = 1
         outer_ipv4.identification.increment.step = 1

--- a/tests/snappi_tests/qos/files/packet_reorder_helper.py
+++ b/tests/snappi_tests/qos/files/packet_reorder_helper.py
@@ -5,6 +5,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,7 @@ def __gen_traffic(testbed_config,
 
         # Configure outer IPv4 header
         outer_ipv4.src.value = tx_port_config.ip
-        outer_ipv4.dst.value = rx_port_config.ip
+        outer_ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
         outer_ipv4.identification.choice = "increment"
         outer_ipv4.identification.increment.start = 1
         outer_ipv4.identification.increment.step = 1

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -12,7 +12,7 @@ from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
 
@@ -75,7 +75,7 @@ def __gen_all_to_all_traffic(testbed_config,
             eth.pfc_queue.value = priority
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+            ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[priority]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
 
@@ -74,7 +75,7 @@ def __gen_all_to_all_traffic(testbed_config,
             eth.pfc_queue.value = priority
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = rx_port_config.ip
+            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[priority]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/test_snappi.py
+++ b/tests/snappi_tests/test_snappi.py
@@ -10,7 +10,7 @@ from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa F401
 from tests.common.snappi_tests.variables import pfcQueueValueDict
-from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
+from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 
 SNAPPI_POLL_DELAY_SEC = 2
 
@@ -65,7 +65,7 @@ def __gen_all_to_all_traffic(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[priority]
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
+            ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[priority]
             ipv4.priority.dscp.ecn.value = (

--- a/tests/snappi_tests/test_snappi.py
+++ b/tests/snappi_tests/test_snappi.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_helpers import wait_for_arp
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map  # noqa F401
 from tests.common.snappi_tests.variables import pfcQueueValueDict
+from tests.common.snappi_tests.snappi_fixtures import static_routes_cisco_8000
 
 SNAPPI_POLL_DELAY_SEC = 2
 
@@ -64,7 +65,7 @@ def __gen_all_to_all_traffic(testbed_config,
             eth.pfc_queue.value = pfcQueueValueDict[priority]
 
             ipv4.src.value = tx_port_config.ip
-            ipv4.dst.value = rx_port_config.ip
+            ipv4.dst.value = static_routes_cisco_8000(rx_port_config.ip)
             ipv4.priority.choice = ipv4.priority.DSCP
             ipv4.priority.dscp.phb.values = prio_dscp_map[priority]
             ipv4.priority.dscp.ecn.value = (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Recently we introduced a function to use static-route and static-routed destinations for traffic in snappi scripts. This was needed for cisco-8000 to make sure that the split-voq functionality is used, and in addition, the connected route was not the use case scenario as well.

In this PR, we propagate the changes to newly rewritten/merged multidut code, which now can be run on T0/T1 and T2. So with this change all scripts use static route for cisco-8000.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Cisco-8000 uses split voq only when the packets are destined to routed dests. The snappi scripts were written for connected routes, which is not the usecase for cisco-8000 platform. This PR changes the traffic to static-routed destinations.

#### How did you do it?
Changed all ipv4.dst.values to the new function that will return static routed dest for cisco-8000.

#### How did you verify/test it?
Ran a subset of pfcwd:
```
==================================================================================================================================== PASSES ====================================================================================================================================
________________________________________________________________________________________________________ test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-True] ________________________________________________________________________________________________________
_______________________________________________________________________________________________________ test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-False] ________________________________________________________________________________________________________
________________________________________________________________________________________________________ test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-True] ________________________________________________________________________________________________________
_______________________________________________________________________________________________________ test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-False] ________________________________________________________________________________________________________
________________________________________________________________________________________________________ test_pfcwd_basic_multi_lossless_prio[multidut_port_info2-True] ________________________________________________________________________________________________________
_______________________________________________________________________________________________________ test_pfcwd_basic_multi_lossless_prio[multidut_port_info2-False] ________________________________________________________________________________________________________
------------------------------------------------------------------------------------------------------ generated xml file: /run_logs/ixia/1011/2025-05-13-21-48-08/tr.xml ------------------------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
=========================================================================================================================== short test summary info ============================================================================================================================
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info1-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info2-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info2-False]
================================================================================================================== 6 passed, 9 warnings in 3254.65s (0:54:14) ==================================================================================================================
sonic@snappi-sonic-mgmt-msft-t2-rraghav:/data/tests$ 
```

#### Any platform specific information?
For cisco-8000 only.