### PR TITLE
Make apt-get install non-interactive in setup-management-network

### DIFF
--- a/ansible/setup-management-network.sh
+++ b/ansible/setup-management-network.sh
@@ -15,6 +15,11 @@ function show_help_and_exit()
     exit $1
 }
 
+function apt_install_noninteractive()
+{
+    DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y "$@"
+}
+
 DEL_EXISTED_BRIDGE=false
 
 while getopts "h?d" opt; do
@@ -48,21 +53,21 @@ echo
 echo "STEP 2: Checking for bridge-utils package..."
 if ! command -v brctl; then
     echo "brctl not found, installing bridge-utils"
-    apt-get install -y bridge-utils
+    apt_install_noninteractive bridge-utils
 fi
 echo
 
 echo "STEP 3: Checking for net-tools package..."
 if ! command -v ifconfig; then
     echo "ifconfig not found, install net-tools"
-    apt-get install -y net-tools
+    apt_install_noninteractive net-tools
 fi
 echo
 
 echo "STEP 4: Checking for ethtool package..."
 if ! command -v ethtool; then
     echo "ethtool not found, install ethtool"
-    apt-get install -y ethtool
+    apt_install_noninteractive ethtool
 fi
 echo
 


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-mgmt/issues/19098

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The script to setup the management network should automatically the restart the necessary services when installing the packages.

Summary:
Fixes # [19098](https://github.com/sonic-net/sonic-mgmt/issues/19098)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
What is the motivation for this PR?
In a virtual testbed, when setting up management-network, the script attempts to install the bridge-utils, which requires some services to be restart and since the install is invoked by a script, the TUI waits for an input and doesnt proceed.

How did you do it?
Use noninteractive mode and also set NEEDRESTART_MODE to automatically restart services when required.

How did you verify/test it?
Verified the management setup is successful

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
