### PR TITLE
Enhance deploy-minigraph ansible playbook

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -291,7 +291,7 @@
 
   - name: find all interface indexes connecting to VM
     set_fact:
-      ifindex_to_vms: "{{ ifindex_to_vms|default([]) }} + {{ item.value['interface_indexes'][dut_index|int] }}"
+      ifindex_to_vms: "{{ ifindex_to_vms|default([]) + item.value['interface_indexes'][dut_index|int] }}"
     with_dict: "{{ vm_topo_config['vm'] }}"
     when: "'cable' not in topo"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhance the playbook to resolve `maximum recursion depth exceeded` issue while deploy-mg on 512-neighbor topo.

```
The full traceback is:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/ansible/executor/task_executor.py", line 524, in _execute
    self._task.post_validate(templar=templar)
  File "/usr/local/lib/python3.8/dist-packages/ansible/playbook/task.py", line 291, in post_validate
    super(Task, self).post_validate(templar)
  File "/usr/local/lib/python3.8/dist-packages/ansible/playbook/base.py", line 656, in post_validate
    value = templar.template(getattr(self, name))
  File "/usr/local/lib/python3.8/dist-packages/ansible/template/__init__.py", line 903, in template
    d[k] = self.template(
  File "/usr/local/lib/python3.8/dist-packages/ansible/template/__init__.py", line 871, in template
    result = self.do_template(
  File "/usr/local/lib/python3.8/dist-packages/ansible/template/__init__.py", line 1128, in do_template
    res = self.environment.concat(rf)
  File "/usr/local/lib/python3.8/dist-packages/ansible/template/native_helpers.py", line 67, in ansible_eval_concat
    Json2Python().visit(
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/usr/lib/python3.8/ast.py", line 456, in generic_visit
    new_node = self.visit(old_value)
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  ......around 90K lines......
   File "/usr/lib/python3.8/ast.py", line 447, in generic_visit
    value = self.visit(value)
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/usr/lib/python3.8/ast.py", line 402, in visit_Constant
    return self.generic_visit(node)
  File "/usr/lib/python3.8/ast.py", line 442, in generic_visit
    for field, old_value in iter_fields(node):
  File "/usr/lib/python3.8/ast.py", line 217, in iter_fields
    yield field, getattr(node, field)
RecursionError: maximum recursion depth exceeded while calling a Python object
failed: [str5-sn5640-1] (item={'key': 'ARISTA02PT0', 'value': {'intfs': [['Ethernet1']], 'interface_indexes': [[513]], 'ip_intf': [['Ethernet1']], 'peer_ipv4': [[]], 'ipv4mask': [[]], 'peer_ipv6': [['FC00:A::806']], 'ipv6mask': [['126']], 'bgp_ipv4': [[]], 'bgp_ipv6': [['FC00:A::805']], 'bgp_asn': 4200000002}}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "key": "ARISTA02PT0",
        "value": {
            "bgp_asn": 4200000002,
            "bgp_ipv4": [
                []
            ],
            ...
            "peer_ipv6": [
                [
                    "FC00:A::806"
                ]
            ]
        }
    }
}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Enhance the playbook to resolve `maximum recursion depth exceeded` issue while deploy-mg on 512-neighbor topo.

#### How did you do it?
Improve the expression to avoid recursion.

#### How did you verify/test it?
Verified by deploy `m1-48` and `t0-isolated-d2u510s2` testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
