### PR TITLE
xfail testcase due to known issue 'https://github.com/sonic-net/sonic…

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -84,7 +84,7 @@ arp/test_wr_arp.py::test_wr_arp:
   xfail:
     reason: "This testcase fails due to known issue 'https://github.com/sonic-net/sonic-buildimage/issues/21844'"
     conditions:
-      - "asic_type in ['marvell-teralynx']"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/21844 and 't0' in topo_name"
 
 #######################################
 #####            bfd              #####


### PR DESCRIPTION
### Description of PR

Summary:
The xfail condition in arp/test_wr_arp.py::test_wr_arp has been added. The testcase 
"test_wr_arp" fails due to known issue 'https://github.com/sonic-net/sonic-buildimage/issues/21844' 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The test_wr_arp test case in arp/test_wr_arp.py intermittently fails on the Marvell-Teralynx platform due to a known issue documented in sonic-buildimage#21844. The failure is caused by the neighbor_advertiser script occasionally being unable to establish a connection during warm-reboot, resulting in the error:
"Failed to establish a new connection: [Errno 113] No route to host."
To prevent this known issue from causing false negatives in test results and to maintain the reliability of the test suite, an xfail condition has been added.

#### How did you do it?
Added an xfail condition for the test_wr_arp test case in arp/test_wr_arp.py, specifically targeting the Marvell-Teralynx platform.
Linked the condition to the known issue for traceability and future resolution tracking.
Ran the affected test cases to confirm that they now xfail instead of being marked as fail.

#### How did you verify/test it?
Executed the test_wr_arp test case on the Marvell-Teralynx platform.
Confirmed that the test is now marked as an expected failure (xfail) rather than an unexpected one.
Verified that the failure behavior aligns with the known issue and that the test suite continues to run without interruption.

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
This is an existing test case designed for the t0 topology.

### Documentation
None
