### PR TITLE
[AI - Snappi] Adding BGP convergence testcase for single session flap Down ( Case 1)

### DIFF
--- a/tests/snappi_tests/dataplane/test_bgp_single_port_down.py
+++ b/tests/snappi_tests/dataplane/test_bgp_single_port_down.py
@@ -1,10 +1,6 @@
-from tests.common.telemetry import (
-    UNIT_SECONDS,       # noqa: F401, F403, F405, E402
-)
-from tests.common.telemetry.constants import (
-    METRIC_LABEL_TG_TRAFFIC_RATE,
-    METRIC_LABEL_TG_FRAME_BYTES,
-)
+from tests.common.telemetry import UNIT_SECONDS  # noqa: F401, F403, F405, E402
+from tests.common.telemetry.constants import METRIC_LABEL_TG_TRAFFIC_RATE, METRIC_LABEL_TG_FRAME_BYTES  # noqa: F401, F403, F405, E402
+
 from tests.snappi_tests.dataplane.imports import *   # noqa: F401, F403, F405
 from snappi_tests.dataplane.files.helper import set_primary_chassis, create_snappi_config, create_traffic_items, \
     get_duthost_interface_details, configure_acl_for_route_withdrawl, start_stop, \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding BGP convergence for single session flap testcase
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To implement the BGP case 1, as part of the Snappi-based BGP Convergence Test
#### How did you do it?
This case flaps one of the Rx port down and withdraws route from one of the Rx port
#### How did you verify/test it?
Tested with 2 BT0s and 1 BT1
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T1
### Documentation
https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/snappi/bgp_convergence_test.md
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
snappi_tests/dataplane/test_bgp_orig.py::test_bgp_sessions[Port Flap-64-10-IPv6] 
-------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------
06/10/2025 18:26:40 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
06/10/2025 18:26:40 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
06/10/2025 18:26:40 conftest.enhance_inventory               L0335 INFO   | Inventory file: ['../ansible/snappi-sonic']
06/10/2025 18:26:45 ptfhost_utils.run_icmp_responder_session L0310 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
06/10/2025 18:26:45 __init__._sanity_check                   L0432 INFO   | Skip sanity check according to command line argument
06/10/2025 18:26:45 conftest.collect_before_test             L2726 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
06/10/2025 18:26:46 conftest.collect_before_test             L2730 INFO   | Collecting core dumps before test on sonic-s6100-dut1
06/10/2025 18:26:47 conftest.collect_before_test             L2739 INFO   | Collecting running config before test on sonic-s6100-dut1
06/10/2025 18:26:51 conftest.temporarily_disable_route_check L3005 INFO   | Skipping temporarily_disable_route_check fixture
06/10/2025 18:26:51 conftest.generate_params_dut_hostname    L1527 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
06/10/2025 18:26:51 conftest.set_rand_one_dut_hostname       L0669 INFO   | Randomly select dut sonic-s6100-dut1 for testing
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
06/10/2025 18:26:51 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
06/10/2025 18:26:51 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
06/10/2025 18:26:51 snappi.api                               L0106 WARNING| Version check is disabled
06/10/2025 18:26:51 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
06/10/2025 18:26:51 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
06/10/2025 18:26:52 conftest.rand_one_dut_front_end_hostname L0705 INFO   | Randomly select dut sonic-s6100-dut1 for testing
06/10/2025 18:26:52 conftest.generate_port_lists             L1619 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68', 'sonic-s6100-dut1|Ethernet72', 'sonic-s6100-dut1|Ethernet76']}
06/10/2025 18:26:52 conftest.generate_port_lists             L1642 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet64', 'sonic-s6100-dut1|Ethernet68', 'sonic-s6100-dut1|Ethernet72', 'sonic-s6100-dut1|Ethernet76']
06/10/2025 18:26:52 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
06/10/2025 18:26:52 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
06/10/2025 18:26:52 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
06/10/2025 18:26:53 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture set_primary_chassis setup starts --------------------
06/10/2025 18:26:53 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture set_primary_chassis setup ends --------------------
06/10/2025 18:26:53 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture create_snappi_config setup starts --------------------
06/10/2025 18:26:53 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture create_snappi_config setup ends --------------------
06/10/2025 18:26:53 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
06/10/2025 18:26:53 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060X6-64PE-C256S2, Platform: x86_64-arista_7060x6_64pe
06/10/2025 18:26:53 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Arista-7060X6-64PE-C256S2
06/10/2025 18:26:53 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7f751af75ca0>
06/10/2025 18:26:53 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f751af754c0>
06/10/2025 18:26:53 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f751af75c10>
06/10/2025 18:26:53 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f751af75d30>
06/10/2025 18:26:53 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7f751af75dc0>
06/10/2025 18:26:53 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f751af75dc0>
06/10/2025 18:26:53 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_2p9nk8a6
06/10/2025 18:26:53 conftest.setup_dualtor_mux_ports         L3465 INFO   | skip setup dualtor mux cables on non-dualtor testbed
06/10/2025 18:26:59 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 20.2}, 'top': {'zebra': 47.5, 'bgpd': 183.1}, 'free': {'used': 6522}, 'docker': {'snmp': 0.2, 'pmon': 0.9, 'lldp': 0.2, 'gnmi': 0.3, 'radv': 0.1, 'syncd': 3.9, 'bgp': 1.0, 'teamd': 0.1, 'swss': 0.7, 'database': 0.4}, 'frr_bgp': {'used': 45.0}, 'frr_zebra': {'used': 7.0}}}, 'after_test': {'sonic-s6100-dut1': {}}}
--------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
06/10/2025 18:27:01 test_bgp_orig.get_convergence_for_single L0160 INFO   | Starting Port Flap Test
06/10/2025 18:27:01 connection._warn                         L0336 WARNING| Verification of certificates is disabled
06/10/2025 18:27:01 connection._info                         L0333 INFO   | Determining the platform and rest_port using the 10.36.78.106 address...
06/10/2025 18:27:01 connection._warn                         L0336 WARNING| Unable to connect to http://10.36.78.106:443.
06/10/2025 18:27:01 connection._info                         L0333 INFO   | Connection established to `https://10.36.78.106:443 on linux`
06/10/2025 18:27:16 connection._info                         L0333 INFO   | Using IxNetwork api server version 11.10.2507.29
06/10/2025 18:27:16 connection._info                         L0333 INFO   | User info IxNetwork/ixnetworkweb/admin-204-2515400
06/10/2025 18:27:17 snappi_api.info                          L1512 INFO   | snappi-1.40.0
06/10/2025 18:27:17 snappi_api.info                          L1512 INFO   | snappi_ixnetwork-1.39.2
06/10/2025 18:27:17 snappi_api.info                          L1512 INFO   | ixnetwork_restpy-1.7.0
06/10/2025 18:27:17 snappi_api.info                          L1512 INFO   | Config validation 0.040s
06/10/2025 18:27:20 snappi_api.info                          L1512 INFO   | Ports configuration 2.325s
06/10/2025 18:27:20 snappi_api.info                          L1512 INFO   | Captures configuration 0.267s
06/10/2025 18:27:21 connection._info                         L0333 INFO   | [0.511s] Timer @ batchadd.py:385 -> Batch Add Completed
06/10/2025 18:27:21 snappi_api.info                          L1512 INFO   | Add location hosts [10.36.84.36] 0.531s
06/10/2025 18:27:27 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.84.36] 6.330s
06/10/2025 18:27:30 snappi_api.info                          L1512 INFO   | Speed conversion is not require for (port.name, speed) : [('Port_1', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_3', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_5', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_7', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_9', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_11', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_13', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_15', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_17', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_19', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_21', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_23', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_25', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_27', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_29', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_31', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_2', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_4', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_6', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_8', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_10', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_12', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_14', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_16', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_18', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_20', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_22', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_24', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_26', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_28', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_30', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_32', 'aresOne-M-EightByOneHundredGigPAM4-106G')]
06/10/2025 18:27:30 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 1.001s
06/10/2025 18:27:57 snappi_api.info                          L1512 INFO   | Location connect [Port_1, Port_2, Port_3, Port_4, Port_5, Port_6, Port_7, Port_8, Port_9, Port_10, Port_11, Port_12, Port_13, Port_14, Port_15, Port_16, Port_17, Port_18, Port_19, Port_20, Port_21, Port_22, Port_23, Port_24, Port_25, Port_26, Port_27, Port_28, Port_29, Port_30, Port_31, Port_32] 26.099s
06/10/2025 18:27:57 snappi_api.info                          L1512 INFO   | Location state check [Port_1, Port_2, Port_3, Port_4, Port_5, Port_6, Port_7, Port_8, Port_9, Port_10, Port_11, Port_12, Port_13, Port_14, Port_15, Port_16, Port_17, Port_18, Port_19, Port_20, Port_21, Port_22, Port_23, Port_24, Port_25, Port_26, Port_27, Port_28, Port_29, Port_30, Port_31, Port_32] 0.291s
06/10/2025 18:27:57 snappi_api.info                          L1512 INFO   | Location configuration 36.871s
06/10/2025 18:27:57 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.510s
06/10/2025 18:27:58 snappi_api.info                          L1512 INFO   | Lag Configuration 0.075s
06/10/2025 18:27:58 snappi_api.info                          L1512 INFO   | Convert device config : 0.238s
06/10/2025 18:27:58 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.002s
06/10/2025 18:28:11 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 13.314s
06/10/2025 18:28:11 snappi_api.info                          L1512 INFO   | Devices configuration 13.627s
06/10/2025 18:28:14 snappi_api.info                          L1512 INFO   | Flows configuration 2.646s
06/10/2025 18:28:33 snappi_api.info                          L1512 INFO   | Start interfaces 18.678s
06/10/2025 18:28:34 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
06/10/2025 18:28:34 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
06/10/2025 18:28:34 helperv2.start_stop                      L0567 INFO   | Start protocols
06/10/2025 18:28:41 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For protocols To start
06/10/2025 18:30:02 helperv2.check_bgp_state                 L0607 INFO   | BGP v6 Session State is UP
06/10/2025 18:30:02 helperv2.start_stop                      L0567 INFO   | Start traffic
06/10/2025 18:30:11 snappi_api.info                          L1512 INFO   | Flows generate/apply 7.662s
06/10/2025 18:30:23 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.377s
06/10/2025 18:30:23 snappi_api.info                          L1512 INFO   | Captures start 0.000s
06/10/2025 18:30:29 snappi_api.info                          L1512 INFO   | Flows start 5.363s
06/10/2025 18:30:29 snappi_api.info                          L1512 INFO   | IxNet - The frame size was increased to 86 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
06/10/2025 18:30:39 test_bgp_orig.get_convergence_for_single L0184 INFO   | All ports Tx and Rx rates are within 0.05% of average rates
06/10/2025 18:30:39 test_bgp_orig.get_convergence_for_single L0185 INFO   | Shutting down Ethernet65 port of sonic-s6100-dut1 dut !!
06/10/2025 18:30:40 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For statistics to be collected
06/10/2025 18:31:01 test_bgp_orig.get_convergence_for_single L0203 INFO   | Total Tx and Rx Rates are equal after link flap
06/10/2025 18:31:01 test_bgp_orig.get_convergence_for_single L0206 INFO   | Delta Frames : 770236
06/10/2025 18:31:01 test_bgp_orig.get_convergence_for_single L0208 INFO   | --------------------------   Convergence Numbers   ----------------------------------
06/10/2025 18:31:01 test_bgp_orig.get_convergence_for_single L0209 INFO   | Convergence Time for Single Port Flap      : 4.08225090348506 (ms)
06/10/2025 18:31:01 test_bgp_orig.get_convergence_for_single L0210 INFO   | --------------------------------------------------------------------------------------
06/10/2025 18:31:01 helperv2.start_stop                      L0567 INFO   | Stop traffic
06/10/2025 18:31:08 snappi_api.info                          L1512 INFO   | Flows stop 6.385s
06/10/2025 18:31:09 db_reporter._report                      L0049 INFO   | DBReporter: Writing 1 metric records to file
06/10/2025 18:31:09 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 1 metric records to /tmp/telemetry_test_2p9nk8a6/test_bgp_orig.metrics.json
06/10/2025 18:31:09 helperv2.start_stop                      L0567 INFO   | Stop protocols
06/10/2025 18:31:10 utilities.wait                           L0120 INFO   | Pause 1 seconds, reason: For protocols To stop
06/10/2025 18:31:11 helperv2.start_stop                      L0567 INFO   | Stop traffic
06/10/2025 18:31:13 test_bgp_orig.get_convergence_for_single L0239 INFO   | Starting up Ethernet65 port of sonic-s6100-dut1 dut !!
PASSED                                                                                                                                                                    


snappi_tests/dataplane/test_bgp_orig.py::test_bgp_sessions[Route Withdraw-64-10-IPv6] 
-------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------
06/10/2025 18:31:20 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
06/10/2025 18:31:20 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
06/10/2025 18:31:20 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
06/10/2025 18:31:20 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060X6-64PE-C256S2, Platform: x86_64-arista_7060x6_64pe
06/10/2025 18:31:20 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Arista-7060X6-64PE-C256S2
06/10/2025 18:31:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7f751af75ca0>
06/10/2025 18:31:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f751af754c0>
06/10/2025 18:31:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f751af75c10>
06/10/2025 18:31:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f751af75d30>
06/10/2025 18:31:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7f751af75dc0>
06/10/2025 18:31:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f751af75dc0>
06/10/2025 18:31:20 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_xw4spsqb
06/10/2025 18:31:20 conftest.setup_dualtor_mux_ports         L3465 INFO   | skip setup dualtor mux cables on non-dualtor testbed
06/10/2025 18:31:27 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 20.3}, 'top': {'zebra': 47.7, 'bgpd': 183.3}, 'free': {'used': 6472}, 'docker': {'snmp': 0.2, 'pmon': 0.9, 'lldp': 0.2, 'gnmi': 0.3, 'radv': 0.1, 'syncd': 3.9, 'bgp': 1.1, 'teamd': 0.1, 'swss': 0.7, 'database': 0.5}, 'frr_bgp': {'used': 45.0}, 'frr_zebra': {'used': 7.0}}}, 'after_test': {'sonic-s6100-dut1': {}}}
--------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
06/10/2025 18:31:28 test_bgp_orig.get_convergence_for_single L0249 INFO   | Starting Route Withdraw Test
06/10/2025 18:31:29 snappi_api.info                          L1512 INFO   | Config validation 0.041s
06/10/2025 18:31:30 snappi_api.info                          L1512 INFO   | Ports configuration 0.305s
06/10/2025 18:31:30 snappi_api.info                          L1512 INFO   | Captures configuration 0.198s
06/10/2025 18:31:30 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.84.36] 0.075s
06/10/2025 18:31:31 snappi_api.info                          L1512 INFO   | Speed change not require due to redundant Layer1 config
06/10/2025 18:31:31 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.099s
06/10/2025 18:31:31 snappi_api.info                          L1512 INFO   | Location configuration 0.586s
06/10/2025 18:31:31 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.357s
06/10/2025 18:31:31 snappi_api.info                          L1512 INFO   | Lag Configuration 0.069s
06/10/2025 18:31:36 snappi_api.info                          L1512 INFO   | Convert device config : 5.140s
06/10/2025 18:31:36 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.002s
06/10/2025 18:31:49 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 13.139s
06/10/2025 18:31:49 snappi_api.info                          L1512 INFO   | Devices configuration 18.353s
06/10/2025 18:31:52 snappi_api.info                          L1512 INFO   | Flows configuration 2.135s
06/10/2025 18:32:03 snappi_api.info                          L1512 INFO   | Start interfaces 11.138s
06/10/2025 18:32:03 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
06/10/2025 18:32:03 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
06/10/2025 18:32:03 helperv2.start_stop                      L0567 INFO   | Start protocols
06/10/2025 18:32:13 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For protocols To start
06/10/2025 18:32:23 helperv2.start_stop                      L0567 INFO   | Start traffic
06/10/2025 18:32:49 snappi_api.info                          L1512 INFO   | Flows generate/apply 25.691s
06/10/2025 18:33:01 snappi_api.info                          L1512 INFO   | Flows clear statistics 11.743s
06/10/2025 18:33:01 snappi_api.info                          L1512 INFO   | Captures start 0.000s
06/10/2025 18:33:07 snappi_api.info                          L1512 INFO   | Flows start 5.641s
06/10/2025 18:33:07 snappi_api.info                          L1512 INFO   | IxNet - The frame size was increased to 86 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
06/10/2025 18:33:19 test_bgp_orig.get_convergence_for_single L0256 INFO   | 

