### PR TITLE
[dhcp_relay] Verify per-interface counter under stress test

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -1,5 +1,9 @@
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def restart_dhcp_service(duthost):
@@ -14,3 +18,127 @@ def restart_dhcp_service(duthost):
                 all(element == 'RUNNING' for element in output['stdout_lines']))
 
     pytest_assert(wait_until(120, 1, 10, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
+
+
+def init_dhcpcom_relay_counters(duthost):
+    command_output = duthost.shell("sudo sonic-clear dhcp_relay ipv4 counters")
+    pytest_assert("Clear DHCPv4 relay counter done" == command_output["stdout"],
+                  "dhcp_relay counters are not cleared successfully, output: {}".format(command_output["stdout"]))
+
+
+def query_dhcpcom_relay_counter_result(duthost, query_key):
+    '''
+    Query the DHCPv4 counters from the COUNTERS_DB by the given key.
+    The returned value is a dictionary and the counter values are converted to integers.
+    Example return value:
+    {"TX": {"Unknown": 0, "Discover": 48, "Offer": 0, "Request": 96, "Decline": 0, "Ack": 0, "Nak": 0, "Release": 0,
+    "Inform": 0, "Bootp": 48}, "RX": {"Unknown": 0, "Discover": 0, "Offer": 1, "Request": 0, "Decline": 0, "Ack": 1,
+    "Nak": 0, "Release": 0, "Inform": 0, "Bootp": 0}}
+    '''
+    counters_query_string = 'sonic-db-cli COUNTERS_DB hgetall "DHCPV4_COUNTER_TABLE:{key}"'
+    shell_result = json.loads(
+        duthost.shell(counters_query_string.format(key=query_key))['stdout'].replace("\"", "").replace("'", "\"")
+    )
+    return {
+        rx_or_tx: {
+            dhcp_type: int(counter_value) for dhcp_type, counter_value in counters.items()
+        } for rx_or_tx, counters in shell_result.items()}
+
+
+def query_and_sum_dhcpcom_relay_counters(duthost, vlan_name, interface_name_list):
+    '''Query the DHCPv4 counters from the COUNTERS_DB and sum the counters for the given interface names.'''
+    if interface_name_list is None or len(interface_name_list) == 0:
+        # If no interface names are provided, return the counters for the VLAN interface only.
+        return query_dhcpcom_relay_counter_result(duthost, vlan_name)
+    total_counters = {}
+    # If interface names are provided, sum all of the provided interface names' counters
+    for interface_name in interface_name_list:
+        internal_shell_result = query_dhcpcom_relay_counter_result(duthost, vlan_name + ":" + interface_name)
+        for rx_or_tx, counters in internal_shell_result.items():
+            total_value = total_counters.setdefault(rx_or_tx, {})
+            for dhcp_type, counter_value in counters.items():
+                total_value[dhcp_type] = total_value.get(dhcp_type, 0) + counter_value
+    return total_counters
+
+
+def compare_dhcpcom_relay_counter_values(dhcp_relay_counter, expected_counter, error_in_percentage=0):
+    """Compare the DHCP relay counter value with the expected counter."""
+    SUPPORTED_DHCPV4_TYPE = [
+        "Unknown", "Discover", "Offer", "Request", "Decline", "Ack", "Nak", "Release", "Inform", "Bootp"
+    ]
+    SUPPORTED_DIR = ["TX", "RX"]
+    for dir in SUPPORTED_DIR:
+        for dhcp_type in SUPPORTED_DHCPV4_TYPE:
+            expected_value = expected_counter.setdefault(dir, {}).get(dhcp_type, 0)
+            actual_value = dhcp_relay_counter.setdefault(dir, {}).get(dhcp_type, 0)
+            logger_message = "DHCP relay counter {} {}: actual value {}, expected value {}".format(
+                dir, dhcp_type, actual_value, expected_value)
+            if expected_value == actual_value:
+                logger.info(logger_message)
+            else:
+                logger.warning(logger_message + ", the actual value is not equal to the expected value")
+            pytest_assert(abs(actual_value - expected_value) <=
+                          expected_value * error_in_percentage / 100,
+                          "DHCP relay counter {} {} {} is not equal to expected value {} within error {}%"
+                          .format(dir, dhcp_type, actual_value, expected_value, error_in_percentage))
+
+
+def validate_dhcpcom_relay_counters(dhcp_relay, duthost, expected_uplink_counter,
+                                    expected_downlink_counter, error_in_percentage=0):
+    """Validate the dhcpcom relay counters"""
+    logger.info("Expected uplink counters: {}, expected downlink counters: {}, error in percentage: {}%".format(
+        expected_uplink_counter, expected_downlink_counter, error_in_percentage))
+    downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
+    # it can be portchannel or interface, it depends on the topology
+    uplink_portchannels_or_interfaces = dhcp_relay['uplink_interfaces']
+    client_iface = dhcp_relay['client_iface']['name']
+    portchannels = dhcp_relay['portchannels']
+
+    '''
+    If the uplink_portchannels_or_interfaces are portchannels,
+        uplink_interfaces will contains the members of the portchannels
+    If the uplink_portchannels_or_interfaces are not portchannels,
+        uplink_interfaces will equal to uplink_portchannels_or_interfaces
+    '''
+    uplink_interfaces = []
+    for portchannel_name in uplink_portchannels_or_interfaces:
+        if portchannel_name in portchannels.keys():
+            uplink_interfaces.extend(portchannels[portchannel_name]['members'])
+            portchannel_counters = query_and_sum_dhcpcom_relay_counters(duthost,
+                                                                        downlink_vlan_iface,
+                                                                        [portchannel_name])
+            members_counters = query_and_sum_dhcpcom_relay_counters(duthost,
+                                                                    downlink_vlan_iface,
+                                                                    portchannels[portchannel_name]['members'])
+            # Compare the portchannel counters with the sum of its members' counters
+            logger.info("Start comparing portchannel {} counters and its member {} counters".format(
+                portchannel_name, portchannels[portchannel_name]['members']))
+            compare_dhcpcom_relay_counter_values(portchannel_counters,
+                                                 members_counters,
+                                                 error_in_percentage)
+        else:
+            uplink_interfaces.append(portchannel_name)
+
+    vlan_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [])
+    client_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [client_iface])
+    uplink_portchannels_interfaces_counter = query_and_sum_dhcpcom_relay_counters(
+        duthost, downlink_vlan_iface, uplink_portchannels_or_interfaces
+    )
+    uplink_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, uplink_interfaces)
+
+    logger.info("Start comparing vlan interface counters and client interface counters")
+    compare_dhcpcom_relay_counter_values(vlan_interface_counter,
+                                         client_interface_counter,
+                                         error_in_percentage)
+    logger.info("Start comparing uplink portchannels counters and uplink interface counters")
+    compare_dhcpcom_relay_counter_values(uplink_portchannels_interfaces_counter,
+                                         uplink_interface_counter,
+                                         error_in_percentage)
+    logger.info("Start comparing vlan interface counters and expected downlink counters")
+    compare_dhcpcom_relay_counter_values(vlan_interface_counter,
+                                         expected_downlink_counter,
+                                         error_in_percentage)
+    logger.info("Start comparing uplink interface counters and expected uplink counters")
+    compare_dhcpcom_relay_counter_values(uplink_interface_counter,
+                                         expected_uplink_counter,
+                                         error_in_percentage)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -485,14 +485,14 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[discover]:
   xfail:
