### PR TITLE
Fix verify_orchagent_running_or_assert() for multi-ASIC

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -328,11 +328,14 @@ def verify_orchagent_running_or_assert(duthost):
                 output = duthost.shell(cmd, module_ignore_errors=True)
                 pytest_assert(not output['rc'], "Unable to check orchagent status output for asic_id {}"
                               .format(asic_index))
+                if 'RUNNING' not in output['stdout']:
+                    return False
+            return True
         else:
             cmds = 'docker exec swss supervisorctl status orchagent'
             output = duthost.shell(cmds, module_ignore_errors=True)
             pytest_assert(not output['rc'], "Unable to check orchagent status output")
-        return 'RUNNING' in output['stdout']
+            return 'RUNNING' in output['stdout']
 
     pytest_assert(
         wait_until(120, 10, 0, _orchagent_running),


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Current implementation of `verify_orchagent_running_or_assert` does not verify orchagent state on all ASIC's. This is the code in question:
```
        if duthost.is_multi_asic:
            num_asic = duthost.facts.get('num_asic')
            for asic_index in range(num_asic):
                cmd = 'docker exec swss{} supervisorctl status orchagent'.format(asic_index)
                output = duthost.shell(cmd, module_ignore_errors=True)
                pytest_assert(not output['rc'], "Unable to check orchagent status output for asic_id {}"
                              .format(asic_index))
        else:
            cmds = 'docker exec swss supervisorctl status orchagent'
            output = duthost.shell(cmds, module_ignore_errors=True)
            pytest_assert(not output['rc'], "Unable to check orchagent status output")
        return 'RUNNING' in output['stdout']
```

On multi-ASIC, the validation of orchagent running state `return 'RUNNING' in output['stdout']` is outside of the for loop. This means only the orchagent state of the ASIC with largest Id is checked.

Fix this by checking the orchagent state in for loop for every ASIC.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
