### PR TITLE
[topo file] Fix pt0 announce routes in bgp scale topologies

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -500,6 +500,9 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
 
     vms = topo['topology']['VMs']
     for vm_name, vm in vms.items():
+        router_type = "leaf"
+        if 'tor' in v['properties']:
+            router_type = 'tor'
         vm_offset = vm['vm_offset']
         port = IPV4_BASE_PORT + vm_offset
         port6 = IPV6_BASE_PORT + vm_offset
@@ -512,6 +515,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
             routes_v4 = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
                                         spine_asn, leaf_asn_start, tor_asn_start,
                                         nhipv4, nhipv4, tor_subnet_size, max_tor_subnet_number, "t0",
+                                        router_type=router_type,
                                         no_default_route=no_default_route)
             if aggregate_routes_v4:
                 filterout_subnet_ipv4(aggregate_routes, routes_v4)
@@ -521,6 +525,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
             routes_v6 = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                         spine_asn, leaf_asn_start, tor_asn_start,
                                         nhipv6, nhipv6, tor_subnet_size, max_tor_subnet_number, "t0",
+                                        router_type=router_type,
                                         no_default_route=no_default_route,
                                         ipv6_address_pattern=ipv6_address_pattern)
             if aggregate_routes_v6:

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -501,7 +501,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce"):
     vms = topo['topology']['VMs']
     for vm_name, vm in vms.items():
         router_type = "leaf"
-        if 'tor' in v['properties']:
+        if 'tor' in topo['configuration'][vm_name]['properties']:
             router_type = 'tor'
         vm_offset = vm['vm_offset']
         port = IPV4_BASE_PORT + vm_offset

--- a/ansible/vars/topo_t0-isolated-d2u254.yml
+++ b/ansible/vars/topo_t0-isolated-d2u254.yml
@@ -1038,7 +1038,6 @@ configuration_properties:
   common:
     dut_asn: 4200000000
     dut_type: ToRRouter
-    swrole: leaf
     podset_number: 1
     tor_number: 512
     tor_subnet_number: 2
@@ -1052,11 +1051,16 @@ configuration_properties:
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
+  leaf:
+    swrole: leaf
+  tor:
+    swrole: tor
 
 configuration:
   ARISTA01T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.3
       asn: 4200100000
@@ -1074,6 +1078,7 @@ configuration:
   ARISTA02T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.4
       asn: 4200100000
@@ -1091,6 +1096,7 @@ configuration:
   ARISTA03T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.5
       asn: 4200100000
@@ -1108,6 +1114,7 @@ configuration:
   ARISTA04T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.6
       asn: 4200100000
@@ -1125,6 +1132,7 @@ configuration:
   ARISTA05T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.7
       asn: 4200100000
@@ -1142,6 +1150,7 @@ configuration:
   ARISTA06T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.8
       asn: 4200100000
@@ -1159,6 +1168,7 @@ configuration:
   ARISTA07T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.9
       asn: 4200100000
@@ -1176,6 +1186,7 @@ configuration:
   ARISTA08T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.10
       asn: 4200100000
@@ -1193,6 +1204,7 @@ configuration:
   ARISTA09T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.11
       asn: 4200100000
@@ -1210,6 +1222,7 @@ configuration:
   ARISTA10T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.12
       asn: 4200100000
@@ -1227,6 +1240,7 @@ configuration:
   ARISTA11T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.13
       asn: 4200100000
@@ -1244,6 +1258,7 @@ configuration:
   ARISTA12T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.14
       asn: 4200100000
@@ -1261,6 +1276,7 @@ configuration:
   ARISTA13T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.15
       asn: 4200100000
@@ -1278,6 +1294,7 @@ configuration:
   ARISTA14T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.16
       asn: 4200100000
@@ -1295,6 +1312,7 @@ configuration:
   ARISTA15T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.17
       asn: 4200100000
@@ -1312,6 +1330,7 @@ configuration:
   ARISTA16T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.18
       asn: 4200100000
@@ -1329,6 +1348,7 @@ configuration:
   ARISTA17T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.19
       asn: 4200100000
@@ -1346,6 +1366,7 @@ configuration:
   ARISTA18T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.20
       asn: 4200100000
@@ -1363,6 +1384,7 @@ configuration:
   ARISTA19T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.21
       asn: 4200100000
@@ -1380,6 +1402,7 @@ configuration:
   ARISTA20T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.22
       asn: 4200100000
@@ -1397,6 +1420,7 @@ configuration:
   ARISTA21T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.23
       asn: 4200100000
@@ -1414,6 +1438,7 @@ configuration:
   ARISTA22T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.24
       asn: 4200100000
@@ -1431,6 +1456,7 @@ configuration:
   ARISTA23T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.25
       asn: 4200100000
@@ -1448,6 +1474,7 @@ configuration:
   ARISTA24T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.26
       asn: 4200100000
@@ -1465,6 +1492,7 @@ configuration:
   ARISTA25T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.27
       asn: 4200100000
@@ -1482,6 +1510,7 @@ configuration:
   ARISTA26T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.28
       asn: 4200100000
@@ -1499,6 +1528,7 @@ configuration:
   ARISTA27T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.29
       asn: 4200100000
@@ -1516,6 +1546,7 @@ configuration:
   ARISTA28T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.30
       asn: 4200100000
@@ -1533,6 +1564,7 @@ configuration:
   ARISTA29T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.31
       asn: 4200100000
@@ -1550,6 +1582,7 @@ configuration:
   ARISTA30T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.32
       asn: 4200100000
@@ -1567,6 +1600,7 @@ configuration:
   ARISTA31T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.33
       asn: 4200100000
@@ -1584,6 +1618,7 @@ configuration:
   ARISTA32T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.34
       asn: 4200100000
@@ -1601,6 +1636,7 @@ configuration:
   ARISTA33T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.35
       asn: 4200100000
@@ -1618,6 +1654,7 @@ configuration:
   ARISTA34T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.36
       asn: 4200100000
@@ -1635,6 +1672,7 @@ configuration:
   ARISTA35T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.37
       asn: 4200100000
@@ -1652,6 +1690,7 @@ configuration:
   ARISTA36T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.38
       asn: 4200100000
@@ -1669,6 +1708,7 @@ configuration:
   ARISTA37T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.39
       asn: 4200100000
@@ -1686,6 +1726,7 @@ configuration:
   ARISTA38T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.40
       asn: 4200100000
@@ -1703,6 +1744,7 @@ configuration:
   ARISTA39T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.41
       asn: 4200100000
@@ -1720,6 +1762,7 @@ configuration:
   ARISTA40T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.42
       asn: 4200100000
@@ -1737,6 +1780,7 @@ configuration:
   ARISTA41T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.43
       asn: 4200100000
@@ -1754,6 +1798,7 @@ configuration:
   ARISTA42T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.44
       asn: 4200100000
@@ -1771,6 +1816,7 @@ configuration:
   ARISTA43T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.45
       asn: 4200100000
@@ -1788,6 +1834,7 @@ configuration:
   ARISTA44T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.46
       asn: 4200100000
@@ -1805,6 +1852,7 @@ configuration:
   ARISTA45T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.47
       asn: 4200100000
@@ -1822,6 +1870,7 @@ configuration:
   ARISTA46T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.48
       asn: 4200100000
@@ -1839,6 +1888,7 @@ configuration:
   ARISTA47T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.49
       asn: 4200100000
@@ -1856,6 +1906,7 @@ configuration:
   ARISTA48T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.50
       asn: 4200100000
@@ -1873,6 +1924,7 @@ configuration:
   ARISTA49T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.51
       asn: 4200100000
@@ -1890,6 +1942,7 @@ configuration:
   ARISTA50T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.52
       asn: 4200100000
@@ -1907,6 +1960,7 @@ configuration:
   ARISTA51T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.53
       asn: 4200100000
@@ -1924,6 +1978,7 @@ configuration:
   ARISTA52T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.54
       asn: 4200100000
@@ -1941,6 +1996,7 @@ configuration:
   ARISTA53T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.55
       asn: 4200100000
@@ -1958,6 +2014,7 @@ configuration:
   ARISTA54T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.56
       asn: 4200100000
@@ -1975,6 +2032,7 @@ configuration:
   ARISTA55T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.57
       asn: 4200100000
@@ -1992,6 +2050,7 @@ configuration:
   ARISTA56T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.58
       asn: 4200100000
@@ -2009,6 +2068,7 @@ configuration:
   ARISTA57T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.59
       asn: 4200100000
@@ -2026,6 +2086,7 @@ configuration:
   ARISTA58T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.60
       asn: 4200100000
@@ -2043,6 +2104,7 @@ configuration:
   ARISTA59T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.61
       asn: 4200100000
@@ -2060,6 +2122,7 @@ configuration:
   ARISTA60T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.62
       asn: 4200100000
@@ -2077,6 +2140,7 @@ configuration:
   ARISTA61T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.63
       asn: 4200100000
@@ -2094,6 +2158,7 @@ configuration:
   ARISTA62T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.64
       asn: 4200100000
@@ -2111,6 +2176,7 @@ configuration:
   ARISTA63T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.65
       asn: 4200100000
@@ -2128,6 +2194,7 @@ configuration:
   ARISTA64T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.66
       asn: 4200100000
@@ -2145,6 +2212,7 @@ configuration:
   ARISTA65T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.67
       asn: 4200100000
@@ -2162,6 +2230,7 @@ configuration:
   ARISTA66T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.68
       asn: 4200100000
@@ -2179,6 +2248,7 @@ configuration:
   ARISTA67T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.69
       asn: 4200100000
@@ -2196,6 +2266,7 @@ configuration:
   ARISTA68T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.70
       asn: 4200100000
@@ -2213,6 +2284,7 @@ configuration:
   ARISTA69T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.71
       asn: 4200100000
@@ -2230,6 +2302,7 @@ configuration:
   ARISTA70T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.72
       asn: 4200100000
@@ -2247,6 +2320,7 @@ configuration:
   ARISTA71T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.73
       asn: 4200100000
@@ -2264,6 +2338,7 @@ configuration:
   ARISTA72T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.74
       asn: 4200100000
@@ -2281,6 +2356,7 @@ configuration:
   ARISTA73T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.75
       asn: 4200100000
@@ -2298,6 +2374,7 @@ configuration:
   ARISTA74T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.76
       asn: 4200100000
@@ -2315,6 +2392,7 @@ configuration:
   ARISTA75T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.77
       asn: 4200100000
@@ -2332,6 +2410,7 @@ configuration:
   ARISTA76T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.78
       asn: 4200100000
@@ -2349,6 +2428,7 @@ configuration:
   ARISTA77T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.79
       asn: 4200100000
@@ -2366,6 +2446,7 @@ configuration:
   ARISTA78T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.80
       asn: 4200100000
@@ -2383,6 +2464,7 @@ configuration:
   ARISTA79T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.81
       asn: 4200100000
@@ -2400,6 +2482,7 @@ configuration:
   ARISTA80T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.82
       asn: 4200100000
@@ -2417,6 +2500,7 @@ configuration:
   ARISTA81T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.83
       asn: 4200100000
@@ -2434,6 +2518,7 @@ configuration:
   ARISTA82T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.84
       asn: 4200100000
@@ -2451,6 +2536,7 @@ configuration:
   ARISTA83T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.85
       asn: 4200100000
@@ -2468,6 +2554,7 @@ configuration:
   ARISTA84T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.86
       asn: 4200100000
@@ -2485,6 +2572,7 @@ configuration:
   ARISTA85T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.87
       asn: 4200100000
@@ -2502,6 +2590,7 @@ configuration:
   ARISTA86T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.88
       asn: 4200100000
@@ -2519,6 +2608,7 @@ configuration:
   ARISTA87T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.89
       asn: 4200100000
@@ -2536,6 +2626,7 @@ configuration:
   ARISTA88T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.90
       asn: 4200100000
@@ -2553,6 +2644,7 @@ configuration:
   ARISTA89T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.91
       asn: 4200100000
@@ -2570,6 +2662,7 @@ configuration:
   ARISTA90T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.92
       asn: 4200100000
@@ -2587,6 +2680,7 @@ configuration:
   ARISTA91T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.93
       asn: 4200100000
@@ -2604,6 +2698,7 @@ configuration:
   ARISTA92T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.94
       asn: 4200100000
@@ -2621,6 +2716,7 @@ configuration:
   ARISTA93T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.95
       asn: 4200100000
@@ -2638,6 +2734,7 @@ configuration:
   ARISTA94T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.96
       asn: 4200100000
@@ -2655,6 +2752,7 @@ configuration:
   ARISTA95T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.97
       asn: 4200100000
@@ -2672,6 +2770,7 @@ configuration:
   ARISTA96T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.98
       asn: 4200100000
@@ -2689,6 +2788,7 @@ configuration:
   ARISTA97T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.99
       asn: 4200100000
@@ -2706,6 +2806,7 @@ configuration:
   ARISTA98T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.100
       asn: 4200100000
@@ -2723,6 +2824,7 @@ configuration:
   ARISTA99T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.101
       asn: 4200100000
@@ -2740,6 +2842,7 @@ configuration:
   ARISTA100T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.102
       asn: 4200100000
@@ -2757,6 +2860,7 @@ configuration:
   ARISTA101T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.103
       asn: 4200100000
@@ -2774,6 +2878,7 @@ configuration:
   ARISTA102T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.104
       asn: 4200100000
@@ -2791,6 +2896,7 @@ configuration:
   ARISTA103T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.105
       asn: 4200100000
@@ -2808,6 +2914,7 @@ configuration:
   ARISTA104T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.106
       asn: 4200100000
@@ -2825,6 +2932,7 @@ configuration:
   ARISTA105T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.107
       asn: 4200100000
@@ -2842,6 +2950,7 @@ configuration:
   ARISTA106T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.108
       asn: 4200100000
@@ -2859,6 +2968,7 @@ configuration:
   ARISTA107T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.109
       asn: 4200100000
@@ -2876,6 +2986,7 @@ configuration:
   ARISTA108T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.110
       asn: 4200100000
@@ -2893,6 +3004,7 @@ configuration:
   ARISTA109T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.111
       asn: 4200100000
@@ -2910,6 +3022,7 @@ configuration:
   ARISTA110T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.112
       asn: 4200100000
@@ -2927,6 +3040,7 @@ configuration:
   ARISTA111T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.113
       asn: 4200100000
@@ -2944,6 +3058,7 @@ configuration:
   ARISTA112T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.114
       asn: 4200100000
@@ -2961,6 +3076,7 @@ configuration:
   ARISTA113T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.115
       asn: 4200100000
@@ -2978,6 +3094,7 @@ configuration:
   ARISTA114T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.116
       asn: 4200100000
@@ -2995,6 +3112,7 @@ configuration:
   ARISTA115T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.117
       asn: 4200100000
@@ -3012,6 +3130,7 @@ configuration:
   ARISTA116T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.118
       asn: 4200100000
@@ -3029,6 +3148,7 @@ configuration:
   ARISTA117T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.119
       asn: 4200100000
@@ -3046,6 +3166,7 @@ configuration:
   ARISTA118T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.120
       asn: 4200100000
@@ -3063,6 +3184,7 @@ configuration:
   ARISTA119T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.121
       asn: 4200100000
@@ -3080,6 +3202,7 @@ configuration:
   ARISTA120T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.122
       asn: 4200100000
@@ -3097,6 +3220,7 @@ configuration:
   ARISTA121T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.123
       asn: 4200100000
@@ -3114,6 +3238,7 @@ configuration:
   ARISTA122T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.124
       asn: 4200100000
@@ -3131,6 +3256,7 @@ configuration:
   ARISTA123T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.125
       asn: 4200100000
@@ -3148,6 +3274,7 @@ configuration:
   ARISTA124T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.126
       asn: 4200100000
@@ -3165,6 +3292,7 @@ configuration:
   ARISTA125T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.127
       asn: 4200100000
@@ -3182,6 +3310,7 @@ configuration:
   ARISTA126T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.128
       asn: 4200100000
@@ -3199,6 +3328,7 @@ configuration:
   ARISTA127T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.129
       asn: 4200100000
@@ -3216,6 +3346,7 @@ configuration:
   ARISTA128T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.130
       asn: 4200100000
@@ -3233,6 +3364,7 @@ configuration:
   ARISTA129T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.131
       asn: 4200100000
@@ -3250,6 +3382,7 @@ configuration:
   ARISTA130T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.132
       asn: 4200100000
@@ -3267,6 +3400,7 @@ configuration:
   ARISTA131T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.133
       asn: 4200100000
@@ -3284,6 +3418,7 @@ configuration:
   ARISTA132T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.134
       asn: 4200100000
@@ -3301,6 +3436,7 @@ configuration:
   ARISTA133T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.135
       asn: 4200100000
@@ -3318,6 +3454,7 @@ configuration:
   ARISTA134T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.136
       asn: 4200100000
@@ -3335,6 +3472,7 @@ configuration:
   ARISTA135T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.137
       asn: 4200100000
@@ -3352,6 +3490,7 @@ configuration:
   ARISTA136T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.138
       asn: 4200100000
@@ -3369,6 +3508,7 @@ configuration:
   ARISTA137T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.139
       asn: 4200100000
@@ -3386,6 +3526,7 @@ configuration:
   ARISTA138T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.140
       asn: 4200100000
@@ -3403,6 +3544,7 @@ configuration:
   ARISTA139T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.141
       asn: 4200100000
@@ -3420,6 +3562,7 @@ configuration:
   ARISTA140T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.142
       asn: 4200100000
@@ -3437,6 +3580,7 @@ configuration:
   ARISTA141T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.143
       asn: 4200100000
@@ -3454,6 +3598,7 @@ configuration:
   ARISTA142T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.144
       asn: 4200100000
@@ -3471,6 +3616,7 @@ configuration:
   ARISTA143T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.145
       asn: 4200100000
@@ -3488,6 +3634,7 @@ configuration:
   ARISTA144T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.146
       asn: 4200100000
@@ -3505,6 +3652,7 @@ configuration:
   ARISTA145T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.147
       asn: 4200100000
@@ -3522,6 +3670,7 @@ configuration:
   ARISTA146T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.148
       asn: 4200100000
@@ -3539,6 +3688,7 @@ configuration:
   ARISTA147T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.149
       asn: 4200100000
@@ -3556,6 +3706,7 @@ configuration:
   ARISTA148T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.150
       asn: 4200100000
@@ -3573,6 +3724,7 @@ configuration:
   ARISTA149T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.151
       asn: 4200100000
@@ -3590,6 +3742,7 @@ configuration:
   ARISTA150T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.152
       asn: 4200100000
@@ -3607,6 +3760,7 @@ configuration:
   ARISTA151T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.153
       asn: 4200100000
@@ -3624,6 +3778,7 @@ configuration:
   ARISTA152T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.154
       asn: 4200100000
@@ -3641,6 +3796,7 @@ configuration:
   ARISTA153T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.155
       asn: 4200100000
@@ -3658,6 +3814,7 @@ configuration:
   ARISTA154T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.156
       asn: 4200100000
@@ -3675,6 +3832,7 @@ configuration:
   ARISTA155T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.157
       asn: 4200100000
@@ -3692,6 +3850,7 @@ configuration:
   ARISTA156T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.158
       asn: 4200100000
@@ -3709,6 +3868,7 @@ configuration:
   ARISTA157T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.159
       asn: 4200100000
@@ -3726,6 +3886,7 @@ configuration:
   ARISTA158T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.160
       asn: 4200100000
@@ -3743,6 +3904,7 @@ configuration:
   ARISTA159T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.161
       asn: 4200100000
@@ -3760,6 +3922,7 @@ configuration:
   ARISTA160T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.162
       asn: 4200100000
@@ -3777,6 +3940,7 @@ configuration:
   ARISTA161T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.163
       asn: 4200100000
@@ -3794,6 +3958,7 @@ configuration:
   ARISTA162T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.164
       asn: 4200100000
@@ -3811,6 +3976,7 @@ configuration:
   ARISTA163T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.165
       asn: 4200100000
@@ -3828,6 +3994,7 @@ configuration:
   ARISTA164T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.166
       asn: 4200100000
@@ -3845,6 +4012,7 @@ configuration:
   ARISTA165T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.167
       asn: 4200100000
@@ -3862,6 +4030,7 @@ configuration:
   ARISTA166T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.168
       asn: 4200100000
@@ -3879,6 +4048,7 @@ configuration:
   ARISTA167T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.169
       asn: 4200100000
@@ -3896,6 +4066,7 @@ configuration:
   ARISTA168T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.170
       asn: 4200100000
@@ -3913,6 +4084,7 @@ configuration:
   ARISTA169T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.171
       asn: 4200100000
@@ -3930,6 +4102,7 @@ configuration:
   ARISTA170T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.172
       asn: 4200100000
@@ -3947,6 +4120,7 @@ configuration:
   ARISTA171T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.173
       asn: 4200100000
@@ -3964,6 +4138,7 @@ configuration:
   ARISTA172T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.174
       asn: 4200100000
@@ -3981,6 +4156,7 @@ configuration:
   ARISTA173T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.175
       asn: 4200100000
@@ -3998,6 +4174,7 @@ configuration:
   ARISTA174T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.176
       asn: 4200100000
@@ -4015,6 +4192,7 @@ configuration:
   ARISTA175T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.177
       asn: 4200100000
@@ -4032,6 +4210,7 @@ configuration:
   ARISTA176T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.178
       asn: 4200100000
@@ -4049,6 +4228,7 @@ configuration:
   ARISTA177T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.179
       asn: 4200100000
@@ -4066,6 +4246,7 @@ configuration:
   ARISTA178T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.180
       asn: 4200100000
@@ -4083,6 +4264,7 @@ configuration:
   ARISTA179T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.181
       asn: 4200100000
@@ -4100,6 +4282,7 @@ configuration:
   ARISTA180T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.182
       asn: 4200100000
@@ -4117,6 +4300,7 @@ configuration:
   ARISTA181T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.183
       asn: 4200100000
@@ -4134,6 +4318,7 @@ configuration:
   ARISTA182T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.184
       asn: 4200100000
@@ -4151,6 +4336,7 @@ configuration:
   ARISTA183T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.185
       asn: 4200100000
@@ -4168,6 +4354,7 @@ configuration:
   ARISTA184T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.186
       asn: 4200100000
@@ -4185,6 +4372,7 @@ configuration:
   ARISTA185T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.187
       asn: 4200100000
@@ -4202,6 +4390,7 @@ configuration:
   ARISTA186T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.188
       asn: 4200100000
@@ -4219,6 +4408,7 @@ configuration:
   ARISTA187T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.189
       asn: 4200100000
@@ -4236,6 +4426,7 @@ configuration:
   ARISTA188T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.190
       asn: 4200100000
@@ -4253,6 +4444,7 @@ configuration:
   ARISTA189T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.191
       asn: 4200100000
@@ -4270,6 +4462,7 @@ configuration:
   ARISTA190T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.192
       asn: 4200100000
@@ -4287,6 +4480,7 @@ configuration:
   ARISTA191T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.193
       asn: 4200100000
@@ -4304,6 +4498,7 @@ configuration:
   ARISTA192T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.194
       asn: 4200100000
@@ -4321,6 +4516,7 @@ configuration:
   ARISTA193T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.195
       asn: 4200100000
@@ -4338,6 +4534,7 @@ configuration:
   ARISTA194T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.196
       asn: 4200100000
@@ -4355,6 +4552,7 @@ configuration:
   ARISTA195T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.197
       asn: 4200100000
@@ -4372,6 +4570,7 @@ configuration:
   ARISTA196T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.198
       asn: 4200100000
@@ -4389,6 +4588,7 @@ configuration:
   ARISTA197T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.199
       asn: 4200100000
@@ -4406,6 +4606,7 @@ configuration:
   ARISTA198T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.200
       asn: 4200100000
@@ -4423,6 +4624,7 @@ configuration:
   ARISTA199T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.201
       asn: 4200100000
@@ -4440,6 +4642,7 @@ configuration:
   ARISTA200T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.202
       asn: 4200100000
@@ -4457,6 +4660,7 @@ configuration:
   ARISTA201T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.203
       asn: 4200100000
@@ -4474,6 +4678,7 @@ configuration:
   ARISTA202T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.204
       asn: 4200100000
@@ -4491,6 +4696,7 @@ configuration:
   ARISTA203T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.205
       asn: 4200100000
@@ -4508,6 +4714,7 @@ configuration:
   ARISTA204T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.206
       asn: 4200100000
@@ -4525,6 +4732,7 @@ configuration:
   ARISTA205T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.207
       asn: 4200100000
@@ -4542,6 +4750,7 @@ configuration:
   ARISTA206T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.208
       asn: 4200100000
@@ -4559,6 +4768,7 @@ configuration:
   ARISTA207T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.209
       asn: 4200100000
@@ -4576,6 +4786,7 @@ configuration:
   ARISTA208T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.210
       asn: 4200100000
@@ -4593,6 +4804,7 @@ configuration:
   ARISTA209T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.211
       asn: 4200100000
@@ -4610,6 +4822,7 @@ configuration:
   ARISTA210T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.212
       asn: 4200100000
