### PR TITLE
[Snappi] - Test Changes to support dynamic port selection for PFC pau…

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py
@@ -3,13 +3,11 @@ from tests.common.helpers.assertions import pytest_require, pytest_assert       
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    snappi_api, snappi_dut_base_config, get_snappi_ports_for_rdma, cleanup_config, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
-    get_snappi_ports_multi_dut, is_snappi_multidut, \
-    get_snappi_ports                                         # noqa: F401
+    get_snappi_ports_multi_dut, is_snappi_multidut, snappi_port_selection, tgen_port_info, \
+    snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config  # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
     lossy_prio_list                         # noqa F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED   # noqa: F401
 from tests.snappi_tests.pfc.files.helper import run_pfc_test
 import logging
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
@@ -20,7 +18,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='module')
 def number_of_tx_rx_ports():
     yield (1, 1)
 
@@ -36,7 +34,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
                                      lossless_prio_list,        # noqa: F811
                                      get_snappi_ports,          # noqa: F811
                                      tbinfo,                    # noqa: F811
-                                     setup_ports_and_dut        # noqa: F811
+                                     tgen_port_info        # noqa: F811
                                      ):
     """
     Test if PFC will impact a single lossy priority in multidut setup
@@ -56,7 +54,7 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     _, lossy_prio = enum_one_dut_lossy_prio.split('|')
     lossy_prio = int(lossy_prio)
@@ -64,7 +62,6 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
     test_prio_list = [lossy_prio]
     bg_prio_list = [p for p in all_prio_list]
     bg_prio_list.remove(lossy_prio)
-
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
 
@@ -72,21 +69,23 @@ def test_pfc_pause_single_lossy_prio(snappi_api,                # noqa: F811
 
     if snappi_ports[0]['asic_type'] == 'cisco-8000' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params,
-                 flow_factor=flow_factor)
+    try:
+        run_pfc_test(api=snappi_api,
+                    testbed_config=testbed_config,
+                    port_config_list=port_config_list,
+                    conn_data=conn_graph_facts,
+                    fanout_data=fanout_graph_facts_multidut,
+                    global_pause=False,
+                    pause_prio_list=pause_prio_list,
+                    test_prio_list=test_prio_list,
+                    bg_prio_list=bg_prio_list,
+                    prio_dscp_map=prio_dscp_map,
+                    test_traffic_pause=False,
+                    test_flow_is_lossless=False,
+                    snappi_extra_params=snappi_extra_params,
+                    flow_factor=flow_factor)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
@@ -98,7 +97,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
                                     lossless_prio_list,              # noqa: F811
                                     get_snappi_ports,         # noqa: F811
                                     tbinfo,                # noqa: F811
-                                    setup_ports_and_dut):                 # noqa: F811
+                                    tgen_port_info):                 # noqa: F811
     """
     Test if PFC will impact multiple lossy priorities in multidut setup
 
@@ -115,7 +114,7 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
@@ -128,21 +127,23 @@ def test_pfc_pause_multi_lossy_prio(snappi_api,             # noqa: F811
 
     if snappi_ports[0]['asic_type'] == 'cisco-8000' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
-
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params,
-                 flow_factor=flow_factor)
+    try:
+        run_pfc_test(api=snappi_api,
+                    testbed_config=testbed_config,
+                    port_config_list=port_config_list,
+                    conn_data=conn_graph_facts,
+                    fanout_data=fanout_graph_facts_multidut,
+                    global_pause=False,
+                    pause_prio_list=pause_prio_list,
+                    test_prio_list=test_prio_list,
+                    bg_prio_list=bg_prio_list,
+                    prio_dscp_map=prio_dscp_map,
+                    test_traffic_pause=False,
+                    test_flow_is_lossless=False,
+                    snappi_extra_params=snappi_extra_params,
+                    flow_factor=flow_factor)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -158,7 +159,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
                                             lossless_prio_list,     # noqa: F811
                                             get_snappi_ports,       # noqa: F811
                                             tbinfo,                 # noqa: F811
