### PR TITLE
Skip multi-hop upgrade tests on non-T0 testbeds

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2648,6 +2648,12 @@ upgrade_path/test_upgrade_path.py::test_upgrade_path_t2:
     conditions:
       - "'t2' not in topo_type"
 
+upgrade_path/test_multi_hop_upgrade_path.py:
+  skip:
+    reason: "Only supported on T0 topology"
+    conditions:
+      - "'t0' not in topo_type"
+
 #######################################
 #####            vlan             #####
 #######################################


### PR DESCRIPTION
Only T0 testbeds perform warm-reboots, hence only these support the multi-hop warmboot test case.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip running tests on topologies that don't support it causing redundant test runs.

#### How did you do it?
Added a check to skip the test on non-T0 testbeds.

#### How did you verify/test it?

#### Any platform specific information?
Only run it on t0 testbeds from now on.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