@@ -4627,6 +4840,7 @@ configuration:
   ARISTA211T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.213
       asn: 4200100000
@@ -4644,6 +4858,7 @@ configuration:
   ARISTA212T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.214
       asn: 4200100000
@@ -4661,6 +4876,7 @@ configuration:
   ARISTA213T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.215
       asn: 4200100000
@@ -4678,6 +4894,7 @@ configuration:
   ARISTA214T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.216
       asn: 4200100000
@@ -4695,6 +4912,7 @@ configuration:
   ARISTA215T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.217
       asn: 4200100000
@@ -4712,6 +4930,7 @@ configuration:
   ARISTA216T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.218
       asn: 4200100000
@@ -4729,6 +4948,7 @@ configuration:
   ARISTA217T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.219
       asn: 4200100000
@@ -4746,6 +4966,7 @@ configuration:
   ARISTA218T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.220
       asn: 4200100000
@@ -4763,6 +4984,7 @@ configuration:
   ARISTA219T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.221
       asn: 4200100000
@@ -4780,6 +5002,7 @@ configuration:
   ARISTA220T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.222
       asn: 4200100000
@@ -4797,6 +5020,7 @@ configuration:
   ARISTA221T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.223
       asn: 4200100000
@@ -4814,6 +5038,7 @@ configuration:
   ARISTA222T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.224
       asn: 4200100000
@@ -4831,6 +5056,7 @@ configuration:
   ARISTA223T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.225
       asn: 4200100000
@@ -4848,6 +5074,7 @@ configuration:
   ARISTA224T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.226
       asn: 4200100000
@@ -4865,6 +5092,7 @@ configuration:
   ARISTA225T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.227
       asn: 4200100000
@@ -4882,6 +5110,7 @@ configuration:
   ARISTA226T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.228
       asn: 4200100000
@@ -4899,6 +5128,7 @@ configuration:
   ARISTA227T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.229
       asn: 4200100000
@@ -4916,6 +5146,7 @@ configuration:
   ARISTA228T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.230
       asn: 4200100000
@@ -4933,6 +5164,7 @@ configuration:
   ARISTA229T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.231
       asn: 4200100000
@@ -4950,6 +5182,7 @@ configuration:
   ARISTA230T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.232
       asn: 4200100000
@@ -4967,6 +5200,7 @@ configuration:
   ARISTA231T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.233
       asn: 4200100000
@@ -4984,6 +5218,7 @@ configuration:
   ARISTA232T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.234
       asn: 4200100000
@@ -5001,6 +5236,7 @@ configuration:
   ARISTA233T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.235
       asn: 4200100000
@@ -5018,6 +5254,7 @@ configuration:
   ARISTA234T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.236
       asn: 4200100000
@@ -5035,6 +5272,7 @@ configuration:
   ARISTA235T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.237
       asn: 4200100000
@@ -5052,6 +5290,7 @@ configuration:
   ARISTA236T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.238
       asn: 4200100000
@@ -5069,6 +5308,7 @@ configuration:
   ARISTA237T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.239
       asn: 4200100000
@@ -5086,6 +5326,7 @@ configuration:
   ARISTA238T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.240
       asn: 4200100000
@@ -5103,6 +5344,7 @@ configuration:
   ARISTA239T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.241
       asn: 4200100000
@@ -5120,6 +5362,7 @@ configuration:
   ARISTA240T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.242
       asn: 4200100000
@@ -5137,6 +5380,7 @@ configuration:
   ARISTA241T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.243
       asn: 4200100000
@@ -5154,6 +5398,7 @@ configuration:
   ARISTA242T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.244
       asn: 4200100000
@@ -5171,6 +5416,7 @@ configuration:
   ARISTA243T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.245
       asn: 4200100000
@@ -5188,6 +5434,7 @@ configuration:
   ARISTA244T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.246
       asn: 4200100000
@@ -5205,6 +5452,7 @@ configuration:
   ARISTA245T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.247
       asn: 4200100000
@@ -5222,6 +5470,7 @@ configuration:
   ARISTA246T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.248
       asn: 4200100000
@@ -5239,6 +5488,7 @@ configuration:
   ARISTA247T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.249
       asn: 4200100000
@@ -5256,6 +5506,7 @@ configuration:
   ARISTA248T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.250
       asn: 4200100000
@@ -5273,6 +5524,7 @@ configuration:
   ARISTA249T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.251
       asn: 4200100000
@@ -5290,6 +5542,7 @@ configuration:
   ARISTA250T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.252
       asn: 4200100000
@@ -5307,6 +5560,7 @@ configuration:
   ARISTA251T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.253
       asn: 4200100000
@@ -5324,6 +5578,7 @@ configuration:
   ARISTA252T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.254
       asn: 4200100000
@@ -5341,6 +5596,7 @@ configuration:
   ARISTA253T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.0
       asn: 4200100000
@@ -5358,6 +5614,7 @@ configuration:
   ARISTA254T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.1
       asn: 4200100000

--- a/ansible/vars/topo_t0-isolated-d2u254s1.yml
+++ b/ansible/vars/topo_t0-isolated-d2u254s1.yml
@@ -1042,7 +1042,6 @@ configuration_properties:
   common:
     dut_asn: 4200000000
     dut_type: ToRRouter
-    swrole: leaf
     podset_number: 1
     tor_number: 512
     tor_subnet_number: 2
@@ -1056,11 +1055,16 @@ configuration_properties:
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
+  leaf:
+    swrole: leaf
+  tor:
+    swrole: tor
 
 configuration:
   ARISTA01T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.3
       asn: 4200100000
@@ -1078,6 +1082,7 @@ configuration:
   ARISTA02T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.4
       asn: 4200100000
@@ -1095,6 +1100,7 @@ configuration:
   ARISTA03T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.5
       asn: 4200100000
@@ -1112,6 +1118,7 @@ configuration:
   ARISTA04T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.6
       asn: 4200100000
@@ -1129,6 +1136,7 @@ configuration:
   ARISTA05T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.7
       asn: 4200100000
@@ -1146,6 +1154,7 @@ configuration:
   ARISTA06T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.8
       asn: 4200100000
@@ -1163,6 +1172,7 @@ configuration:
   ARISTA07T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.9
       asn: 4200100000
@@ -1180,6 +1190,7 @@ configuration:
   ARISTA08T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.10
       asn: 4200100000
@@ -1197,6 +1208,7 @@ configuration:
   ARISTA09T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.11
       asn: 4200100000
@@ -1214,6 +1226,7 @@ configuration:
   ARISTA10T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.12
       asn: 4200100000
@@ -1231,6 +1244,7 @@ configuration:
   ARISTA11T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.13
       asn: 4200100000
@@ -1248,6 +1262,7 @@ configuration:
   ARISTA12T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.14
       asn: 4200100000
@@ -1265,6 +1280,7 @@ configuration:
   ARISTA13T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.15
       asn: 4200100000
@@ -1282,6 +1298,7 @@ configuration:
   ARISTA14T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.16
       asn: 4200100000
@@ -1299,6 +1316,7 @@ configuration:
   ARISTA15T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.17
       asn: 4200100000
@@ -1316,6 +1334,7 @@ configuration:
   ARISTA16T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.18
       asn: 4200100000
@@ -1333,6 +1352,7 @@ configuration:
   ARISTA17T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.19
       asn: 4200100000
@@ -1350,6 +1370,7 @@ configuration:
   ARISTA18T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.20
       asn: 4200100000
@@ -1367,6 +1388,7 @@ configuration:
   ARISTA19T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.21
       asn: 4200100000
@@ -1384,6 +1406,7 @@ configuration:
   ARISTA20T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.22
       asn: 4200100000
@@ -1401,6 +1424,7 @@ configuration:
   ARISTA21T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.23
       asn: 4200100000
@@ -1418,6 +1442,7 @@ configuration:
   ARISTA22T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.24
       asn: 4200100000
@@ -1435,6 +1460,7 @@ configuration:
   ARISTA23T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.25
       asn: 4200100000
@@ -1452,6 +1478,7 @@ configuration:
   ARISTA24T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.26
       asn: 4200100000
@@ -1469,6 +1496,7 @@ configuration:
   ARISTA25T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.27
       asn: 4200100000
@@ -1486,6 +1514,7 @@ configuration:
   ARISTA26T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.28
       asn: 4200100000
@@ -1503,6 +1532,7 @@ configuration:
   ARISTA27T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.29
       asn: 4200100000
@@ -1520,6 +1550,7 @@ configuration:
   ARISTA28T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.30
       asn: 4200100000
@@ -1537,6 +1568,7 @@ configuration:
   ARISTA29T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.31
       asn: 4200100000
@@ -1554,6 +1586,7 @@ configuration:
   ARISTA30T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.32
       asn: 4200100000
@@ -1571,6 +1604,7 @@ configuration:
   ARISTA31T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.33
       asn: 4200100000
@@ -1588,6 +1622,7 @@ configuration:
   ARISTA32T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.34
       asn: 4200100000
@@ -1605,6 +1640,7 @@ configuration:
   ARISTA33T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.35
       asn: 4200100000
@@ -1622,6 +1658,7 @@ configuration:
   ARISTA34T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.36
       asn: 4200100000
@@ -1639,6 +1676,7 @@ configuration:
   ARISTA35T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.37
       asn: 4200100000
@@ -1656,6 +1694,7 @@ configuration:
   ARISTA36T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.38
       asn: 4200100000
@@ -1673,6 +1712,7 @@ configuration:
   ARISTA37T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.39
       asn: 4200100000
@@ -1690,6 +1730,7 @@ configuration:
   ARISTA38T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.40
       asn: 4200100000
@@ -1707,6 +1748,7 @@ configuration:
   ARISTA39T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.41
       asn: 4200100000
@@ -1724,6 +1766,7 @@ configuration:
   ARISTA40T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.42
       asn: 4200100000
@@ -1741,6 +1784,7 @@ configuration:
   ARISTA41T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.43
       asn: 4200100000
@@ -1758,6 +1802,7 @@ configuration:
   ARISTA42T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.44
       asn: 4200100000
@@ -1775,6 +1820,7 @@ configuration:
   ARISTA43T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.45
       asn: 4200100000
@@ -1792,6 +1838,7 @@ configuration:
   ARISTA44T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.46
       asn: 4200100000
@@ -1809,6 +1856,7 @@ configuration:
   ARISTA45T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.47
       asn: 4200100000
@@ -1826,6 +1874,7 @@ configuration:
   ARISTA46T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.48
       asn: 4200100000
@@ -1843,6 +1892,7 @@ configuration:
   ARISTA47T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.49
       asn: 4200100000
@@ -1860,6 +1910,7 @@ configuration:
   ARISTA48T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.50
       asn: 4200100000
@@ -1877,6 +1928,7 @@ configuration:
   ARISTA49T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.51
       asn: 4200100000
@@ -1894,6 +1946,7 @@ configuration:
   ARISTA50T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.52
       asn: 4200100000
@@ -1911,6 +1964,7 @@ configuration:
   ARISTA51T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.53
       asn: 4200100000
@@ -1928,6 +1982,7 @@ configuration:
   ARISTA52T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.54
       asn: 4200100000
@@ -1945,6 +2000,7 @@ configuration:
   ARISTA53T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.55
       asn: 4200100000
@@ -1962,6 +2018,7 @@ configuration:
   ARISTA54T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.56
       asn: 4200100000
@@ -1979,6 +2036,7 @@ configuration:
   ARISTA55T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.57
       asn: 4200100000
@@ -1996,6 +2054,7 @@ configuration:
   ARISTA56T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.58
       asn: 4200100000
@@ -2013,6 +2072,7 @@ configuration:
   ARISTA57T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.59
       asn: 4200100000
@@ -2030,6 +2090,7 @@ configuration:
   ARISTA58T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.60
       asn: 4200100000
@@ -2047,6 +2108,7 @@ configuration:
   ARISTA59T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.61
       asn: 4200100000
@@ -2064,6 +2126,7 @@ configuration:
   ARISTA60T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.62
       asn: 4200100000
@@ -2081,6 +2144,7 @@ configuration:
   ARISTA61T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.63
       asn: 4200100000
@@ -2098,6 +2162,7 @@ configuration:
   ARISTA62T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.64
       asn: 4200100000
@@ -2115,6 +2180,7 @@ configuration:
   ARISTA63T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.65
       asn: 4200100000
@@ -2132,6 +2198,7 @@ configuration:
   ARISTA64T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.66
       asn: 4200100000
@@ -2149,6 +2216,7 @@ configuration:
   ARISTA65T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.67
       asn: 4200100000
@@ -2166,6 +2234,7 @@ configuration:
   ARISTA66T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.68
       asn: 4200100000
@@ -2183,6 +2252,7 @@ configuration:
   ARISTA67T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.69
       asn: 4200100000
@@ -2200,6 +2270,7 @@ configuration:
   ARISTA68T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.70
       asn: 4200100000
@@ -2217,6 +2288,7 @@ configuration:
   ARISTA69T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.71
       asn: 4200100000
@@ -2234,6 +2306,7 @@ configuration:
   ARISTA70T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.72
       asn: 4200100000
@@ -2251,6 +2324,7 @@ configuration:
   ARISTA71T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.73
       asn: 4200100000
@@ -2268,6 +2342,7 @@ configuration:
   ARISTA72T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.74
       asn: 4200100000
@@ -2285,6 +2360,7 @@ configuration:
   ARISTA73T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.75
       asn: 4200100000
@@ -2302,6 +2378,7 @@ configuration:
   ARISTA74T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.76
       asn: 4200100000
@@ -2319,6 +2396,7 @@ configuration:
   ARISTA75T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.77
       asn: 4200100000
@@ -2336,6 +2414,7 @@ configuration:
   ARISTA76T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.78
       asn: 4200100000
@@ -2353,6 +2432,7 @@ configuration:
   ARISTA77T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.79
       asn: 4200100000
@@ -2370,6 +2450,7 @@ configuration:
   ARISTA78T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.80
       asn: 4200100000
@@ -2387,6 +2468,7 @@ configuration:
   ARISTA79T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.81
       asn: 4200100000
@@ -2404,6 +2486,7 @@ configuration:
   ARISTA80T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.82
       asn: 4200100000
@@ -2421,6 +2504,7 @@ configuration:
   ARISTA81T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.83
       asn: 4200100000
@@ -2438,6 +2522,7 @@ configuration:
   ARISTA82T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.84
       asn: 4200100000
@@ -2455,6 +2540,7 @@ configuration:
   ARISTA83T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.85
       asn: 4200100000
@@ -2472,6 +2558,7 @@ configuration:
   ARISTA84T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.86
       asn: 4200100000
@@ -2489,6 +2576,7 @@ configuration:
   ARISTA85T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.87
       asn: 4200100000
@@ -2506,6 +2594,7 @@ configuration:
   ARISTA86T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.88
       asn: 4200100000
@@ -2523,6 +2612,7 @@ configuration:
   ARISTA87T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.89
       asn: 4200100000
@@ -2540,6 +2630,7 @@ configuration:
   ARISTA88T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.90
       asn: 4200100000
@@ -2557,6 +2648,7 @@ configuration:
   ARISTA89T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.91
       asn: 4200100000
@@ -2574,6 +2666,7 @@ configuration:
   ARISTA90T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.92
       asn: 4200100000
@@ -2591,6 +2684,7 @@ configuration:
   ARISTA91T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.93
       asn: 4200100000
@@ -2608,6 +2702,7 @@ configuration:
   ARISTA92T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.94
       asn: 4200100000
@@ -2625,6 +2720,7 @@ configuration:
   ARISTA93T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.95
       asn: 4200100000
@@ -2642,6 +2738,7 @@ configuration:
   ARISTA94T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.96
       asn: 4200100000
@@ -2659,6 +2756,7 @@ configuration:
   ARISTA95T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.97
       asn: 4200100000
@@ -2676,6 +2774,7 @@ configuration:
   ARISTA96T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.98
       asn: 4200100000
@@ -2693,6 +2792,7 @@ configuration:
   ARISTA97T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.99
       asn: 4200100000
@@ -2710,6 +2810,7 @@ configuration:
   ARISTA98T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.100
       asn: 4200100000
@@ -2727,6 +2828,7 @@ configuration:
   ARISTA99T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.101
       asn: 4200100000
@@ -2744,6 +2846,7 @@ configuration:
   ARISTA100T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.102
       asn: 4200100000
@@ -2761,6 +2864,7 @@ configuration:
   ARISTA101T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.103
       asn: 4200100000
@@ -2778,6 +2882,7 @@ configuration:
   ARISTA102T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.104
       asn: 4200100000
@@ -2795,6 +2900,7 @@ configuration:
   ARISTA103T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.105
       asn: 4200100000
@@ -2812,6 +2918,7 @@ configuration:
   ARISTA104T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.106
       asn: 4200100000
@@ -2829,6 +2936,7 @@ configuration:
   ARISTA105T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.107
       asn: 4200100000
@@ -2846,6 +2954,7 @@ configuration:
   ARISTA106T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.108
       asn: 4200100000
@@ -2863,6 +2972,7 @@ configuration:
   ARISTA107T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.109
       asn: 4200100000
@@ -2880,6 +2990,7 @@ configuration:
   ARISTA108T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.110
       asn: 4200100000
@@ -2897,6 +3008,7 @@ configuration:
   ARISTA109T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.111
       asn: 4200100000
@@ -2914,6 +3026,7 @@ configuration:
   ARISTA110T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.112
       asn: 4200100000
@@ -2931,6 +3044,7 @@ configuration:
   ARISTA111T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.113
       asn: 4200100000
@@ -2948,6 +3062,7 @@ configuration:
   ARISTA112T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.114
       asn: 4200100000
@@ -2965,6 +3080,7 @@ configuration:
   ARISTA113T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.115
       asn: 4200100000
@@ -2982,6 +3098,7 @@ configuration:
   ARISTA114T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.116
       asn: 4200100000
@@ -2999,6 +3116,7 @@ configuration:
   ARISTA115T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.117
       asn: 4200100000
@@ -3016,6 +3134,7 @@ configuration:
   ARISTA116T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.118
       asn: 4200100000
@@ -3033,6 +3152,7 @@ configuration:
   ARISTA117T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.119
       asn: 4200100000
@@ -3050,6 +3170,7 @@ configuration:
   ARISTA118T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.120
       asn: 4200100000
@@ -3067,6 +3188,7 @@ configuration:
   ARISTA119T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.121
       asn: 4200100000
@@ -3084,6 +3206,7 @@ configuration:
   ARISTA120T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.122
       asn: 4200100000
@@ -3101,6 +3224,7 @@ configuration:
   ARISTA121T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.123
       asn: 4200100000
@@ -3118,6 +3242,7 @@ configuration:
   ARISTA122T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.124
       asn: 4200100000
@@ -3135,6 +3260,7 @@ configuration:
   ARISTA123T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.125
       asn: 4200100000
@@ -3152,6 +3278,7 @@ configuration:
   ARISTA124T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.126
       asn: 4200100000
@@ -3169,6 +3296,7 @@ configuration:
   ARISTA125T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.127
       asn: 4200100000
@@ -3186,6 +3314,7 @@ configuration:
   ARISTA126T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.128
       asn: 4200100000
@@ -3203,6 +3332,7 @@ configuration:
   ARISTA127T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.129
       asn: 4200100000
@@ -3220,6 +3350,7 @@ configuration:
   ARISTA128T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.130
       asn: 4200100000
@@ -3237,6 +3368,7 @@ configuration:
   ARISTA129T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.131
       asn: 4200100000
@@ -3254,6 +3386,7 @@ configuration:
   ARISTA130T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.132
       asn: 4200100000
@@ -3271,6 +3404,7 @@ configuration:
   ARISTA131T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.133
       asn: 4200100000
@@ -3288,6 +3422,7 @@ configuration:
   ARISTA132T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.134
       asn: 4200100000
@@ -3305,6 +3440,7 @@ configuration:
   ARISTA133T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.135
       asn: 4200100000
@@ -3322,6 +3458,7 @@ configuration:
   ARISTA134T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.136
       asn: 4200100000
@@ -3339,6 +3476,7 @@ configuration:
   ARISTA135T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.137
       asn: 4200100000
@@ -3356,6 +3494,7 @@ configuration:
   ARISTA136T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.138
       asn: 4200100000
@@ -3373,6 +3512,7 @@ configuration:
   ARISTA137T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.139
       asn: 4200100000
@@ -3390,6 +3530,7 @@ configuration:
   ARISTA138T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.140
       asn: 4200100000
@@ -3407,6 +3548,7 @@ configuration:
   ARISTA139T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.141
       asn: 4200100000
@@ -3424,6 +3566,7 @@ configuration:
   ARISTA140T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.142
       asn: 4200100000
@@ -3441,6 +3584,7 @@ configuration:
   ARISTA141T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.143
       asn: 4200100000
@@ -3458,6 +3602,7 @@ configuration:
   ARISTA142T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.144
       asn: 4200100000
@@ -3475,6 +3620,7 @@ configuration:
   ARISTA143T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.145
       asn: 4200100000
@@ -3492,6 +3638,7 @@ configuration:
   ARISTA144T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.146
       asn: 4200100000
@@ -3509,6 +3656,7 @@ configuration:
   ARISTA145T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.147
       asn: 4200100000
@@ -3526,6 +3674,7 @@ configuration:
   ARISTA146T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.148
       asn: 4200100000
@@ -3543,6 +3692,7 @@ configuration:
   ARISTA147T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.149
       asn: 4200100000
@@ -3560,6 +3710,7 @@ configuration:
   ARISTA148T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.150
       asn: 4200100000
@@ -3577,6 +3728,7 @@ configuration:
   ARISTA149T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.151
       asn: 4200100000
@@ -3594,6 +3746,7 @@ configuration:
   ARISTA150T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.152
       asn: 4200100000
@@ -3611,6 +3764,7 @@ configuration:
   ARISTA151T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.153
       asn: 4200100000
@@ -3628,6 +3782,7 @@ configuration:
   ARISTA152T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.154
       asn: 4200100000
@@ -3645,6 +3800,7 @@ configuration:
   ARISTA153T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.155
       asn: 4200100000
@@ -3662,6 +3818,7 @@ configuration:
   ARISTA154T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.156
       asn: 4200100000
@@ -3679,6 +3836,7 @@ configuration:
   ARISTA155T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.157
       asn: 4200100000
@@ -3696,6 +3854,7 @@ configuration:
   ARISTA156T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.158
       asn: 4200100000
@@ -3713,6 +3872,7 @@ configuration:
   ARISTA157T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.159
       asn: 4200100000
@@ -3730,6 +3890,7 @@ configuration:
   ARISTA158T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.160
       asn: 4200100000
@@ -3747,6 +3908,7 @@ configuration:
   ARISTA159T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.161
       asn: 4200100000
@@ -3764,6 +3926,7 @@ configuration:
   ARISTA160T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.162
       asn: 4200100000
@@ -3781,6 +3944,7 @@ configuration:
   ARISTA161T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.163
       asn: 4200100000
@@ -3798,6 +3962,7 @@ configuration:
   ARISTA162T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.164
       asn: 4200100000
@@ -3815,6 +3980,7 @@ configuration:
   ARISTA163T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.165
       asn: 4200100000
@@ -3832,6 +3998,7 @@ configuration:
   ARISTA164T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.166
       asn: 4200100000
@@ -3849,6 +4016,7 @@ configuration:
   ARISTA165T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.167
       asn: 4200100000
@@ -3866,6 +4034,7 @@ configuration:
   ARISTA166T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.168
       asn: 4200100000
@@ -3883,6 +4052,7 @@ configuration:
   ARISTA167T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.169
       asn: 4200100000
@@ -3900,6 +4070,7 @@ configuration:
   ARISTA168T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.170
       asn: 4200100000
@@ -3917,6 +4088,7 @@ configuration:
   ARISTA169T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.171
       asn: 4200100000
@@ -3934,6 +4106,7 @@ configuration:
   ARISTA170T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.172
       asn: 4200100000
@@ -3951,6 +4124,7 @@ configuration:
   ARISTA171T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.173
       asn: 4200100000
@@ -3968,6 +4142,7 @@ configuration:
   ARISTA172T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.174
       asn: 4200100000
@@ -3985,6 +4160,7 @@ configuration:
   ARISTA173T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.175
       asn: 4200100000
@@ -4002,6 +4178,7 @@ configuration:
   ARISTA174T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.176
       asn: 4200100000
@@ -4019,6 +4196,7 @@ configuration:
   ARISTA175T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.177
       asn: 4200100000
@@ -4036,6 +4214,7 @@ configuration:
   ARISTA176T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.178
       asn: 4200100000
@@ -4053,6 +4232,7 @@ configuration:
   ARISTA177T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.179
       asn: 4200100000
@@ -4070,6 +4250,7 @@ configuration:
   ARISTA178T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.180
       asn: 4200100000
@@ -4087,6 +4268,7 @@ configuration:
   ARISTA179T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.181
       asn: 4200100000
@@ -4104,6 +4286,7 @@ configuration:
   ARISTA180T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.182
       asn: 4200100000
@@ -4121,6 +4304,7 @@ configuration:
   ARISTA181T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.183
       asn: 4200100000
