### PR TITLE
[DT2] Enhance fib test to support FT2

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -176,6 +176,7 @@ class FibTest(BaseTest):
         self.ignore_ttl = self.test_params.get('ignore_ttl', False)
         self.single_fib = self.test_params.get(
             'single_fib_for_duts', "multiple-fib")
+        self.topo_type = self.test_params.get('topo_type', None)
 
     def check_ip_ranges(self, ipv4=True):
         for dut_index, dut_fib in enumerate(self.fibs):
@@ -210,8 +211,14 @@ class FibTest(BaseTest):
                          for active_dut_index in active_dut_indexes]
             exp_port_lists = [next_hop.get_next_hop_list()
                               for next_hop in next_hops]
+            # On FT2 topo, since all the ports are in the next hop list of default route,
+            # we need to skip check if the src_port is in exp_port_list. Otherwise, it will
+            # cause the function to stuck in infinite loop.
+            lt2_default_route = False
+            if self.topo_type == 'ft2' and len(exp_port_lists) == 1 and len(self.src_ports) == len(exp_port_lists[0]):
+                lt2_default_route = True
             for exp_port_list in exp_port_lists:
-                if src_port in exp_port_list:
+                if src_port in exp_port_list and not lt2_default_route:
                     break
             else:
                 if self.switch_type == "chassis-packet":

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -117,7 +117,7 @@ class HashTest(BaseTest):
         self.is_active_active_dualtor = self.test_params.get("is_active_active_dualtor", False)
 
         self.topo_name = self.test_params.get('topo_name', '')
-
+        self.topo_type = self.test_params.get('topo_type', '')
         # set the base mac here to make it persistent across calls of check_ip_route
         self.base_mac = self.dataplane.get_mac(
             *random.choice(list(self.dataplane.ports.keys())))
@@ -138,8 +138,14 @@ class HashTest(BaseTest):
             next_hops = self._get_nexthops(src_port, dst_ip)
             exp_port_lists = [next_hop.get_next_hop_list()
                               for next_hop in next_hops]
+            # On FT2 topo, since all the ports are in the next hop list of default route,
+            # we need to skip check if the src_port is in exp_port_list. Otherwise, it will
+            # cause the function to stuck in infinite loop.
+            lt2_default_route = False
+            if self.topo_type == 'ft2' and len(exp_port_lists) == 1 and len(self.src_ports) == len(exp_port_lists[0]):
+                lt2_default_route = True
             for exp_port_list in exp_port_lists:
-                if src_port in exp_port_list:
+                if src_port in exp_port_list and not lt2_default_route:
                     break
             else:
                 if self.single_fib == "single-fib-single-hop" and exp_port_lists[0]:
@@ -201,7 +207,13 @@ class HashTest(BaseTest):
             # The 'ingress-port' key is not used in hash by design. We are doing negative test for 'ingress-port'.
             # When 'ingress-port' is included in HASH_KEYS, the PTF test will try to inject same packet to different
             # ingress ports and expect that they are forwarded from same egress port.
-            for ingress_port in self.get_ingress_ports(exp_port_lists, dst_ip):
+            if self.topo_type == 'ft2':
+                # For FT2 topo, all the ports are connected to LT2
+                # So we can use any port as ingress port
+                port_list = self.src_ports
+            else:
+                port_list = self.get_ingress_ports(exp_port_lists, dst_ip)
+            for ingress_port in port_list:
                 print(ingress_port)
                 logging.info('Checking hash key {}, src_port={}, exp_ports={}, dst_ip={}'
                              .format(hash_key, ingress_port, exp_port_lists, dst_ip))
