### PR TITLE
Enable user_auth for telemetry test

### DIFF
--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -27,9 +27,11 @@ def setup_user_auth(duthosts, enum_rand_one_per_hwsku_hostname):
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     duthost.shell('sonic-db-cli CONFIG_DB hset "%s|gnmi" user_auth none' % (env.gnmi_config_table),
                   module_ignore_errors=False)
+    duthost.shell('config save -y', module_ignore_errors=False)
     yield
     duthost.shell('sonic-db-cli CONFIG_DB hdel "%s|gnmi" user_auth' % (env.gnmi_config_table),
                   module_ignore_errors=False)
+    duthost.shell('config save -y', module_ignore_errors=False)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -7,6 +7,7 @@ from tests.common.helpers.assertions import pytest_assert as py_assert
 from tests.common.utilities import wait_until
 from tests.telemetry.telemetry_utils import get_list_stdout
 from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_context
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
 EVENTS_TESTS_PATH = "./telemetry/events"
 sys.path.append(EVENTS_TESTS_PATH)
@@ -15,6 +16,20 @@ BASE_DIR = "logs/telemetry"
 DATA_DIR = os.path.join(BASE_DIR, "files")
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_user_auth(duthosts, enum_rand_one_per_hwsku_hostname):
+    """
+    Setup user authentication for telemetry tests
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    duthost.shell('sonic-db-cli CONFIG_DB hset "%s|gnmi" user_auth none' % (env.gnmi_config_table),
+                  module_ignore_errors=False)
+    yield
+    duthost.shell('sonic-db-cli CONFIG_DB hdel "%s|gnmi" user_auth' % (env.gnmi_config_table),
+                  module_ignore_errors=False)
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 33257886

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We will enable user_auth by default, and then telemetry test will be blocked.

#### How did you do it?
Set user_auth as none before the telemetry test, and recover user_auth after the telemetry test.

#### How did you verify/test it?
Run telemetry end to end test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
