### PR TITLE
voqWD disabling and method to check dshellClient is running

### DIFF
--- a/tests/common/cisco_data.py
+++ b/tests/common/cisco_data.py
@@ -97,3 +97,12 @@ set_voq_watchdog({})
 '''.format(enable)
 
     copy_dshell_script_cisco_8000(dut, asic, dshell_script, script_name="set_voq_watchdog.py")
+
+
+def check_dshell_ready(duthost):
+    show_command = "sudo show platform npu rx cgm_global"
+    err_msg = "debug shell server for asic 0 is not running"
+    output = duthost.command(show_command)['stdout']
+    if err_msg in output:
+        return False
+    return True

--- a/tests/snappi_tests/cisco/helper.py
+++ b/tests/snappi_tests/cisco/helper.py
@@ -1,5 +1,6 @@
 # Helper functions to be used only for cisco platforms.
-from tests.common.cisco_data import copy_set_voq_watchdog_script_cisco_8000
+from tests.common.utilities import wait_until
+from tests.common.cisco_data import copy_set_voq_watchdog_script_cisco_8000, check_dshell_ready
 import pytest
 
 
@@ -27,6 +28,8 @@ def modify_voq_watchdog_cisco_8000(duthost, enable):
     #    copy_set_voq_watchdog_script_cisco_8000(duthost, "", enable=enable)
     '''
 
+    if not wait_until(300, 20, 0, check_dshell_ready, duthost):
+        raise RuntimeError("Debug shell is not ready on {}".format(duthost.hostname))
     for asic in asics:
         copy_set_voq_watchdog_script_cisco_8000(duthost, asic, enable=enable)
         duthost.shell(f"sudo show platform npu script -n asic{asic} -s set_voq_watchdog.py")

--- a/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_actions.py
@@ -15,7 +15,7 @@ from tests.snappi_tests.pfcwd.files.pfcwd_actions_helper import run_pfc_test
 from tests.common.config_reload import config_reload
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
-from tests.snappi_tests.cisco.helper import disable_voq_watchdog               # noqa: F401
+from tests.snappi_tests.cisco.helper import modify_voq_watchdog_cisco_8000              # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -1001,6 +1001,8 @@ def test_pfcwd_disable_pause_cngtn(snappi_api,                  # noqa: F811
 
     for dut in duthosts:
         clear_fabric_counters(dut)
+        if dut.facts.get('asic_type') == "cisco-8000":
+            modify_voq_watchdog_cisco_8000(dut, False)
 
     try:
         run_pfc_test(api=snappi_api,
@@ -1022,5 +1024,8 @@ def test_pfcwd_disable_pause_cngtn(snappi_api,                  # noqa: F811
 
     finally:
         cleanup_config(duthosts, snappi_ports)
+        for dut in duthosts:
+            if dut.facts.get('asic_type') == "cisco-8000":
+                modify_voq_watchdog_cisco_8000(dut, True)
         for duthost in dut_list:
             config_reload(sonic_host=duthost, config_source='config_db', safe_reload=True)


### PR DESCRIPTION
### Description of PR
Disabling voqWD in testcase where PFCWD is disabled and traffic is run for more than 1min. Added a method to check if dshell client is up and running

Summary:
Fixes # 
`FAILED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info0-port_map0] - Failed: Losses observed in lossy traffic streams`

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We had added the fixture to disable the voqWD.
https://github.com/sonic-net/sonic-mgmt/blob/939485fd3e5d890de5d94f3b7eedd44e82844180/tests/snappi_tests/pfcwd/test_pfcwd_actions.py#L18
 
But every tests does config reload on the DUT’s which reverses disabled voqWD config.
Hence the test was failing
 FAILED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info0-port_map0] - Failed: Losses observed in lossy traffic streamsWe had added the fixture to disable the voqWD.

config reload done as part of teardown:
https://github.com/sonic-net/sonic-mgmt/blob/939485fd3e5d890de5d94f3b7eedd44e82844180/tests/snappi_tests/pfcwd/test_pfcwd_actions.py#L885
 

#### How did you do it?
Disabling the voqWD in the test case where PFCWD is disabled and traffic is sent for > 1min

#### How did you verify/test it?
Manually ran the tests with change

```
========================= short test summary info =========================================
PASSED snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_a2a_with_snappi.py::test_multidut_pfcwd_all_to_all[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10[multidut_port_info0-port_map0]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_uni[multidut_port_info0-port_map0]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_over_subs_40_09[multidut_port_info0-port_map0]
PASSED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info0-port_map0]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-yy40-mixed-rp|4-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-cold-True]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-cold-False]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-True-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-False-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-True-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-False-swss]
PASSED snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py::test_pfcwd_burst_storm_single_lossless_prio[multidut_port_info0]
PASSED snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-True]
PASSED snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py::test_pfcwd_many_to_one[multidut_port_info0-False]
PASSED snappi_tests/pfcwd/test_pfcwd_mixed_speed.py::test_mixed_speed_pfcwd_enable[multidut_port_info0-port_map0]
PASSED snappi_tests/pfcwd/test_pfcwd_mixed_speed.py::test_mixed_speed_pfcwd_disable[multidut_port_info0-port_map0]
PASSED snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py::test_pfcwd_runtime_traffic[multidut_port_info0]
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:370: Forward action is not supported in cisco-8000.
SKIPPED [1] common/helpers/assertions.py:22: Need Minimum of 2 ports defined in ansible/files/*links.csv file
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:715: Forward action is not supported in cisco-8000.
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:141: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:141: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:190: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:190: Reboot type fast is not supported on cisco-8000 switches
FAILED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_90_10[multidut_port_info0-port_map1] - Failed: Rx Ports for yy40-mixed-tb in MULTIDUT_PORT_INFO doesn't match with ansible/files/*links.csv
FAILED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_drop_uni[multidut_port_info0-port_map1] - Failed: Rx Ports for yy40-mixed-tb in MULTIDUT_PORT_INFO doesn't match with ansible/files/*links.csv
FAILED snappi_tests/pfcwd/test_pfcwd_actions.py::test_pfcwd_disable_pause_cngtn[multidut_port_info0-port_map1] - Failed: Rx Ports for yy40-mixed-tb in MULTIDUT_PORT_INFO doesn't match with ansible/files/*links.csv
=========== 3 failed, 23 passed, 11 skipped, 22 warnings in 17703.22s (4:55:03) ===================
```

#### Any platform specific information?
Cisco8000

