### PR TITLE
Enable sequential IDF isolation test on LowerSpineRouter

### DIFF
--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -9,7 +9,7 @@ from route_checker import assert_only_loopback_routes_announced_to_neighs, parse
 from route_checker import verify_current_routes_announced_to_neighs, check_and_log_routes_diff
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2', 'lt2')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -55,10 +55,10 @@ def check_idf_isolation_support(duthost):
     namespace = duthost.get_namespace_from_asic_id(asic_index)
     sonic_db_cmd = "sonic-db-cli {}".format("-n " +
                                             namespace if namespace else "")
-    tsa_in_configdb = duthost.shell(
+    idf_isolation_state_in_db = duthost.shell(
         '{} CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "idf_isolation_state"'.format(sonic_db_cmd),
         module_ignore_errors=False)['stdout_lines']
-    if not tsa_in_configdb:
+    if not idf_isolation_state_in_db:
         return False
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enabling test_seq_idf_isolation.py on LowerSpineRouter

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
For disaggregated T2, sequential IDF isolation needs to be done on LowerSpineRouter

#### How did you do it?
Enable test to run on topo 'lt2' 

#### How did you verify/test it?
Ran idf isolation commands manually and verified isolation/unisolation on a couple of T1 neighbors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
