### PR TITLE
[CRM AVAILABLE] To enhance the crm tests for TD3 and Cisco devices

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -353,8 +353,8 @@ def crm_resources(duthosts, rand_one_dut_hostname):
                     }
         return True if resources_dict else False
 
-    # Wait up to 90 seconds, checking every 5 seconds
-    wait_until(90, 5, 0, get_crm_resources, resources)
+    # Wait up to 360 seconds, checking every 5 seconds
+    wait_until(360, 5, 0, get_crm_resources, resources)
     if not resources:
         pytest.fail("CRM counters are not ready after multiple retries.")
 

--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -15,6 +15,9 @@ SKU_NEXTHOP_THRESHOLDS = {
     'nokia-m0-7215': 126,
     'nokia-7215-a1': 126,
     'nokia-7215': 126,
+    'arista-7050cx3-32s-c28s4': 255,
+    'Arista-7050CX3-32S-C32': 255,
+    'arista-7050cx3-32s-s128': 255,
 }
 
 DEFAULT_NEXTHOP_THRESHOLD = 256
@@ -29,8 +32,8 @@ def test_crm_next_hop_group(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     hwsku = duthost.facts["hwsku"].lower()
-
-    nexthop_group_threshold = SKU_NEXTHOP_THRESHOLDS.get(hwsku, DEFAULT_NEXTHOP_THRESHOLD)
+    lower_sku_nexthop_thresholds = {k.lower(): v for k, v in SKU_NEXTHOP_THRESHOLDS.items()}
+    nexthop_group_threshold = lower_sku_nexthop_thresholds.get(hwsku, DEFAULT_NEXTHOP_THRESHOLD)
 
     resource_name = "nexthop_group"
     if resource_name in crm_resources:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
For TD3, the maximum number of nexthop groups is 255, which is below the minimum requirement of 256, resulting in test failures. To address this, TD3 should be added to SKU_NEXTHOP_THRESHOLDS.

Additionally, some HWSKUs require more time for the crm command to become operational. To accommodate this, the wait time has been increased from 90 seconds to 360 seconds in worst case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To fix the flaky failure on Cisco devices and the consistent failure on TD3

#### How did you do it?
1. For TD3, add 255 as a threshold. 
2. Extend maximum wait time from 90 seconds to 360 seconds. 

#### How did you verify/test it?
1. Run test on TD3 and Cisco devices. 

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
