### PR TITLE
Skip test_cacl_application for PR test temporarily

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -253,6 +253,12 @@ bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away:
 #######################################
 #####            cacl             #####
 #######################################
+cacl/test_cacl_application.py:
+  skip:
+    reason: "skip test_cacl_application in PR test temporarily"
+    conditions:
+      - "asic_type in ['vs']"
+
 cacl/test_cacl_application.py::test_cacl_application_dualtor:
   skip:
     reason: "test_cacl_application_dualtor is only supported on dualtor topology"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-host-services/pull/197 added a new change for caclmgrd,
PR test for submodule advanced PR of sonic-host-services failed.

Disable test_cacl_application in PR test temporarily for merging submodule PR.

```
>       pytest_assert(len(missing_iptables_rules) == 0, "Missing expected iptables rules: {}"
                      .format(repr(missing_iptables_rules)))
E       Failed: Missing expected iptables rules: {'-A INPUT -p tcp -m tcp --dport 179 -j ACCEPT'}
```


For any changes in caclmgrd, if it will fail test_cacl_application case, need to follow the steps:

1. skip test_cacl_application from PR test
2. imagebuild PR get merged
3. update test case
4. add test_cacl_application back for PR test

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-host-services/pull/197 added a new change for caclmgrd,
PR test for submodule advanced PR of sonic-host-services failed.
#### How did you do it?
Disable test_cacl_application in PR test temporarily for merging submodule PR.
#### How did you verify/test it?
Retrigger PR test for sonic-host-services submodule advance PR.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
