### PR TITLE
[Configlet] Ignore the state_db validation for value of last_update_time in TRANSCEIVER_STATUS_FLAG

### DIFF
--- a/tests/common/configlet/utils.py
+++ b/tests/common/configlet/utils.py
@@ -134,7 +134,9 @@ scan_dbs = {
             "keys_to_skip_comp": {
                 "PORT_TABLE"
             },
-            "keys_skip_val_comp": set()
+            "keys_skip_val_comp": {
+                "last_update_time"
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Issue is caused by a behavior change in sonic which was introduced by PR: https://github.com/sonic-net/sonic-platform-daemons/pull/604. 
It added a kv "last_update_time" to the table TRANSCEIVER_STATUS_FLAG, and the value changes after config reload in the test. So it should be skipped when validating the state_db.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the test on SN5600 and it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
