### PR TITLE
chore: disable default dynamic var snappi fallback

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2054,11 +2054,13 @@ def parse_override(testbed, field):
     with open(override_file, 'r') as f:
         all_values = yaml.safe_load(f)
         if testbed not in all_values or field not in all_values[testbed]:
-            return False, None
+            # When T1-tgen is available, we should do "return False, None"
+            return True, []
 
         return True, all_values[testbed][field]
 
-    return False, None
+    # When T1-tgen is available, we should do "return False, None"
+    return True, []
 
 
 def generate_skeleton_port_info(request):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Disable the default dynamic variable snappi fallback since T1-tgen testbed does not support this feature yet and currently generating alert. Disabling this now to suspress the alert.

Fixes # (issue) 33123296

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Disable the default dynamic variable snappi fallback since T1-tgen testbed does not support this feature yet and currently generating alert. Disabling this now to suspress the alert.

@sdszhang @kamalsahu0001 @amitpawar12 for viz

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
