### PR TITLE
Refactor fdb_mac_move test to use actual port numbers

### DIFF
--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -125,8 +125,10 @@ def test_fdb_mac_move(ptfadapter, duthosts, fanouthosts, rand_one_dut_hostname, 
     for loop_time in range(0, loop_times):
         port_index_start = (0 + loop_time) % len(port_list)
 
-        for (port, dummy_mac_set) in zip(list(range(len(port_list))), dummy_mac_list):
-            port_index = (port_index_start + port) % len(port_list)
+        # Use actual port numbers from port_list instead of calculating indices
+        for i in range(len(port_list)):
+            port_index = port_list[(port_index_start + i) % len(port_list)]
+            dummy_mac_set = dummy_mac_list[(port_index_start + i) % len(port_list)]
             for dummy_mac in dummy_mac_set:
                 send_arp_request(ptfadapter, port_index, dummy_mac, router_mac, vlan_id)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Refactor fdb_mac_move test to use actual port numbers from port_list for improved clarity and accuracy in ARP request handling.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix KeyError failure on fdb mac move test when trying to send arp request:
`>   ptf.dataplane_instance.port_to_device = lambda port: ptf.dataplane_instance.port_device_map[port]
E   KeyError: 1`

#### How did you do it?
Use actual port numbers from port_list instead of calculating indices

#### How did you verify/test it?
Ran the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
