### PR TITLE
Check if inner header hashing is supported before checking ECMP balance

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -631,6 +631,11 @@ class IPinIPHashTest(HashTest):
     for IPinIP packet.
     '''
 
+    def setUp(self):
+        HashTest.setUp(self)
+        self.ecmp_inner_header_hash_supported = self.test_params.get(
+            'ecmp_inner_header_hash_supported', False)
+
     def check_ipv4_route(self, hash_key, src_port, dst_port_lists, outer_src_ip, outer_dst_ip):
         '''
         @summary: Check IPv4 route works.
@@ -900,8 +905,9 @@ class IPinIPHashTest(HashTest):
             logging.info("hash_key={}, hit count map: {}".format(
                 hash_key, hit_count_map))
 
-            for next_hop in next_hops:
-                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
+            if self.ecmp_inner_header_hash_supported:
+                for next_hop in next_hops:
+                    self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
 
     def runTest(self):
         """
@@ -1208,6 +1214,11 @@ class NvgreHashTest(HashTest):
     for NvGRE packet.
     '''
 
+    def setUp(self):
+        HashTest.setUp(self)
+        self.ecmp_inner_header_hash_supported = self.test_params.get(
+            'ecmp_inner_header_hash_supported', False)
+
     def simple_nvgrev6_packet(self, pktlen=300,
                               eth_dst='00:01:02:03:04:05',
                               eth_src='00:06:07:08:09:0a',
@@ -1504,8 +1515,9 @@ class NvgreHashTest(HashTest):
         logging.info("hash_key={}, hit count map: {}".format(
             hash_key, hit_count_map))
 
-        for next_hop in next_hops:
-            self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
+        if self.ecmp_inner_header_hash_supported:
+            for next_hop in next_hops:
+                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
 
     def runTest(self):
         """

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -207,6 +207,21 @@ def fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, du
     return files
 
 
+@pytest.fixture(scope='module')
+def global_hash_capabilities(duthost):
+    """
+    Get the generic hash capabilities.
+    Args:
+        duthost (AnsibleHost): Device Under Test (DUT)
+    Returns:
+        ecmp_hash_fields: a list of supported ecmp hash fields
+        lag_hash_fields: a list of supported lag hash fields
+    """
+    global_hash_capabilities = duthost.get_switch_hash_capabilities()
+    return {'ecmp': global_hash_capabilities['ecmp'], 'ecmp_algo': global_hash_capabilities['ecmp_algo'],
+            'lag': global_hash_capabilities['lag'], 'lag_algo': global_hash_capabilities['lag_algo']}
+
+
 @pytest.fixture(scope="module")
 def ignore_ttl(duthosts):
     # on the multi asic devices, the packet can have different ttl based on how the packet is routed
@@ -229,6 +244,14 @@ def updated_tbinfo(tbinfo):
             tbinfo['topo']['properties']['topology']['disabled_host_interfaces'].append(
                 iface)
     return tbinfo
+
+
+@pytest.fixture(scope="module")
+def ecmp_inner_header_hash_supported(global_hash_capabilities):
+    for field in global_hash_capabilities["ecmp"]:
+        if 'INNER' in field:
+            return True
+    return False
 
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, True, 1514)])
@@ -525,7 +548,7 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
 def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa F811
                      hash_keys, ptfhost, ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa F811
-                     duts_minigraph_facts, request):                                # noqa F811
+                     duts_minigraph_facts, ecmp_inner_header_hash_supported, request): # noqa F811
     # Only run this test on T1 or T0 (including dualtor) topologies
     pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
     logging.info(f"Topology type: {tbinfo['topo']['type']}")
@@ -558,7 +581,8 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa F811
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": ipver,
-                       "topo_name": tbinfo['topo']['name']
+                       "topo_name": tbinfo['topo']['name'],
+                       "ecmp_inner_header_hash_supported": ecmp_inner_header_hash_supported,
                        },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -672,7 +696,7 @@ def nvgre_ipver(request):
 def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                          # noqa F811
                      hash_keys, ptfhost, nvgre_ipver, tbinfo, mux_server_url,             # noqa F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,          # noqa F811
-                     duts_minigraph_facts, request):                                      # noqa F811
+                     duts_minigraph_facts, ecmp_inner_header_hash_supported, request):    # noqa F811
 
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
                                             tbinfo, request)
@@ -711,7 +735,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": nvgre_ipver,
-                       "topo_name": tbinfo['topo']['name']
+                       "topo_name": tbinfo['topo']['name'],
+                       "ecmp_inner_header_hash_supported": ecmp_inner_header_hash_supported,
                        },
                log_file=log_file,
                qlen=PTF_QLEN,


### PR DESCRIPTION
### Description of PR
Summary:
test_fib.py: test_hash test cases for IPinIP and NVGRE fail because received packets are not uniformly distributed across the received nexthops on platforms that do not support hashing on inner packet header fields.
Adding a check for platform support of inner header fields before checking balance.

Fixes # (issue)
#18751 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
test_fib.py: test_hash test cases for IPinIP and NVGRE fail.

#### How did you do it?
Added a check for platform support of inner header fields before checking balance.

#### How did you verify/test it?
Tests pass with the fix.

#### Any platform specific information?
Any platform that does not support hashing on inner header fields.

#### Supported testbed topology if it's a new test case?

### Documentation
