### PR TITLE
Snmp credentials added for mvrf Test Suites

### DIFF
--- a/tests/mvrf/conftest.py
+++ b/tests/mvrf/conftest.py
@@ -1,0 +1,111 @@
+import pytest
+from tests.common.utilities import wait_until
+import shutil
+import yaml
+
+from tests.common.gu_utils import create_checkpoint, rollback
+
+SETUP_ENV_CP = "test_setup_checkpoint"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_check_snmp_ready(duthosts, localhost):
+    for duthost in duthosts:
+        assert wait_until(300, 20, 0, duthost.is_service_fully_started,
+                          "snmp"), "SNMP service is not running"
+
+        # creating checkpoint before any configuration changes
+        create_checkpoint(duthost, SETUP_ENV_CP)
+
+        snmp_config_path = "/etc/sonic/snmp.yml"
+
+        # copy snmp.yml to ucs
+        output = duthost.shell("sudo find /etc/sonic -name 'snmp.yml'")
+        filename = output["stdout"].split("\n")
+
+        if snmp_config_path in filename:
+            ret = duthost.fetch(src=snmp_config_path, dest=".")
+            ret_bin = ret.get("dest", None)
+            shutil.copyfile(ret_bin, "snmp/snmp.yml")
+        else:
+            assert False, f'{snmp_config_path} does not exist'
+
+        # configure snmp for every host
+        full_snmp_comm_list = ['snmp_rocommunity', 'snmp_rocommunities', 'snmp_rwcommunity', 'snmp_rwcommunities']
+        with open('./snmp/snmp.yml', 'r') as yaml_file:
+            yaml_snmp_info = yaml.load(yaml_file, Loader=yaml.FullLoader)
+
+        # get redis output for SNMP_COMMUNITY & SNMP_LOCATION
+        snmp_comm_redis_keys = check_redis_output(duthost, 'SNMP_COMMUNITY')
+        snmp_comm_redis_vals = list(map(extract_redis_keys, snmp_comm_redis_keys))
+        snmp_location_redis_keys = check_redis_output(duthost, 'SNMP|LOCATION')
+        snmp_location_redis_vals = list(map(extract_redis_keys, snmp_location_redis_keys))
+
+        for comm_type in full_snmp_comm_list:
+            if comm_type in yaml_snmp_info.keys():
+                if comm_type.startswith('snmp_rocommunities'):
+                    for community in yaml_snmp_info[comm_type]:
+                        if community not in snmp_comm_redis_vals:
+                            duthost.shell(f"sudo config snmp community add {community} 'ro'")  # set snmp cli
+
+                elif comm_type.startswith('snmp_rocommunity'):
+                    community = yaml_snmp_info[comm_type]
+                    if community not in snmp_comm_redis_vals:
+                        duthost.shell(f"sudo config snmp community add {community} 'ro'")  # set snmp cli
+
+                elif comm_type.startswith('snmp_rwcommunities'):
+                    for community in yaml_snmp_info[comm_type]:
+                        if community not in snmp_comm_redis_vals:
+                            duthost.shell(f"sudo config snmp community add {community} 'rw'")  # set snmp cli
+
+                elif comm_type.startswith('snmp_rwcommunity'):
+                    community = yaml_snmp_info[comm_type]
+                    if community not in snmp_comm_redis_vals:
+                        duthost.shell(f"sudo config snmp community add {community} 'rw'")  # set snmp cli
+
+        yaml_snmp_location = yaml_snmp_info.get('snmp_location')
+        if yaml_snmp_location:
+            if 'LOCATION' not in snmp_location_redis_vals:
+                duthost.shell(f'sudo config snmp location add {yaml_snmp_location}')  # set snmp cli
+
+    yield
+
+    for duthost in duthosts:
+        # rollback configuration
+        rollback(duthost, SETUP_ENV_CP)
+
+    # remove snmp files downloaded
+    local_command = "find ./snmp/ -type f -name 'snmp.yml' -exec rm -f {} +"
+    localhost.shell(local_command)
+
+
+def extract_redis_keys(item):
+    return item.split('|')[1]
+
+
+def check_redis_output(duthost, key):
+    snmp_redis_keys = duthost.shell(f"redis-cli -n 4 keys '{key}*'")
+    if snmp_redis_keys["stdout"] == "":
+        return []
+    else:
+        snmp_redis_keys = snmp_redis_keys["stdout"].split("\n")
+        return snmp_redis_keys
+
+
+@pytest.fixture(scope="module", autouse=True)
+def enable_queue_counterpoll_type(duthosts):
+    for duthost in duthosts:
+        if duthost.facts['platform'] not in ['armhf-nokia_ixs7215_52x-r0']:
+            duthost.command('counterpoll queue enable')
+
+
+def pytest_addoption(parser):
+    """
+    Adds options to pytest that are used by the snmp tests.
+    """
+    parser.addoption(
+        "--percentage",
+        action="store",
+        default=False,
+        help="Set percentage difference for snmp test",
+        type=int)

--- a/tests/mvrf/conftest.py
+++ b/tests/mvrf/conftest.py
@@ -97,15 +97,3 @@ def enable_queue_counterpoll_type(duthosts):
     for duthost in duthosts:
         if duthost.facts['platform'] not in ['armhf-nokia_ixs7215_52x-r0']:
             duthost.command('counterpoll queue enable')
-
-
-def pytest_addoption(parser):
-    """
-    Adds options to pytest that are used by the snmp tests.
-    """
-    parser.addoption(
-        "--percentage",
-        action="store",
-        default=False,
-        help="Set percentage difference for snmp test",
-        type=int)


### PR DESCRIPTION
Description:
The PR contains changes to mvrf/conftest.py with logic to configure snmp credentials stored in snmp.yml for every host before running any test script.This configuration was already added for snmp test suites we have enabled it for mvrf test suites also.

Fixes # (issue)
The SNMP credentials for snmp_rocommunity: public were not consistently added each time we attempted to configure them. Although the MVRF test suite was running, the credentials were not applied before the timeout occurred when calling snmp_facts().

Fix:
Added the conftest.py file to add the snmp configurations for mvrf test suites. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

#### What is the motivation for this PR?
If credentials in snmp.yml isn't configured, then the changes in PR configures them before running the tests and restores the original configuration after the TC execution.For mvrf test cases snmp credentials were not configured before timeout.


#### How did you do it?
For mvrf test suites mvrf/conftest.py will now copy the snmp.yml from DUT to UCS (if DUT has snmp.yml) & then it will configure the SNMP credentials for every host via sudo config snmp command. The logic it configures is same as in snmp_yml_to_configdb.py script; where it checks whether the credentials in yml are configured in config_db or not, if the keys are configured but the values are different / the keys are not configured - then it will configure them. Before the test script execution, SNMP is configured, once the execution completes, it reverts the configuration that existed before.Using this method we can add credentials for snmp and all functions of snmp for mvrf test cases.


#### How did you verify/test it?
We checked it with 202405 image multiple times firstly without adding the mvrf/conftest.py and then by adding these changes. 
