### PR TITLE
[dualtor-io] Validate and recover active-active setup

### DIFF
--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -7,9 +7,11 @@ from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action,
                                                   send_server_to_server_with_action, select_test_mux_ports  # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType
+from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, \
                                                 force_active_tor, force_standby_tor                 # noqa F401
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
+from tests.common.dualtor.dual_tor_utils import validate_active_active_dualtor_setup                # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
@@ -22,6 +24,11 @@ from tests.common.helpers.assertions import pytest_assert
 pytestmark = [
     pytest.mark.topology("dualtor")
 ]
+
+
+@pytest.fixture(autouse=True)
+def common_setup_teardown(validate_active_active_dualtor_setup):    # noqa F811
+    return
 
 
 @pytest.mark.enable_active_active


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
If the previous testcase (in the same test session) leaves the DUT in an error state - mux status is not active for libra, the testcases following this one will suffer from this to fail.
Let's validate before each testcase run to ensure the DUTs are in active-active setup, and recover if neccessary.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
1. leaves the DUT in an error state, as this issue: https://github.com/sonic-net/sonic-linkmgrd/issues/292

2. run test
```
dualtor_io/test_normal_op.py::test_tor_switch_upstream[active-active] PASSED                                                                                                                                                                                           [100%]

============================================================================================================================== warnings summary ==============================================================================================================================
../../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

dualtor_io/test_normal_op.py::test_tor_switch_upstream[active-active]
  /home/lolv/workspace/sonic-mgmt/tests/common/dualtor/control_plane_utils.py:272: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    if not isinstance(expected_active_host, collections.Iterable):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================== 1 passed, 1 deselected, 2 warnings in 542.76s (0:09:02) ===========================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