06/10/2025 18:33:19 test_bgp_orig.get_convergence_for_single L0257 INFO   | Configuring ACL for packet drop on one of the BGP peer
06/10/2025 18:33:20 test_bgp_orig.get_convergence_for_single L0261 INFO   | sudo config acl add table AI_ACL_TABLE l3v6
06/10/2025 18:33:21 test_bgp_orig.get_convergence_for_single L0264 INFO   | sudo config acl add table AI_ACL_TABLE L3v6 -p Ethernet67 -s egress
06/10/2025 18:33:24 test_bgp_orig.get_convergence_for_single L0273 INFO   | Withdrawing Routes from Rx_Network_Group_1
06/10/2025 18:33:26 snappi_api.info                          L1512 INFO   | Setting route state 1.136s
06/10/2025 18:33:26 utilities.wait                           L0120 INFO   | Pause 50 seconds, reason: For routes to be withdrawn
06/10/2025 18:34:17 test_bgp_orig.get_convergence_for_single L0283 INFO   | Delta Frames : 124660900
06/10/2025 18:34:17 test_bgp_orig.get_convergence_for_single L0286 INFO   | PACKET LOSS DURATION After Route Withdraw (ms): 660.7027674893294
06/10/2025 18:34:20 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For clear stats
06/10/2025 18:34:41 test_bgp_orig.get_convergence_for_single L0294 INFO   | Total Tx and Rx Rates are equal after route withdraw
06/10/2025 18:34:42 test_bgp_orig.get_convergence_for_single L0296 INFO   | 

