### PR TITLE
[macsec]: Improve test_dataplane for DT2 topology

### DIFF
--- a/tests/macsec/test_dataplane.py
+++ b/tests/macsec/test_dataplane.py
@@ -84,6 +84,8 @@ class TestDataPlane():
         portchannels = list(get_portchannel(duthost).values())
         for i in range(len(portchannels)):
             assert portchannels[i]["members"]
+            if portchannels[i]["members"][0] not in upstream_links:
+                continue
             requester = upstream_links[portchannels[i]["members"][0]]
             # Set DUT as the gateway of requester
             if isinstance(requester["host"], EosHost):
@@ -94,6 +96,8 @@ class TestDataPlane():
                     requester["peer_ipv4_addr"]), module_ignore_errors=True)
             for j in range(i + 1, len(portchannels)):
                 if portchannels[i]["members"][0] not in ctrl_links and portchannels[j]["members"][0] not in ctrl_links:
+                    continue
+                if portchannels[j]["members"][0] not in upstream_links:
                     continue
                 responser = upstream_links[portchannels[j]["members"][0]]
                 # Set DUT as the gateway of responser


### PR DESCRIPTION
### Description of PR

Summary:
In the DT2 topology, there is a scenario where DUT and LT2 are connected via a portchannel, but it is not configured as an upstream.
The current MACsec unit test assumes all portchannels are upstream, which causes the test to fail when trying to retrieve an upstream object by iterating through portchannels.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
When running tests using the t2_single_node_max topology, and enable MACsec, we encountered failures in test_dataplane test. The root cause was using requester = upstream_links[portchannels[i]["members"][0]] to get upstream_links, while some portchannels link to LT2 and is not in upstream_links. Use this way can't get proper upstream.

#### How did you do it?
When iterating through portchannels, check if the current portchannel is in upstream_links. If it is not, skip the subsequent tests.

#### How did you verify/test it?
Tested the macsec/test_dataplane.py script locally using the t2_single_node_man topology with MACsec enabled and confirmed that the tests passed successfully.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
