### PR TITLE
Fix macsec test_interop_protocol for t2 single node topo

### DIFF
--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -631,21 +631,25 @@ def parse_linkmeta(meta, hname):
     macsec_neighbors = []
     macsec_enabled_ports = []
     for linkmeta in link.findall(str(QName(ns1, "LinkMetadata"))):
-        local_port = None
-        # Sample: ARISTA05T1:Ethernet1/33;switch-t0:fortyGigE0/4
-        key = linkmeta.find(str(QName(ns1, "Key"))).text
-        endpoints = key.split(';')
-        local_endpoint = endpoints[1]
-        remote_endpoint = endpoints[0]
-        t = local_endpoint.split(':')
-        if len(t) == 2 and t[0].lower() == hname.lower():
-            local_port = t[1]
-            macsec_enabled_ports.append(local_port)
-            neighbor_host = remote_endpoint.split(':')[0]
-            macsec_neighbors.append(neighbor_host)
-        else:
-            # Cannot find a matching hname, something went wrong
-            continue
+        linkprop = linkmeta.find(str(QName(ns1, "Properties")))
+        linkdevprop = linkprop.find(str(QName(ns1, "DeviceProperty")))
+        macsec_en_lnk = linkdevprop.find(str(QName(ns1, "Value"))).text
+        if macsec_en_lnk:
+            local_port = None
+            # Sample: ARISTA05T1:Ethernet1/33;switch-t0:fortyGigE0/4
+            key = linkmeta.find(str(QName(ns1, "Key"))).text
+            endpoints = key.split(';')
+            local_endpoint = endpoints[1]
+            remote_endpoint = endpoints[0]
+            t = local_endpoint.split(':')
+            if len(t) == 2 and t[0].lower() == hname.lower():
+                local_port = t[1]
+                macsec_enabled_ports.append(local_port)
+                neighbor_host = remote_endpoint.split(':')[0]
+                macsec_neighbors.append(neighbor_host)
+            else:
+                # Cannot find a matching hname, something went wrong
+                continue
     return macsec_enabled_ports, macsec_neighbors
 
 

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -633,7 +633,9 @@ def parse_linkmeta(meta, hname):
     for linkmeta in link.findall(str(QName(ns1, "LinkMetadata"))):
         linkprop = linkmeta.find(str(QName(ns1, "Properties")))
         linkdevprop = linkprop.find(str(QName(ns1, "DeviceProperty")))
-        macsec_en_lnk = linkdevprop.find(str(QName(ns1, "Value"))).text
+        macsec_en_name = linkdevprop.find(str(QName(ns1, "Name"))).text
+        if macsec_en_name == "MacSecEnabled":
+            macsec_en_lnk = linkdevprop.find(str(QName(ns1, "Value"))).text
         if macsec_en_lnk:
             local_port = None
             # Sample: ARISTA05T1:Ethernet1/33;switch-t0:fortyGigE0/4

--- a/ansible/library/minigraph_facts.py
+++ b/ansible/library/minigraph_facts.py
@@ -636,22 +636,22 @@ def parse_linkmeta(meta, hname):
         macsec_en_name = linkdevprop.find(str(QName(ns1, "Name"))).text
         if macsec_en_name == "MacSecEnabled":
             macsec_en_lnk = linkdevprop.find(str(QName(ns1, "Value"))).text
-        if macsec_en_lnk:
-            local_port = None
-            # Sample: ARISTA05T1:Ethernet1/33;switch-t0:fortyGigE0/4
-            key = linkmeta.find(str(QName(ns1, "Key"))).text
-            endpoints = key.split(';')
-            local_endpoint = endpoints[1]
-            remote_endpoint = endpoints[0]
-            t = local_endpoint.split(':')
-            if len(t) == 2 and t[0].lower() == hname.lower():
-                local_port = t[1]
-                macsec_enabled_ports.append(local_port)
-                neighbor_host = remote_endpoint.split(':')[0]
-                macsec_neighbors.append(neighbor_host)
-            else:
-                # Cannot find a matching hname, something went wrong
-                continue
+            if macsec_en_lnk:
+                local_port = None
+                # Sample: ARISTA05T1:Ethernet1/33;switch-t0:fortyGigE0/4
+                key = linkmeta.find(str(QName(ns1, "Key"))).text
+                endpoints = key.split(';')
+                local_endpoint = endpoints[1]
+                remote_endpoint = endpoints[0]
+                t = local_endpoint.split(':')
+                if len(t) == 2 and t[0].lower() == hname.lower():
+                    local_port = t[1]
+                    macsec_enabled_ports.append(local_port)
+                    neighbor_host = remote_endpoint.split(':')[0]
+                    macsec_neighbors.append(neighbor_host)
+                else:
+                    # Cannot find a matching hname, something went wrong
+                    continue
     return macsec_enabled_ports, macsec_neighbors
 
 

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,6 +1,6 @@
 {%- set ns = namespace(link_metadata_defined=False) -%}
 
-{%- if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) or ('ixia' in topo) -%}
+{%- if 'dualtor' in topo or (macsec_card is defined and enable_macsec is defined and macsec_card == True and 't2' in topo) or ('ixia' in topo) -%}
     {% set ns.link_metadata_defined = True %}
 {%- endif -%}
 

--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -1,6 +1,6 @@
 {%- set ns = namespace(link_metadata_defined=False) -%}
 
-{%- if 'dualtor' in topo or (macsec_card is defined and enable_macsec is defined and macsec_card == True and 't2' in topo) or ("ixia" in topo) -%}
+{%- if 'dualtor' in topo or (macsec_card is defined and macsec_card == True and 't2' in topo) or ('ixia' in topo) -%}
     {% set ns.link_metadata_defined = True %}
 {%- endif -%}
 
@@ -43,7 +43,7 @@
 {% set vm_intfs=vm_topo_config['vm'][vms[index]]['intfs'][dut_index|int]|sort %}
 {% set dut_intfs=vm_topo_config['vm'][vms[index]]['interface_indexes'][dut_index|int]|sort %}
 {% for if_index in range(vm_intfs | length) %}
-{% if 'IB' not in port_alias[dut_intfs[if_index]] %}
+{% if 'IB' not in port_alias[dut_intfs[if_index]]  and vms[index].endswith('T3') %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix test_interop_protocol.py::TestInteropProtocol::test_bgp  for t2 single node topo. 

Summary:
Fixes # (issue)
The test_interop_protocol.py::TestInteropProtocol::test_bgp  is failing for t2 single node topo. This is due to mimatch between ctrl_links and upstream_links content were not matching which is current assumption. This is due to both upstream and downstream neighbors are present on same card, this change will address this issue.
### Type of change
Test case change to support  T2 single node topo 
<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ x] 202505
Please Backport to 202503 also
### Approach
#### What is the motivation for this PR?
Fix test_interop_protocol.py::TestInteropProtocol::test_bgp for t2 single node
#### How did you do it?
Change minigraph_link_meta.j2 template to enable MACSec only for upstream neighbors for topo T2.
Change in minigraph facts for getting macsec enabled ports only if value is true for macsec under link metadata.
test_bgp:
Remove PC check for dnx platform as this should be fixed in SAI 11.x and later.
Add condition to check portchannel up if only port is part of port channel member.
#### How did you verify/test it?
Verified the test passed with t2 and t2_single_node topos
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