-    reason: "Need to skip for discover and request test cases on dualtor"
+    reason: "Need to skip for discover test cases on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
 
 dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[request]:
   xfail:
-    reason: "Need to skip for discover and request test cases on dualtor"
+    reason: "Need to skip for request test cases on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -483,11 +483,19 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 #####         dhcp_relay        #####
 #######################################
-dhcp_relay/test_dhcp_counter_stress.py:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[discover]:
   xfail:
-    reason: "Need to monitor the test stability"
+    reason: "Need to skip for discover and request test cases on dualtor"
     conditions:
-      - "topo_type in ['t0']"
+      - "'dualtor' in topo_name"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
+
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[request]:
+  xfail:
+    reason: "Need to skip for discover and request test cases on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
 
 dhcp_relay/test_dhcp_relay.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -483,6 +483,12 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 #####         dhcp_relay        #####
 #######################################
+dhcp_relay/test_dhcp_counter_stress.py:
+  xfail:
+    reason: "Need to monitor the test stability"
+    conditions:
+      - "topo_type in ['t0']"
+
 dhcp_relay/test_dhcp_relay.py:
   skip:
     reason: "Need to skip for Cisco backend platform"

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -33,6 +33,12 @@ def pytest_addoption(parser):
         default=100,
         help="Set custom restart rounds",
     )
