### PR TITLE
Set KVM NIC type to virtio to fix reset adapter issue

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -79,7 +79,7 @@
     {% if asic_type == 'vpp' %}
         <model type='virtio-net-pci' />
     {% else %}
-        <model type='virtio-net-pci' />
+        <model type='e1000e' />
     {% endif %}
     </interface>
 {% for i in range(port_alias|length) %}
@@ -88,7 +88,7 @@
     {% if asic_type == 'vpp' %}
         <model type='virtio-net-pci' />
     {% else %}
-        <model type='virtio-net-pci' />
+        <model type='e1000e' />
     {% endif %}
         <mtu size='{{ fp_mtu_size }}' />
     </interface>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
