### PR TITLE
Fix ntp synchronization issue for test_ntp

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -30,6 +30,18 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
+    # Comment out the default pool configuration
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="#pool 0.debian.pool.ntp.org iburst", regexp="^pool.*0.debian.*pool.*ntp.*org.*")
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="#pool 1.debian.pool.ntp.org iburst", regexp="^pool.*1.debian.*pool.*ntp.*org.*")
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="#pool 2.debian.pool.ntp.org iburst", regexp="^pool.*2.debian.*pool.*ntp.*org.*")
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="#pool 3.debian.pool.ntp.org iburst", regexp="^pool.*3.debian.*pool.*ntp.*org.*")
+
+    ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
+
     # restart ntp server
     ntp_en_res = ptfhost.service(name=ntp_service_name, state="restarted")
 
@@ -63,6 +75,19 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     # stop ntp server
     ptfhost.service(name=ntp_service_name, state="stopped")
+
+    # restore the default pool configuration
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="pool 0.debian.pool.ntp.org iburst", regexp="#pool.*0.debian.*pool.*ntp.*org.*")
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="pool 1.debian.pool.ntp.org iburst", regexp="#pool.*1.debian.*pool.*ntp.*org.*")
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="pool 2.debian.pool.ntp.org iburst", regexp="#pool.*2.debian.*pool.*ntp.*org.*")
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="pool 3.debian.pool.ntp.org iburst", regexp="#pool.*3.debian.*pool.*ntp.*org.*")
+
+    ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
+
     # reset ntp client configuration
     duthost.command("config ntp del %s" % (ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip))
     for ntp_server in ntp_servers:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The test initiates an NTP server on PTF, which has a pool of 4 network NTP servers and sets the local clock as the preferred option. However, the local server's clock (crystal oscillator) has poor accuracy, causing the PTF's NTP server to dynamically switch to other network NTP servers in the pool. As a result, when DUT uses the PTF NTP server as the clock, synchronization becomes difficult. To  resolve the issue, remove the network NTP configuration from the pool.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix ntp synchronization issue for test_ntp

#### How did you do it?
Just keep one ntp clock for the ptf ntp server

#### How did you verify/test it?
Run test_ntp.py

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
