### PR TITLE
[dualtor-io] Fix duplication merge condition

### DIFF
--- a/tests/common/dualtor/data_plane_utils.py
+++ b/tests/common/dualtor/data_plane_utils.py
@@ -87,7 +87,7 @@ def validate_traffic_results(tor_IO, allowed_disruption, delay,
         # The dualtor I/O flow examine logic will regard those duplications as packet delivery,
         # so multiple disruptions will be reported. So we need to reassemble the true disruption
         # with the duplications here.
-        if merge_duplications_into_disruptions and result['disruptions'] and result['duplications']:
+        if merge_duplications_into_disruptions and result['disruptions']:
             logger.debug("Server %s disruptions before merge:\n%s",
                          server_ip, json.dumps(result['disruptions'], indent=4))
             logger.debug("Server %s duplications before merge:\n%s",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Work Item: 33161844

Fix the `dualtor_io.test_link_failure.test_active_link_down_downstream_active_soc[active-active]` failure:
```
Failed: 
Traffic to server 192.168.0.15 was disrupted 2 times. Allowed number of disruptions: 1
```
The server 192.168.0.15 I/O result shows that there are two disruptions:
```
01/06/2025 15:06:12 dual_tor_io.examine_flow                 L0740 INFO   | Server 192.168.0.15 results:
{
    "sent_packets": 652,
    "received_packets": 650,
    "disruption_before_traffic": false,
    "disruption_after_traffic": false,
    "duplications": [],
    "disruptions": [
        {
            "start_time": 1748790187.24364,
            "end_time": 1748790187.772263,
            "start_id": 70,
            "end_id": 72
        },
        {
            "start_time": 1748790187.772263,
            "end_time": 1748790188.304254,
            "start_id": 72,
            "end_id": 74
        }
    ]
}
```
Actually, there is only one disruption, but due to the vlan flooding behavior, packet with id 70 is flooded in the vlan and received; so two disruptions are detected.
So for this case, the following two disruptions should be merged into one.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Change the merge condition to allow merge in this case.

#### How did you verify/test it?
Run on Cisco dualtor testbed and pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
