### PR TITLE
Skip fast / warm reboot testcases in snappi test suite

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -33,10 +33,10 @@ def skip_warm_reboot(duthost, reboot_type):
     Returns:
         None
     """
-    SKIP_LIST = ["td2"]
+    SKIP_LIST = ["td2", "jr2", "j2c+"]
     asic_type = duthost.get_asic_name()
     reboot_case_supported = True
-    if (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
+    if (reboot_type == "warm" and is_cisco_device(duthost)) or reboot_type == "fast":
         reboot_case_supported = False
     elif is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type:
         reboot_case_supported = False

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -36,7 +36,7 @@ def skip_warm_reboot(duthost, reboot_type):
     SKIP_LIST = ["td2", "jr2", "j2c+"]
     asic_type = duthost.get_asic_name()
     reboot_case_supported = True
-    if (reboot_type == "fast") and (asic_type == "jr2" or asic_type=="j2c+"):
+    if (reboot_type == "fast") and asic_type in ["jr2", "j2c+"]:
         reboot_case_supported = False
     elif (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
         reboot_case_supported = False

--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -36,7 +36,9 @@ def skip_warm_reboot(duthost, reboot_type):
     SKIP_LIST = ["td2", "jr2", "j2c+"]
     asic_type = duthost.get_asic_name()
     reboot_case_supported = True
-    if (reboot_type == "warm" and is_cisco_device(duthost)) or reboot_type == "fast":
+    if (reboot_type == "fast") and (asic_type == "jr2" or asic_type=="j2c+"):
+        reboot_case_supported = False
+    elif (reboot_type == "warm" or reboot_type == "fast") and is_cisco_device(duthost):
         reboot_case_supported = False
     elif is_broadcom_device(duthost) and asic_type in SKIP_LIST and "warm" in reboot_type:
         reboot_case_supported = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip fast / warm reboot testcases
Fixes [#18410](https://github.com/sonic-net/sonic-mgmt/issues/18410), [#18409](https://github.com/sonic-net/sonic-mgmt/pull/18409)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202412
- [x] msft-202405

### Approach
#### What is the motivation for this PR?
Warm reboot is not needed for Jericho2 and Jericho2C+ 
Fast reboot is being skipped for all topologies in sonic-mgmt, so same should be done for snappi_tests

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
