### PR TITLE
[test_orchagent_slb] Enable `exabgp` debug mode and collect logs

### DIFF
--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -183,10 +183,15 @@ numprocs=1
 exabgp_supervisord_conf_tmpl_p2_v3 = '''\
 command=/usr/local/bin/exabgp /etc/exabgp/{{ name }}.conf
 '''
+exabgp_supervisord_conf_tmpl_p2_v3_debug = '''\
+command=/usr/local/bin/exabgp --debug /etc/exabgp/{{ name }}.conf
+'''
 exabgp_supervisord_conf_tmpl_p2_v4 = '''\
 command=/usr/local/bin/exabgp -e /etc/exabgp/exabgp.env /etc/exabgp/{{ name }}.conf
 '''
-
+exabgp_supervisord_conf_tmpl_p2_v4_debug = '''\
+command=/usr/local/bin/exabgp --debug --env /etc/exabgp/exabgp.env /etc/exabgp/{{ name }}.conf
+'''
 
 def exec_command(module, cmd, ignore_error=False, msg="executing command"):
     rc, out, err = module.run_command(cmd)
@@ -291,16 +296,26 @@ def remove_exabgp_conf(name):
         pass
 
 
-def setup_exabgp_supervisord_conf(name):
+def setup_exabgp_supervisord_conf(name, debug=False):
     exabgp_supervisord_conf_tmpl = None
     if six.PY2:
-        exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
-            exabgp_supervisord_conf_tmpl_p2_v3 + \
-            exabgp_supervisord_conf_tmpl_p3
+        if debug:
+            exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
+                exabgp_supervisord_conf_tmpl_p2_v3_debug + \
+                exabgp_supervisord_conf_tmpl_p3
+        else:
+            exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
+                exabgp_supervisord_conf_tmpl_p2_v3 + \
+                exabgp_supervisord_conf_tmpl_p3
     else:
-        exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
-            exabgp_supervisord_conf_tmpl_p2_v4 + \
-            exabgp_supervisord_conf_tmpl_p3
+        if debug:
+            exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
+                exabgp_supervisord_conf_tmpl_p2_v4_debug + \
+                exabgp_supervisord_conf_tmpl_p3
+        else:
+            exabgp_supervisord_conf_tmpl = exabgp_supervisord_conf_tmpl_p1 + \
+                exabgp_supervisord_conf_tmpl_p2_v4 + \
+                exabgp_supervisord_conf_tmpl_p3
     t = jinja2.Template(exabgp_supervisord_conf_tmpl)
     data = t.render(name=name)
     with open("/etc/supervisor/conf.d/exabgp-%s.conf" % name, 'w') as out_file:
@@ -336,7 +351,8 @@ def main():
             peer_asn=dict(required=False, type='int'),
             port=dict(required=False, type='int', default=5000),
             dump_script=dict(required=False, type='str', default=None),
-            passive=dict(required=False, type='bool', default=False)
+            passive=dict(required=False, type='bool', default=False),
+            debug=dict(required=False, type='bool', default=False)
         ),
         supports_check_mode=False)
 
@@ -350,6 +366,7 @@ def main():
     port = module.params['port']
     dump_script = module.params['dump_script']
     passive = module.params['passive']
+    debug = module.params['debug']
 
     setup_exabgp_processor()
     if not six.PY2:
@@ -360,24 +377,24 @@ def main():
         if state == 'started':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn,
                               peer_asn, port, dump_script=dump_script, passive=passive)
-            setup_exabgp_supervisord_conf(name)
+            setup_exabgp_supervisord_conf(name, debug=debug)
             refresh_supervisord(module)
             start_exabgp(module, name)
         elif state == 'restarted':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn,
                               peer_asn, port, dump_script=dump_script, passive=passive)
-            setup_exabgp_supervisord_conf(name)
+            setup_exabgp_supervisord_conf(name, debug=debug)
             refresh_supervisord(module)
             restart_exabgp(module, name)
         elif state == 'present':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn,
                               peer_asn, port, dump_script=dump_script, passive=passive)
-            setup_exabgp_supervisord_conf(name)
+            setup_exabgp_supervisord_conf(name, debug=debug)
             refresh_supervisord(module)
         elif state == 'configure':
             setup_exabgp_conf(name, router_id, local_ip, peer_ip, local_asn,
                               peer_asn, port, dump_script=dump_script, passive=passive)
-            setup_exabgp_supervisord_conf(name)
+            setup_exabgp_supervisord_conf(name, debug=debug)
         elif state == 'stopped':
             stop_exabgp(module, name)
         elif state == 'absent':

--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -193,6 +193,7 @@ exabgp_supervisord_conf_tmpl_p2_v4_debug = '''\
 command=/usr/local/bin/exabgp --debug --env /etc/exabgp/exabgp.env /etc/exabgp/{{ name }}.conf
 '''
 
+
 def exec_command(module, cmd, ignore_error=False, msg="executing command"):
     rc, out, err = module.run_command(cmd)
     if not ignore_error and rc != 0:

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -61,7 +61,7 @@ class BGPNeighbor(object):
     def __init__(self, duthost, ptfhost, name,
                  neighbor_ip, neighbor_asn,
                  dut_ip, dut_asn, port, neigh_type=None,
-                 namespace=None, is_multihop=False, is_passive=False):
+                 namespace=None, is_multihop=False, is_passive=False, debug=False):
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.ptfip = ptfhost.mgmt_ip
@@ -75,6 +75,7 @@ class BGPNeighbor(object):
         self.namespace = namespace
         self.is_passive = is_passive
         self.is_multihop = not is_passive and is_multihop
+        self.debug = debug
 
     def start_session(self):
         """Start the BGP session."""
@@ -113,7 +114,8 @@ class BGPNeighbor(object):
             peer_ip=self.peer_ip,
             local_asn=self.asn,
             peer_asn=self.peer_asn,
-            port=self.port
+            port=self.port,
+            debug=self.debug
         )
         if not wait_tcp_connection(self.ptfhost, self.ptfip, self.port, timeout_s=60):
             raise RuntimeError("Failed to start BGP neighbor %s" % self.name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
`test_orchagent_slb` is flaky, let's collect more test information:
1. enable `exabgp` to run in debug mode.
2. collect slb `exabgp` logs and save to the logs directory so nightly can collect them afterwards.
3. show the l3 neighbor on the DUTs and FIB on PTF in teardown.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
```
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4-active-standby] PASSED                                                                                                                  [100%]
====================================================================== 1 passed, 3 deselected, 97 warnings in 617.67s (0:10:17) ======================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
