### PR TITLE
Xfail test_dir_bcast.py due to known issue on Broadcom platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1511,6 +1511,12 @@ ipfwd/test_dir_bcast.py:
     reason: "Unsupported topology."
     conditions:
       - "topo_type not in ['t0', 'm0', 'mx'] or 'dualtor' in topo_name or 't0-backend' in topo_name"
+  xfail:
+    reason: "Xfail due to known issue with the secondary subnet."
+    conditions:
+      - "topo_type in ['t0']"
+      - "asic_type in ['broadcom']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/18786
 
 ipfwd/test_mtu.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
t0-118 DUTs running ipfwd/test_dir_bcast.py do not seem to be broadcasting (ip) packets to all VLAN members when the packet is sent to the VLAN broadcast IP.

Looking at the counters CLI output in sonic, "Broadcast Packets Transmitted" is not incrementing for a few interfaces in the VLAN

The test passes if the secondary_subnet ip address is removed from the first vlan in the t0-118 topo file.

But for now we enabled secondary subnet for most of t0 topologies https://github.com/sonic-net/sonic-mgmt/pull/18399.

We have a CSP to track this issue with Broadcom, for now, xfail test_dir_bcast.py on Broadcom T0 testbeds.
File a github issue to track it https://github.com/sonic-net/sonic-mgmt/issues/18786, once the issue is fixed, we close this issue can disable xfail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Xfail test_dir_bcast.py on Broadcom T0 testbeds.
#### How did you do it?
Add xfail section in conditional mark file
#### How did you verify/test it?
Run test_dir_bcast on Broadcom T0 testbed to see if it's xfailed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
