### PR TITLE
[Snappi][Documentation] Dynamic vs Static port selection documentation.

### DIFF
--- a/tests/snappi_tests/static_vs_dynamic_port_selection.md
+++ b/tests/snappi_tests/static_vs_dynamic_port_selection.md
@@ -1,0 +1,82 @@
+# Static and Dynamic Port Selection for Snappi
+
+Snappi tests support two modes of port selection:
+
+- **Static Port Selection**
+- **Dynamic Port Selection**
+
+These tests are typically executed across three test subtypes:
+
+- Single line card, single ASIC  
+- Single line card, multiple ASICs  
+- Multiple line cards  
+
+---
+
+## Static Port Selection
+
+Static port selection is the existing method used for assigning ports. It relies on the `tests/snappi_tests/variables.override.yml` file to define the ports.
+
+A dictionary maps each test subtype to its corresponding Tx and Rx ports. The test framework uses these mappings as parameterized variables and iterates through each subtype.
+
+**Dictionary format:**
+
+```yaml
+<test-subtype>:
+  tx-ports: [list of ports]
+  rx-ports: [list of ports]
+```
+
+Users can customize or extend subtypes as needed by modifying the `variables.py` file.
+
+**Advantages:**
+
+- Full control over which subtypes and ports are used.
+- Easy to define and reuse specific configurations.
+
+**Disadvantages:**
+
+- Not portable across different setups�requires manual updates to `variables.py` for each new environment.
+- Cannot easily handle setups with interfaces of varying speeds unless subtypes are explicitly defined for each speed.
+
+---
+
+## Dynamic Port Selection
+
+Dynamic port selection is a newer feature that automatically determines available ports based on the testbed configuration. It uses metadata stored in:
+
+```
+tests/metadata/snappi_tests/<testbed>.json
+```
+
+This file includes information about available ports, their speeds, and associated ASICs. During test execution, `test_pretest.py` generates subtypes dynamically based on interface speeds and assigns appropriate ports.
+
+**Dictionary format:**
+
+```
+{
+  "<test-subtype>_<interface-speed>": [list of ports]
+}
+```
+
+**Advantages:**
+
+- Automatically adapts to different setups and interface speeds.
+- No manual configuration required.
+
+**Disadvantages:**
+
+- No fine-grained control over which subtypes or ports are selected.
+- Dynamic subtypes cannot be customized.
+
+---
+
+## Port Selection Logic
+
+The test framework chooses between static and dynamic port selection based on the following logic:
+
+1. **Static Selection** is used if the testbed name, subtype, and ports are defined in `tests/snappi_tests/variables.override.yml`.
+2. **Dynamic Selection** is used if the above file does not contain the required configuration.
+3. Users can **force dynamic selection** by passing the `--enable-snappi-dynamic-ports` flag to `pytest`, even if static configuration is present.
+
+---


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Documentation for the snappi dynamic vs static port selection.

Summary:
Fixes #18216 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Recently, there is change in Snappi infra to select the Rx and Tx ports for the test dynamically, thus removing dependency from variables.py hardcoded entries.

There is further enhancement to fallback to static port selection as well. However, documentation to run these test was missing.

@auspham , @sdszhang , @vmittal-msft .

#### How did you do it?
Added documentation in tests/snappi_tests/ folder.

#### How did you verify/test it?
Created a markdown file for the same.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
