### PR TITLE
[8101] Fix bug that confuses sonic name with alias

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_cisco_8101_202205.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_cisco_8101_202205.yml
@@ -15,6 +15,8 @@
 
 - name: backup config_db.json
   shell: cp /etc/sonic/config_db.json /etc/sonic/config_db.json.bak
+  become: yes
+  ignore_errors: yes
 
 - name: generate config_db.json
   shell: sonic-cfggen -H -j /tmp/base_config.json --print-data > /etc/sonic/config_db.json
@@ -35,23 +37,23 @@
       block:
         - name: disable feature teamd
           shell: config feature state teamd disabled
-          become: true
+          become: yes
         - name: ensure teamd container is stopped
           docker_container:
             name: teamd
             state: stopped
-          become: true
+          become: yes
           ignore_errors: yes
         - name: remove teamd container
           docker_container:
             name: teamd
             state: absent
-          become: true
+          become: yes
       when: teamd_container.stdout != ""
 
 - name: SONiC update config db
   shell: config reload -y -f
-  become: true
+  become: yes
 
 - name: wait for SONiC update config db finish
   pause:

--- a/ansible/roles/fanout/templates/sonic_deploy_cisco_8101_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_cisco_8101_202205.j2
@@ -20,14 +20,14 @@
 {% if device_port_vlans[port_name]["mode"].lower() == "access" %}
 {% if ns.notFirstPrinted %},
 {% endif %}
-        "Vlan{{ device_port_vlans[port_name]["vlanids"] }}|{{ port_name }}": {
+        "Vlan{{ device_port_vlans[port_name]["vlanids"] }}|{{ lookup("cisco_8101_port_convert", port_name, speed=device_conn[port_name]["speed"], output="sonic") }}": {
             "tagging_mode": "untagged"
         }{% if ns.update({"notFirstPrinted": True}) %} {% endif %}
 {% elif device_port_vlans[port_name]["mode"].lower() == "trunk" %}
 {% for vlanid in device_port_vlans[port_name]["vlanlist"] %}
 {% if ns.notFirstPrinted %},
 {% endif %}
-        "Vlan{{ vlanid }}|{{ port_name }}": {
+        "Vlan{{ vlanid }}|{{ lookup("cisco_8101_port_convert", port_name, speed=device_conn[port_name]["speed"], output="sonic") }}": {
             "tagging_mode": "tagged"
         }{% if ns.update({"notFirstPrinted": True}) %} {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The previous ansible template does not distinguish between sonic name and alias in the links file, which causes sonic unable to understand vlan members which should always be sonic name

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Fix 8101 fanout deployment bug

#### How did you do it?
Fix bug

#### How did you verify/test it?
Deployed fanout

#### Any platform specific information?
Cisco-8101 only

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
