### PR TITLE
Add test_rate_limit to auditd watchdog test cases

### DIFF
--- a/tests/auditd/test_auditd.py
+++ b/tests/auditd/test_auditd.py
@@ -284,7 +284,7 @@ def test_rate_limit(duthosts, enum_rand_one_per_hwsku_hostname, check_auditd_fai
 
     rate_limit_status = response.get("rate_limit")
     pytest_assert(rate_limit_status == "OK",
-                      "Auditd watchdog check rate limit failed for: {}".format(rate_limit_status))
+                  "Auditd watchdog check rate limit failed for: {}".format(rate_limit_status))
 
     # change rate limit config
     duthost.command(r"sudo cp /etc/audit/rules.d/audit.rules /etc/audit.rules_backup")
@@ -298,4 +298,16 @@ def test_rate_limit(duthosts, enum_rand_one_per_hwsku_hostname, check_auditd_fai
     duthost.command(r"sudo auditctl -R /etc/audit/audit.rules")
 
     pytest_assert(rate_limit_status.startswith("FAIL"),
-                      "Auditd watchdog check rate limit failed for: {}".format(rate_limit_status))
+                  "Auditd watchdog check rate limit failed for: {}".format(rate_limit_status))
+
+    # delete rate limit config
+    duthost.command(r"sudo cp /etc/audit/rules.d/audit.rules /etc/audit.rules_backup")
+    duthost.command(r"sudo rm /etc/audit.rules")
+
+    rate_limit_status = response.get("rate_limit")
+
+    # revert change before check result, so assert failed will not break next test
+    duthost.command(r"sudo cp /etc/audit.rules_backup /etc/audit/rules.d/audit.rules")
+
+    pytest_assert(rate_limit_status.startswith("FAIL"),
+                  "Auditd watchdog check rate limit failed for: {}".format(rate_limit_status))


### PR DESCRIPTION
Add test_rate_limit to auditd watchdod test cases

#### Why I did it
Auditd watchgod container add ratelimit check in this PR: 
https://github.com/sonic-net/sonic-buildimage/pull/22620

Also, json format fix in this PR:
https://github.com/sonic-net/sonic-buildimage/pull/22709

Add new test case to prevent regression

##### Work item tracking
- Microsoft ADO **(number only)**:32313402

#### How I did it
Add test_rate_limit to auditd watchdod test cases

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Add test_rate_limit to auditd watchdod test cases

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


