### PR TITLE
fix: no module named tests.common

### DIFF
--- a/.azure-pipelines/collect_dump.py
+++ b/.azure-pipelines/collect_dump.py
@@ -13,10 +13,10 @@ from concurrent.futures import ThreadPoolExecutor
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 from devutil.devices.factory import init_testbed_sonichosts  # noqa: E402
 

--- a/.azure-pipelines/common.py
+++ b/.azure-pipelines/common.py
@@ -6,10 +6,10 @@ import json
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory     # noqa: E402
 

--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -10,10 +10,10 @@ import yaml
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 from devutil.devices.factory import init_localhost, init_testbed_sonichosts  # noqa: E402
 

--- a/.azure-pipelines/recover_testbed/common.py
+++ b/.azure-pipelines/recover_testbed/common.py
@@ -12,10 +12,10 @@ from constants import OS_VERSION_IN_GRUB, ONIE_ENTRY_IN_GRUB, ONIE_INSTALL_MODEL
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, "../.."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 from tests.common.plugins.pdu_controller.pdu_manager import pdu_manager_factory     # noqa: E402
 

--- a/.azure-pipelines/recover_testbed/dut_connection.py
+++ b/.azure-pipelines/recover_testbed/dut_connection.py
@@ -18,10 +18,10 @@ from constants import RC_SSH_FAILED, RC_PASSWORD_FAILED
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, "../.."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 logger = logging.getLogger(__name__)
 

--- a/.azure-pipelines/recover_testbed/recover_testbed.py
+++ b/.azure-pipelines/recover_testbed/recover_testbed.py
@@ -13,10 +13,10 @@ from testbed_status import dut_lose_management_ip
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, "../.."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 from devutil.devices.factory import init_localhost, init_testbed_sonichosts  # noqa: E402
 

--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -20,10 +20,10 @@ from netaddr import valid_ipv4
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 from devutil.devices.factory import init_host, init_localhost, init_testbed_sonichosts  # noqa: E402
 from devutil.devices.ansible_hosts import HostsUnreachable, RunAnsibleModuleFailed  # noqa: E402

--- a/.azure-pipelines/upgrade_image.py
+++ b/.azure-pipelines/upgrade_image.py
@@ -23,10 +23,10 @@ from common import get_pdu_managers, check_reachability
 _self_dir = os.path.dirname(os.path.abspath(__file__))
 base_path = os.path.realpath(os.path.join(_self_dir, ".."))
 if base_path not in sys.path:
-    sys.path.append(base_path)
+    sys.path.insert(0, base_path)
 ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
-    sys.path.append(ansible_path)
+    sys.path.insert(0, ansible_path)
 
 
 from devutil.devices.factory import init_localhost, init_testbed_sonichosts         # noqa: E402


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix issue:

![image](https://github.com/user-attachments/assets/6c79660a-b75f-42d4-9ab5-5a12c8b0119c)

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

With the recent update of `msal-extensions` they shipped with the `tests` folder with as path:

```
austinpham@sonic-mgmt-austinpham_master:/usr/local/lib/python3.8/dist-packages$ ls | grep tests
tests
```

This will affect our utilities call. Therefore, we need to prioritise our path by shifting it up in `sys.path`

#### How did you do it?

Shift the path up in `sys.path` to prioritise our utilities call

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
