### PR TITLE
Change to do string comparison with white-space ignorance in gcu/test_k8s_config.py

### DIFF
--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -208,6 +208,13 @@ def setup_env(duthosts, rand_one_dut_hostname):
         delete_checkpoint(duthost)
 
 
+def compare_strings_ignore_whitespace(s1, s2):
+    # Remove all whitespace characters using regex
+    s1_clean = re.sub(r'\s+', '', s1)
+    s2_clean = re.sub(r'\s+', '', s2)
+    return s1_clean == s2_clean
+
+
 def get_k8s_runningconfig(duthost):
     """ Get k8s config from running config
     Sample output: K8SEMPTYCONFIG, K8SHALFCONFIG, K8SFULLCONFIG
@@ -277,8 +284,11 @@ def k8s_config_update(duthost, test_data):
                 expect_op_failure(output)
 
             k8s_config = get_k8s_runningconfig(duthost)
+            consistent = True
+            for i in range(len(k8s_config)):
+                consistent = consistent and compare_strings_ignore_whitespace(k8s_config[i], target_config[i])
             pytest_assert(
-                k8s_config == target_config,
+                consistent,
                 f"Failed to run num.{num+1} test case to update k8s config."
             )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Previously, GCU/test_k8s_config.py failed on multi-asic kvm pr checker because of white space difference in stdout. To fix this issue, I changed the code to do string comparison with white-space ignorance.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
