### PR TITLE
New test cases for voq watchdog

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2833,7 +2833,7 @@ set_voq_watchdog({})
 
         self.copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_voq_watchdog.py")
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(scope='function', autouse=False)
     def disable_voq_watchdog(self, duthosts, get_src_dst_asic_and_duts, dutConfig):
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
         dst_asic = get_src_dst_asic_and_duts['dst_asic']

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -387,7 +387,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiPfcXoffLimit(
         self, xoffProfile, duthosts, get_src_dst_asic_and_duts,
         ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, egressLosslessProfile, change_lag_lacp_timer
+        ingressLosslessProfile, egressLosslessProfile, change_lag_lacp_timer, disable_voq_watchdog
     ):
         # NOTE: this test will be skipped for t2 cisco 8800 if it's not xoff_1 or xoff_2
         """
@@ -662,7 +662,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("xonProfile", ["xon_1", "xon_2", "xon_3", "xon_4"])
     def testQosSaiPfcXonLimit(
         self, get_src_dst_asic_and_duts, xonProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        ingressLosslessProfile, change_lag_lacp_timer
+        ingressLosslessProfile, change_lag_lacp_timer, disable_voq_watchdog
     ):
         # NOTE: cisco 8800 will skip this test if it's not xon_1 or xon_2
         """
@@ -773,7 +773,7 @@ class TestQosSai(QosSaiBase):
          "lossless_voq_3", "lossless_voq_4"])
     def testQosSaiLosslessVoq(
             self, LosslessVoqProfile, ptfhost, dutTestParams, dutConfig,
-            dutQosConfig, get_src_dst_asic_and_duts, skip_longlink
+            dutQosConfig, get_src_dst_asic_and_duts, skip_longlink, disable_voq_watchdog
     ):
         """
             Test QoS SAI XOFF limits for various voq mode configurations
@@ -974,7 +974,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("sharedResSizeKey", ["shared_res_size_1", "shared_res_size_2"])
     def testQosSaiSharedReservationSize(
         self, sharedResSizeKey, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        get_src_dst_asic_and_duts, check_skip_shared_res_test
+        get_src_dst_asic_and_duts, check_skip_shared_res_test, disable_voq_watchdog
     ):
         # NOTE: Cisco T2 skip due to reduced number of port in multi asic
         """
@@ -1160,7 +1160,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiBufferPoolWatermark(
         self, request, get_src_dst_asic_and_duts, bufPool, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         ingressLosslessProfile, egressLossyProfile, resetWatermark,
-        skip_src_dst_different_asic
+        skip_src_dst_different_asic, disable_voq_watchdog
     ):
         """
             Test QoS SAI Queue buffer pool watermark for lossless/lossy traffic
@@ -1251,7 +1251,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiLossyQueue(
         self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        ingressLossyProfile, skip_src_dst_different_asic, change_lag_lacp_timer
+        ingressLossyProfile, skip_src_dst_different_asic, change_lag_lacp_timer, disable_voq_watchdog
     ):
         """
             Test QoS SAI Lossy queue, shared buffer dynamic allocation
@@ -1324,7 +1324,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiLossyQueueVoq(
         self, LossyVoq, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             ingressLossyProfile, duthost, localhost, get_src_dst_asic_and_duts,
-            skip_src_dst_different_asic, dut_qos_maps    # noqa:  F811
+            skip_src_dst_different_asic, dut_qos_maps, disable_voq_watchdog    # noqa:  F811
     ):
         # NOTE: cisco 8800 will skip this test, this test only for single asic with long link
         """
@@ -1428,7 +1428,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiDscpQueueMapping(
         self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dut_qos_maps, # noqa F811
-        tc_to_dscp_count, change_lag_lacp_timer
+        tc_to_dscp_count, change_lag_lacp_timer, disable_voq_watchdog
     ):
         """
             Test QoS SAI DSCP to queue mapping
