### PR TITLE
Building All Test Targets available in Ondatra repo

### DIFF
--- a/sdn_tests/pins_ondatra/BUILD.bazel
+++ b/sdn_tests/pins_ondatra/BUILD.bazel
@@ -33,6 +33,8 @@ filegroup(
         "//tests:z_gnmi_stress_test",
         "//tests:system_paths_test",
         "//tests:gnmi_wildcard_subscription_test",
+        "//tests/thinkit:thikit_tests",
+        "//infrastructure/thinkit:infrastructure_thinkit_tests",
     ],
     testonly = 1,
     visibility = ["//visibility:public"],

--- a/sdn_tests/pins_ondatra/infrastructure/thinkit/BUILD.bazel
+++ b/sdn_tests/pins_ondatra/infrastructure/thinkit/BUILD.bazel
@@ -197,3 +197,12 @@ build_test(
     name = "ondatra_params_test",
     targets = [":ondatra_params"],
 )
+
+#To run all Infrastructure Thinkit testcases
+test_suite(
+    name = "infrastructure_thinkit_tests",
+    tests = [
+        ":ondatra_generic_testbed_fixture_test",
+        ":ondatra_params_test",
+    ],
+)

--- a/sdn_tests/pins_ondatra/tests/thinkit/BUILD.bazel
+++ b/sdn_tests/pins_ondatra/tests/thinkit/BUILD.bazel
@@ -102,3 +102,14 @@ cc_test(
     ],
     linkopts = ["-lresolv"],
 )
+
+#To run all Thinkit testcases
+test_suite(
+    name = "thinkit_tests",
+    tests = [
+        ":arbitration_test",
+        ":arriba_test",
+        ":configure_mirror_testbed_test",
+        ":random_blackbox_events_test",
+    ],
+)


### PR DESCRIPTION
Adding all Ondatra Test Targets in BUILD. Bazel to build all the targets successfully.
