### PR TITLE
[test_default_route]: Fix default route for PT0

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -9,7 +9,7 @@ from tests.common.storage_backend.backend_utils import skip_test_module_over_bac
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.utilities import find_duthost_on_role
-from tests.common.utilities import get_upstream_neigh_type
+from tests.common.utilities import get_upstream_neigh_type, get_all_upstream_neigh_type
 from tests.common.helpers.syslog_helpers import is_mgmt_vrf_enabled
 
 
@@ -38,6 +38,16 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
     return None
 
 
+def is_in_neighbor(neigh_types, neigh_name):
+    """
+    Check if the neighbor name is in the list of neighbor types
+    """
+    for neigh_type in neigh_types:
+        if neigh_type in neigh_name:
+            return True
+    return False
+
+
 def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     """
     Get the information for upstream neighbors present in the testbed
@@ -45,16 +55,16 @@ def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     returns dict: {"upstream_neigh_name" : (ipv4_intf_ip, ipv6_intf_ip)}
     """
     upstream_neighbors = {}
-    neigh_type = get_upstream_neigh_type(tb['topo']['type'])
-    logging.info("testbed topo {} upstream neigh type {}".format(
-        tb['topo']['name'], neigh_type))
+    neigh_types = get_all_upstream_neigh_type(tb['topo']['type'])
+    logging.info("testbed topo {} upstream neigh types {}".format(
+        tb['topo']['name'], neigh_types))
 
     topo_cfg_facts = tb['topo']['properties'].get('configuration', None)
     if topo_cfg_facts is None:
         return upstream_neighbors
 
     for neigh_name, neigh_cfg in list(topo_cfg_facts.items()):
-        if neigh_type not in neigh_name:
+        if not is_in_neighbor(neigh_types, neigh_name):
             continue
         interfaces = neigh_cfg.get('interfaces', {})
         ipv4_addr = None
@@ -78,12 +88,12 @@ def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
 
 
 def get_uplink_ns(tbinfo, bgp_name_to_ns_mapping, device_neigh_metadata):
-    neigh_type = get_upstream_neigh_type(tbinfo['topo']['type'])
+    neigh_types = get_all_upstream_neigh_type(tbinfo['topo']['type'])
     asics = set()
     for name, asic in list(bgp_name_to_ns_mapping.items()):
-        if neigh_type not in name:
+        if not is_in_neighbor(neigh_types, name):
             continue
-        if neigh_type == 'T3' and device_neigh_metadata[name]['type'] == 'AZNGHub':
+        if 'T3' in neigh_types and device_neigh_metadata[name]['type'] == 'AZNGHub':
             continue
         asics.add(asic)
     return asics


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Fix the test `route/test_default_route.py::test_default_route_with_bgp_flap` failure in the topo with PT0.

#### How did you do it?
Add PT0 to the upstream neighbors

#### How did you verify/test it?
Check it locally

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
