### PR TITLE
test_fib.py: test_ecmp_group_member_flap fails when selected source port is shut

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -808,8 +808,8 @@ def test_ecmp_group_member_flap(
     num_asic = duthosts[0].num_asics()
     asic_ns = ""
     if num_asic > 1:
-        asic_ns = "-n asic{}".format(nh_dut_ports[0][0])
-    logging.info("Shutting down port {}".format(nh_dut_ports[0][1]))
+        asic_ns = "-n asic{}".format(nh_dut_ports[port_index_to_shut][0])
+    logging.info("Shutting down port {}".format(nh_dut_ports[port_index_to_shut][1]))
     duthosts[0].shell("sudo config interface {} shutdown {}".format(asic_ns, nh_dut_ports[port_index_to_shut][1]))
 
     time.sleep(10)  # Allow time for the state to stabilize
@@ -855,7 +855,7 @@ def test_ecmp_group_member_flap(
     # --- Bring the port back up and verify ---
     logging.info("Bringing the uplink port back up.")
 
-    logging.info("Enabling port {}".format(nh_dut_ports[0][1]))
+    logging.info("Enabling port {}".format(nh_dut_ports[port_index_to_shut][1]))
     duthosts[0].shell("sudo config interface {} startup {}".format(asic_ns, nh_dut_ports[port_index_to_shut][1]))
     filtered_ports.pop()
 

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -803,15 +803,17 @@ def test_ecmp_group_member_flap(
     )
 
     # --- Simulate port flap: shutdown one uplink port ---
+    port_index_to_shut = 0
     logging.info("Shutting down one uplink port.")
     num_asic = duthosts[0].num_asics()
     asic_ns = ""
     if num_asic > 1:
         asic_ns = "-n asic{}".format(nh_dut_ports[0][0])
     logging.info("Shutting down port {}".format(nh_dut_ports[0][1]))
-    duthosts[0].shell("sudo config interface {} shutdown {}".format(asic_ns, nh_dut_ports[0][1]))
+    duthosts[0].shell("sudo config interface {} shutdown {}".format(asic_ns, nh_dut_ports[port_index_to_shut][1]))
 
     time.sleep(10)  # Allow time for the state to stabilize
+    filtered_ports.append(nh_ptf_ports[port_index_to_shut])
 
     # --- Re-run the PTF test after member down ---
     logging.info("Verifying ECMP behavior after member down.")
@@ -854,7 +856,8 @@ def test_ecmp_group_member_flap(
     logging.info("Bringing the uplink port back up.")
 
     logging.info("Enabling port {}".format(nh_dut_ports[0][1]))
-    duthosts[0].shell("sudo config interface {} startup {}".format(asic_ns, nh_dut_ports[0][1]))
+    duthosts[0].shell("sudo config interface {} startup {}".format(asic_ns, nh_dut_ports[port_index_to_shut][1]))
+    filtered_ports.pop()
 
     time.sleep(60)  # Allow time for the state to stabilize
 


### PR DESCRIPTION
### Description of PR

Summary:
test_fib.py: test_ecmp_group_member_flap fails when selected source port for the packet ingress is the one that is shut in the test.

Fixes # (issue)
#18807 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix failing test case test_fib.py: test_ecmp_group_member_flap

#### How did you do it?
To avoid selecting the port that is shutdown, in the fix it is being removed from the set of possible ingress ports.

#### How did you verify/test it?
Verified that the test case always passes with this fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
