### PR TITLE
Skip test_console_chassis_conn for T2 single node topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -795,8 +795,10 @@ dut_console/test_console_baud_rate.py::test_baud_rate_sonic_connect:
 dut_console/test_console_chassis_conn.py::test_console_availability_serial_ports:
   skip:
     reason: "Skipping test because test is not supported on this hwsku"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-nokia_ixr7250_x3b-r0']"
+      - "'t2_single_node' in topo_name"
 
 #######################################
 #####             ecmp            #####


### PR DESCRIPTION
Test fails since there is no linecard connection to be made from supervisor on a disaggregated T2 chassis.

Requesting backport for msft-202503.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
I added the t2_single_node condition to skip dut_console/test_console_chassis_conn.py::test_console_availability_serial_ports:

#### How did you verify/test it?
I ran the test case with and without the skip on a t2 disagg chassis to see that it errored prior and would now skip.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
