### PR TITLE
Support skip ptf test files copy

### DIFF
--- a/tests/dualtor/test_orchagent_slb.py
+++ b/tests/dualtor/test_orchagent_slb.py
@@ -18,7 +18,6 @@ from tests.common.dualtor.server_traffic_utils import ServerTrafficMonitor
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                                # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa F401
 from tests.common.helpers import bgp
 from tests.common.utilities import is_ipv4_address
 

--- a/tests/dualtor/test_orchagent_standby_tor_downstream.py
+++ b/tests/dualtor/test_orchagent_standby_tor_downstream.py
@@ -15,7 +15,6 @@ from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports
 from tests.common.dualtor.dual_tor_utils import build_packet_to_server
 from tests.common.dualtor.dual_tor_utils import crm_neighbor_checker
 from tests.common.dualtor.dual_tor_utils import add_nexthop_routes, remove_static_routes
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory             # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                    # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                  # noqa F401

--- a/tests/dualtor_io/test_grpc_server_failure.py
+++ b/tests/dualtor_io/test_grpc_server_failure.py
@@ -7,7 +7,6 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host                  
 from tests.common.dualtor.dual_tor_utils import lower_tor_host                      # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder                  # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_garp_service                    # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory             # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                # noqa F401
 from tests.common.dualtor.dual_tor_common import active_active_ports                # noqa F401
 from tests.common.dualtor.dual_tor_common import cable_type                         # noqa F401

--- a/tests/dualtor_io/test_heartbeat_failure.py
+++ b/tests/dualtor_io/test_heartbeat_failure.py
@@ -8,7 +8,7 @@ from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter    
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor  # noqa F401
 from tests.common.dualtor.tor_failure_utils import shutdown_tor_heartbeat                       # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
-                                                copy_ptftests_directory, change_mac_addresses   # noqa F401
+                                                 change_mac_addresses   # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                     # noqa F401
 from tests.common.dualtor.dual_tor_common import CableType

--- a/tests/dualtor_io/test_link_drop.py
+++ b/tests/dualtor_io/test_link_drop.py
@@ -17,7 +17,6 @@ from tests.common.dualtor.nic_simulator_control import set_drop_active_active   
 from tests.common.dualtor.nic_simulator_control import TrafficDirection
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service            # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import ActiveActivePortID
 from tests.common.dualtor.dual_tor_common import active_active_ports                            # noqa F401

--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -10,7 +10,7 @@ from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host, 
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
-                                                copy_ptftests_directory, change_mac_addresses       # noqa F401
+                                                 change_mac_addresses       # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa F401
 from tests.common.dualtor.dual_tor_common import mux_config                                         # noqa F401

--- a/tests/dualtor_io/test_normal_op.py
+++ b/tests/dualtor_io/test_normal_op.py
@@ -13,7 +13,7 @@ from tests.common.dualtor.dual_tor_utils import show_muxcable_status
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_upper_tor      # noqa F401
 from tests.common.dualtor.dual_tor_utils import check_simulator_flap_counter                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
-                                                copy_ptftests_directory, change_mac_addresses       # noqa F401
+                                                 change_mac_addresses       # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC, CONFIG_RELOAD_ALLOWED_DISRUPTION_SEC
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/dualtor_io/test_switchover_impact.py
+++ b/tests/dualtor_io/test_switchover_impact.py
@@ -11,7 +11,7 @@ from tests.common.dualtor.data_plane_utils import send_t1_to_server_with_action,
 from tests.common.dualtor.dual_tor_common import cable_type                                                 # noqa F401
 from tests.common.dualtor.dual_tor_utils import upper_tor_host, lower_tor_host                              # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
-                                                copy_ptftests_directory, change_mac_addresses               # noqa F401
+                                                 change_mac_addresses               # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 
 import logging

