### PR TITLE
[show_techsupport]: Fix test_techsupport.py on marvell-teralynx

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -213,7 +213,7 @@ def gre_version(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         SESSION_INFO['gre'] = 0x8949  # Mellanox specific
     elif asic_type in ["barefoot"]:
         SESSION_INFO['gre'] = 0x22EB  # barefoot specific
-    elif asic_type in ["cisco-8000"]:
+    elif asic_type in ["cisco-8000", "marvell-teralynx"]:
         SESSION_INFO['gre'] = 0x88BE  # ERSPAN type-2
     else:
         SESSION_INFO['gre'] = 0x6558


### PR DESCRIPTION
### Description of PR
Fix for test_techsupport.py failure on marvell-teralynx platform.

Default GRE version `0x6558` used by the test case is not correct for marvell-teralynx platform resulting in testcase failure.

Marvell-teralynx platforms support GRE protocol type 0x88BE i.e., ERSPAN Type II.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
To fix show_techsupport/test_techsupport.py failures on marvell-teralynx platform

#### How did you do it?
Added marvell-teralynx platform check to fix failure.

#### How did you verify/test it?
By running show_techsupport PTF testcases.

```
show_techsupport/test_techsupport.py::test_techsupport[acl-str-marvell-01] PASSED         [ 25%]
show_techsupport/test_techsupport.py::test_techsupport[mirroring-str-marvell-01] PASSED   [ 50%]
show_techsupport/test_techsupport.py::test_techsupport_commands[str-marvell-01] PASSED    [ 75%]
```

#### Any platform specific information?
Fix is specific to marvell-teralynx platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
