### PR TITLE
Fix for port channel names mismatch in global and asic minigraph template files

### DIFF
--- a/ansible/templates/minigraph_dpg_asic.j2
+++ b/ansible/templates/minigraph_dpg_asic.j2
@@ -96,7 +96,7 @@
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int]|lower %}
 {% set port_channel_intf=';'.join(vm_asic_ifnames[vms[index]])  %}
         <PortChannel>
-          <Name>PortChannel{{ '10' + ((index+1)|string) }}</Name>
+          <Name>PortChannel{{ (100 + index + 1)|string }}</Name>
           <AttachTo>{{ port_channel_intf }}</AttachTo>
           <SubInterface/>
         </PortChannel>
@@ -144,7 +144,7 @@
         <IPInterface>
           <Name i:nil="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int][intf_index]|lower %}
-          <AttachTo>PortChannel{{ '10' + ((index+1)|string) }}</AttachTo>
+          <AttachTo>PortChannel{{ (100 + index + 1)|string }}</AttachTo>
 {% else %}
           <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -153,7 +153,7 @@
         <IPInterface>
           <Name i:Name="true"/>
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][dut_index|int][intf_index]|lower %}
-          <AttachTo>PortChannel{{ '10' + ((index+1)|string) }}</AttachTo>
+          <AttachTo>PortChannel{{ (100 + index + 1)|string }}</AttachTo>
 {% else %}
           <AttachTo>{{ front_panel_asic_ifnames[vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int][0]] }}</AttachTo>
 {% endif %}
@@ -271,7 +271,7 @@
 {%- for index in range(vms_number) %}
 {% if vms[index] in vm_asic_ifnames and vm_asic_ids[vms[index]][0] == asic_name %}
 {% if 'port-channel' in vm_topo_config['vm'][vms[index]]['ip_intf'][0]|lower %}
-{% set a_intf = 'PortChannel' + '10' + ((index+1)|string) %}
+{% set a_intf = 'PortChannel' ~ (100 + index + 1)|string %}
 {{- acl_intfs.append(a_intf) -}}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes the issue #18507  caused by #18161 
- Portchannel name changes are done in file _ansible/templates/minigraph_dpg.j2_ but we need corresponding change in _ansible/templates/minigraph_dpg_asic.j2_ file as well so the names are same in both global and asic configs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

- To fix the minigraph template issues w.r.t Portchannel names for global and asic.

#### How did you do it?

- Add corresponding changes on _ansible/templates/minigraph_dpg_asic.j2_ similar to  _ansible/templates/minigraph_dpg.j2_

#### How did you verify/test it?

- Run gen-mg with the new template modifications. With the new minigraph, made sure tests are passing for multi-asics

#### Any platform specific information?
Mutliasic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
