### PR TITLE
Fix bgpcfgd error of "Peer-group members must be all internal or all external" for some topos

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -470,7 +470,7 @@ def generate_routes(family, podset_number, tor_number, tor_subnet_number,
     return routes
 
 
-def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
+def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", skip_peer_switches=False):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -492,6 +492,8 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
 
     vms = topo['topology']['VMs']
     for vm_name, vm in vms.items():
+        if 'P' in vm_name and skip_peer_switches:
+            continue
         vm_offset = vm['vm_offset']
         port = IPV4_BASE_PORT + vm_offset
         port6 = IPV6_BASE_PORT + vm_offset
@@ -1456,6 +1458,7 @@ def main():
 
     is_storage_backend = "backend" in topo_name
     tor_default_route = "t1-isolated" in topo_name
+    skip_peer_switches = topo_name in ['t0-isolated-d16u16s2', 't0-isolated-d96u32s2', 't0-isolated-d128u128s2']
 
     topo_type = get_topo_type(topo_name)
 
@@ -1464,7 +1467,7 @@ def main():
             adhoc_routes(topo, ptf_ip, peers_routes_to_change, action)
             module.exit_json(change=True)
         elif topo_type == "t0":
-            fib_t0(topo, ptf_ip, no_default_route=is_storage_backend, action=action)
+            fib_t0(topo, ptf_ip, no_default_route=is_storage_backend, action=action, skip_peer_switches=skip_peer_switches)
             module.exit_json(changed=True)
         elif topo_type == "t1" or topo_type == "smartswitch-t1":
             fib_t1_lag(

--- a/ansible/vars/topo_t0-isolated-d128u128s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s2.yml
@@ -3152,7 +3152,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65101
       peers:
         65100:
           - 10.0.2.0
@@ -3171,7 +3171,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65102
       peers:
         65100:
           - 10.0.2.2

--- a/ansible/vars/topo_t0-isolated-d16u16s2.yml
+++ b/ansible/vars/topo_t0-isolated-d16u16s2.yml
@@ -464,7 +464,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65101
       peers:
         65100:
           - 10.0.2.0
@@ -483,7 +483,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65102
       peers:
         65100:
           - 10.0.2.2

--- a/ansible/vars/topo_t0-isolated-d96u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-d96u32s2.yml
@@ -912,7 +912,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65101
       peers:
         65100:
           - 10.0.1.0
@@ -931,7 +931,7 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65102
       peers:
         65100:
           - 10.0.1.2


### PR DESCRIPTION
…



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This change is to fix the issue of bgpcfgd error of "Peer-group members must be all internal or all external" for topos t0-isolated-d16u16s2, t0-isolated-d96u32s2 and t0-isolated-d128u128s2.

#### How did you do it?
We followed the changes below to avoid existence of internal bgp by changing ASN of peer switches:
https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/vars/topo_t0-isolated-d32u32s2.yml and PR https://github.com/sonic-net/sonic-mgmt/pull/17888
Then the routes to peer switches is added to the existing ecmp routes originally only to t1 switch. The added routes will break the assumption of existing testcases, so we have to change anounce_routes.py so that the routes to peer switches are not announced.

#### How did you verify/test it?
Tested that this will fix the bgpcfgd error of "Peer-group members must be all internal or all external"

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
