### PR TITLE
Check other buffer pool watermark during buf pool wmk test case

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1201,6 +1201,7 @@ class TestQosSai(QosSaiBase):
             triggerDrop = qosConfig[bufPool]["pkts_num_trig_pfc"]
             fillMin = qosConfig[bufPool]["pkts_num_fill_ingr_min"]
             buf_pool_roid = ingressLosslessProfile["bufferPoolRoid"]
+            other_buf_pool_roid = egressLossyProfile["bufferPoolRoid"]
         elif "wm_buf_pool_lossy" in bufPool:
             baseQosConfig = dutQosConfig["param"]
             qosConfig = baseQosConfig.get(portSpeedCableLength, baseQosConfig)
@@ -1211,6 +1212,7 @@ class TestQosSai(QosSaiBase):
                 triggerDrop = qosConfig[bufPool]["pkts_num_trig_egr_drp"]
             fillMin = qosConfig[bufPool]["pkts_num_fill_egr_min"]
             buf_pool_roid = egressLossyProfile["bufferPoolRoid"]
+            other_buf_pool_roid = ingressLosslessProfile["bufferPoolRoid"]
         else:
             pytest.fail("Unknown pool type")
 
@@ -1230,7 +1232,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_fill_min": fillMin,
             "pkts_num_fill_shared": triggerDrop - 1,
             "cell_size": qosConfig[bufPool]["cell_size"],
-            "buf_pool_roid": buf_pool_roid
+            "buf_pool_roid": buf_pool_roid,
+            "other_buf_pool_roid": other_buf_pool_roid
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -5675,6 +5675,8 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
               (self.test_params['buf_pool_roid']), file=sys.stderr)
         buf_pool_roid = int(self.test_params['buf_pool_roid'], 0)
         print("buf_pool_roid: 0x%lx" % (buf_pool_roid), file=sys.stderr)
+        other_buf_pool_roid = int(self.test_params['other_buf_pool_roid'], 0)
+        print("other_buf_pool_roid: 0x%lx" % (other_buf_pool_roid), file=sys.stderr)
 
         buffer_pool_wm_base = 0
         if 'cisco-8000' in asic_type:
@@ -5683,9 +5685,12 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
             client_to_use = self.dst_client
             buffer_pool_wm_base = sai_thrift_read_buffer_pool_watermark(
                 client_to_use, buf_pool_roid)
+            other_buffer_pool_wm_base = sai_thrift_read_buffer_pool_watermark(
+                client_to_use, other_buf_pool_roid)
         else:
             client_to_use = self.src_client
         print("Initial watermark: {}".format(buffer_pool_wm_base))
+        print("Initial non-used pool's watermark: {}".format(other_buffer_pool_wm_base))
 
         # Prepare TCP packet data
         tos = dscp << 2
@@ -5857,6 +5862,15 @@ class BufferPoolWatermarkTest(sai_base_test.ThriftInterfaceDataPlane):
                     * cell_size <= buffer_pool_wm)
             assert (buffer_pool_wm <= (
                 expected_wm + extra_cap_margin) * cell_size)
+
+            # Check that the other buffer pool (lossy vs lossless) did not increase above an acceptable margin
+            if asic_type == "cisco-8000":
+                other_buffer_pool_wm = sai_thrift_read_buffer_pool_watermark(
+                    client_to_use, other_buf_pool_roid) - other_buffer_pool_wm_base
+                margin_buffers = 10
+                assert other_buffer_pool_wm < margin_buffers * cell_size, \
+                    "The wrong buffer pool watermark also increased, by {} bytes which exceeds margin {}".format(
+                        other_buffer_pool_wm, margin_buffers * cell_size)
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a new Cisco-only check to validate that the unused pool in the pool watermark test parametrizations do not increase. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
- [ ] Validate on Cisco-8102
- [ ] Validate on Cisco-8122

#### Any platform specific information?
Access of variables is across all platforms, but actual check in test case is Cisco-only. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
