### PR TITLE
Skip bgp_port_disable test in 202505 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -165,7 +165,7 @@ bgp/test_bgp_port_disable.py:
   skip:
     reason: "Not supperted on master."
     conditions:
-      - "release in ['master']"
+      - "release in ['master', '202505']"
 
 bgp/test_bgp_queue.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The bgp_port_disable test is skipped on master branch, after 202505 branch forked, it's running by default, which fails and block PR test of 202505 branch, need to skip it also.
https://elastictest.org/scheduler/testplan/6834026620695d24d9d20c8e?testcase=bgp%2Ftest_bgp_port_disable.py%7C%7C%7C1&type=console
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Unblock 202505 PR tests.
#### How did you do it?
Skip bgp_port_disable on 202505 branch
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
