### PR TITLE
Fix decap test on FT2 topo

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
+++ b/ansible/roles/test/files/ptftests/py3/IP_decap_test.py
@@ -522,8 +522,11 @@ class DecapPacketTest(BaseTest):
 
             next_hops = [self.fibs[active_dut_index][dst_ip] for active_dut_index in active_dut_indexes]
             exp_port_lists = [next_hop.get_next_hop_list() for next_hop in next_hops]
+            lt2_default_route = False
+            if self.topo == 'ft2' and len(exp_port_lists) == 1 and len(self.src_ports) == len(exp_port_lists[0]):
+                lt2_default_route = True
             for exp_port_list in exp_port_lists:
-                if src_port in exp_port_list:
+                if src_port in exp_port_list and not lt2_default_route:
                     break
             else:
                 if self.single_fib == "single-fib-single-hop" and exp_port_lists[0]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix decap test on FT2 topo.

The test gets stuck on FT2 because all the ports are in nexthop for default route. Hence the check in function `get_src_and_exp_ports` runs into dead loop.

This PR addressed that issue by checking if the route points to default route, and ignore the check `src_port in exp_port_list` if that's the case.

This PR depends on https://github.com/sonic-net/sonic-mgmt/pull/18442
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to fix decap test on FT2 topo.

#### How did you do it?
This PR addressed that issue by checking if the route points to default route, and ignore the check `src_port in exp_port_list` if that's the case.

#### How did you verify/test it?
The change is verified on a FT2 topo.
```
collected 4 items                                                                                                                                                                                                             

decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
23:29:27 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
PASSED                                                                                                                                                                                                                  [ 25%]
decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset] SKIPPED (Not supported on backend, T2 topologies , broadcom platforms before 202012 release, marvell-teralynx, x86_64-8111_32eh_o-r0 platform. Skip on mellanox 202412 release. Skip on 7260CX3 T1 topo in 202305 release) [ 50%]
decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable] SKIPPED (Not supported on broadcom after 201911 release and cisco-8000 all releases and marvell asics)                                              [ 75%]
decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=set_unset] SKIPPED (Not supported on broadcom after 201911 release, and cisco-8000 all releases and marvell asics)                                           [100%]
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
