### PR TITLE
Fix txvr tests after diagnostic table restructuring

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -70,7 +70,7 @@ def get_transceiver_info_firmware_versions(conn, index):
     return sfp_api(conn, index, 'get_transceiver_info_firmware_versions')
 
 
-def get_transceiver_bulk_status(conn, index):
+def get_transceiver_dom_real_value(conn, index):
     return sfp_api(conn, index, 'get_transceiver_dom_real_value')
 
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -142,7 +142,7 @@ class TestSfpApi(PlatformApiTestBase):
         'dom_capability'
     ]
 
-    EXPECTED_XCVR_BULK_STATUS_KEYS = [
+    EXPECTED_XCVR_DOM_REAL_VALUE_KEYS = [
         'temperature',
         'voltage',
         'rx1power',
@@ -459,7 +459,7 @@ class TestSfpApi(PlatformApiTestBase):
                         self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()
 
-    def test_get_transceiver_bulk_status(self, duthosts, enum_rand_one_per_hwsku_hostname,
+    def test_get_transceiver_dom_real_value(self, duthosts, enum_rand_one_per_hwsku_hostname,
                                          localhost, platform_api_conn, port_list_with_flat_memory): # noqa F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
@@ -469,18 +469,18 @@ class TestSfpApi(PlatformApiTestBase):
             if index_physical_port_map[i] in port_list_with_flat_memory[duthost.hostname]:
                 logger.info(f"skip test on spf {i} due to the port with flat memory")
                 continue
-            bulk_status_dict = sfp.get_transceiver_bulk_status(platform_api_conn, i)
-            if self.expect(bulk_status_dict is not None, "Unable to retrieve transceiver {} bulk status".format(i)):
-                if self.expect(isinstance(bulk_status_dict, dict),
-                               "Transceiver {} bulk status appears incorrect".format(i)):
+            dom_real_value_dict = sfp.get_transceiver_dom_real_value(platform_api_conn, i)
+            if self.expect(dom_real_value_dict is not None, "Unable to retrieve transceiver {} dom real value status".format(i)):
+                if self.expect(isinstance(dom_real_value_dict, dict),
+                               "Transceiver {} dom real value appears incorrect".format(i)):
                     # TODO: This set of keys should be present no matter how many channels are present on the xcvr
                     #       If the xcvr has multiple channels, we should adjust the fields here accordingly
-                    actual_keys = list(bulk_status_dict.keys())
+                    actual_keys = list(dom_real_value_dict.keys())
 
-                    missing_keys = set(self.EXPECTED_XCVR_BULK_STATUS_KEYS) - set(actual_keys)
+                    missing_keys = set(self.EXPECTED_XCVR_DOM_REAL_VALUE_KEYS) - set(actual_keys)
                     for key in missing_keys:
                         self.expect(
-                            False, "Transceiver {} bulk status does not contain field: '{}'".format(i, key))
+                            False, "Transceiver {} dom real value does not contain field: '{}'".format(i, key))
         self.assert_expectations()
 
     def test_get_transceiver_threshold_info(self, duthosts, enum_rand_one_per_hwsku_hostname,

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -122,7 +122,8 @@ class TestSfpApi(PlatformApiTestBase):
                                                 'media_interface_technology',
                                                 'media_interface_code',
                                                 'host_electrical_interface',
-                                                'media_lane_assignment_option']
+                                                'media_lane_assignment_option',
+                                                'vdm_supported']
 
     EXPECTED_XCVR_NEW_QSFP_DD_OSFP_FIRMWARE_INFO_KEYS = ['active_firmware',
                                                          'inactive_firmware']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix txvr tests after diagnostic table restructuring
Fixes # (issue) The changes to the sonic-mgmt testcases are required due to the below changes:
[[cmis] Separate Flag-Specific Fields for DOM and Status APIs by mihirpat1 · Pull Request #556 · sonic-net/sonic-platform-common](https://github.com/sonic-net/sonic-platform-common/pull/556)
[[xcvrd] Re-organize transceiver DOM and STATUS tables + enable link event handling for DOM monitoring + DOM polling based on physical port by mihirpat1 · Pull Request #604 · sonic-net/sonic-platform-daemons](https://github.com/sonic-net/sonic-platform-daemons/pull/604)
[Transceiver CLI changes to support DOM and STATUS table related changes by mihirpat1 · Pull Request #3844 · sonic-net/sonic-utilities](https://github.com/sonic-net/sonic-utilities/pull/3844)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
`vdm_supported` field was added to the CMIS output but the tests were not update.
#### How did you do it?
Added `vdm_supported` to the expected keys list.
#### How did you verify/test it?
Ran the sfp tests on a couple of platforms.
#### Any platform specific information?
None.
#### Supported testbed topology if it's a new test case?
N/A.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