@@ -514,7 +526,7 @@ class HashTest(BaseTest):
         '''
         percentage = (actual - expected) / float(expected)
         balancing_range = self.balancing_range
-        if hash_key == 'ip-proto' and self.topo_name == 't2':
+        if hash_key == 'ip-proto' and 't2' in self.topo_name:
             # ip-protocol only has 8-bits of entropy which results in poor hashing distributions on topologies with
             # a large number of ecmp paths so relax the hashing requirements
             balancing_range = self.RELAXED_BALANCING_RANGE

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -282,7 +282,8 @@ def test_basic_fib(duthosts, ptfhost, tbinfo, ipv4, ipv6, mtu,
             "ignore_ttl": ignore_ttl,
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
-            "asic_type": asic_type
+            "asic_type": asic_type,
+            "topo_type": updated_tbinfo['topo']['type']
         },
         log_file=log_file,
         qlen=PTF_QLEN,
@@ -514,7 +515,8 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
             "single_fib_for_duts": single_fib_for_duts,
             "switch_type": switch_type,
             "is_active_active_dualtor": is_active_active_dualtor,
-            "topo_name": updated_tbinfo['topo']['name']
+            "topo_name": updated_tbinfo['topo']['name'],
+            "topo_type": updated_tbinfo['topo']['type']
         },
         log_file=log_file,
         qlen=PTF_QLEN,
@@ -606,7 +608,8 @@ def test_ipinip_hash_negative(add_default_route_to_dut, duthosts,           # no
                    "ignore_ttl": ignore_ttl,
                    "single_fib_for_duts": single_fib_for_duts,
                    "ipver": ipver,
-                   "topo_name": tbinfo['topo']['name']
+                   "topo_name": tbinfo['topo']['name'],
+                   "topo_type": tbinfo['topo']['type']
                },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -661,7 +664,8 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": vxlan_ipver,
-                       "topo_name": tbinfo['topo']['name']
+                       "topo_name": tbinfo['topo']['name'],
+                       "topo_type": tbinfo['topo']['type']
                        },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -714,7 +718,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": nvgre_ipver,
-                       "topo_name": tbinfo['topo']['name']
+                       "topo_name": tbinfo['topo']['name'],
+                       "topo_type": tbinfo['topo']['type']
                        },
                log_file=log_file,
                qlen=PTF_QLEN,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enhance `test_fib` to support a new topology `FT2`.

Changes include
1. Pass `topo_type` to ptf script 
2. Improve port selection for `FT2`
3. Fix the exception when `hash_key` is `ingress-port`. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR is to enhance `test_fib` to support a new topology `FT2`.

#### How did you do it?
1. Pass `topo_type` to ptf script 
2. Improve port selection for `FT2`
3. Fix the exception when `hash_key` is `ingress-port`. 

#### How did you verify/test it?
The change is verified on a FT2 testbed.
```
collected 15 items                                                                                                                                                                                                            

fib/test_fib.py::test_basic_fib[True-True-1514] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
17:55:10 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^HPASSED                                                                                                                                                                                                                  [  6%]
fib/test_fib.py::test_hash[ipv4] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
17:59:17 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^H ^H ^H ^H ^H ^H ^H ^HPASSED                                                                                                                                                                                                                  [ 13%]
fib/test_fib.py::test_hash[ipv6] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
18:43:37 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^H ^H
 ^H ^H
 ^H ^HPASSED                                                                                                                                                                                                                  [ 20%] ^H
fib/test_fib.py::test_ipinip_hash[ipv4] SKIPPED (The test case runs on T1 topology)                                                                                                                                     [ 26%]
fib/test_fib.py::test_ipinip_hash[ipv6] SKIPPED (The test case runs on T1 topology)                                                                                                                                     [ 33%]
fib/test_fib.py::test_ipinip_hash_negative[ipv4] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
19:31:14 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^HPASSED                                                                                                                                                                                                                  [ 40%]
fib/test_fib.py::test_ipinip_hash_negative[ipv6] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
19:42:15 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^HPASSED                                                                                                                                                                                                                  [ 46%]
fib/test_fib.py::test_vxlan_hash[ipv4-ipv4] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
19:52:52 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^HPASSED                                                                                                                                                                                                                  [ 53%] ^H
fib/test_fib.py::test_vxlan_hash[ipv4-ipv6] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
20:05:52 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^HPASSED                                                                                                                                                                                                                  [ 60%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv6] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
20:18:18 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^HPASSED                                                                                                                                                                                                                  [ 66%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv4]  ^H
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
20:30:43 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H
PASSED                                                                                                                                                                                                                  [ 73%]
....                                                            [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