+    parser.addoption(
+        "--max_packets_per_sec",
+        action="store",
+        type=int,
+        help="Set maximum packets per second for stress test",
+    )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -165,3 +165,10 @@ def testing_config(duthosts, rand_one_dut_hostname, tbinfo):
         yield DUAL_TOR_MODE, duthost
     else:
         yield SINGLE_TOR_MODE, duthost
+
+
+@pytest.fixture(scope="function")
+def clean_processes_after_stress_test(ptfhost):
+    yield
+    ptfhost.shell("kill -9 $(ps aux | grep  dhcp_relay_stress_test | grep -v 'grep' | awk '{print $2}')",
+                  module_ignore_errors=True)

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -1,6 +1,7 @@
 
 import pytest
 import ptf.packet as scapy
+import logging
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -15,6 +16,7 @@ BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 DUAL_TOR_MODE = 'dual'
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
@@ -31,6 +33,8 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
     error_margin = 0.01
     client_packets_per_sec = 25\
         if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec
+    logger.info("Testing mode: {}, client packets per second: {}, error margin: {}".format(
+        testing_mode, client_packets_per_sec, error_margin))
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])
         client_port_id = dhcp_relay['client_iface']['port_idx']

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -1,0 +1,121 @@
+
+import pytest
+import ptf.packet as scapy
+
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
+from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters
+from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
+from tests.dhcp_relay.dhcp_relay_utils import check_dhcp_stress_status
+from tests.common.helpers.assertions import pytest_assert
+from tests.ptf_runner import ptf_runner
+
+
+BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+DEFAULT_DHCP_CLIENT_PORT = 68
+DEFAULT_DHCP_SERVER_PORT = 67
+DUAL_TOR_MODE = 'dual'
+
+
+@pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
+def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+                                       testing_config, setup_standby_ports_on_rand_unselected_tor,
+                                       toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
+                                       dhcp_type, clean_processes_after_stress_test,
+                                       rand_unselected_dut, request):
+    '''
+    Test DHCP relay counters functionality can handle the maximum load within 5% miss.
+    '''
+    testing_mode, duthost = testing_config
+    packets_send_duration = 120
+    error_margin = 0.01
+    client_packets_per_sec = 25\
+        if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec
+    for dhcp_relay in dut_dhcp_relay_data:
+        client_port_name = str(dhcp_relay['client_iface']['name'])
+        client_port_id = dhcp_relay['client_iface']['port_idx']
+        client_mac = ptfadapter.dataplane.get_mac(0, client_port_id).decode('utf-8')
+        server_port_name = dhcp_relay['uplink_interfaces'][0]
+        server_mac = ptfadapter.dataplane.get_mac(0, dhcp_relay['uplink_port_indices'][0]).decode('utf-8')
+        num_dhcp_servers = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+        init_dhcpcom_relay_counters(duthost)
+        if testing_mode == DUAL_TOR_MODE:
+            standby_duthost = rand_unselected_dut
+            init_dhcpcom_relay_counters(standby_duthost)
+
+        params = {
+            "hostname": duthost.hostname,
+            "client_port_index": client_port_id,
+            "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+            "other_client_ports": repr(dhcp_relay['other_client_ports']),
+            "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+            "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+            "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
+            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+            "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+            "dest_mac_address": BROADCAST_MAC,
+            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+            "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
+            "uplink_mac": str(dhcp_relay['uplink_mac']),
+            "packets_send_duration": packets_send_duration,
+            "client_packets_per_sec": client_packets_per_sec,
+            "testing_mode": testing_mode,
+            "kvm_support": True
+        }
+        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+
+        def _check_count_file_exists():
+            command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)
+            output = ptfhost.shell(command)
+            return not output['rc'] and output['stdout'].strip() == "exists"
+
+        def _verify_server_packets(pkts, dhcp_type):
+            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0]) * num_dhcp_servers
+            expected_uplink_counter = {
+                "RX": {},
+                "TX": {dhcp_type.capitalize(): actual_count}
+            }
+            expected_downlink_counter = {
+                "RX": {dhcp_type.capitalize(): actual_count / num_dhcp_servers},
+                "TX": {}
+            }
+            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
+                                            expected_uplink_counter,
+                                            expected_downlink_counter, error_margin)
+
+        def _verify_client_packets(pkts, dhcp_type):
+            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
+            expected_uplink_counter = {
+                "RX": {dhcp_type.capitalize(): actual_count},
+                "TX": {}
+            }
+            expected_downlink_counter = {
+                "RX": {},
+                "TX": {dhcp_type.capitalize(): actual_count}
+            }
+            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
+                                            expected_uplink_counter,
+                                            expected_downlink_counter, error_margin)
+
+        if dhcp_type in ['discover', 'request']:
+            interface = client_port_name
+            eth_src = client_mac
+            pkts_validator = _verify_server_packets
+        else:
+            interface = server_port_name
+            eth_src = server_mac
+            pkts_validator = _verify_client_packets
+        with capture_and_check_packet_on_dut(
+            duthost=duthost, interface=interface,
+            pkts_filter="ether src %s and udp dst port %s" % (eth_src, DEFAULT_DHCP_SERVER_PORT),
+            pkts_validator=pkts_validator,
+            pkts_validator_args=[dhcp_type]
+        ):
+            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
+                       platform_dir="ptftests", params=params,
+                       log_file="/tmp/test_dhcpcom_relay_counters_stress.DHCPStressTest.log",
+                       qlen=100000, is_python3=True, async_mode=True)
+            check_dhcp_stress_status(duthost, packets_send_duration)
+            pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
+            ptfhost.shell('rm -f {}'.format(count_file))

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -83,6 +83,9 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             validate_dhcpcom_relay_counters(dhcp_relay, duthost,
                                             expected_uplink_counter,
                                             expected_downlink_counter, error_margin)
