### PR TITLE
Enable the test_ipinip_hash for T0 topo

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -528,7 +528,7 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa F811
                      hash_keys, ptfhost, ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
                      duts_minigraph_facts, request):                                # noqa F811
-    # Skip test on none T1 testbed
+    # Only run this test on T1 or T0 (including dualtor) topologies
     pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
     logging.info(f"Topology type: {tbinfo['topo']['type']}")
     fib_files = fib_info_files_per_function(duthosts,

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -524,19 +524,18 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
 
 # The test case is to verify src-ip, dst-ip, src-port, dst-port and ip-proto of inner_frame in a IPinIP packet are
 # used as hash keys
-
-
 def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa F811
                      hash_keys, ptfhost, ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
                      duts_minigraph_facts, request):                                # noqa F811
     # Skip test on none T1 testbed
-    pytest_require('t1' == tbinfo['topo']['type'],
-                   "The test case runs on T1 topology")
-
-    fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
+    pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
+    logging.info(f"Topology type: {tbinfo['topo']['type']}")
+    fib_files = fib_info_files_per_function(duthosts,
+                                            ptfhost,
+                                            duts_running_config_facts,
+                                            duts_minigraph_facts,
                                             tbinfo, request)
-
     timestamp = datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
     log_file = "/tmp/hash_test.IPinIPHashTest.{}.{}.log".format(
         ipver, timestamp)


### PR DESCRIPTION
### Description of PR
**Summary:**
This PR introduces a new test case to verify the hash behavior of IPinIP traffic on T0 topology, addressing the need outlined in [Issue #16531](https://github.com/sonic-net/sonic-mgmt/issues/16531).

**Type of change**
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement
### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

**What is the motivation for this PR?**
To validate the hashing behavior of IPinIP traffic on T0 devices, ensuring consistent and expected ECMP behavior.

**How did you do it?**
Analyzed the codebase and testbed setup.
Developed the test case targeting IPinIP hash behavior.
Resolved login issues with the SAW device to enable test execution 1.

**How did you verify/test it?**
Using fib/test_fib.py::test_ipinip_hash

Deployed the T0 topology and dualtor in the testbed.
Ran sample pytest cases to validate the environment.
Verified hash behavior through controlled traffic patterns.

**Any platform specific information?**
x86_64-arista_7260cx3_64 Ran test in this platform

**Supported testbed topology if it's a new test case?**
T0 and T1


![image](https://github.com/user-attachments/assets/85eb1abc-e4af-41fd-b420-cee55ef294a1)