@@ -4138,6 +4322,7 @@ configuration:
   ARISTA182T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.184
       asn: 4200100000
@@ -4155,6 +4340,7 @@ configuration:
   ARISTA183T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.185
       asn: 4200100000
@@ -4172,6 +4358,7 @@ configuration:
   ARISTA184T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.186
       asn: 4200100000
@@ -4189,6 +4376,7 @@ configuration:
   ARISTA185T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.187
       asn: 4200100000
@@ -4206,6 +4394,7 @@ configuration:
   ARISTA186T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.188
       asn: 4200100000
@@ -4223,6 +4412,7 @@ configuration:
   ARISTA187T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.189
       asn: 4200100000
@@ -4240,6 +4430,7 @@ configuration:
   ARISTA188T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.190
       asn: 4200100000
@@ -4257,6 +4448,7 @@ configuration:
   ARISTA189T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.191
       asn: 4200100000
@@ -4274,6 +4466,7 @@ configuration:
   ARISTA190T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.192
       asn: 4200100000
@@ -4291,6 +4484,7 @@ configuration:
   ARISTA191T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.193
       asn: 4200100000
@@ -4308,6 +4502,7 @@ configuration:
   ARISTA192T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.194
       asn: 4200100000
@@ -4325,6 +4520,7 @@ configuration:
   ARISTA193T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.195
       asn: 4200100000
@@ -4342,6 +4538,7 @@ configuration:
   ARISTA194T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.196
       asn: 4200100000
@@ -4359,6 +4556,7 @@ configuration:
   ARISTA195T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.197
       asn: 4200100000
@@ -4376,6 +4574,7 @@ configuration:
   ARISTA196T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.198
       asn: 4200100000
@@ -4393,6 +4592,7 @@ configuration:
   ARISTA197T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.199
       asn: 4200100000
@@ -4410,6 +4610,7 @@ configuration:
   ARISTA198T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.200
       asn: 4200100000
@@ -4427,6 +4628,7 @@ configuration:
   ARISTA199T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.201
       asn: 4200100000
@@ -4444,6 +4646,7 @@ configuration:
   ARISTA200T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.202
       asn: 4200100000
@@ -4461,6 +4664,7 @@ configuration:
   ARISTA201T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.203
       asn: 4200100000
@@ -4478,6 +4682,7 @@ configuration:
   ARISTA202T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.204
       asn: 4200100000
@@ -4495,6 +4700,7 @@ configuration:
   ARISTA203T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.205
       asn: 4200100000
@@ -4512,6 +4718,7 @@ configuration:
   ARISTA204T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.206
       asn: 4200100000
@@ -4529,6 +4736,7 @@ configuration:
   ARISTA205T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.207
       asn: 4200100000
@@ -4546,6 +4754,7 @@ configuration:
   ARISTA206T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.208
       asn: 4200100000
@@ -4563,6 +4772,7 @@ configuration:
   ARISTA207T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.209
       asn: 4200100000
@@ -4580,6 +4790,7 @@ configuration:
   ARISTA208T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.210
       asn: 4200100000
@@ -4597,6 +4808,7 @@ configuration:
   ARISTA209T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.211
       asn: 4200100000
@@ -4614,6 +4826,7 @@ configuration:
   ARISTA210T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.212
       asn: 4200100000
@@ -4631,6 +4844,7 @@ configuration:
   ARISTA211T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.213
       asn: 4200100000
@@ -4648,6 +4862,7 @@ configuration:
   ARISTA212T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.214
       asn: 4200100000
@@ -4665,6 +4880,7 @@ configuration:
   ARISTA213T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.215
       asn: 4200100000
@@ -4682,6 +4898,7 @@ configuration:
   ARISTA214T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.216
       asn: 4200100000
@@ -4699,6 +4916,7 @@ configuration:
   ARISTA215T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.217
       asn: 4200100000
@@ -4716,6 +4934,7 @@ configuration:
   ARISTA216T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.218
       asn: 4200100000
@@ -4733,6 +4952,7 @@ configuration:
   ARISTA217T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.219
       asn: 4200100000
@@ -4750,6 +4970,7 @@ configuration:
   ARISTA218T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.220
       asn: 4200100000
@@ -4767,6 +4988,7 @@ configuration:
   ARISTA219T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.221
       asn: 4200100000
@@ -4784,6 +5006,7 @@ configuration:
   ARISTA220T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.222
       asn: 4200100000
@@ -4801,6 +5024,7 @@ configuration:
   ARISTA221T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.223
       asn: 4200100000
@@ -4818,6 +5042,7 @@ configuration:
   ARISTA222T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.224
       asn: 4200100000
@@ -4835,6 +5060,7 @@ configuration:
   ARISTA223T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.225
       asn: 4200100000
@@ -4852,6 +5078,7 @@ configuration:
   ARISTA224T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.226
       asn: 4200100000
@@ -4869,6 +5096,7 @@ configuration:
   ARISTA225T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.227
       asn: 4200100000
@@ -4886,6 +5114,7 @@ configuration:
   ARISTA226T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.228
       asn: 4200100000
@@ -4903,6 +5132,7 @@ configuration:
   ARISTA227T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.229
       asn: 4200100000
@@ -4920,6 +5150,7 @@ configuration:
   ARISTA228T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.230
       asn: 4200100000
@@ -4937,6 +5168,7 @@ configuration:
   ARISTA229T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.231
       asn: 4200100000
@@ -4954,6 +5186,7 @@ configuration:
   ARISTA230T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.232
       asn: 4200100000
@@ -4971,6 +5204,7 @@ configuration:
   ARISTA231T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.233
       asn: 4200100000
@@ -4988,6 +5222,7 @@ configuration:
   ARISTA232T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.234
       asn: 4200100000
@@ -5005,6 +5240,7 @@ configuration:
   ARISTA233T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.235
       asn: 4200100000
@@ -5022,6 +5258,7 @@ configuration:
   ARISTA234T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.236
       asn: 4200100000
@@ -5039,6 +5276,7 @@ configuration:
   ARISTA235T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.237
       asn: 4200100000
@@ -5056,6 +5294,7 @@ configuration:
   ARISTA236T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.238
       asn: 4200100000
@@ -5073,6 +5312,7 @@ configuration:
   ARISTA237T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.239
       asn: 4200100000
@@ -5090,6 +5330,7 @@ configuration:
   ARISTA238T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.240
       asn: 4200100000
@@ -5107,6 +5348,7 @@ configuration:
   ARISTA239T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.241
       asn: 4200100000
@@ -5124,6 +5366,7 @@ configuration:
   ARISTA240T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.242
       asn: 4200100000
@@ -5141,6 +5384,7 @@ configuration:
   ARISTA241T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.243
       asn: 4200100000
@@ -5158,6 +5402,7 @@ configuration:
   ARISTA242T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.244
       asn: 4200100000
@@ -5175,6 +5420,7 @@ configuration:
   ARISTA243T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.245
       asn: 4200100000
@@ -5192,6 +5438,7 @@ configuration:
   ARISTA244T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.246
       asn: 4200100000
@@ -5209,6 +5456,7 @@ configuration:
   ARISTA245T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.247
       asn: 4200100000
@@ -5226,6 +5474,7 @@ configuration:
   ARISTA246T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.248
       asn: 4200100000
@@ -5243,6 +5492,7 @@ configuration:
   ARISTA247T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.249
       asn: 4200100000
@@ -5260,6 +5510,7 @@ configuration:
   ARISTA248T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.250
       asn: 4200100000
@@ -5277,6 +5528,7 @@ configuration:
   ARISTA249T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.251
       asn: 4200100000
@@ -5294,6 +5546,7 @@ configuration:
   ARISTA250T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.252
       asn: 4200100000
@@ -5311,6 +5564,7 @@ configuration:
   ARISTA251T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.253
       asn: 4200100000
@@ -5328,6 +5582,7 @@ configuration:
   ARISTA252T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.254
       asn: 4200100000
@@ -5345,6 +5600,7 @@ configuration:
   ARISTA253T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.0
       asn: 4200100000
@@ -5362,6 +5618,7 @@ configuration:
   ARISTA254T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.1
       asn: 4200100000
@@ -5379,6 +5636,7 @@ configuration:
   ARISTA01PT0:
     properties:
     - common
+    - tor
     bgp:
       router-id: 0.12.1.2
       asn: 4200000001

--- a/ansible/vars/topo_t0-isolated-d2u254s2.yml
+++ b/ansible/vars/topo_t0-isolated-d2u254s2.yml
@@ -1046,7 +1046,6 @@ configuration_properties:
   common:
     dut_asn: 4200000000
     dut_type: ToRRouter
-    swrole: leaf
     podset_number: 1
     tor_number: 512
     tor_subnet_number: 2
@@ -1060,11 +1059,16 @@ configuration_properties:
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
+  leaf:
+    swrole: leaf
+  tor:
+    swrole: tor
 
 configuration:
   ARISTA01T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.3
       asn: 4200100000
@@ -1082,6 +1086,7 @@ configuration:
   ARISTA02T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.4
       asn: 4200100000
@@ -1099,6 +1104,7 @@ configuration:
   ARISTA03T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.5
       asn: 4200100000
@@ -1116,6 +1122,7 @@ configuration:
   ARISTA04T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.6
       asn: 4200100000
@@ -1133,6 +1140,7 @@ configuration:
   ARISTA05T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.7
       asn: 4200100000
@@ -1150,6 +1158,7 @@ configuration:
   ARISTA06T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.8
       asn: 4200100000
@@ -1167,6 +1176,7 @@ configuration:
   ARISTA07T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.9
       asn: 4200100000
@@ -1184,6 +1194,7 @@ configuration:
   ARISTA08T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.10
       asn: 4200100000
@@ -1201,6 +1212,7 @@ configuration:
   ARISTA09T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.11
       asn: 4200100000
@@ -1218,6 +1230,7 @@ configuration:
   ARISTA10T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.12
       asn: 4200100000
@@ -1235,6 +1248,7 @@ configuration:
   ARISTA11T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.13
       asn: 4200100000
@@ -1252,6 +1266,7 @@ configuration:
   ARISTA12T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.14
       asn: 4200100000
@@ -1269,6 +1284,7 @@ configuration:
   ARISTA13T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.15
       asn: 4200100000
@@ -1286,6 +1302,7 @@ configuration:
   ARISTA14T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.16
       asn: 4200100000
@@ -1303,6 +1320,7 @@ configuration:
   ARISTA15T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.17
       asn: 4200100000
@@ -1320,6 +1338,7 @@ configuration:
   ARISTA16T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.18
       asn: 4200100000
@@ -1337,6 +1356,7 @@ configuration:
   ARISTA17T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.19
       asn: 4200100000
@@ -1354,6 +1374,7 @@ configuration:
   ARISTA18T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.20
       asn: 4200100000
@@ -1371,6 +1392,7 @@ configuration:
   ARISTA19T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.21
       asn: 4200100000
@@ -1388,6 +1410,7 @@ configuration:
   ARISTA20T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.22
       asn: 4200100000
@@ -1405,6 +1428,7 @@ configuration:
   ARISTA21T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.23
       asn: 4200100000
@@ -1422,6 +1446,7 @@ configuration:
   ARISTA22T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.24
       asn: 4200100000
@@ -1439,6 +1464,7 @@ configuration:
   ARISTA23T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.25
       asn: 4200100000
@@ -1456,6 +1482,7 @@ configuration:
   ARISTA24T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.26
       asn: 4200100000
@@ -1473,6 +1500,7 @@ configuration:
   ARISTA25T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.27
       asn: 4200100000
@@ -1490,6 +1518,7 @@ configuration:
   ARISTA26T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.28
       asn: 4200100000
@@ -1507,6 +1536,7 @@ configuration:
   ARISTA27T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.29
       asn: 4200100000
@@ -1524,6 +1554,7 @@ configuration:
   ARISTA28T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.30
       asn: 4200100000
@@ -1541,6 +1572,7 @@ configuration:
   ARISTA29T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.31
       asn: 4200100000
@@ -1558,6 +1590,7 @@ configuration:
   ARISTA30T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.32
       asn: 4200100000
@@ -1575,6 +1608,7 @@ configuration:
   ARISTA31T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.33
       asn: 4200100000
@@ -1592,6 +1626,7 @@ configuration:
   ARISTA32T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.34
       asn: 4200100000
@@ -1609,6 +1644,7 @@ configuration:
   ARISTA33T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.35
       asn: 4200100000
@@ -1626,6 +1662,7 @@ configuration:
   ARISTA34T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.36
       asn: 4200100000
@@ -1643,6 +1680,7 @@ configuration:
   ARISTA35T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.37
       asn: 4200100000
@@ -1660,6 +1698,7 @@ configuration:
   ARISTA36T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.38
       asn: 4200100000
@@ -1677,6 +1716,7 @@ configuration:
   ARISTA37T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.39
       asn: 4200100000
@@ -1694,6 +1734,7 @@ configuration:
   ARISTA38T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.40
       asn: 4200100000
@@ -1711,6 +1752,7 @@ configuration:
   ARISTA39T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.41
       asn: 4200100000
@@ -1728,6 +1770,7 @@ configuration:
   ARISTA40T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.42
       asn: 4200100000
@@ -1745,6 +1788,7 @@ configuration:
   ARISTA41T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.43
       asn: 4200100000
@@ -1762,6 +1806,7 @@ configuration:
   ARISTA42T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.44
       asn: 4200100000
@@ -1779,6 +1824,7 @@ configuration:
   ARISTA43T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.45
       asn: 4200100000
@@ -1796,6 +1842,7 @@ configuration:
   ARISTA44T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.46
       asn: 4200100000
@@ -1813,6 +1860,7 @@ configuration:
   ARISTA45T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.47
       asn: 4200100000
@@ -1830,6 +1878,7 @@ configuration:
   ARISTA46T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.48
       asn: 4200100000
@@ -1847,6 +1896,7 @@ configuration:
   ARISTA47T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.49
       asn: 4200100000
@@ -1864,6 +1914,7 @@ configuration:
   ARISTA48T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.50
       asn: 4200100000
@@ -1881,6 +1932,7 @@ configuration:
   ARISTA49T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.51
       asn: 4200100000
@@ -1898,6 +1950,7 @@ configuration:
   ARISTA50T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.52
       asn: 4200100000
@@ -1915,6 +1968,7 @@ configuration:
   ARISTA51T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.53
       asn: 4200100000
@@ -1932,6 +1986,7 @@ configuration:
   ARISTA52T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.54
       asn: 4200100000
@@ -1949,6 +2004,7 @@ configuration:
   ARISTA53T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.55
       asn: 4200100000
@@ -1966,6 +2022,7 @@ configuration:
   ARISTA54T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.56
       asn: 4200100000
@@ -1983,6 +2040,7 @@ configuration:
   ARISTA55T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.57
       asn: 4200100000
@@ -2000,6 +2058,7 @@ configuration:
   ARISTA56T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.58
       asn: 4200100000
@@ -2017,6 +2076,7 @@ configuration:
   ARISTA57T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.59
       asn: 4200100000
@@ -2034,6 +2094,7 @@ configuration:
   ARISTA58T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.60
       asn: 4200100000
@@ -2051,6 +2112,7 @@ configuration:
   ARISTA59T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.61
       asn: 4200100000
@@ -2068,6 +2130,7 @@ configuration:
   ARISTA60T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.62
       asn: 4200100000
@@ -2085,6 +2148,7 @@ configuration:
   ARISTA61T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.63
       asn: 4200100000
@@ -2102,6 +2166,7 @@ configuration:
   ARISTA62T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.64
       asn: 4200100000
@@ -2119,6 +2184,7 @@ configuration:
   ARISTA63T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.65
       asn: 4200100000
@@ -2136,6 +2202,7 @@ configuration:
   ARISTA64T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.66
       asn: 4200100000
@@ -2153,6 +2220,7 @@ configuration:
   ARISTA65T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.67
       asn: 4200100000
@@ -2170,6 +2238,7 @@ configuration:
   ARISTA66T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.68
       asn: 4200100000
@@ -2187,6 +2256,7 @@ configuration:
   ARISTA67T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.69
       asn: 4200100000
@@ -2204,6 +2274,7 @@ configuration:
   ARISTA68T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.70
       asn: 4200100000
@@ -2221,6 +2292,7 @@ configuration:
   ARISTA69T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.71
       asn: 4200100000
@@ -2238,6 +2310,7 @@ configuration:
   ARISTA70T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.72
       asn: 4200100000
@@ -2255,6 +2328,7 @@ configuration:
   ARISTA71T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.73
       asn: 4200100000
@@ -2272,6 +2346,7 @@ configuration:
   ARISTA72T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.74
       asn: 4200100000
@@ -2289,6 +2364,7 @@ configuration:
   ARISTA73T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.75
       asn: 4200100000
@@ -2306,6 +2382,7 @@ configuration:
   ARISTA74T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.76
       asn: 4200100000
@@ -2323,6 +2400,7 @@ configuration:
   ARISTA75T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.77
       asn: 4200100000
@@ -2340,6 +2418,7 @@ configuration:
   ARISTA76T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.78
       asn: 4200100000
@@ -2357,6 +2436,7 @@ configuration:
   ARISTA77T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.79
       asn: 4200100000
@@ -2374,6 +2454,7 @@ configuration:
   ARISTA78T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.80
       asn: 4200100000
@@ -2391,6 +2472,7 @@ configuration:
   ARISTA79T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.81
       asn: 4200100000
@@ -2408,6 +2490,7 @@ configuration:
   ARISTA80T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.82
       asn: 4200100000
@@ -2425,6 +2508,7 @@ configuration:
   ARISTA81T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.83
       asn: 4200100000
@@ -2442,6 +2526,7 @@ configuration:
   ARISTA82T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.84
       asn: 4200100000
@@ -2459,6 +2544,7 @@ configuration:
   ARISTA83T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.85
       asn: 4200100000
@@ -2476,6 +2562,7 @@ configuration:
   ARISTA84T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.86
       asn: 4200100000
@@ -2493,6 +2580,7 @@ configuration:
   ARISTA85T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.87
       asn: 4200100000
@@ -2510,6 +2598,7 @@ configuration:
   ARISTA86T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.88
       asn: 4200100000
@@ -2527,6 +2616,7 @@ configuration:
   ARISTA87T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.89
       asn: 4200100000
@@ -2544,6 +2634,7 @@ configuration:
   ARISTA88T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.90
       asn: 4200100000
@@ -2561,6 +2652,7 @@ configuration:
   ARISTA89T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.91
       asn: 4200100000
@@ -2578,6 +2670,7 @@ configuration:
   ARISTA90T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.92
       asn: 4200100000
@@ -2595,6 +2688,7 @@ configuration:
   ARISTA91T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.93
       asn: 4200100000
@@ -2612,6 +2706,7 @@ configuration:
   ARISTA92T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.94
       asn: 4200100000
@@ -2629,6 +2724,7 @@ configuration:
   ARISTA93T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.95
       asn: 4200100000
@@ -2646,6 +2742,7 @@ configuration:
   ARISTA94T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.96
       asn: 4200100000
@@ -2663,6 +2760,7 @@ configuration:
   ARISTA95T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.97
       asn: 4200100000
@@ -2680,6 +2778,7 @@ configuration:
   ARISTA96T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.98
       asn: 4200100000
@@ -2697,6 +2796,7 @@ configuration:
   ARISTA97T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.99
       asn: 4200100000
@@ -2714,6 +2814,7 @@ configuration:
   ARISTA98T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.100
       asn: 4200100000
@@ -2731,6 +2832,7 @@ configuration:
   ARISTA99T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.101
       asn: 4200100000
@@ -2748,6 +2850,7 @@ configuration:
   ARISTA100T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.102
       asn: 4200100000
@@ -2765,6 +2868,7 @@ configuration:
   ARISTA101T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.103
       asn: 4200100000
@@ -2782,6 +2886,7 @@ configuration:
   ARISTA102T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.104
       asn: 4200100000
@@ -2799,6 +2904,7 @@ configuration:
   ARISTA103T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.105
       asn: 4200100000
@@ -2816,6 +2922,7 @@ configuration:
   ARISTA104T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.106
       asn: 4200100000
@@ -2833,6 +2940,7 @@ configuration:
   ARISTA105T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.107
       asn: 4200100000
@@ -2850,6 +2958,7 @@ configuration:
   ARISTA106T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.108
       asn: 4200100000
@@ -2867,6 +2976,7 @@ configuration:
   ARISTA107T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.109
       asn: 4200100000
@@ -2884,6 +2994,7 @@ configuration:
   ARISTA108T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.110
       asn: 4200100000
@@ -2901,6 +3012,7 @@ configuration:
   ARISTA109T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.111
       asn: 4200100000
@@ -2918,6 +3030,7 @@ configuration:
   ARISTA110T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.112
       asn: 4200100000
@@ -2935,6 +3048,7 @@ configuration:
   ARISTA111T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.113
       asn: 4200100000
@@ -2952,6 +3066,7 @@ configuration:
   ARISTA112T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.114
       asn: 4200100000
@@ -2969,6 +3084,7 @@ configuration:
   ARISTA113T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.115
       asn: 4200100000
@@ -2986,6 +3102,7 @@ configuration:
   ARISTA114T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.116
       asn: 4200100000
@@ -3003,6 +3120,7 @@ configuration:
   ARISTA115T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.117
       asn: 4200100000
@@ -3020,6 +3138,7 @@ configuration:
   ARISTA116T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.118
       asn: 4200100000
@@ -3037,6 +3156,7 @@ configuration:
   ARISTA117T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.119
       asn: 4200100000
@@ -3054,6 +3174,7 @@ configuration:
   ARISTA118T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.120
       asn: 4200100000
@@ -3071,6 +3192,7 @@ configuration:
   ARISTA119T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.121
       asn: 4200100000
@@ -3088,6 +3210,7 @@ configuration:
   ARISTA120T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.122
       asn: 4200100000
@@ -3105,6 +3228,7 @@ configuration:
   ARISTA121T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.123
       asn: 4200100000
@@ -3122,6 +3246,7 @@ configuration:
   ARISTA122T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.124
       asn: 4200100000
@@ -3139,6 +3264,7 @@ configuration:
   ARISTA123T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.125
       asn: 4200100000
@@ -3156,6 +3282,7 @@ configuration:
   ARISTA124T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.126
       asn: 4200100000
@@ -3173,6 +3300,7 @@ configuration:
   ARISTA125T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.127
       asn: 4200100000
@@ -3190,6 +3318,7 @@ configuration:
   ARISTA126T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.128
       asn: 4200100000
@@ -3207,6 +3336,7 @@ configuration:
   ARISTA127T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.129
       asn: 4200100000
@@ -3224,6 +3354,7 @@ configuration:
   ARISTA128T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.130
       asn: 4200100000
@@ -3241,6 +3372,7 @@ configuration:
   ARISTA129T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.131
       asn: 4200100000
@@ -3258,6 +3390,7 @@ configuration:
   ARISTA130T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.132
       asn: 4200100000
@@ -3275,6 +3408,7 @@ configuration:
   ARISTA131T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.133
       asn: 4200100000
@@ -3292,6 +3426,7 @@ configuration:
   ARISTA132T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.134
       asn: 4200100000
@@ -3309,6 +3444,7 @@ configuration:
   ARISTA133T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.135
       asn: 4200100000
@@ -3326,6 +3462,7 @@ configuration:
   ARISTA134T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.136
       asn: 4200100000
@@ -3343,6 +3480,7 @@ configuration:
   ARISTA135T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.137
       asn: 4200100000
@@ -3360,6 +3498,7 @@ configuration:
   ARISTA136T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.138
       asn: 4200100000
@@ -3377,6 +3516,7 @@ configuration:
   ARISTA137T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.139
       asn: 4200100000
@@ -3394,6 +3534,7 @@ configuration:
   ARISTA138T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.140
       asn: 4200100000
@@ -3411,6 +3552,7 @@ configuration:
   ARISTA139T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.141
       asn: 4200100000
@@ -3428,6 +3570,7 @@ configuration:
   ARISTA140T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.142
       asn: 4200100000
@@ -3445,6 +3588,7 @@ configuration:
   ARISTA141T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.143
       asn: 4200100000
@@ -3462,6 +3606,7 @@ configuration:
   ARISTA142T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.144
       asn: 4200100000
@@ -3479,6 +3624,7 @@ configuration:
   ARISTA143T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.145
       asn: 4200100000
@@ -3496,6 +3642,7 @@ configuration:
   ARISTA144T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.146
       asn: 4200100000
@@ -3513,6 +3660,7 @@ configuration:
   ARISTA145T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.147
       asn: 4200100000
@@ -3530,6 +3678,7 @@ configuration:
   ARISTA146T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.148
       asn: 4200100000
@@ -3547,6 +3696,7 @@ configuration:
   ARISTA147T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.149
       asn: 4200100000
@@ -3564,6 +3714,7 @@ configuration:
   ARISTA148T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.150
       asn: 4200100000
@@ -3581,6 +3732,7 @@ configuration:
   ARISTA149T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.151
       asn: 4200100000
@@ -3598,6 +3750,7 @@ configuration:
   ARISTA150T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.152
       asn: 4200100000
