### PR TITLE
skip speed change for Arista 7060x6 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1476,12 +1476,9 @@ iface_namingmode/test_iface_namingmode.py::TestConfigInterface:
 
 iface_namingmode/test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed:
   skip:
-    reason: "Incorrect supported speeds for 7060X6 in STATE_DB, fix TBD"
-    conditions_logical_operator: and
+    reason: "Arista-7060X6 doesn't support speed change as it's ASIC limitation. Skipping this test."
     conditions:
-      - "'7060X6' in hwsku"
-      - "topo_type in ['t1']"
-      - https://github.com/sonic-net/sonic-mgmt/issues/19034
+      - "'Arista-7060X6' in hwsku"
 
 iface_namingmode/test_iface_namingmode.py::TestShowPriorityGroup:
   xfail:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes skip condition for test_iface_namingmode.py::TestConfigInterface::test_config_interface_speed due to ASIC limitation.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Correct the skip condition.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?
This is for Arista 7060X6 platform only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
