### PR TITLE
calling teh fixture to disable the voqWD before test execution and en…

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -186,6 +186,8 @@ def reboot_duts(setup_ports_and_dut, localhost, request):
         wait_until(180, 20, 0, node.critical_services_fully_started)
         wait_until(180, 20, 0, check_interface_status_of_up_ports, node)
         wait_until(300, 10, 0, node.check_bgp_session_state_all_asics, up_bgp_neighbors, "established")
+        if duthost.facts['asic_type'] == "cisco-8000":
+            modify_voq_watchdog_cisco_8000(duthost, False)
 
     # Convert the list of duthosts into a list of tuples as required for parallel func.
     args = set((snappi_ports[0]['duthost'], snappi_ports[1]['duthost']))

--- a/tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
     lossless_prio_list, lossy_prio_list     # noqa F401
 from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog           # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
@@ -15,6 +15,7 @@ from tests.snappi_tests.pfcwd.files.pfcwd_actions_helper import run_pfc_test
 from tests.common.config_reload import config_reload
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog               # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -20,6 +20,7 @@ from tests.snappi_tests.pfcwd.files.pfcwd_basic_helper import run_pfcwd_basic_te
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.files.helper import skip_pfcwd_test, reboot_duts, \
     setup_ports_and_dut, multidut_port_info   # noqa: F401
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog, modify_voq_watchdog_cisco_8000     # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
@@ -292,6 +293,8 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
                           "Not all interfaces are up.")
             pytest_assert(wait_until(
                 WAIT_TIME, INTERVAL, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"))
+            if duthost.facts['asic_type'] == "cisco-8000":
+                modify_voq_watchdog_cisco_8000(duthost, False)
 
     else:
         for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):
@@ -379,6 +382,8 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
                           "Not all interfaces are up.")
             pytest_assert(wait_until(
                 WAIT_TIME, INTERVAL, 0, duthost.check_bgp_session_state_all_asics, up_bgp_neighbors, "established"))
+            if duthost.facts['asic_type'] == "cisco-8000":
+                modify_voq_watchdog_cisco_8000(duthost, False)
 
     else:
         for duthost in list(set([snappi_ports[0]['duthost'], snappi_ports[1]['duthost']])):

--- a/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfcwd.files.pfcwd_burst_storm_helper import run_pfcwd_burst_storm_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog              # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
@@ -13,6 +13,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 

--- a/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py
@@ -12,6 +12,7 @@ from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_
 from tests.snappi_tests.variables import MIXED_SPEED_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfc.files.mixed_speed_multidut_helper import run_pfc_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 
 import logging
 logger = logging.getLogger(__name__)

--- a/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
@@ -12,6 +12,7 @@ from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfcwd.files.\
     pfcwd_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
+from tests.snappi_tests.cisco.helper import disable_voq_watchdog                  # noqa: F401
 logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]


### PR DESCRIPTION
Updating all the PFCWD test scripts to run the fixture to disable voq watchdog at the begining of the test execution and enable it at the end

### Description of PR
Disabling the voqWD at the beginning of test execution in every test script. Fixture enables it back in after the test execution.
These changes are extension of this PR https://github.com/sonic-net/sonic-mgmt/pull/18564

### Type of change
- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ X] 202411
- [ X] 202505

### Approach
#### What is the motivation for this PR?
PFCWD tests were failing as voqWD was getting triggered

#### How did you do it?
Calling the fixture to disable voqWD before the test execution starts, which enables it back after the test execution

#### How did you verify/test it?
Manually tested the scripts with changes

#### Any platform specific information?
Cisco8000
