### PR TITLE
Test plan and test for feature VXLAN source port range

### DIFF
--- a/docs/testplan/dash/VXLAN_source_port_range.md
+++ b/docs/testplan/dash/VXLAN_source_port_range.md
@@ -1,0 +1,64 @@
+# DASH VXLAN source port range test plan
+
+* [Overview](#Overview)
+   * [Scope](#Scope)
+   * [Testbed](#Testbed)
+   * [Setup configuration](#Setup%20configuration)
+* [Test](#Test)
+* [Test cases](#Test%20cases)
+* [TODO](#TODO)
+* [Open questions](#Open%20questions)
+
+## Overview
+  The feature "VXLAN source port range" is to support entropy in the VxLAN UDP source port field on the smartsiwtch.
+  A smartswitch DPU should use connection 5-tuple to calculate entropy, and fill it in the VxLAN UDP source port field.
+  The entropy should be within the range of [64128, 64255].
+  The configuration should be applied on the DPU via swssconfig in the swss container, and it takes effect immediatly after the configuration is applied.
+  The purpose of this test is to verify the functionality of VXLAN source port range on smartswitch.
+
+
+### Scope
+The test is targeting on the verification of functionality on a smartswitch testbed.
+The feature is tested along with the existing dash private link test, there will be no new dedicated test cases for this feature.
+The configration is not persistent, it disappears after reload/reboot. So, the reload/reboot test is not in the scope.
+
+### Testbed
+The test will run on a smartswitch testbed with DPUs enabled.
+
+### Setup configuration
+Common tests configuration:
+- Same as the dash priivate link test.
+
+Common tests cleanup:
+- Same as the dash priivate link test.
+
+Configuration example to config the VxLAN UDP source port range:
+```
+[
+    {
+        "SWITCH_TABLE:switch": {
+            "vxlan_sport": 64128,
+            "vxlan_mask": 7
+        },
+        "OP": "SET"
+    }
+]
+```
+
+## Test
+## Functionality test integrated to dash private link test
+### Test objective
+Verify VXLAN UDP source port range can be configured as user defined range on the smartswitch DPU, and the value of VxLAN UDP source port field in the PL inbound packet sent by DPU is in the range.
+### Test steps
+* The validation of the VxLAN port is integrated to the dash PL test tests/dash/test_dash_privatelink.py.
+* For now there is only one test case in the PL test: test_privatelink_basic_transform.
+* The UDP port range configuration(vxlan_sport=64128, vxlan_mask=7) is applied in the setup phase of the PL test module.
+* Send the outbound and inbound PL traffic.
+* Validate that the VxLAN UDP source port in the captured inbound packet is in the range of [64128, 64255]
+* Restore the source port range config to the default by config reload on the DPU.
+
+
+## TODO
+The validation of the VxLAN UDP source port range can be integrated to all future dash test cases if needed.
+
+## Open questions

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -9,7 +9,7 @@ from constants import ENI, VM_VNI, VNET1_VNI, VNET2_VNI, REMOTE_CA_IP, LOCAL_CA_
     LOCAL_ENI_MAC, REMOTE_CA_PREFIX, LOOPBACK_IP, DUT_MAC, LOCAL_PA_IP, LOCAL_PTF_INTF, LOCAL_PTF_MAC, \
     REMOTE_PA_IP, REMOTE_PTF_INTF, REMOTE_PTF_MAC, REMOTE_PA_PREFIX, VNET1_NAME, VNET2_NAME, ROUTING_ACTION, \
     ROUTING_ACTION_TYPE, LOOKUP_OVERLAY_IP, ACL_GROUP, ACL_STAGE, LOCAL_DUT_INTF, REMOTE_DUT_INTF, \
-    REMOTE_PTF_SEND_INTF, REMOTE_PTF_RECV_INTF, LOCAL_REGION_ID
+    REMOTE_PTF_SEND_INTF, REMOTE_PTF_RECV_INTF, LOCAL_REGION_ID, VXLAN_UDP_BASE_SRC_PORT, VXLAN_UDP_SRC_PORT_MASK
 from dash_utils import render_template_to_host, apply_swssconfig_file
 from gnmi_utils import generate_gnmi_cert, apply_gnmi_cert, recover_gnmi_cert, apply_gnmi_file
 from dash_acl import AclGroup, DEFAULT_ACL_GROUP, WAIT_AFTER_CONFIG, DefaultAclRule
@@ -432,6 +432,30 @@ def vxlan_udp_dport(request, duthost):
 
     logger.info("Restore the VXLAN UDP dst port to 4789")
     config_vxlan_udp_dport(duthost, 4789)
+
+
+
+@pytest.fixture(scope="module")
+def set_vxlan_udp_sport_range(dpuhosts, dpu_index):
+    """
+    Configure VXLAN UDP source port range in dpu configuration.
+
+    """
+    dpuhost = dpuhosts[dpu_index]
+    vxlan_sport_config = [
+        {
+            "SWITCH_TABLE:switch": {
+                "vxlan_sport": VXLAN_UDP_BASE_SRC_PORT,
+                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK
+            },
+            "OP": "SET"
+        }
+    ]
+
+    config_path = "/tmp/vxlan_sport_config.json"
+    dpuhost.copy(content=json.dumps(vxlan_sport_config, indent=4), dest=config_path, verbose=False)
+    apply_swssconfig_file(dpuhost, config_path)
+
 
 
 @pytest.fixture(scope="function")

--- a/tests/dash/constants.py
+++ b/tests/dash/constants.py
@@ -47,3 +47,6 @@ ACL_DST_TAG = "dst_tag"
 ACL_PROTOCOL = "protocol"
 ACL_TAG = "acl_tag"
 ACL_PREFIX_LIST = "prefix_list"
+# For VxLAN source UDP port range
+VXLAN_UDP_BASE_SRC_PORT = 64128
+VXLAN_UDP_SRC_PORT_MASK = 7  # number of least significant bits

--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -127,6 +127,7 @@ def inbound_pl_packets(config, use_pkt_alt_attrs=False, inner_packet_type='udp',
         ip_ttl=63 if use_pkt_alt_attrs else 254,
         ip_id=0,
         udp_dport=vxlan_udp_dport,
+        udp_sport=VXLAN_UDP_BASE_SRC_PORT,
         vxlan_vni=int(pl.VNET1_VNI) if use_pkt_alt_attrs else int(pl.VM_VNI),
         inner_frame=exp_inner_packet
     )
@@ -134,7 +135,8 @@ def inbound_pl_packets(config, use_pkt_alt_attrs=False, inner_packet_type='udp',
     masked_exp_packet = Mask(exp_vxlan_packet)
     masked_exp_packet.set_do_not_care_packet(scapy.Ether, "src")
     masked_exp_packet.set_do_not_care_packet(scapy.Ether, "dst")
-    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "sport")
+    # 34 is the sport offset, 2 is the length of UDP sport field
+    masked_exp_packet.set_do_not_care(8 * (34 + 2) - VXLAN_UDP_SRC_PORT_MASK, VXLAN_UDP_SRC_PORT_MASK)
     masked_exp_packet.set_do_not_care_packet(scapy.UDP, "chksum")
 
     return gre_packet, masked_exp_packet

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -3,7 +3,7 @@ import logging
 import configs.privatelink_config as pl
 import ptf.testutils as testutils
 import pytest
-from constants import LOCAL_PTF_INTF, LOCAL_DUT_INTF, REMOTE_DUT_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
+from constants import LOCAL_PTF_INTF, LOCAL_DUT_INTF, REMOTE_DUT_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF, VXLAN_UDP_BASE_SRC_PORT
 from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
 from tests.dash.conftest import get_interface_ip
@@ -59,7 +59,7 @@ def add_npu_static_routes(duthost, dash_pl_config, skip_config, skip_cleanup, dp
 
 
 @pytest.fixture(autouse=True, scope="module")
-def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config, dpuhosts):
+def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config, dpuhosts, set_vxlan_udp_sport_range):
     if skip_config:
         return
     dpuhost = dpuhosts[dpu_index]
@@ -102,6 +102,9 @@ def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, skip_config, d
     apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
     apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
+
+    if str(VXLAN_UDP_BASE_SRC_PORT) in dpuhost.shell("redis-cli -n 0 hget SWITCH_TABLE:switch vxlan_sport")['stdout']:
+        config_reload(dpuhost, safe_reload=True)
 
 
 @pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is the Test plan and dash PL test update for feature VXLAN source port range.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Run the test on SN4280 and it passed. Also tested the negative flow by configuring the port range but still check the original vxlan source port, test failed as expected.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
