### PR TITLE
Fix test_poweroff_reboot

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -1,7 +1,8 @@
 import logging
 import pytest
 
-from tests.common.reboot import wait_for_startup, REBOOT_TYPE_POWEROFF
+from tests.common.reboot import REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS, reboot_ctrl_dict, wait_for_startup, \
+    REBOOT_TYPE_POWEROFF
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.psu_helpers import get_grouped_pdus_by_psu
@@ -34,10 +35,13 @@ def teardown_module(duthosts, enum_supervisor_dut_hostname, conn_graph_facts, xc
     duthost = duthosts[enum_supervisor_dut_hostname]
     yield
 
-    logging.info("Tearing down: to make sure all the critical services, interfaces and transceivers are good")
-    interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
+    logging.info(
+        "Tearing down: to make sure all the critical services, interfaces and transceivers are good")
+    interfaces = conn_graph_facts.get(
+        "device_conn", {}).get(duthost.hostname, {})
     check_critical_processes(duthost, watch_secs=10)
-    check_interfaces_and_services(duthost, interfaces, xcvr_skip_list, INTERFACE_WAIT_TIME)
+    check_interfaces_and_services(
+        duthost, interfaces, xcvr_skip_list, INTERFACE_WAIT_TIME)
 
 
 def _power_off_reboot_helper(kwargs, power_on_event=None):
@@ -69,8 +73,27 @@ def _power_off_reboot_helper(kwargs, power_on_event=None):
     power_on_event.clear()
 
 
+@pytest.fixture
+def adjust_reboot_cause_sequence():
+    """
+    TODO: Fix this workaround
+    By removing the key and readding it, we make sure that the key will append at the end of the list. Therefore modify
+    the sequence of to fix https://github.com/sonic-net/sonic-mgmt/pull/18488
+
+    After this, we add back REBOOT_TYPE_POWEROFF so that it will appear at the end default
+    """
+    heartbeat_loss_reboot = reboot_ctrl_dict.pop(
+        REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS)
+    reboot_ctrl_dict[REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS] = heartbeat_loss_reboot
+
+    yield
+
+    reboot_type_poweroff = reboot_ctrl_dict.pop(REBOOT_TYPE_POWEROFF)
+    reboot_ctrl_dict[REBOOT_TYPE_POWEROFF] = reboot_type_poweroff
+
+
 def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, conn_graph_facts,
-                          xcvr_skip_list, get_pdu_controller, power_off_delay):
+                          xcvr_skip_list, get_pdu_controller, power_off_delay, adjust_reboot_cause_sequence):
     """
     @summary: This test case is to perform reboot via powercycle and check platform status
     @param duthost: Fixture for DUT AnsibleHost object
@@ -83,7 +106,8 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     duthost = duthosts[enum_supervisor_dut_hostname]
     pdu_ctrl = get_pdu_controller(duthost)
     if pdu_ctrl is None:
-        pytest.skip("No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
+        pytest.skip(
+            "No PSU controller for %s, skip rest of the testing in this case" % duthost.hostname)
     is_chassis = duthost.get_facts().get("modular_chassis")
     if is_chassis and duthost.is_supervisor_node():
         # Following is to accomodate for chassis, when no '--power_off_delay' option is given on pipeline run
@@ -92,7 +116,8 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     # If PDU supports returning output_watts, making sure that all PSUs has power.
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
     for psu, pdus in psu_to_pdus.items():
-        pytest_assert(any(int(pdu.get('output_watts', '1')) != 0 for pdu in pdus), "Not all PSUs are getting power")
+        pytest_assert(any(int(pdu.get('output_watts', '1')) !=
+                      0 for pdu in pdus), "Not all PSUs are getting power")
 
     # Purpose of this list is to control sequence of turning on PSUs in power off testing.
     # If there are 2 PSUs, then 3 scenarios would be covered:
@@ -115,7 +140,8 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
             poweroff_reboot_kwargs["power_on_seq"] = all_outlets
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
             reboot_and_check(
-                localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
+                localhost, duthost, conn_graph_facts.get(
+                    "device_conn", {}).get(duthost.hostname, {}),
                 xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                 _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts)
         else:
@@ -125,7 +151,8 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
                 poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
                 poweroff_reboot_kwargs["delay_time"] = power_off_delay
                 reboot_and_check(
-                    localhost, duthost, conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {}),
+                    localhost, duthost, conn_graph_facts.get(
+                        "device_conn", {}).get(duthost.hostname, {}),
                     xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                     _power_off_reboot_helper, poweroff_reboot_kwargs)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md



Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:


From https://github.com/sonic-net/sonic-mgmt/pull/18488 it introduced a bug where if the reboot cause is power off, it will return REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS which fail test_power_off_reboot.

This PR fix this issue


Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Described above

#### How did you do it?
Intercept the reboot_ctrl_dict before the test, adjusted the order of REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS to be last by popping the key out and putting it back again.

This will make sure that .items() will loop through the REBOOT_TYPE_SUPERVISOR_HEARTBEAT_LOSS last and get to the right condition first for test_poweroff_reboot_only

#### How did you verify/test it?
test_power_off_reboot
![image](https://github.com/user-attachments/assets/5c34c0d6-4597-41d7-85c8-376d2426a225)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
