### PR TITLE
Fix tests/common/snappi_tests/traffic_generation.py

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -465,7 +465,7 @@ def run_traffic(duthost,
         # The 'wait' parameter should ideally be set to 0, but since reboot overwrites 'wait' if it is 0, I have
         # set it to a very small positive value instead.
         reboot(duthost, snappi_extra_params.localhost, reboot_type=snappi_extra_params.reboot_type,
-               delay=0, wait=0.01, plt_reboot_ctrl_overwrite=False)
+               delay=0, wait=0.01, return_after_reconnect=True)
 
     # Test needs to run for at least 10 seconds to allow successive device polling
     if snappi_extra_params.poll_device_runtime and exp_dur_sec > 10:


### PR DESCRIPTION
reboot call is still using the outdated argument `plt_reboot_ctrl_overwrite` instead of `return_after_reconnect` that was introduced in https://github.com/sonic-net/sonic-mgmt/pull/16031

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix snappi_tests/pfc/warm_reboot/test_pfc_pause_lossless_warm_reboot.py failure
Fixes # #18933 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Test is failing with: `TypeError: reboot() got an unexpected keyword argument 'plt_reboot_ctrl_overwrite'`

#### How did you do it?
Passed `return_after_reconnect ` instead of removed argument `plt_reboot_ctrl_overwrite` in `reboot()` call of `common/snappi_tests/traffic_generation.py`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
