### PR TITLE
Enable pfcwd at global level for snappi tests involving pfcwd

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -795,6 +795,21 @@ def get_pfcwd_stats(duthost, port, prio, asic_value=None):
     return pfcwd_stats
 
 
+def enable_default_pfcwd_status(duthost, asic_value=None):
+    """
+    Enable PFC watchdog default status.
+    Note: "pfcwd start_default" has no effect on config without enabling
+          "default_pfcwd_status".
+    """
+    cmd_prefix = f'sudo ip netns exec {asic_value} ' if asic_value is not None else ''
+    cmd = cmd_prefix + 'sonic-db-dump -n CONFIG_DB -y -k \"DEVICE_METADATA|localhost\"'
+    res = duthost.shell(cmd)
+    meta_data = json.loads(res["stdout"])
+    pfc_status = meta_data["DEVICE_METADATA|localhost"]["value"].get("default_pfcwd_status", "")
+    if pfc_status == 'disable':
+        cmd = cmd_prefix + 'sonic-db-cli CONFIG_DB hset \"DEVICE_METADATA|localhost\" default_pfcwd_status enable'
+        duthost.shell(cmd)
+
 def start_pfcwd(duthost, asic_value=None):
     """
     Start PFC watchdog with default setting
@@ -805,6 +820,7 @@ def start_pfcwd(duthost, asic_value=None):
     Returns:
         N/A
     """
+    enable_default_pfcwd_status(duthost, asic_value)
     if asic_value is None:
         duthost.shell('sudo pfcwd start_default')
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable pfcwd at global level for snappi tests involving pfcwd
Fixes [#18405](https://github.com/sonic-net/sonic-mgmt/issues/18405)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202405
- [x] msft-202412

### Approach
#### What is the motivation for this PR?
The issue is described in detail here: https://github.com/sonic-net/sonic-mgmt/issues/18405

#### How did you do it?
Introduced a helper to emable pfcwd globally for pfcwd snappi tests.

#### How did you verify/test it?
Ran snappi pfcwd tests on Arista platform and didn't notice the symptom.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Signed-off-by: vivekverma@arista.com and vkjammala@arista.com
