### PR TITLE
Add Power loss match for Kernel Panic - Cisco 8000 chassis

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -472,7 +472,7 @@ def get_reboot_cause(dut):
 
     for type, ctrl in list(reboot_ctrl_dict.items()):
         if dut.facts['asic_type'] == "cisco-8000" and dut.get_facts().get("modular_chassis") \
-            and type == REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS:
+           and type == REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS:
             # Skip the check for SUP heartbeat loss on T2 chassis
             if re.search(r"Heartbeat|headless|Power Loss", cause):
                 return type

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -51,12 +51,6 @@ DUT_ACTIVE.set()
     test_reboot_cause_only : indicate if the purpose of test is for reboot cause only
 '''
 reboot_ctrl_dict = {
-    REBOOT_TYPE_POWEROFF: {
-        "timeout": 300,
-        "wait": 120,
-        "cause": "Power Loss",
-        "test_reboot_cause_only": True
-    },
     REBOOT_TYPE_SOFT: {
         "command": "soft-reboot",
         "timeout": 300,
@@ -138,6 +132,12 @@ reboot_ctrl_dict = {
         # This change relates to changes of PR #6130 in sonic-buildimage repository
         "cause": r"'reboot'|Non-Hardware \(reboot|^reboot",
         "test_reboot_cause_only": False
+    },
+    REBOOT_TYPE_POWEROFF: {
+        "timeout": 300,
+        "wait": 120,
+        "cause": "Power Loss",
+        "test_reboot_cause_only": True
     }
 }
 
@@ -471,8 +471,14 @@ def get_reboot_cause(dut):
             cause = match.groups()[0]
 
     for type, ctrl in list(reboot_ctrl_dict.items()):
-        if re.search(ctrl['cause'], cause):
-            return type
+        if dut.facts['asic_type'] == "cisco-8000" and dut.get_facts().get("modular_chassis") \
+            and type == REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS:
+            # Skip the check for SUP heartbeat loss on T2 chassis
+            if re.search(r"Heartbeat|headless|Power Loss", cause):
+                return type
+        else:
+            if re.search(ctrl['cause'], cause):
+                return type
 
     return REBOOT_TYPE_UNKNOWN
 


### PR DESCRIPTION
### Description of PR

Add power loss to list of causes for Cisco-8000 distributed chassis. @abdosi and @yejianquan have context of the issue

==================================== PASSES ====================================
________________ TestKernelPanic.test_kernel_panic[sfd-lt2-lc0] ________________
________________ TestKernelPanic.test_kernel_panic[sfd-lt2-lc1] ________________
________________ TestKernelPanic.test_kernel_panic[sfd-lt2-sup] ________________

generated xml file: /run_logs/24505_nightly/platform_tests/test_kdump_2025-05-17-18-43-09.xml -
=========================== short test summary info ============================
PASSED platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic[sfd-lt2-lc0]
PASSED platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic[sfd-lt2-lc1]
PASSED platform_tests/test_kdump.py::TestKernelPanic::test_kernel_panic[sfd-lt2-sup]
================== 3 passed, 1 warning in 3472.83s (0:57:52) ===================

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
