### PR TITLE
Update CoPP configs to handle neighbor_miss trap type

### DIFF
--- a/tests/copp/scripts/update_copp_config.py
+++ b/tests/copp/scripts/update_copp_config.py
@@ -84,11 +84,20 @@ def generate_limited_pps_config(pps_limit, input_config_file, output_config_file
             # Setting these two values to pps_limit restricts the policer to allowing exactly
             # that number of packets per second, which is what we want for our tests.
             # For queue4_group3, use the default value in copp
-            # configuration as this is lower than 600 PPS
+            # configuration as this is lower than 600 PPS.
+            # For queue1_group3, we aim to rate limit punted traffic to a very low rate of 200 PPS.
+            # This is done to prevent any impact on more critical punted traffic and
+            # is specifically applied to traffic associated with the NEIGHBOR_MISS trap ID.
             if tg == "queue4_group3":
                 if asic_type == "cisco-8000":
                     group_config["cir"] = "400"
                     group_config["cbs"] = "400"
+                else:
+                    continue
+            elif tg == "queue1_group3":
+                if asic_type == "cisco-8000":
+                    group_config["cir"] = "200"
+                    group_config["cbs"] = "200"
                 else:
                     continue
             else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Added neighbor_miss trap copp configuration

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
New trap id was added to handle `NEIGHBOR_MISS` packets, punted traffic with this type
go to a dedicated queue that has lower policer rate limiting than other control plane traffic.

#### How did you do it?
Added new config for the queue used `queue1_group3` for neigh_miss trap id.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
depends on 
https://github.com/sonic-net/sonic-swss/pull/3624

