### PR TITLE
[sonic-mgmt] Fix test_posttest.py::test_collect_ptf_logs failure

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -69,7 +69,7 @@ def test_enable_startup_tsa_tsb_service(duthosts, localhost):
 def test_collect_ptf_logs(ptfhost):
     if ptfhost is None:
         return
-    log_files = ptfhost.shell('ls /tmp/*.log')['stdout'].split()
+    log_files = ptfhost.shell('ls /tmp/*.log || true')['stdout'].split()
     if not os.path.exists('logs/ptf'):
         os.makedirs('logs/ptf')
     for log_file in log_files:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_posttest.py::test_collect_ptf_logs failure
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] msft-202412  
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
For snappi testbeds, IXIA API server acts as a ptfhost and *.log files doesn't seem to be there at "/tmp", which is causing ansible command "ls /tmp/*.log" to fail with
`ls: cannot access /tmp/*.log: No such file or directory`.

#### How did you do it?
Handle *.log files doesn't exist case by modifying the command to `ls /tmp/*.log || true`

#### How did you verify/test it?
Verified that test is passing with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
