### PR TITLE
[202405] Skip warm reboot related case on Arista-7050cx3-32s-c28s4

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -161,7 +161,8 @@ bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot:
             or over topologies which doesn't support slb."
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56'] and https://github.com/sonic-net/sonic-mgmt/issues/9201"
-      - "'backend' in topo_name or 'mgmttor' in topo_name"
+      - "'backend' in topo_name or 'mgmttor' in topo_name or 'isolated' in topo_name"
+      - "hwsku in ['Arista-7050CX3-32S-C28S4']"
 
 bgp/test_bgp_speaker.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -968,6 +968,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
     conditions:
       - "topo_type in ['m0', 'mx', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
+      - "hwsku in ['Arista-7050CX3-32S-C28S4']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is a cherry-pick PR of #18171 .
Skip following cases due to warm reboot is not supported on Arista-7050CX3-32S-C28S4 with t0-d18u8s4 topology:
- platform_tests/test_reboot.py::test_warm_reboot -> conditional mark
- bgp/test_bgp_slb.py::test_bgp_slb_neighbor_persistence_across_advanced_reboot -> conditional mark
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
