### PR TITLE
Update timeout for gnmi subscribe API

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -431,7 +431,7 @@ def gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, count):
     ip = duthost.mgmt_ip
     port = env.gnmi_port
     cmd = 'python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
-    cmd += '--timeout 30 '
+    cmd += '--timeout 120 '
     cmd += '-t %s -p %u ' % (ip, port)
     cmd += '-xo sonic-db '
     cmd += '-rcert /root/gnmiCA.pem '


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 33257276

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
test_gnmi_configdb_streaming_onchange_01 failed on KVM DUT, and test logs show that it needs more than 30 seconds to get all the results from GNMI server.

#### How did you do it?
Update timeout from 30 seconds to 120 seconds.

#### How did you verify/test it?
Run gnmi end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
