### PR TITLE
[Mellanox]Update the ecn_mode  on Mellanox to be same as other platforms

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -2,9 +2,9 @@
 IPinIP Decap configs for different ASICs:
 Table Name in APP_DB: TUNNEL_DECAP_TABLE:IPINIP_TUNNEL
 
-Config          Mellanox <= [201911]        Mellanox >= [202012]        Broadcom <= [201911]        Broadcom >= [202012]     Innovium               # noqa: E501
+Config          Mellanox <= [202411]        Mellanox >= [202505]        Broadcom <= [201911]        Broadcom >= [202012]     Innovium               # noqa: E501
 dscp_mode       uniform                     uniform                     pipe                        uniform                  pipe                   # noqa: E501
-ecn_mode        standard                    standard                    copy_from_outer             copy_from_outer          copy_from_outer        # noqa: E501
+ecn_mode        standard                    copy_from_outer             copy_from_outer             copy_from_outer          copy_from_outer        # noqa: E501
 ttl_mode        pipe                        pipe                        pipe                        pipe                     pipe                   # noqa: E501
 '''
 import json
@@ -256,8 +256,6 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
     ttl_mode = supported_ttl_dscp_params['ttl']
     dscp_mode = supported_ttl_dscp_params['dscp']
     vxlan = supported_ttl_dscp_params['vxlan']
-    if duthosts[0].facts['asic_type'] in ['mellanox']:
-        ecn_mode = 'standard'
 
     cross_decap = True
     # Skip the IPv4inIPv6 and IPv6inIPv4. Run only the IPv4inIPv4 and IPv6inIPv6


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [Mellanox]Update the ecn_mode  on Mellanox to be same as other platforms, The update is for the feature https://github.com/sonic-net/sonic-buildimage/pull/22667[Mellanox] remove mlnx specific condition for the ipinip tunnel ecn_mode
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
