### PR TITLE
Skip gnoi warm reboot test on t1-lag

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1189,6 +1189,12 @@ gnmi/test_gnoi_killprocess.py:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
 
+gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
+  skip:
+    reason: "Warm reboot should only run on t0 topology"
+    conditions:
+      - "topo_type not in ['t0']"
+
 #######################################
 #####           hash              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
tests/gnmi/test_gnoi_system_reboot.py will test warm reboot on t1-lag, but warm reboot should only be run on t0, running on t1-lag may have some error syslog and fail the test or following test
```
2025 May 18 23:03:55.351396 vlab-03 NOTICE sysmgr#sysmgr#rebootbackend: :- HandleRebootRequest: Forwarding request to RebootThread: method: WARM#012message: "gnoi test reboot"
2025 May 18 23:03:55.351396 vlab-03 NOTICE sysmgr#sysmgr#rebootbackend: :- do_warm_reboot: Sending warm reboot request to platform
2025 May 18 23:03:55.351396 vlab-03 NOTICE sysmgr#sysmgr#rebootbackend: :- send_dbus_reboot_request: Sending reboot request to platform
2025 May 18 23:03:55.369017 vlab-03 INFO python3[6688]: reboot: issue_reboot rpc called
2025 May 18 23:03:55.374217 vlab-03 INFO python3[6688]: reboot: Issuing WARM reboot
2025 May 18 23:03:55.383701 vlab-03 INFO python3[6688]: /usr/lib/python3.11/subprocess.py:1014: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
2025 May 18 23:03:55.383760 vlab-03 INFO python3[6688]:   self.stdout = io.open(c2pread, 'rb', bufsize)
2025 May 18 23:03:55.383789 vlab-03 INFO python3[6688]: /usr/lib/python3.11/subprocess.py:1019: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
2025 May 18 23:03:55.383806 vlab-03 INFO python3[6688]:   self.stderr = io.open(errread, 'rb', bufsize)
2025 May 18 23:03:55.449600 vlab-03 INFO python3[6688]: reboot: Reboot failed execution with stdout: [], stderr: ['logname: no login name']


2025 May 18 23:08:15.378411 vlab-03 ERR sysmgr#sysmgr#rebootbackend: :- log_error_and_set_non_retry_failure: failed to warm reboot
2025 May 18 23:08:15.378411 vlab-03 WARNING sysmgr#sysmgr#rebootbackend: :- HandleRebootFinish: Receieved notification that reboot has finished. This probably means something is wrong
```
#### How did you do it?
Skip tests/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm on other platforms except for t0
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
