### PR TITLE
Consolidate voq watchdog testcases to single testcase

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2825,8 +2825,12 @@ def set_port_cir(interface, rate):
         match = re.search(pattern, result["stdout"])
         return match
 
-    @contextmanager
-    def disable_voq_watchdog(self, duthosts, get_src_dst_asic_and_duts, dutConfig):
+    def modify_voq_watchdog(self, duthosts, get_src_dst_asic_and_duts, dutConfig, enable):
+        # Skip if voq watchdog is not enabled.
+        if not self.voq_watchdog_enabled(get_src_dst_asic_and_duts):
+            logger.info("voq_watchdog is not enabled, skipping modify voq watchdog")
+            return
+
         dst_dut = get_src_dst_asic_and_duts['dst_dut']
         dst_asic = get_src_dst_asic_and_duts['dst_asic']
         dut_list = [dst_dut]
@@ -2843,35 +2847,24 @@ def set_port_cir(interface, rate):
                     dut_list.append(rp_dut)
                     asic_index_list.append(asic.asic_index)
 
-        # Skip if voq watchdog is not enabled.
-        if not self.voq_watchdog_enabled(get_src_dst_asic_and_duts):
-            logger.info("voq_watchdog is not enabled, skipping disable voq watchdog")
-            yield
-            return
+        # Modify voq watchdog.
+        for (dut, asic_index) in zip(dut_list, asic_index_list):
+            copy_set_voq_watchdog_script_cisco_8000(
+                dut=dut,
+                asic=asic_index,
+                enable=enable)
+            cmd_opt = "-n asic{}".format(asic_index)
+            if not dst_dut.sonichost.is_multi_asic:
+                cmd_opt = ""
+            dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
 
+    @contextmanager
+    def disable_voq_watchdog(self, duthosts, get_src_dst_asic_and_duts, dutConfig):
         # Disable voq watchdog.
-        for (dut, asic_index) in zip(dut_list, asic_index_list):
-            copy_set_voq_watchdog_script_cisco_8000(
-                dut=dut,
-                asic=asic_index,
-                enable=False)
-            cmd_opt = "-n asic{}".format(asic_index)
-            if not dst_dut.sonichost.is_multi_asic:
-                cmd_opt = ""
-            dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
-
+        self.modify_voq_watchdog(duthosts, get_src_dst_asic_and_duts, dutConfig, enable=False)
         yield
-
         # Enable voq watchdog.
-        for (dut, asic_index) in zip(dut_list, asic_index_list):
-            copy_set_voq_watchdog_script_cisco_8000(
-                dut=dut,
-                asic=asic_index,
-                enable=True)
-            cmd_opt = "-n asic{}".format(asic_index)
-            if not dst_dut.sonichost.is_multi_asic:
-                cmd_opt = ""
-            dut.shell("sudo show platform npu script {} -s set_voq_watchdog.py".format(cmd_opt))
+        self.modify_voq_watchdog(duthosts, get_src_dst_asic_and_duts, dutConfig, enable=True)
 
     @pytest.fixture(scope='function')
     def disable_voq_watchdog_function_scope(self, duthosts, get_src_dst_asic_and_duts, dutConfig):

--- a/tests/qos/test_voq_watchdog.py
+++ b/tests/qos/test_voq_watchdog.py
@@ -99,7 +99,7 @@ class TestVoqWatchdog(QosSaiBase):
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.VoqWatchdogTest",
                 testParams=testParams)
-            
+
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.TrafficSanityTest",
                 testParams=testParams)

--- a/tests/qos/test_voq_watchdog.py
+++ b/tests/qos/test_voq_watchdog.py
@@ -58,7 +58,7 @@ class TestVoqWatchdog(QosSaiBase):
         if not self.voq_watchdog_enabled(get_src_dst_asic_and_duts):
             pytest.skip("Voq watchdog test is skipped since voq watchdog is not enabled.")
 
