### PR TITLE
noqa replaced with noqa: in tests/configlet files

### DIFF
--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -147,7 +147,7 @@ def prepare_for_test(duthost):
     mini_wo_to = managed_files["minigraph_wo_to"]
     if not mini_wo_to:
         report_error("Failed to get files wo_to={} clet={}".format(
-            mini_wo_to, clet_file))     # noqa F821
+            mini_wo_to, clet_file))     # noqa: F821
 
     if not os.path.exists(mini_wo_to):
         report_error("minigraph {} file absent".format(mini_wo_to))
@@ -176,7 +176,7 @@ def apply_clet(duthost, skip_test=False):
 
     if not clet_file:
         report_error("Failed to get files wo_to={} clet={}".format(
-            mini_wo_to, clet_file))     # noqa F821
+            mini_wo_to, clet_file))     # noqa: F821
 
     if not os.path.exists(clet_file):
         report_error("configlet {} file absent".format(clet_file))

--- a/tests/configlet/util/configlet.py
+++ b/tests/configlet/util/configlet.py
@@ -4,7 +4,7 @@ import json
 
 from tempfile import mkstemp
 from tests.common.configlet.helpers import log_info, log_debug
-from tests.common.configlet.utils import tor_data, init_data, config_db_data_orig, managed_files      # noqa F401
+from tests.common.configlet.utils import tor_data, init_data, config_db_data_orig, managed_files      # noqa: F401
 
 from tests.configlet.util import strip
 

--- a/tests/configlet/util/strip.py
+++ b/tests/configlet/util/strip.py
@@ -5,7 +5,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 from tests.common.configlet.helpers import log_info, log_debug
-from tests.common.configlet.utils import tor_data, config_db_data_orig, managed_files, report_error   # noqa F401
+from tests.common.configlet.utils import tor_data, config_db_data_orig, managed_files, report_error   # noqa: F401
 from tempfile import mkstemp
 
 ns_val = "Microsoft.Search.Autopilot.Evolution"


### PR DESCRIPTION
Changed noqa to noqa: in the files under tests/configlet.
![image](https://github.com/user-attachments/assets/df202026-aa7f-4f35-89d2-ed60a64441a9)

