### PR TITLE
sonic-mgmt: increase ptf container memory

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -175,8 +175,8 @@
       capabilities:
         - net_admin
       privileged: yes
-      memory: 16G
-      memory_swap: 32G
+      memory: 64G
+      memory_swap: 64G
     become: yes
 
   - name: Update ptf password


### PR DESCRIPTION
### Description of PR
Increase the memory and swap limits of the PTF container to 64 GB.

This is necessary for handling the increased memory consumption from the additional `exabgp` processes as a result of the additional number of VM peers of the larger topologies.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202503
- [x] 202505

### Approach
#### What is the motivation for this PR?
To prevent the PTF container from running out of memory when setting up a tesbed for a topology with a large number of VMs.

#### How did you do it?
Increased the memory/swap limits of the PTF docker container in the ansible playbook.

#### How did you verify/test it?
Ran the setup with the new memory limits and confirmed that the setup now succeeds.