### PR TITLE
[dualtor_io] Enable switchover test and add argument to enable run.

### DIFF
--- a/.azure-pipelines/pr_test_skip_scripts.yaml
+++ b/.azure-pipelines/pr_test_skip_scripts.yaml
@@ -5,6 +5,8 @@ t0:
   - dualtor/test_orchagent_slb.py
   # KVM do not support dualtor tunnel functionality, verify DB status would fail
   - dualtor_io/test_normal_op.py
+  # Not supported on KVM testbeds
+  - dualtor_io/test_switchover_impact.py
   # This script would toggle PDU, which is not supported on KVM
   - dualtor_io/test_tor_failure.py
   # This script only supported on Broadcom
@@ -206,6 +208,8 @@ t2:
 dualtor:
   # This test only support on dualtor-aa testbed
   - dualtor_io/test_grpc_server_failure.py
+  # This test is not intended for pr tests
+  - dualtor_io/test_tor_switchover_impact
   # This test is only for Nvidia platforms.
   - dualtor_mgmt/test_egress_drop_nvidia.py
   # This test needs some additional SAI attributes, do not support on KVM.

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -730,10 +730,6 @@ dualtor_io/test_normal_op.py:
     conditions:
       - "asic_type in ['vs']"
 
-dualtor_io/test_switchover_impact.py:
-  skip:
-    reason: "This test takes a long time, skipping until it can be triggered weekly rather than nightly"
-
 dualtor_io/test_tor_bgp_failure.py:
   skip:
     reason: "Skip on kvm due to an issue."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_skip_traffic_test.yaml
@@ -169,6 +169,12 @@ dualtor_io/test_tor_bgp_failure.py:
     conditions:
       - "asic_type in ['vs']"
 
+dualtor_io/test_switchover_impact.py:
+  skip_traffic_test:
+    reason: "Skip traffic test for KVM testbed"
+    conditions:
+      - "asic_type in ['vs']"
+
 #######################################
 #####         dualtor_mgmt        #####
 #######################################

--- a/tests/dualtor_io/conftest.py
+++ b/tests/dualtor_io/conftest.py
@@ -18,6 +18,17 @@ def pytest_configure(config):
     )
 
 
+def pytest_addoption(parser):
+    """
+    Adds pytest options that are used by dual ToR IO tests
+    """
+
+    dual_tor_io_group = parser.getgroup("Dual ToR IO test suite options")
+
+    dual_tor_io_group.addoption("--enable_switchover_impact_test", action="store_true", default=False, type=bool,
+                                help="Enable switchover impact test to be run.")
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_generate_tests(metafunc):
     yield

--- a/tests/dualtor_io/test_switchover_impact.py
+++ b/tests/dualtor_io/test_switchover_impact.py
@@ -18,7 +18,8 @@ import logging
 
 
 @pytest.mark.parametrize("switchover", ["planned"])
-def test_tor_switchover_impact(upper_tor_host, lower_tor_host,                             # noqa: F811
+def test_tor_switchover_impact(request,                                                    # noqa: F811
+                               upper_tor_host, lower_tor_host,                             # noqa: F811
                                send_t1_to_server_with_action,                              # noqa: F811
                                cable_type,                                                 # noqa: F811
                                select_test_mux_ports,                                      # noqa: F811
@@ -28,7 +29,7 @@ def test_tor_switchover_impact(upper_tor_host, lower_tor_host,                  
                                planned_threshold=0.1, unplanned_threshold=0.4,             # noqa: F811
                                iterations=100):                                            # noqa: F811
     """
-    Measure impact when active-standby ToR is going through switchover.
+    Measure impact when active-standby ToR is going through switchover. must run with --enable_switchover_impact_test to enable.
 
     Steps:
         1. sets upper tor to active on all ports.
@@ -189,6 +190,12 @@ def test_tor_switchover_impact(upper_tor_host, lower_tor_host,                  
                 failures[ipv4]["Failed test cases"]["Multiple disruptions detected for single switchover"] = True
 
         return results, failures
+
+    ## Test Start ##
+
+    if not request.config.getoption('--enable_switchover_impact_test'):
+        logging.info("Switchover impact test disabled. To enable the test, run with '--enable_switchover_impact_test'")
+        return
 
     logs = {}
     logs["results"] = {}


### PR DESCRIPTION
switchover impact test was disabled due to being a long test. This will enable the test, but also disable it for any PR or KVM tests.

Added an explicit argument to enable switchover impact tests to prevent accidental run.

### Description of PR

Summary:
enables the switchover impact test to allow for weekly runs and adds flag to disable test for normal runs unless explicitly enabled.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
switchover impact tests were disabled due to taking a long time. This will enable the tests again, but only if --enable_switchover_impact_test is passed as an argument.

#### How did you do it?
removed skip condition and added PR skip condition. Added pytest argument --enable_switchover_impact_test
