### PR TITLE
Support skip ptf test files copy

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -60,20 +60,21 @@ def copy_acstests_directory(ptfhost):
 @pytest.fixture(scope="session", autouse=True)
 def copy_ptftests_directory(request, ptfhost):
     """
-    Optionally copy PTF tests directory to PTF host if any test is marked with 'need_ptftests'.
+    Copy PTF tests directory to PTF host by default.
+    Skip only if any test is marked with 'need_ptftests' = False.
     """
-    need_ptftests = any(
-        'need_ptftests' in getattr(item, 'keywords', {}) for item in getattr(request.session, 'items', [])
+    skip_ptftests = any(
+        'no_ptftests' in getattr(item, 'keywords', {}) for item in getattr(request.session, 'items', [])
     )
-    if not need_ptftests:
-        logger.info("Skipping copy of PTF test files to PTF host as 'need_ptftests' marker is not set.")
+    if skip_ptftests:
+        logger.info("Skipping copy of PTF test files to PTF host due to 'no_ptftests' marker.")
         yield
         return
 
-    logger.info("Copy PTF test files to PTF host '{0}'".format(ptfhost.hostname))
+    logger.info("Copying PTF test files to PTF host '%s'", ptfhost.hostname)
     ptfhost.copy(src=PTF_TESTS, dest=ROOT_DIR)
     yield
-    logger.info("Delete PTF test files from PTF host '{0}'".format(ptfhost.hostname))
+    logger.info("Deleting PTF test files from PTF host '%s'", ptfhost.hostname)
     ptfhost.file(path=os.path.join(ROOT_DIR, PTF_TESTS), state="absent")
 
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -25,6 +25,7 @@ markers:
     dependency: dependency marker
     skip_traffic_test: skip_traffic_test marker
     stress_test: mark test as stress test
+    no_ptftests: mark test to skip copying PTF test files to PTF host
 
 log_cli_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s
 log_file_format: %(asctime)s %(funcNamewithModule)-40.40s L%(lineno)-.4d %(levelname)-7s| %(message)s


### PR DESCRIPTION
### Description of PR
**Summary:**
The copy_ptftests_directory fixture now performs the copy step for all test sessions unless explicitly skipped. A new pytest marker @pytest.mark.no_ptftests has been introduced to allow tests to opt out of this behavior. This change ensures test environments are fully prepared by default while still allowing flexibility to reduce setup time when PTF test files are not needed.


**Type of change**
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement
### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
**Approach**
What is the motivation for this PR?
Copying the ptftests directory to the PTF host takes significant time, but most tests do not require these files. This PR optimizes test execution by only copying the files when necessary, based on a marker.

**How did you do it?**
Updated the copy_ptftests_directory fixture in ptfhost_utils.py to check if any test is marked with @pytest.mark.need_ptftests.
If no test is marked, the copy is skipped.
If at least one test is marked, the directory is copied as before.
**How did you verify/test it?**
Ran test sessions with and without the marker.
Verified that the copy step is skipped when not needed and performed when required.
Checked logs for correct behavior.
**Any platform specific information?**
No platform-specific changes.

**Supported testbed topology if it's a new test case?**
N/A
