### PR TITLE
[Snappi][Broadcom-DNX]:New ECN testcases for Broadcom-DNX platforms

### DIFF
--- a/tests/snappi_tests/ecn/files/restpy_multidut_helper.py
+++ b/tests/snappi_tests/ecn/files/restpy_multidut_helper.py
@@ -227,10 +227,10 @@ def run_ecn_traffic(duthost,
 
     if pcap_type != packet_capture.NO_CAPTURE:
         logger.info("Starting packet capture ...")
-        cs = api.capture_state()
-        cs.port_names = snappi_extra_params.packet_capture_ports
-        cs.state = cs.START
-        api.set_capture_state(cs)
+        cs = api.control_state()
+        cs.port.capture.port_names = snappi_extra_params.packet_capture_ports
+        cs.port.capture.state = cs.port.capture.START
+        api.set_control_state(cs)
 
     logger.info('Clearing DUT interfaces, queue and drop counters')
     device_list = []
@@ -254,9 +254,9 @@ def run_ecn_traffic(duthost,
         logger.info("Stopping packet capture ...")
         request = api.capture_request()
         request.port_name = snappi_extra_params.packet_capture_ports[0]
-        cs = api.capture_state()
-        cs.state = cs.STOP
-        api.set_capture_state(cs)
+        cs = api.control_state()
+        cs.port.capture.state = cs.port.capture.STOP
+        api.set_control_state(cs)
         logger.info("Retrieving and saving packet capture to {}.pcapng".format(snappi_extra_params.packet_capture_file))
         pcap_bytes = api.get_capture(request)
         with open(snappi_extra_params.packet_capture_file + ".pcapng", 'wb') as fid:

--- a/tests/snappi_tests/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
+++ b/tests/snappi_tests/ecn/test_multidut_dequeue_ecn_brcm_dnx.py
@@ -75,11 +75,7 @@ def test_dequeue_ecn(request,
         pytest.skip("Test is specific to Broadcom-DNX platform. Skipping for other platforms.")
 
     # Selecting Tx and Rx ports for the test based on port_map definitions.
-    multidut_port_info = tgen_port_info
-    logger.info('Ports:{}'.format(multidut_port_info))
-
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
-            duthosts, multidut_port_info, snappi_api, setup=True)
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     # Selecting lossless priority for the test.
     lossless_prio = random.sample(lossless_prio_list, 1)[0]
@@ -183,11 +179,7 @@ def test_dequeue_ecn_default(request,
         pytest.skip("Test is specific to Broadcom-DNX platform. Skipping for other platforms.")
 
     # Selecting Tx and Rx ports for the test based on port_map definitions.
-    multidut_port_info = tgen_port_info
-    logger.info('Ports:{}'.format(multidut_port_info))
-
-    testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
-            duthosts, multidut_port_info, snappi_api, setup=True)
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
 
     # Selecting lossless priority for the test.
     lossless_prio = random.sample(lossless_prio_list, 1)[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The original ECN dequeue test case has Kmin and Kmax to 50k and 51k respectively. This leaves only a single packet gap between Kmin and Kmax values (with packet-size of 1024B), and hence difficult to test congestion testcases.

(1)
Based on discussion, we changed the test case setting of Kmin and Kmax to 800k and 2000k, Now the test will have different packet counts - namely 800, 1600, and 2400 packets of 1024B.

New test case is specifically meant for Broadcom-DNX platform and ensures that packets in range of Kmin-Kmax have the ECN marking probability less than or equal to Pmax.

Test also uses range of Pmax values to ensure that different ECN marking probability works for different Pmax values.

There is an associated README file also created to explain in more detail about the testcase.

(2)
Second testcase does not change the default Kmin, Kmax and Pmax parameters. With default ECN parameters, around 8500 packets (1024B) are sent and checked for ECN marking to adhere the ECN marking probability.

(3) 
Restpy is used for capturing and analyzing the packets. Existing Snappi infrastructure allows to capture only 1024 packets of 1024B, hence, slicing needs to be enabled on IXIA to capture wider range of packets. Hence, use of restpy.

(4)
The new support for dynamic port selection is also incorporated.

Summary:
Fixes #12903 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Based on the platform - Broadcom-DNX, the kmin, kmax values are set to 800k and 2000k respectively and the packets are checked with offset for congestion.

Original ECN dequeue test is pristine and has no changes whatsoever. We will need another PR maybe to exclude it for the test runs on Broadcom-DNX platforms.

#### How did you verify/test it?
Tested on 100 and 400G Broadcom-DNX platforms.

#### Any platform specific information?
Test is ONLY applicable for Broadcom-DNX platforms. It will be skipped for other platforms.

#### Supported testbed topology if it's a new test case?
T2 topology ONLY.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
