### PR TITLE
[LLDP] Add critical process check after restart orchagent

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -63,10 +63,11 @@ def check_critical_processes(dut, watch_secs=0):
         watch_secs = watch_secs - 5
 
 
-def wait_critical_processes(dut):
+def wait_critical_processes(dut, delay=0):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
+    @param delay: delay in seconds before checking the status of critical processes.
     """
     timeout = reset_timeout(dut)
     # No matter what we set in inventory file, we always set sup timeout to 900
@@ -75,5 +76,5 @@ def wait_critical_processes(dut):
         timeout = 900
     logging.info("Wait until all critical processes are healthy in {} sec"
                  .format(timeout))
-    pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
+    pytest_assert(wait_until(timeout, 20, delay, _all_critical_processes_healthy, dut),
                   "Not all critical processes are healthy")

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -58,8 +58,8 @@ def restart_orchagent(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         is_running = is_container_running(duthost, container_name)
         pytest_assert(is_running, "Container '{}' is not running. Exiting...".format(container_name))
         duthost.shell("docker exec {} supervisorctl start {}".format(container_name, program_name))
-        # There was a issue that orchagent exited after start 1~2 minutes.
-        # Add critical service check here to make sure all critical services are up
+        # There was an image issue that orchagent exited after start 1~2 minutes.
+        # Add critical process check here to make sure all critical processes are up
         time.sleep(120)
         wait_critical_processes(duthost)
     yield

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 from tests.common.platform.interface_utils import get_dpu_npu_ports_from_hwsku
+from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.helpers.dut_utils import get_program_info, kill_process_by_pid, is_container_running
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
@@ -57,6 +58,10 @@ def restart_orchagent(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         is_running = is_container_running(duthost, container_name)
         pytest_assert(is_running, "Container '{}' is not running. Exiting...".format(container_name))
         duthost.shell("docker exec {} supervisorctl start {}".format(container_name, program_name))
+        # There was a issue that orchagent exited after start 1~2 minutes.
+        # Add critical service check here to make sure all critical services are up
+        time.sleep(120)
+        wait_critical_processes(duthost)
     yield
 
 

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -60,8 +60,7 @@ def restart_orchagent(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         duthost.shell("docker exec {} supervisorctl start {}".format(container_name, program_name))
         # There was an image issue that orchagent exited after start 1~2 minutes.
         # Add critical process check here to make sure all critical processes are up
-        time.sleep(120)
-        wait_critical_processes(duthost)
+        wait_critical_processes(duthost, delay=120)
     yield
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Recently we observed an image issue that orchagent process exited in 1~2 minutes after restart.
Enhance the LLDP testcase to catch this issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Recently we observed an image issue that orchagent process exited in 1~2 minutes after restart.
Enhance the LLDP testcase to catch this issue.

#### How did you do it?
Add critical process check after restart orchagent.

#### How did you verify/test it?
Verified on bad image, got below failure:
```
ERROR lldp/test_lldp.py::test_lldp_neighbor_post_orchagent_reboot[bjw2-can-720dt-3-None] - Failed: Not all critical processes are healthy
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