@@ -3615,6 +3768,7 @@ configuration:
   ARISTA151T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.153
       asn: 4200100000
@@ -3632,6 +3786,7 @@ configuration:
   ARISTA152T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.154
       asn: 4200100000
@@ -3649,6 +3804,7 @@ configuration:
   ARISTA153T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.155
       asn: 4200100000
@@ -3666,6 +3822,7 @@ configuration:
   ARISTA154T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.156
       asn: 4200100000
@@ -3683,6 +3840,7 @@ configuration:
   ARISTA155T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.157
       asn: 4200100000
@@ -3700,6 +3858,7 @@ configuration:
   ARISTA156T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.158
       asn: 4200100000
@@ -3717,6 +3876,7 @@ configuration:
   ARISTA157T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.159
       asn: 4200100000
@@ -3734,6 +3894,7 @@ configuration:
   ARISTA158T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.160
       asn: 4200100000
@@ -3751,6 +3912,7 @@ configuration:
   ARISTA159T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.161
       asn: 4200100000
@@ -3768,6 +3930,7 @@ configuration:
   ARISTA160T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.162
       asn: 4200100000
@@ -3785,6 +3948,7 @@ configuration:
   ARISTA161T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.163
       asn: 4200100000
@@ -3802,6 +3966,7 @@ configuration:
   ARISTA162T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.164
       asn: 4200100000
@@ -3819,6 +3984,7 @@ configuration:
   ARISTA163T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.165
       asn: 4200100000
@@ -3836,6 +4002,7 @@ configuration:
   ARISTA164T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.166
       asn: 4200100000
@@ -3853,6 +4020,7 @@ configuration:
   ARISTA165T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.167
       asn: 4200100000
@@ -3870,6 +4038,7 @@ configuration:
   ARISTA166T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.168
       asn: 4200100000
@@ -3887,6 +4056,7 @@ configuration:
   ARISTA167T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.169
       asn: 4200100000
@@ -3904,6 +4074,7 @@ configuration:
   ARISTA168T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.170
       asn: 4200100000
@@ -3921,6 +4092,7 @@ configuration:
   ARISTA169T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.171
       asn: 4200100000
@@ -3938,6 +4110,7 @@ configuration:
   ARISTA170T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.172
       asn: 4200100000
@@ -3955,6 +4128,7 @@ configuration:
   ARISTA171T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.173
       asn: 4200100000
@@ -3972,6 +4146,7 @@ configuration:
   ARISTA172T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.174
       asn: 4200100000
@@ -3989,6 +4164,7 @@ configuration:
   ARISTA173T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.175
       asn: 4200100000
@@ -4006,6 +4182,7 @@ configuration:
   ARISTA174T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.176
       asn: 4200100000
@@ -4023,6 +4200,7 @@ configuration:
   ARISTA175T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.177
       asn: 4200100000
@@ -4040,6 +4218,7 @@ configuration:
   ARISTA176T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.178
       asn: 4200100000
@@ -4057,6 +4236,7 @@ configuration:
   ARISTA177T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.179
       asn: 4200100000
@@ -4074,6 +4254,7 @@ configuration:
   ARISTA178T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.180
       asn: 4200100000
@@ -4091,6 +4272,7 @@ configuration:
   ARISTA179T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.181
       asn: 4200100000
@@ -4108,6 +4290,7 @@ configuration:
   ARISTA180T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.182
       asn: 4200100000
@@ -4125,6 +4308,7 @@ configuration:
   ARISTA181T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.183
       asn: 4200100000
@@ -4142,6 +4326,7 @@ configuration:
   ARISTA182T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.184
       asn: 4200100000
@@ -4159,6 +4344,7 @@ configuration:
   ARISTA183T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.185
       asn: 4200100000
@@ -4176,6 +4362,7 @@ configuration:
   ARISTA184T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.186
       asn: 4200100000
@@ -4193,6 +4380,7 @@ configuration:
   ARISTA185T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.187
       asn: 4200100000
@@ -4210,6 +4398,7 @@ configuration:
   ARISTA186T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.188
       asn: 4200100000
@@ -4227,6 +4416,7 @@ configuration:
   ARISTA187T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.189
       asn: 4200100000
@@ -4244,6 +4434,7 @@ configuration:
   ARISTA188T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.190
       asn: 4200100000
@@ -4261,6 +4452,7 @@ configuration:
   ARISTA189T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.191
       asn: 4200100000
@@ -4278,6 +4470,7 @@ configuration:
   ARISTA190T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.192
       asn: 4200100000
@@ -4295,6 +4488,7 @@ configuration:
   ARISTA191T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.193
       asn: 4200100000
@@ -4312,6 +4506,7 @@ configuration:
   ARISTA192T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.194
       asn: 4200100000
@@ -4329,6 +4524,7 @@ configuration:
   ARISTA193T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.195
       asn: 4200100000
@@ -4346,6 +4542,7 @@ configuration:
   ARISTA194T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.196
       asn: 4200100000
@@ -4363,6 +4560,7 @@ configuration:
   ARISTA195T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.197
       asn: 4200100000
@@ -4380,6 +4578,7 @@ configuration:
   ARISTA196T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.198
       asn: 4200100000
@@ -4397,6 +4596,7 @@ configuration:
   ARISTA197T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.199
       asn: 4200100000
@@ -4414,6 +4614,7 @@ configuration:
   ARISTA198T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.200
       asn: 4200100000
@@ -4431,6 +4632,7 @@ configuration:
   ARISTA199T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.201
       asn: 4200100000
@@ -4448,6 +4650,7 @@ configuration:
   ARISTA200T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.202
       asn: 4200100000
@@ -4465,6 +4668,7 @@ configuration:
   ARISTA201T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.203
       asn: 4200100000
@@ -4482,6 +4686,7 @@ configuration:
   ARISTA202T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.204
       asn: 4200100000
@@ -4499,6 +4704,7 @@ configuration:
   ARISTA203T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.205
       asn: 4200100000
@@ -4516,6 +4722,7 @@ configuration:
   ARISTA204T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.206
       asn: 4200100000
@@ -4533,6 +4740,7 @@ configuration:
   ARISTA205T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.207
       asn: 4200100000
@@ -4550,6 +4758,7 @@ configuration:
   ARISTA206T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.208
       asn: 4200100000
@@ -4567,6 +4776,7 @@ configuration:
   ARISTA207T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.209
       asn: 4200100000
@@ -4584,6 +4794,7 @@ configuration:
   ARISTA208T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.210
       asn: 4200100000
@@ -4601,6 +4812,7 @@ configuration:
   ARISTA209T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.211
       asn: 4200100000
@@ -4618,6 +4830,7 @@ configuration:
   ARISTA210T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.212
       asn: 4200100000
@@ -4635,6 +4848,7 @@ configuration:
   ARISTA211T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.213
       asn: 4200100000
@@ -4652,6 +4866,7 @@ configuration:
   ARISTA212T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.214
       asn: 4200100000
@@ -4669,6 +4884,7 @@ configuration:
   ARISTA213T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.215
       asn: 4200100000
@@ -4686,6 +4902,7 @@ configuration:
   ARISTA214T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.216
       asn: 4200100000
@@ -4703,6 +4920,7 @@ configuration:
   ARISTA215T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.217
       asn: 4200100000
@@ -4720,6 +4938,7 @@ configuration:
   ARISTA216T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.218
       asn: 4200100000
@@ -4737,6 +4956,7 @@ configuration:
   ARISTA217T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.219
       asn: 4200100000
@@ -4754,6 +4974,7 @@ configuration:
   ARISTA218T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.220
       asn: 4200100000
@@ -4771,6 +4992,7 @@ configuration:
   ARISTA219T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.221
       asn: 4200100000
@@ -4788,6 +5010,7 @@ configuration:
   ARISTA220T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.222
       asn: 4200100000
@@ -4805,6 +5028,7 @@ configuration:
   ARISTA221T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.223
       asn: 4200100000
@@ -4822,6 +5046,7 @@ configuration:
   ARISTA222T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.224
       asn: 4200100000
@@ -4839,6 +5064,7 @@ configuration:
   ARISTA223T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.225
       asn: 4200100000
@@ -4856,6 +5082,7 @@ configuration:
   ARISTA224T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.226
       asn: 4200100000
@@ -4873,6 +5100,7 @@ configuration:
   ARISTA225T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.227
       asn: 4200100000
@@ -4890,6 +5118,7 @@ configuration:
   ARISTA226T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.228
       asn: 4200100000
@@ -4907,6 +5136,7 @@ configuration:
   ARISTA227T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.229
       asn: 4200100000
@@ -4924,6 +5154,7 @@ configuration:
   ARISTA228T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.230
       asn: 4200100000
@@ -4941,6 +5172,7 @@ configuration:
   ARISTA229T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.231
       asn: 4200100000
@@ -4958,6 +5190,7 @@ configuration:
   ARISTA230T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.232
       asn: 4200100000
@@ -4975,6 +5208,7 @@ configuration:
   ARISTA231T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.233
       asn: 4200100000
@@ -4992,6 +5226,7 @@ configuration:
   ARISTA232T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.234
       asn: 4200100000
@@ -5009,6 +5244,7 @@ configuration:
   ARISTA233T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.235
       asn: 4200100000
@@ -5026,6 +5262,7 @@ configuration:
   ARISTA234T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.236
       asn: 4200100000
@@ -5043,6 +5280,7 @@ configuration:
   ARISTA235T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.237
       asn: 4200100000
@@ -5060,6 +5298,7 @@ configuration:
   ARISTA236T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.238
       asn: 4200100000
@@ -5077,6 +5316,7 @@ configuration:
   ARISTA237T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.239
       asn: 4200100000
@@ -5094,6 +5334,7 @@ configuration:
   ARISTA238T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.240
       asn: 4200100000
@@ -5111,6 +5352,7 @@ configuration:
   ARISTA239T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.241
       asn: 4200100000
@@ -5128,6 +5370,7 @@ configuration:
   ARISTA240T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.242
       asn: 4200100000
@@ -5145,6 +5388,7 @@ configuration:
   ARISTA241T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.243
       asn: 4200100000
@@ -5162,6 +5406,7 @@ configuration:
   ARISTA242T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.244
       asn: 4200100000
@@ -5179,6 +5424,7 @@ configuration:
   ARISTA243T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.245
       asn: 4200100000
@@ -5196,6 +5442,7 @@ configuration:
   ARISTA244T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.246
       asn: 4200100000
@@ -5213,6 +5460,7 @@ configuration:
   ARISTA245T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.247
       asn: 4200100000
@@ -5230,6 +5478,7 @@ configuration:
   ARISTA246T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.248
       asn: 4200100000
@@ -5247,6 +5496,7 @@ configuration:
   ARISTA247T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.249
       asn: 4200100000
@@ -5264,6 +5514,7 @@ configuration:
   ARISTA248T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.250
       asn: 4200100000
@@ -5281,6 +5532,7 @@ configuration:
   ARISTA249T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.251
       asn: 4200100000
@@ -5298,6 +5550,7 @@ configuration:
   ARISTA250T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.252
       asn: 4200100000
@@ -5315,6 +5568,7 @@ configuration:
   ARISTA251T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.253
       asn: 4200100000
@@ -5332,6 +5586,7 @@ configuration:
   ARISTA252T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.254
       asn: 4200100000
@@ -5349,6 +5604,7 @@ configuration:
   ARISTA253T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.0
       asn: 4200100000
@@ -5366,6 +5622,7 @@ configuration:
   ARISTA254T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.1
       asn: 4200100000
@@ -5383,6 +5640,7 @@ configuration:
   ARISTA01PT0:
     properties:
     - common
+    - tor
     bgp:
       router-id: 0.12.1.2
       asn: 4200000001
@@ -5400,6 +5658,7 @@ configuration:
   ARISTA02PT0:
     properties:
     - common
+    - tor
     bgp:
       router-id: 0.12.1.3
       asn: 4200000002

--- a/ansible/vars/topo_t0-isolated-d2u510.yml
+++ b/ansible/vars/topo_t0-isolated-d2u510.yml
@@ -2062,7 +2062,6 @@ configuration_properties:
   common:
     dut_asn: 4200000000
     dut_type: ToRRouter
-    swrole: leaf
     podset_number: 1
     tor_number: 512
     tor_subnet_number: 2
@@ -2076,11 +2075,16 @@ configuration_properties:
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
+  leaf:
+    swrole: leaf
+  tor:
+    swrole: tor
 
 configuration:
   ARISTA01T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.3
       asn: 4200100000
@@ -2098,6 +2102,7 @@ configuration:
   ARISTA02T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.4
       asn: 4200100000
@@ -2115,6 +2120,7 @@ configuration:
   ARISTA03T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.5
       asn: 4200100000
@@ -2132,6 +2138,7 @@ configuration:
   ARISTA04T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.6
       asn: 4200100000
@@ -2149,6 +2156,7 @@ configuration:
   ARISTA05T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.7
       asn: 4200100000
@@ -2166,6 +2174,7 @@ configuration:
   ARISTA06T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.8
       asn: 4200100000
@@ -2183,6 +2192,7 @@ configuration:
   ARISTA07T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.9
       asn: 4200100000
@@ -2200,6 +2210,7 @@ configuration:
   ARISTA08T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.10
       asn: 4200100000
@@ -2217,6 +2228,7 @@ configuration:
   ARISTA09T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.11
       asn: 4200100000
@@ -2234,6 +2246,7 @@ configuration:
   ARISTA10T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.12
       asn: 4200100000
@@ -2251,6 +2264,7 @@ configuration:
   ARISTA11T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.13
       asn: 4200100000
@@ -2268,6 +2282,7 @@ configuration:
   ARISTA12T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.14
       asn: 4200100000
@@ -2285,6 +2300,7 @@ configuration:
   ARISTA13T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.15
       asn: 4200100000
@@ -2302,6 +2318,7 @@ configuration:
   ARISTA14T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.16
       asn: 4200100000
@@ -2319,6 +2336,7 @@ configuration:
   ARISTA15T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.17
       asn: 4200100000
@@ -2336,6 +2354,7 @@ configuration:
   ARISTA16T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.18
       asn: 4200100000
@@ -2353,6 +2372,7 @@ configuration:
   ARISTA17T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.19
       asn: 4200100000
@@ -2370,6 +2390,7 @@ configuration:
   ARISTA18T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.20
       asn: 4200100000
@@ -2387,6 +2408,7 @@ configuration:
   ARISTA19T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.21
       asn: 4200100000
@@ -2404,6 +2426,7 @@ configuration:
   ARISTA20T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.22
       asn: 4200100000
@@ -2421,6 +2444,7 @@ configuration:
   ARISTA21T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.23
       asn: 4200100000
@@ -2438,6 +2462,7 @@ configuration:
   ARISTA22T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.24
       asn: 4200100000
@@ -2455,6 +2480,7 @@ configuration:
   ARISTA23T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.25
       asn: 4200100000
@@ -2472,6 +2498,7 @@ configuration:
   ARISTA24T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.26
       asn: 4200100000
@@ -2489,6 +2516,7 @@ configuration:
   ARISTA25T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.27
       asn: 4200100000
@@ -2506,6 +2534,7 @@ configuration:
   ARISTA26T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.28
       asn: 4200100000
@@ -2523,6 +2552,7 @@ configuration:
   ARISTA27T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.29
       asn: 4200100000
@@ -2540,6 +2570,7 @@ configuration:
   ARISTA28T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.30
       asn: 4200100000
@@ -2557,6 +2588,7 @@ configuration:
   ARISTA29T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.31
       asn: 4200100000
@@ -2574,6 +2606,7 @@ configuration:
   ARISTA30T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.32
       asn: 4200100000
@@ -2591,6 +2624,7 @@ configuration:
   ARISTA31T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.33
       asn: 4200100000
@@ -2608,6 +2642,7 @@ configuration:
   ARISTA32T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.34
       asn: 4200100000
@@ -2625,6 +2660,7 @@ configuration:
   ARISTA33T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.35
       asn: 4200100000
@@ -2642,6 +2678,7 @@ configuration:
   ARISTA34T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.36
       asn: 4200100000
@@ -2659,6 +2696,7 @@ configuration:
   ARISTA35T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.37
       asn: 4200100000
@@ -2676,6 +2714,7 @@ configuration:
   ARISTA36T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.38
       asn: 4200100000
@@ -2693,6 +2732,7 @@ configuration:
   ARISTA37T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.39
       asn: 4200100000
@@ -2710,6 +2750,7 @@ configuration:
   ARISTA38T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.40
       asn: 4200100000
@@ -2727,6 +2768,7 @@ configuration:
   ARISTA39T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.41
       asn: 4200100000
@@ -2744,6 +2786,7 @@ configuration:
   ARISTA40T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.42
       asn: 4200100000
@@ -2761,6 +2804,7 @@ configuration:
   ARISTA41T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.43
       asn: 4200100000
@@ -2778,6 +2822,7 @@ configuration:
   ARISTA42T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.44
       asn: 4200100000
@@ -2795,6 +2840,7 @@ configuration:
   ARISTA43T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.45
       asn: 4200100000
@@ -2812,6 +2858,7 @@ configuration:
   ARISTA44T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.46
       asn: 4200100000
@@ -2829,6 +2876,7 @@ configuration:
   ARISTA45T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.47
       asn: 4200100000
@@ -2846,6 +2894,7 @@ configuration:
   ARISTA46T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.48
       asn: 4200100000
@@ -2863,6 +2912,7 @@ configuration:
   ARISTA47T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.49
       asn: 4200100000
@@ -2880,6 +2930,7 @@ configuration:
   ARISTA48T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.50
       asn: 4200100000
@@ -2897,6 +2948,7 @@ configuration:
   ARISTA49T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.51
       asn: 4200100000
@@ -2914,6 +2966,7 @@ configuration:
   ARISTA50T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.52
       asn: 4200100000
@@ -2931,6 +2984,7 @@ configuration:
   ARISTA51T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.53
       asn: 4200100000
@@ -2948,6 +3002,7 @@ configuration:
   ARISTA52T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.54
       asn: 4200100000
@@ -2965,6 +3020,7 @@ configuration:
   ARISTA53T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.55
       asn: 4200100000
@@ -2982,6 +3038,7 @@ configuration:
   ARISTA54T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.56
       asn: 4200100000
@@ -2999,6 +3056,7 @@ configuration:
   ARISTA55T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.57
       asn: 4200100000
@@ -3016,6 +3074,7 @@ configuration:
   ARISTA56T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.58
       asn: 4200100000
@@ -3033,6 +3092,7 @@ configuration:
   ARISTA57T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.59
       asn: 4200100000
@@ -3050,6 +3110,7 @@ configuration:
   ARISTA58T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.60
       asn: 4200100000
@@ -3067,6 +3128,7 @@ configuration:
   ARISTA59T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.61
       asn: 4200100000
@@ -3084,6 +3146,7 @@ configuration:
   ARISTA60T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.62
       asn: 4200100000
@@ -3101,6 +3164,7 @@ configuration:
   ARISTA61T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.63
       asn: 4200100000
@@ -3118,6 +3182,7 @@ configuration:
   ARISTA62T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.64
       asn: 4200100000
@@ -3135,6 +3200,7 @@ configuration:
   ARISTA63T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.65
       asn: 4200100000
@@ -3152,6 +3218,7 @@ configuration:
   ARISTA64T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.66
       asn: 4200100000
@@ -3169,6 +3236,7 @@ configuration:
   ARISTA65T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.67
       asn: 4200100000
@@ -3186,6 +3254,7 @@ configuration:
   ARISTA66T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.68
       asn: 4200100000
@@ -3203,6 +3272,7 @@ configuration:
   ARISTA67T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.69
       asn: 4200100000
@@ -3220,6 +3290,7 @@ configuration:
   ARISTA68T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.70
       asn: 4200100000
@@ -3237,6 +3308,7 @@ configuration:
   ARISTA69T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.71
       asn: 4200100000
@@ -3254,6 +3326,7 @@ configuration:
   ARISTA70T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.72
       asn: 4200100000
@@ -3271,6 +3344,7 @@ configuration:
   ARISTA71T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.73
       asn: 4200100000
@@ -3288,6 +3362,7 @@ configuration:
   ARISTA72T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.74
       asn: 4200100000
@@ -3305,6 +3380,7 @@ configuration:
   ARISTA73T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.75
       asn: 4200100000
@@ -3322,6 +3398,7 @@ configuration:
   ARISTA74T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.76
       asn: 4200100000
@@ -3339,6 +3416,7 @@ configuration:
   ARISTA75T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.77
       asn: 4200100000
@@ -3356,6 +3434,7 @@ configuration:
   ARISTA76T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.78
       asn: 4200100000
@@ -3373,6 +3452,7 @@ configuration:
   ARISTA77T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.79
       asn: 4200100000
@@ -3390,6 +3470,7 @@ configuration:
   ARISTA78T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.80
       asn: 4200100000
@@ -3407,6 +3488,7 @@ configuration:
   ARISTA79T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.81
       asn: 4200100000
@@ -3424,6 +3506,7 @@ configuration:
   ARISTA80T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.82
       asn: 4200100000
@@ -3441,6 +3524,7 @@ configuration:
   ARISTA81T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.83
       asn: 4200100000
@@ -3458,6 +3542,7 @@ configuration:
   ARISTA82T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.84
       asn: 4200100000
@@ -3475,6 +3560,7 @@ configuration:
   ARISTA83T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.85
       asn: 4200100000
@@ -3492,6 +3578,7 @@ configuration:
   ARISTA84T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.86
       asn: 4200100000
@@ -3509,6 +3596,7 @@ configuration:
   ARISTA85T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.87
       asn: 4200100000
@@ -3526,6 +3614,7 @@ configuration:
   ARISTA86T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.88
       asn: 4200100000
@@ -3543,6 +3632,7 @@ configuration:
   ARISTA87T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.89
       asn: 4200100000
@@ -3560,6 +3650,7 @@ configuration:
   ARISTA88T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.90
       asn: 4200100000
@@ -3577,6 +3668,7 @@ configuration:
   ARISTA89T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.91
       asn: 4200100000
@@ -3594,6 +3686,7 @@ configuration:
   ARISTA90T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.92
       asn: 4200100000
@@ -3611,6 +3704,7 @@ configuration:
   ARISTA91T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.93
       asn: 4200100000
@@ -3628,6 +3722,7 @@ configuration:
   ARISTA92T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.94
       asn: 4200100000
@@ -3645,6 +3740,7 @@ configuration:
   ARISTA93T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.95
       asn: 4200100000
@@ -3662,6 +3758,7 @@ configuration:
   ARISTA94T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.96
       asn: 4200100000
@@ -3679,6 +3776,7 @@ configuration:
   ARISTA95T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.97
       asn: 4200100000
@@ -3696,6 +3794,7 @@ configuration:
   ARISTA96T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.98
       asn: 4200100000
@@ -3713,6 +3812,7 @@ configuration:
   ARISTA97T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.99
       asn: 4200100000
@@ -3730,6 +3830,7 @@ configuration:
   ARISTA98T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.100
       asn: 4200100000
@@ -3747,6 +3848,7 @@ configuration:
   ARISTA99T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.101
       asn: 4200100000
@@ -3764,6 +3866,7 @@ configuration:
   ARISTA100T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.102
       asn: 4200100000
@@ -3781,6 +3884,7 @@ configuration:
   ARISTA101T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.103
       asn: 4200100000
@@ -3798,6 +3902,7 @@ configuration:
   ARISTA102T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.104
       asn: 4200100000
@@ -3815,6 +3920,7 @@ configuration:
   ARISTA103T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.105
       asn: 4200100000
@@ -3832,6 +3938,7 @@ configuration:
   ARISTA104T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.106
       asn: 4200100000
@@ -3849,6 +3956,7 @@ configuration:
   ARISTA105T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.107
       asn: 4200100000
@@ -3866,6 +3974,7 @@ configuration:
   ARISTA106T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.108
       asn: 4200100000
@@ -3883,6 +3992,7 @@ configuration:
   ARISTA107T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.109
       asn: 4200100000
@@ -3900,6 +4010,7 @@ configuration:
   ARISTA108T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.110
       asn: 4200100000
@@ -3917,6 +4028,7 @@ configuration:
   ARISTA109T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.111
       asn: 4200100000
@@ -3934,6 +4046,7 @@ configuration:
   ARISTA110T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.112
       asn: 4200100000
@@ -3951,6 +4064,7 @@ configuration:
   ARISTA111T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.113
       asn: 4200100000
@@ -3968,6 +4082,7 @@ configuration:
   ARISTA112T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.114
       asn: 4200100000
@@ -3985,6 +4100,7 @@ configuration:
   ARISTA113T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.115
       asn: 4200100000
@@ -4002,6 +4118,7 @@ configuration:
   ARISTA114T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.116
       asn: 4200100000
@@ -4019,6 +4136,7 @@ configuration:
   ARISTA115T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.117
       asn: 4200100000
@@ -4036,6 +4154,7 @@ configuration:
   ARISTA116T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.118
       asn: 4200100000
@@ -4053,6 +4172,7 @@ configuration:
   ARISTA117T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.119
       asn: 4200100000
