### PR TITLE
Update test_iface_namingmode.py

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -651,16 +651,10 @@ class TestShowQueue():
             for intf in setup['default_interfaces']:
                 assert re.search(r'{}'.format(intf), show_queue_wm_ucast) is not None
 
+
 # Tests to be run in t0/m0 topology
-
-
+@pytest.mark.topology('t0', 'm0')
 class TestShowVlan():
-
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, tbinfo):
-        if tbinfo['topo']['type'] not in ['t0', 'm0']:
-            pytest.skip('Unsupported topology')
-
     @pytest.fixture()
     def setup_vlan(self, setup_config_mode):
         """
@@ -732,13 +726,8 @@ class TestShowVlan():
 
 
 # Tests to be run in t1 topology
+@pytest.mark.topology('t1')
 class TestConfigInterface():
-
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, tbinfo):
-        if tbinfo['topo']['type'] not in ['t1']:
-            pytest.skip('Unsupported topology')
-
     def check_speed_change(self, duthost, asic_index, interface, change_speed):
         db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'\
             .format(duthost.asic_instance(asic_index).sonic_db_cli,
@@ -978,15 +967,15 @@ class TestConfigInterface():
 
         try:
             # Verify speed and link status
-            _verify_speed(target_speed)
             assert wait_until(60, 1, 0, duthost.links_status_up, [interface])
+            _verify_speed(target_speed)
         finally:
             # Restore to native speed after test
             _set_speed(native_speed)
 
         # After restoration, verify again
-        _verify_speed(native_speed)
         assert wait_until(60, 1, 0, duthost.links_status_up, [interface])
+        _verify_speed(native_speed)
         # Revert inconsistent config changes
         config_reload(duthost)
 
@@ -1055,12 +1044,11 @@ def test_show_interfaces_neighbor_expected(setup, setup_config_mode, tbinfo, dut
                                  show_int_neighbor[value["namespace"]]) is not None
 
 
+@pytest.mark.topology('t1', 't2')
 class TestNeighbors():
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, setup, tbinfo, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
-        if tbinfo['topo']['type'] not in ['t2', 't1']:
-            pytest.skip('Unsupported topology')
+    def setup_check_topo(self, setup, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         if duthost.is_multi_asic:
             pytest.skip("CLI not supported")
@@ -1120,13 +1108,11 @@ class TestNeighbors():
                     assert re.search(r'{}.*\s+{}'.format(addr, detail['interface']), ndp_output) is not None
 
 
+@pytest.mark.topology('t1', 't2')
 class TestShowIP():
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_check_topo(self, setup, tbinfo):
-        if tbinfo['topo']['type'] not in ['t2', 't1']:
-            pytest.skip('Unsupported topology')
-
+    def setup_check_topo(self, setup):
         if not setup['physical_interfaces']:
             pytest.skip('No non-portchannel member interface present')
 


### PR DESCRIPTION
 * await until port is up before speed check in test_config_interface_speed_40G_100G
 * update skip by topology in test_iface_namingmode.py 
   the motivation is to avoid fixtures execution in case the test is not supported

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
