### PR TITLE
Modify gnmi stub generate script in line with issue in protoc fixed

### DIFF
--- a/tests/build-gnmi-stubs.sh
+++ b/tests/build-gnmi-stubs.sh
@@ -55,17 +55,20 @@ find "$GENERATED_DIR/github/" -type d -exec touch {}/__init__.py \;
 
 # Step 3: Move generated files to correct locations
 # This is due to a bug in the gRPC compiler: https://github.com/grpc/grpc/issues/39583
-echo "Moving generated files to correct locations..."
-mv "$GENERATED_DIR/github.com/openconfig/gnmi/proto/gnmi/gnmi_pb2_grpc.py" \
-   "$GENERATED_DIR/github/com/openconfig/gnmi/proto/gnmi/gnmi_pb2_grpc.py"
+# Fixed in https://github.com/grpc/grpc/pull/39586
+# For versions that still have this bug, we need to move the generated files manually.
+if [ -f "$GENERATED_DIR/github.com/openconfig/gnmi/proto/gnmi/gnmi_pb2_grpc.py" ]; then
+    echo "Moving generated files to correct locations..."
+    mv "$GENERATED_DIR/github.com/openconfig/gnmi/proto/gnmi/gnmi_pb2_grpc.py" \
+       "$GENERATED_DIR/github/com/openconfig/gnmi/proto/gnmi/gnmi_pb2_grpc.py"
+fi
 
-mv "$GENERATED_DIR/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext_pb2_grpc.py" \
-   "$GENERATED_DIR/github/com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext_pb2_grpc.py"
-
-echo "Files moved successfully."
-
-# Step 4: Remove $GENERATED_DIR/github.com directory
-echo "Removing $GENERATED_DIR/github.com directory..."
-rm -rf "$GENERATED_DIR/github.com"
-
-echo "$GENERATED_DIR/github.com directory removed successfully."
+if [ -f "$GENERATED_DIR/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext_pb2_grpc.py" ]; then
+    mv "$GENERATED_DIR/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext_pb2_grpc.py" \
+       "$GENERATED_DIR/github/com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext_pb2_grpc.py"
+    echo "Files moved successfully."
+    # Step 4: Remove $GENERATED_DIR/github.com directory
+    echo "Removing $GENERATED_DIR/github.com directory..."
+    rm -rf "$GENERATED_DIR/github.com"
+    echo "$GENERATED_DIR/github.com directory removed successfully."
+fi


### PR DESCRIPTION
### Description of PR

Modify the generate gNMI stub script to check if the directory exists. This was due to a bug https://github.com/grpc/grpc/issues/39583 in `grpc_tools.protoc` which is now fixed.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Fix issue with stub generation script.

#### How did you do it?

See description above.

#### How did you verify/test it?

Manually

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA