### PR TITLE
Refine sanity check bgp recover

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -185,7 +185,7 @@ def check_bgp(duthosts, tbinfo):
         def _restart_bgp(dut):
             # Restart BGP service
             try:
-                dut.command("supervisorctl restart bgp.service")
+                dut.command("systemctl restart bgp.service")
             except RunAnsibleModuleFail as e:
                 logger.error("Failed to restart BGP service on %s: %s" % (dut.hostname, str(e)))
                 return False

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -182,6 +182,15 @@ def check_bgp(duthosts, tbinfo):
                             module_ignore_errors=True)
             return not res["rc"] and len(res["stdout"].strip()) != 0
 
+        def _restart_bgp(dut):
+            # Restart BGP service
+            try:
+                dut.command("supervisorctl restart bgp.service")
+            except RunAnsibleModuleFail as e:
+                logger.error("Failed to restart BGP service on %s: %s" % (dut.hostname, str(e)))
+                return False
+            return True
+
         def _check_bgp_status_helper():
             asic_check_results = []
             bgp_facts = dut.bgp_facts(asic_index='all')
@@ -272,16 +281,20 @@ def check_bgp(duthosts, tbinfo):
         interval = 20
         wait_until(timeout, interval, 0, _check_bgp_status_helper)
         if (check_result['failed']):
-            for a_result in list(check_result.keys()):
-                if a_result != 'failed':
-                    # Dealing with asic result
-                    if 'down_neighbors' in check_result[a_result]:
-                        logger.info('BGP neighbors down: %s on bgp instance %s on dut %s' % (
-                            check_result[a_result]['down_neighbors'], a_result, dut.hostname))
-                    if "no_v4_default_route" in check_result[a_result]:
-                        logger.info('Deafult v4 route for {} {} is missing'.format(dut.hostname, a_result))
-                    if "no_v6_default_route" in check_result[a_result]:
-                        logger.info('Deafult v6 route for {} {} is missing'.format(dut.hostname, a_result))
+            # try restart bgp and verify again
+            _restart_bgp(dut)
+            wait_until(60, interval, 0, _check_bgp_status_helper)
+            if (check_result['failed']):
+                for a_result in list(check_result.keys()):
+                    if a_result != 'failed':
+                        # Dealing with asic result
+                        if 'down_neighbors' in check_result[a_result]:
+                            logger.info('BGP neighbors down: %s on bgp instance %s on dut %s' % (
+                                check_result[a_result]['down_neighbors'], a_result, dut.hostname))
+                        if "no_v4_default_route" in check_result[a_result]:
+                            logger.info('Deafult v4 route for {} {} is missing'.format(dut.hostname, a_result))
+                        if "no_v6_default_route" in check_result[a_result]:
+                            logger.info('Deafult v6 route for {} {} is missing'.format(dut.hostname, a_result))
         else:
             logger.info('No BGP neighbors are down or default route missing on %s' % dut.hostname)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Recently, t1-lag PR test may fail in sanity check for a bgp session not up, current sanity check recover plan will do re_announce_routes or neighbor_vm_restore, these recover plan won't recover bgp in t1-lag, but restart bgp could recover.
#### How did you do it?
Restart bgp service first, if couldn't recover, then continue with re_announce_routes or neighbor_vm_restore.
#### How did you verify/test it?
Created test plans to prepare 100 t1-lag and all succeeded, here is the sample of successful recover:
https://elastictest.org/scheduler/testplan/6832be87f67373e6d4638b45?testcase=test_pretest.py%7C%7C%7Cvms-kvm-t1-lag_7814&type=log
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
