### PR TITLE
Update vlan ping test to override the affection of secondary vlan ip

### DIFF
--- a/tests/vlan/test_vlan_ping.py
+++ b/tests/vlan/test_vlan_ping.py
@@ -145,6 +145,8 @@ def vlan_ping_setup(duthosts, rand_one_dut_hostname, ptfhost, nbrhosts, tbinfo, 
         if len(my_cfg_facts['VLAN_MEMBER']['Vlan' + vlanid]) >= 2:
             for addr in my_cfg_facts['VLAN_INTERFACE']['Vlan' + vlanid]:
                 if addr.find(':') == -1:
+                    if 'secondary' in my_cfg_facts['VLAN_INTERFACE']['Vlan' + vlanid][addr]:
+                        continue
                     ip4 = addr
                 else:
                     ip6 = addr


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update vlan ping test to override the affection of secondary vlan ip address
Related community PR https://github.com/sonic-net/sonic-mgmt/pull/18399

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Update vlan ping test to override the affection of secondary vlan ip address
Related community PR https://github.com/sonic-net/sonic-mgmt/pull/18399
#### How did you do it?
Handle the secondary ip
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
