### PR TITLE
[draft] Fix the hardcoded interface issue in PTF reading

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -898,7 +898,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         if ip_version == "ipv4":
             pkt = testutils.simple_tcp_packet(
                 eth_dst=setup["destination_mac"][direction][self.src_port],
-                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                 ip_dst=dst_ip,
                 ip_src=src_ip,
                 tcp_sport=sport,
@@ -911,7 +911,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         else:
             pkt = testutils.simple_tcpv6_packet(
                 eth_dst=setup["destination_mac"][direction][self.src_port],
-                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                 ipv6_dst=dst_ip,
                 ipv6_src=src_ip,
                 tcp_sport=sport,
@@ -934,7 +934,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         if ip_version == "ipv4":
             return testutils.simple_udp_packet(
                 eth_dst=setup["destination_mac"][direction][self.src_port],
-                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                 ip_dst=dst_ip,
                 ip_src=src_ip,
                 udp_sport=sport,
@@ -944,7 +944,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         else:
             return testutils.simple_udpv6_packet(
                 eth_dst=setup["destination_mac"][direction][self.src_port],
-                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                 ipv6_dst=dst_ip,
                 ipv6_src=src_ip,
                 udp_sport=sport,
@@ -959,7 +959,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         if ip_version == "ipv4":
             return testutils.simple_icmp_packet(
                 eth_dst=setup["destination_mac"][direction][self.src_port],
-                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                 ip_dst=dst_ip,
                 ip_src=src_ip,
                 icmp_type=icmp_type,
@@ -969,7 +969,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
         else:
             return testutils.simple_icmpv6_packet(
                 eth_dst=setup["destination_mac"][direction][self.src_port],
-                eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                 ipv6_dst=dst_ip,
                 ipv6_src=src_ip,
                 icmp_type=icmp_type,

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -309,7 +309,7 @@ def tcp_packet(rand_selected_dut, ptfadapter, ip_version,
     if ip_version == "ipv4":
         pkt = testutils.simple_tcp_packet(
             eth_dst=rand_selected_dut.facts['router_mac'],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             ip_dst=dst_ip,
             ip_src=src_ip,
             tcp_sport=int(sport),
@@ -322,7 +322,7 @@ def tcp_packet(rand_selected_dut, ptfadapter, ip_version,
     else:
         pkt = testutils.simple_tcpv6_packet(
             eth_dst=rand_selected_dut.facts['router_mac'],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             ipv6_dst=dst_ip,
             ipv6_src=src_ip,
             tcp_sport=int(sport),
@@ -347,7 +347,7 @@ def udp_packet(rand_selected_dut, ptfadapter, ip_version,
     if ip_version == "ipv4":
         return testutils.simple_udp_packet(
             eth_dst=rand_selected_dut.facts['router_mac'],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             ip_dst=dst_ip,
             ip_src=src_ip,
             udp_sport=int(sport),
@@ -357,7 +357,7 @@ def udp_packet(rand_selected_dut, ptfadapter, ip_version,
     else:
         return testutils.simple_udpv6_packet(
             eth_dst=rand_selected_dut.facts['router_mac'],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             ipv6_dst=dst_ip,
             ipv6_src=src_ip,
             udp_sport=int(sport),

--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1024,7 +1024,7 @@ def generate_hashed_packet_to_server(ptfadapter, duthost, hash_key, target_serve
 
         return send_pkt, exp_pkt, exp_tunnel_pkt
 
-    src_mac = ptfadapter.dataplane.get_mac(0, 0)
+    src_mac = ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0])
     dst_mac = duthost.facts["router_mac"]
 
     # initialize the packets cache
@@ -1424,7 +1424,7 @@ def build_ipv4_packet_to_server(duthost, ptfadapter, target_server_ip):
     pkt_ttl = random.choice(list(range(3, 65)))
     pkt = testutils.simple_ip_packet(
         eth_dst=duthost.facts["router_mac"],
-        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
         ip_src="1.1.1.1",
         ip_dst=target_server_ip,
         ip_dscp=pkt_dscp,
@@ -1450,7 +1450,12 @@ def build_ipv6_packet_to_server(duthost, ptfadapter, target_server_ip):
     pkt_hl = random.choice(list(range(3, 65)))
     pktlen = 100
     pkt_tc = testutils.ip_make_tos(0, 0, pkt_dscp)
-    pkt = Ether(src=ptfadapter.dataplane.get_mac(0, 0), dst=duthost.facts["router_mac"])
+    pkt = Ether(
+        src=ptfadapter.dataplane.get_mac(
+            *list(ptfadapter.dataplane.ports.keys())[0]
+        ),
+        dst=duthost.facts["router_mac"]
+    )
     pkt /= IPv6(src="fc02:1200::1", dst=target_server_ip, fl=0, tc=pkt_tc, hlim=pkt_hl)
     pkt /= "".join(random.choice(string.ascii_lowercase) for _ in range(pktlen - len(pkt)))
     logging.info(

--- a/tests/common/plugins/ptfadapter/README.md
+++ b/tests/common/plugins/ptfadapter/README.md
@@ -20,7 +20,7 @@ import ptf.mask as mask
 def test_some_traffic(duthost, ptfadapter):
     pkt = testutils.simple_tcp_packet(
         eth_dst=duthost.facts["router_mac"],
-        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
         ip_src='1.1.1.1',
         ip_dst='192.168.0.1',
         ip_ttl=64,

--- a/tests/decap/test_subnet_decap.py
+++ b/tests/decap/test_subnet_decap.py
@@ -124,7 +124,7 @@ def setup_arp_responder(rand_selected_dut, ptfhost, prepare_negative_ip_port_map
 
 def build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_version, stage):
     eth_dst = rand_selected_dut.facts["router_mac"]
-    eth_src = ptfadapter.dataplane.get_mac(0, 0)
+    eth_src = ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0])
     logger.info("eth_src: {}, eth_dst: {}".format(eth_src, eth_dst))
 
     if ip_version == "IPv4":

--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -76,7 +76,7 @@ def build_encapsulated_packet(rand_selected_interface, ptfadapter,          # no
     )[IP]
     packet = testutils.simple_ipv4ip_packet(
         eth_dst=tor.facts["router_mac"],
-        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
         ip_src=peer_ipv4_address,
         ip_dst=tor_ipv4_address,
         ip_dscp=inner_dscp,

--- a/tests/dualtor/test_tor_ecn.py
+++ b/tests/dualtor/test_tor_ecn.py
@@ -120,7 +120,7 @@ def build_encapsulated_ip_packet(
     )[IP]
     packet = testutils.simple_ipv4ip_packet(
         eth_dst=tor.facts["router_mac"],
-        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
         ip_src=peer_ipv4_address,
         ip_dst=tor_ipv4_address,
         ip_dscp=outer_dscp,
@@ -162,7 +162,7 @@ def build_non_encapsulated_ip_packet(
 
     packet = testutils.simple_ip_packet(
         eth_dst=tor.facts["router_mac"],
-        eth_src=ptfadapter.dataplane.get_mac(0, 0),
+        eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
         ip_src="1.1.1.1",
         ip_dst=server_ipv4,
         ip_dscp=dscp,

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -117,7 +117,9 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
                 packets = [
                     testutils.simple_ipv6ip_packet(ipv6_src=selected_addrs2[0],
-                                                   eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                                                   eth_src=ptfadapter.dataplane.get_mac(
+                                                       *list(ptfadapter.dataplane.ports.keys())[0]
+                                                    ),
                                                    eth_dst=setup_info[everflow_direction]["ingress_router_mac"],
                                                    ipv6_dst=selected_addrs2[1],
                                                    inner_frame=inner_pkt2),
@@ -682,7 +684,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            dport=8080,
                            flags=0x10):
         pkt = testutils.simple_tcpv6_packet(
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,
             ipv6_dst=dst_ip,
@@ -709,7 +711,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                            sport=2020,
                            dport=8080):
         pkt = testutils.simple_udpv6_packet(
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=setup[direction]["ingress_router_mac"],
             ipv6_src=src_ip,
             ipv6_dst=dst_ip,

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -171,9 +171,19 @@ def apply_acl_rule(setup_info, tbinfo, setup_mirror_session_dest_ip_route, ip_ve
 def generate_testing_packet(ptfadapter, duthost, mirror_session_info, router_mac, setup, pkt_ip_ver,
                             erspan_ip_ver=4):  # noqa F811
     if pkt_ip_ver == 'ipv4':
-        packet = testutils.simple_tcp_packet(eth_src=ptfadapter.dataplane.get_mac(0, 0), eth_dst=router_mac)
+        packet = testutils.simple_tcp_packet(
+            eth_src=ptfadapter.dataplane.get_mac(
+                *list(ptfadapter.dataplane.ports.keys())[0]
+            ),
+            eth_dst=router_mac
+        )
     else:
-        packet = testutils.simple_tcpv6_packet(eth_src=ptfadapter.dataplane.get_mac(0, 0), eth_dst=router_mac)
+        packet = testutils.simple_tcpv6_packet(
+            eth_src=ptfadapter.dataplane.get_mac(
+                *list(ptfadapter.dataplane.ports.keys())[0]
+            ),
+            eth_dst=router_mac
+        )
 
     dec_ttl = 0
 

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -712,7 +712,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                     ip_src=selected_addrs2[0],
                     eth_dst=router_mac,
                     ip_dst=selected_addrs2[1],
-                    eth_src=ptfadapter.dataplane.get_mac(0, 0),
+                    eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
                     inner_frame=inner_pkt2[scapy.IP]
                 ),
                 self._base_tcp_packet(ptfadapter, setup_info, router_mac, src_ip=selected_addrs3[0],
@@ -893,7 +893,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         flags=0x10
     ):
         pkt = testutils.simple_tcp_packet(
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             eth_dst=router_mac,
             ip_src=src_ip,
             ip_dst=dst_ip,

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -90,7 +90,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, expected_po
     if ipv6:
         pkt = testutils.simple_tcpv6_packet(
             eth_dst=duthost.facts["router_mac"],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             ipv6_src='2001:db8:85a3::8a2e:370:7334',
             ipv6_dst=ip_dst,
             ipv6_hlim=64,
@@ -99,7 +99,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, expected_po
     else:
         pkt = testutils.simple_tcp_packet(
             eth_dst=duthost.facts["router_mac"],
-            eth_src=ptfadapter.dataplane.get_mac(0, 0),
+            eth_src=ptfadapter.dataplane.get_mac(*list(ptfadapter.dataplane.ports.keys())[0]),
             ip_src='1.1.1.1',
             ip_dst=ip_dst,
             ip_ttl=64,


### PR DESCRIPTION
### Description of PR

Summary:
Replace hardcoded value (0, 0) in ACL test with a dynamic selection to improve robustness across diverse topologies.

Fixes:
The hardcoded value (0, 0) does not account for scenarios where device_number or port_number is not 0, which causes failures in certain topologies. 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When running nightly tests using the t2_single_node_min topology, we encountered failures in the ACL test. The root cause was a hardcoded call to get_mac(0, 0), which assumes that a device with device_number = 0 and port_number = 0 exists. This assumption does not hold true in some topologies like t2_single_node_min.

#### How did you do it?
Instead of using the hardcoded (0, 0) port index, this PR dynamically selects the first available port from the existing list of ports. This improves compatibility and prevents test failures across topologies with varying port configurations. 

#### How did you verify/test it?
Tested locally by running acl/test_acl.py against the t2_single_node_min topology and confirmed that the tests pass successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

