### PR TITLE
Add Broadcom Tomahawk-5 support for test_ecmp_sai_value.py

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -202,6 +202,9 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
             # For TD2, 7050qx, the total number of ports are 362
             pytest_assert(offset_count == 362, "the count of 0 OFFSET_ECMP is not correct. \
                           Expected {}, but got {}.".format(362, offset_count))
+        elif asic_name == "th5":
+            pytest_assert(offset_count == 352, "the count of 0 OFFSET_ECMP is not correct. \
+                          Expected {}, but got {}.".format(352, offset_count))
         else:
             pytest_assert(offset_count == 392, "the count of 0 OFFSET_ECMP is not correct. \
                           Expected {}, but got {}.".format(392, offset_count))

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -43,8 +43,14 @@ seed_cmd_td3 = [
     'bcmcmd "getreg RTAG7_HASH_SEED_B_PIPE0"',
 ]
 
-offset_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP"'
+seed_cmd_th5 = []
+for i in range(8):
+    seed_cmd_th5.append('bcmcmd "dsh -c \'get RTAG7_HASH_SEED_Ar{' + str(i) + '}.ipipe0\'"')
+for i in range(8):
+    seed_cmd_th5.append('bcmcmd "dsh -c \'get RTAG7_HASH_SEED_Br{' + str(i) + '}.ipipe0\'"')
 
+offset_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP"'
+offset_cmd_th5 = 'bcmcmd "bsh -c \'pt dump RTAG7_PORT_BASED_HASH 0 351 OFFSET_ECMP\'"'
 
 @pytest.fixture
 def enable_container_autorestart(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
@@ -79,9 +85,12 @@ def parse_hash_seed(output, asic_name):
     return numeric_value
 
 
-def parse_ecmp_offset(outputs):
+def parse_ecmp_offset(outputs, asic_name):
     # Regular expression pattern to extract OFFSET_ECMP values (hexadecimal)
-    pattern = r'OFFSET_ECMP=(0x?[0-9a-fA-F]?)'
+    if asic_name == "th5":
+        pattern = r'OFFSET_ECMP_PRIMARY=(0x?[0-9a-fA-F]?)'
+    else:
+        pattern = r'OFFSET_ECMP=(0x?[0-9a-fA-F]?)'
 
     # Extracted values
     extracted_values = []
@@ -151,10 +160,17 @@ def check_hash_seed_value(duthost, asic_name, topo_type):
         seed_cmd_input = seed_cmd_td2
     elif asic_name == "td3":
         seed_cmd_input = seed_cmd_td3
+    elif asic_name == "th5":
+        seed_cmd_input = seed_cmd_th5
     else:
         seed_cmd_input = seed_cmd
     for cmd in seed_cmd_input:
-        output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
+        if asic_name == "th5":
+            # TH5 output format is slightly different. Expected pattern comes in a different line
+            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][3].strip()
+        else:
+            output = duthost.command(cmd, module_ignore_errors=True)["stdout_lines"][2].strip()
+        logger.info(f"Seed cmd: {cmd}, output: {output}")
         hash_seed = parse_hash_seed(output, asic_name)
         if topo_type == "t1":
             pytest_assert(hash_seed == '0xa', "HASH_SEED is not set to 0xa")
@@ -169,8 +185,12 @@ def check_ecmp_offset_value(duthost, asic_name, topo_type, hwsku):
     TD2: the count of 0xa is 33
     """
     pytest_assert(wait_until(300, 20, 0, check_syncd_is_running, duthost), "syncd is not running!")
-    output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
-    offset_list = parse_ecmp_offset(output)
+    if asic_name == "th5":
+        output = duthost.shell(offset_cmd_th5, module_ignore_errors=True)['stdout']
+        logger.info(f"Offset cmd: {offset_cmd_th5}, output: {output}")
+    else:
+        output = duthost.shell(offset_cmd, module_ignore_errors=True)['stdout']
+    offset_list = parse_ecmp_offset(output, asic_name)
     if topo_type == "t0":
         offset_count = offset_list.count('0')
         if asic_name == "td3":
@@ -213,7 +233,7 @@ def test_ecmp_hash_seed_value(localhost, duthosts, tbinfo, enum_rand_one_per_hws
     hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
     hwsku = duthost.facts['hwsku']
     supported_platforms = ['broadcom_td2_hwskus', 'broadcom_td3_hwskus', 'broadcom_th_hwskus',
-                           'broadcom_th2_hwskus', 'broadcom_th3_hwskus']
+                           'broadcom_th2_hwskus', 'broadcom_th3_hwskus', 'broadcom_th5_hwskus']
     asic_name = None
     for platform in supported_platforms:
         supported_skus = hostvars.get(platform, [])
@@ -266,7 +286,7 @@ def test_ecmp_offset_value(localhost, duthosts, tbinfo, enum_rand_one_per_hwsku_
     hostvars = get_host_visible_vars(duthost.host.options['inventory'], duthost.hostname)
     hwsku = duthost.facts['hwsku']
     supported_platforms = ['broadcom_td2_hwskus', 'broadcom_td3_hwskus', 'broadcom_th_hwskus',
-                           'broadcom_th2_hwskus', 'broadcom_th3_hwskus']
+                           'broadcom_th2_hwskus', 'broadcom_th3_hwskus', 'broadcom_th5_hwskus']
     asic_name = None
     for platform in supported_platforms:
         supported_skus = hostvars.get(platform, [])

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -52,6 +52,7 @@ for i in range(8):
 offset_cmd = 'bcmcmd  "dump RTAG7_PORT_BASED_HASH 0 392 OFFSET_ECMP"'
 offset_cmd_th5 = 'bcmcmd "bsh -c \'pt dump RTAG7_PORT_BASED_HASH 0 351 OFFSET_ECMP\'"'
 
+
 @pytest.fixture
 def enable_container_autorestart(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     # Enable autorestart for all features


### PR DESCRIPTION
### Description of PR

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/18689

BCM shell commands are different for TH5 compared to TH3 based platforms which is causing the
failure in verification of ECMP hash configuration.

Fixes # (issue)
#18689

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
As described in issue #18689

#### How did you do it?
Using the right bcm shell commands to get/dump the ECMP hash config tables and verifying the
expected values.

#### How did you verify/test it?
Ran the test tests/ecmp/test_ecmp_sai_value.py with the fix to verify it succeeds.

ecmp/test_ecmp_sai_value.py::test_ecmp_hash_seed_value[tb4-dut-common] PASSED [ 50%]
ecmp/test_ecmp_sai_value.py::test_ecmp_offset_value[tb4-dut-common] PASSED [100%]

--------------------------------------------------- generated xml file: /tmp/test-logs/tr.xml ---------------------------------------------------
=================================================== 2 passed, 11 warnings in 76.81s (0:01:16) ===================================================

#### Any platform specific information?
Issue is specific to broadcom Tomahawk-5 ASIC

#### Supported testbed topology if it's a new test case?

### Documentation

