### PR TITLE
[platform_tests] Fix test_auto_negotiation.py 

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2299,6 +2299,19 @@ Totals               6450                 6449
         supported_speeds = self.shell(cmd)['stdout'].strip()
         return None if not supported_speeds else supported_speeds.split(',')
 
+    def get_supported_fecs(self, interface_name):
+        """Get supported fecs for a given interface
+
+        Args:
+            interface_name (str): Interface name
+
+        Returns:
+            list: A list of supported fec strings or None
+        """
+        cmd = 'sonic-db-cli STATE_DB HGET \"PORT_TABLE|{}\" \"{}\"'.format(interface_name, 'supported_fecs')
+        supported_fecs = self.shell(cmd)['stdout'].strip()
+        return None if not supported_fecs else supported_fecs.split(',')
+
     def set_auto_negotiation_mode(self, interface_name, mode):
         """Set auto negotiation mode for a given interface
 

--- a/tests/common/helpers/port_utils.py
+++ b/tests/common/helpers/port_utils.py
@@ -23,12 +23,12 @@ def get_common_supported_speeds(duthost, dut_port_name, fanout, fanout_port_name
 
     fanout_supported_speeds = fanout.get_supported_speeds(fanout_port_name)
     if not fanout_supported_speeds:
-        dut_supported_speeds = [dut_current_port_speed]
+        fanout_supported_speeds = [dut_current_port_speed]
 
     # get supported speeds for the cable
     cable_supported_speeds = get_cable_supported_speeds(duthost, dut_port_name)
     if not cable_supported_speeds:
-        dut_supported_speeds = [dut_current_port_speed]
+        cable_supported_speeds = [dut_current_port_speed]
 
     supported_speeds = set(dut_supported_speeds) & set(fanout_supported_speeds) & set(cable_supported_speeds)
     if not supported_speeds:

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -189,7 +189,7 @@ def test_auto_negotiation_advertised_speeds_all(enum_dut_portname_module_fixture
                                                                                                     fanout_port))
 
         # Advertise all supported speeds in fanout port
-        success = fanout.set_speed(fanout_port, None)
+        success = fanout.set_speed(fanout_port, "all")
         pytest_require(
             success,
             'Failed to advertise all speeds on fanout. Fanout: {}, port: {}'.format(fanout, fanout_port)
@@ -241,7 +241,7 @@ def test_auto_negotiation_dut_advertises_each_speed(enum_speed_per_dutport_fixtu
         pytest_require(success, 'Failed to set port autoneg on fanout port {}'.format(fanout_port))
 
         # Advertise all supported speeds in fanout port
-        success = fanout.set_speed(fanout_port, None)
+        success = fanout.set_speed(fanout_port, "all")
         pytest_require(success, 'Failed to advertise all speeds on fanout port {}'.format(fanout_port))
 
         duthost.shell('config interface autoneg {} enabled'.format(dut_port))

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -329,14 +329,31 @@ def test_force_speed(enum_speed_per_dutport_fixture):
     )
 
     FEC_FOR_SPEED = {
-        25000: 'fc',
-        50000: 'fc',
-        100000: 'rs',
-        200000: 'rs',
-        400000: 'rs'
+        10000: ['none', 'fc'],
+        25000: ['none', 'fc', 'rs'],
+        50000: ['none', 'fc', 'rs'],
+        100000: ['none', 'rs'],
+        200000: ['rs'],
+        400000: ['rs'],
+        800000: ['rs']
     }
 
-    fec_mode = FEC_FOR_SPEED.get(int(speed))
+    fec_mode_for_speed = FEC_FOR_SPEED.get(int(speed))
+    if not fec_mode_for_speed:
+        fec_mode_for_speed = ['None']
+
+    dut_current_port_fec = duthost.get_port_fec(dut_port)
+    dut_supported_fecs = duthost.get_supported_fecs(dut_port)
+    if not dut_supported_fecs:
+        dut_supported_fecs = [dut_current_port_fec]
+
+    fanout_supported_fecs = fanout.get_supported_fecs(fanout_port)
+    if not fanout_supported_fecs:
+        fanout_supported_fecs = [dut_current_port_fec]
+
+    fec_mode = list(set(dut_supported_fecs) & set(fanout_supported_fecs) & set(fec_mode_for_speed))[0]
+    if not fec_mode:
+        fec_mode = dut_current_port_fec
 
     logger.info('Start test for DUT port {} and fanout port {}'.format(dut_port, fanout_port))
     # Disable auto negotiation on fanout port


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This change aims to fix multiple issues in test_auto_negotiation.py platform tests.

Also Fixes #18429 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511 

### Approach
#### What is the motivation for this PR?
To fix issues in running test_auto_negotiation.py.
Issues: 
* Pretest failed to generate metadata/autoneg-test-params.json.
* test_force_speed - Failed to find common fix for some of the speeds.
* test_auto_negotiation_dut_advertises_each_speed and test_auto_negotiation_advertised_speeds_all - Failed to set all advertised speed for fanout with invalid config.

#### How did you do it?
* Fix get_common_supported_speeds() which helps in generating metadata/autoneg-test-params.json in pretest(Fixes #18429).
* test_force_speed - Test is updated to derive the FEC mode from the subset of supported FECs of the DUT, fanout, and the FECs per speed.
* Fix setting of advertised speed for fanout with 'all' instead of 'None'. 'None' is a invalid value for set advertised speed.

#### How did you verify/test it?
With a autoneg port profile in dut and fanout, run platform_tests/test_auto_negotiation.py with pretest.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
