### PR TITLE
Update copp test to get the correct ipv6 vlan interface address

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -456,7 +456,7 @@ def get_vlan_ip(duthost, ip_version):
     if ip_version == "4":
         vlan_subnet = ipaddress.ip_network(mg_vlan_intfs[0]['subnet'])
     else:
-        vlan_subnet = ipaddress.ip_network(mg_vlan_intfs[1]['subnet'])
+        vlan_subnet = ipaddress.ip_network(mg_vlan_intfs[-1]['subnet'])
 
     ip_addr = str(vlan_subnet[2])
     return ip_addr


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Due to the affection of PR https://github.com/sonic-net/sonic-mgmt/pull/18399
Script would get the secondary ip as the ipv6 vlan interface address 
Update the method to get the correct ipv6 vlan interface address

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Script get the secondary ip vlan interface address as the ipv6 vlan interface address.
#### How did you do it?
Update the method to get correct ipv6 vlan interface
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?
T0 topology related
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
