### PR TITLE
advertise tor default route for t1-isolated-d128 only

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1473,7 +1473,7 @@ def main():
                 topo['configuration'].pop(vm_name)
 
     is_storage_backend = "backend" in topo_name
-    tor_default_route = "t1-isolated" in topo_name
+    tor_default_route = "t1-isolated-d128" in topo_name
 
     topo_type = get_topo_type(topo_name)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
After the change in : https://github.com/sonic-net/sonic-mgmt/pull/17943,  default route will advertised from T0 peer in t1-isolated-d56u2 or t1-isolated-d56u1-lag topo. and caused multiple failures in test_acl, as both T0 and T2 are advertising default route.

This PR will limit the default route advertisement to -d128 topology only.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix failures in test_acl due to the route advertisement change.

#### How did you do it?

#### How did you verify/test it?
acl/test_acl.py::TestBasicAcl::test_ingress_unmatched_blocked[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  0%]
acl/test_acl.py::TestBasicAcl::test_egress_unmatched_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] SKIPPED [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  0%]
acl/test_acl.py::TestBasicAcl::test_rules_priority_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  0%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  0%]
acl/test_acl.py::TestBasicAcl::test_dest_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  0%]
acl/test_acl.py::TestBasicAcl::test_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  1%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_forwarded[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  1%]
acl/test_acl.py::TestBasicAcl::test_udp_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  1%]
acl/test_acl.py::TestBasicAcl::test_icmp_source_ip_match_dropped[ipv4-ingress-downlink->uplink-default-no_vlan] PASSED [  1%]
......

========= 768 passed, 32 skipped, 2690 warnings in 8803.15s (2:26:43) ==========

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
