### PR TITLE
Add monit test case with disable bmp but enable frr_bmp feature switch to block regression

### DIFF
--- a/tests/bmp/helper.py
+++ b/tests/bmp/helper.py
@@ -105,6 +105,24 @@ def disable_bmp_rib_out_table(duthost):
     return ret
 
 
+def disable_bmp_feature(duthost):
+
+    cmd_disable_feature = 'sudo config feature state bmp disabled'
+    logging.debug("cmd_disable_feature command is: {}".format(cmd_disable_feature))
+    ret = duthost.command(cmd_disable_feature, module_ignore_errors=True)
+    logging.debug("cmd_disable_feature output is: {}".format(ret))
+    return ret
+
+
+def enable_bmp_feature(duthost):
+
+    cmd_enable_feature = 'sudo config feature state bmp enabled'
+    logging.debug("cmd_enable_feature command is: {}".format(cmd_enable_feature))
+    ret = duthost.command(cmd_enable_feature, module_ignore_errors=True)
+    logging.debug("cmd_enable_feature output is: {}".format(ret))
+    return ret
+
+
 """
     Usage: show bmp [OPTIONS] COMMAND [ARGS]...
 

--- a/tests/bmp/test_frr_bmp_sanity.py
+++ b/tests/bmp/test_frr_bmp_sanity.py
@@ -1,0 +1,15 @@
+import pytest
+from tests.common.helpers.bgp import run_bgp_facts
+from bmp.helper import enable_bmp_feature, disable_bmp_feature
+
+pytestmark = [
+    pytest.mark.topology('any', 't0-sonic', 't1-multi-asic'),
+    pytest.mark.device_type('vs')
+]
+
+
+def test_frr_bmp_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index):
+    duthost = duthosts[enum_frontend_dut_hostname]
+    disable_bmp_feature(duthost)
+    run_bgp_facts(duthost, enum_asic_index)
+    enable_bmp_feature(duthost)

--- a/tests/bmp/test_frr_bmp_sanity.py
+++ b/tests/bmp/test_frr_bmp_sanity.py
@@ -1,5 +1,6 @@
 import pytest
-from tests.common.helpers.bgp import run_bgp_facts
+from tests.common.helpers.monit import check_monit_expected_container_logging
+from tests.common.utilities import wait_until
 from bmp.helper import enable_bmp_feature, disable_bmp_feature
 
 pytestmark = [
@@ -8,8 +9,10 @@ pytestmark = [
 ]
 
 
-def test_frr_bmp_bgp_facts(duthosts, enum_frontend_dut_hostname, enum_asic_index):
+def test_frr_bmp_monit_log(duthosts, enum_frontend_dut_hostname, enum_asic_index):
     duthost = duthosts[enum_frontend_dut_hostname]
     disable_bmp_feature(duthost)
-    run_bgp_facts(duthost, enum_asic_index)
+
+    wait_until(180, 60, 0, check_monit_expected_container_logging, duthost)
+
     enable_bmp_feature(duthost)

--- a/tests/common/helpers/monit.py
+++ b/tests/common/helpers/monit.py
@@ -1,0 +1,14 @@
+from tests.common.helpers.assertions import pytest_assert
+
+
+def check_monit_expected_container_logging(duthost):
+    """Checks whether alerting message appears as syslog if
+    there is unexpected container not running.
+    Args:
+        duthost: An AnsibleHost object of DuT.
+    Returns:
+        None.
+    """
+    syslog_output = duthost.command("sudo grep 'ERR monit' /var/log/syslog")["stdout"]
+    pytest_assert("Expected containers not running" not in syslog_output,
+                  f"Expected containers not running found in syslog. Output was:\n{syslog_output}")

--- a/tests/monit/test_monit_status.py
+++ b/tests/monit/test_monit_status.py
@@ -9,6 +9,7 @@ import random
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.assertions import pytest_require
+from tests.common.helpers.monit import check_monit_expected_container_logging
 
 logger = logging.getLogger(__name__)
 
@@ -75,19 +76,6 @@ def check_monit_last_output(duthost):
             return "/usr/bin/lldpmgrd' is not running in host" in monit_last_output
     else:
         return False
-
-
-def check_monit_expected_container_logging(duthost):
-    """Checks whether alerting message appears as syslog if
-    there is unexpected container not running.
-    Args:
-        duthost: An AnsibleHost object of DuT.
-    Returns:
-        None.
-    """
-    syslog_output = duthost.command("sudo grep 'ERR monit' /var/log/syslog")["stdout"]
-    pytest_assert("Expected containers not running" not in syslog_output,
-                  f"Expected containers not running found in syslog. Output was:\n{syslog_output}")
 
 
 def test_monit_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Add monit test case with disable bmp but enable frr_bmp feature switch to block regression

#### How did you do it?
Add one more test for monit syslog checking and disable bmp in advance which reflects real production config.

#### How did you verify/test it?
New test case passed without issue
![image](https://github.com/user-attachments/assets/4193d341-b511-46f7-8bd6-3538b97bec17)


Used old image which does not have monit fix https://github.com/sonic-net/sonic-buildimage/pull/22588 it broke the test case

![image](https://github.com/user-attachments/assets/5bfb3149-d182-4864-b715-ef7c8175965e)

With new image all test verification with frr_bmp enable + bmp disable are also passed, result could be found https://dev.azure.com/mssonic/build/_build/results?buildId=859705&view=results

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
