### PR TITLE
[TESTGAP] Implement new test case to check the crm nexthop_group

### DIFF
--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -1,0 +1,50 @@
+import pytest
+import logging
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.broadcom_data import is_broadcom_device
+
+pytestmark = [
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'm2', 'm3'),
+]
+
+logger = logging.getLogger(__name__)
+
+NEXTHOP_GROUP_TOTAL = 256
+
+SKU_NEXTHOP_THRESHOLDS = {
+    # arista
+    '720dt': 15,
+    '7215': 126,
+}
+
+DEFAULT_NEXTHOP_THRESHOLD = 256
+
+
+def test_crm_next_hop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname, crm_resources):
+    """
+    test that runs `crm show resources` and parses next-hop group usage.
+    """
+    # Example check: ensure next-hop group usage is below a certain threshold
+    # This is a placeholder for the actual resource name; adjust as needed
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if not is_broadcom_device(duthost):
+        pytest.skip("Skipping test for non broadcom devices")
+
+    hwsku = duthost.facts["hwsku"].lower()
+    # If "7215" is in hwsku, take the second split element (index=2); otherwise use index=1
+    if "7215" in hwsku:
+        model_str = hwsku.split('-')[2]
+    else:
+        model_str = hwsku.split('-')[1]
+
+    nexthop_group_threshold = SKU_NEXTHOP_THRESHOLDS.get(model_str, DEFAULT_NEXTHOP_THRESHOLD)
+
+    resource_name = "nexthop_group"
+    if resource_name in crm_resources:
+        used = crm_resources[resource_name]["used"]
+        available = crm_resources[resource_name]["available"]
+        total = used + available
+        pytest_assert(total >= nexthop_group_threshold,
+                      f"next-hop groups ({total}) should be greater than or equal to {nexthop_group_threshold}")
+    else:
+        pytest.fail(f"Resource '{resource_name}' not found in CRM resources output.")

--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 NEXTHOP_GROUP_TOTAL = 256
 
 SKU_NEXTHOP_THRESHOLDS = {
-    # arista
-    '720dt': 15,
-    '7215': 126,
+    'arista-720dt-g48s4': 15,
+    'nokia-m0-7215': 126,
+    'nokia-7215-a1': 126,
+    'nokia-7215': 126,
 }
 
 DEFAULT_NEXTHOP_THRESHOLD = 256
@@ -28,13 +29,8 @@ def test_crm_next_hop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     hwsku = duthost.facts["hwsku"].lower()
-    # If "7215" is in hwsku, take the second split element (index=2); otherwise use index=1
-    if "7215" in hwsku:
-        model_str = hwsku.split('-')[2]
-    else:
-        model_str = hwsku.split('-')[1]
 
-    nexthop_group_threshold = SKU_NEXTHOP_THRESHOLDS.get(model_str, DEFAULT_NEXTHOP_THRESHOLD)
+    nexthop_group_threshold = SKU_NEXTHOP_THRESHOLDS.get(hwsku, DEFAULT_NEXTHOP_THRESHOLD)
 
     resource_name = "nexthop_group"
     if resource_name in crm_resources:

--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.broadcom_data import is_broadcom_device
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'm2', 'm3'),
@@ -27,8 +26,6 @@ def test_crm_next_hop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     # Example check: ensure next-hop group usage is below a certain threshold
     # This is a placeholder for the actual resource name; adjust as needed
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if not is_broadcom_device(duthost):
-        pytest.skip("Skipping test for non broadcom devices")
 
     hwsku = duthost.facts["hwsku"].lower()
     # If "7215" is in hwsku, take the second split element (index=2); otherwise use index=1
@@ -45,6 +42,6 @@ def test_crm_next_hop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         available = crm_resources[resource_name]["available"]
         total = used + available
         pytest_assert(total >= nexthop_group_threshold,
-                      f"next-hop groups ({total}) should be greater than or equal to {nexthop_group_threshold}")
+                      f"next-hop groups ({total}) should be greater than or equal to {nexthop_group_threshold} on platform '{hwsku}'") # noqa
     else:
-        pytest.fail(f"Resource '{resource_name}' not found in CRM resources output.")
+        pytest.fail(f"Resource '{resource_name}' not found in CRM resources output on platform '{hwsku}'.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is a new test case to verify the CRM nexthop_group threshold, which is typically set to at least 256. However, for some HWSKUs, such as 7215 and 720dt, the value is lower. This is acceptable due to their specific application scenarios, which have lower requirements for ECMP group capacity.
 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To address the test gap related to nexthop group requirements.

#### How did you do it?
To verify the total number of nexthop groups supported by the platform and ensure it meets the minimum required threshold.

#### How did you verify/test it?
Run the test case on device. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
't0', 't1', 'm0', 'mx', 'm1', 'm2', 'm3'

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
