### PR TITLE
[topo] Clear m2 m3 topo

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -20,7 +20,7 @@ from tests.common.utilities import get_neighbor_port_list
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t0", "m0", "mx", "m1", "m2", "m3"),
+    pytest.mark.topology("t0", "m0", "mx", "m1"),
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
 ]
 

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.acl,
     pytest.mark.disable_loganalyzer,  # Disable automatic loganalyzer, since we use it for the test
-    pytest.mark.topology("t0", "t1", "t2", "lt2", "m0", "mx", "m1", "m2", "m3"),
+    pytest.mark.topology("t0", "t1", "t2", "lt2", "m0", "mx", "m1"),
     pytest.mark.disable_memory_utilization
 ]
 

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -14,7 +14,7 @@ from tests.common.utilities import wait_until
 from tests.common.fixtures.ptfhost_utils import skip_traffic_test  # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "m2", "m3"),
+    pytest.mark.topology("t0", "t1", "m0", "mx", "m1"),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -11,7 +11,7 @@ from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # no
 
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1', 'm2', 'm3')
+    pytest.mark.topology('t1', 't2', 'm1')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/arp/test_neighbor_mac.py
+++ b/tests/arp/test_neighbor_mac.py
@@ -9,7 +9,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('m1', 'm2', 'm3', 't1', 'ptf')
+    pytest.mark.topology('m1', 't1', 'ptf')
 ]
 
 

--- a/tests/bgp/test_bgp_allow_list.py
+++ b/tests/bgp/test_bgp_allow_list.py
@@ -13,7 +13,7 @@ from bgp_helpers import check_routes_on_neighbors_empty_allow_list, checkout_bgp
 from bgp_helpers import bgp_allow_list_setup, prepare_eos_routes    # noqa:F401
 
 pytestmark = [
-    pytest.mark.topology('t1', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t1', 'm1'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -6,7 +6,7 @@ from tests.common.helpers.assertions import pytest_assert
 
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "m0", "mx", "m1", "m2", "m3"),
+    pytest.mark.topology("t0", "t1", "m0", "mx", "m1"),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -15,7 +15,7 @@ from tests.common.helpers.constants import DEFAULT_NAMESPACE
 from tests.common.utilities import wait_until, delete_running_config
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 't1', 't2', 'm1'),
 ]
 
 TEST_ITERATIONS = 5

--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 vrfname = 'default'
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", 'm1', 'm2', 'm3'),
+    pytest.mark.topology("t0", "t1", 'm1'),
 ]
 
 

--- a/tests/bgp/test_bgp_session_flap.py
+++ b/tests/bgp/test_bgp_session_flap.py
@@ -29,7 +29,7 @@ cpuSpike = 10
 memSpike = 1.3
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1', 'm2', 'm3')
+    pytest.mark.topology('t1', 't2', 'm1')
 ]
 
 

--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1', 'm2', 'm3')
+    pytest.mark.topology('t0', 't1', "m0", "mx", 'm1')
 ]
 
 stop_tasks = False

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -20,11 +20,11 @@ acl/custom_acl_table/test_custom_acl_table.py:
 #######################################
 acl/null_route/test_null_route_helper.py:
   skip:
-    reason: "Skip running on dualtor/m1/m2/m3 testbed"
+    reason: "Skip running on dualtor /m1 testbed"
     conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name"
-      - "'m1' in topo_type or 'm2' in topo_type or 'm3' in topo_type"
+      - "'m1' in topo_type"
 
 acl/test_acl.py:
   skip:
@@ -171,7 +171,7 @@ bgp/test_bgp_queue.py:
   skip:
     reason: "Not supported on mgmt device"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 bgp/test_bgp_router_id.py:
   skip:
@@ -299,7 +299,7 @@ copp/test_copp.py:
   skip:
     reason: "Topology not supported by COPP tests"
     conditions:
-      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48', 'm2-48'] and 't2' not in topo_type)"
+      - "(topo_name not in ['dualtor-aa', 'dualtor-aa-64-breakout', 'ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_add_new_trap:
   skip:
@@ -307,7 +307,7 @@ copp/test_copp.py::TestCOPP::test_add_new_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48', 'm2-48'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_remove_trap:
   skip:
@@ -315,7 +315,7 @@ copp/test_copp.py::TestCOPP::test_remove_trap:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==True"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48', 'm2-48'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
   skip:
