### PR TITLE
[Snappi] fix link operdown from tx_drop_counter test

### DIFF
--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -399,7 +399,7 @@ def run_tx_drop_counter(
                                         exp_dur_sec=DATA_FLOW_DURATION_SEC +
                                         data_flow_delay_sec,
                                         snappi_extra_params=snappi_extra_params)
-    link_state = None
+    cs = None
     try:
         time.sleep(1)
         # Collect metrics from DUT once again
@@ -434,7 +434,7 @@ def run_tx_drop_counter(
         pytest_assert(tx_dut_drop_frames == tx_dut_drop_frames_1,
                       "Mismatch in TX drop counters post DUT port {} oper down".format(dut_port))
     finally:
-        if link_state:
+        if cs:
             # Bring the link back up
             cs.port.link.state = cs.port.link.UP
             api.set_control_state(cs)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Due to the new API changes, we're not using the variable `link_state` anymore. During recovery, we checked for this variable to perform recovery, however this is never set.


Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Fix the link oper down on IXIA test case

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