@@ -4070,6 +4190,7 @@ configuration:
   ARISTA118T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.120
       asn: 4200100000
@@ -4087,6 +4208,7 @@ configuration:
   ARISTA119T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.121
       asn: 4200100000
@@ -4104,6 +4226,7 @@ configuration:
   ARISTA120T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.122
       asn: 4200100000
@@ -4121,6 +4244,7 @@ configuration:
   ARISTA121T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.123
       asn: 4200100000
@@ -4138,6 +4262,7 @@ configuration:
   ARISTA122T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.124
       asn: 4200100000
@@ -4155,6 +4280,7 @@ configuration:
   ARISTA123T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.125
       asn: 4200100000
@@ -4172,6 +4298,7 @@ configuration:
   ARISTA124T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.126
       asn: 4200100000
@@ -4189,6 +4316,7 @@ configuration:
   ARISTA125T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.127
       asn: 4200100000
@@ -4206,6 +4334,7 @@ configuration:
   ARISTA126T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.128
       asn: 4200100000
@@ -4223,6 +4352,7 @@ configuration:
   ARISTA127T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.129
       asn: 4200100000
@@ -4240,6 +4370,7 @@ configuration:
   ARISTA128T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.130
       asn: 4200100000
@@ -4257,6 +4388,7 @@ configuration:
   ARISTA129T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.131
       asn: 4200100000
@@ -4274,6 +4406,7 @@ configuration:
   ARISTA130T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.132
       asn: 4200100000
@@ -4291,6 +4424,7 @@ configuration:
   ARISTA131T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.133
       asn: 4200100000
@@ -4308,6 +4442,7 @@ configuration:
   ARISTA132T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.134
       asn: 4200100000
@@ -4325,6 +4460,7 @@ configuration:
   ARISTA133T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.135
       asn: 4200100000
@@ -4342,6 +4478,7 @@ configuration:
   ARISTA134T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.136
       asn: 4200100000
@@ -4359,6 +4496,7 @@ configuration:
   ARISTA135T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.137
       asn: 4200100000
@@ -4376,6 +4514,7 @@ configuration:
   ARISTA136T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.138
       asn: 4200100000
@@ -4393,6 +4532,7 @@ configuration:
   ARISTA137T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.139
       asn: 4200100000
@@ -4410,6 +4550,7 @@ configuration:
   ARISTA138T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.140
       asn: 4200100000
@@ -4427,6 +4568,7 @@ configuration:
   ARISTA139T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.141
       asn: 4200100000
@@ -4444,6 +4586,7 @@ configuration:
   ARISTA140T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.142
       asn: 4200100000
@@ -4461,6 +4604,7 @@ configuration:
   ARISTA141T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.143
       asn: 4200100000
@@ -4478,6 +4622,7 @@ configuration:
   ARISTA142T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.144
       asn: 4200100000
@@ -4495,6 +4640,7 @@ configuration:
   ARISTA143T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.145
       asn: 4200100000
@@ -4512,6 +4658,7 @@ configuration:
   ARISTA144T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.146
       asn: 4200100000
@@ -4529,6 +4676,7 @@ configuration:
   ARISTA145T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.147
       asn: 4200100000
@@ -4546,6 +4694,7 @@ configuration:
   ARISTA146T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.148
       asn: 4200100000
@@ -4563,6 +4712,7 @@ configuration:
   ARISTA147T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.149
       asn: 4200100000
@@ -4580,6 +4730,7 @@ configuration:
   ARISTA148T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.150
       asn: 4200100000
@@ -4597,6 +4748,7 @@ configuration:
   ARISTA149T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.151
       asn: 4200100000
@@ -4614,6 +4766,7 @@ configuration:
   ARISTA150T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.152
       asn: 4200100000
@@ -4631,6 +4784,7 @@ configuration:
   ARISTA151T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.153
       asn: 4200100000
@@ -4648,6 +4802,7 @@ configuration:
   ARISTA152T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.154
       asn: 4200100000
@@ -4665,6 +4820,7 @@ configuration:
   ARISTA153T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.155
       asn: 4200100000
@@ -4682,6 +4838,7 @@ configuration:
   ARISTA154T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.156
       asn: 4200100000
@@ -4699,6 +4856,7 @@ configuration:
   ARISTA155T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.157
       asn: 4200100000
@@ -4716,6 +4874,7 @@ configuration:
   ARISTA156T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.158
       asn: 4200100000
@@ -4733,6 +4892,7 @@ configuration:
   ARISTA157T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.159
       asn: 4200100000
@@ -4750,6 +4910,7 @@ configuration:
   ARISTA158T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.160
       asn: 4200100000
@@ -4767,6 +4928,7 @@ configuration:
   ARISTA159T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.161
       asn: 4200100000
@@ -4784,6 +4946,7 @@ configuration:
   ARISTA160T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.162
       asn: 4200100000
@@ -4801,6 +4964,7 @@ configuration:
   ARISTA161T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.163
       asn: 4200100000
@@ -4818,6 +4982,7 @@ configuration:
   ARISTA162T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.164
       asn: 4200100000
@@ -4835,6 +5000,7 @@ configuration:
   ARISTA163T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.165
       asn: 4200100000
@@ -4852,6 +5018,7 @@ configuration:
   ARISTA164T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.166
       asn: 4200100000
@@ -4869,6 +5036,7 @@ configuration:
   ARISTA165T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.167
       asn: 4200100000
@@ -4886,6 +5054,7 @@ configuration:
   ARISTA166T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.168
       asn: 4200100000
@@ -4903,6 +5072,7 @@ configuration:
   ARISTA167T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.169
       asn: 4200100000
@@ -4920,6 +5090,7 @@ configuration:
   ARISTA168T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.170
       asn: 4200100000
@@ -4937,6 +5108,7 @@ configuration:
   ARISTA169T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.171
       asn: 4200100000
@@ -4954,6 +5126,7 @@ configuration:
   ARISTA170T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.172
       asn: 4200100000
@@ -4971,6 +5144,7 @@ configuration:
   ARISTA171T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.173
       asn: 4200100000
@@ -4988,6 +5162,7 @@ configuration:
   ARISTA172T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.174
       asn: 4200100000
@@ -5005,6 +5180,7 @@ configuration:
   ARISTA173T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.175
       asn: 4200100000
@@ -5022,6 +5198,7 @@ configuration:
   ARISTA174T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.176
       asn: 4200100000
@@ -5039,6 +5216,7 @@ configuration:
   ARISTA175T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.177
       asn: 4200100000
@@ -5056,6 +5234,7 @@ configuration:
   ARISTA176T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.178
       asn: 4200100000
@@ -5073,6 +5252,7 @@ configuration:
   ARISTA177T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.179
       asn: 4200100000
@@ -5090,6 +5270,7 @@ configuration:
   ARISTA178T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.180
       asn: 4200100000
@@ -5107,6 +5288,7 @@ configuration:
   ARISTA179T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.181
       asn: 4200100000
@@ -5124,6 +5306,7 @@ configuration:
   ARISTA180T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.182
       asn: 4200100000
@@ -5141,6 +5324,7 @@ configuration:
   ARISTA181T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.183
       asn: 4200100000
@@ -5158,6 +5342,7 @@ configuration:
   ARISTA182T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.184
       asn: 4200100000
@@ -5175,6 +5360,7 @@ configuration:
   ARISTA183T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.185
       asn: 4200100000
@@ -5192,6 +5378,7 @@ configuration:
   ARISTA184T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.186
       asn: 4200100000
@@ -5209,6 +5396,7 @@ configuration:
   ARISTA185T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.187
       asn: 4200100000
@@ -5226,6 +5414,7 @@ configuration:
   ARISTA186T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.188
       asn: 4200100000
@@ -5243,6 +5432,7 @@ configuration:
   ARISTA187T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.189
       asn: 4200100000
@@ -5260,6 +5450,7 @@ configuration:
   ARISTA188T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.190
       asn: 4200100000
@@ -5277,6 +5468,7 @@ configuration:
   ARISTA189T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.191
       asn: 4200100000
@@ -5294,6 +5486,7 @@ configuration:
   ARISTA190T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.192
       asn: 4200100000
@@ -5311,6 +5504,7 @@ configuration:
   ARISTA191T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.193
       asn: 4200100000
@@ -5328,6 +5522,7 @@ configuration:
   ARISTA192T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.194
       asn: 4200100000
@@ -5345,6 +5540,7 @@ configuration:
   ARISTA193T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.195
       asn: 4200100000
@@ -5362,6 +5558,7 @@ configuration:
   ARISTA194T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.196
       asn: 4200100000
@@ -5379,6 +5576,7 @@ configuration:
   ARISTA195T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.197
       asn: 4200100000
@@ -5396,6 +5594,7 @@ configuration:
   ARISTA196T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.198
       asn: 4200100000
@@ -5413,6 +5612,7 @@ configuration:
   ARISTA197T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.199
       asn: 4200100000
@@ -5430,6 +5630,7 @@ configuration:
   ARISTA198T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.200
       asn: 4200100000
@@ -5447,6 +5648,7 @@ configuration:
   ARISTA199T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.201
       asn: 4200100000
@@ -5464,6 +5666,7 @@ configuration:
   ARISTA200T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.202
       asn: 4200100000
@@ -5481,6 +5684,7 @@ configuration:
   ARISTA201T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.203
       asn: 4200100000
@@ -5498,6 +5702,7 @@ configuration:
   ARISTA202T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.204
       asn: 4200100000
@@ -5515,6 +5720,7 @@ configuration:
   ARISTA203T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.205
       asn: 4200100000
@@ -5532,6 +5738,7 @@ configuration:
   ARISTA204T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.206
       asn: 4200100000
@@ -5549,6 +5756,7 @@ configuration:
   ARISTA205T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.207
       asn: 4200100000
@@ -5566,6 +5774,7 @@ configuration:
   ARISTA206T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.208
       asn: 4200100000
@@ -5583,6 +5792,7 @@ configuration:
   ARISTA207T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.209
       asn: 4200100000
@@ -5600,6 +5810,7 @@ configuration:
   ARISTA208T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.210
       asn: 4200100000
@@ -5617,6 +5828,7 @@ configuration:
   ARISTA209T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.211
       asn: 4200100000
@@ -5634,6 +5846,7 @@ configuration:
   ARISTA210T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.212
       asn: 4200100000
@@ -5651,6 +5864,7 @@ configuration:
   ARISTA211T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.213
       asn: 4200100000
@@ -5668,6 +5882,7 @@ configuration:
   ARISTA212T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.214
       asn: 4200100000
@@ -5685,6 +5900,7 @@ configuration:
   ARISTA213T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.215
       asn: 4200100000
@@ -5702,6 +5918,7 @@ configuration:
   ARISTA214T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.216
       asn: 4200100000
@@ -5719,6 +5936,7 @@ configuration:
   ARISTA215T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.217
       asn: 4200100000
@@ -5736,6 +5954,7 @@ configuration:
   ARISTA216T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.218
       asn: 4200100000
@@ -5753,6 +5972,7 @@ configuration:
   ARISTA217T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.219
       asn: 4200100000
@@ -5770,6 +5990,7 @@ configuration:
   ARISTA218T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.220
       asn: 4200100000
@@ -5787,6 +6008,7 @@ configuration:
   ARISTA219T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.221
       asn: 4200100000
@@ -5804,6 +6026,7 @@ configuration:
   ARISTA220T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.222
       asn: 4200100000
@@ -5821,6 +6044,7 @@ configuration:
   ARISTA221T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.223
       asn: 4200100000
@@ -5838,6 +6062,7 @@ configuration:
   ARISTA222T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.224
       asn: 4200100000
@@ -5855,6 +6080,7 @@ configuration:
   ARISTA223T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.225
       asn: 4200100000
@@ -5872,6 +6098,7 @@ configuration:
   ARISTA224T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.226
       asn: 4200100000
@@ -5889,6 +6116,7 @@ configuration:
   ARISTA225T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.227
       asn: 4200100000
@@ -5906,6 +6134,7 @@ configuration:
   ARISTA226T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.228
       asn: 4200100000
@@ -5923,6 +6152,7 @@ configuration:
   ARISTA227T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.229
       asn: 4200100000
@@ -5940,6 +6170,7 @@ configuration:
   ARISTA228T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.230
       asn: 4200100000
@@ -5957,6 +6188,7 @@ configuration:
   ARISTA229T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.231
       asn: 4200100000
@@ -5974,6 +6206,7 @@ configuration:
   ARISTA230T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.232
       asn: 4200100000
@@ -5991,6 +6224,7 @@ configuration:
   ARISTA231T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.233
       asn: 4200100000
@@ -6008,6 +6242,7 @@ configuration:
   ARISTA232T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.234
       asn: 4200100000
@@ -6025,6 +6260,7 @@ configuration:
   ARISTA233T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.235
       asn: 4200100000
@@ -6042,6 +6278,7 @@ configuration:
   ARISTA234T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.236
       asn: 4200100000
@@ -6059,6 +6296,7 @@ configuration:
   ARISTA235T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.237
       asn: 4200100000
@@ -6076,6 +6314,7 @@ configuration:
   ARISTA236T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.238
       asn: 4200100000
@@ -6093,6 +6332,7 @@ configuration:
   ARISTA237T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.239
       asn: 4200100000
@@ -6110,6 +6350,7 @@ configuration:
   ARISTA238T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.240
       asn: 4200100000
@@ -6127,6 +6368,7 @@ configuration:
   ARISTA239T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.241
       asn: 4200100000
@@ -6144,6 +6386,7 @@ configuration:
   ARISTA240T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.242
       asn: 4200100000
@@ -6161,6 +6404,7 @@ configuration:
   ARISTA241T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.243
       asn: 4200100000
@@ -6178,6 +6422,7 @@ configuration:
   ARISTA242T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.244
       asn: 4200100000
@@ -6195,6 +6440,7 @@ configuration:
   ARISTA243T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.245
       asn: 4200100000
@@ -6212,6 +6458,7 @@ configuration:
   ARISTA244T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.246
       asn: 4200100000
@@ -6229,6 +6476,7 @@ configuration:
   ARISTA245T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.247
       asn: 4200100000
@@ -6246,6 +6494,7 @@ configuration:
   ARISTA246T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.248
       asn: 4200100000
@@ -6263,6 +6512,7 @@ configuration:
   ARISTA247T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.249
       asn: 4200100000
@@ -6280,6 +6530,7 @@ configuration:
   ARISTA248T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.250
       asn: 4200100000
@@ -6297,6 +6548,7 @@ configuration:
   ARISTA249T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.251
       asn: 4200100000
@@ -6314,6 +6566,7 @@ configuration:
   ARISTA250T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.252
       asn: 4200100000
@@ -6331,6 +6584,7 @@ configuration:
   ARISTA251T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.253
       asn: 4200100000
@@ -6348,6 +6602,7 @@ configuration:
   ARISTA252T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.254
       asn: 4200100000
@@ -6365,6 +6620,7 @@ configuration:
   ARISTA253T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.0
       asn: 4200100000
@@ -6382,6 +6638,7 @@ configuration:
   ARISTA254T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.1
       asn: 4200100000
@@ -6399,6 +6656,7 @@ configuration:
   ARISTA255T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.2
       asn: 4200100000
@@ -6416,6 +6674,7 @@ configuration:
   ARISTA256T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.3
       asn: 4200100000
@@ -6433,6 +6692,7 @@ configuration:
   ARISTA257T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.4
       asn: 4200100000
@@ -6450,6 +6710,7 @@ configuration:
   ARISTA258T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.5
       asn: 4200100000
@@ -6467,6 +6728,7 @@ configuration:
   ARISTA259T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.6
       asn: 4200100000
@@ -6484,6 +6746,7 @@ configuration:
   ARISTA260T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.7
       asn: 4200100000
@@ -6501,6 +6764,7 @@ configuration:
   ARISTA261T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.8
       asn: 4200100000
@@ -6518,6 +6782,7 @@ configuration:
   ARISTA262T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.9
       asn: 4200100000
@@ -6535,6 +6800,7 @@ configuration:
   ARISTA263T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.10
       asn: 4200100000
@@ -6552,6 +6818,7 @@ configuration:
   ARISTA264T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.11
       asn: 4200100000
@@ -6569,6 +6836,7 @@ configuration:
   ARISTA265T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.12
       asn: 4200100000
@@ -6586,6 +6854,7 @@ configuration:
   ARISTA266T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.13
       asn: 4200100000
@@ -6603,6 +6872,7 @@ configuration:
   ARISTA267T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.14
       asn: 4200100000
@@ -6620,6 +6890,7 @@ configuration:
   ARISTA268T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.15
       asn: 4200100000
@@ -6637,6 +6908,7 @@ configuration:
   ARISTA269T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.16
       asn: 4200100000
@@ -6654,6 +6926,7 @@ configuration:
   ARISTA270T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.17
       asn: 4200100000
@@ -6671,6 +6944,7 @@ configuration:
   ARISTA271T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.18
       asn: 4200100000
@@ -6688,6 +6962,7 @@ configuration:
   ARISTA272T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.19
       asn: 4200100000
@@ -6705,6 +6980,7 @@ configuration:
   ARISTA273T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.20
       asn: 4200100000
@@ -6722,6 +6998,7 @@ configuration:
   ARISTA274T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.21
       asn: 4200100000
@@ -6739,6 +7016,7 @@ configuration:
   ARISTA275T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.22
       asn: 4200100000
@@ -6756,6 +7034,7 @@ configuration:
   ARISTA276T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.23
       asn: 4200100000
@@ -6773,6 +7052,7 @@ configuration:
   ARISTA277T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.24
       asn: 4200100000
@@ -6790,6 +7070,7 @@ configuration:
   ARISTA278T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.25
       asn: 4200100000
@@ -6807,6 +7088,7 @@ configuration:
   ARISTA279T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.26
       asn: 4200100000
@@ -6824,6 +7106,7 @@ configuration:
   ARISTA280T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.27
       asn: 4200100000
@@ -6841,6 +7124,7 @@ configuration:
   ARISTA281T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.28
       asn: 4200100000
@@ -6858,6 +7142,7 @@ configuration:
   ARISTA282T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.29
       asn: 4200100000
@@ -6875,6 +7160,7 @@ configuration:
   ARISTA283T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.30
       asn: 4200100000
@@ -6892,6 +7178,7 @@ configuration:
   ARISTA284T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.31
       asn: 4200100000
@@ -6909,6 +7196,7 @@ configuration:
   ARISTA285T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.32
       asn: 4200100000
@@ -6926,6 +7214,7 @@ configuration:
   ARISTA286T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.33
       asn: 4200100000
@@ -6943,6 +7232,7 @@ configuration:
   ARISTA287T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.34
       asn: 4200100000
@@ -6960,6 +7250,7 @@ configuration:
   ARISTA288T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.35
       asn: 4200100000
@@ -6977,6 +7268,7 @@ configuration:
   ARISTA289T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.36
       asn: 4200100000
@@ -6994,6 +7286,7 @@ configuration:
   ARISTA290T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.37
       asn: 4200100000
@@ -7011,6 +7304,7 @@ configuration:
   ARISTA291T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.38
       asn: 4200100000
@@ -7028,6 +7322,7 @@ configuration:
   ARISTA292T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.39
       asn: 4200100000
@@ -7045,6 +7340,7 @@ configuration:
   ARISTA293T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.40
       asn: 4200100000
@@ -7062,6 +7358,7 @@ configuration:
   ARISTA294T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.41
       asn: 4200100000
@@ -7079,6 +7376,7 @@ configuration:
   ARISTA295T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.42
       asn: 4200100000
@@ -7096,6 +7394,7 @@ configuration:
   ARISTA296T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.43
       asn: 4200100000
@@ -7113,6 +7412,7 @@ configuration:
   ARISTA297T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.44
       asn: 4200100000
@@ -7130,6 +7430,7 @@ configuration:
   ARISTA298T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.45
       asn: 4200100000
@@ -7147,6 +7448,7 @@ configuration:
   ARISTA299T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.46
       asn: 4200100000
@@ -7164,6 +7466,7 @@ configuration:
   ARISTA300T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.47
       asn: 4200100000
@@ -7181,6 +7484,7 @@ configuration:
   ARISTA301T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.48
       asn: 4200100000
@@ -7198,6 +7502,7 @@ configuration:
   ARISTA302T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.49
       asn: 4200100000
@@ -7215,6 +7520,7 @@ configuration:
   ARISTA303T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.50
       asn: 4200100000
@@ -7232,6 +7538,7 @@ configuration:
   ARISTA304T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.51
       asn: 4200100000
@@ -7249,6 +7556,7 @@ configuration:
   ARISTA305T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.52
       asn: 4200100000
@@ -7266,6 +7574,7 @@ configuration:
   ARISTA306T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.53
       asn: 4200100000
@@ -7283,6 +7592,7 @@ configuration:
   ARISTA307T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.54
       asn: 4200100000
@@ -7300,6 +7610,7 @@ configuration:
   ARISTA308T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.55
       asn: 4200100000
@@ -7317,6 +7628,7 @@ configuration:
   ARISTA309T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.56
       asn: 4200100000
@@ -7334,6 +7646,7 @@ configuration:
   ARISTA310T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.57
       asn: 4200100000
@@ -7351,6 +7664,7 @@ configuration:
   ARISTA311T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.58
       asn: 4200100000
@@ -7368,6 +7682,7 @@ configuration:
   ARISTA312T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.59
       asn: 4200100000
@@ -7385,6 +7700,7 @@ configuration:
   ARISTA313T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.60
       asn: 4200100000
@@ -7402,6 +7718,7 @@ configuration:
   ARISTA314T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.61
       asn: 4200100000
@@ -7419,6 +7736,7 @@ configuration:
   ARISTA315T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.62
       asn: 4200100000
@@ -7436,6 +7754,7 @@ configuration:
   ARISTA316T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.63
       asn: 4200100000
@@ -7453,6 +7772,7 @@ configuration:
   ARISTA317T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.64
       asn: 4200100000
@@ -7470,6 +7790,7 @@ configuration:
   ARISTA318T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.65
       asn: 4200100000
@@ -7487,6 +7808,7 @@ configuration:
   ARISTA319T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.66
       asn: 4200100000
@@ -7504,6 +7826,7 @@ configuration:
   ARISTA320T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.67
       asn: 4200100000
@@ -7521,6 +7844,7 @@ configuration:
   ARISTA321T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.68
       asn: 4200100000
@@ -7538,6 +7862,7 @@ configuration:
   ARISTA322T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.69
       asn: 4200100000
@@ -7555,6 +7880,7 @@ configuration:
   ARISTA323T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.70
       asn: 4200100000
@@ -7572,6 +7898,7 @@ configuration:
   ARISTA324T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.71
       asn: 4200100000
@@ -7589,6 +7916,7 @@ configuration:
   ARISTA325T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.72
       asn: 4200100000
@@ -7606,6 +7934,7 @@ configuration:
   ARISTA326T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.73
       asn: 4200100000
@@ -7623,6 +7952,7 @@ configuration:
   ARISTA327T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.74
       asn: 4200100000
@@ -7640,6 +7970,7 @@ configuration:
   ARISTA328T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.75
       asn: 4200100000
@@ -7657,6 +7988,7 @@ configuration:
   ARISTA329T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.76
       asn: 4200100000
@@ -7674,6 +8006,7 @@ configuration:
   ARISTA330T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.77
       asn: 4200100000
@@ -7691,6 +8024,7 @@ configuration:
   ARISTA331T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.78
       asn: 4200100000
@@ -7708,6 +8042,7 @@ configuration:
   ARISTA332T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.79
       asn: 4200100000
@@ -7725,6 +8060,7 @@ configuration:
   ARISTA333T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.80
       asn: 4200100000
@@ -7742,6 +8078,7 @@ configuration:
   ARISTA334T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.81
       asn: 4200100000
@@ -7759,6 +8096,7 @@ configuration:
   ARISTA335T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.82
       asn: 4200100000
@@ -7776,6 +8114,7 @@ configuration:
   ARISTA336T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.83
       asn: 4200100000
@@ -7793,6 +8132,7 @@ configuration:
   ARISTA337T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.84
       asn: 4200100000
@@ -7810,6 +8150,7 @@ configuration:
   ARISTA338T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.85
       asn: 4200100000
@@ -7827,6 +8168,7 @@ configuration:
   ARISTA339T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.86
       asn: 4200100000
@@ -7844,6 +8186,7 @@ configuration:
   ARISTA340T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.87
       asn: 4200100000
@@ -7861,6 +8204,7 @@ configuration:
   ARISTA341T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.88
       asn: 4200100000
@@ -7878,6 +8222,7 @@ configuration:
   ARISTA342T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.89
       asn: 4200100000
@@ -7895,6 +8240,7 @@ configuration:
   ARISTA343T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.90
       asn: 4200100000
@@ -7912,6 +8258,7 @@ configuration:
   ARISTA344T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.91
       asn: 4200100000
@@ -7929,6 +8276,7 @@ configuration:
   ARISTA345T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.92
       asn: 4200100000
@@ -7946,6 +8294,7 @@ configuration:
   ARISTA346T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.93
       asn: 4200100000
