### PR TITLE
ACL rule entry to drop NPU to local DPU probe packets

### DIFF
--- a/tests/ha/ha_helper.py
+++ b/tests/ha/ha_helper.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+# npu_ip and dpu_ip fixured already commited
+@pytest.fixture
+def acl_rule_fixture(npu_ip, dpu_ip):
+    """
+    Fixture to return ACL_RULE dictionary using real NPU and DPU IPs.
+    """
+    acl_rule = {
+        "ACL_RULE": {
+            "ACL_LINK_DROP_TEST|LOCAL_PROBE_DROP1": {
+                "PACKET_ACTION": "DROP",
+                "PRIORITY": "1",
+                "SRC_IP": npu_ip,
+                "DST_IP": dpu_ip,
+                "IP_TYPE": "IP",
+                "L4_SRC_PORT": "3784"
+            },
+            "ACL_LINK_DROP_TEST|LOCAL_PROBE_DROP2": {
+                "PACKET_ACTION": "DROP",
+                "PRIORITY": "1",
+                "SRC_IP": dpu_ip,
+                "DST_IP": npu_ip,
+                "IP_TYPE": "IP",
+                "L4_SRC_PORT": "3784"
+            }
+        }
+    }
+
+    return acl_rule

--- a/tests/ha/ha_helper.py
+++ b/tests/ha/ha_helper.py
@@ -1,31 +1,57 @@
 import pytest
 
 
-# npu_ip and dpu_ip fixured already commited
 @pytest.fixture
-def acl_rule_fixture(npu_ip, dpu_ip):
+def acl_rule_fixture_npu1_dpu1(npu1_ip, dpu1_ip):
     """
-    Fixture to return ACL_RULE dictionary using real NPU and DPU IPs.
+    Fixture to return ACL_RULE dictionary using NPU1 and DPU1 IPs.
     """
     acl_rule = {
         "ACL_RULE": {
             "ACL_LINK_DROP_TEST|LOCAL_PROBE_DROP1": {
                 "PACKET_ACTION": "DROP",
                 "PRIORITY": "1",
-                "SRC_IP": npu_ip,
-                "DST_IP": dpu_ip,
+                "SRC_IP": npu1_ip,
+                "DST_IP": dpu1_ip,
                 "IP_TYPE": "IP",
                 "L4_SRC_PORT": "3784"
             },
             "ACL_LINK_DROP_TEST|LOCAL_PROBE_DROP2": {
                 "PACKET_ACTION": "DROP",
                 "PRIORITY": "1",
-                "SRC_IP": dpu_ip,
-                "DST_IP": npu_ip,
+                "SRC_IP": dpu1_ip,
+                "DST_IP": npu1_ip,
                 "IP_TYPE": "IP",
                 "L4_SRC_PORT": "3784"
             }
         }
     }
+    return acl_rule
 
+
+@pytest.fixture
+def acl_rule_fixture_npu2_dpu2(npu2_ip, dpu2_ip):
+    """
+    Fixture to return ACL_RULE dictionary using NPU2 and DPU2 IPs.
+    """
+    acl_rule = {
+        "ACL_RULE": {
+            "ACL_LINK_DROP_TEST|LOCAL_PROBE_DROP1": {
+                "PACKET_ACTION": "DROP",
+                "PRIORITY": "1",
+                "SRC_IP": npu2_ip,
+                "DST_IP": dpu2_ip,
+                "IP_TYPE": "IP",
+                "L4_SRC_PORT": "3784"
+            },
+            "ACL_LINK_DROP_TEST|LOCAL_PROBE_DROP2": {
+                "PACKET_ACTION": "DROP",
+                "PRIORITY": "1",
+                "SRC_IP": dpu2_ip,
+                "DST_IP": npu2_ip,
+                "IP_TYPE": "IP",
+                "L4_SRC_PORT": "3784"
+            }
+        }
+    }
     return acl_rule


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: CONFIG_DB ACL rule entry to drop NPU to local DPU probe packets 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
New fixure for HA automation.

#### How did you do it?
New fixure created
#### How did you verify/test it?
None
#### Any platform specific information?
HwSKU: Cisco-8102-28FH-DPU-O
#### Supported testbed topology if it's a new test case?
t1-28-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
