### PR TITLE
[ACL] Include service port into upstream neighbors

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -440,7 +440,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
             )
             or 't1-isolated' in tbinfo["topo"]["name"]
         )
-        and not re.match(r"t0-.*-s\d+$", tbinfo["topo"]["name"])
+        and not re.match(r"t0-.*s\d+", tbinfo["topo"]["name"])
     ):
 
         for k, v in list(port_channels.items()):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -10,6 +10,7 @@ import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
 import queue
+import re
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
@@ -152,8 +153,6 @@ LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
 
 PACKETS_COUNT = "packets_count"
 BYTES_COUNT = "bytes_count"
-
-TOPOLOGY_WITH_SERVICE_PORT = ["t0-d18u8s4", "t0-isolated-d16u16s1", "t0-isolated-d32u32s2"]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -441,7 +440,7 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
             )
             or 't1-isolated' in tbinfo["topo"]["name"]
         )
-        and tbinfo["topo"]["name"] not in TOPOLOGY_WITH_SERVICE_PORT
+        and not re.match(r"t0-.*-s\d+$", tbinfo["topo"]["name"])
     ):
 
         for k, v in list(port_channels.items()):

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -153,6 +153,8 @@ LOG_EXPECT_ACL_RULE_REMOVE_RE = ".*Successfully deleted ACL rule.*"
 PACKETS_COUNT = "packets_count"
 BYTES_COUNT = "bytes_count"
 
+TOPOLOGY_WITH_SERVICE_PORT = ["t0-d18u8s4", "t0-isolated-d16u16s1", "t0-isolated-d32u32s2"]
+
 
 @pytest.fixture(scope="module", autouse=True)
 def remove_dataacl_table(duthosts):
@@ -429,10 +431,18 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
             # In multi-asic we need config both in host and namespace.
             if namespace:
                 acl_table_ports[''] += port
-    if len(port_channels) and (topo in ["t0", "m0_vlan", "m0_l3"]
-                               or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag", "t1-64-lag-clet",
-                                                             "t1-56-lag", "t1-28-lag", "t1-32-lag")
-                               or 't1-isolated' in tbinfo["topo"]["name"]):
+    if (
+        len(port_channels)
+        and (
+            topo in ["t0", "m0_vlan", "m0_l3"]
+            or tbinfo["topo"]["name"] in (
+                "t1-lag", "t1-64-lag", "t1-64-lag-clet",
+                "t1-56-lag", "t1-28-lag", "t1-32-lag"
+            )
+            or 't1-isolated' in tbinfo["topo"]["name"]
+        )
+        and tbinfo["topo"]["name"] not in TOPOLOGY_WITH_SERVICE_PORT
+    ):
 
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -195,7 +195,8 @@ def prepare_test_port(rand_selected_dut, tbinfo):
         port_id = mg_facts["minigraph_ptf_indices"][interface]
         if (topo == "t1" and "T2" in neighbor["name"]) or \
                 (topo == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"])) or \
-                (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]):
+                (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]) or \
+                (topo_name in ("t1-isolated-d32", "t1-isolated-d128") and "T0" in neighbor["name"]):
             upstream_ports[neighbor['namespace']].append(interface)
             upstream_port_ids.append(port_id)
             ipv4_addr = [bgp_neighbor['addr'] for bgp_neighbor in mg_facts['minigraph_bgp']

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -193,9 +193,9 @@ def prepare_test_port(rand_selected_dut, tbinfo):
     upstream_port_neighbor_ips = {}
     for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
         port_id = mg_facts["minigraph_ptf_indices"][interface]
-        if (topo == "t1" and "T2" in neighbor["name"]) or (topo == "t0" and "T1" in neighbor["name"]) or \
-                (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]) or \
-                (topo_name in ("t1-isolated-d32", "t1-isolated-d128") and "T0" in neighbor["name"]):
+        if (topo == "t1" and "T2" in neighbor["name"]) or \
+                (topo == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"])) or \
+                (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]):
             upstream_ports[neighbor['namespace']].append(interface)
             upstream_port_ids.append(port_id)
             ipv4_addr = [bgp_neighbor['addr'] for bgp_neighbor in mg_facts['minigraph_bgp']

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -25,7 +25,7 @@ UPSTREAM_NEIGHBOR_MAP = {
 
 # Describe ALL upstream neighbor of dut in different topos
 UPSTREAM_ALL_NEIGHBOR_MAP = {
-    "t0": ["t1"],
+    "t0": ["t1", "pt0"],
     "t1": ["t2"],
     "m1": ["ma", "mb"],
     "m0": ["m1"],

--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -57,7 +57,7 @@ def upstream_links(rand_selected_dut, tbinfo, nbrhosts):
     duthost = rand_selected_dut
 
     def filter(interface, neighbor, mg_facts, tbinfo):
-        if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"])
+        if ((tbinfo["topo"]["type"] == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"]))
                 or (tbinfo["topo"]["type"] == "t1" and "T2" in neighbor["name"])):
             local_ipv4_addr = None
             peer_ipv4_addr = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In the topology with service ports, like t0-d18u8s4, t0-isolated-d16u16s1, t0-isolated-d32u32s2. we should include the PT0 neighbor port in the upstream neighbor list. With the enhancement in #18516, we can achieve this by adding pt0 in UPSTREAM_ALL_NEIGHBOR_MAP.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To include service ports into upstream neighbors list.

#### How did you do it?
Update the UPSTREAM_ALL_NEIGHBOR_MAP.

#### How did you verify/test it?
Run acl test and passed.

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
