### PR TITLE
[snappi] Replace hardcoded lossy flows to random priority lossy flows in PFC m2o oversubscribe tests

### DIFF
--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py
@@ -319,11 +319,10 @@ def __gen_data_flow(testbed_config,
         elif 'Test Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = flow_prio[1]
     else:
-        if 'Background Flow' in flow.name:
-            eth.pfc_queue.value = pfcQueueValueDict[1]
-        elif 'Test Flow 1 -> 0' in flow.name:
+        # Adding queue values based on flow_priorities for both test and background flows.
+        if 'Flow 1 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
-        elif 'Test Flow 2 -> 0' in flow.name:
+        elif 'Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
     global UDP_PORT_START
@@ -338,19 +337,11 @@ def __gen_data_flow(testbed_config,
     ipv4.priority.choice = ipv4.priority.DSCP
 
     flow_prio_dscp_list = []
+    # Background flows have dynamic lossy priorities.
     if 'Background Flow 1 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [
-            ipv4.priority.dscp.phb.CS1,
-        ]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[0]]
     elif 'Background Flow 2 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [
-            ipv4.priority.dscp.phb.AF11,
-        ]
-        ipv4.priority.dscp.phb.values = [
-            60, 61, 62, 63, 24, 25, 27, 21, 23, 29,
-            0, 2, 6, 59, 11, 13, 15, 58, 17, 16, 19, 54, 57,
-            56, 51, 50, 53, 52, 59, 49, 47, 44, 45, 42, 43, 40, 41
-        ]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[1]]
     elif 'Test Flow 1 -> 0' in flow.name:
         for fp in flow_prio:
             for val in prio_dscp_map[fp]:

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py
@@ -348,28 +348,22 @@ def __gen_data_flow(testbed_config,
         else:
             eth.pfc_queue.value = flow_prio[0]
     else:
-        if 'Background Flow' in flow.name:
-            eth.pfc_queue.value = pfcQueueValueDict[1]
-        else:
+        # Ingress#1 uses flow_prio[0] and ingress#2 uses flow_prio[1] queues.
+        if 'Flow 1 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
+        elif 'Flow 2 -> 0' in flow.name:
+            eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
     ipv4.src.value = tx_port_config.ip
     ipv4.dst.value = gen_data_flow_dest_ip(rx_port_config.ip)
     ipv4.priority.choice = ipv4.priority.DSCP
 
+    # Dynamically assigning lossy priorities to background flows
     if 'Background Flow 1 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [
-            ipv4.priority.dscp.phb.CS1,
-        ]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[0]]
     elif 'Background Flow 2 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [
-            ipv4.priority.dscp.phb.AF11,
-        ]
-        ipv4.priority.dscp.phb.values = [
-            60, 61, 62, 63, 24, 25, 27, 21, 23, 29,
-            0, 2, 6, 59, 11, 13, 15, 58, 17, 16, 19, 54, 57,
-            56, 51, 50, 53, 52, 59, 49, 47, 44, 45, 42, 43, 40, 41
-        ]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[1]]
+    # Dynamically assigning lossless priorities to test flows
     elif 'Test Flow 1 -> 0' in flow.name:
         ipv4.priority.dscp.phb.values = [
             ipv4.priority.dscp.phb.DEFAULT,

--- a/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
+++ b/tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py
@@ -356,11 +356,9 @@ def __gen_data_flow(testbed_config,
         elif 'Background Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = flow_prio[1]
     else:
-        if 'Test Flow' in flow.name:
-            eth.pfc_queue.value = pfcQueueValueDict[1]
-        elif 'Background Flow 1 -> 0' in flow.name:
+        if 'Flow 1 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
-        elif 'Background Flow 2 -> 0' in flow.name:
+        elif 'Flow 2 -> 0' in flow.name:
             eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]
 
     global UDP_PORT_START
@@ -384,19 +382,11 @@ def __gen_data_flow(testbed_config,
             ipv4.priority.dscp.phb.AF11,
         ]
         ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[1]]
+    # Adding flow_prio[0] for ingress#1 and flow_prio[1] for ingress#2.
     elif 'Test Flow 1 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [
-            ipv4.priority.dscp.phb.CS1,
-        ]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[0]]
     elif 'Test Flow 2 -> 0' in flow.name:
