### PR TITLE
Enable Impacted Area Based PR Testing for sonic-buildimage

### DIFF
--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -1,82 +1,87 @@
 steps:
-- script: |
-    set -x
+  - script: |
+      set -x
 
-    git fetch --all
-    DIFF_FOLDERS=$(git diff $(git merge-base origin/${{ parameters.BUILD_BRANCH }} HEAD)..HEAD  --name-only | xargs -n1 dirname | sort -u | tr '\n' ' ')
+      git fetch --all
+      DIFF_FOLDERS=$(git diff $(git merge-base origin/${{ parameters.BUILD_BRANCH }} HEAD)..HEAD  --name-only | xargs -n1 dirname | sort -u | tr '\n' ' ')
 
-    if [[ $? -ne 0 ]]; then
-      echo "##vso[task.complete result=Failed;]Get diff folders fails."
-      exit 1
-    else
-      echo -n "##vso[task.setvariable variable=DIFF_FOLDERS]$DIFF_FOLDERS"
-    fi
-
-  continueOnError: false
-  displayName: "Get diff folders"
-
-- script: |
-    set -x
-
-    pip install PyYAML
-    pip install natsort
-
-    sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
-
-    FINAL_FEATURES=""
-    IFS=' ' read -ra FEATURES_LIST <<< "$(DIFF_FOLDERS)"
-
-    # Define the list of folders include common features
-    COMMON_DIRS=("tests/common" "tests/scripts")
-
-    for FEATURE in "${FEATURES_LIST[@]}"
-    do
-      for COMMON_DIR in "${COMMON_DIRS[@]}"; do
-        if [[ "$FEATURE" == *$COMMON_DIR* ]]; then
-          FINAL_FEATURES=""
-          break 2
-        fi
-      done
-
-      # If changes only limited to specific feature, the scope of PR testing is impacted area.
-      if [[ "$FEATURE" =~ ^tests\/.* ]]; then
-        # Cut the feature path
-        if [[ $FEATURE == */*/* ]]; then
-            FEATURE=$(echo "$FEATURE" | cut -d'/' -f1-2)
-        fi
-
-        FEATURE=${FEATURE#tests/}
-
-        if [[ -z "$FINAL_FEATURES" ]]; then
-          FINAL_FEATURES="$FEATURE"
-        elif [[ ! "$FINAL_FEATURES" == *$FEATURE* ]]; then
-          FINAL_FEATURES="$FINAL_FEATURES,$FEATURE"
-        fi
-
-      # If changes related to other folders excpet tests, we also consider them as common part.
-      # The scope of PR testing is all test scripts.
+      if [[ $? -ne 0 ]]; then
+        echo "##vso[task.complete result=Failed;]Get diff folders fails."
+        exit 1
       else
-        FINAL_FEATURES=""
-        break
+        echo -n "##vso[task.setvariable variable=DIFF_FOLDERS]$DIFF_FOLDERS"
       fi
-    done
 
-    TEST_SCRIPTS=$(python ./.azure-pipelines/impacted_area_testing/get_test_scripts.py --features ${FINAL_FEATURES} --location tests)
+    continueOnError: false
+    displayName: "Get diff folders"
 
-    if [[ $? -ne 0 ]]; then
-      echo "##vso[task.complete result=Failed;]Get test scripts fails."
-      exit 1
-    fi
+  - script: |
+      set -x
 
-    PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
+      pip install PyYAML
+      pip install natsort
 
-    if [[ $? -ne 0 ]]; then
-      echo "##vso[task.complete result=Failed;]Get valid PR checkers fails."
-      exit 1
-    fi
+      sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
-    echo "##vso[task.setvariable variable=PR_CHECKERS;isOutput=true]$PR_CHECKERS"
-    echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
-  name: SetVariableTask
-  continueOnError: false
-  displayName: "Get impacted area"
+      FINAL_FEATURES=""
+      IFS=' ' read -ra FEATURES_LIST <<< "$(DIFF_FOLDERS)"
+
+      # Define the list of folders include common features
+      COMMON_DIRS=("tests/common" "tests/scripts")
+
+      if [[ "$(BUILD.REPOSITORY.NAME)" = "sonic-net/sonic-buildimage" ]]; then
+        FINAL_FEATURES=""
+
+      else
+        for FEATURE in "${FEATURES_LIST[@]}"
+        do
+          for COMMON_DIR in "${COMMON_DIRS[@]}"; do
+            if [[ "$FEATURE" == *$COMMON_DIR* ]]; then
+              FINAL_FEATURES=""
+              break 2
+            fi
+          done
+
+          # If changes only limited to specific feature, the scope of PR testing is impacted area.
+          if [[ "$FEATURE" =~ ^tests\/.* ]]; then
+            # Cut the feature path
+            if [[ $FEATURE == */*/* ]]; then
+                FEATURE=$(echo "$FEATURE" | cut -d'/' -f1-2)
+            fi
+
+            FEATURE=${FEATURE#tests/}
+
+            if [[ -z "$FINAL_FEATURES" ]]; then
+              FINAL_FEATURES="$FEATURE"
+            elif [[ ! "$FINAL_FEATURES" == *$FEATURE* ]]; then
+              FINAL_FEATURES="$FINAL_FEATURES,$FEATURE"
+            fi
+
+          # If changes related to other folders excpet tests, we also consider them as common part.
+          # The scope of PR testing is all test scripts.
+          else
+            FINAL_FEATURES=""
+            break
+          fi
+        done
+      fi
+
+      TEST_SCRIPTS=$(python ./.azure-pipelines/impacted_area_testing/get_test_scripts.py --features ${FINAL_FEATURES} --location tests)
+
+      if [[ $? -ne 0 ]]; then
+        echo "##vso[task.complete result=Failed;]Get test scripts fails."
+        exit 1
+      fi
+
+      PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
+
+      if [[ $? -ne 0 ]]; then
+        echo "##vso[task.complete result=Failed;]Get valid PR checkers fails."
+        exit 1
+      fi
+
+      echo "##vso[task.setvariable variable=PR_CHECKERS;isOutput=true]$PR_CHECKERS"
+      echo "##vso[task.setvariable variable=TEST_SCRIPTS;isOutput=true]$TEST_SCRIPTS"
+    name: SetVariableTask
+    continueOnError: false
+    displayName: "Get impacted area"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
As the repo `sonic-mgmt` has adopted impacted area-based PR testing, we no longer maintain hardcoded test scripts in `pr_test_scripts.yaml`. However, the repo `sonic-buildimage` still uses the classical PR testing approach, which relies on the test scripts listed in `pr_test_scripts.yaml`. This means that any new test scripts added in sonic-mgmt are not automatically covered in sonic-buildimage unless explicitly added to `pr_test_scripts.yaml`.

This PR updates sonic-buildimage to also use impacted area-based PR testing. By doing so, we ensure that all test scripts are properly executed in sonic-buildimage without relying on manually maintaining the script list.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
As the repo `sonic-mgmt` has adopted impacted area-based PR testing, we no longer maintain hardcoded test scripts in `pr_test_scripts.yaml`. However, the repo `sonic-buildimage` still uses the classical PR testing approach, which relies on the test scripts listed in `pr_test_scripts.yaml`. This means that any new test scripts added in sonic-mgmt are not automatically covered in sonic-buildimage unless explicitly added to `pr_test_scripts.yaml`.

This PR updates sonic-buildimage to also use impacted area-based PR testing. By doing so, we ensure that all test scripts are properly executed in sonic-buildimage without relying on manually maintaining the script list.

#### How did you do it?
This PR updates sonic-buildimage to also use impacted area-based PR testing. By doing so, we ensure that all test scripts are properly executed in sonic-buildimage without relying on manually maintaining the script list.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
