### PR TITLE
deploy-mg script fails while generating config for MX testbeds

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -95,7 +95,7 @@ class GenerateGoldenConfigDBModule(object):
         # Generate FEATURE table from init_cfg.ini
         ori_config_db = json.loads(out)
         if "FEATURE" not in ori_config_db or "dhcp_server" not in ori_config_db["FEATURE"]:
-            return "{}"
+            return {}
 
         ori_config_db["FEATURE"]["dhcp_server"]["state"] = "enabled"
         gold_config_db = {


### PR DESCRIPTION
### Description of PR

Summary:
deploy-mg script fails while generating config for MX testbeds. Script has a typo.

Fixes # (issue)
#18809 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix deploy-mg failure on MX topology testbeds

#### How did you do it?
Fix the typo in the config generation function.

#### How did you verify/test it?
Verified that deploy-mg does not fail for MX testbeds with the fix

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

