### PR TITLE
Snappi: pfcwd: Skip forward action tests for cisco-8000

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2320,6 +2320,18 @@ snappi_tests/pfc/test_global_pause_with_snappi.py:
       - "asic_type in ['cisco-8000', 'vs']"
       - "topo_type in ['t2', 'multidut-tgen']"
 
+snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_frwd_90_10:
+  skip:
+    reason: "Forward action is not supported in cisco-8000."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
+snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_frwd_over_subs_40_09:
+  skip:
+    reason: "Forward action is not supported in cisco-8000."
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 #######################################
 #####            snmp             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Cisco-8000 doesn't support forward action for pfcwd. We should skip these testcases:
```
sonic@sonic-ucs-m4-3:~/rraghav/Ixia/400G-T2/sonic-mgmt.msft/tests/snappi_tests/pfcwd$ grep "def test" test_pfcwd_actions.py | grep frwd
def test_pfcwd_frwd_90_10(snappi_api,                  # noqa: F811
def test_pfcwd_frwd_over_subs_40_09(snappi_api,                  # noqa: F811
sonic@sonic-ucs-m4-3:~/rraghav/Ixia/400G-T2/sonic-mgmt.msft/tests/snappi_tests/pfcwd$ 
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Pls see description.

#### How did you do it?
Added the tests to the skip conditions.

#### How did you verify/test it?
Ran the two tests to verify it skips.
```

=============================================================================================================================== warnings summary ===============================================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------------------------------------------------------------------- generated xml file: /run_logs/ixia/pfcwd-frwd/2025-05-15-18-34-55/tr.xml ---------------------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
=========================================================================================================================== short test summary info ============================================================================================================================
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_actions.py:367: Forward action is not supported in cisco-8000.
SKIPPED [4] snappi_tests/pfcwd/test_pfcwd_actions.py:710: Forward action is not supported in cisco-8000.
================================================================================================================ 8 skipped, 16 deselected, 1 warning in 12.78s =================================================================================================================
sonic@snappi-sonic-mgmt-msft-t2-rraghav:/data/tests$ 
```
#### Any platform specific information?
For cisco-8000 only.