### PR TITLE
[Snappi] Changed logging from info to debug for ECN packet marking

### DIFF
--- a/tests/common/snappi_tests/read_pcap.py
+++ b/tests/common/snappi_tests/read_pcap.py
@@ -158,5 +158,5 @@ def is_ecn_marked(ip_pkt):
     Returns:
         Return if the packet is ECN congestion marked (bool)
     """
-    logger.info("Checking if the packet is ECN congestion marked")
+    logger.debug("Checking if the packet is ECN congestion marked")
     return (ip_pkt.tos & 3) == 3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18590 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
The read_pcap.py file has function "is_ecn_marked" which is checking if the packet is ECN marked or not.

However the logging is set to INFO level, which means that every packet in the PCAP when checked for ECN marking, will generate an INFO level log. For check of 1000 packets, it will generate 1000 such INFO level logs.

#### How did you do it?
Reduced the severity of the log from INFO->DEBUG. 

#### How did you verify/test it?
Ran ECN marking testcase. In 'Before' output, since 9k packets are being checked for ECN marked, it will generate 9k INFO level logs. In 'After' logs, the test-case itself is printing if the packet is detected as ECN marked or not.

Before:
```
14:20:21 test_multidut_dequeue_ecn_brcm_dnx.verif L0261 INFO   | Running verification for ECN dequeue test
14:20:21 test_multidut_dequeue_ecn_brcm_dnx.verif L0267 INFO   | Analyzing PCAP with 9000 pkts
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
------ curtailed output ------
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 test_multidut_dequeue_ecn_brcm_dnx.verif L0279 INFO   | First packet to be ECN-Marked:898
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 test_multidut_dequeue_ecn_brcm_dnx.verif L0293 INFO   | Last packet to be ECN-Marked:900
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
------ curtailed output ------
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 test_multidut_dequeue_ecn_brcm_dnx.verif L0279 INFO   | First packet to be ECN-Marked:1030
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 test_multidut_dequeue_ecn_brcm_dnx.verif L0293 INFO   | Last packet to be ECN-Marked:1032
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
14:20:21 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
------ curtailed output ------
16:12:51 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
16:12:51 read_pcap.is_ecn_marked                  L0162 INFO   | Checking if the packet is ECN congestion marked
16:12:51 test_multidut_dequeue_ecn_brcm_dnx.verif L0299 INFO   | Result - Pkts marked before Kmin:66
16:12:51 test_multidut_dequeue_ecn_brcm_dnx.verif L0300 INFO   | Result - Pkts marked between Kmin and Kmax :224
16:12:51 test_multidut_dequeue_ecn_brcm_dnx.verif L0301 INFO   | Result - Pkts marked after Kmax:0
16:12:51 test_multidut_dequeue_ecn_brcm_dnx.verif L0311 INFO   | ECN Marking range:7812.5
16:12:51 test_multidut_dequeue_ecn_brcm_dnx.verif L0314 INFO   | ECN Marking Probability between Kmin-Kmax for pmax of 5 : 2.87%
```

After:
```
16:30:49 test_multidut_dequeue_ecn_brcm_dnx.verif L0264 INFO   | Running verification for ECN dequeue test
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0270 INFO   | Analyzing PCAP with 8500 pkts
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0274 INFO   | Checking the packets for the ECN markings
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0283 INFO   | First packet to be ECN-Marked:741
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0297 INFO   | Last packet to be ECN-Marked:743
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0283 INFO   | First packet to be ECN-Marked:759
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0297 INFO   | Last packet to be ECN-Marked:761
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0283 INFO   | First packet to be ECN-Marked:804
------ curtailed output ------
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0300 INFO   | Result - Pkts marked before Kmin:69
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0301 INFO   | Result - Pkts marked between Kmin and Kmax :262
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0302 INFO   | Result - Pkts marked after Kmax:0
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0312 INFO   | ECN Marking range:7812.5
16:30:50 test_multidut_dequeue_ecn_brcm_dnx.verif L0315 INFO   | ECN Marking Probability between Kmin-Kmax for pmax of 5 : 3.35%

```

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
