### PR TITLE
Remove special characters (special quotes) from Python scripts

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -45,7 +45,7 @@ LOSSY_HWSKU = frozenset({'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8
 
 def is_full_lossy_hwsku(hwsku):
     """
-    Return True if the platform is lossy-only and PFCWD should default to ‘disable’.
+    Return True if the platform is lossy-only and PFCWD should default to 'disable'.
     """
     return hwsku in LOSSY_HWSKU
 

--- a/ansible/verify_config.py
+++ b/ansible/verify_config.py
@@ -21,7 +21,7 @@ NOTE: For now this script only supports yaml format
 
 General Usage:
 
-To verify the entire project’s configuration:
+To verify the entire project's configuration:
 - python3 verify_config.py
 
 This will use the default testbed file (`testbed.yaml`) and the default vm file (`veos`)
@@ -37,7 +37,7 @@ To confirm connectivity with all Devices Under Test (DUTs) within a single testb
 
 This will use the default testbed file (`testbed.yaml`) and the default vm file (`veos`)
 
-To verify a single testbed’s connectivity using specific testbed and VM files:
+To verify a single testbed's connectivity using specific testbed and VM files:
 - python3 verify_config.py -t <testbed-file> -m <vm-file> -tb <testbed-name>
 
 Replace <testbed-file>, <vm-file>, and <testbed-name> with the actual file names and testbed identifier as required.

--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -129,7 +129,7 @@ def duthost_shell_with_unreachable_retry(duthost, command):
             return duthost.shell(command)
         except AnsibleConnectionFailure as e:
             retries += 1
-            logger.warning("retry_when_dut_unreachable exception： {}, retry {}/{}"
+            logger.warning("retry_when_dut_unreachable exception: {}, retry {}/{}"
                            .format(e, retries, DEVICE_UNREACHABLE_MAX_RETRIES))
             if retries > DEVICE_UNREACHABLE_MAX_RETRIES:
                 raise e


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Remove non-standard quote marks from two Python scripts in the ansible directory. For Python 3, things will still work. However, in cases where these scripts are executed in a Python 2 context (because the SONiC device is running an old version of SONiC), it will cause problems. This may be the case for upgrade path testing, where old versions of SONiC might be running on the device.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
