### PR TITLE
Skipped IPv6 Everflow tests on virtual switch to speed up PR test execution

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -388,6 +388,15 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     time.sleep(60)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def skip_ipv6_everflow_tests(setup_info, erspan_ip_ver):
+    """
+    Skip IPv6 Everflow tests if the DUT is a virtual switch.
+    """
+    if erspan_ip_ver == 6 and setup_info[UP_STREAM]["everflow_dut"].facts["asic_type"] == "vs":
+        pytest.skip("Skipping IPv6 Everflow tests to speed up PR test execution.")
+
+
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def add_route(duthost, prefix, nexthop, namespace):
     """

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -7,11 +7,11 @@ from ptf import packet
 from ptf.mask import Mask
 import ptf.packet as scapy
 from . import everflow_test_utilities as everflow_utils
-from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM, erspan_ip_ver      # noqa F401
+from .everflow_test_utilities import BaseEverflowTest, DOWN_STREAM, UP_STREAM, erspan_ip_ver              # noqa: F401
 import random
 # Module-level fixtures
-from .everflow_test_utilities import setup_info      # noqa: F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor      # noqa F401
+from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests                                 # noqa: F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0", "m1", "m2", "m3")

--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -10,7 +10,7 @@ from scapy.layers.l2 import Dot1Q
 from scapy.layers.vxlan import VXLAN
 from . import everflow_test_utilities as everflow_utils
 
-from .everflow_test_utilities import BaseEverflowTest, erspan_ip_ver  # noqa: F401
+from .everflow_test_utilities import BaseEverflowTest, erspan_ip_ver, skip_ipv6_everflow_tests  # noqa: F401
 from .everflow_test_utilities import TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE, \
     DUT_RUN_DIR, EVERFLOW_RULE_CREATE_FILE, UP_STREAM
 from tests.common.helpers.assertions import pytest_require

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -15,6 +15,7 @@ from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_ST
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                   # noqa: F401
 from .everflow_test_utilities import setup_info, setup_arp_responder, erspan_ip_ver, EVERFLOW_DSCP_RULES  # noqa: F401
+from .everflow_test_utilities import skip_ipv6_everflow_tests                                             # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                     # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR skips the IPv6 Everflow tests on KVM testbeds to improve PR test execution time.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
Everflow tests take a lot of time to execute. After adding IPv6 test cases (#16836), the execution time has roughly doubled. Now it takes more than 2 hours to run all tests in `everflow/test_everflow_testbed.py`. Since these tests are part of PR tests, if they take too long to run, the PR test will be cancelled. This PR skips the IPv6 Everflow tests on KVM testbeds (which are used for PR tests) to address this issue.
**Note:** The IPv6 Everflow tests will still run during nightly tests.

#### How did you do it?
Added a new pytest fixture that will skip the tests when `erspan_ip_ver == 6` and the DUT is a virtual switch.

#### How did you verify/test it?
Ran the tests to ensure that the tests will be skipped when `erspan_ip_ver == 6`.

#### Any platform specific information?
Only applies to KVM testbeds ("vs" ASIC).

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
