### PR TITLE
Snmp credentials added for mvrf test suites

### DIFF
--- a/tests/mvrf/conftest.py
+++ b/tests/mvrf/conftest.py
@@ -7,7 +7,6 @@ from tests.common.gu_utils import create_checkpoint, rollback
 
 SETUP_ENV_CP = "test_setup_checkpoint"
 
-
 @pytest.fixture(scope="module", autouse=True)
 def setup_check_snmp_ready(duthosts, localhost):
     for duthost in duthosts:


### PR DESCRIPTION
Description:
The PR contains changes to mvrf/conftest.py with logic to configure snmp credentials stored in snmp.yml for every host before running any test script.This configuration was already added for snmp test suites we have enabled it for mvrf test suites also.

Fixes # (issue)
The SNMP credentials for snmp_rocommunity: public were not consistently added each time we attempted to configure them. Although the MVRF test suite was running, the credentials were not applied before the timeout occurred when calling snmp_facts().

Fix:
Added the conftest.py file to add the snmp configurations for mvrf test suites. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

#### What is the motivation for this PR?
If credentials in snmp.yml isn't configured, then the changes in PR configures them before running the tests and restores the original configuration after the TC execution.For mvrf test cases snmp credentials were not configured before timeout.


#### How did you do it?
For mvrf test suites mvrf/conftest.py will now copy the snmp.yml from DUT to UCS (if DUT has snmp.yml) & then it will configure the SNMP credentials for every host via sudo config snmp command. The logic it configures is same as in snmp_yml_to_configdb.py script; where it checks whether the credentials in yml are configured in config_db or not, if the keys are configured but the values are different / the keys are not configured - then it will configure them. Before the test script execution, SNMP is configured, once the execution completes, it reverts the configuration that existed before.Using this method we can add credentials for snmp and all functions of snmp for mvrf test cases.


#### How did you verify/test it?
We checked it with 202405 image multiple times firstly without adding the mvrf/conftest.py and then by adding these changes. 

