### PR TITLE
LogAnalyzer: Ignore a non-functional error thrown from Linkmgrd

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -31,6 +31,7 @@ r, ".* ERR monit.*Expected containers not running: telemetry.*"
 r, ".* sonic systemd.* kdump-tools.service - Kernel crash dump capture service.*"
 r, ".* ERR swss#orchagent: :- getPort: Failed to get cached bridge port ID.*"
 r, ".* ERR syncd#syncd: .* SAI_API_PORT:brcm_sai_get_port_attribute:\d+ Error -2 processing  port attribute ID: 17.*"
+r, ".* ERR mux#linkmgrd: MuxManager\.cpp:.*Unsupported link failure detection type for : software.*"
 
 # Errors for config reload on broadcom platform on 202405
 r, ".* ERR syncd\d*#syncd.*_attribute_enum_values_capability.*count.*greater than capability-count 0.*"


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Whenever CFG_MUX_CABLE_TABLE_NAME is updated we get the following error,

2025 Jun 15 22:30:03.459694 gd272 ERR mux#linkmgrd: MuxManager.cpp:297 updateProberType: Ethernet140: Unsupported link failure detection type for : software

This is a regression caused by PR : https://github.com/sonic-net/sonic-linkmgrd/pull/288.

This is not causing any functionality breakage. But log analyzer reports this new error and hence the testcase fails.
Since there is no functionality impact, we have added this error message to the list of ignored patterns.

Summary:
Fixes # 
https://github.com/aristanetworks/sonic-qual.msft/issues/624 
https://github.com/sonic-net/sonic-linkmgrd/issues/301

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Loganalyzer was not aware of this newly introduced error message and was failing many of the tests.

#### How did you do it?
Added a regex pattern to ignore these errors.

#### How did you verify/test it?
By running sonic-mgmt tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
