### PR TITLE
[test_dynamic_acl] Include all upstream neighbors for t0-d18u8s4

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -34,7 +34,7 @@ from tests.common.gu_utils import expect_acl_table_match_multiple_bindings
 from tests.generic_config_updater.gu_utils import format_and_apply_template, load_and_apply_json_patch
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
 from tests.common.dualtor.dual_tor_utils import setup_standby_ports_on_rand_unselected_tor # noqa F401
-from tests.common.utilities import get_upstream_neigh_type, get_downstream_neigh_type, \
+from tests.common.utilities import get_all_upstream_neigh_type, get_downstream_neigh_type, \
     increment_ipv4_addr, increment_ipv6_addr
 
 pytestmark = [
@@ -158,21 +158,23 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
     topos_no_portchannels = (
         't0-isolated-d128u128s2',
         't0-isolated-d16u16s2',
+        't0-d18u8s4',
     )
 
     if topo == "m0_l3" or tbinfo['topo']['name'] in topos_no_portchannels:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
+        upstream_neigh_type = get_all_upstream_neigh_type(topo)
         downstream_neigh_type = get_downstream_neigh_type(topo)
-        pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,
+        pytest_require(len(upstream_neigh_type) > 0 and downstream_neigh_type is not None,
                        "Cannot get neighbor type for unsupported topo: {}".format(topo))
         for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
             port_id = mg_facts["minigraph_ptf_indices"][interface]
             if downstream_neigh_type in neighbor["name"].upper():
                 downstream_ports.append(interface)
                 downstream_port_ids.append(port_id)
-            elif upstream_neigh_type in neighbor["name"].upper():
-                upstream_ports.append(interface)
-                upstream_port_ids.append(port_id)
+            for upstream_type in upstream_neigh_type:
+                if upstream_type in neighbor["name"].upper():
+                    upstream_ports.append(interface)
+                    upstream_port_ids.append(port_id)
     else:
         downstream_ports = list(mg_facts["minigraph_vlans"][vlan_name]["members"])
         # Put all portchannel members into dst_ports


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix generic_config_updater/test_dynamic_acl.py failure due to not including service ports in upstream neighbors.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix the generic_config_updater/test_dynamic_acl.py failure by adding service ports in upstream neighbors.

#### How did you do it?
Use `get_all_upstream_neigh_type` instead of `get_upstream_neigh_type` in `setup`.

#### How did you verify/test it?
Run test_dynamic_acl.py on topo t0-d18u8s4 and all passed.
```
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_drop_rule_removal[default-Vlan1000] PASSED                                                                                                                                                      [100%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV4-str4-7050cx3-c28s4-1-None-default-Vlan1000] PASSED                                                                                                                       [ 50%]
generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV6-str4-7050cx3-c28s4-1-None-default-Vlan1000] PASSED                                                                                                                       [100%]
```
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
