### PR TITLE
Skip test_bgp_multipath_relax.py on t1-isolated

### DIFF
--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -67,6 +67,9 @@ def get_bgp_v4_neighbors_from_minigraph(duthost, tbinfo):
 
 
 def test_bgp_multipath_relax(tbinfo, duthosts, rand_one_dut_hostname):
+    if 't1-isolated' in tbinfo['topo']['name']:
+        pytest.skip("Test skipped for t1-isolated topologies")
+
     duthost = duthosts[rand_one_dut_hostname]
 
     logger.info("Starting test_bgp_multipath_relax on topology {}".format(tbinfo['topo']['name']))

--- a/tests/bgp/test_bgp_multipath_relax.py
+++ b/tests/bgp/test_bgp_multipath_relax.py
@@ -67,9 +67,6 @@ def get_bgp_v4_neighbors_from_minigraph(duthost, tbinfo):
 
 
 def test_bgp_multipath_relax(tbinfo, duthosts, rand_one_dut_hostname):
-    if 't1-isolated' in tbinfo['topo']['name']:
-        pytest.skip("Test skipped for t1-isolated topologies")
-
     duthost = duthosts[rand_one_dut_hostname]
 
     logger.info("Starting test_bgp_multipath_relax on topology {}".format(tbinfo['topo']['name']))

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -158,8 +158,10 @@ bgp/test_bgp_gr_helper.py:
 bgp/test_bgp_multipath_relax.py:
   skip:
     reason: "Not supported topology backend."
+    conditions_logical_operator: or
     conditions:
       - "'backend' in topo_name"
+      - "'t1-isolated' in topo_name"
 
 bgp/test_bgp_port_disable.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip `bgp/test_bgp_multipath_relax.py` on t1-isolated topologies.
Skip because the test is not designed for t1-isolated and it fails.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