-    @pytest.mark.parametrize("voq_watchdog_enabled", ["True", "False"])
+    @pytest.mark.parametrize("voq_watchdog_enabled", [True, False])
     def testVoqWatchdog(
             self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
             duthosts, get_src_dst_asic_and_duts, voq_watchdog_enabled

--- a/tests/qos/test_voq_watchdog.py
+++ b/tests/qos/test_voq_watchdog.py
@@ -37,7 +37,7 @@ pytestmark = [
 PKTS_NUM = 100
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", autouse=True)
 def ignore_log_voq_watchdog(duthosts, loganalyzer):
     if not loganalyzer:
         yield
@@ -58,9 +58,10 @@ class TestVoqWatchdog(QosSaiBase):
         if not self.voq_watchdog_enabled(get_src_dst_asic_and_duts):
             pytest.skip("Voq watchdog test is skipped since voq watchdog is not enabled.")
 
+    @pytest.mark.parametrize("voq_watchdog_enabled", ["True", "False"])
     def testVoqWatchdog(
             self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            get_src_dst_asic_and_duts, ignore_log_voq_watchdog
+            duthosts, get_src_dst_asic_and_duts, voq_watchdog_enabled
     ):
         """
             Test VOQ watchdog
@@ -70,62 +71,35 @@ class TestVoqWatchdog(QosSaiBase):
                 dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
                     and test ports
                 dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+                voq_watchdog_enabled (bool): if VOQ watchdog is enabled or not
             Returns:
                 None
             Raises:
                 RunAnsibleModuleFail if ptf test fails
         """
 
-        testParams = dict()
-        testParams.update(dutTestParams["basicParams"])
-        testParams.update({
-            "dscp": 8,
-            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
-            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
-            "src_port_id": dutConfig["testPorts"]["src_port_id"],
-            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
-            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
-            "packet_size": 1350,
-            "pkts_num": PKTS_NUM,
-            "voq_watchdog_enabled": True,
-        })
+        try:
+            if not voq_watchdog_enabled:
+                self.modify_voq_watchdog(duthosts, get_src_dst_asic_and_duts, dutConfig, enable=False)
 
-        self.runPtfTest(
-            ptfhost, testCase="sai_qos_tests.VoqWatchdogTest",
-            testParams=testParams)
+            testParams = dict()
+            testParams.update(dutTestParams["basicParams"])
+            testParams.update({
+                "dscp": 8,
+                "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+                "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+                "src_port_id": dutConfig["testPorts"]["src_port_id"],
+                "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+                "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+                "packet_size": 1350,
+                "pkts_num": PKTS_NUM,
+                "voq_watchdog_enabled": voq_watchdog_enabled,
+            })
 
-    def testVoqWatchdogDisable(
-            self, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            get_src_dst_asic_and_duts, disable_voq_watchdog_function_scope
-    ):
-        """
-            Test VOQ watchdog
-            Args:
-                ptfhost (AnsibleHost): Packet Test Framework (PTF)
-                dutTestParams (Fixture, dict): DUT host test params
-                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
-                    and test ports
-                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
-            Returns:
-                None
-            Raises:
-                RunAnsibleModuleFail if ptf test fails
-        """
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.VoqWatchdogTest",
+                testParams=testParams)
 
-        testParams = dict()
-        testParams.update(dutTestParams["basicParams"])
-        testParams.update({
-            "dscp": 8,
-            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
-            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
-            "src_port_id": dutConfig["testPorts"]["src_port_id"],
-            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
-            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
-            "packet_size": 1350,
-            "pkts_num": PKTS_NUM,
-            "voq_watchdog_enabled": False,
-        })
-
-        self.runPtfTest(
-            ptfhost, testCase="sai_qos_tests.VoqWatchdogTest",
-            testParams=testParams)
+        finally:
+            if not voq_watchdog_enabled:
+                self.modify_voq_watchdog(duthosts, get_src_dst_asic_and_duts, dutConfig, enable=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Consolidate voq watchdog test cases into a single test case using parametrize to simplify the code.
A requirement from PR comments: https://github.com/Azure/sonic-mgmt.msft/pull/405

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on T1 testbed:
```
------------------------------- generated xml file: /tmp/qos/test_voq_watchdog_2025-06-18-00-56-38.xml --------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
01:05:43 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_asic-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_asic-False]
SKIPPED [2] qos/test_voq_watchdog.py:61: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [6] qos/test_voq_watchdog.py:61: multi-dut is not supported on T1 topologies
========================================= 2 passed, 8 skipped, 1 warning in 543.11s (0:09:03) =========================================
sonic@sonic-ucs-m6-26:/data/tests$ 
```

T2:
```
----------------------------- generated xml file: /run_logs/qos/test_voq_watchdog_2025-06-24-03-43-12.xml -----------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
05:21:22 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_asic-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_asic-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_dut_multi_asic-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_dut_multi_asic-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_longlink_to_shortlink-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_longlink_to_shortlink-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_shortlink-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_shortlink-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_longlink-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_longlink-False]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