--- a/tests/dualtor_io/test_tor_bgp_failure.py
+++ b/tests/dualtor_io/test_tor_bgp_failure.py
@@ -10,7 +10,7 @@ from tests.common.dualtor.tor_failure_utils import kill_bgpd                    
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions                            # noqa F401
 from tests.common.dualtor.tor_failure_utils import shutdown_bgp_sessions_on_duthost
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service, \
-                                                copy_ptftests_directory, change_mac_addresses       # noqa F401
+                                                 change_mac_addresses       # noqa F401
 from tests.common.dualtor.tunnel_traffic_utils import tunnel_traffic_monitor                        # noqa F401
 from tests.common.dualtor.constants import MUX_SIM_ALLOWED_DISRUPTION_SEC
 from tests.common.dualtor.dual_tor_common import cable_type                                         # noqa F401

--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 import pytest
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory, change_mac_addresses   # noqa F401
+from tests.common.fixtures.ptfhost_utils import  change_mac_addresses   # noqa F401
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)

--- a/tests/pfc_asym/conftest.py
+++ b/tests/pfc_asym/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 
 from tests.common.fixtures.conn_graph_facts import fanout_graph_facts       # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory     # noqa F401
 
 

--- a/tests/pfcwd/conftest.py
+++ b/tests/pfcwd/conftest.py
@@ -4,7 +4,6 @@ import os
 import os.path
 
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts         # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 from tests.common.fixtures.ptfhost_utils import pause_garp_service          # noqa F401

--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -2,7 +2,6 @@ import pytest
 import logging
 import random
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses            # noqa F401
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db    # noqa F401
 from tests.common.fixtures.advanced_reboot import get_advanced_reboot           # noqa F401

--- a/tests/platform_tests/test_cont_warm_reboot.py
+++ b/tests/platform_tests/test_cont_warm_reboot.py
@@ -11,11 +11,10 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.reboot import get_reboot_cause
 from tests.common.fixtures.advanced_reboot import AdvancedReboot
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa F401
 
-from tests.common.platform.device_utils import RebootHealthError,\
-    check_services, check_interfaces_and_transceivers, check_neighbors,\
+from tests.common.platform.device_utils import RebootHealthError, \
+    check_services, check_interfaces_and_transceivers, check_neighbors, \
     verify_no_coredumps, handle_test_error
 from tests.platform_tests.verify_dut_health import wait_until_uptime, get_test_report
 

