### PR TITLE
update test_pfc_pause_lossless_with_snappi.py to use dynamic port selection

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -4,9 +4,9 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, get_snappi_ports_multi_dut, \
-    snappi_testbed_config, get_snappi_ports_single_dut, \
+    snappi_testbed_config, get_snappi_ports_single_dut, snappi_port_selection, tgen_port_info, \
     get_snappi_ports, is_snappi_multidut                                        # noqa: F401
-from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut, reboot_duts, \
+from tests.snappi_tests.files.helper import reboot_duts, \
     reboot_duts_and_disable_wd                                              # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list, disable_pfcwd          # noqa F401
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='module')
 def number_of_tx_rx_ports():
     yield (1, 1)
 
@@ -36,7 +36,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
                                         get_snappi_ports,               # noqa: F811
                                         tbinfo,                         # noqa: F811
                                         disable_pfcwd,                  # noqa: F811
-                                        setup_ports_and_dut):           # noqa: F811
+                                        tgen_port_info):                # noqa: F811
 
     """
     Test if PFC can pause a single lossless priority in multidut setup
@@ -57,7 +57,7 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
         N/A
     """
 
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     _, lossless_prio = enum_one_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
@@ -71,18 +71,21 @@ def test_pfc_pause_single_lossless_prio(snappi_api,                     # noqa: 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 def test_pfc_pause_counter_check(snappi_api,                     # noqa: F811
@@ -96,7 +99,7 @@ def test_pfc_pause_counter_check(snappi_api,                     # noqa: F811
                                  get_snappi_ports,               # noqa: F811
                                  tbinfo,                         # noqa: F811
                                  disable_pfcwd,                  # noqa: F811
-                                 setup_ports_and_dut):                  # noqa F811
+                                 tgen_port_info):                # noqa F811
     """
     Test if PFC pause frames are counted properly by the DUT. This test is slightly different to the other
     PFC pause tests. We will only send lossless prio packets i.e. no background traffic.
@@ -117,7 +120,7 @@ def test_pfc_pause_counter_check(snappi_api,                     # noqa: F811
         N/A
     """
 
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     _, lossless_prio = enum_one_dut_lossless_prio.split('|')
     lossless_prio = int(lossless_prio)
@@ -132,18 +135,21 @@ def test_pfc_pause_counter_check(snappi_api,                     # noqa: F811
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
     snappi_extra_params.gen_background_traffic = False
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 def test_pfc_pause_multi_lossless_prio(snappi_api,                   # noqa: F811
@@ -156,7 +162,7 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                   # noqa: F81
                                        get_snappi_ports,             # noqa: F811
                                        tbinfo,
                                        disable_pfcwd,                # noqa: F811
-                                       setup_ports_and_dut):         # noqa: F811
+                                       tgen_port_info):              # noqa: F811
 
     """
     Test if PFC can pause multiple lossless priorities in multidut setup
@@ -174,7 +180,7 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                   # noqa: F81
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
@@ -184,18 +190,21 @@ def test_pfc_pause_multi_lossless_prio(snappi_api,                   # noqa: F81
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -211,7 +220,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # n
                                                get_snappi_ports,            # noqa: F811
                                                tbinfo,                      # noqa: F811
                                                reboot_duts_and_disable_wd,  # noqa: F811
-                                               setup_ports_and_dut):        # noqa: F811
+                                               tgen_port_info):             # noqa: F811
     """
     Test if PFC can pause a single lossless priority even after various types of reboot in multidut setup
 
@@ -231,7 +240,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # n
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     _, lossless_prio = enum_one_dut_lossless_prio_with_completeness_level.split('|')
     lossless_prio = int(lossless_prio)
@@ -244,18 +253,21 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # n
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -270,7 +282,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
                                               get_snappi_ports,             # noqa: F811
                                               tbinfo,                       # noqa: F811
                                               reboot_duts_and_disable_wd,   # noqa: F811
-                                              setup_ports_and_dut):         # noqa: F811
+                                              tgen_port_info):              # noqa: F811
     """
     Test if PFC can pause multiple lossless priorities even after various types of reboot in multidut setup
 
@@ -289,7 +301,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     pause_prio_list = lossless_prio_list
     test_prio_list = lossless_prio_list
@@ -299,15 +311,18 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=True,
-                 snappi_extra_params=snappi_extra_params)
+    try:
+        run_pfc_test(api=snappi_api,
+                     testbed_config=testbed_config,
+                     port_config_list=port_config_list,
+                     conn_data=conn_graph_facts,
+                     fanout_data=fanout_graph_facts_multidut,
+                     global_pause=False,
+                     pause_prio_list=pause_prio_list,
+                     test_prio_list=test_prio_list,
+                     bg_prio_list=bg_prio_list,
+                     prio_dscp_map=prio_dscp_map,
+                     test_traffic_pause=True,
+                     snappi_extra_params=snappi_extra_params)
+    finally:
+        cleanup_config(duthosts, snappi_ports)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
After #16729 and  #15069, existing test cases need to be updated to support dynamic port selection. 


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Update test case to adopt the new feature

#### How did you do it?

#### How did you verify/test it?

snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[str3-8800-lc4-1|3-tgen_port_info0] 
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[str3-8800-lc4-1|3-tgen_port_info1] PASSED [ 50%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[str3-8800-lc4-1|4-tgen_port_info0] PASSED [ 75%]
snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[str3-8800-lc4-1|4-tgen_port_info1] PASSED [100%]
------------------------------ live log teardown -------------------------------

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
