### PR TITLE
[configlet] Skip last_update_time for comparison per design

### DIFF
--- a/tests/common/configlet/utils.py
+++ b/tests/common/configlet/utils.py
@@ -134,7 +134,9 @@ scan_dbs = {
             "keys_to_skip_comp": {
                 "PORT_TABLE"
             },
-            "keys_skip_val_comp": set()
+            "keys_skip_val_comp": {
+                "last_update_time"
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip last_update_time per design.
Fixes # (issue) ADO: 32970571

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Due to recent change in https://github.com/sonic-net/sonic-platform-daemons/pull/604, the last_udpate_time was added. It should be skipped for comparison per design.
The `last_update_time` field was added in four place including `post_diagnostic_values_to_db, post_port_dom_flags_to_db, post_port_transceiver_hw_status_flags_to_db, post_port_vdm_thresholds_to_db`.
So there are many table involved such as `TRANSCEIVER_STATUS`, `TRANSCEIVER_STATUS_FLAG`. Thus skip in the val comparison.
#### How did you do it?
Skip the last_update_time for comparison
#### How did you verify/test it?
E2E
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
