### PR TITLE
Add restoration of autorestart for swss

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -58,6 +58,8 @@ def restart_orchagent(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         pytest_assert(is_running, "Container '{}' is not running. Exiting...".format(container_name))
         duthost.shell("docker exec {} supervisorctl start {}".format(container_name, program_name))
     yield
+    if duthost.facts['switch_type'] != "voq":
+        duthost.shell("sudo config feature autorestart {} enabled".format(feature_name))
 
 
 def get_num_lldpctl_facts(duthost, enum_frontend_asic_index):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add missing restoration of `autorestart` config for `swss`. It is currently missing and may interfere with subsequent tests.

Fixes # (issue)
Fixes potential orchagent/syncd crash (swss not autorestarting).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