--- a/tests/platform_tests/test_service_warm_restart.py
+++ b/tests/platform_tests/test_service_warm_restart.py
@@ -5,7 +5,6 @@ from tests.common.fixtures.advanced_reboot import get_advanced_reboot       # no
 from tests.common.helpers.assertions import pytest_require
 from tests.common.utilities import skip_release
 from tests.common.platform.device_utils import verify_dut_health         # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa F401
 from tests.common.platform.device_utils import advanceboot_loganalyzer # noqa F401
 
 pytestmark = [

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -30,7 +30,6 @@ from tabulate import tabulate
 from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, conn_graph_facts, get_graph_facts    # noqa F401
 from tests.common.fixtures.duthost_utils import dut_qos_maps, \
     separated_dscp_to_tc_map_on_uplink, load_dscp_to_pg_map                                 # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                            # noqa F401

--- a/tests/qos/test_tunnel_qos_remap.py
+++ b/tests/qos/test_tunnel_qos_remap.py
@@ -3,7 +3,6 @@ import pytest
 import time
 from ptf.mask import Mask
 import ptf.packet as scapy
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder        # noqa F401

--- a/tests/testbed_setup/test_populate_fdb.py
+++ b/tests/testbed_setup/test_populate_fdb.py
@@ -1,6 +1,5 @@
 import pytest
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx')

--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -12,7 +12,6 @@ from tests.common.helpers.upgrade_helpers import SYSTEM_STABILIZE_MAX_TIME, chec
     check_services, install_sonic, multi_hop_warm_upgrade_test_helper, restore_image                    # noqa F401
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db                            # noqa F401
 from tests.upgrade_path.utilities import cleanup_prev_images, boot_into_base_image
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa F401
 
 pytestmark = [
     pytest.mark.topology('any'),

--- a/tests/upgrade_path/test_upgrade_path.py
+++ b/tests/upgrade_path/test_upgrade_path.py
@@ -9,7 +9,6 @@ from tests.common.fixtures.consistency_checker.consistency_checker import consis
 from tests.common.platform.device_utils import verify_dut_health, verify_testbed_health    # noqa F401
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db    # noqa F401
 from tests.common.platform.device_utils import advanceboot_loganalyzer, advanceboot_neighbor_restore # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1551,14 +1551,14 @@ class TestVrfUnbindIntf():
             "ip addr show {}".format(PORTCHANNEL_TEMP_1))['stdout']
         for ver, ips in list(g_vars['vrf_intfs']['Vrf1'][PORTCHANNEL_TEMP_1].items()):
             for ip in ips:
-                assert str(ip) not in ip_addr_show,\
+                assert str(ip) not in ip_addr_show, \
                     "The ip addresses on {} should be flushed after unbind from vrf.".format(PORTCHANNEL_TEMP_1)
 
     def test_pc1_neigh_flushed(self, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
         # verify ipv4
         show_arp = duthost.shell("show arp")['stdout']
-        assert PORTCHANNEL_TEMP_1 not in show_arp,\
+        assert PORTCHANNEL_TEMP_1 not in show_arp, \
             "The arps on {} should be flushed after unbind from vrf.".format(PORTCHANNEL_TEMP_1)
 
         # FIXME
@@ -1702,13 +1702,13 @@ class TestVrfDeletion():
     def test_pc1_ip_addr_flushed(self, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
         show_interfaces = duthost.shell("show ip interfaces")['stdout']
-        assert PORTCHANNEL_TEMP_1 not in show_interfaces,\
+        assert PORTCHANNEL_TEMP_1 not in show_interfaces, \
             "The ip addr of {} should be flushed after Vrf1 is deleted.".format(PORTCHANNEL_TEMP_1)
 
     def test_pc2_ip_addr_flushed(self, duthosts, rand_one_dut_hostname):
         duthost = duthosts[rand_one_dut_hostname]
         show_interfaces = duthost.shell("show ip interfaces")['stdout']
-        assert PORTCHANNEL_TEMP_2 not in show_interfaces,\
+        assert PORTCHANNEL_TEMP_2 not in show_interfaces, \
             "The ip addr of {} should be flushed after Vrf1 is deleted.".format(PORTCHANNEL_TEMP_2)
 
     def test_vlan1000_ip_addr_flushed(self, duthosts, rand_one_dut_hostname):

--- a/tests/vxlan/test_vxlan_crm.py
+++ b/tests/vxlan/test_vxlan_crm.py
@@ -5,7 +5,6 @@ from functools import reduce
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_on_duts    # noqa F401
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 from tests.vxlan.test_vxlan_ecmp import (   # noqa: F401
     Test_VxLAN,

--- a/tests/wan/lacp/test_wan_lag_member.py
+++ b/tests/wan/lacp/test_wan_lag_member.py
@@ -8,7 +8,6 @@ import sys
 from tests.common.utilities import wait
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.ptf_runner import ptf_runner
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa F401
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR

Summary:
This PR refines test case behavior by removing redundant PTF fixture imports and implementing a more efficient skip logic for test files. It ensures that only test cases using PTF files import the fixture, reducing unnecessary overhead and improving pipeline clarity.

Fixes # (issue)
N/A

### Type of change

<!--
- Fill x for your type of change.
-->

- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach

#### What is the motivation for this PR?
To reduce pipeline noise and prevent PR checker failures caused by unnecessary PTF fixture imports in test cases that do not use PTF files.

#### How did you do it?
- Audited test cases to identify those importing the PTF fixture without using it.
- Removed the fixture from those test cases.
- Added logic to skip tests gracefully when PTF is not applicable.

#### How did you verify/test it?
- Verified that only relevant tests import the PTF fixture and others are skipped cleanly.

#### Any platform specific information?
No platform-specific changes.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation

N/A – This is a test case improvement and does not require documentation updates.
