### PR TITLE
Fix test_nexthop_group_member_scale ecmp_routes

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -385,7 +385,7 @@ def test_nexthop_group_member_scale(
     startup_routes = get_all_bgp_ipv6_routes(duthost)
     ecmp_routes = {
         r: v for r, v in startup_routes.items()
-        if len(v[0]['nexthops']) == len(bgp_peers_info) and r not in STATIC_ROUTES
+        if len(v[0]['nexthops']) >= len(bgp_peers_info) and r not in STATIC_ROUTES
     }
     pkts = generate_packets(
         ecmp_routes,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202412

### Approach
#### What is the motivation for this PR?

Fix test_nexthop_group_member_scale where ecmp_routes should be startup_routes with nexthops >= len(bgp_peers_info) to account for extra routes learnt

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