+            if testing_mode == DUAL_TOR_MODE:
+                validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
+                                                {}, {}, 0)
 
         def _verify_client_packets(pkts, dhcp_type):
             actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
@@ -97,6 +100,9 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             validate_dhcpcom_relay_counters(dhcp_relay, duthost,
                                             expected_uplink_counter,
                                             expected_downlink_counter, error_margin)
+            if testing_mode == DUAL_TOR_MODE:
+                validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
+                                                {}, {}, 0)
 
         if dhcp_type in ['discover', 'request']:
             interface = client_port_name

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -3,8 +3,8 @@ import random
 import time
 import logging
 import re
-import json
 
+from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -59,111 +59,6 @@ def check_interface_status(duthost):
         return True
 
     return False
-
-
-def query_dhcpcom_relay_counter_result(duthost, query_key):
-    '''
-    Query the DHCPv4 counters from the COUNTERS_DB by the given key.
-    The returned value is a dictionary and the counter values are converted to integers.
-
-    Example return value:
-    {"TX": {"Unknown": 0, "Discover": 48, "Offer": 0, "Request": 96, "Decline": 0, "Ack": 0, "Nak": 0, "Release": 0,
-    "Inform": 0, "Bootp": 48}, "RX": {"Unknown": 0, "Discover": 0, "Offer": 1, "Request": 0, "Decline": 0, "Ack": 1,
-    "Nak": 0, "Release": 0, "Inform": 0, "Bootp": 0}}
-    '''
-    counters_query_string = 'sonic-db-cli COUNTERS_DB hgetall "DHCPV4_COUNTER_TABLE:{key}"'
-    shell_result = json.loads(
-        duthost.shell(counters_query_string.format(key=query_key))['stdout'].replace("\"", "").replace("'", "\"")
-    )
-    return {
-        rx_or_tx: {
-            dhcp_type: int(counter_value) for dhcp_type, counter_value in counters.items()
-        } for rx_or_tx, counters in shell_result.items()}
-
-
-def query_and_sum_dhcpcom_relay_counters(duthost, vlan_name, interface_name_list):
-    '''Query the DHCPv4 counters from the COUNTERS_DB and sum the counters for the given interface names.'''
-    if interface_name_list is None or len(interface_name_list) == 0:
-        # If no interface names are provided, return the counters for the VLAN interface only.
-        return query_dhcpcom_relay_counter_result(duthost, vlan_name)
-    total_counters = {}
-    # If interface names are provided, sum all of the provided interface names' counters
-    for interface_name in interface_name_list:
-        internal_shell_result = query_dhcpcom_relay_counter_result(duthost, vlan_name + ":" + interface_name)
-        for rx_or_tx, counters in internal_shell_result.items():
-            total_value = total_counters.setdefault(rx_or_tx, {})
-            for dhcp_type, counter_value in counters.items():
-                total_value[dhcp_type] = total_value.get(dhcp_type, 0) + counter_value
-    return total_counters
-
-
-def compare_dhcpcom_relay_counter_values(dhcp_relay_counter, expected_counter):
-    """Compare the DHCP relay counter value with the expected counter."""
-    for dir in SUPPORTED_DIR:
-        for dhcp_type in SUPPORTED_DHCPV4_TYPE:
-            expected_value = expected_counter.setdefault(dir, {}).get(dhcp_type, 0)
-            actual_value = dhcp_relay_counter.setdefault(dir, {}).get(dhcp_type, 0)
-            pytest_assert(actual_value == expected_value,
-                          "DHCP relay counter {} {} is {}, but expected {}".format(dir, dhcp_type,
-                                                                                   actual_value,
-                                                                                   expected_value))
-
-
-def validate_dhcpcom_relay_counters(dhcp_relay, duthost, expected_uplink_counter, expected_downlink_counter):
-    """Validate the dhcpcom relay counters"""
-    downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
-    # it can be portchannel or interface, it depends on the topology
-    uplink_portchannels_or_interfaces = dhcp_relay['uplink_interfaces']
-    client_iface = dhcp_relay['client_iface']['name']
-    portchannels = dhcp_relay['portchannels']
-
-    '''
-    If the uplink_portchannels_or_interfaces are portchannels,
-        uplink_interfaces will contains the members of the portchannels
-    If the uplink_portchannels_or_interfaces are not portchannels,
-        uplink_interfaces will equal to uplink_portchannels_or_interfaces
-    '''
-    uplink_interfaces = []
-    for portchannel_name in uplink_portchannels_or_interfaces:
-        if portchannel_name in portchannels.keys():
-            uplink_interfaces.extend(portchannels[portchannel_name]['members'])
-            portchannel_counters = query_and_sum_dhcpcom_relay_counters(duthost,
-                                                                        downlink_vlan_iface,
-                                                                        [portchannel_name])
-            members_counters = query_and_sum_dhcpcom_relay_counters(duthost,
-                                                                    downlink_vlan_iface,
-                                                                    portchannels[portchannel_name]['members'])
-            pytest_assert(portchannel_counters == members_counters,
-                          "Portchannel {} counters {} are not equal to its members counters {}"
-                          .format(portchannel_name, portchannel_counters, members_counters))
-        else:
-            uplink_interfaces.append(portchannel_name)
-
-    vlan_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [])
-    client_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [client_iface])
-    uplink_portchannels_interfaces_counter = query_and_sum_dhcpcom_relay_counters(
-        duthost, downlink_vlan_iface, uplink_portchannels_or_interfaces
-    )
-    uplink_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, uplink_interfaces)
-
-    pytest_assert(vlan_interface_counter == client_interface_counter,
-                  "VLAN interface {} counters {} are not equal to client interface {} counters {}"
-                  .format(downlink_vlan_iface, vlan_interface_counter, client_iface, client_interface_counter))
-    pytest_assert(uplink_interface_counter == uplink_portchannels_interfaces_counter,
-                  "Uplink interfaces {} counters {} are not equal to uplink portchannels or interfaces {} counters {}"
-                  .format(uplink_interfaces, uplink_interface_counter,
-                          uplink_portchannels_or_interfaces, uplink_portchannels_interfaces_counter))
-    compare_dhcpcom_relay_counter_values(vlan_interface_counter,
-                                         expected_downlink_counter)
-
-    compare_dhcpcom_relay_counter_values(uplink_interface_counter,
-                                         expected_uplink_counter)
-
-
-def init_dhcpcom_relay_counters(duthost):
-    command_output = duthost.shell("sudo sonic-clear dhcp_relay ipv4 counters")
-    pytest_assert("Clear DHCPv4 relay counter done" == command_output["stdout"],
-                  "dhcp_relay counters are not cleared successfully, output: {}".format(command_output["stdout"]))
 
 
 @pytest.fixture(scope="function")

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -229,7 +229,6 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
     packets_send_duration = 120
     client_packets_per_sec = 50\
         if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec
