### PR TITLE
[Snappi]: Pass/fail criteria for pfc m2o testcase have thinner margins causing intermittent failures.

### DIFF
--- a/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_fluctuating_lossless_helper.py
@@ -424,4 +424,4 @@ def verify_m2o_fluctuating_lossless_result(rows,
             pytest_assert(int(row.loss) == 0, "FAIL: {} must have 0% loss".format(row.name))
         elif 'Background Flow' in row.name:
             background_loss += float(row.loss)
-    pytest_assert(round(background_loss/4) == 10, "Each Background Flow must have an avg of 10% loss ")
+    pytest_assert((abs(background_loss/4) - 10) < 1, "Each Background Flow must have an avg of 10% loss ")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Currently, the results were verified using round which resulted in some failures where 10.85% rounds to 11 and fails the test on Nokia Platforms. Modified the condition to have some more room for values of drop between 9-11%.


Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/18043
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
To enhance the check for verification of drops in the test case.
#### How did you do it?
By changing the assertion used to verify the drops.
#### How did you verify/test it?
Tested on Nokia Chassis in msft lab
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