@@ -325,7 +325,7 @@ copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot:
       - "is_multi_asic==True"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) == 20220531 and int(build_version.split('.')[1]) > 27 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
       - "build_version.split('.')[0].isdigit() and int(build_version.split('.')[0]) > 20220531 and hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX32S-Q32', 'Arista-7050-QX32', 'Arista-7050QX-32S-S4Q31', 'Arista-7060CX-32S-D48C8', 'Arista-7060CX-32S-C32', 'Arista-7060CX-32S-Q32', 'Arista-7060CX-32S-C32-T1']"
-      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48', 'm2-48'] and 't2' not in topo_type)"
+      - "(topo_name not in ['ptf32', 'ptf64', 't0', 't0-64', 't0-52', 't0-116', 't0-118', 't1', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 'm0', 'm0-2vlan', 'mx', 'm1-48'] and 't2' not in topo_type)"
 
 copp/test_copp.py::TestCOPP::test_trap_neighbor_miss:
   skip:
@@ -962,7 +962,6 @@ everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_eve
     conditions:
       - "asic_subtype in ['broadcom-dnx']"
       - "asic_type in ['cisco-8000']"
-      - "topo_type in ['lt2', 'ft2']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_frwd_with_bkg_trf:
   skip:
@@ -977,7 +976,6 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
     conditions:
       - "asic_type in ['cisco-8000']"
       - "asic_subtype in ['broadcom-dnx']"
-      - "topo_type in ['lt2', 'ft2']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_frwd_with_bkg_trf:
   skip:
@@ -1013,7 +1011,7 @@ fib/test_fib.py::test_nvgre_hash:
   skip:
     reason: 'Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*'
     conditions:
-      - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx', 'm1']"
   xfail:
     reason: 'Nvgre hash test is not fully supported on SPC1 platform due to known limitation'
     conditions:
@@ -1023,7 +1021,7 @@ fib/test_fib.py::test_vxlan_hash:
   skip:
     reason: 'Vxlan hash test is not fully supported on VS platform; Not supported on M*'
     conditions:
-      - "asic_type in ['vs'] or topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "asic_type in ['vs'] or topo_type in ['m0', 'mx', 'm1']"
 
 #######################################
 #####   generic_config_updater    #####
@@ -1070,7 +1068,7 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
     conditions_logical_operator: "OR"
     conditions:
       - "asic_type in ['cisco-8000']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
 
 generic_config_updater/test_eth_interface.py::test_replace_fec:
@@ -1146,7 +1144,7 @@ generic_config_updater/test_pfcwd_status.py:
     reason: "This test is not run on this topo type or version or topology currently"
     conditions_logical_operator: "OR"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
 
 generic_config_updater/test_pg_headroom_update.py:
@@ -1154,7 +1152,7 @@ generic_config_updater/test_pg_headroom_update.py:
     reason: "Unsupported topology."
     conditions_logical_operator: "OR"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 #######################################
 #####           gnmi              #####
@@ -1445,13 +1443,13 @@ iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup:
   skip:
     reason: "M* topo does not support TestShowPriorityGroup"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 iface_namingmode/test_iface_namingmode.py::TestShowQueue:
   skip:
     reason: "M* topo does not support TestShowQueue"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_persistent_watermark:
   xfail:
@@ -1500,7 +1498,7 @@ ip/test_mgmt_ipv6_only.py:
   skip:
     reason: "Skipping mgmt ipv6 test for M* topo"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 #######################################
 #####            ipfwd            #####
@@ -1511,7 +1509,7 @@ ipfwd/test_dip_sip.py:
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
-      - "topo_type not in ['t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type not in ['t0', 't1', 't2', 'm0', 'mx', 'm1']"
 
 ipfwd/test_dir_bcast.py:
   skip:
@@ -1638,7 +1636,7 @@ mvrf:
     reason: "mvrf is not supported in x86_64-nokia_ixr7250e_36x400g-r0 platform, M* topo"
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 
 mvrf/test_mgmtvrf.py:
@@ -1647,7 +1645,7 @@ mvrf/test_mgmtvrf.py:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 
 #######################################
@@ -1748,7 +1746,7 @@ pfcwd:
   skip:
     reason: "Pfcwd tests skipped on M* testbed."
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
    skip:
@@ -1756,7 +1754,7 @@ pfcwd/test_pfc_config.py::TestPfcConfig::test_forward_action_cfg:
      conditions_logical_operator: or
      conditions:
         - "asic_type in ['cisco-8000']"
-        - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+        - "topo_type in ['m0', 'mx', 'm1']"
 
 pfcwd/test_pfcwd_all_port_storm.py:
    skip:
@@ -1766,7 +1764,7 @@ pfcwd/test_pfcwd_all_port_storm.py:
      conditions_logical_operator: or
      conditions:
       - "hwsku in ['Arista-7060X6-64PE-256x200G']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions:
   xfail:
