### PR TITLE
T2:snappi_tests:Add a fixture to disable voq watchdog, use it in pfc scripts.

### DIFF
--- a/tests/snappi_tests/cisco/helper.py
+++ b/tests/snappi_tests/cisco/helper.py
@@ -1,0 +1,33 @@
+# Helper functions to be used only for cisco platforms.
+from tests.qos.qos_sai_base import QosSaiBase
+import pytest
+
+
+@pytest.fixture(scope='module', autouse=True)
+def disable_voq_watchdog(duthosts):
+    if duthosts[0].facts['asic_type'] != "cisco-8000":
+        yield
+        return
+
+    for duthost in duthosts:
+        modify_voq_watchdog_cisco_8000(duthost, False)
+
+    yield
+
+    for duthost in duthosts:
+        modify_voq_watchdog_cisco_8000(duthost, True)
+
+
+def modify_voq_watchdog_cisco_8000(duthost, enable):
+    asics = duthost.get_asic_ids()
+    qsb_obj = QosSaiBase()
+
+    '''
+    # Enable when T0/T1 supports voq_watchdog
+    #if not asics:
+    #    qsb_obj.copy_set_voq_watchdog_script_cisco_8000(duthost, "", enable=enable)
+    '''
+
+    for asic in asics:
+        qsb_obj.copy_set_voq_watchdog_script_cisco_8000(duthost, asic, enable=enable)
+        duthost.shell(f"sudo show platform npu script -n asic{asic} -s set_voq_watchdog.py")

--- a/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_global_pause_with_snappi.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import lossless_prio_list, prio_dscp
 from tests.snappi_tests.pfc.files.helper import run_pfc_test                      # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_lossless_response_to_external_pause_storms.py
+++ b/tests/snappi_tests/pfc/test_lossless_response_to_external_pause_storms.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.lossless_response_to_external_pause_storms_hel
      run_lossless_response_to_external_pause_storms_test,
     )
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py
+++ b/tests/snappi_tests/pfc/test_lossless_response_to_throttling_pause_storms.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.lossless_response_to_throttling_pause_storms_h
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info   # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict     # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_fluctuating_lossless.py
+++ b/tests/snappi_tests/pfc/test_m2o_fluctuating_lossless.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut   # noqa: F401
 from tests.snappi_tests.pfc.files.m2o_fluctuating_lossless_helper import run_m2o_fluctuating_lossless_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py
@@ -13,6 +13,7 @@ from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossless_helper import (
     )
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info   # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -14,6 +14,7 @@ from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossless_lossy_helper import
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams            # noqa: F401
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info  # noqa: F401
 from tests.common.snappi_tests.variables import pfcQueueGroupSize, pfcQueueValueDict        # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.pfc.files.m2o_oversubscribe_lossy_helper import run_pfc_m2o_oversubscribe_lossy_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import setup_ports_and_dut, multidut_port_info   # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen')]
 

--- a/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
+++ b/tests/snappi_tests/pfc/test_pfc_mixed_speed.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.variables import MIXED_SPEED_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfc.files.mixed_speed_multidut_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
+++ b/tests/snappi_tests/pfc/test_pfc_no_congestion_throughput.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -14,6 +14,7 @@ from tests.snappi_tests.pfc.files.helper import run_pfc_test
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import reboot_duts, setup_ports_and_dut, multidut_port_info  # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd          # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_unset_bit_enable_vector.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_zero_mac.py
@@ -10,6 +10,7 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd  # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfc.files.pfc_congestion_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfc/test_tx_drop_counter_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_tx_drop_counter_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, \
 from tests.snappi_tests.pfc.files.helper import run_tx_drop_counter
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]

--- a/tests/snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_valid_pfc_frame_with_snappi.py
@@ -11,6 +11,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
     lossy_prio_list, disable_pfcwd # noqa F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.common_helpers import packet_capture
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
+++ b/tests/snappi_tests/pfc/test_valid_src_mac_pfc_frame.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.common_helpers import packet_capture
 from tests.common.cisco_data import is_cisco_device
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Recently cisco-8000 enabled VoQ Watchdog feature, which is similar to PfcWd feature. It drops the packets which get stuck in voq, and resets all the counters, when the interface is experiencing congestion due to pfc Xoff. This causes a number of failures in the PFC scripts which assume there is no watchdog. To prevent these failures, we add a fixture to disable the voq Watchdog in all DUT asics, and enable it at the end of the script.

This PR uses the voq-wd-disable function implemented in https://github.com/sonic-net/sonic-mgmt/pull/17937

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411

### Approach
#### What is the motivation for this PR?
Pls see description.
#### How did you do it?
Implemented a new fixture to disable voq Watchdog.

#### How did you verify/test it?
Ran the failing test:
```

```
#### Any platform specific information?
Specific to cisco-8000.