@@ -7963,6 +8312,7 @@ configuration:
   ARISTA347T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.94
       asn: 4200100000
@@ -7980,6 +8330,7 @@ configuration:
   ARISTA348T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.95
       asn: 4200100000
@@ -7997,6 +8348,7 @@ configuration:
   ARISTA349T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.96
       asn: 4200100000
@@ -8014,6 +8366,7 @@ configuration:
   ARISTA350T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.97
       asn: 4200100000
@@ -8031,6 +8384,7 @@ configuration:
   ARISTA351T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.98
       asn: 4200100000
@@ -8048,6 +8402,7 @@ configuration:
   ARISTA352T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.99
       asn: 4200100000
@@ -8065,6 +8420,7 @@ configuration:
   ARISTA353T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.100
       asn: 4200100000
@@ -8082,6 +8438,7 @@ configuration:
   ARISTA354T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.101
       asn: 4200100000
@@ -8099,6 +8456,7 @@ configuration:
   ARISTA355T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.102
       asn: 4200100000
@@ -8116,6 +8474,7 @@ configuration:
   ARISTA356T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.103
       asn: 4200100000
@@ -8133,6 +8492,7 @@ configuration:
   ARISTA357T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.104
       asn: 4200100000
@@ -8150,6 +8510,7 @@ configuration:
   ARISTA358T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.105
       asn: 4200100000
@@ -8167,6 +8528,7 @@ configuration:
   ARISTA359T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.106
       asn: 4200100000
@@ -8184,6 +8546,7 @@ configuration:
   ARISTA360T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.107
       asn: 4200100000
@@ -8201,6 +8564,7 @@ configuration:
   ARISTA361T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.108
       asn: 4200100000
@@ -8218,6 +8582,7 @@ configuration:
   ARISTA362T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.109
       asn: 4200100000
@@ -8235,6 +8600,7 @@ configuration:
   ARISTA363T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.110
       asn: 4200100000
@@ -8252,6 +8618,7 @@ configuration:
   ARISTA364T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.111
       asn: 4200100000
@@ -8269,6 +8636,7 @@ configuration:
   ARISTA365T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.112
       asn: 4200100000
@@ -8286,6 +8654,7 @@ configuration:
   ARISTA366T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.113
       asn: 4200100000
@@ -8303,6 +8672,7 @@ configuration:
   ARISTA367T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.114
       asn: 4200100000
@@ -8320,6 +8690,7 @@ configuration:
   ARISTA368T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.115
       asn: 4200100000
@@ -8337,6 +8708,7 @@ configuration:
   ARISTA369T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.116
       asn: 4200100000
@@ -8354,6 +8726,7 @@ configuration:
   ARISTA370T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.117
       asn: 4200100000
@@ -8371,6 +8744,7 @@ configuration:
   ARISTA371T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.118
       asn: 4200100000
@@ -8388,6 +8762,7 @@ configuration:
   ARISTA372T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.119
       asn: 4200100000
@@ -8405,6 +8780,7 @@ configuration:
   ARISTA373T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.120
       asn: 4200100000
@@ -8422,6 +8798,7 @@ configuration:
   ARISTA374T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.121
       asn: 4200100000
@@ -8439,6 +8816,7 @@ configuration:
   ARISTA375T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.122
       asn: 4200100000
@@ -8456,6 +8834,7 @@ configuration:
   ARISTA376T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.123
       asn: 4200100000
@@ -8473,6 +8852,7 @@ configuration:
   ARISTA377T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.124
       asn: 4200100000
@@ -8490,6 +8870,7 @@ configuration:
   ARISTA378T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.125
       asn: 4200100000
@@ -8507,6 +8888,7 @@ configuration:
   ARISTA379T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.126
       asn: 4200100000
@@ -8524,6 +8906,7 @@ configuration:
   ARISTA380T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.127
       asn: 4200100000
@@ -8541,6 +8924,7 @@ configuration:
   ARISTA381T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.128
       asn: 4200100000
@@ -8558,6 +8942,7 @@ configuration:
   ARISTA382T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.129
       asn: 4200100000
@@ -8575,6 +8960,7 @@ configuration:
   ARISTA383T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.130
       asn: 4200100000
@@ -8592,6 +8978,7 @@ configuration:
   ARISTA384T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.131
       asn: 4200100000
@@ -8609,6 +8996,7 @@ configuration:
   ARISTA385T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.132
       asn: 4200100000
@@ -8626,6 +9014,7 @@ configuration:
   ARISTA386T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.133
       asn: 4200100000
@@ -8643,6 +9032,7 @@ configuration:
   ARISTA387T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.134
       asn: 4200100000
@@ -8660,6 +9050,7 @@ configuration:
   ARISTA388T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.135
       asn: 4200100000
@@ -8677,6 +9068,7 @@ configuration:
   ARISTA389T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.136
       asn: 4200100000
@@ -8694,6 +9086,7 @@ configuration:
   ARISTA390T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.137
       asn: 4200100000
@@ -8711,6 +9104,7 @@ configuration:
   ARISTA391T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.138
       asn: 4200100000
@@ -8728,6 +9122,7 @@ configuration:
   ARISTA392T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.139
       asn: 4200100000
@@ -8745,6 +9140,7 @@ configuration:
   ARISTA393T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.140
       asn: 4200100000
@@ -8762,6 +9158,7 @@ configuration:
   ARISTA394T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.141
       asn: 4200100000
@@ -8779,6 +9176,7 @@ configuration:
   ARISTA395T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.142
       asn: 4200100000
@@ -8796,6 +9194,7 @@ configuration:
   ARISTA396T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.143
       asn: 4200100000
@@ -8813,6 +9212,7 @@ configuration:
   ARISTA397T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.144
       asn: 4200100000
@@ -8830,6 +9230,7 @@ configuration:
   ARISTA398T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.145
       asn: 4200100000
@@ -8847,6 +9248,7 @@ configuration:
   ARISTA399T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.146
       asn: 4200100000
@@ -8864,6 +9266,7 @@ configuration:
   ARISTA400T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.147
       asn: 4200100000
@@ -8881,6 +9284,7 @@ configuration:
   ARISTA401T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.148
       asn: 4200100000
@@ -8898,6 +9302,7 @@ configuration:
   ARISTA402T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.149
       asn: 4200100000
@@ -8915,6 +9320,7 @@ configuration:
   ARISTA403T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.150
       asn: 4200100000
@@ -8932,6 +9338,7 @@ configuration:
   ARISTA404T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.151
       asn: 4200100000
@@ -8949,6 +9356,7 @@ configuration:
   ARISTA405T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.152
       asn: 4200100000
@@ -8966,6 +9374,7 @@ configuration:
   ARISTA406T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.153
       asn: 4200100000
@@ -8983,6 +9392,7 @@ configuration:
   ARISTA407T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.154
       asn: 4200100000
@@ -9000,6 +9410,7 @@ configuration:
   ARISTA408T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.155
       asn: 4200100000
@@ -9017,6 +9428,7 @@ configuration:
   ARISTA409T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.156
       asn: 4200100000
@@ -9034,6 +9446,7 @@ configuration:
   ARISTA410T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.157
       asn: 4200100000
@@ -9051,6 +9464,7 @@ configuration:
   ARISTA411T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.158
       asn: 4200100000
@@ -9068,6 +9482,7 @@ configuration:
   ARISTA412T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.159
       asn: 4200100000
@@ -9085,6 +9500,7 @@ configuration:
   ARISTA413T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.160
       asn: 4200100000
@@ -9102,6 +9518,7 @@ configuration:
   ARISTA414T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.161
       asn: 4200100000
@@ -9119,6 +9536,7 @@ configuration:
   ARISTA415T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.162
       asn: 4200100000
@@ -9136,6 +9554,7 @@ configuration:
   ARISTA416T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.163
       asn: 4200100000
@@ -9153,6 +9572,7 @@ configuration:
   ARISTA417T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.164
       asn: 4200100000
@@ -9170,6 +9590,7 @@ configuration:
   ARISTA418T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.165
       asn: 4200100000
@@ -9187,6 +9608,7 @@ configuration:
   ARISTA419T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.166
       asn: 4200100000
@@ -9204,6 +9626,7 @@ configuration:
   ARISTA420T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.167
       asn: 4200100000
@@ -9221,6 +9644,7 @@ configuration:
   ARISTA421T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.168
       asn: 4200100000
@@ -9238,6 +9662,7 @@ configuration:
   ARISTA422T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.169
       asn: 4200100000
@@ -9255,6 +9680,7 @@ configuration:
   ARISTA423T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.170
       asn: 4200100000
@@ -9272,6 +9698,7 @@ configuration:
   ARISTA424T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.171
       asn: 4200100000
@@ -9289,6 +9716,7 @@ configuration:
   ARISTA425T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.172
       asn: 4200100000
@@ -9306,6 +9734,7 @@ configuration:
   ARISTA426T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.173
       asn: 4200100000
@@ -9323,6 +9752,7 @@ configuration:
   ARISTA427T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.174
       asn: 4200100000
@@ -9340,6 +9770,7 @@ configuration:
   ARISTA428T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.175
       asn: 4200100000
@@ -9357,6 +9788,7 @@ configuration:
   ARISTA429T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.176
       asn: 4200100000
@@ -9374,6 +9806,7 @@ configuration:
   ARISTA430T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.177
       asn: 4200100000
@@ -9391,6 +9824,7 @@ configuration:
   ARISTA431T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.178
       asn: 4200100000
@@ -9408,6 +9842,7 @@ configuration:
   ARISTA432T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.179
       asn: 4200100000
@@ -9425,6 +9860,7 @@ configuration:
   ARISTA433T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.180
       asn: 4200100000
@@ -9442,6 +9878,7 @@ configuration:
   ARISTA434T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.181
       asn: 4200100000
@@ -9459,6 +9896,7 @@ configuration:
   ARISTA435T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.182
       asn: 4200100000
@@ -9476,6 +9914,7 @@ configuration:
   ARISTA436T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.183
       asn: 4200100000
@@ -9493,6 +9932,7 @@ configuration:
   ARISTA437T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.184
       asn: 4200100000
@@ -9510,6 +9950,7 @@ configuration:
   ARISTA438T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.185
       asn: 4200100000
@@ -9527,6 +9968,7 @@ configuration:
   ARISTA439T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.186
       asn: 4200100000
@@ -9544,6 +9986,7 @@ configuration:
   ARISTA440T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.187
       asn: 4200100000
@@ -9561,6 +10004,7 @@ configuration:
   ARISTA441T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.188
       asn: 4200100000
@@ -9578,6 +10022,7 @@ configuration:
   ARISTA442T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.189
       asn: 4200100000
@@ -9595,6 +10040,7 @@ configuration:
   ARISTA443T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.190
       asn: 4200100000
@@ -9612,6 +10058,7 @@ configuration:
   ARISTA444T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.191
       asn: 4200100000
@@ -9629,6 +10076,7 @@ configuration:
   ARISTA445T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.192
       asn: 4200100000
@@ -9646,6 +10094,7 @@ configuration:
   ARISTA446T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.193
       asn: 4200100000
@@ -9663,6 +10112,7 @@ configuration:
   ARISTA447T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.194
       asn: 4200100000
@@ -9680,6 +10130,7 @@ configuration:
   ARISTA448T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.195
       asn: 4200100000
@@ -9697,6 +10148,7 @@ configuration:
   ARISTA449T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.196
       asn: 4200100000
@@ -9714,6 +10166,7 @@ configuration:
   ARISTA450T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.197
       asn: 4200100000
@@ -9731,6 +10184,7 @@ configuration:
   ARISTA451T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.198
       asn: 4200100000
@@ -9748,6 +10202,7 @@ configuration:
   ARISTA452T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.199
       asn: 4200100000
@@ -9765,6 +10220,7 @@ configuration:
   ARISTA453T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.200
       asn: 4200100000
@@ -9782,6 +10238,7 @@ configuration:
   ARISTA454T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.201
       asn: 4200100000
@@ -9799,6 +10256,7 @@ configuration:
   ARISTA455T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.202
       asn: 4200100000
@@ -9816,6 +10274,7 @@ configuration:
   ARISTA456T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.203
       asn: 4200100000
@@ -9833,6 +10292,7 @@ configuration:
   ARISTA457T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.204
       asn: 4200100000
@@ -9850,6 +10310,7 @@ configuration:
   ARISTA458T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.205
       asn: 4200100000
@@ -9867,6 +10328,7 @@ configuration:
   ARISTA459T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.206
       asn: 4200100000
@@ -9884,6 +10346,7 @@ configuration:
   ARISTA460T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.207
       asn: 4200100000
@@ -9901,6 +10364,7 @@ configuration:
   ARISTA461T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.208
       asn: 4200100000
@@ -9918,6 +10382,7 @@ configuration:
   ARISTA462T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.209
       asn: 4200100000
@@ -9935,6 +10400,7 @@ configuration:
   ARISTA463T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.210
       asn: 4200100000
@@ -9952,6 +10418,7 @@ configuration:
   ARISTA464T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.211
       asn: 4200100000
@@ -9969,6 +10436,7 @@ configuration:
   ARISTA465T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.212
       asn: 4200100000
@@ -9986,6 +10454,7 @@ configuration:
   ARISTA466T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.213
       asn: 4200100000
@@ -10003,6 +10472,7 @@ configuration:
   ARISTA467T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.214
       asn: 4200100000
@@ -10020,6 +10490,7 @@ configuration:
   ARISTA468T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.215
       asn: 4200100000
@@ -10037,6 +10508,7 @@ configuration:
   ARISTA469T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.216
       asn: 4200100000
@@ -10054,6 +10526,7 @@ configuration:
   ARISTA470T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.217
       asn: 4200100000
@@ -10071,6 +10544,7 @@ configuration:
   ARISTA471T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.218
       asn: 4200100000
@@ -10088,6 +10562,7 @@ configuration:
   ARISTA472T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.219
       asn: 4200100000
@@ -10105,6 +10580,7 @@ configuration:
   ARISTA473T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.220
       asn: 4200100000
@@ -10122,6 +10598,7 @@ configuration:
   ARISTA474T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.221
       asn: 4200100000
@@ -10139,6 +10616,7 @@ configuration:
   ARISTA475T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.222
       asn: 4200100000
@@ -10156,6 +10634,7 @@ configuration:
   ARISTA476T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.223
       asn: 4200100000
@@ -10173,6 +10652,7 @@ configuration:
   ARISTA477T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.224
       asn: 4200100000
@@ -10190,6 +10670,7 @@ configuration:
   ARISTA478T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.225
       asn: 4200100000
@@ -10207,6 +10688,7 @@ configuration:
   ARISTA479T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.226
       asn: 4200100000
@@ -10224,6 +10706,7 @@ configuration:
   ARISTA480T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.227
       asn: 4200100000
@@ -10241,6 +10724,7 @@ configuration:
   ARISTA481T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.228
       asn: 4200100000
@@ -10258,6 +10742,7 @@ configuration:
   ARISTA482T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.229
       asn: 4200100000
@@ -10275,6 +10760,7 @@ configuration:
   ARISTA483T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.230
       asn: 4200100000
@@ -10292,6 +10778,7 @@ configuration:
   ARISTA484T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.231
       asn: 4200100000
@@ -10309,6 +10796,7 @@ configuration:
   ARISTA485T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.232
       asn: 4200100000
@@ -10326,6 +10814,7 @@ configuration:
   ARISTA486T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.233
       asn: 4200100000
@@ -10343,6 +10832,7 @@ configuration:
   ARISTA487T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.234
       asn: 4200100000
@@ -10360,6 +10850,7 @@ configuration:
   ARISTA488T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.235
       asn: 4200100000
@@ -10377,6 +10868,7 @@ configuration:
   ARISTA489T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.236
       asn: 4200100000
@@ -10394,6 +10886,7 @@ configuration:
   ARISTA490T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.237
       asn: 4200100000
@@ -10411,6 +10904,7 @@ configuration:
   ARISTA491T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.238
       asn: 4200100000
@@ -10428,6 +10922,7 @@ configuration:
   ARISTA492T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.239
       asn: 4200100000
@@ -10445,6 +10940,7 @@ configuration:
   ARISTA493T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.240
       asn: 4200100000
@@ -10462,6 +10958,7 @@ configuration:
   ARISTA494T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.241
       asn: 4200100000
@@ -10479,6 +10976,7 @@ configuration:
   ARISTA495T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.242
       asn: 4200100000
@@ -10496,6 +10994,7 @@ configuration:
   ARISTA496T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.243
       asn: 4200100000
@@ -10513,6 +11012,7 @@ configuration:
   ARISTA497T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.244
       asn: 4200100000
@@ -10530,6 +11030,7 @@ configuration:
   ARISTA498T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.245
       asn: 4200100000
@@ -10547,6 +11048,7 @@ configuration:
   ARISTA499T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.246
       asn: 4200100000
@@ -10564,6 +11066,7 @@ configuration:
   ARISTA500T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.247
       asn: 4200100000
@@ -10581,6 +11084,7 @@ configuration:
   ARISTA501T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.248
       asn: 4200100000
@@ -10598,6 +11102,7 @@ configuration:
   ARISTA502T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.249
       asn: 4200100000
@@ -10615,6 +11120,7 @@ configuration:
   ARISTA503T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.250
       asn: 4200100000
@@ -10632,6 +11138,7 @@ configuration:
   ARISTA504T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.251
       asn: 4200100000
@@ -10649,6 +11156,7 @@ configuration:
   ARISTA505T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.252
       asn: 4200100000
@@ -10666,6 +11174,7 @@ configuration:
   ARISTA506T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.253
       asn: 4200100000
@@ -10683,6 +11192,7 @@ configuration:
   ARISTA507T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.254
       asn: 4200100000
@@ -10700,6 +11210,7 @@ configuration:
   ARISTA508T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.255
       asn: 4200100000
@@ -10717,6 +11228,7 @@ configuration:
   ARISTA509T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.2.0
       asn: 4200100000
@@ -10734,6 +11246,7 @@ configuration:
   ARISTA510T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.2.1
       asn: 4200100000

--- a/ansible/vars/topo_t0-isolated-d2u510s2.yml
+++ b/ansible/vars/topo_t0-isolated-d2u510s2.yml
@@ -2070,7 +2070,6 @@ configuration_properties:
   common:
     dut_asn: 4200000000
     dut_type: ToRRouter
-    swrole: leaf
     podset_number: 1
     tor_number: 512
     tor_subnet_number: 2
@@ -2084,11 +2083,16 @@ configuration_properties:
     ipv6_address_pattern: FC00:C:C::%02X%02X:%02X%02X:0/120
     enable_ipv4_routes_generation: false
     enable_ipv6_routes_generation: true
+  leaf:
+    swrole: leaf
+  tor:
+    swrole: tor
 
 configuration:
   ARISTA01T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.3
       asn: 4200100000
@@ -2106,6 +2110,7 @@ configuration:
   ARISTA02T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.4
       asn: 4200100000
@@ -2123,6 +2128,7 @@ configuration:
   ARISTA03T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.5
       asn: 4200100000
@@ -2140,6 +2146,7 @@ configuration:
   ARISTA04T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.6
       asn: 4200100000
@@ -2157,6 +2164,7 @@ configuration:
   ARISTA05T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.7
       asn: 4200100000
@@ -2174,6 +2182,7 @@ configuration:
   ARISTA06T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.8
       asn: 4200100000
@@ -2191,6 +2200,7 @@ configuration:
   ARISTA07T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.9
       asn: 4200100000
@@ -2208,6 +2218,7 @@ configuration:
   ARISTA08T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.10
       asn: 4200100000
@@ -2225,6 +2236,7 @@ configuration:
   ARISTA09T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.11
       asn: 4200100000
@@ -2242,6 +2254,7 @@ configuration:
   ARISTA10T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.12
       asn: 4200100000
@@ -2259,6 +2272,7 @@ configuration:
   ARISTA11T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.13
       asn: 4200100000
@@ -2276,6 +2290,7 @@ configuration:
   ARISTA12T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.14
       asn: 4200100000
@@ -2293,6 +2308,7 @@ configuration:
   ARISTA13T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.15
       asn: 4200100000
@@ -2310,6 +2326,7 @@ configuration:
   ARISTA14T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.16
       asn: 4200100000
@@ -2327,6 +2344,7 @@ configuration:
   ARISTA15T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.17
       asn: 4200100000
@@ -2344,6 +2362,7 @@ configuration:
   ARISTA16T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.18
       asn: 4200100000
@@ -2361,6 +2380,7 @@ configuration:
   ARISTA17T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.19
       asn: 4200100000
@@ -2378,6 +2398,7 @@ configuration:
   ARISTA18T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.20
       asn: 4200100000
@@ -2395,6 +2416,7 @@ configuration:
   ARISTA19T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.21
       asn: 4200100000
@@ -2412,6 +2434,7 @@ configuration:
   ARISTA20T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.22
       asn: 4200100000
@@ -2429,6 +2452,7 @@ configuration:
   ARISTA21T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.23
       asn: 4200100000
@@ -2446,6 +2470,7 @@ configuration:
   ARISTA22T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.24
       asn: 4200100000
@@ -2463,6 +2488,7 @@ configuration:
   ARISTA23T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.25
       asn: 4200100000
@@ -2480,6 +2506,7 @@ configuration:
   ARISTA24T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.26
       asn: 4200100000
@@ -2497,6 +2524,7 @@ configuration:
   ARISTA25T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.27
       asn: 4200100000
@@ -2514,6 +2542,7 @@ configuration:
   ARISTA26T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.28
       asn: 4200100000
@@ -2531,6 +2560,7 @@ configuration:
   ARISTA27T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.29
       asn: 4200100000
@@ -2548,6 +2578,7 @@ configuration:
   ARISTA28T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.30
       asn: 4200100000
@@ -2565,6 +2596,7 @@ configuration:
   ARISTA29T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.31
       asn: 4200100000
@@ -2582,6 +2614,7 @@ configuration:
   ARISTA30T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.32
       asn: 4200100000
@@ -2599,6 +2632,7 @@ configuration:
   ARISTA31T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.33
       asn: 4200100000
@@ -2616,6 +2650,7 @@ configuration:
   ARISTA32T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.34
       asn: 4200100000
@@ -2633,6 +2668,7 @@ configuration:
   ARISTA33T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.35
       asn: 4200100000
@@ -2650,6 +2686,7 @@ configuration:
   ARISTA34T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.36
       asn: 4200100000
@@ -2667,6 +2704,7 @@ configuration:
   ARISTA35T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.37
       asn: 4200100000
@@ -2684,6 +2722,7 @@ configuration:
   ARISTA36T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.38
       asn: 4200100000
@@ -2701,6 +2740,7 @@ configuration:
   ARISTA37T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.39
       asn: 4200100000
@@ -2718,6 +2758,7 @@ configuration:
   ARISTA38T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.40
       asn: 4200100000
@@ -2735,6 +2776,7 @@ configuration:
   ARISTA39T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.41
       asn: 4200100000
@@ -2752,6 +2794,7 @@ configuration:
   ARISTA40T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.42
       asn: 4200100000
@@ -2769,6 +2812,7 @@ configuration:
   ARISTA41T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.43
       asn: 4200100000
@@ -2786,6 +2830,7 @@ configuration:
   ARISTA42T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.44
       asn: 4200100000
@@ -2803,6 +2848,7 @@ configuration:
   ARISTA43T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.45
       asn: 4200100000
@@ -2820,6 +2866,7 @@ configuration:
   ARISTA44T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.46
       asn: 4200100000
@@ -2837,6 +2884,7 @@ configuration:
   ARISTA45T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.47
       asn: 4200100000
@@ -2854,6 +2902,7 @@ configuration:
   ARISTA46T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.48
       asn: 4200100000
@@ -2871,6 +2920,7 @@ configuration:
   ARISTA47T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.49
       asn: 4200100000
@@ -2888,6 +2938,7 @@ configuration:
   ARISTA48T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.50
       asn: 4200100000
@@ -2905,6 +2956,7 @@ configuration:
   ARISTA49T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.51
       asn: 4200100000
@@ -2922,6 +2974,7 @@ configuration:
   ARISTA50T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.52
       asn: 4200100000
@@ -2939,6 +2992,7 @@ configuration:
   ARISTA51T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.53
       asn: 4200100000
@@ -2956,6 +3010,7 @@ configuration:
   ARISTA52T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.54
       asn: 4200100000
@@ -2973,6 +3028,7 @@ configuration:
   ARISTA53T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.55
       asn: 4200100000
@@ -2990,6 +3046,7 @@ configuration:
   ARISTA54T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.56
       asn: 4200100000
@@ -3007,6 +3064,7 @@ configuration:
   ARISTA55T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.57
       asn: 4200100000
@@ -3024,6 +3082,7 @@ configuration:
   ARISTA56T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.58
       asn: 4200100000
@@ -3041,6 +3100,7 @@ configuration:
   ARISTA57T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.59
       asn: 4200100000
@@ -3058,6 +3118,7 @@ configuration:
   ARISTA58T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.60
       asn: 4200100000
@@ -3075,6 +3136,7 @@ configuration:
   ARISTA59T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.61
       asn: 4200100000
