### PR TITLE
Skip test_dscp_to_queue_mapping_uniform_mode for marvell-teralynx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1888,6 +1888,12 @@ qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
       - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
 
+qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping_uniform_mode:
+  skip:
+    reason: "For marvell-teralynx - Need to be skipped due to HW resource oversubscription detected during test setup."
+    conditions:
+      - "asic_type in ['marvell-teralynx']"
+
 qos/test_qos_masic.py:
   skip:
     reason: "QoS tests for multi-ASIC only. Supported topos: t1-lag, t1-64-lag, t1-56-lag, t1-backend. / M* topo does not support qos. / KVM do not support swap syncd."


### PR DESCRIPTION
### Description of PR
For marvell-teralynx test_dscp_to_queue_mapping_uniform_mode test case needs to be skipped due to HW resource oversubscription detected during test setup.

Summary:
Fixes # (issue)

### Type of change
Added a skip reason in  tests_mark_conditions.yaml for test case test_dscp_to_queue_mapping_uniform_mode for marvell teralynx ASIC.

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This is meant to skip the testcase test_dscp_to_queue_mapping_uniform_mode as it results in HW resource oversubscription 

#### How did you do it?
Added a skip reason in  tests_mark_conditions.yaml

#### How did you verify/test it?
Execute testcase qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping_uniform_mode


#### Any platform specific information?
Applicable only to marvell-teralynx ASIC

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
