### PR TITLE
Fix for reboot-cause history when dut is rebooted by Kernel Panic

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -162,7 +162,6 @@ reboot_ss_ctrl_dict = {
 }
 
 MAX_NUM_REBOOT_CAUSE_HISTORY = 10
-REBOOT_TYPE_HISTOYR_QUEUE = deque([], MAX_NUM_REBOOT_CAUSE_HISTORY)
 REBOOT_CAUSE_HISTORY_TITLE = ["name", "cause", "time", "user", "comment"]
 
 # Retry logic config
@@ -487,14 +486,12 @@ def check_reboot_cause(dut, reboot_cause_expected):
     logger.debug("dut {} last reboot-cause {}".format(dut.hostname, reboot_cause_got))
     return reboot_cause_got == reboot_cause_expected
 
-
 def sync_reboot_history_queue_with_dut(dut):
     """
     @summary: Sync DUT and internal history queues
     @param dut: The AnsibleHost object of DUT.
     """
 
-    global REBOOT_TYPE_HISTOYR_QUEUE
     global MAX_NUM_REBOOT_CAUSE_HISTORY
 
     # Initialize local deque for storing DUT reboot cause history
@@ -504,6 +501,8 @@ def sync_reboot_history_queue_with_dut(dut):
     if "201811" in dut.os_version or "201911" in dut.os_version:
         logger.info("Skip sync reboot-cause history for version before 202012")
         return
+
+    dut.reboot_type_history_queue = deque([], MAX_NUM_REBOOT_CAUSE_HISTORY)
 
     # IF control is here it means the SONiC image version is > 201911
     # Try and get the entire reboot-cause history from DUT
@@ -536,12 +535,12 @@ def sync_reboot_history_queue_with_dut(dut):
     # If the reboot cause history is received from DUT,
     # we sync the two queues. TO that end,
     # Clear the current reboot history queue
-    REBOOT_TYPE_HISTOYR_QUEUE.clear()
+    dut.reboot_type_history_queue.clear()
 
     # For each item in the DUT reboot queue,
     # iterate through every item in the reboot dict until
     # a "cause" match is found. Then add that key to the
-    # reboot history queue REBOOT_TYPE_HISTOYR_QUEUE
+    # reboot history queue reboot_type_history_queue
     # If no cause is found add 'Unknown' as reboot type.
 
     # NB: appendleft used because queue received from DUT
@@ -551,14 +550,30 @@ def sync_reboot_history_queue_with_dut(dut):
         dict_iter_found = False
         for dict_iter in (reboot_ctrl_dict):
             if re.search(reboot_ctrl_dict[dict_iter]["cause"], reboot_type["cause"]):
-                logger.info("Adding {} to REBOOT_TYPE_HISTOYR_QUEUE".format(dict_iter))
-                REBOOT_TYPE_HISTOYR_QUEUE.appendleft(dict_iter)
+                logger.info("Adding {} to reboot_type_history_queue for {}".format(dict_iter, dut.hostname))
+                dut.reboot_type_history_queue.appendleft(dict_iter)
                 dict_iter_found = True
                 break
         if not dict_iter_found:
-            logger.info("Adding {} to REBOOT_TYPE_HISTOYR_QUEUE".format(REBOOT_TYPE_UNKNOWN))
-            REBOOT_TYPE_HISTOYR_QUEUE.appendleft(REBOOT_TYPE_UNKNOWN)
+            logger.info("Adding {} to reboot_type_history_queue for {}".format(dict_iter, dut.hostname))
+            dut.reboot_type_history_queue.appendleft(REBOOT_TYPE_UNKNOWN)
 
+def sync_reboot_history_queue_with_duthosts(duthosts, enum_rand_one_per_hwsku_hostname):
+    """
+    @summary: Sync DUT and internal history queues
+    @param duthosts: The AnsibleHosts object of DUTs.
+    @param enum_rand_one_per_hwsku_hostname: TBD
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    global MAX_NUM_REBOOT_CAUSE_HISTORY
+
+    if duthost.is_supervisor_node():
+        for dut in duthosts:
+            logging.info("Sync reboot cause history queue to reboot type history queue for {}".format(dut.hostname))
+            sync_reboot_history_queue_with_dut(dut)
+    else:
+        logging.info("Sync reboot cause history queue to reboot type history queue for {}".format(duthost.hostname))
+        sync_reboot_history_queue_with_dut(duthost)
 
 def check_reboot_cause_history(dut, reboot_type_history_queue):
     """