-                                            setup_ports_and_dut,    # noqa: F811
+                                            tgen_port_info,    # noqa: F811
                                             reboot_duts):           # noqa: F811
     """
     Test if PFC will impact a single lossy priority after various kinds of reboots in multidut setup
@@ -179,7 +180,7 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     _, lossy_prio = enum_one_dut_lossy_prio_with_completeness_level.split('|')
     lossy_prio = int(lossy_prio)
@@ -196,20 +197,23 @@ def test_pfc_pause_single_lossy_prio_reboot(snappi_api,             # noqa: F811
     if snappi_ports[0]['asic_type'] == 'cisco-8000' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params,
-                 flow_factor=flow_factor)
+    try:
+        run_pfc_test(api=snappi_api,
+                    testbed_config=testbed_config,
+                    port_config_list=port_config_list,
+                    conn_data=conn_graph_facts,
+                    fanout_data=fanout_graph_facts_multidut,
+                    global_pause=False,
+                    pause_prio_list=pause_prio_list,
+                    test_prio_list=test_prio_list,
+                    bg_prio_list=bg_prio_list,
+                    prio_dscp_map=prio_dscp_map,
+                    test_traffic_pause=False,
+                    test_flow_is_lossless=False,
+                    snappi_extra_params=snappi_extra_params,
+                    flow_factor=flow_factor)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
 
 @pytest.mark.disable_loganalyzer
@@ -223,7 +227,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
                                            lossless_prio_list,   # noqa: F811
                                            get_snappi_ports,     # noqa: F811
                                            tbinfo,               # noqa: F811
-                                           setup_ports_and_dut,  # noqa: F811
+                                           tgen_port_info,  # noqa: F811
                                            reboot_duts):         # noqa: F811
     """
     Test if PFC will impact multiple lossy priorities after various kinds of reboots
@@ -244,7 +248,7 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     pause_prio_list = lossy_prio_list
     test_prio_list = lossy_prio_list
