### PR TITLE
[M1] Adapt test_route_flap to M1 topo

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ from tests.common.utilities import get_test_server_host
 from tests.common.utilities import str2bool
 from tests.common.utilities import safe_filename
 from tests.common.utilities import get_duts_from_host_pattern
+from tests.common.utilities import get_upstream_neigh_type
 from tests.common.helpers.dut_utils import is_supervisor_node, is_frontend_node, create_duthost_console, creds_on_dut, \
     is_enabled_nat_for_dpu, get_dpu_names_and_ssh_ports, enable_nat_for_dpus, is_macsec_capable_node
 from tests.common.cache import FactsCache
@@ -2218,15 +2219,8 @@ def enum_rand_one_frontend_asic_index(request):
 
 @pytest.fixture(scope='module')
 def enum_upstream_dut_hostname(duthosts, tbinfo):
-    if tbinfo["topo"]["type"] == "m0":
-        upstream_nbr_type = "M1"
-    elif tbinfo["topo"]["type"] == "mx":
-        upstream_nbr_type = "M0"
-    elif tbinfo["topo"]["type"] == "t0":
-        upstream_nbr_type = "T1"
-    elif tbinfo["topo"]["type"] == "t1":
-        upstream_nbr_type = "T2"
-    else:
+    upstream_nbr_type = get_upstream_neigh_type(tbinfo["topo"]["type"], is_upper=True)
+    if upstream_nbr_type is None:
         upstream_nbr_type = "T3"
 
     for a_dut in duthosts.frontend_nodes:

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -46,9 +46,9 @@ def get_prefix_len_by_net_size(net_size):
 
 
 def get_route_prefix_len(tbinfo, common_config):
-    if tbinfo["topo"]["name"] == "m0":
+    if tbinfo["topo"]["type"] in ["m0", "m1"]:
         subnet_size = common_config.get("m0_subnet_size", M0_SUBNET_SIZE)
-    elif tbinfo["topo"]["name"] == "mx":
+    elif tbinfo["topo"]["type"] == "mx":
         subnet_size = common_config.get("mx_subnet_size", MX_SUBNET_SIZE)
     else:
         subnet_size = common_config.get("tor_subnet_size", TOR_SUBNET_SIZE)

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -46,7 +46,10 @@ def get_prefix_len_by_net_size(net_size):
 
 
 def get_route_prefix_len(tbinfo, common_config):
-    if tbinfo["topo"]["type"] in ["m0", "m1"]:
+    if tbinfo["topo"]["type"] == "m1":
+        # The only multipath route in m1 topo is the default route
+        subnet_size = 2 ** 32
+    elif tbinfo["topo"]["type"] == "m0":
         subnet_size = common_config.get("m0_subnet_size", M0_SUBNET_SIZE)
     elif tbinfo["topo"]["type"] == "mx":
         subnet_size = common_config.get("mx_subnet_size", MX_SUBNET_SIZE)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adapt testcase `test_route_flap` to M1 topo.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Adapt testcase `test_route_flap` to M1 topo.

#### How did you do it?
1. Support M1 topo.
2. Use default route for flap test because default route is the only multipath route on M1 topo.

#### How did you verify/test it?
Verified on Arista-7050CX3 M1-48 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
