### PR TITLE
Fix posttest issue for frr_bmp container checker

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -35,6 +35,9 @@ def test_recover_rsyslog_rate_limit(duthosts, enum_dut_hostname):
     for feature_name, state in list(features_dict.items()):
         if 'enabled' not in state:
             continue
+        # Skip frr_bmp since it's not expected container
+        if feature_name == "frr_bmp":
+            continue
         if feature_name == "telemetry":
             # Skip telemetry if there's no docker image
             output = duthost.shell("docker images", module_ignore_errors=True)['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
frr_bmp is not container but feature switch, thus in
https://github.com/sonic-net/sonic-mgmt/blob/4db1dc010a538303b1a24c6be99f7b582ab5d9e7/tests/test_posttest.py#L43
recover log rate limit by default, actually for frr_bmp this property was set as false https://github.com/sonic-net/sonic-mgmt/blob/4db1dc010a538303b1a24c6be99f7b582ab5d9e7/ansible/library/generate_golden_config_db.py#L192.

#### How did you do it?
skip frr_bmp feature check in posttest.py

#### How did you verify/test it?
![image](https://github.com/user-attachments/assets/d10c1653-91d8-47b0-beef-ec6b9e084187)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
