### PR TITLE
[dut_console] Fix failure on test_baud_rate_boot_connect

### DIFF
--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -2,7 +2,6 @@ import pytest
 import time
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.helpers.console_helper import assert_expect_text, create_ssh_client, ensure_console_session_up
-from tests.common.reboot import reboot
 
 
 pytestmark = [

--- a/tests/dut_console/test_console_baud_rate.py
+++ b/tests/dut_console/test_console_baud_rate.py
@@ -104,11 +104,11 @@ def test_baud_rate_sonic_connect(console_client_setup_teardown):
     assert_expect_text(client, "login:", console_port, timeout_sec=1)
 
 
-def test_baud_rate_boot_connect(localhost, duthost, console_client_setup_teardown, boot_connect_teardown):
+def test_baud_rate_boot_connect(duthost, console_client_setup_teardown, boot_connect_teardown):
     client, console_port = console_client_setup_teardown
     platform = duthost.facts["platform"]
     pytest_require(platform in BOOT_TYPE, "Unsupported platform: {}".format(platform))
-    reboot(duthost, localhost, wait_for_ssh=False)
+    duthost.shell("sudo reboot", module_async=True)
     if BOOT_TYPE[platform] == "ABoot":
         run_aboot_test(client, console_port)
     elif BOOT_TYPE[platform] == "UBoot-ONIE":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Previously, test_baud_rate_boot_connect would invoke helper function `reboot` to reboot device. But this function would collect console log, which would clear console line https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/reboot.py#L342. It would cause this case fail

#### How did you do it?
Use duthost.sheel to directly reboot device instead of using helper function `reboot` to avoid clearing console line

#### How did you verify/test it?
Run test
```
collected 1 item                                                                                                                                                                                        

dut_console/test_console_baud_rate.py::test_baud_rate_boot_connect PASSED                                                                                                                         [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
