### PR TITLE
Fix test_orchagent_heartbeat failed because orchagent freeze failed issue

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -529,9 +529,6 @@ def get_skip_containers(tbinfo, skip_vendor_specific_container):
     # Skip 'restapi' container since 'restapi' service will be restarted immediately after exited,
     # which will not trigger alarm message.
     skip_containers.append("restapi")
-    # Skip 'acms' container since 'acms' process is not running on lab devices and
-    # another process `cert_converter.py' is set to auto-restart if exited.
-    skip_containers.append("acms")
     # Skip 'radv' container on devices whose role is not T0.
     if tbinfo["topo"]["type"] != "t0":
         skip_containers.append("radv")

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -522,7 +522,7 @@ def ensure_all_critical_processes_running(duthost, containers_in_namespaces):
                     ensure_process_is_running(duthost, container_name_in_namespace, program_name)
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture
 def recover_critical_container(duthosts, rand_one_dut_hostname):
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -564,7 +564,7 @@ def test_monitoring_critical_processes(
                                    rand_one_dut_hostname,
                                    tbinfo,
                                    skip_vendor_specific_container,
-                                   recover_critical_container):
+                                   recover_critical_processes):
     """Tests the feature of monitoring critical processes by Monit and Supervisord.
 
     This function will check whether names of critical processes will appear

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -522,7 +522,7 @@ def ensure_all_critical_processes_running(duthost, containers_in_namespaces):
                     ensure_process_is_running(duthost, container_name_in_namespace, program_name)
 
 
-def get_skip_containers(tbinfo):
+def get_skip_containers(tbinfo, skip_vendor_specific_container):
     skip_containers = []
     skip_containers.append("database")
     skip_containers.append("gbsyncd")
@@ -540,7 +540,7 @@ def get_skip_containers(tbinfo):
 
 
 @pytest.fixture
-def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo):
+def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container):
     duthost = duthosts[rand_one_dut_hostname]
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     skip_containers = get_skip_containers(tbinfo)
@@ -559,7 +559,12 @@ def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo):
     logger.info("Post-checking status of critical processes and BGP sessions was done!")
 
 
-def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container, recover_critical_container):
+def test_monitoring_critical_processes(
+                                   duthosts,
+                                   rand_one_dut_hostname,
+                                   tbinfo,
+                                   skip_vendor_specific_container,
+                                   recover_critical_container):
     """Tests the feature of monitoring critical processes by Monit and Supervisord.
 
     This function will check whether names of critical processes will appear
@@ -579,7 +584,7 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="monitoring_critical_processes")
     loganalyzer.expect_regex = []
 
-    skip_containers = get_skip_containers(tbinfo)
+    skip_containers = get_skip_containers(tbinfo, skip_vendor_specific_container,)
 
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -541,9 +541,9 @@ def get_skip_containers(tbinfo):
 
 @pytest.fixture
 def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
     skip_containers = get_skip_containers(tbinfo)
-    duthost = duthosts[rand_one_dut_hostname]
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 
     yield

--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -543,7 +543,7 @@ def get_skip_containers(tbinfo, skip_vendor_specific_container):
 def recover_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, skip_vendor_specific_container):
     duthost = duthosts[rand_one_dut_hostname]
     up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
-    skip_containers = get_skip_containers(tbinfo)
+    skip_containers = get_skip_containers(tbinfo, skip_vendor_specific_container)
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 
     yield
@@ -584,7 +584,7 @@ def test_monitoring_critical_processes(
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="monitoring_critical_processes")
     loganalyzer.expect_regex = []
 
-    skip_containers = get_skip_containers(tbinfo, skip_vendor_specific_container,)
+    skip_containers = get_skip_containers(tbinfo, skip_vendor_specific_container)
 
     containers_in_namespaces = get_containers_namespace_ids(duthost, skip_containers)
 


### PR DESCRIPTION
Fix test_orchagent_heartbeat failed because orchagent freeze failed issue

#### Why I did it
The test case test_orchagent_heartbeat fails intermittently due to a failure in freezing orchagent. This issue occurs because test_monitoring_critical_processes stops orchagent, and when the test fails, it does not restart the process, leaving orchagent in a stopped state.

##### Work item tracking
- Microsoft ADO **(number only)**:33034949

#### How I did it
Add new fixture to recover all container after test_monitoring_critical_processes finished

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fix test_orchagent_heartbeat failed because orchagent freeze failed issue

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


