### PR TITLE
fix error in generate topo.

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -269,7 +269,7 @@ def generate_topo(role: str,
     def _find_lag_port(port_id: int) -> bool:
         nonlocal port_cfg
         if not isinstance(port_cfg["uplink_ports"], PortList):
-            return False,
+            return False, None
 
         lag_port = next(
             (lp for lp in port_cfg["uplink_ports"] if isinstance(lp, LagPort) and port_id in lp), None)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the following error in generate_topo.py,  as this is a master only change. Separate this change with other topo changes which is needed in 202412 for https://github.com/sonic-net/sonic-mgmt/pull/18224

```
~/.../sonic-mgmt-fix/ansible $ ./generate_topo.py -r t1 -k isolated -t t1-isolated -c 64 -l 'c448o16-sparse'
Traceback (most recent call last):
  File "./generate_topo.py", line 492, in <module>
    main()
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "./generate_topo.py", line 480, in main
    vm_list, downlinkif_list, uplinkif_list = generate_topo(role, port_count, uplink_ports, peer_ports,
  File "./generate_topo.py", line 325, in generate_topo
    is_lag_port, lag_port = _find_lag_port(panel_port_id)
ValueError: not enough values to unpack (expected 2, got 1)
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
syntax error in generate topo scripts

#### How did you do it?
Fix syntax error.

#### How did you verify/test it?
ran the same command.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
