### PR TITLE
Skip `frr_bmp` in `test_posttest.py::test_recover_rsyslog_rate_limit`

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -40,6 +40,9 @@ def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
             output = duthost.shell("docker images", module_ignore_errors=True)['stdout']
             if "sonic-telemetry" not in output:
                 continue
+        if feature_name == "frr_bmp":
+            # Skip frr_bmp since it's not container just bmp option used by bgpd
+            continue
         duthost.modify_syslog_rate_limit(feature_name, rl_option='enable')
 
 


### PR DESCRIPTION
`test_posttest.py::test_recover_rsyslog_rate_limit` iterates over the results of `show feature status` and executes the following commands:
```
docker exec -i frr_bmp sed -i 's/^#\\$SystemLogRateLimit/\\$SystemLogRateLimit/g' /etc/rsyslog.conf
docker exec -i frr_bmp supervisorctl restart rsyslogd
```

`frr_bmp` shows up in `show feature status` but it isn't a real docker container so we should skip it.
Similar PR: https://github.com/sonic-net/sonic-buildimage/pull/22588

Summary:
Fixes #18753 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
