### PR TITLE
Stabilize the crm test

### DIFF
--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -145,7 +145,7 @@ def crm_interface(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, e
                                                                                           asichost.asic_index))
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module", autouse=False)
 def set_polling_interval(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     wait_time = 2
@@ -309,7 +309,7 @@ def cleanup_ptf_interface(duthosts, ip_ver, enum_rand_one_per_hwsku_frontend_hos
 
 
 @pytest.fixture(scope="module", autouse=True)
-def crm_resources(duthosts, rand_one_dut_hostname):
+def crm_resources(duthosts, rand_one_dut_hostname, set_polling_interval):
     """
     Parse the CRM resource table from the 'crm show resources all' command output,
     retrying if CRM counters are not ready.


### PR DESCRIPTION
The fixture crm_resources is auto use fixture, in it, it will check the crm resources, the timeout of checking the crm resource is 90s, if there is a config reload did before the test, and since the default crm polling interval is 360s, so the 90s timeout is not enough, actually, there is another auto use fixture set_polling_interval which is also module level, in it, the crm polling interval will be changed to 1s, but it is called after the crm_resources, change the set_polling_interval always called before the crm_resources, then even if there is config reload did before this test, 90s timeout is enough to get the crm resources.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The fixture crm_resources  is new added in https://github.com/sonic-net/sonic-mgmt/pull/18465. 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