@@ -257,18 +261,21 @@ def test_pfc_pause_multi_lossy_prio_reboot(snappi_api,          # noqa: F811
 
     if snappi_ports[0]['asic_type'] == 'cisco-8000' and int(snappi_ports[0]['speed']) > 200000:
         flow_factor = int(snappi_ports[0]['speed']) / 200000
+    try:
+        run_pfc_test(api=snappi_api,
+                    testbed_config=testbed_config,
+                    port_config_list=port_config_list,
+                    conn_data=conn_graph_facts,
+                    fanout_data=fanout_graph_facts_multidut,
+                    global_pause=False,
+                    pause_prio_list=pause_prio_list,
+                    test_prio_list=test_prio_list,
+                    bg_prio_list=bg_prio_list,
+                    prio_dscp_map=prio_dscp_map,
+                    test_traffic_pause=False,
+                    test_flow_is_lossless=False,
+                    snappi_extra_params=snappi_extra_params,
+                    flow_factor=flow_factor)
+    finally:
+        cleanup_config(duthosts, snappi_ports)
 
-    run_pfc_test(api=snappi_api,
-                 testbed_config=testbed_config,
-                 port_config_list=port_config_list,
-                 conn_data=conn_graph_facts,
-                 fanout_data=fanout_graph_facts_multidut,
-                 global_pause=False,
-                 pause_prio_list=pause_prio_list,
-                 test_prio_list=test_prio_list,
-                 bg_prio_list=bg_prio_list,
-                 prio_dscp_map=prio_dscp_map,
-                 test_traffic_pause=False,
-                 test_flow_is_lossless=False,
-                 snappi_extra_params=snappi_extra_params,
-                 flow_factor=flow_factor)


### PR DESCRIPTION
…se lossy

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)https://github.com/sonic-net/sonic-mgmt/issues/13769
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To support infra changes in snappi tests introduced by this Pull Request - https://github.com/sonic-net/sonic-mgmt/pull/15069
#### How did you do it?
We don't need the setup_ports_and_dut now and we can simply call the snappi_testbed_config in the test itself and iterate through the available ports.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
# OUTPUT
snappi_tests/pfc/test_pfc_pause_lossy_with_snappi.py::test_pfc_pause_single_lossy_prio[multidut_port_info0-sonic-s6100-dut1|0-400.0-single_linecard_single_asic] 
----------------------------------------------------------------------------------------------------------------------------------------- live log setup ------------------------------------------------------------------------------------------------------------------------------------------
16:01:24 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
16:01:24 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
16:01:24 conftest.enhance_inventory               L0313 INFO   | Inventory file: ['../ansible/snappi-sonic']
16:01:27 ptfhost_utils.run_icmp_responder_session L0310 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
16:01:27 __init__._sanity_check                   L0431 INFO   | Skip sanity check according to command line argument
16:01:27 conftest.collect_before_test             L2695 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
16:01:28 conftest.collect_before_test             L2699 INFO   | Collecting core dumps before test on sonic-s6100-dut1
16:01:28 conftest.collect_before_test             L2708 INFO   | Collecting running config before test on sonic-s6100-dut1
16:01:30 conftest.temporarily_disable_route_check L2974 INFO   | Skipping temporarily_disable_route_check fixture
16:01:30 conftest.generate_params_dut_hostname    L1498 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
16:01:30 conftest.set_rand_one_dut_hostname       L0647 INFO   | Randomly select dut sonic-s6100-dut1 for testing
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture disable_voq_watchdog setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture disable_voq_watchdog setup ends --------------------
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture number_of_tx_rx_ports setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture number_of_tx_rx_ports setup ends --------------------
16:01:30 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
16:01:30 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
16:01:30 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
16:01:30 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
16:01:30 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
16:01:30 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
16:01:31 conftest.rand_one_dut_front_end_hostname L0683 INFO   | Randomly select dut sonic-s6100-dut1 for testing
16:01:31 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture prio_dscp_map setup starts --------------------
16:01:32 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture prio_dscp_map setup ends --------------------
16:01:32 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture all_prio_list setup starts --------------------
16:01:32 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture all_prio_list setup ends --------------------
16:01:32 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossless_prio_list setup starts --------------------
16:01:33 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossless_prio_list setup ends --------------------
16:01:33 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossy_prio_list setup starts --------------------
16:01:33 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossy_prio_list setup ends --------------------
16:01:33 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
16:01:34 conftest.generate_port_lists             L1590 INFO   | Generate dut_port_map: {'sonic-s6100-dut1': ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet8', 'sonic-s6100-dut1|Ethernet16', 'sonic-s6100-dut1|Ethernet24']}
16:01:34 conftest.generate_port_lists             L1613 INFO   | Generate port_list: ['sonic-s6100-dut1|Ethernet0', 'sonic-s6100-dut1|Ethernet8', 'sonic-s6100-dut1|Ethernet16', 'sonic-s6100-dut1|Ethernet24']
16:01:34 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
16:01:34 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
16:01:34 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
16:01:34 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_port_selection setup starts --------------------
16:01:34 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_port_selection setup ends --------------------
16:01:34 __init__.loganalyzer                     L0074 INFO   | Log analyzer is disabled
16:01:34 __init__.memory_utilization              L0125 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Accton-AS9716-32D, Platform: x86_64-accton_as9716_32d-r0
16:01:34 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit status, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'value', 'value': 10}, 'memory_high_threshold': {'type': 'value', 'value': 70}}}, memory_check=<function parse_monit_status_output at 0x7f9baa8983a0>
16:01:34 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 64}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f9baa88cd30>
16:01:34 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f9baa898310>
16:01:34 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'value', 'value': 5}, 'memory_high_threshold': {'type': 'value', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'value', 'value': 4}, 'memory_high_threshold': {'type': 'value', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'value', 'value': 3}, 'memory_high_threshold': {'type': 'value', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'value', 'value': 2}, 'memory_high_threshold': {'type': 'value', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f9baa898430>
16:01:34 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 32}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f9baa8984c0>
16:01:34 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 16}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f9baa8984c0>
16:01:34 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture multidut_port_info setup starts --------------------
16:01:34 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture multidut_port_info setup ends --------------------
16:01:34 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture setup_ports_and_dut setup starts --------------------
16:01:34 helper.setup_ports_and_dut               L0152 INFO   | Running test for testbed subtype: single-dut-single-asic
16:01:34 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture setup_ports_and_dut setup ends --------------------
16:01:34 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture tgen_port_info setup starts --------------------
16:01:35 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture tgen_port_info setup ends --------------------
16:01:40 memory_utilization.execute_command       L0039 WARNING| Command 'vtysh -c "show memory bgp"' returned no output
16:01:40 memory_utilization.parse_frr_memory_outp L0481 WARNING| Empty output for FRR memory command, returning empty values
16:01:41 memory_utilization.execute_command       L0039 WARNING| Command 'vtysh -c "show memory zebra"' returned no output
16:01:41 memory_utilization.parse_frr_memory_outp L0481 WARNING| Empty output for FRR memory command, returning empty values
16:01:41 __init__.pytest_runtest_setup            L0061 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 7.8}, 'top': {}, 'free': {'used': 1988}, 'docker': {'radv': '0.24', 'syncd': '3.76', 'teamd': '0.26', 'swss': '0.60', 'pmon': '0.76', 'database': '0.88', 'bgp': '0.03', 'lldp': '0.10'}, 'frr_bgp': {}, 'frr_zebra': {}}}, 'after_test': {'sonic-s6100-dut1': {}}}
------------------------------------------------------------------------------------------------------------------------------------------ live log call ------------------------------------------------------------------------------------------------------------------------------------------
16:01:54 connection._warn                         L0336 WARNING| Verification of certificates is disabled
16:01:54 connection._info                         L0333 INFO   | Determining the platform and rest_port using the 10.36.79.8 address...
16:01:54 connection._warn                         L0336 WARNING| Unable to connect to http://10.36.79.8:443.
16:01:55 connection._info                         L0333 INFO   | Connection established to `https://10.36.79.8:443 on linux`
16:02:14 connection._info                         L0333 INFO   | Using IxNetwork api server version 10.25.2406.6
16:02:14 connection._info                         L0333 INFO   | User info IxNetwork/ixnetworkweb/admin-162-10063
16:02:16 snappi_api.info                          L1488 INFO   | snappi-1.31.1
16:02:16 snappi_api.info                          L1488 INFO   | snappi_ixnetwork-1.31.2
16:02:16 snappi_api.info                          L1488 INFO   | ixnetwork_restpy-1.7.0
16:02:16 snappi_api.info                          L1488 INFO   | Config validation 0.020s
16:02:19 snappi_api.info                          L1488 INFO   | Ports configuration 1.715s
16:02:19 snappi_api.info                          L1488 INFO   | Captures configuration 0.200s
16:02:22 snappi_api.info                          L1488 INFO   | Add location hosts [10.36.79.8] 2.336s
16:02:24 snappi_api.info                          L1488 INFO   | Location hosts ready [10.36.79.8] 2.482s
16:02:25 snappi_api.info                          L1488 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'aresOneOneByFourHundredGigNonFanOut'), ('Port 1', 'aresOneOneByFourHundredGigNonFanOut')]
16:02:25 snappi_api.info                          L1488 INFO   | Aggregation mode speed change 0.412s
16:02:25 snappi_api.info                          L1488 INFO   | Location preemption [10.36.79.8/3, 10.36.79.8/1] 0.143s
16:02:42 snappi_api.info                          L1488 INFO   | Location connect [Port 0, Port 1] 16.540s
16:02:42 snappi_api.info                          L1488 INFO   | Location state check [Port 0, Port 1] 0.363s
16:02:42 snappi_api.info                          L1488 INFO   | Location configuration 23.254s
16:02:46 snappi_api.info                          L1488 INFO   | Layer1 configuration 3.795s
16:02:46 snappi_api.info                          L1488 INFO   | Lag Configuration 0.157s
16:02:47 snappi_api.info                          L1488 INFO   | Convert device config : 0.325s
16:02:47 snappi_api.info                          L1488 INFO   | Create IxNetwork device config : 0.000s
16:02:48 snappi_api.info                          L1488 INFO   | Push IxNetwork device config : 0.963s
16:02:48 snappi_api.info                          L1488 INFO   | Devices configuration 1.391s
16:02:56 snappi_api.info                          L1488 INFO   | Flows configuration 8.034s
16:03:03 snappi_api.info                          L1488 INFO   | Start interfaces 7.636s
16:03:04 snappi_api.info                          L1488 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
16:03:04 traffic_generation.run_traffic           L0433 INFO   | Wait for Arp to Resolve ...
16:03:10 traffic_generation.run_traffic           L0456 INFO   | Starting transmit on all flows ...
16:03:14 snappi_api.info                          L1488 INFO   | Flows generate/apply 3.528s
16:03:27 snappi_api.info                          L1488 INFO   | Flows clear statistics 12.289s
16:03:27 snappi_api.info                          L1488 INFO   | Captures start 0.000s
16:03:30 snappi_api.info                          L1488 INFO   | Flows start 2.733s
16:03:30 traffic_generation.run_traffic           L0472 INFO   | Polling DUT for traffic statistics for 23 seconds ...
16:03:57 traffic_generation.run_traffic           L0491 INFO   | Polling TGEN for in-flight traffic statistics...
16:03:59 traffic_generation.run_traffic           L0496 INFO   | In-flight traffic statistics for flows: ['Test Flow Prio 0', 'Background Flow Prio 1', 'Background Flow Prio 3', 'Background Flow Prio 4', 'Background Flow Prio 5', 'Background Flow Prio 6', 'Background Flow Prio 2']
16:03:59 traffic_generation.run_traffic           L0497 INFO   | In-flight TX frames: [409482758, 63697318, 63697318, 63697318, 63697318, 63697318, 63697318]
16:03:59 traffic_generation.run_traffic           L0498 INFO   | In-flight RX frames: [409482758, 63697318, 63697318, 63697318, 63697318, 63697318, 63697318]
16:04:16 traffic_generation.run_traffic           L0499 INFO   | DUT polling complete
16:04:16 traffic_generation.run_traffic           L0510 INFO   | Checking if all flows have stopped. Attempt #1
16:04:18 traffic_generation.run_traffic           L0517 INFO   | All test and background traffic flows stopped
16:04:20 traffic_generation.run_traffic           L0540 INFO   | Dumping per-flow statistics
16:04:21 traffic_generation.run_traffic           L0542 INFO   | Stopping transmit on all remaining flows
16:04:26 snappi_api.info                          L1488 INFO   | Flows stop 5.387s
PASSED       