### PR TITLE
Restore configuration after test_vxlan_crm

### DIFF
--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import ipaddress
 from functools import reduce
-
+from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
@@ -127,6 +127,14 @@ def fixture_setup_neighbors(setUp, encap_type, minigraph_facts):
         duthost.shell(
             "sudo config interface ip remove {} DDDD::200:0:0:1/64".format(
                 intf))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_config_by_config_reload(setUp):
+    yield
+    duthost = setUp['duthost']
+
+    config_reload(duthost, safe_reload=True)
 
 
 class Test_VxLAN_Crm(Test_VxLAN):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Similar with https://github.com/sonic-net/sonic-mgmt/pull/17046

In test_vxlan_crm, it will do config save command and after enable bfd session, iptables will add the following iptables rules, and it didn't have any chance to restore the configuration after the test. These iptables rules will be left on the DUT, which will fail `test_cacl_application` with the following unexpected iptable rules

```
 iptables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT
 ip6tables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Backup and restore configuration for test_vxlan_crm

#### How did you do it?
Call the existing function backup_and_restore_config_db_on_duts in fixture_setUp fixture of test_vxlan_bfd_tsa and do config reload after config_db.json restoration.

#### How did you verify/test it?
Run test_vxlan_crm on dut and check if

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
