### PR TITLE
Fix everflow test for erspan V6

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -67,7 +67,7 @@ def build_candidate_ports(duthost, tbinfo, ns):
     return candidate_ports, unselected_ports
 
 
-def build_acl_rule_vars(candidate_ports, ip_ver):
+def build_acl_rule_vars(candidate_ports, ip_ver, erspan_ip_ver):  # noqa F811
     """
     Build vars for generating ACL rule
     """
@@ -78,7 +78,7 @@ def build_acl_rule_vars(candidate_ports, ip_ver):
     # trying to resolve link-local IPv6 addresses. All of these packets were mirrored by the DUT. This overwhelmed
     # the PTF container, causing the kernel to drop some packets. As a result, the IPv6 tests sometimes failed.
     # To prevent this issue from happening, we restrict Everflow IPv6 mirroring to TCP packets.
-    if ip_ver == "ipv6":
+    if ip_ver == "ipv6" or erspan_ip_ver == 6:
         qualifiers["ip"] = {"protocol": 6}  # Only mirror TCP packets
     config_vars['rules'] = [{'qualifiers': qualifiers}]
     return config_vars
@@ -130,7 +130,7 @@ def ip_ver(request):
 
 
 @pytest.fixture(scope='module')
-def apply_acl_rule(setup_info, tbinfo, setup_mirror_session_dest_ip_route, ip_ver):  # noqa F811
+def apply_acl_rule(setup_info, tbinfo, setup_mirror_session_dest_ip_route, ip_ver, erspan_ip_ver):  # noqa F811
     """
     Apply ACL rule for matching input_ports
     """
@@ -147,7 +147,7 @@ def apply_acl_rule(setup_info, tbinfo, setup_mirror_session_dest_ip_route, ip_ve
     pytest_require(len(unselected_ports) >= 1, "Not sufficient ports for testing")
 
     # Copy and apply ACL rule
-    config_vars = build_acl_rule_vars(candidate_ports, ip_ver)
+    config_vars = build_acl_rule_vars(candidate_ports, ip_ver, erspan_ip_ver)
     setup_info[UP_STREAM]['everflow_dut'].host.options["variable_manager"].extra_vars.update(config_vars)
     setup_info[UP_STREAM]['everflow_dut'].command("mkdir -p {}".format(DUT_RUN_DIR))
     setup_info[UP_STREAM]['everflow_dut'].template(src=os.path.join(TEMPLATE_DIR, EVERFLOW_RULE_CREATE_TEMPLATE),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the test everflow/test_everflow_per_interface.py::test_everflow_per_interface
When the erspan version is IPv6 and the topo is t0, there will be a storm in the vlan when the test packet is sent to the dut.
And the test fails sometimes because the flooded packets are all sent to ptf and the ptf is not able to finish the poll in timeout.

AssertionError: Did not receive expected packet on any of ports [29] for device 0.
========== EXPECTED ==========
Mask:

packet status: OK
packet:
0000  00 01 02 03 04 05 B0 CF 0E 39 76 00 86 DD 62 00  .........9v...b.
0010  00 00 00 7E 2F 04 11 11 00 00 00 00 00 00 00 01  ...~/...........
0020  00 01 00 01 00 01 22 22 00 00 00 00 00 00 00 02  ......""........
0030  00 02 00 02 00 02 00 00 89 49 00 00 00 00 00 00  .........I......
0040  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0050  B0 CF 0E 39 76 00 5C 25 73 93 80 00 08 00 45 00  ...9v.\%s.....E.
0060  00 56 00 01 00 00 40 06 F9 4D C0 A8 00 01 C0 A8  .V....@..M......
0070  00 02 04 D2 00 50 00 00 00 00 00 00 00 00 50 02  .....P........P.
0080  20 00 0D 2C 00 00 00 01 02 03 04 05 06 07 08 09   ..,............
0090  0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19  ................
00a0  1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28 29  ...... !"#$%&'()
00b0  2A 2B 2C 2D                                      *+,-

packet's mask:
0000  00 00 00 00 00 00 FF FF FF FF FF FF FF FF F0 00  ................
0010  00 00 00 00 FF FF FF FF FF FF FF FF FF FF FF FF  ................
0020  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF  ................
0030  FF FF FF FF FF FF FF FF FF FF 00 00 00 00 00 00  ................
0040  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0070  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0080  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0090  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
00a0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
00b0  00 00 00 00                                      ....

========== RECEIVED ==========
**54823 total packets. Displaying most recent 3 packets:**. 

The reason for the storm is:
1. The test packet is mirrored and encapsulated with IPv6
2. The encap packet is send to ptf.
3. Ptf received the packet and send ipv6 NS to all ptf interfaces(including those in the vlan) to resolve the neighbor.
4. The IPv6 NS is mirrored and sent to the ptf with the same ipv6 encap, and then trigger the IPv6 NS again, which causes the storm.

There is already a logic in the test to handle this issue for the IPv6 packet mirroring test cases, but it doesn't cover the case when it's erspan v6.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the fixed test in regression the issue never reproduced.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
