### PR TITLE
Replaced noqa eith noqa: in tests/drop_packets

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -8,7 +8,7 @@ import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
 
-from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa F401
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa: F401
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.platform.device_utils import fanout_switch_port_lookup
@@ -516,7 +516,7 @@ def send_packets(pkt, ptfadapter, ptf_tx_port_id, num_packets=1):
 
 
 def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
-                              pkt_fields, ports_info, enum_fanout_graph_facts):      # noqa F811
+                              pkt_fields, ports_info, enum_fanout_graph_facts):      # noqa: F811
     """
     @summary: Create a packet with equal SMAC and DMAC.
     """
@@ -559,7 +559,7 @@ def test_equal_smac_dmac_drop(do_test, ptfadapter, setup, fanouthost,
 
 
 def test_multicast_smac_drop(do_test, ptfadapter, setup, fanouthost,
-                             pkt_fields, ports_info, enum_fanout_graph_facts):   # noqa F811
+                             pkt_fields, ports_info, enum_fanout_graph_facts):   # noqa: F811
     """
     @summary: Create a packet with multicast SMAC.
     """
@@ -1043,7 +1043,7 @@ def test_non_routable_igmp_pkts(do_test, ptfadapter, setup, fanouthost, tx_dut_p
         "v2": {"membership_report": IGMP(type=0x16, gaddr=multicast_group_addr),
                "leave_group": IGMP(type=0x17, gaddr=multicast_group_addr)},
         "v3": {"general_query": "\x11\x00L2\xe0\x00\x00\x01\x01}\x00\x02\xac\x10\x0b\x01\n\x00\x00;",
-               "membership_report": "\"\x009\xa9\x00\x00\x00\x01\x01\x00\x00\x02\xe0\x02\x02\x04\xac\x10\x0b\x01\n\x00\x00;"}   # noqa E501
+               "membership_report": "\"\x009\xa9\x00\x00\x00\x01\x01\x00\x00\x02\xe0\x02\x02\x04\xac\x10\x0b\x01\n\x00\x00;"}   # noqa: E501
     }
 
     if igmp_version == "v3":

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -24,8 +24,8 @@ from . import configurable_drop_counters as cdc
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import fanout_switch_port_lookup
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa: F401
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # noqa: F401
 from tests.common.utilities import is_ipv4_address
 from tests.common import constants
 from tests.common import config_reload
@@ -149,8 +149,8 @@ def verifyFdbArp(duthost, dst_ip, dst_mac, dst_intf):
 
 @pytest.mark.parametrize("drop_reason", ["L3_EGRESS_LINK_DOWN"])
 def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                            setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
-                            toggle_all_simulator_ports_to_rand_selected_tor_m, mock_server,         # noqa F811
+                            setup_standby_ports_on_rand_unselected_tor,                             # noqa: F811
+                            toggle_all_simulator_ports_to_rand_selected_tor_m, mock_server,         # noqa: F811
                             send_dropped_traffic, drop_reason, generate_dropped_packet, tbinfo):
     """
     Verifies counters that check for a neighbor link being down.
@@ -199,8 +199,8 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
 
 @pytest.mark.parametrize("drop_reason", ["DIP_LINK_LOCAL"])
 def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                        toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa F811
-                        setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
+                        toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa: F811
+                        setup_standby_ports_on_rand_unselected_tor,                             # noqa: F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """
     Verifies counters that check for link local dst IP.
@@ -226,8 +226,8 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_h
 
 @pytest.mark.parametrize("drop_reason", ["SIP_LINK_LOCAL"])
 def test_sip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                        toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa F811