06/10/2025 18:34:42 test_bgp_orig.get_convergence_for_single L0297 INFO   | --------------------------   Convergence Numbers   ----------------------------------
06/10/2025 18:34:42 test_bgp_orig.get_convergence_for_single L0298 INFO   | Convergence Time for Single Route Withdraw : 660.7027674893294 (ms)
06/10/2025 18:34:42 test_bgp_orig.get_convergence_for_single L0299 INFO   | Time taken to apply acl and route withdraw on snappi port: 3.3281638622283936 (s)
06/10/2025 18:34:42 test_bgp_orig.get_convergence_for_single L0301 INFO   | --------------------------------------------------------------------------------------
06/10/2025 18:34:42 helperv2.start_stop                      L0567 INFO   | Stop traffic
06/10/2025 18:34:49 snappi_api.info                          L1512 INFO   | Flows stop 6.755s
06/10/2025 18:34:50 db_reporter._report                      L0049 INFO   | DBReporter: Writing 1 metric records to file
06/10/2025 18:34:50 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 1 metric records to /tmp/telemetry_test_xw4spsqb/test_bgp_orig.metrics.json
06/10/2025 18:34:50 helperv2.start_stop                      L0567 INFO   | Stop protocols
06/10/2025 18:34:51 utilities.wait                           L0120 INFO   | Pause 1 seconds, reason: For protocols To stop
06/10/2025 18:34:52 helperv2.start_stop                      L0567 INFO   | Stop traffic
06/10/2025 18:34:54 test_bgp_orig.get_convergence_for_single L0319 INFO   | Removing acl table AI_ACL_TABLE
PASSED    