### PR TITLE
Adding fix for port_alias mapping in test_route_flap.py

### DIFF
--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -119,15 +119,11 @@ def get_neighbor_info(duthost, dev_port, tbinfo):
     neighs = config_facts['BGP_NEIGHBOR']
     dev_neigh_mdata = config_facts['DEVICE_NEIGHBOR_METADATA'] if 'DEVICE_NEIGHBOR_METADATA' in config_facts else {}
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    nbr_port_map = mg_facts['minigraph_port_name_to_alias_map'] \
-        if 'minigraph_port_name_to_alias_map' in mg_facts else {}
     for neighbor in neighs:
         local_ip = neighs[neighbor]['local_addr']
-        nbr_port = get_port_by_ip(config_facts, local_ip)
-        for p_key, p_value in nbr_port_map.items():
-            if p_value == nbr_port:
-                nbr_port = p_key
-        if dev_port == nbr_port:
+        nbr_port_alias = get_port_by_ip(config_facts, local_ip)
+        nbr_port_name = mg_facts['minigraph_port_alias_to_name_map'].get(nbr_port_alias, nbr_port_alias)
+        if dev_port == nbr_port_name:
             neighbor_name = neighs[neighbor]['name']
     for k, v in dev_neigh_mdata.items():
         if k == neighbor_name:

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -124,10 +124,9 @@ def get_neighbor_info(duthost, dev_port, tbinfo):
     for neighbor in neighs:
         local_ip = neighs[neighbor]['local_addr']
         nbr_port = get_port_by_ip(config_facts, local_ip)
-        if 'Ethernet' in nbr_port:
-            for p_key, p_value in nbr_port_map.items():
-                if p_value == nbr_port:
-                    nbr_port = p_key
+        for p_key, p_value in nbr_port_map.items():
+            if p_value == nbr_port:
+                nbr_port = p_key
         if dev_port == nbr_port:
             neighbor_name = neighs[neighbor]['name']
     for k, v in dev_neigh_mdata.items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

We currently have a condition in this test case that searches for the string "Ethernet" in the port alias mapping. However, some platforms use "etp" in the alias, which causes the test to fail on those platforms. Rather than explicitly adding support for "etp", it would be more robust to remove this check entirely to better accommodate future devices and variations in port alias naming.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To fix test_route_flap on x3b platforms.
#### How did you do it?
By removing a condition that checks for Ethernet string in port alias mapping
#### How did you verify/test it?
Ran on x3b platforms in msft lab.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