-                        setup_standby_ports_on_rand_unselected_tor,                             # noqa F811
+                        toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa: F811
+                        setup_standby_ports_on_rand_unselected_tor,                             # noqa: F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
     """
     Verifies counters that check for link local src IP.

--- a/tests/drop_packets/test_drop_counters.py
+++ b/tests/drop_packets/test_drop_counters.py
@@ -19,9 +19,9 @@ from .drop_packets import L2_COL_KEY, L3_COL_KEY, RX_ERR, RX_DRP, ACL_COUNTERS_U
     test_dst_ip_absent, test_src_ip_is_multicast_addr, test_src_ip_is_class_e, test_ip_is_zero_addr, \
     test_dst_ip_link_local, test_loopback_filter, test_ip_pkt_with_expired_ttl, test_broken_ip_header, \
     test_absent_ip_header, test_unicast_ip_incorrect_eth_dst, test_non_routable_igmp_pkts, test_acl_drop, \
-    test_acl_egress_drop  # noqa F401
+    test_acl_egress_drop  # noqa: F401
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
-from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa F401
+from tests.common.fixtures.conn_graph_facts import enum_fanout_graph_facts  # noqa: F401
 from ..common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 
 pytestmark = [
@@ -157,8 +157,8 @@ def handle_backend_acl(duthost, tbinfo):
         duthost.shell('systemctl restart backend-acl')
 
 
-def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,     # noqa F811
-                      tx_dut_ports=None, skip_counter_check=False, drop_information=None):  # noqa F811
+def base_verification(discard_group, pkt, ptfadapter, duthosts, asic_index, ports_info,     # noqa: F811
+                      tx_dut_ports=None, skip_counter_check=False, drop_information=None):  # noqa: F811
     """
     Base test function for verification of L2 or L3 packet drops. Verification type depends on 'discard_group' value.
     Supported 'discard_group' values: 'L2', 'L3', 'ACL', 'NO_DROPS'
@@ -319,7 +319,7 @@ def check_if_skip():
 
 @pytest.fixture(scope='module')
 def do_test(duthosts):
-    def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa F811
+    def do_counters_test(discard_group, pkt, ptfadapter, ports_info, sniff_ports, tx_dut_ports=None,    # noqa: F811
                          comparable_pkt=None, skip_counter_check=False, drop_information=None, ip_ver='ipv4'):
         """
         Execute test - send packet, check that expected discard counters were incremented and packet was dropped
@@ -349,7 +349,7 @@ def do_test(duthosts):
 
 
 def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                            setup, fanouthost, pkt_fields, ports_info):  # noqa F811
+                            setup, fanouthost, pkt_fields, ports_info):  # noqa: F811
     """
     @summary: Verify that packet with reserved DMAC is dropped and L2 drop counter incremented
     @used_mac_address:
@@ -386,8 +386,8 @@ def test_reserved_dmac_drop(do_test, ptfadapter, duthosts, enum_rand_one_per_hws
         do_test(group, pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"])
 
 
-def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports,   # noqa F811
-                                     pkt_fields, rif_port_down, ports_info):     # noqa F811
+def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports,   # noqa: F811
+                                     pkt_fields, rif_port_down, ports_info):     # noqa: F811
     """
     @summary: Verify that packets on ingress port are not dropped
               when egress RIF link is down and check that drop counters not incremented
@@ -409,7 +409,7 @@ def test_no_egress_drop_on_down_link(do_test, ptfadapter, setup, tx_dut_ports,  
 
 
 def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                           setup, tx_dut_ports, pkt_fields, ports_info):    # noqa F811
+                           setup, tx_dut_ports, pkt_fields, ports_info):    # noqa: F811
     """
     @summary: Verify that packet with link-local address "169.254.0.0/16" is dropped and L3 drop counter incremented
     """
@@ -435,8 +435,8 @@ def test_src_ip_link_local(do_test, ptfadapter, duthosts, enum_rand_one_per_hwsk
     do_test("L3", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], tx_dut_ports)
 
 
-def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports,                 # noqa F811
-                                  pkt_fields, mtu_config, ports_info):                      # noqa F811
+def test_ip_pkt_with_exceeded_mtu(do_test, ptfadapter, setup, tx_dut_ports,                 # noqa: F811
+                                  pkt_fields, mtu_config, ports_info):                      # noqa: F811
     """
     @summary: Verify that IP packet with exceeded MTU is dropped and L3 drop counter incremented
     """


### PR DESCRIPTION
Changes made in tests/drop_packets files.
Noqa replaced with noqa:

![image](https://github.com/user-attachments/assets/4cca8f80-b736-4e7d-8b23-0c152b4eb8c6)
