### PR TITLE
[CI] Fix elastictest template by adding quotes to add-topo-params

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -264,7 +264,7 @@ steps:
       --kvm-build-id $(KVM_BUILD_ID) \
       --kvm-image-branch "${{ parameters.KVM_IMAGE_BRANCH }}" \
       --skip-remove-add-topo-for-nightly ${{ parameters.SKIP_REMOVE_ADD_TOPO_FOR_NIGHTLY }} \
-      --add-topo-params ${{ parameters.ADD_TOPO_PARAMS }} \
+      --add-topo-params "${{ parameters.ADD_TOPO_PARAMS }}" \
       --deploy-mg-extra-params="${{ parameters.DEPLOY_MG_EXTRA_PARAMS }}" \
       --common-extra-params="${{ parameters.COMMON_EXTRA_PARAMS }}" \
       --vm-type ${{ parameters.VM_TYPE }} --num-asic ${{ parameters.NUM_ASIC }} \


### PR DESCRIPTION
### Description of PR
[CI] Fix elastictest template by adding quotes to add-topo-params
- Relate to Microsoft ADO 33157382:

Summary:
Without quotes in the add-topo-params template, users have to add them manually, which is easy to miss.
![image](https://github.com/user-attachments/assets/dddd3607-2354-4409-b338-9295b7989aec)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Previously, when setting ADD_TOPO_PARAMS, users had to wrap the value in double quotes inside single quotes, like this:
```
  - name: ADD_TOPO_PARAMS
    type: string
    default: "'-e enable_macsec=True -e macsec_profile=MACSEC_PROFILE'"
    displayName: "Add topo parameters"
```
This quoting pattern was error-prone and easy to get wrong by missing a quote.

#### How did you do it?
This PR moves the quoting into the template itself. With this change, users can simply provide the value as-is without worrying about extra quotes:
```
  - name: ADD_TOPO_PARAMS
    type: string
    default: "-e enable_macsec=True -e macsec_profile=MACSEC_PROFILE"
    displayName: "Add topo parameters"
```

#### How did you verify/test it?
I triggered a pipeline run and confirmed that the YAML parsed successfully and the parameters were applied correctly.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
