### PR TITLE
[T2 MACSec] Skip macsec tests for T2 without macsec enable param

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1584,6 +1584,12 @@ lldp/test_lldp.py::test_lldp_neighbor:
 #######################################
 #####           macsec            #####
 #######################################
+macsec:
+  skip:
+    reason: 'Skip macsec test for T2, if macsec is not enabled'
+    conditions:
+      - "macsec_en==False and 't2' in topo_type"
+
 macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
   skip:
     reason: 'test_server_to_neighbor needs downstream neighbors, which is not present in this topo'

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1584,12 +1584,6 @@ lldp/test_lldp.py::test_lldp_neighbor:
 #######################################
 #####           macsec            #####
 #######################################
-macsec:
-  skip:
-    reason: 'Skip macsec test for T2, if macsec is not enabled'
-    conditions:
-      - "macsec_en==False"
-
 macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
   skip:
     reason: 'test_server_to_neighbor needs downstream neighbors, which is not present in this topo'

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1588,7 +1588,7 @@ macsec:
   skip:
     reason: 'Skip macsec test for T2, if macsec is not enabled'
     conditions:
-      - "macsec_en==False and 't2' in topo_type"
+      - "macsec_en==False"
 
 macsec/test_dataplane.py::TestDataPlane::test_server_to_neighbor:
   skip:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1376,8 +1376,9 @@ def generate_params_frontend_hostname(request, macsec_only=False):
     if macsec_only:
         host_type = "macsec"
         if 't2' in tbinfo['topo']['name']:
-            # currently in the T2 topo only the uplink linecard will have
-            # macsec enabled
+            # currently in the T2 topo only the uplink linecard will have macsec enabled
+            # Please add "macsec_card = True" param to inventory the inventory file
+            # under Line Card with macsec capability.
             for dut in duts:
                 if is_frontend_node(inv_files, dut) and is_macsec_capable_node(inv_files, dut):
                     frontend_duts.append(dut)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1376,9 +1376,11 @@ def generate_params_frontend_hostname(request, macsec_only=False):
     if macsec_only:
         host_type = "macsec"
         if 't2' in tbinfo['topo']['name']:
+            if request.config.getoption("--enable_macsec", default=False) is False:
+                # return empty hostname, as it should get skipped
+                logging.info("MACSec not enabled, skipping test")
+                return frontend_duts
             # currently in the T2 topo only the uplink linecard will have macsec enabled
-            # Please add "macsec_card = True" param to inventory the inventory file
-            # under Line Card with macsec capability.
             for dut in duts:
                 if is_frontend_node(inv_files, dut) and is_macsec_capable_node(inv_files, dut):
                     frontend_duts.append(dut)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1378,9 +1378,11 @@ def generate_params_frontend_hostname(request, macsec_only=False):
         if 't2' in tbinfo['topo']['name']:
             if request.config.getoption("--enable_macsec", default=False) is False:
                 # return empty hostname, as it should get skipped
-                logging.info("MACSec not enabled, skipping test")
+                logging.info("MACSec not enabled, return empty hostname to skip test")
                 return frontend_duts
             # currently in the T2 topo only the uplink linecard will have macsec enabled
+            # Please add "macsec_card = True" param to inventory the inventory file
+            # under Line Card with macsec capability.
             for dut in duts:
                 if is_frontend_node(inv_files, dut) and is_macsec_capable_node(inv_files, dut):
                     frontend_duts.append(dut)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1375,17 +1375,15 @@ def generate_params_frontend_hostname(request, macsec_only=False):
 
     if macsec_only:
         host_type = "macsec"
-        if 't2' in tbinfo['topo']['name']:
-            if request.config.getoption("--enable_macsec", default=False) is False:
-                # return empty hostname, as it should get skipped
-                logging.info("MACSec not enabled, return empty hostname to skip test")
-                return frontend_duts
+        if 't2' in tbinfo['topo']['name'] and request.config.getoption("--enable_macsec", default=False):
             # currently in the T2 topo only the uplink linecard will have macsec enabled
             # Please add "macsec_card = True" param to inventory the inventory file
             # under Line Card with macsec capability.
             for dut in duts:
                 if is_frontend_node(inv_files, dut) and is_macsec_capable_node(inv_files, dut):
                     frontend_duts.append(dut)
+            if not frontend_duts:
+                logging.info("no macsec card found")
         else:
             frontend_duts.append(duts[0])
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1375,7 +1375,7 @@ def generate_params_frontend_hostname(request, macsec_only=False):
 
     if macsec_only:
         host_type = "macsec"
-        if 't2' in tbinfo['topo']['name'] and request.config.getoption("--enable_macsec", default=False):
+        if 't2' in tbinfo['topo']['name'] and request.config.option.enable_macsec:
             # currently in the T2 topo only the uplink linecard will have macsec enabled
             # Please add "macsec_card = True" param to inventory the inventory file
             # under Line Card with macsec capability.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18619, added comment to improve user experience on T2 MACSec tests 

Also skip MACSec tests for T2, when enable_macsec is not set during test run.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
macsec_enabled:
macsec/test_docker_restart.py::test_restart_macsec_docker[macsec_LC1] PASSED                                                                   [100%]
================================================================= 1 passed, 1 warning in 332.85s (0:05:32) ================================================================

not passing in macsec_enabled:
SKIPPED [1] macsec/test_docker_restart.py: got empty parameter set ['enum_rand_one_per_hwsku_macsec_frontend_hostname'], function test_restart_macsec_docker at /tests/macsec/test_docker_restart.py:14
====================================================================== 1 skipped, 1 warning in 52.95s
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
