### PR TITLE
Fix Auditd File Deletion Assertion.

### DIFF
--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -96,7 +96,6 @@ def test_auditd_watchdog_functionality(duthosts, enum_rand_one_per_hwsku_hostnam
 def test_auditd_file_deletion(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
                               tacacs_creds, check_tacacs, check_auditd):            # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dutip = duthost.mgmt_ip
     container_name = "auditd"
     verify_container_running(duthost, container_name)
 

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import logging
+import uuid
 from tests.common.fixtures.tacacs import tacacs_creds   # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.dut_utils import is_container_running
@@ -99,15 +100,38 @@ def test_auditd_file_deletion(localhost, duthosts, enum_rand_one_per_hwsku_hostn
     container_name = "auditd"
     verify_container_running(duthost, container_name)
 
-    duthost.command("rm -f /tmp/test_file_deletion")
+    random_uuid = str(uuid.uuid4())
+    random_file = f"/tmp/test_file_deletion_{random_uuid}"
+    duthost.command(f"touch {random_file}")
+    duthost.command(f"rm -f  {random_file}")
+    cmd = "show logging | grep 'audisp-syslog' | grep '{random_uuid}'"
+    result = duthost.shell(cmd)["stdout_lines"]
+    logger.info(result)
+    assert any(random_uuid in line for line in result if line.strip()), \
+        "Auditd file_deletion rule does not contain the expected logs"
+
+    random_uuid = str(uuid.uuid4())
+    random_file = f"/tmp/test_file_deletion_{random_uuid}"
+    duthost.command(f"touch {random_file}")
+    duthost.command(f"sudo rm -f {random_file}")
+    cmd = "show logging | grep 'audisp-syslog' | grep '{random_uuid}'"
+    result = duthost.shell(cmd)["stdout_lines"]
+    logger.info(result)
+    assert any(random_uuid in line for line in result if line.strip()), \
+        "Auditd file_deletion rule does not contain the expected logs"
+
+    random_uuid = str(uuid.uuid4())
+    random_file = f"/tmp/test_file_deletion_{random_uuid}"
     ssh_remote_run(localhost,
                    dutip,
                    tacacs_creds['tacacs_rw_user'],
                    tacacs_creds['tacacs_rw_user_passwd'],
                    "sudo touch /tmp/test_file_deletion && sudo rm -f /tmp/test_file_deletion")
-    cmd = """show logging | grep 'audisp-syslog' | grep 'file_deletion' | grep 'AUID="test_rwuser"' """
+    cmd = f"""show logging | grep 'audisp-syslog' | grep '{random_uuid}' """
     result = duthost.shell(cmd)["stdout_lines"]
-    assert len(result) > 0, "Auditd file_deletion rule does not contain the expected logs"
+    logger.info(result)
+    assert any(random_uuid in line for line in result if line.strip()), \
+        "Auditd file_deletion rule does not contain the expected logs"
 
 
 def test_auditd_process_audit(localhost, duthosts, enum_rand_one_per_hwsku_hostname,

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -120,19 +120,6 @@ def test_auditd_file_deletion(localhost, duthosts, enum_rand_one_per_hwsku_hostn
     assert any(random_uuid in line for line in result if line.strip()), \
         "Auditd file_deletion rule does not contain the expected logs"
 
-    random_uuid = str(uuid.uuid4())
-    random_file = f"/tmp/test_file_deletion_{random_uuid}"
-    ssh_remote_run(localhost,
-                   dutip,
-                   tacacs_creds['tacacs_rw_user'],
-                   tacacs_creds['tacacs_rw_user_passwd'],
-                   "sudo touch /tmp/test_file_deletion && sudo rm -f /tmp/test_file_deletion")
-    cmd = f"""show logging | grep 'audisp-syslog' | grep '{random_uuid}' """
-    result = duthost.shell(cmd)["stdout_lines"]
-    logger.info(result)
-    assert any(random_uuid in line for line in result if line.strip()), \
-        "Auditd file_deletion rule does not contain the expected logs"
-
 
 def test_auditd_process_audit(localhost, duthosts, enum_rand_one_per_hwsku_hostname,
                               tacacs_creds, check_tacacs, check_auditd):            # noqa: F811

--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -103,8 +103,9 @@ def test_auditd_file_deletion(localhost, duthosts, enum_rand_one_per_hwsku_hostn
     random_file = f"/tmp/test_file_deletion_{random_uuid}"
     duthost.command(f"touch {random_file}")
     duthost.command(f"rm -f  {random_file}")
-    cmd = "show logging | grep 'audisp-syslog' | grep '{random_uuid}'"
+    cmd = f"sudo zgrep '{random_uuid}' /var/log/syslog* | grep 'audisp-syslog'"
     result = duthost.shell(cmd)["stdout_lines"]
+    print(result)
     logger.info(result)
     assert any(random_uuid in line for line in result if line.strip()), \
         "Auditd file_deletion rule does not contain the expected logs"
@@ -113,8 +114,9 @@ def test_auditd_file_deletion(localhost, duthosts, enum_rand_one_per_hwsku_hostn
     random_file = f"/tmp/test_file_deletion_{random_uuid}"
     duthost.command(f"touch {random_file}")
     duthost.command(f"sudo rm -f {random_file}")
-    cmd = "show logging | grep 'audisp-syslog' | grep '{random_uuid}'"
+    cmd = f"sudo zgrep '{random_uuid}' /var/log/syslog* | grep 'audisp-syslog'"
     result = duthost.shell(cmd)["stdout_lines"]
+    print(result)
     logger.info(result)
     assert any(random_uuid in line for line in result if line.strip()), \
         "Auditd file_deletion rule does not contain the expected logs"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Bug fix addressing an incorrect auditd file deletion assertion.

Updated auditd file deletion test to use dynamically generated filenames with UUIDs for more reliable log verification.

1. static filenames are replaced with dynamic ones using uuid to create unique identifiers.
1. the test now checks log outputs for the unique UUID in both non-sudo and sudo file deletion scenarios
1. removing redundant SSH execution and hardcoded management IP usage.

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

There was an incorrect auditd file deletion assertion.

#### How did you do it?

Checks log outputs for the unique UUID in both non-sudo and sudo file deletion scenarios

#### How did you verify/test it?
Ran test in testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