@@ -3092,6 +3154,7 @@ configuration:
   ARISTA60T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.62
       asn: 4200100000
@@ -3109,6 +3172,7 @@ configuration:
   ARISTA61T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.63
       asn: 4200100000
@@ -3126,6 +3190,7 @@ configuration:
   ARISTA62T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.64
       asn: 4200100000
@@ -3143,6 +3208,7 @@ configuration:
   ARISTA63T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.65
       asn: 4200100000
@@ -3160,6 +3226,7 @@ configuration:
   ARISTA64T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.66
       asn: 4200100000
@@ -3177,6 +3244,7 @@ configuration:
   ARISTA65T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.67
       asn: 4200100000
@@ -3194,6 +3262,7 @@ configuration:
   ARISTA66T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.68
       asn: 4200100000
@@ -3211,6 +3280,7 @@ configuration:
   ARISTA67T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.69
       asn: 4200100000
@@ -3228,6 +3298,7 @@ configuration:
   ARISTA68T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.70
       asn: 4200100000
@@ -3245,6 +3316,7 @@ configuration:
   ARISTA69T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.71
       asn: 4200100000
@@ -3262,6 +3334,7 @@ configuration:
   ARISTA70T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.72
       asn: 4200100000
@@ -3279,6 +3352,7 @@ configuration:
   ARISTA71T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.73
       asn: 4200100000
@@ -3296,6 +3370,7 @@ configuration:
   ARISTA72T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.74
       asn: 4200100000
@@ -3313,6 +3388,7 @@ configuration:
   ARISTA73T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.75
       asn: 4200100000
@@ -3330,6 +3406,7 @@ configuration:
   ARISTA74T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.76
       asn: 4200100000
@@ -3347,6 +3424,7 @@ configuration:
   ARISTA75T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.77
       asn: 4200100000
@@ -3364,6 +3442,7 @@ configuration:
   ARISTA76T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.78
       asn: 4200100000
@@ -3381,6 +3460,7 @@ configuration:
   ARISTA77T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.79
       asn: 4200100000
@@ -3398,6 +3478,7 @@ configuration:
   ARISTA78T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.80
       asn: 4200100000
@@ -3415,6 +3496,7 @@ configuration:
   ARISTA79T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.81
       asn: 4200100000
@@ -3432,6 +3514,7 @@ configuration:
   ARISTA80T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.82
       asn: 4200100000
@@ -3449,6 +3532,7 @@ configuration:
   ARISTA81T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.83
       asn: 4200100000
@@ -3466,6 +3550,7 @@ configuration:
   ARISTA82T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.84
       asn: 4200100000
@@ -3483,6 +3568,7 @@ configuration:
   ARISTA83T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.85
       asn: 4200100000
@@ -3500,6 +3586,7 @@ configuration:
   ARISTA84T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.86
       asn: 4200100000
@@ -3517,6 +3604,7 @@ configuration:
   ARISTA85T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.87
       asn: 4200100000
@@ -3534,6 +3622,7 @@ configuration:
   ARISTA86T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.88
       asn: 4200100000
@@ -3551,6 +3640,7 @@ configuration:
   ARISTA87T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.89
       asn: 4200100000
@@ -3568,6 +3658,7 @@ configuration:
   ARISTA88T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.90
       asn: 4200100000
@@ -3585,6 +3676,7 @@ configuration:
   ARISTA89T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.91
       asn: 4200100000
@@ -3602,6 +3694,7 @@ configuration:
   ARISTA90T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.92
       asn: 4200100000
@@ -3619,6 +3712,7 @@ configuration:
   ARISTA91T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.93
       asn: 4200100000
@@ -3636,6 +3730,7 @@ configuration:
   ARISTA92T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.94
       asn: 4200100000
@@ -3653,6 +3748,7 @@ configuration:
   ARISTA93T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.95
       asn: 4200100000
@@ -3670,6 +3766,7 @@ configuration:
   ARISTA94T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.96
       asn: 4200100000
@@ -3687,6 +3784,7 @@ configuration:
   ARISTA95T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.97
       asn: 4200100000
@@ -3704,6 +3802,7 @@ configuration:
   ARISTA96T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.98
       asn: 4200100000
@@ -3721,6 +3820,7 @@ configuration:
   ARISTA97T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.99
       asn: 4200100000
@@ -3738,6 +3838,7 @@ configuration:
   ARISTA98T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.100
       asn: 4200100000
@@ -3755,6 +3856,7 @@ configuration:
   ARISTA99T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.101
       asn: 4200100000
@@ -3772,6 +3874,7 @@ configuration:
   ARISTA100T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.102
       asn: 4200100000
@@ -3789,6 +3892,7 @@ configuration:
   ARISTA101T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.103
       asn: 4200100000
@@ -3806,6 +3910,7 @@ configuration:
   ARISTA102T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.104
       asn: 4200100000
@@ -3823,6 +3928,7 @@ configuration:
   ARISTA103T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.105
       asn: 4200100000
@@ -3840,6 +3946,7 @@ configuration:
   ARISTA104T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.106
       asn: 4200100000
@@ -3857,6 +3964,7 @@ configuration:
   ARISTA105T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.107
       asn: 4200100000
@@ -3874,6 +3982,7 @@ configuration:
   ARISTA106T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.108
       asn: 4200100000
@@ -3891,6 +4000,7 @@ configuration:
   ARISTA107T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.109
       asn: 4200100000
@@ -3908,6 +4018,7 @@ configuration:
   ARISTA108T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.110
       asn: 4200100000
@@ -3925,6 +4036,7 @@ configuration:
   ARISTA109T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.111
       asn: 4200100000
@@ -3942,6 +4054,7 @@ configuration:
   ARISTA110T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.112
       asn: 4200100000
@@ -3959,6 +4072,7 @@ configuration:
   ARISTA111T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.113
       asn: 4200100000
@@ -3976,6 +4090,7 @@ configuration:
   ARISTA112T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.114
       asn: 4200100000
@@ -3993,6 +4108,7 @@ configuration:
   ARISTA113T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.115
       asn: 4200100000
@@ -4010,6 +4126,7 @@ configuration:
   ARISTA114T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.116
       asn: 4200100000
@@ -4027,6 +4144,7 @@ configuration:
   ARISTA115T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.117
       asn: 4200100000
@@ -4044,6 +4162,7 @@ configuration:
   ARISTA116T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.118
       asn: 4200100000
@@ -4061,6 +4180,7 @@ configuration:
   ARISTA117T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.119
       asn: 4200100000
@@ -4078,6 +4198,7 @@ configuration:
   ARISTA118T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.120
       asn: 4200100000
@@ -4095,6 +4216,7 @@ configuration:
   ARISTA119T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.121
       asn: 4200100000
@@ -4112,6 +4234,7 @@ configuration:
   ARISTA120T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.122
       asn: 4200100000
@@ -4129,6 +4252,7 @@ configuration:
   ARISTA121T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.123
       asn: 4200100000
@@ -4146,6 +4270,7 @@ configuration:
   ARISTA122T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.124
       asn: 4200100000
@@ -4163,6 +4288,7 @@ configuration:
   ARISTA123T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.125
       asn: 4200100000
@@ -4180,6 +4306,7 @@ configuration:
   ARISTA124T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.126
       asn: 4200100000
@@ -4197,6 +4324,7 @@ configuration:
   ARISTA125T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.127
       asn: 4200100000
@@ -4214,6 +4342,7 @@ configuration:
   ARISTA126T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.128
       asn: 4200100000
@@ -4231,6 +4360,7 @@ configuration:
   ARISTA127T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.129
       asn: 4200100000
@@ -4248,6 +4378,7 @@ configuration:
   ARISTA128T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.130
       asn: 4200100000
@@ -4265,6 +4396,7 @@ configuration:
   ARISTA129T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.131
       asn: 4200100000
@@ -4282,6 +4414,7 @@ configuration:
   ARISTA130T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.132
       asn: 4200100000
@@ -4299,6 +4432,7 @@ configuration:
   ARISTA131T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.133
       asn: 4200100000
@@ -4316,6 +4450,7 @@ configuration:
   ARISTA132T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.134
       asn: 4200100000
@@ -4333,6 +4468,7 @@ configuration:
   ARISTA133T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.135
       asn: 4200100000
@@ -4350,6 +4486,7 @@ configuration:
   ARISTA134T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.136
       asn: 4200100000
@@ -4367,6 +4504,7 @@ configuration:
   ARISTA135T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.137
       asn: 4200100000
@@ -4384,6 +4522,7 @@ configuration:
   ARISTA136T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.138
       asn: 4200100000
@@ -4401,6 +4540,7 @@ configuration:
   ARISTA137T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.139
       asn: 4200100000
@@ -4418,6 +4558,7 @@ configuration:
   ARISTA138T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.140
       asn: 4200100000
@@ -4435,6 +4576,7 @@ configuration:
   ARISTA139T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.141
       asn: 4200100000
@@ -4452,6 +4594,7 @@ configuration:
   ARISTA140T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.142
       asn: 4200100000
@@ -4469,6 +4612,7 @@ configuration:
   ARISTA141T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.143
       asn: 4200100000
@@ -4486,6 +4630,7 @@ configuration:
   ARISTA142T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.144
       asn: 4200100000
@@ -4503,6 +4648,7 @@ configuration:
   ARISTA143T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.145
       asn: 4200100000
@@ -4520,6 +4666,7 @@ configuration:
   ARISTA144T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.146
       asn: 4200100000
@@ -4537,6 +4684,7 @@ configuration:
   ARISTA145T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.147
       asn: 4200100000
@@ -4554,6 +4702,7 @@ configuration:
   ARISTA146T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.148
       asn: 4200100000
@@ -4571,6 +4720,7 @@ configuration:
   ARISTA147T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.149
       asn: 4200100000
@@ -4588,6 +4738,7 @@ configuration:
   ARISTA148T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.150
       asn: 4200100000
@@ -4605,6 +4756,7 @@ configuration:
   ARISTA149T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.151
       asn: 4200100000
@@ -4622,6 +4774,7 @@ configuration:
   ARISTA150T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.152
       asn: 4200100000
@@ -4639,6 +4792,7 @@ configuration:
   ARISTA151T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.153
       asn: 4200100000
@@ -4656,6 +4810,7 @@ configuration:
   ARISTA152T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.154
       asn: 4200100000
@@ -4673,6 +4828,7 @@ configuration:
   ARISTA153T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.155
       asn: 4200100000
@@ -4690,6 +4846,7 @@ configuration:
   ARISTA154T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.156
       asn: 4200100000
@@ -4707,6 +4864,7 @@ configuration:
   ARISTA155T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.157
       asn: 4200100000
@@ -4724,6 +4882,7 @@ configuration:
   ARISTA156T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.158
       asn: 4200100000
@@ -4741,6 +4900,7 @@ configuration:
   ARISTA157T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.159
       asn: 4200100000
@@ -4758,6 +4918,7 @@ configuration:
   ARISTA158T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.160
       asn: 4200100000
@@ -4775,6 +4936,7 @@ configuration:
   ARISTA159T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.161
       asn: 4200100000
@@ -4792,6 +4954,7 @@ configuration:
   ARISTA160T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.162
       asn: 4200100000
@@ -4809,6 +4972,7 @@ configuration:
   ARISTA161T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.163
       asn: 4200100000
@@ -4826,6 +4990,7 @@ configuration:
   ARISTA162T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.164
       asn: 4200100000
@@ -4843,6 +5008,7 @@ configuration:
   ARISTA163T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.165
       asn: 4200100000
@@ -4860,6 +5026,7 @@ configuration:
   ARISTA164T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.166
       asn: 4200100000
@@ -4877,6 +5044,7 @@ configuration:
   ARISTA165T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.167
       asn: 4200100000
@@ -4894,6 +5062,7 @@ configuration:
   ARISTA166T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.168
       asn: 4200100000
@@ -4911,6 +5080,7 @@ configuration:
   ARISTA167T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.169
       asn: 4200100000
@@ -4928,6 +5098,7 @@ configuration:
   ARISTA168T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.170
       asn: 4200100000
@@ -4945,6 +5116,7 @@ configuration:
   ARISTA169T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.171
       asn: 4200100000
@@ -4962,6 +5134,7 @@ configuration:
   ARISTA170T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.172
       asn: 4200100000
@@ -4979,6 +5152,7 @@ configuration:
   ARISTA171T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.173
       asn: 4200100000
@@ -4996,6 +5170,7 @@ configuration:
   ARISTA172T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.174
       asn: 4200100000
@@ -5013,6 +5188,7 @@ configuration:
   ARISTA173T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.175
       asn: 4200100000
@@ -5030,6 +5206,7 @@ configuration:
   ARISTA174T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.176
       asn: 4200100000
@@ -5047,6 +5224,7 @@ configuration:
   ARISTA175T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.177
       asn: 4200100000
@@ -5064,6 +5242,7 @@ configuration:
   ARISTA176T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.178
       asn: 4200100000
@@ -5081,6 +5260,7 @@ configuration:
   ARISTA177T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.179
       asn: 4200100000
@@ -5098,6 +5278,7 @@ configuration:
   ARISTA178T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.180
       asn: 4200100000
@@ -5115,6 +5296,7 @@ configuration:
   ARISTA179T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.181
       asn: 4200100000
@@ -5132,6 +5314,7 @@ configuration:
   ARISTA180T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.182
       asn: 4200100000
@@ -5149,6 +5332,7 @@ configuration:
   ARISTA181T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.183
       asn: 4200100000
@@ -5166,6 +5350,7 @@ configuration:
   ARISTA182T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.184
       asn: 4200100000
@@ -5183,6 +5368,7 @@ configuration:
   ARISTA183T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.185
       asn: 4200100000
@@ -5200,6 +5386,7 @@ configuration:
   ARISTA184T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.186
       asn: 4200100000
@@ -5217,6 +5404,7 @@ configuration:
   ARISTA185T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.187
       asn: 4200100000
@@ -5234,6 +5422,7 @@ configuration:
   ARISTA186T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.188
       asn: 4200100000
@@ -5251,6 +5440,7 @@ configuration:
   ARISTA187T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.189
       asn: 4200100000
@@ -5268,6 +5458,7 @@ configuration:
   ARISTA188T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.190
       asn: 4200100000
@@ -5285,6 +5476,7 @@ configuration:
   ARISTA189T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.191
       asn: 4200100000
@@ -5302,6 +5494,7 @@ configuration:
   ARISTA190T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.192
       asn: 4200100000
@@ -5319,6 +5512,7 @@ configuration:
   ARISTA191T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.193
       asn: 4200100000
@@ -5336,6 +5530,7 @@ configuration:
   ARISTA192T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.194
       asn: 4200100000
@@ -5353,6 +5548,7 @@ configuration:
   ARISTA193T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.195
       asn: 4200100000
@@ -5370,6 +5566,7 @@ configuration:
   ARISTA194T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.196
       asn: 4200100000
@@ -5387,6 +5584,7 @@ configuration:
   ARISTA195T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.197
       asn: 4200100000
@@ -5404,6 +5602,7 @@ configuration:
   ARISTA196T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.198
       asn: 4200100000
@@ -5421,6 +5620,7 @@ configuration:
   ARISTA197T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.199
       asn: 4200100000
@@ -5438,6 +5638,7 @@ configuration:
   ARISTA198T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.200
       asn: 4200100000
@@ -5455,6 +5656,7 @@ configuration:
   ARISTA199T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.201
       asn: 4200100000
@@ -5472,6 +5674,7 @@ configuration:
   ARISTA200T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.202
       asn: 4200100000
@@ -5489,6 +5692,7 @@ configuration:
   ARISTA201T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.203
       asn: 4200100000
@@ -5506,6 +5710,7 @@ configuration:
   ARISTA202T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.204
       asn: 4200100000
@@ -5523,6 +5728,7 @@ configuration:
   ARISTA203T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.205
       asn: 4200100000
@@ -5540,6 +5746,7 @@ configuration:
   ARISTA204T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.206
       asn: 4200100000
@@ -5557,6 +5764,7 @@ configuration:
   ARISTA205T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.207
       asn: 4200100000
@@ -5574,6 +5782,7 @@ configuration:
   ARISTA206T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.208
       asn: 4200100000
@@ -5591,6 +5800,7 @@ configuration:
   ARISTA207T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.209
       asn: 4200100000
@@ -5608,6 +5818,7 @@ configuration:
   ARISTA208T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.210
       asn: 4200100000
@@ -5625,6 +5836,7 @@ configuration:
   ARISTA209T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.211
       asn: 4200100000
@@ -5642,6 +5854,7 @@ configuration:
   ARISTA210T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.212
       asn: 4200100000
@@ -5659,6 +5872,7 @@ configuration:
   ARISTA211T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.213
       asn: 4200100000
@@ -5676,6 +5890,7 @@ configuration:
   ARISTA212T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.214
       asn: 4200100000
@@ -5693,6 +5908,7 @@ configuration:
   ARISTA213T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.215
       asn: 4200100000
@@ -5710,6 +5926,7 @@ configuration:
   ARISTA214T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.216
       asn: 4200100000
@@ -5727,6 +5944,7 @@ configuration:
   ARISTA215T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.217
       asn: 4200100000
@@ -5744,6 +5962,7 @@ configuration:
   ARISTA216T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.218
       asn: 4200100000
@@ -5761,6 +5980,7 @@ configuration:
   ARISTA217T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.219
       asn: 4200100000
@@ -5778,6 +5998,7 @@ configuration:
   ARISTA218T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.220
       asn: 4200100000
@@ -5795,6 +6016,7 @@ configuration:
   ARISTA219T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.221
       asn: 4200100000
@@ -5812,6 +6034,7 @@ configuration:
   ARISTA220T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.222
       asn: 4200100000
@@ -5829,6 +6052,7 @@ configuration:
   ARISTA221T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.223
       asn: 4200100000
@@ -5846,6 +6070,7 @@ configuration:
   ARISTA222T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.224
       asn: 4200100000
@@ -5863,6 +6088,7 @@ configuration:
   ARISTA223T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.225
       asn: 4200100000
@@ -5880,6 +6106,7 @@ configuration:
   ARISTA224T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.226
       asn: 4200100000
@@ -5897,6 +6124,7 @@ configuration:
   ARISTA225T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.227
       asn: 4200100000
@@ -5914,6 +6142,7 @@ configuration:
   ARISTA226T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.228
       asn: 4200100000
@@ -5931,6 +6160,7 @@ configuration:
   ARISTA227T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.229
       asn: 4200100000
@@ -5948,6 +6178,7 @@ configuration:
   ARISTA228T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.230
       asn: 4200100000
@@ -5965,6 +6196,7 @@ configuration:
   ARISTA229T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.231
       asn: 4200100000
@@ -5982,6 +6214,7 @@ configuration:
   ARISTA230T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.232
       asn: 4200100000
@@ -5999,6 +6232,7 @@ configuration:
   ARISTA231T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.233
       asn: 4200100000
@@ -6016,6 +6250,7 @@ configuration:
   ARISTA232T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.234
       asn: 4200100000
@@ -6033,6 +6268,7 @@ configuration:
   ARISTA233T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.235
       asn: 4200100000
@@ -6050,6 +6286,7 @@ configuration:
   ARISTA234T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.236
       asn: 4200100000
@@ -6067,6 +6304,7 @@ configuration:
   ARISTA235T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.237
       asn: 4200100000
@@ -6084,6 +6322,7 @@ configuration:
   ARISTA236T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.238
       asn: 4200100000
@@ -6101,6 +6340,7 @@ configuration:
   ARISTA237T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.239
       asn: 4200100000
@@ -6118,6 +6358,7 @@ configuration:
   ARISTA238T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.240
       asn: 4200100000
@@ -6135,6 +6376,7 @@ configuration:
   ARISTA239T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.241
       asn: 4200100000
@@ -6152,6 +6394,7 @@ configuration:
   ARISTA240T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.242
       asn: 4200100000
@@ -6169,6 +6412,7 @@ configuration:
   ARISTA241T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.243
       asn: 4200100000
@@ -6186,6 +6430,7 @@ configuration:
   ARISTA242T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.244
       asn: 4200100000
@@ -6203,6 +6448,7 @@ configuration:
   ARISTA243T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.245
       asn: 4200100000
@@ -6220,6 +6466,7 @@ configuration:
   ARISTA244T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.246
       asn: 4200100000
@@ -6237,6 +6484,7 @@ configuration:
   ARISTA245T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.247
       asn: 4200100000
@@ -6254,6 +6502,7 @@ configuration:
   ARISTA246T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.248
       asn: 4200100000
@@ -6271,6 +6520,7 @@ configuration:
   ARISTA247T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.249
       asn: 4200100000
@@ -6288,6 +6538,7 @@ configuration:
   ARISTA248T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.250
       asn: 4200100000
@@ -6305,6 +6556,7 @@ configuration:
   ARISTA249T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.251
       asn: 4200100000
@@ -6322,6 +6574,7 @@ configuration:
   ARISTA250T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.252
       asn: 4200100000
@@ -6339,6 +6592,7 @@ configuration:
   ARISTA251T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.253
       asn: 4200100000
@@ -6356,6 +6610,7 @@ configuration:
   ARISTA252T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.0.254
       asn: 4200100000
@@ -6373,6 +6628,7 @@ configuration:
   ARISTA253T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.0
       asn: 4200100000
@@ -6390,6 +6646,7 @@ configuration:
   ARISTA254T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.1
       asn: 4200100000
@@ -6407,6 +6664,7 @@ configuration:
   ARISTA255T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.2
       asn: 4200100000
@@ -6424,6 +6682,7 @@ configuration:
   ARISTA256T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.3
       asn: 4200100000
@@ -6441,6 +6700,7 @@ configuration:
   ARISTA257T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.4
       asn: 4200100000
@@ -6458,6 +6718,7 @@ configuration:
   ARISTA258T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.5
       asn: 4200100000
@@ -6475,6 +6736,7 @@ configuration:
   ARISTA259T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.6
       asn: 4200100000
@@ -6492,6 +6754,7 @@ configuration:
   ARISTA260T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.7
       asn: 4200100000
@@ -6509,6 +6772,7 @@ configuration:
   ARISTA261T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.8
       asn: 4200100000
@@ -6526,6 +6790,7 @@ configuration:
   ARISTA262T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.9
       asn: 4200100000
@@ -6543,6 +6808,7 @@ configuration:
   ARISTA263T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.10
       asn: 4200100000
@@ -6560,6 +6826,7 @@ configuration:
   ARISTA264T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.11
       asn: 4200100000
@@ -6577,6 +6844,7 @@ configuration:
   ARISTA265T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.12
       asn: 4200100000
@@ -6594,6 +6862,7 @@ configuration:
   ARISTA266T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.13
       asn: 4200100000
@@ -6611,6 +6880,7 @@ configuration:
   ARISTA267T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.14
       asn: 4200100000
@@ -6628,6 +6898,7 @@ configuration:
   ARISTA268T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.15
       asn: 4200100000
@@ -6645,6 +6916,7 @@ configuration:
   ARISTA269T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.16
       asn: 4200100000
@@ -6662,6 +6934,7 @@ configuration:
   ARISTA270T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.17
       asn: 4200100000
@@ -6679,6 +6952,7 @@ configuration:
   ARISTA271T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.18
       asn: 4200100000
@@ -6696,6 +6970,7 @@ configuration:
   ARISTA272T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.19
       asn: 4200100000
@@ -6713,6 +6988,7 @@ configuration:
   ARISTA273T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.20
       asn: 4200100000
@@ -6730,6 +7006,7 @@ configuration:
   ARISTA274T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.21
       asn: 4200100000
@@ -6747,6 +7024,7 @@ configuration:
   ARISTA275T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.22
       asn: 4200100000
@@ -6764,6 +7042,7 @@ configuration:
   ARISTA276T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.23
       asn: 4200100000
@@ -6781,6 +7060,7 @@ configuration:
   ARISTA277T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.24
       asn: 4200100000
@@ -6798,6 +7078,7 @@ configuration:
   ARISTA278T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.25
       asn: 4200100000
@@ -6815,6 +7096,7 @@ configuration:
   ARISTA279T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.26
       asn: 4200100000
@@ -6832,6 +7114,7 @@ configuration:
   ARISTA280T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.27
       asn: 4200100000
@@ -6849,6 +7132,7 @@ configuration:
   ARISTA281T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.28
       asn: 4200100000
@@ -6866,6 +7150,7 @@ configuration:
   ARISTA282T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.29
       asn: 4200100000
@@ -6883,6 +7168,7 @@ configuration:
   ARISTA283T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.30
       asn: 4200100000
@@ -6900,6 +7186,7 @@ configuration:
   ARISTA284T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.31
       asn: 4200100000
@@ -6917,6 +7204,7 @@ configuration:
   ARISTA285T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.32
       asn: 4200100000
@@ -6934,6 +7222,7 @@ configuration:
   ARISTA286T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.33
       asn: 4200100000
@@ -6951,6 +7240,7 @@ configuration:
   ARISTA287T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.34
       asn: 4200100000
@@ -6968,6 +7258,7 @@ configuration:
   ARISTA288T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.35
       asn: 4200100000
