### PR TITLE
Ignore audit rate limit exceeded syslog and avoid false alert for kernel syslog

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -345,3 +345,9 @@ r, ".* ERR hostcfgd: \['sonic-kdump-config'[^]]*\] - failed.*"
 
 # https://github.com/sonic-net/sonic-buildimage/issues/22348
 r, ".* ERR pmon#chassis_db_init: Failed to load chassis due to ModuleNotFoundError.*"
+
+# https://msazure.visualstudio.com/One/_workitems/edit/33411748
+r, ".* NOTICE kernel:.*exe=\"/usr/bin/kill\".*"
+
+# https://msazure.visualstudio.com/One/_workitems/edit/33376635
+r, ".* ERR kernel.*audit: rate limit exceeded.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
1. `2025 Jun 14 02:28:46.206949 str2-8101-05 ERR kernel: [17800.425621] audit: rate limit exceeded`
This syslog was caused by setting rate limit and many audit syslog exceed the rate limit. Due to security, we enable audit syslog, but in some sonic-mgmt cases, it enables rate limit, so many audit syslogs could exceed the rate limit and it will print out this error. 
Confirmed with feature owner, we can ignore this error syslog to avoid teardown error for many cases.

3. `2025 Jun 12 05:51:29.810090 str2-7050cx3-acs-01 NOTICE kernel: [16041.304670] audit: type=1300 audit(1749707485.287:111698): arch=c000003e syscall=59 success=yes exit=0 a0=7f11c7911010 a1=560342061e40 a2=7ffee6493a08 a3=0 items=2 ppid=265359 pid=265360 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=21 comm="kill" exe="/usr/bin/kill" subj=unconfined key="process_audit""`
The syslog above is NOTICE level, but it matched the regex pattern `"kernel:.*kill"` in `tests/common/plugins/loganalyzer/loganalyzer_common_match.txt`.
Need to add a new ignore pattern to avoid this false alert.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix the teardown errors for wrong matched syslog.

#### How did you do it?
Add the patterns in ignore list file.

#### How did you verify/test it?
Run case with loganalyzer enabled.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
