### PR TITLE
[202411][sonic-mgmt]Fix decap/test_subnet_decap.py::test_vlan_subnet_…

### DIFF
--- a/tests/decap/test_subnet_decap.py
+++ b/tests/decap/test_subnet_decap.py
@@ -10,6 +10,7 @@ import ptf.testutils as testutils
 from ptf.mask import Mask
 from tests.common.dualtor.dual_tor_utils import rand_selected_interface     # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py       # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m   # noqa F401
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -206,7 +207,9 @@ def verify_packet_with_expected(ptfadapter, stage, pkt, exp_pkt, send_port,
 @pytest.mark.parametrize("stage", ["positive", "negative"])
 def test_vlan_subnet_decap(request, rand_selected_dut, tbinfo, ptfhost, ptfadapter, ip_version, stage,
                            prepare_subnet_decap_config, prepare_vlan_subnet_test_port,
-                           prepare_negative_ip_port_map, setup_arp_responder):     # noqa F811
+                           prepare_negative_ip_port_map, setup_arp_responder,   # noqa F811
+                           toggle_all_simulator_ports_to_rand_selected_tor_m,   # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor):         # noqa F811
     ptf_src_port, _, upstream_port_ids = prepare_vlan_subnet_test_port
 
     encapsulated_packet = build_encapsulated_vlan_subnet_packet(ptfadapter, rand_selected_dut, ip_version, stage)


### PR DESCRIPTION
…decap

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([591](https://github.com/aristanetworks/sonic-qual.msft/issues/591))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
- Fixes failures for decap/test_subnet_decap::test_vlan_subnet_decap[negative-IPv4/6] for active-standby dualtor topos 
- The test selects the DUT randomly, irrespective of it being the standby ToR
- In the positive case, this will not be a problem - the encapsulated packet is sent with an outer SIP that matches the
config on the DUT, the packet gets decapped and gets routed towards the upstream T1s
- In the negative case, the outer SIP does not match the config on the DUT and hence will not be decapsulated, but
forwarded to the outer DIP, which is set to IP 192.168.0.200/fc02:1000::200
- This will require forwarding over one of the downstream ports where the ARP responder is also set up  - if the
DUT is a standby; this forwarding will not happen

#### How did you do it?
- This fix calls fixture to ensure the selected DUT will be the active ToR, and the non-decapsulated packet can be
forwarded along the downstream port

#### How did you verify/test it?
Ran decap/test_subnet_decap.py on DCS-7050CX3
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