@@ -611,7 +626,7 @@ def check_reboot_cause_history(dut, reboot_type_history_queue):
                              reboot_cause_history_got[reboot_type_history_len - index - 1]["cause"]):
                 logger.error("The {} reboot-cause not match. expected_reboot type={}, actual_reboot_cause={}".format(
                     index, reboot_ctrl_dict[reboot_type]["cause"],
-                    reboot_cause_history_got[reboot_type_history_len - index]["cause"]))
+                    reboot_cause_history_got[reboot_type_history_len - index-1]["cause"]))
                 return False
         return True
     logger.error("The number of expected reboot-cause:{} is more than that of actual reboot-cuase:{}".format(

--- a/tests/platform_tests/test_chassis_reboot.py
+++ b/tests/platform_tests/test_chassis_reboot.py
@@ -6,12 +6,11 @@ import random
 import logging
 import time
 from multiprocessing.pool import ThreadPool
+import concurrent.futures
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from tests.common.reboot import wait_for_startup,\
-                                wait_for_shutdown,\
-                                sync_reboot_history_queue_with_dut,\
-                                REBOOT_TYPE_HISTOYR_QUEUE
+from tests.common.reboot import wait_for_startup, wait_for_shutdown,\
+                                sync_reboot_history_queue_with_dut
 from tests.platform_tests.test_reboot import check_interfaces_and_services
 
 
@@ -40,7 +39,7 @@ def chassis_cold_reboot(dut, pool, localhost):
 
     # Append the last reboot type to the queue
     logging.info("Append the latest reboot type to the queue")
-    REBOOT_TYPE_HISTOYR_QUEUE.append("cold")
+    dut.reboot_type_history_queue.append("cold")
 
     return shutdown_res
 

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -13,8 +13,8 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 from tests.common.reboot import sync_reboot_history_queue_with_dut, reboot, check_reboot_cause,\
-    check_reboot_cause_history, check_determine_reboot_cause_service, reboot_ctrl_dict,\
-    wait_for_startup, REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
+    check_reboot_cause_history, reboot_ctrl_dict, wait_for_startup,\
+    REBOOT_TYPE_COLD,\
     REBOOT_TYPE_SOFT, REBOOT_TYPE_FAST, REBOOT_TYPE_WARM, REBOOT_TYPE_WATCHDOG
 from tests.common.platform.transceiver_utils import check_transceiver_basic
 from tests.common.platform.interface_utils import check_all_interface_information, get_port_map
@@ -88,7 +88,7 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
 
     # Append the last reboot type to the queue
     logging.info("Append the latest reboot type to the queue")
-    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
+    dut.reboot_type_history_queue.append(reboot_type)
 
     check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)
     if dut.is_supervisor_node():
@@ -171,7 +171,7 @@ def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,
         else:
             logging.info("Check reboot-cause history")
             assert wait_until(MAX_WAIT_TIME_FOR_REBOOT_CAUSE, 20, 0, check_reboot_cause_history, dut,
-                              REBOOT_TYPE_HISTOYR_QUEUE), \
+                              dut.reboot_type_history_queue), \
                 "Check reboot-cause history failed after rebooted by %s" % reboot_type
         if reboot_ctrl_dict[reboot_type]["test_reboot_cause_only"]:
             logging.info(


### PR DESCRIPTION
### Description of PR
After a reboot by kernel panic, reboot-cause history is not showing the correct reboot cause.
This PR will fix the issue for:
1. When an LC is rebooted by kernel panic - reboot-cause history should be "Kernel Panic"
2. When supervisor is rebooted by a kernel panic - reboot-cause history should be "Kernel Panic" on supervisr.
   Since a supervisor reboot will cause LCs to be rebooted, the reboot-cause history on LCs 
   should be "Heartbeat with the Supervisor card lost"


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ x] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?
This PR introduces reboot_type_history_queue as per dut instead of global (global REBOOT_TYPE_HISTOYR_QUEUE)
The per dut definition provides the capability of differentiating the reboot_cause between a supervisor and LCs.

#### How did you do it?
introduced reboot_type_history_queue as per dut instead of global (global REBOOT_TYPE_HISTOYR_QUEUE)

#### How did you verify/test it?
Tests against multi ASICs chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
