### PR TITLE
Restore configuration after vxlan module

### DIFF
--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -309,7 +309,7 @@ def vnet_test_params(duthost, request):
 
 
 @pytest.fixture(scope="module")
-def minigraph_facts(duthosts, rand_one_dut_hostname, tbinfo):
+def minigraph_facts(duthosts, rand_one_dut_hostname, tbinfo, backup_and_restore_config_db_on_duts):        # noqa F811
     """
     Fixture to get minigraph facts
     Args:
@@ -355,5 +355,5 @@ def vnet_config(minigraph_facts, vnet_test_params, scaled_vnet_params):
 def restore_config_by_config_reload(duthosts, rand_one_dut_hostname):
     yield
     duthost = duthosts[rand_one_dut_hostname]
-
+    logger.info("Restore config after running tests")
     config_reload(duthost, safe_reload=True)

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -20,6 +20,8 @@ from tests.vxlan.vnet_constants import (
     NUM_INTF_PER_VNET_KEY,
     TEMPLATE_DIR
 )
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts # noqa F401
+from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
 
@@ -347,3 +349,11 @@ def vnet_config(minigraph_facts, vnet_test_params, scaled_vnet_params):
     return yaml.safe_load(
         safe_open_template(
             join(TEMPLATE_DIR, "vnet_config.j2")).render(combined_args))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_config_by_config_reload(duthosts, rand_one_dut_hostname):
+    yield
+    duthost = duthosts[rand_one_dut_hostname]
+
+    config_reload(duthost, safe_reload=True)

--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -16,7 +16,6 @@ from tests.common.utilities import wait_until
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.config_reload import config_reload
 Logger = logging.getLogger(__name__)
 ecmp_utils = Ecmp_Utils()
@@ -70,8 +69,7 @@ def fixture_setUp(duthosts,
                   rand_one_dut_hostname,
                   minigraph_facts,
                   tbinfo,
-                  encap_type,
-                  backup_and_restore_config_db_on_duts):        # noqa F811
+                  encap_type):
     '''
         Setup for the entire script.
         The basic steps in VxLAN configs are:
@@ -233,14 +231,6 @@ def fixture_setUp(duthosts,
     ecmp_utils.stop_bfd_responder(data['ptfhost'])
 
 
-@pytest.fixture(scope="module", autouse=True)
-def restore_config_by_config_reload(duthosts, rand_one_dut_hostname, localhost):
-    yield
-    duthost = duthosts[rand_one_dut_hostname]
-
-    config_reload(duthost, safe_reload=True)
-
-
 def is_vnet_route_configured_on_asic(duthost, dest):
     '''
         Function to check if a VNET route to dest is configured on ASIC DB.
@@ -248,7 +238,7 @@ def is_vnet_route_configured_on_asic(duthost, dest):
         PTF tests.
     '''
     result = duthost.shell(f"sonic-db-cli ASIC_DB KEYS \
-                           'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY*{dest}*'")["stdout_lines"]
+                           'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY*{dest}*'")["stdout_lines"]  # noqa: E231
     return bool(result)
 
 

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -4,7 +4,6 @@ import ipaddress
 from functools import reduce
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import ipaddress
 from functools import reduce
-
+from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
@@ -127,6 +127,14 @@ def fixture_setup_neighbors(setUp, encap_type, minigraph_facts):
         duthost.shell(
             "sudo config interface ip remove {} DDDD::200:0:0:1/64".format(
                 intf))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def restore_config_by_config_reload(setUp):
+    yield
+    duthost = setUp['duthost']
+
+    config_reload(duthost, safe_reload=True)
 
 
 class Test_VxLAN_Crm(Test_VxLAN):

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import ipaddress
 from functools import reduce
-from tests.common.config_reload import config_reload
+
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
@@ -127,14 +127,6 @@ def fixture_setup_neighbors(setUp, encap_type, minigraph_facts):
         duthost.shell(
             "sudo config interface ip remove {} DDDD::200:0:0:1/64".format(
                 intf))
-
-
-@pytest.fixture(scope="module", autouse=True)
-def restore_config_by_config_reload(setUp):
-    yield
-    duthost = setUp['duthost']
-
-    config_reload(duthost, safe_reload=True)
 
 
 class Test_VxLAN_Crm(Test_VxLAN):

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -60,8 +60,6 @@ import copy
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
-from tests.common.config_reload import config_reload
 from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
@@ -142,8 +140,7 @@ def fixture_setUp(duthosts,
                   rand_one_dut_hostname,
                   minigraph_facts,
                   tbinfo,
-                  encap_type,
-                  backup_and_restore_config_db_on_duts):        # noqa F811
+                  encap_type):        # noqa F811
     '''
         Setup for the entire script.
         The basic steps in VxLAN configs are:
@@ -340,14 +337,6 @@ def fixture_setUp(duthosts,
         ecmp_utils.stop_bfd_responder(data['ptfhost'])
 
     setup_crm_interval(data['duthost'], int(data['original_crm_interval']))
-
-
-@pytest.fixture(scope="module", autouse=True)
-def restore_config_by_config_reload(duthosts, rand_one_dut_hostname, localhost):
-    yield
-    duthost = duthosts[rand_one_dut_hostname]
-
-    config_reload(duthost, safe_reload=True)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/pull/17046 and https://github.com/sonic-net/sonic-mgmt/pull/17767 all all restore  configuration after running tests.
But for  `test_vxlan_crm`, it has similar issue. In `test_vxlan_crm`, it will do config save command and after enable bfd session, iptables will add the following iptables rules, and it didn't have any chance to restore the configuration after the test. These iptables rules will be left on the DUT, which will fail `test_cacl_application` with the following unexpected iptable rules

```
 iptables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT
 ip6tables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Move the configuration restoration from each test case level to the common `conftest.py` which is module level.
It also saves time to do config reload one by one, each config reload may take 5 mins.
Module level configuration restore is more reasonable.

#### How did you do it?
Call the existing function `backup_and_restore_config_db_on_duts` in `conftest.py` and do config reload after config_db.json restoration.
Make sure if `vxlan` module run, the configuration will be restored after the test.

#### How did you verify/test it?
Run `test_vxlan_crm` on dut and check the log.
Backup config file before running tests

```
29/05/2025 08:48:01 conftest.restore_config_by_config_reload L0356 INFO   | Prepare backup config before running tests
29/05/2025 08:48:01 duthost_utils._backup_and_restore_config L0043 INFO   | Backup /etc/sonic/config_db.json to /host/config_db.json.before_test_module on <bound method DutHosts._Nodes._run_on_nodes of [<MultiAsicSonicHost bjw2-can-8101-2>]>
29/05/2025 08:48:01 base._run                                L0071 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell, args=["cp /etc/sonic/config_db.json /host/config_db.json.before_test_module"], kwargs={}
29/05/2025 08:48:02 base._run                                L0108 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell Result => {"changed": true, "stdout": "", "stderr": "", "rc": 0, "cmd": "cp /etc/sonic/config_db.json /host/config_db.json.before_test_module", "start": "2025-05-29 08:48:02.236422", "end": "2025-05-29 08:48:02.242861", "delta": "0:00:00.006439", "msg": "", "invocation": {"module_args": {"_raw_params": "cp /etc/sonic/config_db.json /host/config_db.json.before_test_module", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": [], "_ansible_no_log": null, "failed": false}

```

Restore configuration file, then do config reload after running tests
```
29/05/2025 09:24:15 conftest.restore_config_by_config_reload L0359 INFO   | Restore config after running tests
29
9/05/2025 09:24:15 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture fixture_setUp teardown ends --------------------
29/05/2025 09:24:15 duthost_utils._backup_and_restore_config L0049 INFO   | Restore /etc/sonic/config_db.json with /host/config_db.json.before_test_module on <bound method DutHosts._Nodes._run_on_nodes of [<MultiAsicSonicHost bjw2-can-8101-2>]>
29/05/2025 09:24:15 base._run                                L0071 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell, args=["mv /host/config_db.json.before_test_module /etc/sonic/config_db.json"], kwargs={}
29/05/2025 09:24:15 base._run                                L0108 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell Result => {"changed": true, "stdout": "", "stderr": "", "rc": 0, "cmd": "mv /host/config_db.json.before_test_module /etc/sonic/config_db.json", "start": "2025-05-29 09:24:15.369677", "end": "2025-05-29 09:24:15.374489", "delta": "0:00:00.004812", "msg": "", "invocation": {"module_args": {"_raw_params": "mv /host/config_db.json.before_test_module /etc/sonic/config_db.json", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
29/05/2025 09:24:15 conftest.restore_config_by_config_reload L0359 INFO   | Restore config after running tests
29/05/2025 09:24:15 config_reload.config_reload              L0145 INFO   | reloading config_db
29/05/2025 09:24:15 base._run                                L0071 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell, args=["config reload -h"], kwargs={"executable": "/bin/bash"}
29/05/2025 09:24:17 base._run                                L0108 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell Result => {"changed": true, "stdout": "Usage: config reload [OPTIONS] [FILENAME]\n\n  Clear current configuration and import a previous saved config DB dump\n  file. <filename> : Names of configuration file(s) to load, separated by\n  comma with no spaces in between\n\nOptions:\n  -y, --yes\n  -l, --load-sysinfo              load system default information (mac,\n                                  portmap etc) first.\n  -n, --no_service_restart        Do not restart docker services\n  -f, --force                     Force config reload without system checks\n  -t, --file_format [config_yang|config_db]\n                                  specify the file format  [default:\n                                  config_db]\n  -b, --bypass-lock               Do reload without acquiring lock\n  -h, -?, --help                  Show this message and exit.", "stderr": "", "rc": 0, "cmd": "config reload -h", "start": "2025-05-29 09:24:15.830852", "end": "2025-05-29 09:24:17.219753", "delta": "0:00:01.388901", "msg": "", "invocation": {"module_args": {"executable": "/bin/bash", "_raw_params": "config reload -h", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["Usage: config reload [OPTIONS] [FILENAME]", "", "  Clear current configuration and import a previous saved config DB dump", "  file. <filename> : Names of configuration file(s) to load, separated by", "  comma with no spaces in between", "", "Options:", "  -y, --yes", "  -l, --load-sysinfo              load system default information (mac,", "                                  portmap etc) first.", "  -n, --no_service_restart        Do not restart docker services", "  -f, --force                     Force config reload without system checks", "  -t, --file_format [config_yang|config_db]", "                                  specify the file format  [default:", "                                  config_db]", "  -b, --bypass-lock               Do reload without acquiring lock", "  -h, -?, --help                  Show this message and exit."], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
29/05/2025 09:24:47 base._run                                L0071 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell, args=["config reload -y -f &>/dev/null"], kwargs={"executable": "/bin/bash"}
29/05/2025 09:25:28 base._run                                L0108 DEBUG  | /data/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [bjw2-can-8101-2] AnsibleModule::shell Result => {"changed": true, "stdout": "", "stderr": "", "rc": 0, "cmd": "config reload -y -f &>/dev/null", "start": "2025-05-29 09:24:48.044408", "end": "2025-05-29 09:25:24.604504", "delta": "0:00:36.560096", "msg": "", "invocation": {"module_args": {"executable": "/bin/bash", "_raw_params": "config reload -y -f &>/dev/null", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