-        ipv4.priority.dscp.phb.values = [
-            ipv4.priority.dscp.phb.AF11,
-        ]
-        ipv4.priority.dscp.phb.values = [
-            60, 61, 62, 63, 24, 25, 26, 27, 21, 23, 28, 29,
-            0, 2, 6, 59, 11, 13, 15, 58, 17, 16, 19, 54, 57,
-            56, 51, 50, 53, 52, 59, 49, 47, 44, 45, 42, 43, 40, 41
-        ]
+        ipv4.priority.dscp.phb.values = prio_dscp_map[flow_prio[1]]
     elif 'Test Flow' in flow.name:
         flow.duration.fixed_seconds.delay.nanoseconds = 5
     else:

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import random
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
@@ -65,7 +66,8 @@ def test_m2o_oversubscribe_lossless(snappi_api,                              # n
     all_prio_list = prio_dscp_map.keys()
     test_prio_list = lossless_prio_list
     pause_prio_list = test_prio_list
-    bg_prio_list = [x for x in all_prio_list if x not in pause_prio_list]
+    bg_prio_list = random.sample([x for x in all_prio_list if x not in pause_prio_list], 2)
+    logger.info('Selected two random lossy background priorities:{}'.format(bg_prio_list))
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossless_lossy.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import random
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
@@ -67,7 +68,8 @@ def test_m2o_oversubscribe_lossless_lossy(snappi_api,                   # noqa: 
     all_prio_list = prio_dscp_map.keys()
     test_prio_list = lossless_prio_list
     pause_prio_list = test_prio_list
-    bg_prio_list = [x for x in all_prio_list if x not in pause_prio_list]
+    bg_prio_list = random.sample([x for x in all_prio_list if x not in pause_prio_list], 2)
+    logger.info('Selected two random lossy background priorities:{}'.format(bg_prio_list))
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports

--- a/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py
+++ b/tests/snappi_tests/pfc/test_m2o_oversubscribe_lossy.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import random
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
@@ -62,7 +63,8 @@ def test_m2o_oversubscribe_lossy(snappi_api,                                  # 
     all_prio_list = prio_dscp_map.keys()
     bg_prio_list = lossless_prio_list
     pause_prio_list = bg_prio_list
-    test_prio_list = [x for x in all_prio_list if x not in pause_prio_list]
+    test_prio_list = random.sample([x for x in all_prio_list if x not in pause_prio_list], 2)
+    logger.info('Selected random test lossy flow priorities:{}'.format(test_prio_list))
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #18599 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
The PFC m2o oversubscribe testcases have 2 ingress interfaces and 1 egress interface. Each ingress interface has 1 test-flow and 1 background flow.

The test and background are either lossless or lossy priority flow depending upon the testcase. 

All three testcases have list for the lossy priorities however, in the helper files, they are hard-coded to select ONLY priority 0 and 1. 

Correspondingly, there is an issue in the PFC-queue assignment as well.

(a) **tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_helper.py**
```
Background flow priorities are assigned to single queue:
        if 'Background Flow' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[1]
        elif 'Test Flow 1 -> 0' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
        elif 'Test Flow 2 -> 0' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]

Background flows are hardcoded:
    if 'Background Flow 1 -> 0' in flow.name:
        ipv4.priority.dscp.phb.values = [
            ipv4.priority.dscp.phb.CS1,
        ]
    elif 'Background Flow 2 -> 0' in flow.name:
        ipv4.priority.dscp.phb.values = [
            ipv4.priority.dscp.phb.AF11,
        ]
        ipv4.priority.dscp.phb.values = [
            60, 61, 62, 63, 24, 25, 27, 21, 23, 29,
            0, 2, 6, 59, 11, 13, 15, 58, 17, 16, 19, 54, 57,
            56, 51, 50, 53, 52, 59, 49, 47, 44, 45, 42, 43, 40, 41
        ]
```

(b) **tests/snappi_tests/pfc/files/m2o_oversubscribe_lossless_lossy_helper.py**
```
Background and test flow priorities are assigned to single queue:
        if 'Background Flow' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[1]
        else:
            eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]

Background flows are hardcoded:
    if 'Background Flow 1 -> 0' in flow.name:
        ipv4.priority.dscp.phb.values = [
            ipv4.priority.dscp.phb.CS1,
        ]
    elif 'Background Flow 2 -> 0' in flow.name:
        ipv4.priority.dscp.phb.values = [
            ipv4.priority.dscp.phb.AF11,
        ]
        ipv4.priority.dscp.phb.values = [
            60, 61, 62, 63, 24, 25, 27, 21, 23, 29,
            0, 2, 6, 59, 11, 13, 15, 58, 17, 16, 19, 54, 57,
            56, 51, 50, 53, 52, 59, 49, 47, 44, 45, 42, 43, 40, 41
        ]
```

c. **tests/snappi_tests/pfc/files/m2o_oversubscribe_lossy_helper.py**
```
Test flow queues are assigned to single queue:
        if 'Test Flow' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[1]
        elif 'Background Flow 1 -> 0' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[flow_prio[0]]
        elif 'Background Flow 2 -> 0' in flow.name:
            eth.pfc_queue.value = pfcQueueValueDict[flow_prio[1]]

Test flows are hardcoded:
    elif 'Test Flow 1 -> 0' in flow.name:
        ipv4.priority.dscp.phb.values = [
            ipv4.priority.dscp.phb.CS1,
        ]
    elif 'Test Flow 2 -> 0' in flow.name:
        ipv4.priority.dscp.phb.values = [
            ipv4.priority.dscp.phb.AF11,
        ]
        ipv4.priority.dscp.phb.values = [
            60, 61, 62, 63, 24, 25, 26, 27, 21, 23, 28, 29,
            0, 2, 6, 59, 11, 13, 15, 58, 17, 16, 19, 54, 57,
            56, 51, 50, 53, 52, 59, 49, 47, 44, 45, 42, 43, 40, 41
        ]

**NOTE**: The test flows are the lossy priorities flow in this testcase.
```
#### How did you do it?

1. Randomly selecting two lossy priority flows in the testcase.
2. The lossy priority flows are now selected from prio_dscp_map[flow_prio[<ingress_interfac_index>]], rather than being hardcoded.
3. The PFC queues are assigned as per the lossy/lossless priority value for both background and test-flows.

@selldinesh , @sdszhang , @auspham, @kamalsahu0001  for viz.

#### How did you verify/test it?
1. Ran the test on chassis setup and put checked via 'show queue counter -n <asic-value> --nonzero' on the DUT to see if the test chooses correct lossy priority and DUT is able to decode it correctly.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
