### PR TITLE
Add snmp lldp state check after config_reload

### DIFF
--- a/tests/snmp/test_snmp_link_local.py
+++ b/tests/snmp/test_snmp_link_local.py
@@ -10,11 +10,25 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True, scope='module')
-def config_reload_after_test(duthosts,
+def config_reload_after_test(duthosts, localhost, creds_all_duts,
                              enum_rand_one_per_hwsku_frontend_hostname):
     yield
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
+
+    hostip = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_host']
+
+    # SNMP LLDP takes longer to be ready after config_reload
+    def check_snmp_lldp_ready():
+        snmp_facts = get_snmp_facts(
+            duthost, localhost, host=hostip, version="v2c",
+            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"],
+            wait=True)['ansible_facts']
+        return "No Such Instance currently exists" not in str(snmp_facts['snmp_lldp'])
+
+    if not wait_until(60, 5, 0, check_snmp_lldp_ready):
+        pytest.fail("SNMP LLDP not ready for next test")
 
 
 def is_snmpagent_listen_on_ip(duthost, ipaddr):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add SNMP LLDP check after config reload in test cleanup

SNMP LLDP takes a bit longer to be ready after `config reload`. Ensure that it is ready before proceeding to the next test (`snmp/test_snmp_lldp.py`).
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The next test fails because SNMP LLDP is not ready (fails on `KeyError` because SNMP LLDP entries are not populated properly from snmpwalk).

#### How did you do it?
Ensure SNMP LLDP is ready after `config reload` before proceeding to the next test.

#### How did you verify/test it?
`snmp/test_snmp_lldp.py` no longer fails when run right after `snmp/test_snmp_link_local.py`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
