### PR TITLE
Added test for sai*xml in the tech_support dumps on the switch

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -712,7 +712,8 @@ def validate_saidump_file_inside_techsupport(duthost, techsupport_folder):
             sai_sdk_dump = duthost.command(f"ls {techsupport_folder}/sai_sdk_dump/")["stdout_lines"]
             assert len(sai_sdk_dump), "Folder 'sai_sdk_dump' in dump archive is empty. Expected not empty folder"
             sai_xml_regex = re.compile(r'sai_[\w-]+\.xml(?:\.gz)?')
-            assert any(sai_xml_regex.fullmatch(file_name) for file_name in sai_sdk_dump), "No SAI XML file found in sai_sdk_dump folder"
+            assert any(sai_xml_regex.fullmatch(file_name) for file_name in sai_sdk_dump),
+            "No SAI XML file found in sai_sdk_dump folder"
 
 
 def validate_techsupport_since(duthost, techsupport_folder, expected_oldest_log_line_timestamps_list):

--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -704,8 +704,15 @@ def validate_saidump_file_inside_techsupport(duthost, techsupport_folder):
     """
     with allure.step('Validate SAI dump file is included in the tech-support dump'):
         saidump_files_inside_techsupport = \
-            duthost.shell('ls {}/sai_failure_dump'.format(techsupport_folder))['stdout_lines']
-        assert saidump_files_inside_techsupport, 'Expected SAI dump file(folder) not available in techsupport dump'
+            duthost.shell(f'ls {techsupport_folder}/sai_failure_dump')['stdout_lines']
+        assert saidump_files_inside_techsupport, 'Expected SAI dump file(folder(s)) not available in techsupport dump'
+        # Check sai_sdk_dump only for mellanox platform, and not for DPU
+        if duthost.facts['asic_type'] in ["mellanox"] and "dpu" not in duthost.hostname:
+            # sai XML dump is only support on the switch
+            sai_sdk_dump = duthost.command(f"ls {techsupport_folder}/sai_sdk_dump/")["stdout_lines"]
+            assert len(sai_sdk_dump), "Folder 'sai_sdk_dump' in dump archive is empty. Expected not empty folder"
+            sai_xml_regex = re.compile(r'sai_[\w-]+\.xml(?:\.gz)?')
+            assert any(sai_xml_regex.fullmatch(file_name) for file_name in sai_sdk_dump), "No SAI XML file found in sai_sdk_dump folder"
 
 
 def validate_techsupport_since(duthost, techsupport_folder, expected_oldest_log_line_timestamps_list):

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -407,6 +407,10 @@ def validate_dump_file_content(duthost, dump_folder_path):
     if duthost.facts['asic_type'] in ["mellanox"]:
         sai_sdk_dump = duthost.command("ls {}/sai_sdk_dump/".format(dump_folder_path))["stdout_lines"]
         assert len(sai_sdk_dump), "Folder 'sai_sdk_dump' in dump archive is empty. Expected not empty folder"
+        if "dpu" not in duthost.hostname:
+            # sai XML dump is only support on the switch
+            sai_xml_regex = re.compile(r'sai_[\w-]+\.xml(?:\.gz)?')
+            assert any(sai_xml_regex.fullmatch(file_name) for file_name in sai_sdk_dump), "No SAI XML file found in sai_sdk_dump folder"
     assert len(dump) > MIN_FILES_NUM, "Seems like not all expected files available in 'dump' folder in dump archive. " \
                                       "Test expects not less than 50 files. Available files: {}".format(dump)
     assert len(etc) > MIN_FILES_NUM, "Seems like not all expected files available in 'etc' folder in dump archive. " \

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -410,7 +410,8 @@ def validate_dump_file_content(duthost, dump_folder_path):
         if "dpu" not in duthost.hostname:
             # sai XML dump is only support on the switch
             sai_xml_regex = re.compile(r'sai_[\w-]+\.xml(?:\.gz)?')
-            assert any(sai_xml_regex.fullmatch(file_name) for file_name in sai_sdk_dump), "No SAI XML file found in sai_sdk_dump folder"
+            assert any(sai_xml_regex.fullmatch(file_name) for file_name in sai_sdk_dump),
+            "No SAI XML file found in sai_sdk_dump folder"
     assert len(dump) > MIN_FILES_NUM, "Seems like not all expected files available in 'dump' folder in dump archive. " \
                                       "Test expects not less than 50 files. Available files: {}".format(dump)
     assert len(etc) > MIN_FILES_NUM, "Seems like not all expected files available in 'etc' folder in dump archive. " \


### PR DESCRIPTION
### Description of PR
Added test for the sai*xml file among the tech support files
Filenames vary depending on the hwsku: sai_<sku>.xml.gz

Supporting image all passed as expected
Non-supporting image all failed as expected

Summary:
Fixes # N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Improve the content of the tech support information collected from the device

#### How did you do it?
Added the filename checks to the list received from the DUT

#### How did you verify/test it?
Ran on the supporting image, all tests passed as expected
Ran on the non-supporting image, all tests failed as expected

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
any topology
### Documentation
Test case improvement for the tech support data collection
