### PR TITLE
fib: Update correct hash fields for Marvell-Teralynx

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -689,6 +689,9 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
     if duthost.facts['asic_type'] in ["mellanox"]:
         logging.info("Mellanox: hash-key is src-ip, dst-ip")
         hash_keys = ['src-ip', 'dst-ip']
+    if duthost.facts['asic_type'] in ["marvell-teralynx"]:
+        logging.info("Marvell-Teralynx: hash-key is src-ip, dst-ip")
+        hash_keys = ['src-ip', 'dst-ip']
 
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.NvgreHashTest.{}.{}.log".format(


### PR DESCRIPTION
### Description of PR
In Fib module, under test_nvgre_hash, update correct hash fields for Marvell-Teralynx

**Summary:**
This test fails because Marvell-Teralynx does not support all hash-fields for this test.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
- [x] Enable test case for new platform


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To enable test case execution for Marvell-Teralynx device

#### How did you do it?
Updated the correct hash-fields for Marvell-Teralynx platform

#### How did you verify/test it?
Yes, executed the test-case on device and ensured its passing

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
