### PR TITLE
Have Nokia-IXR7250E SKUs check for hearbeat lost with sup when Sup kernel panics

### DIFF
--- a/tests/platform_tests/test_kdump.py
+++ b/tests/platform_tests/test_kdump.py
@@ -28,7 +28,7 @@ class TestKernelPanic:
         # For sup, we also need to ensure linecards are back and healthy for following tests
         is_sup = duthost.get_facts().get("modular_chassis") and duthost.is_supervisor_node()
         if is_sup:
-            if 'Cisco-8800-RP' in duthost.facts.get('hwsku'):
+            if any(hwsku in duthost.facts.get('hwsku') for hwsku in ['Cisco-8800-RP', 'Nokia-IXR7250E']):
                 reboot_type = REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS
             else:
                 reboot_type = REBOOT_TYPE_COLD


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18392

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Changed in 7250e code makes kernel panic on sup cards leave reboot-cause on LCs as `Heartbeat with supervisor card lost` instead of `cold`

https://github.com/sonic-net/sonic-buildimage/pull/22034
#### How did you do it?
Add `Nokia-IXR7250E` to SKUs checking for `Heartbeat lost` cause rather than `cold` cause in `test_kdump.py`
#### How did you verify/test it?
TBC
#### Any platform specific information?
7250E
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A