### PR TITLE
[XFAIL: test_crm_available.py] set xfail of test_crm_available on dualtor platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -352,6 +352,12 @@ crm/test_crm.py::test_crm_fdb_entry:
     conditions:
       - "'t0' not in topo_name and topo_type not in ['m0', 'mx']"
 
+crm/test_crm_available.py:
+  xfail:
+    reason: "There is a known issue with broadcom dualtor"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/18873 and 'dualtor' in topo_name and asic_type in ['broadcom']"
+
 #######################################
 #####           dash              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
https://github.com/sonic-net/sonic-mgmt/issues/18873

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To xfail test_crm_available, which has a known issue on broadcom dualtor platform. 

#### How did you do it?
Add xfail in tests_mark_conditions.yaml

#### How did you verify/test it?
Run test on dualtor platform
=================================================================================================================== short test summary info ====================================================================================================================
XFAIL crm/test_crm_available.py::test_crm_next_hop_group[bjw-can-7260-16-None] - There is a known issue with broadcom dualtor

#### Any platform specific information?
Broadcom dualtor platform


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
