### PR TITLE
[dualtor] Fix `test_orchagent_slb`

### DIFF
--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -22,7 +22,9 @@ from tests.common.fixtures.ptfhost_utils import run_icmp_responder              
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
 from tests.common.helpers import bgp
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import is_ipv4_address
+from tests.common.utilities import wait_until
 
 
 pytestmark = [
@@ -180,7 +182,8 @@ def bgp_neighbors(ptfhost, setup_interfaces):
 def save_slb_exabgp_logfiles(ptfhost, pytestconfig, request):
     """Save slb exabgp log files to the log directory."""
     # remove log files before test
-    log_files_before = ptfhost.shell("ls /tmp/exabgp-slb_*.log")["stdout"].split()
+    log_files_before = ptfhost.shell("ls /tmp/exabgp-slb_*.log*",
+                                     module_ignore_errors=True)["stdout"].split()
     for log_file in log_files_before:
         ptfhost.file(path=log_file, state="absent")
 
@@ -189,7 +192,8 @@ def save_slb_exabgp_logfiles(ptfhost, pytestconfig, request):
     test_log_file = pytestconfig.getoption("log_file", None)
     if test_log_file:
         log_dir = os.path.dirname(os.path.abspath(test_log_file))
-        log_files = ptfhost.shell("ls /tmp/exabgp-slb_*.log")["stdout"].split()
+        log_files = ptfhost.shell("ls /tmp/exabgp-slb_*.log*",
+                                  module_ignore_errors=True)["stdout"].split()
         for log_file in log_files:
             logging.debug("Save slb exabgp log %s to %s", log_file, log_dir)
             ptfhost.fetch(src=log_file, dest=log_dir + os.path.sep, fail_on_missing=False, flat=True)
@@ -256,9 +260,9 @@ def test_orchagent_slb(
         prefix = ipaddress.ip_network(route["prefix"])
         existing_route = duthost.get_ip_route_info(dstip=prefix)
         if existing:
-            assert route["nexthop"] in [str(_[0]) for _ in existing_route["nexthops"]]
+            return route["nexthop"] in [str(_[0]) for _ in existing_route["nexthops"]]
         else:
-            assert len(existing_route["nexthops"]) == 0
+            return len(existing_route["nexthops"]) == 0
 
     def verify_traffic(duthost, connection, route, is_duthost_active=True, is_route_existed=True):
 
@@ -311,8 +315,10 @@ def test_orchagent_slb(
 
         time.sleep(constants.bgp_update_sleep_interval)
 
-        verify_route(upper_tor_host, constants.route, existing=True)
-        verify_route(lower_tor_host, constants.route, existing=True)
+        pytest_assert(verify_route(upper_tor_host, constants.route, existing=True),
+                      "route is not present on the upper ToR")
+        pytest_assert(verify_route(lower_tor_host, constants.route, existing=True),
+                      "route is not present on the lower ToR")
 
         # STEP 3: verify the route by sending some downstream traffic
         verify_traffic(
@@ -330,8 +336,12 @@ def test_orchagent_slb(
 
         time.sleep(constants.bgp_update_sleep_interval)
 
-        verify_route(upper_tor_host, constants.route, existing=False)
-        verify_route(lower_tor_host, constants.route, existing=False)
+        pytest_assert(wait_until(10, 5, 0, verify_route, upper_tor_host,
+                                 constants.route, existing=False),
+                      "route is not withdrawed from the upper ToR")
+        pytest_assert(wait_until(10, 5, 0, verify_route, lower_tor_host,
+                                 constants.route, existing=False),
+                      "route is not withdrawed from the lower ToR")
 
         # STEP 5: verify the route is removed by verifying that downstream traffic is dropped
         verify_traffic(
@@ -357,8 +367,10 @@ def test_orchagent_slb(
 
         time.sleep(constants.bgp_update_sleep_interval)
 
-        verify_route(upper_tor_host, constants.route, existing=True)
-        verify_route(lower_tor_host, constants.route, existing=True)
+        pytest_assert(verify_route(upper_tor_host, constants.route, existing=True),
+                      "route is not present on the upper ToR")
+        pytest_assert(verify_route(lower_tor_host, constants.route, existing=True),
+                      "route is not present on the lower ToR")
 
         # STEP 8: verify the route by sending some downstream traffic
         verify_traffic(
@@ -374,7 +386,8 @@ def test_orchagent_slb(
         upper_tor_bgp_neighbor.stop_session()
 
         verify_bgp_session(lower_tor_host, lower_tor_bgp_neighbor)
-        verify_route(lower_tor_host, constants.route, existing=True)
+        pytest_assert(verify_route(lower_tor_host, constants.route, existing=True),
+                      "route is not present on the lower ToR")
 
         lower_tor_bgp_neighbor.stop_session()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix `test_orchagent_slb`:
1. the `exabgp` log collection log has an issue that the logs might not exists before test, so it will error in this case.
2. when the slb sessions withdraw the route, the upper ToR slb session withdraws first, then the lower ToR; so there is a time period that, the route is withdrawed from the upper ToR but not the lower ToR, as T1s still have this route learnt from the lower ToR, the upper ToR still have this route in its FIB that is learnt from T1s and has nexthops as T1s.
So, let's wait for more time to allow the lower ToR withdraw to happen.

#### How did you do it?
1. ignore exabgp log not exist error in log collection.
2. add `wait_until` logic for the withdraw check.

#### How did you verify/test it?
```
dualtor/test_orchagent_slb.py::test_orchagent_slb[ipv4-active-standby] PASSED                                                                                                                                                                                          [100%]

============================================================================================================================== warnings summary ==============================================================================================================================
../../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

dualtor/test_orchagent_slb.py: 96 warnings
  /usr/local/lib/python3.8/dist-packages/ptf/mask.py:69: DeprecationWarning: "set_do_not_care_scapy" is going to be deprecated, please switch to the new one: "set_do_not_care_packet"
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================== 1 passed, 3 deselected, 97 warnings in 554.61s (0:09:14) ==========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