@@ -1780,7 +1778,7 @@ pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
      conditions_logical_operator: or
      conditions:
         - "asic_type != 'cisco-8000'"
-        - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+        - "topo_type in ['m0', 'mx', 'm1']"
 
 pfcwd/test_pfcwd_warm_reboot.py:
    skip:
@@ -1789,7 +1787,7 @@ pfcwd/test_pfcwd_warm_reboot.py:
      conditions:
         - "'t2' in topo_name"
         - "'standalone' in topo_name"
-        - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+        - "topo_type in ['m0', 'mx', 'm1']"
         - "asic_type in ['cisco-8000']"
         - "release in ['202412']"
         - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/8400"
@@ -1801,7 +1799,7 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
      conditions:
         - "'t2' in topo_name"
         - "'standalone' in topo_name"
-        - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+        - "topo_type in ['m0', 'mx', 'm1']"
         - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17803"
         - "release in ['202412']"
 
@@ -1831,7 +1829,7 @@ qos:
     reason: "M* topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "macsec_en==True"
 
 qos/test_buffer.py:
@@ -1840,7 +1838,7 @@ qos/test_buffer.py:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000'] or 't2' in topo_name"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 qos/test_buffer.py::test_buffer_model_test:
   skip:
@@ -1849,7 +1847,7 @@ qos/test_buffer.py::test_buffer_model_test:
     conditions:
       - "asic_type in ['mellanox'] or asic_subtype in ['broadcom-dnx']"
       - "asic_type in ['cisco-8000'] or 't2' in topo_name"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 qos/test_buffer_traditional.py:
   skip:
@@ -1857,7 +1855,7 @@ qos/test_buffer_traditional.py:
     conditions_logical_operator: or
     conditions:
       - "release not in ['201911']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 qos/test_ecn_config.py:
   skip:
@@ -1888,7 +1886,7 @@ qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to
     conditions:
       - "asic_type in ['mellanox', 'broadcom', 'cisco-8000']"
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 qos/test_qos_masic.py:
   skip:
@@ -1896,7 +1894,7 @@ qos/test_qos_masic.py:
     conditions_logical_operator: or
     conditions:
       - "is_multi_asic==False or topo_name not in ['t1-lag', 't1-64-lag', 't1-56-lag', 't1-backend']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "asic_type in ['vs']"
 
 qos/test_qos_sai.py:
@@ -1905,14 +1903,14 @@ qos/test_qos_sai.py:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['barefoot'] and topo_name in ['t1']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 qos/test_qos_sai.py::TestQosSai:
   skip:
     reason: "Unsupported testbed type. / M* topo does not support qos"
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
@@ -1922,7 +1920,7 @@ qos/test_qos_sai.py::TestQosSai::testIPIPQosSaiDscpToPgMapping:
     conditions:
       - "asic_type in ['mellanox']"
       - https://github.com/sonic-net/sonic-mgmt/issues/12906
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
@@ -1931,7 +1929,7 @@ qos/test_qos_sai.py::TestQosSai::testPfcStormWithSharedHeadroomOccupancy:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
@@ -1940,7 +1938,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark:
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc','x86_64-arista_7800r3ak_36dm2_lc']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
@@ -1949,7 +1947,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping:
     conditions_logical_operator: or
     conditions:
       - "'backend' not in topo_name"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
@@ -1958,7 +1956,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
     conditions_logical_operator: or
     conditions:
       - "'backend' not in topo_name"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
@@ -1967,7 +1965,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
     conditions_logical_operator: or
     conditions:
       - "'backend' in topo_name"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
@@ -1976,7 +1974,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpToPgMapping:
     conditions_logical_operator: or
     conditions:
       - "'backend' in topo_name"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
@@ -1985,7 +1983,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['mellanox']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
@@ -1994,7 +1992,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiFullMeshTrafficSanity:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000'] or topo_name not in ['ptf64']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
@@ -2005,7 +2003,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
       - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100']
       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
       and asic_type in ['cisco-8000']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
       - "asic_type in ['vs']"
 
@@ -2017,7 +2015,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc', 'x86_64-arista_7800r3ak_36dm2_lc'] or asic_type in ['mellanox']
          and asic_type in ['cisco-8000']
          and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
   xfail:
     reason: "Headroom pool size not supported."
