### PR TITLE
skip loganalyzer when its not instantiated

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -91,14 +91,14 @@ def test_snmp_queue_counters(duthosts,
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    ignore_regex_list = [
-        r".* ERR memory_checker: \[memory_checker\] Failed to get container ID of.*",
-        r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file.*"
-        ]
-    if duthost.sonichost.facts['platform_asic'] == 'broadcom':
-        ignore_regex_list.append(r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value \d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*")    # noqa: E501
-
-    loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)
+    if loganalyzer:
+        ignore_regex_list = [
+            r".* ERR memory_checker: \[memory_checker\] Failed to get container ID of.*",
+            r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file.*"
+            ]
+        if duthost.sonichost.facts['platform_asic'] == 'broadcom':
+            ignore_regex_list.append(r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value \d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*")    # noqa: E501
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)
     global ORIG_CFG_DB, CFG_DB_PATH
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']


### PR DESCRIPTION
### Description of PR

Summary:
Fix 'loganalyzer object is not subscriptable' error when using the --disable_loganalyzer option.

![image](https://github.com/user-attachments/assets/13918aff-713c-4b1b-b37b-689a22760fed)


### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
When running tests with the --disable_loganalyzer option, a 'loganalyzer' object is not subscriptable error occurs in the snmp/test_snmp_queue_counters.py.
The expected behavior is that tests should still run even when log analyzer is disabled.

#### How did you do it?
Add a check to see if the loganalyzer instance exists before accessing loganalyzer.ignore_regex. If it doesn't exist skip the related operations.

#### How did you verify/test it?
Local testing and Elastic platform testing (https://elastictest.org/scheduler/testplan/682da599ff4b6456dcc655f7)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

