### PR TITLE
Change the scope of selected_asic_id and dependent fixtures to function level

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3020,7 +3020,7 @@ def gnxi_path(ptfhost):
     return gnxipath
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def selected_asic_index(request):
     asic_index = DEFAULT_ASIC_ID
     if "enum_asic_index" in request.fixturenames:
@@ -3037,7 +3037,7 @@ def selected_asic_index(request):
     return asic_index
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ip_netns_namespace_prefix(request, selected_asic_index):
     """
     Construct the formatted namespace prefix for executed commands inside the specific
@@ -3049,7 +3049,7 @@ def ip_netns_namespace_prefix(request, selected_asic_index):
         return f'sudo ip netns exec {NAMESPACE_PREFIX}{selected_asic_index}'
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def cli_namespace_prefix(request, selected_asic_index):
     """
     Construct the formatted namespace prefix for executed commands inside the specific


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The value of selected ASIC in ASIC enum fixtures is determined per function, so it is inappropriate to set the scope of selected_asic_id  and relevant fixtures to be module level.
Fixes #18422 (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
