### PR TITLE
[T2 IXIA] free variable 'duthost' referenced before assignment in enclosing scope

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -186,8 +186,8 @@ def reboot_duts(setup_ports_and_dut, localhost, request):
         wait_until(180, 20, 0, node.critical_services_fully_started)
         wait_until(180, 20, 0, check_interface_status_of_up_ports, node)
         wait_until(300, 10, 0, node.check_bgp_session_state_all_asics, up_bgp_neighbors, "established")
-        if duthost.facts['asic_type'] == "cisco-8000":
-            modify_voq_watchdog_cisco_8000(duthost, False)
+        if node.facts.get('asic_type') == "cisco-8000":
+            modify_voq_watchdog_cisco_8000(node, False)
 
     # Convert the list of duthosts into a list of tuples as required for parallel func.
     args = set((snappi_ports[0]['duthost'], snappi_ports[1]['duthost']))


### PR DESCRIPTION
### Description of PR
Fixing the NameError duthost reference

Summary:
Fixes # https://migsonic.atlassian.net/browse/MIGSMSFT-1066

### Type of change
- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ X] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Test failed with NameError

#### How did you do it?
Referenced the correct variable.

#### How did you verify/test it?
Ran the test with change


```
================================================================================== short test summary info ==================================================================================
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-yy40-mixed-short|3-True]
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:141: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:141: Reboot type fast is not supported on cisco-8000 switches
======= 1 passed, 2 skipped, 2 warnings in 1377.41s (0:22:57)======================================
sonic@sonic-ucs-m4-3:/data/tests$ 
```


#### Any platform specific information?
No


