### PR TITLE
[dualtor-aa] fixed add-topo for dualtor

### DIFF
--- a/ansible/roles/vm_set/tasks/control_mux_simulator.yml
+++ b/ansible/roles/vm_set/tasks/control_mux_simulator.yml
@@ -31,8 +31,13 @@
 
   - name: Install Flask and Werkzeug
     block:
+    - name: Install blinker
+      pip: name=blinker executable={{ pip_executable }} extra_args="--ignore-installed"
+      become: yes
+      environment: "{{ proxy_env | default({}) }}"
+
     - name: Install flask
-      pip: name=flask version={{ flask_version }} state=forcereinstall executable={{ pip_executable }}
+      pip: name=flask version={{ flask_version }} executable={{ pip_executable }}
       become: yes
       environment: "{{ proxy_env | default({}) }}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
On server < 2024.04, when the script attempts to install flask==2.3.3, it requires blinker >= 1.6.2. However server already has blinker from apt and it is only 1.4 and cannot be upgraded. The change force pip to install new blinker.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
