### PR TITLE
Updated the max topo file for disagg spine role

### DIFF
--- a/ansible/vars/topo_t2-single-node-max.yml
+++ b/ansible/vars/topo_t2-single-node-max.yml
@@ -1,0 +1,746 @@
+topology:
+  VMs:
+    VM01T3:
+      vlans:
+        - 0
+      vm_offset: 0
+    VM02T3:
+      vlans:
+        - 2
+      vm_offset: 1
+    VM03T3:
+      vlans:
+        - 4
+      vm_offset: 2
+    VM04T3:
+      vlans:
+        - 6
+      vm_offset: 3
+    VM05T3:
+      vlans:
+        - 8
+      vm_offset: 4
+    VM06T3:
+      vlans:
+        - 10
+      vm_offset: 5
+    VM07T3:
+      vlans:
+        - 12
+      vm_offset: 6
+    VM08T3:
+      vlans:
+        - 14
+      vm_offset: 7
+    VM09T3:
+      vlans:
+        - 16
+      vm_offset: 8
+    VM10T3:
+      vlans:
+        - 18
+      vm_offset: 9
+    VM11T3:
+      vlans:
+        - 20
+      vm_offset: 10
+    VM12T3:
+      vlans:
+        - 22
+      vm_offset: 11
+    VM13T3:
+      vlans:
+        - 24
+        - 26
+      vm_offset: 12
+    VM14T3:
+      vlans:
+        - 28
+        - 30
+      vm_offset: 13
+    VM01LT2:
+      vlans:
+        - 1
+      vm_offset: 14
+    VM02LT2:
+      vlans:
+        - 3
+      vm_offset: 15
+    VM03LT2:
+      vlans:
+        - 5
+      vm_offset: 16
+    VM04LT2:
+      vlans:
+        - 7
+      vm_offset: 17
+    VM05LT2:
+      vlans:
+        - 9
+      vm_offset: 18
+    VM06LT2:
+      vlans:
+        - 11
+      vm_offset: 19
+    VM07LT2:
+      vlans:
+        - 13
+      vm_offset: 20
+    VM08LT2:
+      vlans:
+        - 15
+      vm_offset: 21
+    VM09LT2:
+      vlans:
+        - 17
+        - 19
+      vm_offset: 22
+    VM10LT2:
+      vlans:
+        - 21
+        - 23
+      vm_offset: 23
+    VM11LT2:
+      vlans:
+        - 25
+        - 27
+      vm_offset: 24
+    VM12LT2:
+      vlans:
+        - 29
+        - 31
+      vm_offset: 25
+
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.1/32
+      ipv6:
+        - FC00:10::1/128
+
+configuration_properties:
+  common:
+    podset_number: 400
+    tor_number: 16
+    tor_subnet_number: 8
+    max_tor_subnet_number: 32
+    tor_subnet_size: 128
+    dut_asn: 65100
+    dut_type: UpperSpineRouter
+    nhipv4: 10.10.246.254
+    nhipv6: FC0A::FF
+  core:
+    swrole: core
+  leaf:
+    swrole: leaf
+
+configuration:
+  VM01T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.0
+          - FC00::1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.1/32
+        ipv6: 2064:100::1/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.1/31
+        ipv6: FC00::2/126
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64
+
+  VM02T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.2
+          - FC00::5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.2/32
+        ipv6: 2064:100::2/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.3/31
+        ipv6: FC00::6/126
+    bp_interface:
+      ipv4: 10.10.246.2/24
+      ipv6: fc0a::4/64
+
+  VM03T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.4
+          - FC00::9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.3/32
+        ipv6: 2064:100::3/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.5/31
+        ipv6: FC00::a/126
+    bp_interface:
+      ipv4: 10.10.246.3/24
+      ipv6: fc0a::6/64
+
+  VM04T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.6
+          - FC00::d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.5/32
+        ipv6: 2064:100::5/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.7/31
+        ipv6: FC00::e/126
+    bp_interface:
+      ipv4: 10.10.246.5/24
+      ipv6: fc0a::8/64
+
+  VM05T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.8
+          - FC00::11
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.6/32
+        ipv6: 2064:100::6/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.9/31
+        ipv6: FC00::12/126
+    bp_interface:
+      ipv4: 10.10.246.6/24
+      ipv6: fc0a::a/64
+
+  VM06T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.10
+          - FC00::15
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.7/32
+        ipv6: 2064:100::7/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.11/31
+        ipv6: FC00::16/126
+    bp_interface:
+      ipv4: 10.10.246.7/24
+      ipv6: fc0a::c/64
+
+  VM07T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.12
+          - FC00::19
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.8/32
+        ipv6: 2064:100::8/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.13/31
+        ipv6: FC00::1a/126
+    bp_interface:
+      ipv4: 10.10.246.8/24
+      ipv6: fc0a::e/64
+
+  VM08T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.14
+          - FC00::1d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.9/32
+        ipv6: 2064:100::9/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.15/31
+        ipv6: FC00::1e/126
+    bp_interface:
+      ipv4: 10.10.246.9/24
+      ipv6: fc0a::10/64
+
+  VM09T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.16
+          - fc00::21
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.10/32
+        ipv6: 2064:100::10/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.17/31
+        ipv6: fc00::22/126
+    bp_interface:
+      ipv4: 10.10.246.10/24
+      ipv6: fc0a::12/64
+
+  VM10T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.20
+          - fc00::29
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.12/32
+        ipv6: 2064:100::12/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.21/31
+        ipv6: fc00::2a/126
+    bp_interface:
+      ipv4: 10.10.246.12/24
+      ipv6: fc0a::16/64
+
+  VM11T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.24
+          - fc00::31
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.14/32
+        ipv6: 2064:100::14/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.25/31
+        ipv6: fc00::32/126
+    bp_interface:
+      ipv4: 10.10.246.14/24
+      ipv6: fc0a::1a/64
+
+  VM12T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.26
+          - fc00::35
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.15/32
+        ipv6: 2064:100::15/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.27/31
+        ipv6: fc00::36/126
+    bp_interface:
+      ipv4: 10.10.246.15/24
+      ipv6: fc0a::1c/64
+
+  VM13T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.28
+          - fc00::39
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.16/32
+        ipv6: 2064:100::16/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.29/31
+        ipv6: fc00::3a/126
+    bp_interface:
+      ipv4: 10.10.246.16/24
+      ipv6: fc0a::1e/64
+
+  VM14T3:
+    properties:
+      - common
+      - core
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.30
+          - fc00::3d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.17/32
+        ipv6: 2064:100::17/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.31/31
+        ipv6: fc00::3e/126
+    bp_interface:
+      ipv4: 10.10.246.17/24
+      ipv6: fc0a::20/64
+
+  VM01LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65012
+      peers:
+        65100:
+          - 10.0.0.98
+          - fc00::c9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.52/32
+        ipv6: 2064:100::32/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.99/31
+        ipv6: fc00::ca/126
+    bp_interface:
+      ipv4: 10.10.246.101/24
+      ipv6: fc0a::64/64
+
+  VM02LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65013
+      peers:
+        65100:
+          - 10.0.0.100
+          - fc00::cd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.53/32
+        ipv6: 2064:100::33/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.101/31
+        ipv6: fc00::ce/126
+    bp_interface:
+      ipv4: 10.10.246.103/24
+      ipv6: fc0a::66/64
+
+  VM03LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65014
+      peers:
+        65100:
+          - 10.0.0.104
+          - fc00::d5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.55/32
+        ipv6: 2064:100::35/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.105/31
+        ipv6: fc00::d6/126
+    bp_interface:
+      ipv4: 10.10.246.107/24
+      ipv6: fc0a::6a/64
+
+  VM04LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65015
+      peers:
+        65100:
+          - 10.0.0.108
+          - fc00::dd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.57/32
+        ipv6: 2064:100::37/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.109/31
+        ipv6: fc00::de/126
+    bp_interface:
+      ipv4: 10.10.246.111/24
+      ipv6: fc0a::6e/64
+
+  VM05LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65016
+      peers:
+        65100:
+          - 10.0.0.112
+          - fc00::e5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.59/32
+        ipv6: 2064:100::39/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.113/31
+        ipv6: fc00::e6/126
+    bp_interface:
+      ipv4: 10.10.246.115/24
+      ipv6: fc0a::72/64
+
+  VM06LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65017
+      peers:
+        65100:
+          - 10.0.0.116
+          - fc00::ed
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.61/32
+        ipv6: 2064:100::3b/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.117/31
+        ipv6: fc00::ee/126
+    bp_interface:
+      ipv4: 10.10.246.119/24
+      ipv6: fc0a::76/64
+
+  VM07LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65018
+      peers:
+        65100:
+          - 10.0.0.118
+          - fc00::f1
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.62/32
+        ipv6: 2064:100::3c/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.119/31
+        ipv6: fc00::f2/126
+    bp_interface:
+      ipv4: 10.10.246.120/24
+      ipv6: fc0a::78/64
+
+  VM08LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65019
+      peers:
+        65100:
+          - 10.0.0.120
+          - fc00::f5
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.63/32
+        ipv6: 2064:100::3d/128
+      Ethernet1:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.121/31
+        ipv6: fc00::f6/126
+    bp_interface:
+      ipv4: 10.10.246.121/24
+      ipv6: fc0a::7a/64
+
+  VM09LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65020
+      peers:
+        65100:
+          - 10.0.0.122
+          - fc00::f9
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.64/32
+        ipv6: 2064:100::3e/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.123/31
+        ipv6: fc00::fa/126
+    bp_interface:
+      ipv4: 10.10.246.122/24
+      ipv6: fc0a::7c/64
+
+  VM10LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65021
+      peers:
+        65100:
+          - 10.0.0.124
+          - fc00::fd
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.65/32
+        ipv6: 2064:100::3f/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.125/31
+        ipv6: fc00::fe/126
+    bp_interface:
+      ipv4: 10.10.246.123/24
+      ipv6: fc0a::7e/64
+
+  VM11LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65022
+      peers:
+        65100:
+          - 10.0.0.126
+          - fc00::101
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.66/32
+        ipv6: 2064:100::3e/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.127/31
+        ipv6: fc00::102/126
+    bp_interface:
+      ipv4: 10.10.246.124/24
+      ipv6: fc0a::80/64
+
+  VM12LT2:
+    properties:
+      - common
+      - leaf
+    bgp:
+      asn: 65023
+      peers:
+        65100:
+          - 10.0.0.128
+          - fc00::105
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.67/32
+        ipv6: 2064:100::3f/128
+      Ethernet1:
+        lacp: 1
+      Ethernet2:
+        lacp: 1
+      Port-Channel1:
+        ipv4: 10.0.0.129/31
+        ipv6: fc00::106/126
+    bp_interface:
+      ipv4: 10.10.246.125/24
+      ipv6: fc0a::82/64


### PR DESCRIPTION
This PR is to rename and update the max topology file for disagg spine role for a 32 port device.

Changes made:

Changed the VM names

This topology file will have 26 total VMs (14x T3 VMs and 12x LT2 VMs)

The upper 16x ports will be connected to the T3 VMs

The lower 16x ports will be connected to the LT2 VMs

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
