### PR TITLE
[dualtor-aa] Add dualtor-aa support to `test_nvgre_hash`

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -673,13 +673,15 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
 @pytest.fixture(params=["ipv4-ipv4", "ipv4-ipv6", "ipv6-ipv6", "ipv6-ipv4"])
 def nvgre_ipver(request):
     return request.param
-def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                          # noqa F811
-                     hash_keys, ptfhost, nvgre_ipver, tbinfo, mux_server_url,             # noqa F811
-                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,          # noqa F811
-                     duts_minigraph_facts, request):                                      # noqa F811
+def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                            # noqa F811
+                     hash_keys, ptfhost, nvgre_ipver, updated_tbinfo, mux_server_url,       # noqa F811
+                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,            # noqa F811
+                     duts_minigraph_facts, request,                                         # noqa F811
+                     setup_active_active_ports, active_active_ports,                        # noqa F811
+                     mux_status_from_nic_simulator):                                        # noqa F811
 
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
-                                            tbinfo, request)
+                                            updated_tbinfo, request)
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.
     # Hash-key will be updated once we get the full support.
@@ -706,8 +708,11 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                "hash_test.NvgreHashTest",
                platform_dir="ptftests",
                params={"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "ptf_test_port_map": ptf_test_port_map_active_active(
+                           ptfhost, updated_tbinfo, duthosts, mux_server_url,
+                           duts_running_config_facts, duts_minigraph_facts,
+                           mux_status_from_nic_simulator()
+                           ),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),
@@ -715,8 +720,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": nvgre_ipver,
-                       "topo_name": tbinfo['topo']['name'],
-                       "topo_type": tbinfo['topo']['type']
+                       "topo_name": updated_tbinfo['topo']['name'],
+                       "topo_type": updated_tbinfo['topo']['type']
                        },
                log_file=log_file,
                qlen=PTF_QLEN,

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -674,14 +674,14 @@ def test_vxlan_hash(add_default_route_to_dut, duthost, duthosts,                
 def nvgre_ipver(request):
     return request.param
 def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                            # noqa F811
-                     hash_keys, ptfhost, nvgre_ipver, updated_tbinfo, mux_server_url,       # noqa F811
-                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,            # noqa F811
-                     duts_minigraph_facts, request,                                         # noqa F811
-                     setup_active_active_ports, active_active_ports,                        # noqa F811
-                     mux_status_from_nic_simulator):                                        # noqa F811
+                    hash_keys, ptfhost, nvgre_ipver, tbinfo, mux_server_url,                # noqa F811
+                    ignore_ttl, single_fib_for_duts, duts_running_config_facts,             # noqa F811
+                    duts_minigraph_facts, request,                                          # noqa F811
+                    setup_active_active_ports, active_active_ports,                         # noqa F811
+                    mux_status_from_nic_simulator):                                         # noqa F811
 
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
-                                            updated_tbinfo, request)
+                                            tbinfo, request)
     # For NVGRE, default hash key is inner 5-tuple.
     # Due to current limitation, NVGRE hash keys are updated for different vendors.
     # Hash-key will be updated once we get the full support.
@@ -709,10 +709,9 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                platform_dir="ptftests",
                params={"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
                        "ptf_test_port_map": ptf_test_port_map_active_active(
-                           ptfhost, updated_tbinfo, duthosts, mux_server_url,
+                           ptfhost, tbinfo, duthosts, mux_server_url,
                            duts_running_config_facts, duts_minigraph_facts,
-                           mux_status_from_nic_simulator()
-                           ),
+                           mux_status_from_nic_simulator()),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),
@@ -720,8 +719,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "ignore_ttl": ignore_ttl,
                        "single_fib_for_duts": single_fib_for_duts,
                        "ipver": nvgre_ipver,
-                       "topo_name": updated_tbinfo['topo']['name'],
-                       "topo_type": updated_tbinfo['topo']['type']
+                       "topo_name": tbinfo['topo']['name'],
+                       "topo_type": tbinfo['topo']['type']
                        },
                log_file=log_file,
                qlen=PTF_QLEN,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Enable `test_nvgre_hash` run on `dualtor-aa` testbeds.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
By using dualtor-aa supported ptf port mapping for the nvgre hashing ptf test.

#### How did you verify/test it?
```
fib/test_fib.py::test_nvgre_hash[ipv4-ipv4] PASSED                                                               [ 25%]
fib/test_fib.py::test_nvgre_hash[ipv4-ipv6] PASSED                                                               [ 50%]
fib/test_fib.py::test_nvgre_hash[ipv6-ipv6] PASSED                                                               [ 75%]
fib/test_fib.py::test_nvgre_hash[ipv6-ipv4] PASSED                                                               [100%]

====================================== 4 passed, 3 warnings in 1129.28s (0:18:49) ======================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
