### PR TITLE
[performance_meter] add -f to config reload

### DIFF
--- a/tests/performance_meter/ops.py
+++ b/tests/performance_meter/ops.py
@@ -47,6 +47,6 @@ async def reboot_by_cmd(duthost):
 
 
 async def config_reload_by_cmd(duthost):
-    command = asyncio.create_task(async_command_ignore_errors(duthost, "config reload -y"))
+    command = asyncio.create_task(async_command_ignore_errors(duthost, "config reload -f -y"))
     yield True
     await command


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add -f to config reload so config reload will always be done

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Sometimes config reload will not perform because of some failed state in sonic

#### How did you do it?
Add -f.

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