-    import pdb; pdb.set_trace()  # noqa: T201
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -17,7 +17,6 @@ pytestmark = [
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
-DUAL_TOR_MODE = 'dual'
 
 
 def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -221,15 +221,15 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
                                        testing_config, setup_standby_ports_on_rand_unselected_tor,
                                        toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                                        dhcp_type, clean_processes_after_stress_test,
-                                       rand_unselected_dut):
+                                       rand_unselected_dut, request):
     '''
     Test DHCP relay counters functionality can handle the maximum load within 5% miss.
     '''
     testing_mode, duthost = testing_config
     packets_send_duration = 120
-    client_packets_per_sec = 50
-    if duthost.hostname.__contains__('720dt'):
-        client_packets_per_sec = 100
+    client_packets_per_sec = 50\
+        if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec
+    import pdb; pdb.set_trace()  # noqa: T201
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_name = str(dhcp_relay['client_iface']['name'])

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -5,6 +5,7 @@ import ptf.packet as scapy
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
 from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.ptf_runner import ptf_runner
@@ -17,6 +18,7 @@ pytestmark = [
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
+DUAL_TOR_MODE = 'dual'
 
 
 def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -211,6 +213,111 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             check_dhcp_stress_status(duthost, packets_send_duration)
             pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
             exp_count = int(ptfhost.shell('cat {}'.format(count_file))['stdout'].strip())
+            ptfhost.shell('rm -f {}'.format(count_file))
+
+
+@pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
+def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+                                       testing_config, setup_standby_ports_on_rand_unselected_tor,
+                                       toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
+                                       dhcp_type, clean_processes_after_stress_test,
+                                       rand_unselected_dut):
+    '''
+    Test DHCP relay counters functionality can handle the maximum load within 5% miss.
+    '''
+    testing_mode, duthost = testing_config
+    packets_send_duration = 120
+    client_packets_per_sec = 50
+    if duthost.hostname.__contains__('720dt'):
+        client_packets_per_sec = 100
+    skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
+    for dhcp_relay in dut_dhcp_relay_data:
+        client_port_name = str(dhcp_relay['client_iface']['name'])
+        client_port_id = dhcp_relay['client_iface']['port_idx']
+        client_mac = ptfadapter.dataplane.get_mac(0, client_port_id).decode('utf-8')
+        server_port_name = dhcp_relay['uplink_interfaces'][0]
+        server_mac = ptfadapter.dataplane.get_mac(0, dhcp_relay['uplink_port_indices'][0]).decode('utf-8')
+        num_dhcp_servers = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+        init_dhcpcom_relay_counters(duthost)
+        if not skip_dhcpmon and testing_mode == DUAL_TOR_MODE:
+            standby_duthost = rand_unselected_dut
+            init_dhcpcom_relay_counters(standby_duthost)
+
+        params = {
+            "hostname": duthost.hostname,
+            "client_port_index": client_port_id,
+            "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
+            "other_client_ports": repr(dhcp_relay['other_client_ports']),
+            "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+            "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
+            "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
+            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+            "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
+            "dest_mac_address": BROADCAST_MAC,
+            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
+            "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
+            "uplink_mac": str(dhcp_relay['uplink_mac']),
+            "packets_send_duration": packets_send_duration,
+            "client_packets_per_sec": client_packets_per_sec,
+            "testing_mode": testing_mode,
+            "kvm_support": True
+        }
+        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+
+        def _check_count_file_exists():
+            command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)
+            output = ptfhost.shell(command)
+            return not output['rc'] and output['stdout'].strip() == "exists"
+
+        def _verify_server_packets(pkts, dhcp_type):
+            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0]) * num_dhcp_servers
+            expected_uplink_counter = {
+                "RX": {},
+                "TX": {dhcp_type.capitalize(): actual_count}
+            }
+            expected_downlink_counter = {
+                "RX": {dhcp_type.capitalize(): actual_count / num_dhcp_servers},
+                "TX": {}
+            }
+            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
+                                            expected_uplink_counter,
+                                            expected_downlink_counter, 1)
+
+        def _verify_client_packets(pkts, dhcp_type):
+            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
+            expected_uplink_counter = {
+                "RX": {dhcp_type.capitalize(): actual_count},
+                "TX": {}
+            }
+            expected_downlink_counter = {
+                "RX": {},
+                "TX": {dhcp_type.capitalize(): actual_count}
+            }
+            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
+                                            expected_uplink_counter,
+                                            expected_downlink_counter, 1)
+
+        if dhcp_type in ['discover', 'request']:
+            interface = client_port_name
+            eth_src = client_mac
+            pkts_validator = _verify_server_packets
+        else:
+            interface = server_port_name
+            eth_src = server_mac
+            pkts_validator = _verify_client_packets
+        with capture_and_check_packet_on_dut(
+            duthost=duthost, interface=interface,
+            pkts_filter="ether src %s and udp dst port %s" % (eth_src, DEFAULT_DHCP_SERVER_PORT),
+            pkts_validator=pkts_validator,
+            pkts_validator_args=[dhcp_type]
+        ):
+            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
+                       platform_dir="ptftests", params=params,
+                       log_file="/tmp/test_dhcpcom_relay_counters_stress.DHCPStressTest.log",
+                       qlen=100000, is_python3=True, async_mode=True)
+            check_dhcp_stress_status(duthost, packets_send_duration)
+            pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
             ptfhost.shell('rm -f {}'.format(count_file))
 
 

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -4,8 +4,7 @@ import ptf.packet as scapy
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
-from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters
+from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service, check_dhcp_stress_status
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.ptf_runner import ptf_runner
@@ -103,35 +102,6 @@ def test_dhcp_relay_restart_with_stress(ptfhost, dut_dhcp_relay_data, validate_d
                    log_file="/tmp/dhcp_relay_test.stress.DHCPTest.log", is_python3=True)
 
 
