### PR TITLE
Extend bgp command check to allow multipath routes and "best" routes

### DIFF
--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -48,7 +48,7 @@ def test_bgp_network_command(
         ),
     )
     pytest_assert(
-        "*=" in bgp_network_output,
+        "*=" in bgp_network_output or "*>" in bgp_network_output,
         "Failed to run '{}' command, output={}".format(
             bgp_network_cmd, bgp_network_output
         ),
@@ -61,7 +61,7 @@ def test_bgp_network_command(
         "{} return value is not 0, output:{}".format(bgp_docker_cmd, bgp_docker_output),
     )
     pytest_assert(
-        "*=" in bgp_docker_output,
+        "*=" in bgp_docker_output or "*>" in bgp_docker_output,
         "Failed to run '{}' command, output={}".format(
             bgp_docker_cmd, bgp_docker_output
         ),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In `bgp/test_bgp_command.py`, the test only checks for the existence of multipath (denoted by `*=`) bgp routes - which requires having multiple uplinks and is not always the case (i.e. [topo_t1-isolated-d28u1](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/vars/topo_t1-isolated-d28u1.yml)).

Changing the test to check for `best` bgp routes (denoted by `*>`) as well.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
Account for topologies without multiple uplinks, which does not have multipath bgp entries.

#### How did you do it?
Changing the test to check for `best` bgp routes (denoted by `*>`) in addition to the existing multipath bgp route check.

#### How did you verify/test it?
Test no longer fails on topo_t1-isolated-d28u1

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
