### PR TITLE
[bgp_scale] Update test_ipv6_bgp_scale to support different routes sets

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -706,6 +706,14 @@ def pytest_addoption(parser):
         default=3,
         help="continuous reboot time number. default is 3"
     )
+    parser.addoption(
+        "--max_flap_neighbor_number",
+        action="store",
+        dest="max_flap_neighbor_number",
+        type=int,
+        default=None,
+        help="Max flap neighbor number, default is None"
+    )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -446,6 +446,9 @@ def test_nexthop_group_member_scale(
             withdraw_number += 1
             if withdraw_number == WITHDRAW_ROUTE_NUMBER:
                 break
+    pytest_assert(max_flap_neighbor_number and len(peers_routes_to_change) == max_flap_neighbor_number or
+                  len(peers_routes_to_change) == len(neighbor_ecmp_routes),
+                  "Flap neighbor count is not enough: {}".format(len(peers_routes_to_change)))
     # ------------withdraw routes and test ------------ #
     terminated = Event()
     traffic_thread = Thread(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
After adding announce different routes set by https://github.com/sonic-net/sonic-mgmt/pull/19041, test_ipv6_bgp_scale need to be updated to support it

#### How did you do it?
1. For `test_sessions_flapping` and `test_device_unisolation`, modify the function to get ecmp routes
2. For `test_nexthop_group_member_scale`:
2.1 Modify the function to get ecmp routes
2.2 Add support to specify flap neighbor count
2.3 Sample:
To be noticed that the parameter is to specify neighbors' number to withdraw one route in test_nexthop_group_member_scale. In this test, we would withdraw 1 route from number of neighbors, the nexthop group member would be increased with the increasing with neighbors' number withdraw routes. Due to hw limitaion in some platform, the blast of nexthop group members would cause swss crash. Hence we add such parameter to limit the number of neighbors who withdraw routes
`./run_tests.sh -i ../ansible/st,../ansible/veos -n testbed -u -m individual -e --disable_loganalyzer  -e --skip_sanity  -c bgp/test_ipv6_bgp_scale.py -e --max_flap_neighbor_number=190`

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