-def check_dhcp_stress_status(duthost, test_duration_seconds):
-    # Monitor DHCP status during the test
-    start_time = time.time()
-    sleep_time = 30
-    while time.time() - start_time < test_duration_seconds - sleep_time:
-        # Check the status of the DHCP container
-        dhcp_container_status = duthost.shell('docker ps | grep dhcp_relay')["stdout"]
-        if dhcp_container_status == "":
-            assert False, "DHCP container is NOT running."
-
-        # Check CPU usage of the DHCP process
-        dhcp_cpu_usage = duthost.shell('show processes cpu --verbose | grep dhc | awk \'{print $9}\'')["stdout"]
-        if dhcp_cpu_usage:
-            dhcp_cpu_usage_lines = dhcp_cpu_usage.splitlines()
-            for cpu_usage in dhcp_cpu_usage_lines:
-                cpu_usage_float = float(cpu_usage)
-            assert cpu_usage_float < 50.0, "DHCP CPU usage is too high: {}%".format(cpu_usage_float)
-
-        # Check the status of multiple DHCP processes inside the container
-        dhcp_process_status = duthost.shell(
-             'docker exec dhcp_relay supervisorctl status | grep dhcp | grep -v dhcp6')["stdout"]
-        if dhcp_process_status:
-            dhcp_process_status_lines = dhcp_process_status.splitlines()
-            for dhcp_process_status_line in dhcp_process_status_lines:
-                process_name, process_status = dhcp_process_status_line.split()[0], dhcp_process_status_line.split()[1],
-                assert process_status == "RUNNING", "{} is not running!".format(process_name)
-    time.sleep(sleep_time)
-
-
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
 def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                            setup_standby_ports_on_rand_unselected_tor,
