### PR TITLE
add COPP policer tests for jumbo packets

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -546,9 +546,11 @@ class UDLDTest(PolicyTest):
 class BGPTest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
+        test_params = testutils.test_params_get()
+        self.packet_size = int(test_params.get('packet_size', 100))
 
     def runTest(self):
-        self.log("BGPTest")
+        self.log("BGPTEst with packet size: {}".format(self.packet_size))
         self.run_suite()
 
     def construct_packet(self, port_number):
@@ -556,6 +558,7 @@ class BGPTest(PolicyTest):
         dst_ip = self.peerip
 
         packet = testutils.simple_tcp_packet(
+            pktlen=self.packet_size,
             eth_dst=dst_mac,
             ip_dst=dst_ip,
             ip_ttl=1,
@@ -675,9 +678,11 @@ class SSHTest(PolicyTest):
 class IP2METest(PolicyTest):
     def __init__(self):
         PolicyTest.__init__(self)
+        test_params = testutils.test_params_get()  # Get a fresh copy to be safe
+        self.packet_size = int(test_params.get('packet_size', 100))
 
     def runTest(self):
-        self.log("IP2METest")
+        self.log("IP2METest with packet size: {}".format(self.packet_size))
         self.run_suite()
 
     def one_port_test(self, port_number):
@@ -699,6 +704,7 @@ class IP2METest(PolicyTest):
         dst_ip = self.peerip
 
         packet = testutils.simple_tcp_packet(
+            pktlen=self.packet_size,
             eth_src=src_mac,
             eth_dst=dst_mac,
             ip_dst=dst_ip

--- a/tests/copp/conftest.py
+++ b/tests/copp/conftest.py
@@ -58,3 +58,13 @@ def is_backend_topology(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbi
     is_backend_topology = mg_facts.get(constants.IS_BACKEND_TOPOLOGY_KEY, False)
 
     return is_backend_topology
+
+
+@pytest.fixture(params=[64, 1518, 4096])
+def packet_size(request):
+    """
+    Parameterized fixture for packet sizes.
+    4096 is the biggest frame size currently because of an issue with
+    ptf_nn_agent, which truncates jumbo packets to 4096 bytes.
+    """
+    yield request.param

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -75,12 +75,10 @@ class TestCOPP(object):
     feature_name = "bgp"
 
     @pytest.mark.parametrize("protocol", ["ARP",
-                                          "IP2ME",
                                           "SNMP",
                                           "SSH",
                                           "DHCP",
                                           "DHCP6",
-                                          "BGP",
                                           "LACP",
                                           "LLDP",
                                           "UDLD",
@@ -99,6 +97,24 @@ class TestCOPP(object):
                      protocol,
                      copp_testbed,
                      dut_type)
+
+    @pytest.mark.parametrize("protocol", ["IP2ME",
+                                          "BGP"])
+    def test_policer_mtu(self, protocol, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                         ptfhost, copp_testbed, dut_type, packet_size):
+        """
+            Validates that rate-limited COPP groups work as expected.
+
+            Checks that the policer enforces the rate limit for protocols
+            that have a set rate limit.
+        """
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+        _copp_runner(duthost,
+                     ptfhost,
+                     protocol,
+                     copp_testbed,
+                     dut_type,
+                     packet_size=packet_size)
 
     @pytest.mark.disable_loganalyzer
     def test_trap_neighbor_miss(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
@@ -296,7 +312,7 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
 
 
 def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True,
-                 ip_version="4"):    # noqa: F811
+                 ip_version="4", packet_size=100):    # noqa: F811
     """
         Configures and runs the PTF test cases.
     """
@@ -315,7 +331,8 @@ def _copp_runner(dut, ptf, protocol, test_params, dut_type, has_trap=True,
               "asic_type": dut.facts["asic_type"],
               "platform": dut.facts["platform"],
               "topo_type": test_params.topo_type,
-              "ip_version": ip_version}
+              "ip_version": ip_version,
+              "packet_size": packet_size}
 
     dut_ip = dut.mgmt_ip
     device_sockets = ["0-{}@tcp://127.0.0.1:10900".format(test_params.nn_target_port),


### PR DESCRIPTION
### Description of PR
The policer tests verify CPU bound traffic by sending packets of fixed length (100 bytes). There's a test gap for verifying traps of jumbo packets (>1514 bytes)

Summary:
Fixes # (issue)
[18781](https://github.com/sonic-net/sonic-mgmt/issues/18781)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
Add a Pytest fixture for parameterizing based on packet sizes. The fixture returns 3 packet sizes - 64, 1514 and 4096 bytes. Use the fixture for IP2ME and BGP traps.

#### What is the motivation for this PR?
Packets greater than 1514 bytes needs special buffer provisioning on the CPU port that is not verified by the existing tests. The PR addresses this test gap.

#### How did you do it?
Add packet size as a pytest parameter for IP2ME and BGP tests.

#### How did you verify/test it?
Ran the test manually on t1 topology and verified it passes.
