### PR TITLE
[doc] Update announce routes doc for isolated t1

### DIFF
--- a/docs/testbed/READ.testbed.AnnounceRoutes.Internal.md
+++ b/docs/testbed/READ.testbed.AnnounceRoutes.Internal.md
@@ -158,8 +158,7 @@ Some definitions:
 |leaf_number|number of other T1s|
 |tor_number|number of downstream T0s|
 
-- Routes annoucned by per T2 device, total number: 2
-  - 1 default route (But with longer as path compared to T0s')
+- Routes annoucned by per T2 device, total number: 1
   - 1 Loopback route
 - Routes advertised by per T0 devices, total number: (1 + tor_subnet_number) * tor_number + leaf_number
   - 1 Loopback route and `tor_subnet_number` subnet routes (Each sets of these routes in DUT has only one different nexthop to each T0)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
T2 shouldn't announce default route to isolated T1

#### How did you do it?
T2 shouldn't announce default route to isolated T1

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
