### PR TITLE
skip interface speed change on 7060x6 as it causes crash

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1479,12 +1479,13 @@ iface_namingmode/test_iface_namingmode.py::TestConfigInterface:
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
 iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
-  xfail:
+  skip:
     reason: "Incorrect supported speeds for 7060X6 in STATE_DB, fix TBD"
     conditions_logical_operator: and
     conditions:
       - "'7060X6' in hwsku"
       - "topo_type in ['t1']"
+      - https://github.com/sonic-net/sonic-mgmt/issues/19034
 
 iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup:
   xfail:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Workaround for https://github.com/sonic-net/sonic-mgmt/issues/19034
As changing port speed on 7060x6 will cause orchagent crash, resulting in subsequence test case failure. Skip it for now until the issue is fixed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Skip test case which cause orchagent crash on 7060x6 platform

#### How did you do it?
change from xfail to skip

#### How did you verify/test it?
=========================== short test summary info ============================
SKIPPED [2] iface_namingmode/test_iface_namingmode.py:678: Unsupported topology
SKIPPED [2] iface_namingmode/test_iface_namingmode.py:699: Unsupported topology
SKIPPED [2] iface_namingmode/test_iface_namingmode.py: Incorrect supported speeds for 7060X6 in STATE_DB, fix TBD
============ 54 passed, 6 skipped, 4 warnings in 1778.39s (0:29:38) ============

#### Any platform specific information?
Only on 7060x6-64pe platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
