### PR TITLE
Fix test_dynamic_acl.py by creating list of topos without LAGs

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -154,7 +154,20 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
     downstream_port_ids = []
     upstream_port_ids = []
 
-    if topo == "m0_l3":
+    topos_no_portchannels = (
+       't0-isolated-d256u256s2',
+       't0-isolated-d128u128s2',
+       't0-isolated-d96u32s2',
+       't0-isolated-d32u32s2',
+       't0-isolated-d16u16s2',
+       't1-isolated-d224u8',
+       't1-isolated-d128',
+       't1-isolated-d56u2',
+       't1-isolated-d28u1',
+       't1-isolated-d28',
+    )
+
+    if topo == "m0_l3" or tbinfo['topo']['name'] in topos_no_portchannels:
         upstream_neigh_type = get_upstream_neigh_type(topo)
         downstream_neigh_type = get_downstream_neigh_type(topo)
         pytest_require(upstream_neigh_type is not None and downstream_neigh_type is not None,


### PR DESCRIPTION
### Description of PR
The list of upstream ports in this test is being generated through reading port channel information. For topos that don't have any configured port channels, the test will fail with an index out of bounds error if they aren't included in the `topos_no_portchannels` tuple. This PR  creates a tuple with topos that currently don't have any port channels configured. This is the same code structure we have in 202412.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The index of out bounds failure was a heavy hitter for us on a few topos.

#### How did you do it?
Added all known topos without LAGs to `topos_no_portchannels` tuple. This changes the code path and fetches the list of upstream ports as expected.

#### How did you verify/test it?
Ran `generic_config_updater/test_dynamic_acl.py` with and without the fix on multiple topos. Index out of bounds failure not occurring with the fix.

#### Any platform specific information?
I see that recently one LAG port has been added to c448o16. Internally we are using this patch to get our pass rate up but we may need to remove those topos from this change or create a follow-up PR when/if that change gets back ported to 202412.

#### Supported testbed topology if it's a new test case?

### Documentation