### PR TITLE
Fix UnboundLocalError in portchannel_to_vlan fixture

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -420,6 +420,7 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
     if "bgp_asn" not in cfg_facts["DEVICE_METADATA"]["localhost"]:
         yield
         return
+    ptf_lag_map = None
     # --------------------- Setup -----------------------
     try:
         dut_lag_map, ptf_lag_map, src_vlan_id = setup_dut_ptf(ptfhost, duthost, tbinfo, vlan_intfs_dict)
@@ -431,7 +432,8 @@ def setup_po2vlan(duthosts, ptfhost, rand_one_dut_hostname, rand_selected_dut, p
     # --------------------- Teardown -----------------------
     finally:
         config_reload(duthost, safe_reload=True)
-        ptf_teardown(ptfhost, ptf_lag_map)
+        if ptf_lag_map is not None:
+            ptf_teardown(ptfhost, ptf_lag_map)
 
 
 def has_portchannels(duthosts, rand_one_dut_hostname):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR fixes an issue where an UnboundLocalError exception was raised when 
the setup_dut_ptf function failed during test execution. The error occurred 
because ptf_lag_map was being referenced in the finally block before being 
assigned a value when an exception was thrown in the try block.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR fixes an issue where an UnboundLocalError exception was raised when 
the setup_dut_ptf function failed during test execution. The error occurred 
because ptf_lag_map was being referenced in the finally block before being 
assigned a value when an exception was thrown in the try block.

#### How did you do it?
Initialize ptf_lag_map = None before the try block, and add conditional check in finally block to only call ptf_teardown when ptf_lag_map is not None

#### How did you verify/test it?
```
-------------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/fdb/test_fdb.xml --------------------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
09:57:37 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================ 8 passed, 1453 warnings in 681.70s (0:11:21) ================================================================================
```

#### Any platform specific information?
str4-sn5640-2
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
