### PR TITLE
Skip multiple servers testbed parsing on branch 202411

### DIFF
--- a/ansible/library/test_facts.py
+++ b/ansible/library/test_facts.py
@@ -169,10 +169,10 @@ class ParseTestbedTopoinfo():
             with open(self.testbed_filename) as f:
                 tb_info = yaml.safe_load(f)
                 for tb in tb_info:
-                    if tb["ptf_ip"]:
+                    if "ptf_ip" in tb and tb["ptf_ip"]:
                         tb["ptf_ip"], tb["ptf_netmask"] = \
                             _cidr_to_ip_mask(tb["ptf_ip"])
-                    if tb["ptf_ipv6"]:
+                    if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
                         tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
                             _cidr_to_ip_mask(tb["ptf_ipv6"])
                     tb["duts"] = tb.pop("dut")

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -107,10 +107,10 @@ class TestbedInfo(object):
         with open(self.testbed_filename) as f:
             tb_info = yaml.safe_load(f)
             for tb in tb_info:
-                if tb["ptf_ip"]:
+                if "ptf_ip" in tb and tb["ptf_ip"]:
                     tb["ptf_ip"], tb["ptf_netmask"] = \
                         self._cidr_to_ip_mask(tb["ptf_ip"])
-                if tb["ptf_ipv6"]:
+                if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
                     tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
                         self._cidr_to_ip_mask(tb["ptf_ipv6"])
                 tb["duts"] = tb.pop("dut")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In PRs: https://github.com/sonic-net/sonic-mgmt/pull/15643 and https://github.com/sonic-net/sonic-mgmt/pull/15881
We implemented multi-servers testbed design, however, to enable parsing multi-servers testbed definition, raise this PR to fix out of index error.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In PRs: https://github.com/sonic-net/sonic-mgmt/pull/15643 and https://github.com/sonic-net/sonic-mgmt/pull/15881
We implemented multi-servers testbed design
#### How did you do it?
Check if key exists before visit
#### How did you verify/test it?
NA
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
