### PR TITLE
Skip test_watchdog on x3b platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1244,7 +1244,7 @@ platform_tests/test_reboot.py::test_watchdog_reboot:
     reason: "Skip watchdog reboot test for Wistron / Nokia 7215 / cisco platform x86_64-8102_64h_o-r0"
     conditions_logical_operator: or
     conditions:
-      - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "'sw_to3200k' in hwsku or platform in ['armhf-nokia_ixs7215_52x-r0', 'x86_64-nokia_ixr7250_x3b-r0']"
 
 #######################################
 #####   test_reload_config.py     #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
To skip test_watchdog_reboot on x3b platforms.
-->

Summary:
Fixes # (issue)
https://github.com/Nokia-ION/ndk/issues/90#issuecomment-2959307315
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To skip unsupported tests.
#### How did you do it?
By adding the platform specific check in tests_mark_conditions_platform_tests.yaml
#### How did you verify/test it?
By running in MSFT Lab
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
