### PR TITLE
chore: update announce routes script to match T2

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import itertools
 import math
 import os
 import yaml
@@ -1324,6 +1325,14 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce"):
     group_nums = len(t1_vms) // T1_GROUP_SIZE
     t1_route_per_group = math.ceil(ROUTE_NUMBER_T1 / T1_GROUP_SIZE / group_nums)
 
+    # 32 route each x 4 to match 110 T1
+    extra_ipv4_t1 = itertools.chain(
+        ipaddress.ip_network("192.168.0.0/27"),
+        ipaddress.ip_network("192.169.0.0/27"),
+        ipaddress.ip_network("192.170.0.0/27"),
+        ipaddress.ip_network("192.171.0.0/27"),
+    )
+
     for group in range(group_nums):
         selected_v4_subnets = all_subnetv4[group * t1_route_per_group: group * t1_route_per_group + t1_route_per_group]
         selected_v6_subnets = all_subnetv6[group * t1_route_per_group: group * t1_route_per_group + t1_route_per_group]
@@ -1340,6 +1349,8 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce"):
             for subnetv4, subnetv6 in zip(selected_v4_subnets, selected_v6_subnets):
                 ipv4_routes.append((str(subnetv4), nhipv4, as_path))
                 ipv6_routes.append((str(subnetv6), nhipv6, as_path))
+
+            ipv4_routes.append((str(next(extra_ipv4_t1)), nhipv4, as_path))
 
             change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
             change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Currently T2 announce route script are publishing 32 routes x 3 for 3 groups of VM to T1. I.e:
- 192.168.x.x first 32 routes
- 192.169.x.x next 32 routes
- 192.170.x.x next 32 routes

Since LT1 have 110 T1, we will use another 192.171.x.x (32 routes) to satisfy the requirement

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Add more routing to match with current T2 setup

#### How did you do it?

Broadcast the following sequentially in 4 groups of 110 VM:

- 192.168.x.x first 32 routes
- 192.169.x.x next 32 routes
- 192.170.x.x next 32 routes
- 192.171.x.x next 32 routes

The last group of 110 will broadcast 14 routes of 192.171.x.x

#### How did you verify/test it?
Verify on LT2 device

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