@@ -214,114 +184,3 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
             exp_count = int(ptfhost.shell('cat {}'.format(count_file))['stdout'].strip())
             ptfhost.shell('rm -f {}'.format(count_file))
-
-
-@pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
-                                       testing_config, setup_standby_ports_on_rand_unselected_tor,
-                                       toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
-                                       dhcp_type, clean_processes_after_stress_test,
-                                       rand_unselected_dut, request):
-    '''
-    Test DHCP relay counters functionality can handle the maximum load within 5% miss.
-    '''
-    testing_mode, duthost = testing_config
-    packets_send_duration = 120
-    client_packets_per_sec = 50\
-        if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec
-    skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
-    for dhcp_relay in dut_dhcp_relay_data:
-        client_port_name = str(dhcp_relay['client_iface']['name'])
-        client_port_id = dhcp_relay['client_iface']['port_idx']
-        client_mac = ptfadapter.dataplane.get_mac(0, client_port_id).decode('utf-8')
-        server_port_name = dhcp_relay['uplink_interfaces'][0]
-        server_mac = ptfadapter.dataplane.get_mac(0, dhcp_relay['uplink_port_indices'][0]).decode('utf-8')
-        num_dhcp_servers = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
-        init_dhcpcom_relay_counters(duthost)
-        if not skip_dhcpmon and testing_mode == DUAL_TOR_MODE:
-            standby_duthost = rand_unselected_dut
-            init_dhcpcom_relay_counters(standby_duthost)
-
-        params = {
-            "hostname": duthost.hostname,
-            "client_port_index": client_port_id,
-            "client_iface_alias": str(dhcp_relay['client_iface']['alias']),
-            "other_client_ports": repr(dhcp_relay['other_client_ports']),
-            "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
-            "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs']),
-            "server_ip": dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'],
-            "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-            "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-            "relay_iface_netmask": str(dhcp_relay['downlink_vlan_iface']['mask']),
-            "dest_mac_address": BROADCAST_MAC,
-            "client_udp_src_port": DEFAULT_DHCP_CLIENT_PORT,
-            "switch_loopback_ip": dhcp_relay['switch_loopback_ip'],
-            "uplink_mac": str(dhcp_relay['uplink_mac']),
-            "packets_send_duration": packets_send_duration,
-            "client_packets_per_sec": client_packets_per_sec,
-            "testing_mode": testing_mode,
-            "kvm_support": True
-        }
-        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
-
-        def _check_count_file_exists():
-            command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)
-            output = ptfhost.shell(command)
-            return not output['rc'] and output['stdout'].strip() == "exists"
-
-        def _verify_server_packets(pkts, dhcp_type):
-            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0]) * num_dhcp_servers
-            expected_uplink_counter = {
-                "RX": {},
-                "TX": {dhcp_type.capitalize(): actual_count}
-            }
-            expected_downlink_counter = {
-                "RX": {dhcp_type.capitalize(): actual_count / num_dhcp_servers},
-                "TX": {}
-            }
-            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                            expected_uplink_counter,
-                                            expected_downlink_counter, 1)
-
-        def _verify_client_packets(pkts, dhcp_type):
-            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
-            expected_uplink_counter = {
-                "RX": {dhcp_type.capitalize(): actual_count},
-                "TX": {}
-            }
-            expected_downlink_counter = {
-                "RX": {},
-                "TX": {dhcp_type.capitalize(): actual_count}
-            }
-            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                            expected_uplink_counter,
-                                            expected_downlink_counter, 1)
-
-        if dhcp_type in ['discover', 'request']:
-            interface = client_port_name
-            eth_src = client_mac
-            pkts_validator = _verify_server_packets
-        else:
-            interface = server_port_name
-            eth_src = server_mac
-            pkts_validator = _verify_client_packets
-        with capture_and_check_packet_on_dut(
-            duthost=duthost, interface=interface,
-            pkts_filter="ether src %s and udp dst port %s" % (eth_src, DEFAULT_DHCP_SERVER_PORT),
-            pkts_validator=pkts_validator,
-            pkts_validator_args=[dhcp_type]
-        ):
-            ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
-                       platform_dir="ptftests", params=params,
-                       log_file="/tmp/test_dhcpcom_relay_counters_stress.DHCPStressTest.log",
-                       qlen=100000, is_python3=True, async_mode=True)
-            check_dhcp_stress_status(duthost, packets_send_duration)
-            pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
-            ptfhost.shell('rm -f {}'.format(count_file))
-
-
-@pytest.fixture(scope="function")
-def clean_processes_after_stress_test(ptfhost):
-    yield
-    ptfhost.shell("kill -9 $(ps aux | grep  dhcp_relay_stress_test | grep -v 'grep' | awk '{print $2}')",
-                  module_ignore_errors=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Currently, there is no test case for dhcp relay per-interface counter stress test.
#### How did you do it?
Add stress test case for dhcp relay per-interface counter to compare the actual packet count and the counter value.
#### How did you verify/test it?
Run the test case
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Test plan: https://github.com/sonic-net/sonic-mgmt/pull/19138
