### PR TITLE
Increasing orch_cpu_timeout to 120 if routes are greater than 10K in duthost_utils.py

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -231,13 +231,16 @@ def shutdown_ebgp(duthosts, rand_one_dut_hostname):
     # increase timeout for check_orch_cpu_utilization to 120sec for chassis
     # especially uplink cards need >60sec for orchagent cpu usage to come down to 10%
     duthost = duthosts[rand_one_dut_hostname]
-    is_chassis = duthost.get_facts().get("modular_chassis")
-    orch_cpu_timeout = 120 if is_chassis else 60
+    orch_cpu_timeout = 60
     for duthost in duthosts.frontend_nodes:
         # Get the original number of eBGP v4 and v6 routes on the DUT.
         sumv4, sumv6 = duthost.get_ip_route_summary()
         v4ebgps[duthost.hostname] = sumv4.get('ebgp', {'routes': 0})['routes']
         v6ebgps[duthost.hostname] = sumv6.get('ebgp', {'routes': 0})['routes']
+        v4_routes_count = v4ebgps[duthost.hostname]
+        v6_routes_count = v6ebgps[duthost.hostname]
+        if v4_routes_count > 10000 or v6_routes_count > 10000:
+            orch_cpu_timeout = 120
         # Shutdown all eBGP neighbors
         duthost.command("sudo config bgp shutdown all")
         # Verify that the total eBGP routes are 0.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Previously, the timeout increase was applied only for modular chassis platforms. However, with the onboarding of several other platforms, we now need to implement this check in a platform-agnostic manner.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Increasing orch_cpu_timeout to 120
#### How did you do it?
By adding a condition
#### How did you verify/test it?
Tested in MSFT LAB
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
