### PR TITLE
Enable macsec only on ports connected to T3

### DIFF
--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -43,7 +43,7 @@
 {% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
 {% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
 {% for if_index in range(vm_intfs | length) %}
-{% if 'IB' not in port_alias[dut_intfs[if_index]] and 'T3' in vms[index] %}
+{% if 'IB' not in port_alias[dut_intfs[if_index]] and vms[index].endswith('T3') %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -43,7 +43,7 @@
 {% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
 {% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
 {% for if_index in range(vm_intfs | length) %}
-{% if 'IB' not in port_alias[dut_intfs[if_index]] %}
+{% if 'IB' not in port_alias[dut_intfs[if_index]] and 'T3' in vms[index] %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Changes to enable macsec only on ports connected to T3

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
On UpperSpineRouter, since the device has neighbors towards T3 and LT2, changes here ensure macsec is enabled only on T3 facing ports

#### How did you do it?
LinkMetadata in minigraph is generated to enable macsec only on T3 facing ports

#### How did you verify/test it?
deploy-mg on macsec enabled device with T3 and LT2 neighbors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
