### PR TITLE
Increase SSH Wait Timeout After DUT Reboot in SN5640 Platform Tests

### DIFF
--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -23,7 +23,7 @@ pytestmark = [
     pytest.mark.disable_loganalyzer,
 ]
 
-MAX_TIME_TO_REBOOT = 120
+MAX_TIME_TO_REBOOT = 300
 
 
 def set_max_to_reboot(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR resolves the test failure in `test_link_status_on_host_reboot`, which occurs when the DUT does not become reachable via SSH within the timeout period after a reboot.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To solve the test failure when the DUT didn’t come back online in time after a reboot. Specifically, the SSH service wasn’t reachable within the expected timeout. 
#### How did you do it?
Increased the SSH wait timeout after reboot to accommodate longer DUT boot times.
#### How did you verify/test it?
```
------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/platform_tests/test_link_down.xml -------------------
-------------------------------------------------- live log sessionfinish ---------------------------------------------------
07:38:52 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================== short test summary info ==================================================
SKIPPED [1] platform_tests/test_link_down.py: Skip for non T2
==================================== 1 passed, 1 skipped, 1 warning in 640.73s (0:10:40) ====================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_link_status_on_host_reboot[str4-sn5640-3]>
```
#### Any platform specific information?
str4-sn5640-3
#### Supported testbed topology if it's a new test case?
t1-isolated-d56u1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
