### PR TITLE
[tests/common/helpers]: Null check for ptf_lag_map

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -69,9 +69,10 @@ def ptf_teardown(ptfhost, ptf_lag_map):
     """
     ptfhost.set_dev_no_master(PTF_LAG_NAME)
 
-    for ptf_lag_member in ptf_lag_map[PTF_LAG_NAME]["port_list"]:
-        ptfhost.set_dev_no_master(ptf_lag_member)
-        ptfhost.set_dev_up_or_down(ptf_lag_member, True)
+    if ptf_lag_map is not None:
+        for ptf_lag_member in ptf_lag_map[PTF_LAG_NAME]["port_list"]:
+            ptfhost.set_dev_no_master(ptf_lag_member)
+            ptfhost.set_dev_up_or_down(ptf_lag_member, True)
 
     ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
     ptfhost.ptf_nn_agent()
@@ -421,6 +422,7 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
         yield
         return
     # --------------------- Setup -----------------------
+    ptf_lag_map = None
     try:
         dut_lag_map, ptf_lag_map, src_vlan_id = setup_dut_ptf(ptfhost, duthost, tbinfo, vlan_intfs_dict)
 


### PR DESCRIPTION
* Added a null check for `ptf_lag_map` in `setup_pov2lan` fixture

Signed-off-by: Onkar Deshpande onkard@nexthop.ai

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The pytest fixture `setup_pov2lan` has a possible `UnboundLocalError`. The variable `ptf_lag_map` is initialized in the `try` block and then used in the `finally` block. It is possible that the variable is not set when the `finally` block is called. This will lead to UnboundLocalError. This PR fixes that by initializing the variable to `None` and then first checking for the variable to be `None` before accessing it.


Summary:
Fixes #18483 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
