### PR TITLE
Fix Incorrect Filter logic in candidate_ports

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -56,8 +56,9 @@ def build_candidate_ports(duthost, tbinfo, ns):
             continue
         ptf_idx = mg_facts["minigraph_ptf_indices"][dut_port]
 
-        if candidate_neigh_name in neigh['name'] and len(candidate_ports) < 4 and i % 2:
-            candidate_ports.update({dut_port: ptf_idx})
+        if candidate_neigh_name in neigh['name'] and len(candidate_ports) < 4:
+            if candidate_neigh_name == 'T0' or i % 2:
+                candidate_ports.update({dut_port: ptf_idx})
         if len(unselected_ports) < 4 and dut_port not in candidate_ports:
             unselected_ports.update({dut_port: ptf_idx})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix for candidate port selection logic in build_candidate_ports fixture in test_everflow_per_interface.py.

In the SONiC PTF test logic for selecting candidate DUT ports "build_candidate_ports" based on topology neighbor types, the current implementation applies a hardcoded index-based filter (i % 2) while selecting neighbor ports. This logic was introduced to suit specific topologies (e.g., T2) but unintentionally excludes valid neighbor ports for other topologies like T1, where neighbor entries may reside at even indices.

As a result, candidate port selection fails for T1 topology due to incorrect filtering logic, leading to either insufficient port coverage or failed test initialization.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18876 issue

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To execute the 2 cases in test_everflow_per_interface.py and currently it is skipped for T1 topo due to insufficient ports.
#### How did you do it?
Added filter logic only for applicable candidate neighbors

#### How did you verify/test it?
By running everflow test:

everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-default] PASSED
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-default] PASSED
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
