### PR TITLE
Collect techsupport on neighbors if fixture fails in pc/test_retry_count

### DIFF
--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -200,7 +200,7 @@ def check_lacpdu_packet_version(duthost):
 
 
 @pytest.fixture(scope="function")
-def disable_retry_count_on_peer(duthost, nbrhosts, higher_retry_count_on_peers):
+def disable_retry_count_on_peer(duthost, nbrhosts, higher_retry_count_on_peers, collect_techsupport_all_nbrs):
     for nbr in list(nbrhosts.keys()):
         nbrhosts[nbr]['host'].shell("teamdctl PortChannel1 state item set runner.enable_retry_count_feature false")
 
@@ -215,7 +215,7 @@ def disable_retry_count_on_peer(duthost, nbrhosts, higher_retry_count_on_peers):
 
 
 @pytest.fixture(scope="function")
-def disable_retry_count_on_dut(duthost, nbrhosts, higher_retry_count_on_dut):
+def disable_retry_count_on_dut(duthost, nbrhosts, higher_retry_count_on_dut, collect_techsupport_all_nbrs):
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     for port_channel in list(cfg_facts["PORTCHANNEL"].keys()):
         duthost.shell("teamdctl {} state item set runner.enable_retry_count_feature false".format(port_channel))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

If the `disable_retry_count_on_peer` or `disable_retry_count_on_dut` fixtures fail, then collect the techsupport on the neighbor devices. There is already code to collect the techsupport on neighbor devices if the main test fails, but not if the fixtures fail. However, the current common cause of failures appear to be in the fixtures failing, which means the current code won't catch that.

#### How did you do it?

Add `collect_techsupport_all_nbrs` to the list of fixtures needed for `disable_retry_count_on_peer` and `disable_retry_count_on_dut`.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
