### PR TITLE
MIGSMSFT-1039: calling the fixture to disable PWCWD on all DUT's in reboot test cases

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
+++ b/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py
@@ -220,6 +220,7 @@ def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # n
                                                all_prio_list,               # noqa: F811
                                                get_snappi_ports,            # noqa: F811
                                                tbinfo,                      # noqa: F811
+                                               disable_pfcwd,               # noqa: F811
                                                reboot_duts_and_disable_wd,  # noqa: F811
                                                tgen_port_info):             # noqa: F811
     """
@@ -282,6 +283,7 @@ def test_pfc_pause_multi_lossless_prio_reboot(snappi_api,                   # no
                                               lossless_prio_list,           # noqa: F811
                                               get_snappi_ports,             # noqa: F811
                                               tbinfo,                       # noqa: F811
+                                              disable_pfcwd,                # noqa: F811
                                               reboot_duts_and_disable_wd,   # noqa: F811
                                               tgen_port_info):              # noqa: F811
     """


### PR DESCRIPTION
### Description of PR
This is to fix the failure reported in [MIGSMSFT-1039](https://migsonic.atlassian.net/browse/MIGSMSFT-1039)

```
FAILED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-svcstr2-8800-lc1-1|3]
FAILED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info1-cold-svcstr2-8800-lc1-1|3]
FAILED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info1-cold]
```

```
        if exceeds_headroom:
            pytest_assert(tx_bytes_total > dut_buffer_size,
                          "Total TX bytes {} should exceed DUT buffer size {}".
                          format(tx_bytes_total, dut_buffer_size))
    
            for peer_port, prios in dut_port_config[0].items():
                for prio in prios:
                    dropped_packets = get_pg_dropped_packets(egress_duthost, peer_port, prio, asic_value)
                    pytest_assert(dropped_packets > 0,
                                  "Total TX dropped packets {} should be more than 0".
                                  format(dropped_packets))
        else:
>           pytest_assert(tx_bytes_total < dut_buffer_size,
                          "Total TX bytes {} should be smaller than DUT buffer size {}".
                          format(tx_bytes_total, dut_buffer_size))
E           Failed: Total TX bytes 1302068965376 should be smaller than DUT buffer size 2521833472
```

Error was seen because these test cases were not disabling PFCWD on all the DUT's. PFCWD was disabled on the DUT where reboot was done. Due to this PFCWD was getting triggered in RP and hence the error.`


Summary:
Fixes # https://migsonic.atlassian.net/browse/MIGSMSFT-1039

### Type of change
- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405
- [ ] 202411
- [ ] 202505

### Approach
Test were failing

#### How did you do it?
Calling the figure to doable PFCWD on all DUT's in robot test cases

#### How did you verify/test it?
Manually ran the test with change

`============================================================================================================ PASSES =============================================================================================================
__________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-yy40-mixed-long|3] ___________________________________________________________________________
__________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-yy40-mixed-long|4] ___________________________________________________________________________
______________________________________________________________________________ test_pfc_pause_counter_check[multidut_port_info0-yy40-mixed-long|3] ______________________________________________________________________________
______________________________________________________________________________ test_pfc_pause_counter_check[multidut_port_info0-yy40-mixed-long|4] ______________________________________________________________________________
____________________________________________________________________________________ test_pfc_pause_multi_lossless_prio[multidut_port_info0] ____________________________________________________________________________________
____________________________________________________________________ test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-yy40-mixed-long|3] _____________________________________________________________________
______________________________________________________________________________ test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold] ______________________________________________________________________________
---------------------------------------------------------------- generated xml file: /run_logs/ixia/debug_tx_byte/2025-06-10-22-56-31/tr_2025-06-10-22-56-31.xml ----------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
==================================================================================================== short test summary info ====================================================================================================
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-yy40-mixed-long|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-yy40-mixed-long|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info0-yy40-mixed-long|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_counter_check[multidut_port_info0-yy40-mixed-long|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio[multidut_port_info0]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio_reboot[multidut_port_info0-cold-yy40-mixed-long|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_multi_lossless_prio_reboot[multidut_port_info0-cold]
SKIPPED [1] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:202: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:202: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:263: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py:263: Reboot type fast is not supported on cisco-8000 switches
============================================================ 7 passed, 4 skipped, 8 warnings in 5097.91s (1:24:57) =====================================================================================`

#### Any platform specific information?
No
