### PR TITLE
[snappi] Fix 'yield' statement scope in "enable_debug_shell" fixture

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -232,8 +232,8 @@ def enable_debug_shell(setup_ports_and_dut):  # noqa: F811
             return True
 
         wait_until(360, 5, 0, is_debug_shell_enabled)
-        yield
-        pass
+    yield
+    pass
 
 
 def compute_expected_packets(flow_rate_bps, pkt_size_bytes, duration_s, num_streams=1):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix 'yield' statement scope in "enable_debug_shell" fixture
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/18905

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] msft-202405
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
`snappi_tests/ecn/test_bp_fabric_ecn_marking_with_snappi.py` is failing currently.

In `enable_debug_shell` fixture, "yield" statement is placed inside the "if" condition `if is_cisco_device(rx_duthost):`, so for `non-cisco` platforms "yield" statement will never execute and this is causing
`E       RuntimeError: generator raised StopIteration` as the infra expects
fixture to be a generator and doing iteration over the return value (See
https://github.com/sonic-net/sonic-mgmt/blob/202411/tests/common/plugins/log_section_start/__init__.py#L82-L85).


#### How did you do it?
Moved `yield` statement to outside `if` block and thus gets executed for all device types.

#### How did you verify/test it?
With the fix test is getting skipped as expected (which was failing earlier).

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
