### PR TITLE
[ceos]: Optimize CEOS image by disabling RPM service

### DIFF
--- a/ansible/roles/vm_set/templates/ceos_dockerfile.j2
+++ b/ansible/roles/vm_set/templates/ceos_dockerfile.j2
@@ -1,3 +1,4 @@
 FROM {{ ceos_image_orig }}
 
 RUN sed -e "/^fs.inotify.max_user_watches/s/[0-9]\+/1024000/" -e "/^fs.inotify.max_user_instances/s/[0-9]\+/8192/" /etc/sysctl.d/99-eos.conf > /etc/sysctl.d/99-eos.conf.bak; mv /etc/sysctl.d/99-eos.conf.bak /etc/sysctl.d/99-eos.conf
+RUN sed -i 's/rpm -qa | LC_ALL="C" sort/# rpm -qa | LC_ALL="C" sort/g' /usr/sbin/core_annotate_util


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
According to the profiling data, we found the disk write operations will become a bottleneck if we start a large number of cEOS container as neighbors at the add-topo step. All most write operations come from the RPM service that will update the package list and upgrade packages during the starting stage.

#### How did you do it?
Comment the RPM service of start script of cEOS to disable the RPM service. Because to update package list and upgrade packages isn't necessary in most of our scenarios.

#### How did you verify/test it?
Check it locally and profiling data, there is no obvious write operations can be found.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