@@ -1480,7 +1480,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
     def testQosSaiSeparatedDscpQueueMapping(self, duthost, ptfhost, dutTestParams,
-                                            dutConfig, direction, dut_qos_maps):        # noqa F811
+                                            dutConfig, direction, dut_qos_maps, disable_voq_watchdog):        # noqa F811
         # NOTE: cisco t2 8800 will skip this test since because of the topology
         """
             Test QoS SAI DSCP to queue mapping.
@@ -1621,7 +1621,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiDwrr(
         self, ptfhost, duthosts, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig, change_port_speed,
-            skip_src_dst_different_asic, set_cir_change, change_lag_lacp_timer
+            skip_src_dst_different_asic, set_cir_change, change_lag_lacp_timer, disable_voq_watchdog
     ):
         """
             Test QoS SAI DWRR
@@ -1699,7 +1699,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, skip_src_dst_different_asic, change_lag_lacp_timer
+        resetWatermark, skip_src_dst_different_asic, change_lag_lacp_timer, disable_voq_watchdog
     ):
         """
             Test QoS SAI PG shared watermark test for lossless/lossy traffic
@@ -1873,7 +1873,7 @@ class TestQosSai(QosSaiBase):
         )
 
     def testQosSaiPGDrop(
-        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, skip_400g_longlink
+        self, ptfhost, dutTestParams, dutConfig, dutQosConfig, skip_400g_longlink, disable_voq_watchdog
     ):
         """
             Test QoS SAI PG drop counter
@@ -1919,7 +1919,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, skip_src_dst_different_asic, skip_pacific_dst_asic, change_lag_lacp_timer
+        resetWatermark, skip_src_dst_different_asic, skip_pacific_dst_asic, change_lag_lacp_timer, disable_voq_watchdog
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic
@@ -2004,7 +2004,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiDscpToPgMapping(
         self, get_src_dst_asic_and_duts, duthost, request, ptfhost, dutTestParams, dutConfig, dut_qos_maps,  # noqa F811
-            change_lag_lacp_timer, dutQosConfig):
+            change_lag_lacp_timer, dutQosConfig, disable_voq_watchdog):
         """
             Test QoS SAI DSCP to PG mapping ptf test
 
@@ -2060,7 +2060,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("decap_mode", ["uniform", "pipe"])
     def testIPIPQosSaiDscpToPgMapping(
-        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode  # noqa F811
+        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode, disable_voq_watchdog  # noqa F811
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -2130,7 +2130,7 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("direction", ["downstream", "upstream"])
     def testQosSaiSeparatedDscpToPgMapping(self, duthost, request, ptfhost,
-                                           dutTestParams, dutConfig, direction, dut_qos_maps):      # noqa F811
+                                           dutTestParams, dutConfig, direction, dut_qos_maps, disable_voq_watchdog):      # noqa F811
         # NOTE: cisco 8800 will skip this test for both upstream and downstream
         """
             Test QoS SAI DSCP to PG mapping ptf test.
@@ -2192,7 +2192,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiDwrrWeightChange(
         self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             updateSchedProfile, skip_src_dst_different_asic, set_cir_change,
-            change_lag_lacp_timer
+            change_lag_lacp_timer, disable_voq_watchdog
     ):
         """
             Test QoS SAI DWRR runtime weight change
@@ -2253,7 +2253,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiQWatermarkAllPorts(
         self, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
         get_src_dst_asic_and_duts, resetWatermark, _skip_watermark_multi_DUT,
-        skip_pacific_dst_asic, dut_qos_maps    # noqa F811
+        skip_pacific_dst_asic, dut_qos_maps, disable_voq_watchdog    # noqa F811
     ):
         """
             Test QoS SAI Queue watermark test for lossless/lossy traffic on all ports