@@ -2030,7 +2028,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
@@ -2039,7 +2037,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoq:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
@@ -2048,7 +2046,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueueVoqMultiSrc:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
@@ -2057,7 +2055,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPGDrop:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
@@ -2066,7 +2064,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000'] and not platform.startswith('x86_64-8122_')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[None-wm_pg_shared_lossy]:
@@ -2081,7 +2079,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiQWatermarkAllPorts:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000']"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
@@ -2090,7 +2088,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiSharedReservationSize:
     conditions_logical_operator: or
     conditions:
       - "asic_type not in ['cisco-8000'] or platform.startswith('x86_64-8122_')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256', 'dualtor-56', 'dualtor-120', 'dualtor', 'dualtor-aa', 't0-80', 't0-backend', 't1-lag', 't1-28-lag', 't1-64-lag', 't1-56-lag', 't1-backend', 't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic'] and asic_type not in ['mellanox']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiXonHysteresis:
@@ -2346,7 +2344,7 @@ snmp/test_snmp_pfc_counters.py:
   skip:
     reason: "M* topo does not support test_snmp_pfc_counters"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 snmp/test_snmp_phy_entity.py:
   skip:
@@ -2358,7 +2356,7 @@ snmp/test_snmp_queue.py:
   skip:
     reason: "Interfaces not present on supervisor node or M* topo does not support test_snmp_queue or unsupported platform"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3'] or asic_type in ['barefoot']"
+      - "topo_type in ['m0', 'mx', 'm1'] or asic_type in ['barefoot']"
 
 snmp/test_snmp_queue_counters.py:
   skip:
@@ -2366,7 +2364,7 @@ snmp/test_snmp_queue_counters.py:
     reason: "Have an known issue on kvm testbed / Unsupported in M* topos"
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/14007"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 #######################################
 #####            span             #####
@@ -2549,7 +2547,7 @@ telemetry/test_telemetry.py::test_telemetry_queue_buffer_cnt:
     reason: "Testcase ignored due to switch type is voq / Unsupported in M* topos / multi-asic issue 15393"
     conditions:
       - "(switch_type=='voq')"
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-mgmt/issues/15393"
 
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -936,7 +936,7 @@ platform_tests/counterpoll/test_counterpoll_watermark.py::test_counterpoll_queue
   skip:
     reason: "Unsupported topology"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3']"
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 #######################################
 #####           daemon            #####
@@ -1205,7 +1205,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
     reason: "Skip test_fast_reboot for M*/t1/t2 / Fast reboot is broken on dualtor topology. Skipping for now."
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3', 't1', 't2']"
+      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "release in ['202412']"
   xfail:
@@ -1218,7 +1218,7 @@ platform_tests/test_reboot.py::test_soft_reboot:
   skip:
     reason: "Skip test_soft_reboot for M* and test is supported only on S6100 hwsku"
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3'] or hwsku not in ['Force10-S6100']"
+      - "topo_type in ['m0', 'mx', 'm1'] or hwsku not in ['Force10-S6100']"
   xfail:
     reason: "case failed and waiting for fix"
     conditions:
@@ -1230,7 +1230,7 @@ platform_tests/test_reboot.py::test_warm_reboot:
     reason: "Skip test_warm_reboot for M*/t1/t2 / Warm reboot is broken on dualtor topology. Skipping for now."
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 'm2', 'm3', 't1', 't2']"
+      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "hwsku in ['Arista-7050CX3-32S-C28S4']"
   xfail:

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -43,7 +43,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t2", "m0", "mx", "m1", "m2", "m3")
+    pytest.mark.topology("t0", "t1", "t2", "m0", "mx", "m1")
 ]
 
 _COPPTestParameters = namedtuple("_COPPTestParameters",

--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -3,7 +3,7 @@ import logging
 from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1'),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/dhcp_relay/test_dhcp_pkt_fwd.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_fwd.py
@@ -11,7 +11,7 @@ from ptf.mask import Mask
 from socket import INADDR_ANY
 
 pytestmark = [
-    pytest.mark.topology("t1", "m0", "m1", "m2", "m3")
+    pytest.mark.topology("t1", "m0", "m1")
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/dhcp_relay/test_dhcp_pkt_recv.py
+++ b/tests/dhcp_relay/test_dhcp_pkt_recv.py
@@ -11,7 +11,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import capture_and_check_packet_on_dut
 
 pytestmark = [
-    pytest.mark.topology("t0", "m0", 'mx', "m1", "m2", "m3")
+    pytest.mark.topology("t0", "m0", 'mx', "m1")
 ]
 
 ACL_TABLE_NAME_DHCPV6_PKT_RECV_TEST = "DHCPV6_PKT_RECV_TEST"

--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.asic('broadcom'),
-    pytest.mark.topology('t0', 't1', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 't1', 'm1'),
     pytest.mark.disable_loganalyzer
 ]
 

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -14,7 +14,7 @@ from .everflow_test_utilities import setup_info, skip_ipv6_everflow_tests       
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t2", "lt2", "ft2", "m0", "m1", "m2", "m3")
+    pytest.mark.topology("t0", "t1", "t2", "lt2", "ft2", "m0", "m1")
 ]
 
 EVERFLOW_V6_RULES = "ipv6_test_rules.yaml"

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -20,7 +20,7 @@ from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py           
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
 
 pytestmark = [
-    pytest.mark.topology("t0", "t1", "t2", "lt2", "ft2", "m0", "m1", "m2", "m3")
+    pytest.mark.topology("t0", "t1", "t2", "lt2", "ft2", "m0", "m1")
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/generic_config_updater/test_bgpl.py
+++ b/tests/generic_config_updater/test_bgpl.py
@@ -11,7 +11,7 @@ from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', "m1", "m2", "m3", 't2'),
+    pytest.mark.topology('t0', 'm0', 'mx', "m1", 't2'),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/generic_config_updater/test_cacl.py
+++ b/tests/generic_config_updater/test_cacl.py
@@ -21,7 +21,7 @@ from tests.common.config_reload import config_reload
 # SSH_ONLY    CTRLPLANE  SSH              SSH_ONLY       ingress
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 'm1', 'm2', 'm3', 't1', 't2'),
+    pytest.mark.topology('t0', 'm0', 'mx', 'm1', 't1', 't2'),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/generic_config_updater/test_ip_bgp.py
+++ b/tests/generic_config_updater/test_ip_bgp.py
@@ -12,7 +12,7 @@ from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1'),
 ]
 
 

