### PR TITLE
Skip frr_bmp during container autorestart check in test_ecmp_sai_value

### DIFF
--- a/tests/ecmp/test_ecmp_sai_value.py
+++ b/tests/ecmp/test_ecmp_sai_value.py
@@ -55,12 +55,18 @@ def enable_container_autorestart(duthosts, enum_rand_one_per_hwsku_frontend_host
     for feature, status in list(feature_list.items()):
         # Enable container autorestart only if the feature is enabled and container autorestart is disabled.
         if status == 'enabled' and container_autorestart_states[feature] == 'disabled':
+            if feature == "frr_bmp":
+                # Skip frr_bmp since it's not container just bmp option used by bgpd
+                continue
             duthost.shell("sudo config feature autorestart {} enabled".format(feature))
 
     yield
     for feature, status in list(feature_list.items()):
         # Disable container autorestart back if it was initially disabled.
         if status == 'enabled' and container_autorestart_states[feature] == 'disabled':
+            if feature == "frr_bmp":
+                # Skip frr_bmp since it's not container just bmp option used by bgpd
+                continue
             duthost.shell("sudo config feature autorestart {} disabled".format(feature))
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the error:
`failed on setup with "KeyError: 'frr_bmp'"`

frr_bmp shows up in show feature status but it isn't a real docker container so we should skip it.
Skip frr_bmp during container autorestart check in test_ecmp_sai_value
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Fix the error:
`failed on setup with "KeyError: 'frr_bmp'"`

frr_bmp shows up in show feature status but it isn't a real docker container so we should skip it.

#### How did you do it?
Skip frr_bmp during container autorestart check in test_ecmp_sai_value

#### How did you verify/test it?
Run test_ecmp_sai_value on testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
