### PR TITLE
Shrink the vxlan_tunnel name len to be less than IFNAMSIZ

### DIFF
--- a/tests/vxlan/test_vxlan_decap.py
+++ b/tests/vxlan/test_vxlan_decap.py
@@ -86,7 +86,7 @@ def generate_vxlan_config_files(duthost, mg_facts):
     # Generate vxlan tunnel config json file on DUT
     vxlan_tunnel_cfg = {
         "VXLAN_TUNNEL": {
-            "tunnelVxlan": {
+            "tlVxlan": {
                 "src_ip": loopback_ip,
                 "dst_ip": VTEP2_IP
             }
@@ -100,7 +100,7 @@ def generate_vxlan_config_files(duthost, mg_facts):
         "VXLAN_TUNNEL_MAP": {}
     }
     for vlan in mg_facts["minigraph_vlans"]:
-        vxlan_maps_cfg["VXLAN_TUNNEL_MAP"]["tunnelVxlan|map%s" % vlan] = {
+        vxlan_maps_cfg["VXLAN_TUNNEL_MAP"]["tlVxlan|map%s" % vlan] = {
             "vni": int(vlan.replace("Vlan", "")) + VNI_BASE,
             "vlan": vlan
         }
@@ -158,9 +158,9 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         "Always try to remove any possible VxLAN tunnel and map configuration")
     for vlan in mg_facts["minigraph_vlans"]:
         duthost.shell(
-            'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map%s"' % vlan)
+            'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tlVxlan|map%s"' % vlan)
     duthost.shell(
-        'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"')
+        'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tlVxlan"')
 
 
 @pytest.fixture(params=["NoVxLAN", "Enabled", "Removed"])
@@ -174,9 +174,9 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname):
     elif request.param == "Removed":
         for vlan in setup["mg_facts"]["minigraph_vlans"]:
             duthost.shell(
-                'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tunnelVxlan|map%s"' % vlan)
+                'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL_MAP|tlVxlan|map%s"' % vlan)
         duthost.shell(
-            'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tunnelVxlan"')
+            'docker exec -i database redis-cli -n 4 -c DEL "VXLAN_TUNNEL|tlVxlan"')
         return False, request.param
     else:
         # clear FDB and arp cache on DUT


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/18618

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix

### Back port request

- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix the broken testcase vxlan/test_vxlan_decap.py.
#### How did you do it?
By changing the name of the vxlan netdev.
#### How did you verify/test it?

1. Manually
2. Running the testcase vxlan/test_vxlan_decap.py

#### Any platform specific information?
generic