@@ -2352,7 +2352,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiLossyQueueVoqMultiSrc(
         self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            get_src_dst_asic_and_duts, skip_longlink
+            get_src_dst_asic_and_duts, skip_longlink, disable_voq_watchdog
     ):
         # NOTE: testQosSaiLossyQueueVoqMultiSrc[lossy_queue_voq_3] will be skipped for t2 cisco since it's multi-asic
         """
@@ -2428,7 +2428,7 @@ class TestQosSai(QosSaiBase):
     def testQosSaiFullMeshTrafficSanity(
             self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             get_src_dst_asic_and_duts, dut_qos_maps, # noqa F811
-            set_static_route_ptf64
+            set_static_route_ptf64, disable_voq_watchdog
     ):
         # NOTE: this test will skip for t2 cisco 8800 since it requires ptf64 topo
         """
@@ -2519,7 +2519,7 @@ class TestQosSai(QosSaiBase):
                                                   "xon_hysteresis_9"])
     def testQosSaiXonHysteresis(
             self, xonHysteresisKey, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            get_src_dst_asic_and_duts, check_skip_xon_hysteresis_test
+            get_src_dst_asic_and_duts, check_skip_xon_hysteresis_test, disable_voq_watchdog
     ):
         """
             Test QoS SAI SQG transitions
@@ -2564,3 +2564,86 @@ class TestQosSai(QosSaiBase):
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.XonHysteresisTest",
             testParams=test_params)
+
+    @pytest.mark.disable_loganalyzer
+    def testQosSaiVoqWatchdog(
+            self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+            get_src_dst_asic_and_duts
+    ):
+        """
+            Test VOQ watchdog
+            Args:
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+            Returns:
+                None
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+
+        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000" or\
+            not ('modular_chassis' in get_src_dst_asic_and_duts['src_dut'].facts and
+                 get_src_dst_asic_and_duts['src_dut'].facts["modular_chassis"]):
+            pytest.skip("VOQ watchdog test is supported on cisco-8000 T2 only")
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "dscp": 8,
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "packet_size": 1350,
+            "pkts_num": 100,
+            "voq_watchdog_enabled": True,
+        })
+
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.VoqWatchdogTest",
+            testParams=testParams)
+
+    def testQosSaiVoqWatchdogDisable(
+            self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
+            get_src_dst_asic_and_duts, disable_voq_watchdog
+    ):
+        """
+            Test VOQ watchdog
+            Args:
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+            Returns:
+                None
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+
+        if dutTestParams["basicParams"]["sonic_asic_type"] != "cisco-8000" or\
+            not ('modular_chassis' in get_src_dst_asic_and_duts['src_dut'].facts and
+                 get_src_dst_asic_and_duts['src_dut'].facts["modular_chassis"]):
+            pytest.skip("VOQ watchdog test is supported on cisco-8000 T2 only")
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({
+            "dscp": 8,
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "packet_size": 1350,
+            "pkts_num": 100,
+            "voq_watchdog_enabled": False,
+        })
+
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.VoqWatchdogTest",
+            testParams=testParams)

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -125,6 +125,13 @@ DEFAULT_ECN = 1
 DEFAULT_PKT_COUNT = 10
 PG_TOLERANCE = 2
 
+# Constants for voq watchdog test
+VOQ_WATCHDOG_TIMEOUT_SECONDS = 60
+SAI_LOG_TO_CHECK = ["HARDWARE_WATCHDOG", "soft_reset"]
+SDK_LOG_TO_CHECK = ["VOQ Appears to be stuck"]
+SAI_LOG = "/var/log/sai.log"
+SDK_LOG = "/var/log/syslog"
+
 
 def log_message(message, level='info', to_stderr=False):
     if to_stderr:
@@ -6622,3 +6629,155 @@ class XonHysteresisTest(sai_base_test.ThriftInterfaceDataPlane):
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, uniq_dst_ports)
+
+
+class VoqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
+    def init_log_check(self):
+        pre_offsets = []
+        for logfile in [SAI_LOG, SDK_LOG]:
+            offset_cmd = "stat -c %s {}".format(logfile)
+            stdout, err, ret = self.exec_cmd_on_dut(
+                self.dst_server_ip,
+                self.test_params['dut_username'],
+                self.test_params['dut_password'],
+                offset_cmd)
+            pre_offsets.append(int(stdout[0]))
+        return pre_offsets
+
+    def verify_log(self, pre_offsets, voq_watchdog_enabled=True):
+        found_list = []
+        for pre_offset, logfile, str_to_check in zip(pre_offsets, [SAI_LOG, SDK_LOG],
+                                                     [SAI_LOG_TO_CHECK, SDK_LOG_TO_CHECK]):
+            egrep_str = '|'.join(str_to_check)
+            check_cmd = "sudo tail -c +{} {} | egrep '{}' || true".format(pre_offset + 1, logfile, egrep_str)
+            stdout, err, ret = self.exec_cmd_on_dut(
+                self.dst_server_ip,
+                self.test_params['dut_username'],
+                self.test_params['dut_password'],
+                check_cmd)
+            log_message("Log for {}: {}".format(egrep_str, stdout))
+            for string in str_to_check:
+                if string in "".join(stdout):
+                    found_list.append(True)
+                else:
+                    found_list.append(False)
+        if voq_watchdog_enabled:
+            qos_test_assert(self, all(found is True for found in found_list),
+                            "VOQ watchdog trigger not detected")
+        else:
+            qos_test_assert(self, all(found is False for found in found_list),
+                            "unexpected VOQ watchdog trigger")
+
+    def runTest(self):
+        switch_init(self.clients)
+
+        # Parse input parameters
+        dscp = int(self.test_params['dscp'])
+        router_mac = self.test_params['router_mac']
+        sonic_version = self.test_params['sonic_version']
+        dst_port_id = int(self.test_params['dst_port_id'])
+        dst_port_ip = self.test_params['dst_port_ip']
+        dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
+        src_port_id = int(self.test_params['src_port_id'])
+        src_port_ip = self.test_params['src_port_ip']
+        src_port_vlan = self.test_params['src_port_vlan']
+        src_port_mac = self.dataplane.get_mac(0, src_port_id)
+        voq_watchdog_enabled = self.test_params['voq_watchdog_enabled']
+        asic_type = self.test_params['sonic_asic_type']
+        pkts_num = int(self.test_params['pkts_num'])
+
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        # get counter names to query
+        ingress_counters, egress_counters = get_counter_names(sonic_version)
+
+        # Prepare IP packet data
+        ttl = 64
+        if 'packet_size' in list(self.test_params.keys()):
+            packet_length = int(self.test_params['packet_size'])
+        else:
+            packet_length = 64
+
+        is_dualtor = self.test_params.get('is_dualtor', False)
+        def_vlan_mac = self.test_params.get('def_vlan_mac', None)
+        if is_dualtor and def_vlan_mac is not None:
+            pkt_dst_mac = def_vlan_mac
+
+        pkt = construct_ip_pkt(packet_length,
+                               pkt_dst_mac,
+                               src_port_mac,
+                               src_port_ip,
+                               dst_port_ip,
+                               dscp,
+                               src_port_vlan,
+                               ttl=ttl)
+
+        log_message("test dst_port_id: {}, src_port_id: {}, src_vlan: {}".format(
+            dst_port_id, src_port_id, src_port_vlan), to_stderr=True)
+        # in case dst_port_id is part of LAG, find out the actual dst port
+        # for given IP parameters
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan
+        )
+        log_message("actual dst_port_id: {}".format(dst_port_id), to_stderr=True)
+
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        pre_offsets = self.init_log_check()
+
+        try:
+            # send packets
+            send_packet(self, src_port_id, pkt, pkts_num)
+
+            # allow enough time to trigger voq watchdog
+            time.sleep(VOQ_WATCHDOG_TIMEOUT_SECONDS + 10)
+
+            # verify voq watchdog is triggered
+            self.verify_log(pre_offsets, voq_watchdog_enabled)
+
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+
+            # allow enough time for the dut to sync up the counter values in counters_db
+            time.sleep(8)
+            # get a snapshot of counter values at recv and transmit ports
+            recv_counters_base, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters_base, queue_counters_base = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            if voq_watchdog_enabled:
+                # queue counters should be cleared after soft reset
+                qos_test_assert(
+                    self, queue_counters_base[0] == 0,
+                    'queue counters are not cleared, soft reset is not triggered')
+
+            # send packets
+            send_packet(self, src_port_id, pkt, pkts_num)
+            # allow enough time for the dut to sync up the counter values in counters_db
+            time.sleep(8)
+
+            # get a snapshot of counter values at recv and transmit ports
+            recv_counters, _ = sai_thrift_read_port_counters(
+                self.src_client, asic_type, port_list['src'][src_port_id])
+            xmit_counters, queue_counters = sai_thrift_read_port_counters(
+                self.dst_client, asic_type, port_list['dst'][dst_port_id])
+            log_message(
+                '\trecv_counters {}\n\trecv_counters_base {}\n\t'
+                'xmit_counters {}\n\txmit_counters_base {}\n\t'
+                'queue_counters {}\n\tqueue_counters_base {}\n'.format(
+                    recv_counters, recv_counters_base, xmit_counters, xmit_counters_base,
+                    queue_counters, queue_counters_base), to_stderr=True)
+            # recv port no ingress drop
+            for cntr in ingress_counters:
+                qos_test_assert(
+                    self, recv_counters[cntr] == recv_counters_base[cntr],
+                    'unexpectedly RX drop counter increase')
+            # xmit port no egress drop
+            for cntr in egress_counters:
+                qos_test_assert(
+                    self, xmit_counters[cntr] == xmit_counters_base[cntr],
+                    'unexpectedly TX drop counter increase')
+            # queue counters increased by pkts_num
+            qos_test_assert(
+                self, queue_counters[0] == queue_counters_base[0] + pkts_num,
+                'unexpectedly TX drop counter increase')
+
+        finally:
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add voq watchdog testcases for cisco-8000 T2.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

```
---------------------------------- generated xml file: /tmp/qos/test_qos_sai_2025-05-25-07-05-13.xml ----------------------------------
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
17:55:05 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_3]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq[single_asic-lossless_voq_4]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_asic-wm_buf_pool_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq[single_asic-lossy_queue_voq_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[single_asic-wm_q_wm_all_ports]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_dut_multi_asic-xoff_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_dut_multi_asic-xoff_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_dut_multi_asic-xon_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_dut_multi_asic-wm_buf_pool_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[single_dut_multi_asic-wm_buf_pool_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_dut_multi_asic-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_dut_multi_asic-wm_q_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_dut_multi_asic-wm_q_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts[single_dut_multi_asic-wm_q_wm_all_ports]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_longlink_to_shortlink-xoff_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_longlink_to_shortlink-xoff_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut_longlink_to_shortlink-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut_longlink_to_shortlink-xon_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[multi_dut_longlink_to_shortlink-wm_buf_pool_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_longlink_to_shortlink-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[multi_dut_longlink_to_shortlink-wm_q_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_shortlink_to_shortlink-xoff_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_shortlink_to_shortlink-xoff_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut_shortlink_to_shortlink-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut_shortlink_to_shortlink-xon_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[multi_dut_shortlink_to_shortlink-wm_buf_pool_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[multi_dut_shortlink_to_shortlink-wm_buf_pool_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_shortlink_to_shortlink-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[multi_dut_shortlink_to_shortlink-wm_q_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[multi_dut_shortlink_to_shortlink-wm_q_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testParameter[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_shortlink_to_longlink-xoff_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[multi_dut_shortlink_to_longlink-xoff_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut_shortlink_to_longlink-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[multi_dut_shortlink_to_longlink-xon_2]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark[multi_dut_shortlink_to_longlink-wm_buf_pool_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[multi_dut_shortlink_to_longlink-wm_pg_shared_lossless]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[multi_dut_shortlink_to_longlink-wm_q_shared_lossy]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdog[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdogDisable[single_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdog[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdogDisable[single_dut_multi_asic]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdog[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdogDisable[multi_dut_longlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdog[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdogDisable[multi_dut_shortlink_to_shortlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdog[multi_dut_shortlink_to_longlink]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiVoqWatchdogDisable[multi_dut_shortlink_to_longlink]
SKIPPED [10] qos/test_qos_sai.py:416: Additional DSCPs are not supported on non-dual ToR ports
SKIPPED [20] qos/test_qos_sai.py:478: This test is only for Mellanox.
SKIPPED [10] qos/test_qos_sai.py:688: Additional DSCPs are not supported on non-dual ToR ports
SKIPPED [5] qos/test_qos_sai.py:874: Headroom pool size is not enabled on this DUT
SKIPPED [2] qos/test_qos_sai.py:974: This test cannot be run since there are not enough ports. Pls see qos.yaml for the port idx's that are needed.
SKIPPED [5] qos/test_qos_sai.py:1086: Headroom pool size is not enabled on this DUT
SKIPPED [1] qos/test_qos_sai.py:1357: LossyQueueVoq: lossy_queue_voq_2 test is not applicable for x86_64-88_lc0_36fh-r0, with split-voq.
SKIPPED [10] qos/test_qos_sai.py:1506: Skip this test since separated DSCP_TO_TC_MAP is not applied
SKIPPED [5] qos/test_qos_sai.py: Dot1p-queue mapping is only supported on backend.
SKIPPED [5] qos/test_qos_sai.py: Dot1p-PG mapping is only supported on backend.
SKIPPED [20] qos/test_qos_sai.py: Unsupported testbed type.
SKIPPED [10] qos/test_qos_sai.py:2061: For DSCP to PG mapping on IPinIP traffic , mellanox device has different behavior to community. For mellanox device, testQosSaiDscpToPgMapping can cover the scenarios / Unsupported testbed type.
SKIPPED [10] qos/test_qos_sai.py:2155: Skip this test since separated DSCP_TO_TC_MAP is not applied
SKIPPED [12] qos/test_qos_sai.py:796: This test needs to be revisited later, for the case where src and dst ASICs are different.
SKIPPED [8] qos/test_qos_sai.py:974: Shared Res Size Keys are not found, will be skipping test.
SKIPPED [8] qos/test_qos_sai.py:1348: Lossy Queue Voq test is only supported on cisco-8000 single-asic
SKIPPED [4] qos/test_qos_sai.py:1740: The lossy test is not valid for multiAsic configuration.
SKIPPED [3] qos/test_qos_sai.py:2372: LossyQueueVoqMultiSrc: This test is skipped on multi-asic,since same ingress backplane port will be used on egress asic.
SKIPPED [4] qos/test_qos_sai.py:770: This test is skipped for longlink.
SKIPPED [2] qos/test_qos_sai.py:1198: Skip buffer pool watermark lossless test since port speed cable length is different between src and dst asic
SKIPPED [1] qos/test_qos_sai.py:1875: PGDrop test is not supported for 400G longlink.
SKIPPED [2] qos/test_qos_sai.py:1951: Skip queue watermark lossless test since port speed cable length is different between src and dst asic
SKIPPED [3] qos/test_qos_sai.py:2252: All WM Tests are skipped for multiDUT for cisco platforms.
SKIPPED [1] qos/test_qos_sai.py:2353: This test is skipped for longlink.
SKIPPED [45] qos/test_qos_sai.py:2515: testQosSaiXonHysteresis case is only supported on cisco-8000 8102/8101/8111.
====================================== 94 passed, 206 skipped, 1 warning in 38990.49s (10:49:50) ======================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function testQosSaiVoqWatchdogDisable[multi_dut_shortlink_to_longlink]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'config_db_check_failed': True, 'core_dump_check_failed': False}}
INFO:root:Can not get Allure report URL. Please check logs
sonic@sonic-ucs-m6-4:/data/tests$ 
```

#### Any platform specific information?
cisco-8000 T2.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