@@ -6985,6 +7276,7 @@ configuration:
   ARISTA289T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.36
       asn: 4200100000
@@ -7002,6 +7294,7 @@ configuration:
   ARISTA290T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.37
       asn: 4200100000
@@ -7019,6 +7312,7 @@ configuration:
   ARISTA291T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.38
       asn: 4200100000
@@ -7036,6 +7330,7 @@ configuration:
   ARISTA292T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.39
       asn: 4200100000
@@ -7053,6 +7348,7 @@ configuration:
   ARISTA293T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.40
       asn: 4200100000
@@ -7070,6 +7366,7 @@ configuration:
   ARISTA294T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.41
       asn: 4200100000
@@ -7087,6 +7384,7 @@ configuration:
   ARISTA295T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.42
       asn: 4200100000
@@ -7104,6 +7402,7 @@ configuration:
   ARISTA296T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.43
       asn: 4200100000
@@ -7121,6 +7420,7 @@ configuration:
   ARISTA297T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.44
       asn: 4200100000
@@ -7138,6 +7438,7 @@ configuration:
   ARISTA298T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.45
       asn: 4200100000
@@ -7155,6 +7456,7 @@ configuration:
   ARISTA299T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.46
       asn: 4200100000
@@ -7172,6 +7474,7 @@ configuration:
   ARISTA300T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.47
       asn: 4200100000
@@ -7189,6 +7492,7 @@ configuration:
   ARISTA301T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.48
       asn: 4200100000
@@ -7206,6 +7510,7 @@ configuration:
   ARISTA302T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.49
       asn: 4200100000
@@ -7223,6 +7528,7 @@ configuration:
   ARISTA303T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.50
       asn: 4200100000
@@ -7240,6 +7546,7 @@ configuration:
   ARISTA304T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.51
       asn: 4200100000
@@ -7257,6 +7564,7 @@ configuration:
   ARISTA305T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.52
       asn: 4200100000
@@ -7274,6 +7582,7 @@ configuration:
   ARISTA306T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.53
       asn: 4200100000
@@ -7291,6 +7600,7 @@ configuration:
   ARISTA307T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.54
       asn: 4200100000
@@ -7308,6 +7618,7 @@ configuration:
   ARISTA308T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.55
       asn: 4200100000
@@ -7325,6 +7636,7 @@ configuration:
   ARISTA309T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.56
       asn: 4200100000
@@ -7342,6 +7654,7 @@ configuration:
   ARISTA310T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.57
       asn: 4200100000
@@ -7359,6 +7672,7 @@ configuration:
   ARISTA311T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.58
       asn: 4200100000
@@ -7376,6 +7690,7 @@ configuration:
   ARISTA312T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.59
       asn: 4200100000
@@ -7393,6 +7708,7 @@ configuration:
   ARISTA313T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.60
       asn: 4200100000
@@ -7410,6 +7726,7 @@ configuration:
   ARISTA314T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.61
       asn: 4200100000
@@ -7427,6 +7744,7 @@ configuration:
   ARISTA315T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.62
       asn: 4200100000
@@ -7444,6 +7762,7 @@ configuration:
   ARISTA316T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.63
       asn: 4200100000
@@ -7461,6 +7780,7 @@ configuration:
   ARISTA317T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.64
       asn: 4200100000
@@ -7478,6 +7798,7 @@ configuration:
   ARISTA318T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.65
       asn: 4200100000
@@ -7495,6 +7816,7 @@ configuration:
   ARISTA319T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.66
       asn: 4200100000
@@ -7512,6 +7834,7 @@ configuration:
   ARISTA320T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.67
       asn: 4200100000
@@ -7529,6 +7852,7 @@ configuration:
   ARISTA321T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.68
       asn: 4200100000
@@ -7546,6 +7870,7 @@ configuration:
   ARISTA322T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.69
       asn: 4200100000
@@ -7563,6 +7888,7 @@ configuration:
   ARISTA323T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.70
       asn: 4200100000
@@ -7580,6 +7906,7 @@ configuration:
   ARISTA324T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.71
       asn: 4200100000
@@ -7597,6 +7924,7 @@ configuration:
   ARISTA325T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.72
       asn: 4200100000
@@ -7614,6 +7942,7 @@ configuration:
   ARISTA326T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.73
       asn: 4200100000
@@ -7631,6 +7960,7 @@ configuration:
   ARISTA327T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.74
       asn: 4200100000
@@ -7648,6 +7978,7 @@ configuration:
   ARISTA328T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.75
       asn: 4200100000
@@ -7665,6 +7996,7 @@ configuration:
   ARISTA329T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.76
       asn: 4200100000
@@ -7682,6 +8014,7 @@ configuration:
   ARISTA330T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.77
       asn: 4200100000
@@ -7699,6 +8032,7 @@ configuration:
   ARISTA331T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.78
       asn: 4200100000
@@ -7716,6 +8050,7 @@ configuration:
   ARISTA332T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.79
       asn: 4200100000
@@ -7733,6 +8068,7 @@ configuration:
   ARISTA333T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.80
       asn: 4200100000
@@ -7750,6 +8086,7 @@ configuration:
   ARISTA334T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.81
       asn: 4200100000
@@ -7767,6 +8104,7 @@ configuration:
   ARISTA335T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.82
       asn: 4200100000
@@ -7784,6 +8122,7 @@ configuration:
   ARISTA336T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.83
       asn: 4200100000
@@ -7801,6 +8140,7 @@ configuration:
   ARISTA337T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.84
       asn: 4200100000
@@ -7818,6 +8158,7 @@ configuration:
   ARISTA338T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.85
       asn: 4200100000
@@ -7835,6 +8176,7 @@ configuration:
   ARISTA339T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.86
       asn: 4200100000
@@ -7852,6 +8194,7 @@ configuration:
   ARISTA340T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.87
       asn: 4200100000
@@ -7869,6 +8212,7 @@ configuration:
   ARISTA341T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.88
       asn: 4200100000
@@ -7886,6 +8230,7 @@ configuration:
   ARISTA342T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.89
       asn: 4200100000
@@ -7903,6 +8248,7 @@ configuration:
   ARISTA343T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.90
       asn: 4200100000
@@ -7920,6 +8266,7 @@ configuration:
   ARISTA344T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.91
       asn: 4200100000
@@ -7937,6 +8284,7 @@ configuration:
   ARISTA345T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.92
       asn: 4200100000
@@ -7954,6 +8302,7 @@ configuration:
   ARISTA346T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.93
       asn: 4200100000
@@ -7971,6 +8320,7 @@ configuration:
   ARISTA347T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.94
       asn: 4200100000
@@ -7988,6 +8338,7 @@ configuration:
   ARISTA348T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.95
       asn: 4200100000
@@ -8005,6 +8356,7 @@ configuration:
   ARISTA349T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.96
       asn: 4200100000
@@ -8022,6 +8374,7 @@ configuration:
   ARISTA350T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.97
       asn: 4200100000
@@ -8039,6 +8392,7 @@ configuration:
   ARISTA351T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.98
       asn: 4200100000
@@ -8056,6 +8410,7 @@ configuration:
   ARISTA352T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.99
       asn: 4200100000
@@ -8073,6 +8428,7 @@ configuration:
   ARISTA353T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.100
       asn: 4200100000
@@ -8090,6 +8446,7 @@ configuration:
   ARISTA354T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.101
       asn: 4200100000
@@ -8107,6 +8464,7 @@ configuration:
   ARISTA355T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.102
       asn: 4200100000
@@ -8124,6 +8482,7 @@ configuration:
   ARISTA356T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.103
       asn: 4200100000
@@ -8141,6 +8500,7 @@ configuration:
   ARISTA357T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.104
       asn: 4200100000
@@ -8158,6 +8518,7 @@ configuration:
   ARISTA358T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.105
       asn: 4200100000
@@ -8175,6 +8536,7 @@ configuration:
   ARISTA359T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.106
       asn: 4200100000
@@ -8192,6 +8554,7 @@ configuration:
   ARISTA360T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.107
       asn: 4200100000
@@ -8209,6 +8572,7 @@ configuration:
   ARISTA361T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.108
       asn: 4200100000
@@ -8226,6 +8590,7 @@ configuration:
   ARISTA362T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.109
       asn: 4200100000
@@ -8243,6 +8608,7 @@ configuration:
   ARISTA363T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.110
       asn: 4200100000
@@ -8260,6 +8626,7 @@ configuration:
   ARISTA364T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.111
       asn: 4200100000
@@ -8277,6 +8644,7 @@ configuration:
   ARISTA365T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.112
       asn: 4200100000
@@ -8294,6 +8662,7 @@ configuration:
   ARISTA366T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.113
       asn: 4200100000
@@ -8311,6 +8680,7 @@ configuration:
   ARISTA367T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.114
       asn: 4200100000
@@ -8328,6 +8698,7 @@ configuration:
   ARISTA368T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.115
       asn: 4200100000
@@ -8345,6 +8716,7 @@ configuration:
   ARISTA369T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.116
       asn: 4200100000
@@ -8362,6 +8734,7 @@ configuration:
   ARISTA370T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.117
       asn: 4200100000
@@ -8379,6 +8752,7 @@ configuration:
   ARISTA371T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.118
       asn: 4200100000
@@ -8396,6 +8770,7 @@ configuration:
   ARISTA372T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.119
       asn: 4200100000
@@ -8413,6 +8788,7 @@ configuration:
   ARISTA373T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.120
       asn: 4200100000
@@ -8430,6 +8806,7 @@ configuration:
   ARISTA374T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.121
       asn: 4200100000
@@ -8447,6 +8824,7 @@ configuration:
   ARISTA375T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.122
       asn: 4200100000
@@ -8464,6 +8842,7 @@ configuration:
   ARISTA376T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.123
       asn: 4200100000
@@ -8481,6 +8860,7 @@ configuration:
   ARISTA377T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.124
       asn: 4200100000
@@ -8498,6 +8878,7 @@ configuration:
   ARISTA378T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.125
       asn: 4200100000
@@ -8515,6 +8896,7 @@ configuration:
   ARISTA379T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.126
       asn: 4200100000
@@ -8532,6 +8914,7 @@ configuration:
   ARISTA380T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.127
       asn: 4200100000
@@ -8549,6 +8932,7 @@ configuration:
   ARISTA381T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.128
       asn: 4200100000
@@ -8566,6 +8950,7 @@ configuration:
   ARISTA382T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.129
       asn: 4200100000
@@ -8583,6 +8968,7 @@ configuration:
   ARISTA383T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.130
       asn: 4200100000
@@ -8600,6 +8986,7 @@ configuration:
   ARISTA384T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.131
       asn: 4200100000
@@ -8617,6 +9004,7 @@ configuration:
   ARISTA385T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.132
       asn: 4200100000
@@ -8634,6 +9022,7 @@ configuration:
   ARISTA386T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.133
       asn: 4200100000
@@ -8651,6 +9040,7 @@ configuration:
   ARISTA387T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.134
       asn: 4200100000
@@ -8668,6 +9058,7 @@ configuration:
   ARISTA388T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.135
       asn: 4200100000
@@ -8685,6 +9076,7 @@ configuration:
   ARISTA389T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.136
       asn: 4200100000
@@ -8702,6 +9094,7 @@ configuration:
   ARISTA390T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.137
       asn: 4200100000
@@ -8719,6 +9112,7 @@ configuration:
   ARISTA391T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.138
       asn: 4200100000
@@ -8736,6 +9130,7 @@ configuration:
   ARISTA392T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.139
       asn: 4200100000
@@ -8753,6 +9148,7 @@ configuration:
   ARISTA393T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.140
       asn: 4200100000
@@ -8770,6 +9166,7 @@ configuration:
   ARISTA394T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.141
       asn: 4200100000
@@ -8787,6 +9184,7 @@ configuration:
   ARISTA395T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.142
       asn: 4200100000
@@ -8804,6 +9202,7 @@ configuration:
   ARISTA396T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.143
       asn: 4200100000
@@ -8821,6 +9220,7 @@ configuration:
   ARISTA397T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.144
       asn: 4200100000
@@ -8838,6 +9238,7 @@ configuration:
   ARISTA398T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.145
       asn: 4200100000
@@ -8855,6 +9256,7 @@ configuration:
   ARISTA399T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.146
       asn: 4200100000
@@ -8872,6 +9274,7 @@ configuration:
   ARISTA400T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.147
       asn: 4200100000
@@ -8889,6 +9292,7 @@ configuration:
   ARISTA401T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.148
       asn: 4200100000
@@ -8906,6 +9310,7 @@ configuration:
   ARISTA402T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.149
       asn: 4200100000
@@ -8923,6 +9328,7 @@ configuration:
   ARISTA403T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.150
       asn: 4200100000
@@ -8940,6 +9346,7 @@ configuration:
   ARISTA404T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.151
       asn: 4200100000
@@ -8957,6 +9364,7 @@ configuration:
   ARISTA405T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.152
       asn: 4200100000
@@ -8974,6 +9382,7 @@ configuration:
   ARISTA406T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.153
       asn: 4200100000
@@ -8991,6 +9400,7 @@ configuration:
   ARISTA407T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.154
       asn: 4200100000
@@ -9008,6 +9418,7 @@ configuration:
   ARISTA408T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.155
       asn: 4200100000
@@ -9025,6 +9436,7 @@ configuration:
   ARISTA409T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.156
       asn: 4200100000
@@ -9042,6 +9454,7 @@ configuration:
   ARISTA410T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.157
       asn: 4200100000
@@ -9059,6 +9472,7 @@ configuration:
   ARISTA411T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.158
       asn: 4200100000
@@ -9076,6 +9490,7 @@ configuration:
   ARISTA412T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.159
       asn: 4200100000
@@ -9093,6 +9508,7 @@ configuration:
   ARISTA413T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.160
       asn: 4200100000
@@ -9110,6 +9526,7 @@ configuration:
   ARISTA414T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.161
       asn: 4200100000
@@ -9127,6 +9544,7 @@ configuration:
   ARISTA415T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.162
       asn: 4200100000
@@ -9144,6 +9562,7 @@ configuration:
   ARISTA416T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.163
       asn: 4200100000
@@ -9161,6 +9580,7 @@ configuration:
   ARISTA417T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.164
       asn: 4200100000
@@ -9178,6 +9598,7 @@ configuration:
   ARISTA418T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.165
       asn: 4200100000
@@ -9195,6 +9616,7 @@ configuration:
   ARISTA419T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.166
       asn: 4200100000
@@ -9212,6 +9634,7 @@ configuration:
   ARISTA420T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.167
       asn: 4200100000
@@ -9229,6 +9652,7 @@ configuration:
   ARISTA421T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.168
       asn: 4200100000
@@ -9246,6 +9670,7 @@ configuration:
   ARISTA422T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.169
       asn: 4200100000
@@ -9263,6 +9688,7 @@ configuration:
   ARISTA423T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.170
       asn: 4200100000
@@ -9280,6 +9706,7 @@ configuration:
   ARISTA424T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.171
       asn: 4200100000
@@ -9297,6 +9724,7 @@ configuration:
   ARISTA425T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.172
       asn: 4200100000
@@ -9314,6 +9742,7 @@ configuration:
   ARISTA426T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.173
       asn: 4200100000
@@ -9331,6 +9760,7 @@ configuration:
   ARISTA427T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.174
       asn: 4200100000
@@ -9348,6 +9778,7 @@ configuration:
   ARISTA428T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.175
       asn: 4200100000
@@ -9365,6 +9796,7 @@ configuration:
   ARISTA429T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.176
       asn: 4200100000
@@ -9382,6 +9814,7 @@ configuration:
   ARISTA430T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.177
       asn: 4200100000
@@ -9399,6 +9832,7 @@ configuration:
   ARISTA431T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.178
       asn: 4200100000
@@ -9416,6 +9850,7 @@ configuration:
   ARISTA432T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.179
       asn: 4200100000
@@ -9433,6 +9868,7 @@ configuration:
   ARISTA433T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.180
       asn: 4200100000
@@ -9450,6 +9886,7 @@ configuration:
   ARISTA434T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.181
       asn: 4200100000
@@ -9467,6 +9904,7 @@ configuration:
   ARISTA435T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.182
       asn: 4200100000
@@ -9484,6 +9922,7 @@ configuration:
   ARISTA436T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.183
       asn: 4200100000
@@ -9501,6 +9940,7 @@ configuration:
   ARISTA437T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.184
       asn: 4200100000
@@ -9518,6 +9958,7 @@ configuration:
   ARISTA438T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.185
       asn: 4200100000
@@ -9535,6 +9976,7 @@ configuration:
   ARISTA439T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.186
       asn: 4200100000
@@ -9552,6 +9994,7 @@ configuration:
   ARISTA440T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.187
       asn: 4200100000
@@ -9569,6 +10012,7 @@ configuration:
   ARISTA441T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.188
       asn: 4200100000
@@ -9586,6 +10030,7 @@ configuration:
   ARISTA442T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.189
       asn: 4200100000
@@ -9603,6 +10048,7 @@ configuration:
   ARISTA443T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.190
       asn: 4200100000
@@ -9620,6 +10066,7 @@ configuration:
   ARISTA444T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.191
       asn: 4200100000
@@ -9637,6 +10084,7 @@ configuration:
   ARISTA445T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.192
       asn: 4200100000
@@ -9654,6 +10102,7 @@ configuration:
   ARISTA446T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.193
       asn: 4200100000
@@ -9671,6 +10120,7 @@ configuration:
   ARISTA447T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.194
       asn: 4200100000
@@ -9688,6 +10138,7 @@ configuration:
   ARISTA448T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.195
       asn: 4200100000
@@ -9705,6 +10156,7 @@ configuration:
   ARISTA449T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.196
       asn: 4200100000
@@ -9722,6 +10174,7 @@ configuration:
   ARISTA450T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.197
       asn: 4200100000
@@ -9739,6 +10192,7 @@ configuration:
   ARISTA451T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.198
       asn: 4200100000
@@ -9756,6 +10210,7 @@ configuration:
   ARISTA452T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.199
       asn: 4200100000
@@ -9773,6 +10228,7 @@ configuration:
   ARISTA453T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.200
       asn: 4200100000
@@ -9790,6 +10246,7 @@ configuration:
   ARISTA454T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.201
       asn: 4200100000
@@ -9807,6 +10264,7 @@ configuration:
   ARISTA455T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.202
       asn: 4200100000
@@ -9824,6 +10282,7 @@ configuration:
   ARISTA456T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.203
       asn: 4200100000
@@ -9841,6 +10300,7 @@ configuration:
   ARISTA457T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.204
       asn: 4200100000
@@ -9858,6 +10318,7 @@ configuration:
   ARISTA458T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.205
       asn: 4200100000
@@ -9875,6 +10336,7 @@ configuration:
   ARISTA459T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.206
       asn: 4200100000
@@ -9892,6 +10354,7 @@ configuration:
   ARISTA460T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.207
       asn: 4200100000
@@ -9909,6 +10372,7 @@ configuration:
   ARISTA461T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.208
       asn: 4200100000
@@ -9926,6 +10390,7 @@ configuration:
   ARISTA462T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.209
       asn: 4200100000
@@ -9943,6 +10408,7 @@ configuration:
   ARISTA463T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.210
       asn: 4200100000
@@ -9960,6 +10426,7 @@ configuration:
   ARISTA464T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.211
       asn: 4200100000
@@ -9977,6 +10444,7 @@ configuration:
   ARISTA465T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.212
       asn: 4200100000
@@ -9994,6 +10462,7 @@ configuration:
   ARISTA466T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.213
       asn: 4200100000
@@ -10011,6 +10480,7 @@ configuration:
   ARISTA467T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.214
       asn: 4200100000
@@ -10028,6 +10498,7 @@ configuration:
   ARISTA468T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.215
       asn: 4200100000
@@ -10045,6 +10516,7 @@ configuration:
   ARISTA469T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.216
       asn: 4200100000
@@ -10062,6 +10534,7 @@ configuration:
   ARISTA470T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.217
       asn: 4200100000
@@ -10079,6 +10552,7 @@ configuration:
   ARISTA471T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.218
       asn: 4200100000
@@ -10096,6 +10570,7 @@ configuration:
   ARISTA472T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.219
       asn: 4200100000
@@ -10113,6 +10588,7 @@ configuration:
   ARISTA473T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.220
       asn: 4200100000
@@ -10130,6 +10606,7 @@ configuration:
   ARISTA474T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.221
       asn: 4200100000
@@ -10147,6 +10624,7 @@ configuration:
   ARISTA475T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.222
       asn: 4200100000
@@ -10164,6 +10642,7 @@ configuration:
   ARISTA476T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.223
       asn: 4200100000
@@ -10181,6 +10660,7 @@ configuration:
   ARISTA477T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.224
       asn: 4200100000
@@ -10198,6 +10678,7 @@ configuration:
   ARISTA478T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.225
       asn: 4200100000
@@ -10215,6 +10696,7 @@ configuration:
   ARISTA479T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.226
       asn: 4200100000
@@ -10232,6 +10714,7 @@ configuration:
   ARISTA480T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.227
       asn: 4200100000
@@ -10249,6 +10732,7 @@ configuration:
   ARISTA481T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.228
       asn: 4200100000
@@ -10266,6 +10750,7 @@ configuration:
   ARISTA482T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.229
       asn: 4200100000
@@ -10283,6 +10768,7 @@ configuration:
   ARISTA483T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.230
       asn: 4200100000
@@ -10300,6 +10786,7 @@ configuration:
   ARISTA484T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.231
       asn: 4200100000
@@ -10317,6 +10804,7 @@ configuration:
   ARISTA485T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.232
       asn: 4200100000
@@ -10334,6 +10822,7 @@ configuration:
   ARISTA486T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.233
       asn: 4200100000
@@ -10351,6 +10840,7 @@ configuration:
   ARISTA487T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.234
       asn: 4200100000
@@ -10368,6 +10858,7 @@ configuration:
   ARISTA488T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.235
       asn: 4200100000
@@ -10385,6 +10876,7 @@ configuration:
   ARISTA489T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.236
       asn: 4200100000
@@ -10402,6 +10894,7 @@ configuration:
   ARISTA490T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.237
       asn: 4200100000
@@ -10419,6 +10912,7 @@ configuration:
   ARISTA491T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.238
       asn: 4200100000
@@ -10436,6 +10930,7 @@ configuration:
   ARISTA492T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.239
       asn: 4200100000
@@ -10453,6 +10948,7 @@ configuration:
   ARISTA493T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.240
       asn: 4200100000
@@ -10470,6 +10966,7 @@ configuration:
   ARISTA494T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.241
       asn: 4200100000
@@ -10487,6 +10984,7 @@ configuration:
   ARISTA495T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.242
       asn: 4200100000
@@ -10504,6 +11002,7 @@ configuration:
   ARISTA496T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.243
       asn: 4200100000
@@ -10521,6 +11020,7 @@ configuration:
   ARISTA497T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.244
       asn: 4200100000
@@ -10538,6 +11038,7 @@ configuration:
   ARISTA498T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.245
       asn: 4200100000
@@ -10555,6 +11056,7 @@ configuration:
   ARISTA499T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.246
       asn: 4200100000
@@ -10572,6 +11074,7 @@ configuration:
   ARISTA500T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.247
       asn: 4200100000
@@ -10589,6 +11092,7 @@ configuration:
   ARISTA501T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.248
       asn: 4200100000
@@ -10606,6 +11110,7 @@ configuration:
   ARISTA502T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.249
       asn: 4200100000
@@ -10623,6 +11128,7 @@ configuration:
   ARISTA503T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.250
       asn: 4200100000
@@ -10640,6 +11146,7 @@ configuration:
   ARISTA504T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.251
       asn: 4200100000
@@ -10657,6 +11164,7 @@ configuration:
   ARISTA505T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.252
       asn: 4200100000
@@ -10674,6 +11182,7 @@ configuration:
   ARISTA506T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.253
       asn: 4200100000
@@ -10691,6 +11200,7 @@ configuration:
   ARISTA507T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.254
       asn: 4200100000
@@ -10708,6 +11218,7 @@ configuration:
   ARISTA508T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.1.255
       asn: 4200100000
@@ -10725,6 +11236,7 @@ configuration:
   ARISTA509T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.2.0
       asn: 4200100000
@@ -10742,6 +11254,7 @@ configuration:
   ARISTA510T1:
     properties:
     - common
+    - leaf
     bgp:
       router-id: 0.12.2.1
       asn: 4200100000
@@ -10759,6 +11272,7 @@ configuration:
   ARISTA01PT0:
     properties:
     - common
+    - tor
     bgp:
       router-id: 0.12.2.2
       asn: 4200000001
@@ -10776,6 +11290,7 @@ configuration:
   ARISTA02PT0:
     properties:
     - common
+    - tor
     bgp:
       router-id: 0.12.2.3
       asn: 4200000002


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In bgp scale test, pt0 should announce vlan routes, so this PR mark pt0 as role tor, and it won't generate routes.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In bgp scale test, pt0 should announce vlan routes
#### How did you do it?
this PR mark pt0 as role tor, and it won't generate routes
#### How did you verify/test it?
Run ansible script to announce routes on testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
