### PR TITLE
noqa replaced with noqa: and pre-commit error has been fixed in tests/r* folders

### DIFF
--- a/tests/radv/test_radv_ipv6_ra.py
+++ b/tests/radv/test_radv_ipv6_ra.py
@@ -3,12 +3,12 @@ import logging
 
 import pytest
 
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # noqa F401
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # noqa F401
-from tests.common.fixtures.ptfhost_utils import run_garp_service                                # noqa F401
-from tests.common.fixtures.ptfhost_utils import run_icmp_responder                              # noqa F401
-from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr                         # noqa F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                         # noqa: F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                            # noqa: F401
+from tests.common.fixtures.ptfhost_utils import run_garp_service                                # noqa: F401
+from tests.common.fixtures.ptfhost_utils import run_icmp_responder                              # noqa: F401
+from tests.common.dualtor.dual_tor_mock import mock_server_base_ip_addr                         # noqa: F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
@@ -43,7 +43,7 @@ def radv_test_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
 
         # Obtain the link-local IPv6 address of the DUT's downlink VLAN interface
         downlink_vlan_iface['mac'] = duthost.get_dut_iface_mac(vlan_iface_name)
-        cmd = ("ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'"      # noqa W605
+        cmd = ("ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'"      # noqa: W605
                .format(vlan_iface_name))
         res = duthost.shell(cmd)
         ip6 = ipaddress.IPv6Address(str(res['stdout']))
@@ -56,7 +56,7 @@ def radv_test_setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         ptf_port = {}
         ptf_port['port_idx'] = mg_facts['minigraph_ptf_indices'][vlan_info_dict['members'][0]]
         ptf_port['name'] = "eth" + str(ptf_port['port_idx'])
-        cmd = ("ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'"      # noqa W605
+        cmd = ("ip -6 -o addr show dev {} scope link | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\\1/;t;d'"      # noqa: W605
                .format(ptf_port['name']))
         res = ptfhost.shell(cmd)
         ip6 = ipaddress.IPv6Address(str(res['stdout']))
@@ -77,7 +77,7 @@ def dut_update_ra_interval(duthost, ra, interval):
     @summary: Updates min/max RA interval in RADVd's config file
     """
     logging.info("Updating %s to %d in RADVd's config file:%s", ra, int(interval), RADV_CONF_FILE)
-    cmd = "sed -ie 's/\(.*\)\({}\) \([[:digit:]]\+\)/\\1\\2 {}/' {}".format(ra, interval, RADV_CONF_FILE)   # noqa W605
+    cmd = "sed -ie 's/\(.*\)\({}\) \([[:digit:]]\+\)/\\1\\2 {}/' {}".format(ra, interval, RADV_CONF_FILE)   # noqa: W605
     duthost.shell("docker exec radv {}".format(cmd))
 
 
@@ -115,7 +115,7 @@ def test_radv_router_advertisement(
         duthosts, rand_one_dut_hostname,
         ptfhost, radv_test_setup,
         dut_update_radv_periodic_ra_interval,
-        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa: F811
 ):
     """
     @summary: Test validates the RADVd's periodic router advertisement sent on each VLAN interface
@@ -142,7 +142,7 @@ def test_radv_router_advertisement(
 def test_solicited_router_advertisement(
         duthosts, rand_one_dut_hostname,
         ptfhost, radv_test_setup,
-        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa: F811
 ):
     """
     @summary: Test validates the RADVd's solicited router advertisement sent on each VLAN interface
@@ -170,7 +170,7 @@ def test_solicited_router_advertisement(
 def test_unsolicited_router_advertisement_with_m_flag(
         duthosts, rand_one_dut_hostname,
         ptfhost, radv_test_setup,
-        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa: F811
 ):
     """
     @summary: Test validates the M flag in RADVd's periodic router advertisement sent on each VLAN interface
@@ -197,7 +197,7 @@ def test_unsolicited_router_advertisement_with_m_flag(
 def test_solicited_router_advertisement_with_m_flag(
         duthosts, rand_one_dut_hostname,
         ptfhost, radv_test_setup,
-        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa F811
+        toggle_all_simulator_ports_to_rand_selected_tor_m       # noqa: F811
 ):
     """
     @summary: Test validates the M flag in RADVd's solicited router advertisement sent on each VLAN interface

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -5,7 +5,7 @@ import psutil
 import threading
 import time
 
-from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa F401
+from tests.common.storage_backend.backend_utils import skip_test_module_over_backend_topologies     # noqa: F401
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.utilities import find_duthost_on_role

--- a/tests/route/test_route_bgp_ecmp.py
+++ b/tests/route/test_route_bgp_ecmp.py
@@ -75,7 +75,7 @@ def check_route(duthost, route, operation):
 
 
 def test_route_bgp_ecmp(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
-                        loganalyzer, setup_and_teardown):    # noqa F811
+                        loganalyzer, setup_and_teardown):    # F811
     ptf_ip = tbinfo['ptf_ip']
     common_config = tbinfo['topo']['properties']['configuration_properties'].get(
         'common', {})

--- a/tests/route/test_route_bgp_ecmp.py
+++ b/tests/route/test_route_bgp_ecmp.py
@@ -75,7 +75,7 @@ def check_route(duthost, route, operation):
 
 
 def test_route_bgp_ecmp(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
-                        loganalyzer, setup_and_teardown):    # F811
+                        loganalyzer, setup_and_teardown):    # noqa: F811
     ptf_ip = tbinfo['ptf_ip']
     common_config = tbinfo['topo']['properties']['configuration_properties'].get(
         'common', {})

--- a/tests/route/test_route_flap.py
+++ b/tests/route/test_route_flap.py
@@ -8,7 +8,7 @@ import pytest
 import ptf.testutils as testutils
 import ptf.packet as scapy
 from tests.common.dualtor.mux_simulator_control import \
-            toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m   # noqa F401
+            toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m   # noqa: F401
 
 from ptf.mask import Mask
 from natsort import natsorted
@@ -395,8 +395,8 @@ def test_route_flap(duthosts, tbinfo, ptfhost, ptfadapter,
                     get_function_completeness_level, announce_default_routes,
                     enum_rand_one_per_hwsku_frontend_hostname,
                     enum_upstream_dut_hostname, enum_rand_one_frontend_asic_index,
-                    setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m,                     # noqa F811
-                    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, loganalyzer):    # noqa F811
+                    setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m,                     # noqa: F811
+                    toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m, loganalyzer):    # noqa: F811
     ptf_ip = tbinfo['ptf_ip']
     common_config = tbinfo['topo']['properties']['configuration_properties'].get(
         'common', {})

--- a/tests/route/test_route_flow_counter.py
+++ b/tests/route/test_route_flow_counter.py
@@ -3,7 +3,7 @@ import pytest
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.flow_counter import flow_counter_utils
-from tests.common.flow_counter.flow_counter_utils import is_route_flow_counter_supported   # noqa F401
+from tests.common.flow_counter.flow_counter_utils import is_route_flow_counter_supported   # noqa: F401
 from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ added_routes = set()
 
 
 @pytest.fixture(scope='function', autouse=True)
-def skip_if_not_supported(is_route_flow_counter_supported):     # noqa F811
+def skip_if_not_supported(is_route_flow_counter_supported):     # noqa: F811
     """Skip the test if route flow counter is not supported on this platform
 
     Args:

--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -7,7 +7,7 @@ import json
 import ptf.testutils as testutils
 import ptf.mask as mask
 import ptf.packet as packet
-from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports  # noqa F811
+from tests.common.dualtor.dual_tor_utils import get_t1_ptf_ports  # noqa: F811, F401
 from datetime import datetime
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -8,12 +8,14 @@ import re
 import six
 from collections import defaultdict
 
-from tests.common.fixtures.ptfhost_utils import change_mac_addresses, copy_arp_responder_py # noqa F811
-from tests.common.fixtures.ptfhost_utils import remove_ip_addresses # noqa F811
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses, copy_arp_responder_py  # noqa: F811, F401
+from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa: F811, F401
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
-from tests.common.dualtor.mux_simulator_control import mux_server_url # noqa F811
+from tests.common.dualtor.mux_simulator_control import mux_server_url  # noqa: F811, F401
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m # noqa F811
+from tests.common.dualtor.mux_simulator_control import (  # noqa: F811, F401
+    toggle_all_simulator_ports_to_rand_selected_tor_m
+)
 from tests.common.utilities import wait_until, get_intf_by_sub_intf
 from tests.common.utilities import get_neighbor_ptf_port_list
 from tests.common.helpers.assertions import pytest_assert
@@ -22,9 +24,12 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP
 from tests.common import config_reload
 import ptf.testutils as testutils
 import ptf.mask as mask
-import ptf.packet as packet
+import ptf.packet as packet  # noqa: F401
 from tests.common import constants
-from tests.common.flow_counter.flow_counter_utils import RouteFlowCounterTestContext, is_route_flow_counter_supported # noqa F811
+from tests.common.flow_counter.flow_counter_utils import (  # noqa: F811, F401
+    RouteFlowCounterTestContext,
+    is_route_flow_counter_supported
+)
 from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 
@@ -209,7 +214,7 @@ def check_mux_status(duthost, expected_status):
 
 def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbinfo,
                           prefix, nexthop_addrs, prefix_len, nexthop_devs, nexthop_interfaces,
-                          is_route_flow_counter_supported, ipv6=False, config_reload_test=False): # noqa F811
+                          is_route_flow_counter_supported, ipv6=False, config_reload_test=False):  # noqa: F811
     is_dual_tor = False
     if 'dualtor' in tbinfo['topo']['name'] and unselected_duthost is not None:
         is_dual_tor = True
@@ -366,8 +371,10 @@ def get_nexthops(duthost, tbinfo, ipv6=False, count=1):
 
 
 def test_static_route(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
-                      setup_standby_ports_on_rand_unselected_tor, # noqa F811
-                      toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
+                      setup_standby_ports_on_rand_unselected_tor,  # noqa: F811
+                      toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa: F401, F811
+                      is_route_flow_counter_supported  # noqa: F811
+                      ):
     duthost = rand_selected_dut
     unselected_duthost = rand_unselected_dut
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo)
@@ -377,8 +384,9 @@ def test_static_route(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhos
 
 @pytest.mark.disable_loganalyzer
 def test_static_route_ecmp(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
-                           setup_standby_ports_on_rand_unselected_tor, # noqa F811
-                           toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor,  # noqa: F811
+                           toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa: F811
+                           is_route_flow_counter_supported):    # noqa: F811
     duthost = rand_selected_dut
     unselected_duthost = rand_unselected_dut
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, count=3)
@@ -388,8 +396,9 @@ def test_static_route_ecmp(rand_selected_dut, rand_unselected_dut, ptfadapter, p
 
 
 def test_static_route_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
-                           setup_standby_ports_on_rand_unselected_tor, # noqa F811
-                           toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor,  # noqa: F811
+                           toggle_all_simulator_ports_to_rand_selected_tor_m,   # noqa: F811
+                           is_route_flow_counter_supported):  # noqa: F811
     duthost = rand_selected_dut
     unselected_duthost = rand_unselected_dut
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, ipv6=True)
@@ -400,8 +409,9 @@ def test_static_route_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapter, p
 
 @pytest.mark.disable_loganalyzer
 def test_static_route_ecmp_ipv6(rand_selected_dut, rand_unselected_dut, ptfadapter, ptfhost, tbinfo,
-                                setup_standby_ports_on_rand_unselected_tor, # noqa F811
-                                toggle_all_simulator_ports_to_rand_selected_tor_m, is_route_flow_counter_supported): # noqa F811
+                                setup_standby_ports_on_rand_unselected_tor,  # noqa: F811
+                                toggle_all_simulator_ports_to_rand_selected_tor_m,  # noqa: F811
+                                is_route_flow_counter_supported):  # noqa: F811
     duthost = rand_selected_dut
     unselected_duthost = rand_unselected_dut
     prefix_len, nexthop_addrs, nexthop_devs, nexthop_interfaces = get_nexthops(duthost, tbinfo, ipv6=True, count=3)


### PR DESCRIPTION
Folders replaces with noqa: and pre-commit errors:

1. tests/radv 
2. tests/route

![image](https://github.com/user-attachments/assets/83a1a158-41ca-4d10-9679-d1ea5ad14ace)
