### PR TITLE
[platform_tests] Skip mellanox sfp eeprom test for other platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -992,6 +992,7 @@ platform_tests/mellanox/test_check_sfp_eeprom.py:
     reason: "202405 and 202411 not support command like 'mlxlink -d /dev/mst/mt53104_pci_cr0 -p 1 -m' on mellanox spc3 devices when software control is enabled"
     conditions_logical_operator: or
     conditions:
+      - "asic_type not in ['mellanox', 'nvidia-bluefield']"
       - "'SN4' in hwsku and (release in ['202405', '202411'])"
       - "'SN5' in hwsku and (release in ['202405', '202411'])"
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Batch run is not skipping the test using pytest.mark.asic('mellanox', 'nvidia-bluefield') present in platform_tests/mellanox/test_check_sfp_eeprom.py though it gets skippend with manual run. Other Mellenox sfp tests gets skipped in batch run through tests_mark_conditions_platform_tests.yaml.

Adding mellanox asic check for platform_tests/mellanox/test_check_sfp_eeprom.py tests in tests_mark_conditions_platform_tests.yaml file like other mellanox tests to skip the test for marvell platform during batch run.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ x] 202411

### Approach
#### What is the motivation for this PR?
To skip the Mellanox platform specific test for Marvell platform

#### How did you do it?
Added mellanox asic check in tests_mark_conditions_platform_tests.yaml
for platform_tests/mellanox/test_check_sfp_eeprom.py tests to skip for 
marvell and other non-mellanox platform.

#### How did you verify/test it?
By running batch run if it getting correctly skipped

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
