### PR TITLE
Add log ignore for unsupported SAI ATTR polling

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -345,3 +345,6 @@ r, ".* ERR hostcfgd: \['sonic-kdump-config'[^]]*\] - failed.*"
 
 # https://github.com/sonic-net/sonic-buildimage/issues/22348
 r, ".* ERR pmon#chassis_db_init: Failed to load chassis due to ModuleNotFoundError.*"
+
+# Ignore SAI_SWITCH_ATTR_PACKET_TRIM related unsupported errors
+r, ".* ERR swss#orchagent: .*queryTrimModeEnumCapabilities: Failed to get attribute\(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE\) enum value capabilities


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Various tests run on Broadcom platforms are failing on a loganalyzer check, where loganalyzer catches:
```
ERR swss#orchagent: :- queryTrimModeEnumCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE) enum value capabilities
```

The attribute that failed polling is not supported in the Broadcom SAI. There is no actual failure caused by the failed poll, only log noise. Ignoring this ERR log to remove false-positives in testing.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
Loganalzyer is catching a SAI ATTR polling failure log in many test cases.

#### How did you do it?
Ignore the ERR log as there is no actual failure caused by the failed poll - only log noise.

#### How did you verify/test it?
Tests that previous fail on this loganalyzer catch no longer fails.

#### Any platform specific information?
Broadcom only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
