### PR TITLE
[sonic-mgmt/tests/arp folder]: Disable ipv6 interfaces

### DIFF
--- a/tests/arp/test_unknown_mac.py
+++ b/tests/arp/test_unknown_mac.py
@@ -14,6 +14,7 @@ import ptf.packet as packet
 from tests.common import constants
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses    # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py   # noqa: F401
+from tests.common.fixtures.ptfhost_utils import disable_ipv6
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa: F401
@@ -176,7 +177,8 @@ def flushArpFdb(duthosts, rand_one_dut_hostname, dut_disable_arp_update):
 @pytest.fixture(autouse=True)
 def populateArp(unknownMacSetup, flushArpFdb, ptfhost, duthosts, rand_one_dut_hostname,
                 toggle_all_simulator_ports_to_rand_selected_tor_m,              # noqa: F811
-                setup_standby_ports_on_rand_unselected_tor_unconditionally):    # noqa: F811
+                setup_standby_ports_on_rand_unselected_tor_unconditionally,     #noqa: F811
+                disable_ipv6):
     """
     Fixture to populate ARP entry on the DUT for the traffic destination
 


### PR DESCRIPTION
ipv6 interfaces are generating v6 specific messages (eg RA/RS) which cause mac_address table population in random times. The side effect is that a testcase criterion:
- "packet drop when arp to mac mapping is present an the arp table and mac to part mapping is absent in the mac-table" could be randomly violated no matter if testcase at the begging clears the mac-table.

Signed-off-by: nikolaos.michos@nokia.com


### Description of PR

Involve disable_ipv6 fixture on populateArp fixture setup/teadown. 
In that way when tests arp/test_unknown_mac.py runs we guarantee that mac-table is not going to be affected (populated) by random events like router advertisments/router solicitation which can be initiated from ptf's ipv6 addressing.
The specific testcase is sensitive on mac-table entries population. It is expecting that when an arp entry exist (ip-mac correlation) but at the same time mac address table is not aware of the mac address (mac-port-vlan correlation) , then a received packet with this dst mac should be dropped. The mac address belongs to ptf.
When due to ipv6 background activity the mac address is inserted on mac-table, testcase results and actions (packet forwarding instead of drop) are affected.

The testcases usually passes and it fails rarely (maybe 1 out of 30 runs). This is because of the ipv6 traffic if generated it will affect the testcase result only when happens in specific timing of the testcase(after mac-address table clearance but before result verification)

Dependency: disable_ipv6 fixture from common fixtures ptfhost_utils. as this exist only on master, the correction is targeting master.

Summary:
Fixes # (issue)
ipv6 interfaces are disabled on ptf to avoid mac-address table random population
### Type of change
an existing fixture has been used/imported from a different case that experienced similar symptoms.



- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
correcting a rare random failure on a testcase
#### How did you do it?
the root cause was identified to be the ipv6 random traffic generation after enough rerun on the case so as to catch the failure. 
#### How did you verify/test it?
enough times running the same testing and observing the cap files plus the mac-address table that is not polluted after the clear cmd unitl test ending.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?
the case was found on t0.
### Documentation
No documentation impact is foreseen for this change.
