### PR TITLE
[Cherry-pick][ACL] Include service port into upstream neighbors

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -9,6 +9,7 @@ import six
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
+import re
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
@@ -423,11 +424,18 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
             # In multi-asic we need config both in host and namespace.
             if namespace:
                 acl_table_ports[''] += port
-    if len(port_channels) and topo in ["t0", "m0_vlan", "m0_l3"] or tbinfo["topo"]["name"] in ("t1-lag", "t1-64-lag",
-                                                                                               "t1-64-lag-clet",
-                                                                                               "t1-56-lag",
-                                                                                               "t1-28-lag",
-                                                                                               "t1-32-lag"):
+    if (
+        len(port_channels)
+        and (
+            topo in ["t0", "m0_vlan", "m0_l3"]
+            or tbinfo["topo"]["name"] in (
+                "t1-lag", "t1-64-lag", "t1-64-lag-clet",
+                "t1-56-lag", "t1-28-lag", "t1-32-lag"
+            )
+            or 't1-isolated' in tbinfo["topo"]["name"]
+        )
+        and not re.match(r"t0-.*s\d+", tbinfo["topo"]["name"])
+    ):
 
         for k, v in list(port_channels.items()):
             acl_table_ports[v['namespace']].append(k)

--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -193,7 +193,8 @@ def prepare_test_port(rand_selected_dut, tbinfo):
     upstream_port_neighbor_ips = {}
     for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
         port_id = mg_facts["minigraph_ptf_indices"][interface]
-        if (topo == "t1" and "T2" in neighbor["name"]) or (topo == "t0" and "T1" in neighbor["name"]) or \
+        if (topo == "t1" and "T2" in neighbor["name"]) or \
+                (topo == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"])) or \
                 (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]) or \
                 (topo_name in ("t1-isolated-d32", "t1-isolated-d128") and "T0" in neighbor["name"]):
             upstream_ports[neighbor['namespace']].append(interface)

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -23,7 +23,7 @@ UPSTREAM_NEIGHBOR_MAP = {
 
 # Describe ALL upstream neighbor of dut in different topos
 UPSTREAM_ALL_NEIGHBOR_MAP = {
-    "t0": ["t1"],
+    "t0": ["t1", "pt0"],
     "t1": ["t2"],
     "m1": ["ma", "mb"],
     "m0": ["m1"],

--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -57,7 +57,7 @@ def upstream_links(rand_selected_dut, tbinfo, nbrhosts):
     duthost = rand_selected_dut
 
     def filter(interface, neighbor, mg_facts, tbinfo):
-        if ((tbinfo["topo"]["type"] == "t0" and "T1" in neighbor["name"])
+        if ((tbinfo["topo"]["type"] == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"]))
                 or (tbinfo["topo"]["type"] == "t1" and "T2" in neighbor["name"])):
             local_ipv4_addr = None
             peer_ipv4_addr = None


### PR DESCRIPTION
Summary:
This is a manual cherry-pick of #18671

Fixes # (issue)
In the topology with service ports, like t0-d18u8s4, t0-isolated-d16u16s1, t0-isolated-d32u32s2. we should include the PT0 neighbor port in the upstream neighbor list. With the enhancement in #18516, we can achieve this by adding pt0 in UPSTREAM_ALL_NEIGHBOR_MAP.

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
