### PR TITLE
support t1-isolated-d56u2 in test_acl.py, test_stress_acl.py and test_qos_sai

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -412,9 +412,9 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
     # TODO: We should make this more robust (i.e. bind all active front-panel ports)
     acl_table_ports = defaultdict(list)
 
-    if (topo in ["t0", "mx", "m0_vlan", "m0_l3"] or
-            tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag") or
-            't1-isolated' in tbinfo["topo"]["name"]):
+    if (topo in ["t0", "mx", "m0_vlan", "m0_l3"]
+            or tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag")
+            or 't1-isolated' in tbinfo["topo"]["name"]):
         for namespace, port in list(downstream_ports.items()):
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -414,6 +414,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
 
     if topo in ["t0", "mx", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag",
                                                                               "t1-isolated-d28u1", "t1-isolated-d28",
+                                                                              "t1-isolated-d56u2",
                                                                               "t1-isolated-d128"):
         for namespace, port in list(downstream_ports.items()):
             acl_table_ports[namespace] += port
@@ -424,7 +425,8 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
                                                                                                "t1-64-lag-clet",
                                                                                                "t1-56-lag",
                                                                                                "t1-28-lag",
-                                                                                               "t1-32-lag"):
+                                                                                               "t1-32-lag",
+                                                                                               "t1-isolated-d56u2"):
 
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -412,21 +412,18 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
     # TODO: We should make this more robust (i.e. bind all active front-panel ports)
     acl_table_ports = defaultdict(list)
 
-    if topo in ["t0", "mx", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag",
-                                                                              "t1-isolated-d28u1", "t1-isolated-d28",
-                                                                              "t1-isolated-d56u2",
-                                                                              "t1-isolated-d128"):
+    if (topo in ["t0", "mx", "m0_vlan", "m0_l3"]
+        or tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag")
+        or 't1-isolated' in tbinfo["topo"]["name"]):
         for namespace, port in list(downstream_ports.items()):
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.
             if namespace:
                 acl_table_ports[''] += port
-    if len(port_channels) and topo in ["t0", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag",
-                                                                                               "t1-64-lag-clet",
-                                                                                               "t1-56-lag",
-                                                                                               "t1-28-lag",
-                                                                                               "t1-32-lag",
-                                                                                               "t1-isolated-d56u2"):
+    if len(port_channels) and (topo in ["t0", "m0_vlan", "m0_l3"]
+                               or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet",
+                                                             "t1-56-lag", "t1-28-lag", "t1-32-lag")
+                               or 't1-isolated' in tbinfo["topo"]["name"]):
 
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -412,9 +412,9 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
     # TODO: We should make this more robust (i.e. bind all active front-panel ports)
     acl_table_ports = defaultdict(list)
 
-    if (topo in ["t0", "mx", "m0_vlan", "m0_l3"]
-        or tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag")
-        or 't1-isolated' in tbinfo["topo"]["name"]):
+    if (topo in ["t0", "mx", "m0_vlan", "m0_l3"] or
+            tbinfo["topo"]["name"] in ("t1", "t1-lag", "t1-28-lag") or
+            't1-isolated' in tbinfo["topo"]["name"]):
         for namespace, port in list(downstream_ports.items()):
             acl_table_ports[namespace] += port
             # In multi-asic we need config both in host and namespace.

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -202,7 +202,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
             upstream_port_neighbor_ips[interface] = ipv4_addr
 
     dst_ip_addr = None
-    if tbinfo["topo"]['name'] in ["t1-isolated-d28u1", "t1-isolated-d56u2"]:
+    if tbinfo["topo"]['name'] in ["t1-isolated-d28u1", "t1-isolated-d56u2", "t1-isolated-d448u16"]:
         dst_ip_addr = random.choices(list(upstream_port_neighbor_ips.values()))
     return ptf_src_port, upstream_port_ids, dut_port, dst_ip_addr
 

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -202,7 +202,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
             upstream_port_neighbor_ips[interface] = ipv4_addr
 
     dst_ip_addr = None
-    if tbinfo["topo"]['name'] == "t1-isolated-d28u1":
+    if tbinfo["topo"]['name'] in ["t1-isolated-d28u1", "t1-isolated-d56u2"]:
         dst_ip_addr = random.choices(list(upstream_port_neighbor_ips.values()))
     return ptf_src_port, upstream_port_ids, dut_port, dst_ip_addr
 

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -49,7 +49,7 @@ class QosBase:
         "t0-standalone-256", "t0-28", "t0-isolated-d16u16s1", "t0-isolated-d16u16s2"
     ]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag",
-                          "t1-isolated-d28u1"]
+                          "t1-isolated-d28u1", "t1-isolated-d56u2"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",
                            "j2c+", "jr2", "th5"]

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -49,7 +49,8 @@ class QosBase:
         "t0-standalone-256", "t0-28", "t0-isolated-d16u16s1", "t0-isolated-d16u16s2"
     ]
     SUPPORTED_T1_TOPOS = ["t1-lag", "t1-64-lag", "t1-56-lag", "t1-backend", "t1-28-lag", "t1-32-lag",
-                          "t1-isolated-d28u1", "t1-isolated-d56u2"]
+                          "t1-isolated-d28u1", "t1-isolated-v6-d28u1", "t1-isolated-d56u2", "t1-isolated-v6-d56u2",
+                          "t1-isolated-d448u16", "t1-isolated-v6-d448u16"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "td3", "th3",
                            "j2c+", "jr2", "th5"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add t1-isolated-d56u2 topo support into test_acl.py, test_stress_acl.py and test_qos_sai

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Add t1-isolated-d56u2 topo support into test_acl.py, test_stress_acl.py and test_qos_sai

#### How did you do it?
Add t1-isolated-d56u2 topo support into test_acl.py, test_stress_acl.py and test_qos_sai

#### How did you verify/test it?
Ran on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