--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -28,7 +28,7 @@ REPLACE_IP = "10.1.0.210/32"
 REPLACE_IPV6 = "FC00:1::210/128"
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 'm0', 'mx', 'm1'),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/generic_config_updater/test_portchannel_interface.py
+++ b/tests/generic_config_updater/test_portchannel_interface.py
@@ -27,7 +27,7 @@ from tests.common.gu_utils import create_path, check_show_ip_intf
 # }
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 'm0', 'm1'),
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -13,7 +13,7 @@ STATIC_ROUTE_IPV6 = '2001:db8:1::1/128'
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3')
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1')
 ]
 
 

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -7,7 +7,7 @@ from tests.ptf_runner import ptf_runner
 from datetime import datetime
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t1', 't2', 'm1'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -22,7 +22,7 @@ from tests.common.platform.device_utils import fanout_switch_port_lookup, toggle
 CISCO_NHOP_GROUP_FILL_PERCENTAGE = 0.92
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1', 'm2', 'm3')
+    pytest.mark.topology('t1', 't2', 'm1')
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -9,7 +9,7 @@ from tests.common.utilities import wait_until
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_default_route.py
+++ b/tests/snmp/test_snmp_default_route.py
@@ -4,7 +4,7 @@ from tests.common.helpers.assertions import pytest_require
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3', 't1-multi-asic'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -21,7 +21,7 @@ from tests.common.helpers.assertions import pytest_assert
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', 'm1', 'm2', 'm3')
+    pytest.mark.topology('t0', 'm0', 'mx', 'm1')
 ]
 
 # Use original ports intead of sub interfaces for ptfadapter if it's t0-backend

--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -4,7 +4,7 @@ from tests.common import config_reload
 from tests.common.utilities import wait_until
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3', 't1-multi-asic'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_lldp.py
+++ b/tests/snmp/test_snmp_lldp.py
@@ -4,7 +4,7 @@ import pytest
 from tests.common.helpers.snmp_helpers import get_snmp_facts
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/snmp/test_snmp_loopback.py
+++ b/tests/snmp/test_snmp_loopback.py
@@ -5,7 +5,7 @@ from tests.common.devices.eos import EosHost
 from tests.common.utilities import skip_release
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'm2', 'm3', 't1-multi-asic'),
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 't1-multi-asic'),
     pytest.mark.device_type('vs')
 ]
 

--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -15,7 +15,7 @@ MAX_WAIT_TIME = 120
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 'm2', 'm3', 't2')
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', 'm1', 't2')
 ]
 
 


### PR DESCRIPTION
Description of PR
Clear unused m2/m3 topo type

Summary:
remove pytest mark for M2/M3 topo.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
Approach
What is the motivation for this PR?
Remove pytest mark for M1/M2/M3 topo.
How did you do it?
Remove pytest mark for M1/M2/M3 topo.

How did you verify/test it?
Verified by PR test.
