### PR TITLE
[cherry-pick] [BGP Tests] Enable Tests for LT2 and FT2 Topologies

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -531,7 +531,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] in ["t0", "mx"]:
         setup_func = _setup_interfaces_t0_or_mx
-    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2"]):
+    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2", "ft2"]):
         setup_func = _setup_interfaces_t1_or_t2
     elif tbinfo["topo"]["type"] == "m0":
         if topo_scenario == "m0_l3_scenario":

--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -531,7 +531,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         setup_func = _setup_interfaces_dualtor
     elif tbinfo["topo"]["type"] in ["t0", "mx"]:
         setup_func = _setup_interfaces_t0_or_mx
-    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1"]):
+    elif tbinfo["topo"]["type"] in set(["t1", "t2", "m1", "lt2"]):
         setup_func = _setup_interfaces_t1_or_t2
     elif tbinfo["topo"]["type"] == "m0":
         if topo_scenario == "m0_l3_scenario":


### PR DESCRIPTION
Manual cherry-pick for #18669

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Small PR to add support for LT2 in BGP tests, through the use of an appropriate setup function for the platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
To ensure that we can run the BGP tests on the Lower T2 platform, we needed to add explicit support and initial testing for these testcases.

#### How did you do it?
Added `lt2` to the list of topologies that uses the t1 & t2 interface setup function.

#### How did you verify/test it?
Running the previously failing tests, we can observe that they pass:
![image](https://github.com/user-attachments/assets/23abc662-883a-4dca-b206-a5618cb37b46)
Other than loganalyzer fail, all testcases run successfully:
![image](https://github.com/user-attachments/assets/8d99e47e-7c59-4859-bb7a-5f00c24c86fc)


#### Any platform specific information?
Change is only relevant to the LT2 platform - all others are unaffected by this change.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A