### PR TITLE
[M1] Collect all upstream ports for ACL test

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -22,7 +22,8 @@ from tests.common.fixtures.ptfhost_utils import \
     copy_arp_responder_py, run_garp_service, change_mac_addresses   # noqa: F401
 from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr     # noqa: F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
-from tests.common.utilities import wait_until, get_upstream_neigh_type, get_downstream_neigh_type, check_msg_in_syslog
+from tests.common.utilities import wait_until, check_msg_in_syslog
+from tests.common.utilities import get_all_upstream_neigh_type, get_downstream_neigh_type
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # noqa: F401
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.platform.interface_utils import check_all_interface_information
@@ -353,9 +354,9 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
         downstream_port_id_to_router_mac_map = t2_info['downstream_port_id_to_router_mac_map']
         upstream_port_id_to_router_mac_map = t2_info['upstream_port_id_to_router_mac_map']
     else:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
+        upstream_neigh_types = get_all_upstream_neigh_type(topo)
         downstream_neigh_type = get_downstream_neigh_type(topo)
-        pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
+        pytest_require(len(upstream_neigh_types) > 0 and downstream_neigh_type is not None,
                        "Cannot get neighbor type for unsupported topo: {}".format(topo))
         mg_vlans = mg_facts["minigraph_vlans"]
         if tbinfo["topo"]["name"] in ("t1-isolated-d28", "t1-isolated-d128"):
@@ -382,10 +383,11 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
                     downstream_ports[neighbor['namespace']].append(interface)
                     downstream_port_ids.append(port_id)
                     downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
-                elif upstream_neigh_type in neighbor["name"].upper():
-                    upstream_ports[neighbor['namespace']].append(interface)
-                    upstream_port_ids.append(port_id)
-                    upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
+                for neigh_type in upstream_neigh_types:
+                    if neigh_type in neighbor["name"].upper():
+                        upstream_ports[neighbor['namespace']].append(interface)
+                        upstream_port_ids.append(port_id)
+                        upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts["router_mac"]
 
     # stop garp service for single tor
     if 'dualtor' not in tbinfo['topo']['name']:

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -20,6 +20,19 @@ UPSTREAM_NEIGHBOR_MAP = {
     "m0_vlan": "m1",
     "m0_l3": "m1"
 }
+
+# Describe ALL upstream neighbor of dut in different topos
+UPSTREAM_ALL_NEIGHBOR_MAP = {
+    "t0": ["t1"],
+    "t1": ["t2"],
+    "m1": ["ma", "mb"],
+    "m0": ["m1"],
+    "mx": ["m0"],
+    "t2": ["t3"],
+    "m0_vlan": ["m1"],
+    "m0_l3": ["m1"],
+}
+
 # Describe downstream neighbor of dut in different topos
 DOWNSTREAM_NEIGHBOR_MAP = {
     "t0": "server",
@@ -30,4 +43,16 @@ DOWNSTREAM_NEIGHBOR_MAP = {
     "t2": "t1",
     "m0_vlan": "server",
     "m0_l3": "mx"
+}
+
+# Describe downstream neighbor of dut in different topos
+DOWNSTREAM_ALL_NEIGHBOR_MAP = {
+    "t0": ["server"],
+    "t1": ["t0"],
+    "m1": ["m0", "c0"],
+    "m0": ["mx", "server"],
+    "mx": ["server"],
+    "t2": ["t1"],
+    "m0_vlan": ["mx", "server"],
+    "m0_l3": ["mx", "server"],
 }

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -33,7 +33,8 @@ from ansible.vars.manager import VariableManager
 from tests.common import constants
 from tests.common.cache import cached
 from tests.common.cache import FactsCache
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, UPSTREAM_ALL_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, UPSTREAM_ALL_NEIGHBOR_MAP
+from tests.common.helpers.constants import DOWNSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP
 from tests.common.helpers.assertions import pytest_assert
 from netaddr import valid_ipv6
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -33,7 +33,7 @@ from ansible.vars.manager import VariableManager
 from tests.common import constants
 from tests.common.cache import cached
 from tests.common.cache import FactsCache
-from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, UPSTREAM_ALL_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP, DOWNSTREAM_ALL_NEIGHBOR_MAP
 from tests.common.helpers.assertions import pytest_assert
 from netaddr import valid_ipv6
 
@@ -933,6 +933,19 @@ def get_upstream_neigh_type(topo_type, is_upper=True):
     return None
 
 
+def get_all_upstream_neigh_type(topo_type, is_upper=True):
+    """
+    @summary: Get ALL upstream neighbor type by topo type
+    @param topo_type: topo type
+    @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
+    @return a list
+        Sample output: ["ma", "mb"]
+    """
+    if is_upper:
+        return [neigh.upper() for neigh in UPSTREAM_ALL_NEIGHBOR_MAP.get(topo_type, [])]
+    return UPSTREAM_ALL_NEIGHBOR_MAP.get(topo_type, [])
+
+
 def get_downstream_neigh_type(topo_type, is_upper=True):
     """
     @summary: Get neighbor type by topo type
@@ -945,6 +958,19 @@ def get_downstream_neigh_type(topo_type, is_upper=True):
         return DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else DOWNSTREAM_NEIGHBOR_MAP[topo_type]
 
     return None
+
+
+def get_all_downstream_neigh_type(topo_type, is_upper=True):
+    """
+    @summary: Get ALL downstream neighbor type by topo type
+    @param topo_type: topo type
+    @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
+    @return a list
+        Sample output: ["m0", "c0"]
+    """
+    if is_upper:
+        return [neigh.upper() for neigh in DOWNSTREAM_ALL_NEIGHBOR_MAP.get(topo_type, [])]
+    return DOWNSTREAM_ALL_NEIGHBOR_MAP.get(topo_type, [])
 
 
 def run_until(interval, delay, retry, condition, function, *args, **kwargs):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In M1 topo, we have 2 upstream neighbor types: MA and MB.
We need to collect all upstream ports to avoid packet capture flaky failure.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
In M1 topo, we have 2 upstream neighbor types: MA and MB.
We need to collect all upstream ports to avoid packet capture flaky failure.


#### How did you do it?
Add function to read all up/down stream neighbor types.

#### How did you verify/test it?
Verified by ACL test on M1.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
