### PR TITLE
[pylintrc] remove discontinued options

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -474,8 +474,6 @@ enable=missing-docstring,
        bare-except,
        super-init-not-called,
        bad-indentation,
-       bad-continuation,
-       bad-whitespace,
        pointless-string-statement,
        consider-using-with,
        consider-using-f-string,
@@ -486,11 +484,7 @@ enable=missing-docstring,
        consider-using-set-comprehension,
        consider-using-join,
        consider-using-min-builtin,
-       consider-using-max-builtin,
-       consider-using-any,
-       consider-using-all,
-       consider-using-namedtuple-or-dataclass,
-       consider-using-assignment-expr
+       consider-using-max-builtin
 
 
 


### PR DESCRIPTION
### Description of PR

Remove discontinued options from pylintrc.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

tests/common2 is enforced with pylintrc. Remove discontinued options.

#### How did you do it?

Remove discontinued options from rc file.

#### How did you verify/test it?

Run pylint

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA