### PR TITLE
Fix failure with unbounded local variable access on Python 3.11+

### DIFF
--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -28,6 +28,7 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     # Check gnmi_get result
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]
+    output = None
     try:
         msg_list1 = gnmi_get(duthost, ptfhost, path_list1)
     except Exception as e:


### PR DESCRIPTION
### Description of PR

Test `gnmi/test_gnmi_appldb.py::test_gnmi_appldb_01` fails with `UnboundLocalError: local variable 'output' referenced before assignment` on Bookworm due to stricter checks in Python 3.11

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Migration of Docker PTF to Bookworm 

#### How did you do it?

NA

#### How did you verify/test it?

Manually

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA
