### PR TITLE
Add config change validation to prevent bad bgp config state

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -1052,7 +1052,7 @@ def test_credit_loop(duthost, tbinfo, nbrhosts, ptfadapter, prepare_param, gener
     for exabgp_port, exabgp_port_v6, recv_port in zip(exabgp_port_list, exabgp_port_list_v6, recv_port_list):
         try:
             with allure.step("Disable bgp suppress-fib-pending function"):
-                config_bgp_suppress_fib(duthost, False)
+                config_bgp_suppress_fib(duthost, False, validate_result=True)
 
             with allure.step(
                     "Validate traffic is forwarded back to T2 VM and routes in HW table are removed by orchagent"):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is a failure with `bgp/test_bgp_suppress_fib.py::test_suppress_fib_stress`, where there is a packet count mismatch within the `test_suppress_fib_stress` test case.

This failure only occurs when the `test_suppress_fib_stress` test case is run right after `test_credit_loop`.

One of the bgp config changes in `test_credit_loop` is not validated, and it seems it is causing issues in bgp config state when the test runs before the config change is fully made. Although it does not impact `test_credit_loop`, it impacts the subsequent test case (`test_suppress_fib_stress`).

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
`bgp/test_bgp_suppress_fib.py::test_suppress_fib_stress` failing

#### How did you do it?
Wait for config to properly take effect `bgp/test_bgp_suppress_fib.py::test_credit_loop` so subsequent tests can run on a clean state.

#### How did you verify/test it?
`bgp/test_bgp_suppress_fib.py::test_suppress_fib_stress` no longer fails.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
