### PR TITLE
Remove skip_dhcpmon in test_dhcp_relay

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -500,7 +500,8 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
   skip:
-    reason: "Skip test_dhcp_relay_default in dualtor and old release version"    conditions_logical_operator: or
+    reason: "Skip test_dhcp_relay_default in dualtor and old release version"    
+    conditions_logical_operator: or
     conditions:
      - "'release in ['201811', '201911']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -500,7 +500,7 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
   skip:
-    reason: "Skip test_dhcp_relay_default in dualtor and old release version"    
+    reason: "Skip test_dhcp_relay_default in dualtor and old release version"
     conditions_logical_operator: or
     conditions:
       - "'release in ['201811', '201911']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -494,13 +494,16 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap:
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
   skip:
     reason: "Skip test_dhcp_relay_counter in 201911"
+    conditions_logical_operator: or
+    conditions:
+     - "'release in ['201811', '201911','202012']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
   skip:
     reason: "Skip test_dhcp_relay_default on dualtor in 201911"
     conditions_logical_operator: or
     conditions:
-      - "'dualtor' in topo_name and release in ['201811', '201911']"
+     - "'release in ['201811', '201911']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
@@ -531,13 +534,13 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enab
     reason: "Skip test_dhcp_relay_with_source_port_ip_in_relay_enabled on dualtor in 201911"
     conditions_logical_operator: or
     conditions:
-      - "'dualtor' in topo_name and release in ['201811', '201911']"
+      - "'release in ['201811', '201911']"
 
 dhcp_relay/test_dhcp_relay.py::test_interface_binding:
   skip:
     reason: "Skip test_interface_binding in 201911"
     conditions:
-      - "'dualtor' in topo_name and release in ['201811', '201911']"
+      - "'release in ['201811', '201911','202126']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:
@@ -581,39 +584,34 @@ dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
   skip:
-    reason: "Skip test_dhcp_relay_after_link_flap on dualtor or 201911"
+    reason: "Skip test_dhcp_relay_after_link_flap in 201911"
     conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
+      - "'release in ['201811','201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
   skip:
-    reason: "Skip test_dhcp_relay_default on dualtor or 201911"
+    reason: "Skip test_dhcp_relay_default in 201911"
     conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
+     - "'release in ['201811','201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
-    reason: "Skip test_dhcp_relay_start_with_uplinks_down on dualtor or 201911"
+    reason: "Skip test_dhcp_relay_start_with_uplinks_down in 201911"
     conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
+      - "'release in ['201811','201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
   skip:
-    reason: "Skip test_dhcpv6_relay_counter on dualtor or 201911"
+    reason: "Skip test_dhcpv6_relay_counter in 201911"
     conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
+      - "'release in ['201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
   skip:
-    reason: "Skip test_interface_binding on dualtor or 201911"
+    reason: "Skip test_interface_binding in 201911"
     conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
-      
+       - "'release in ['201911', '202106']"
+
 #######################################
 #####         drop_packets        #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -605,7 +605,7 @@ dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
     reason: "Skip test_dhcp_relay_after_link_flap on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
+      - "'201911' in duthost.os_version"   
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -491,6 +491,17 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap:
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
+  skip:
+    reason: "Skip test_dhcp_relay_counter in 201911"
+
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
+  skip:
+    reason: "Skip test_dhcp_relay_default on dualtor in 201911"
+    conditions_logical_operator: or
+    conditions:
+      - "'dualtor' in topo_name and release in ['201811', '201911']"
+
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
     reason: "Skip test_dhcp_relay_random_sport on dualtor in 201811 and 201911 or platform x86_64-8111_32eh_o-r0"
@@ -515,23 +526,12 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
-dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
-  skip:
-    reason: "Skip test_dhcp_relay_default on dualtor in 201911"
-    conditions_logical_operator: or
-    conditions:
-      - "'dualtor' in topo_name and release in ['201811', '201911']"
-
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled:
   skip:
     reason: "Skip test_dhcp_relay_with_source_port_ip_in_relay_enabled on dualtor in 201911"
     conditions_logical_operator: or
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
-
-dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
-  skip:
-    reason: "Skip test_dhcp_relay_counter in 201911"
 
 dhcp_relay/test_dhcp_relay.py::test_interface_binding:
   skip:
@@ -579,16 +579,9 @@ dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
     conditions:
       - "'dualtor-aa' in topo_name"
 
-dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
+dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
   skip:
-    reason: "Skip test_interface_binding on dualtor or 201911"
-    conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"
-
-dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
-  skip:
-    reason: "Skip test_dhcpv6_relay_counter on dualtor or 201911"
+    reason: "Skip test_dhcp_relay_after_link_flap on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
       - "'201911' in duthost.os_version"
@@ -600,20 +593,27 @@ dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
       - "'dualtor' in topo_name"
       - "'201911' in duthost.os_version"
 
-dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
-  skip:
-    reason: "Skip test_dhcp_relay_after_link_flap on dualtor or 201911"
-    conditions:
-      - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"   
-
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
     reason: "Skip test_dhcp_relay_start_with_uplinks_down on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
-      - "'201911' in duthost.os_version"     
+      - "'201911' in duthost.os_version"
 
+dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
+  skip:
+    reason: "Skip test_dhcpv6_relay_counter on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"
+
+dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
+  skip:
+    reason: "Skip test_interface_binding on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"
+      
 #######################################
 #####         drop_packets        #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -493,15 +493,14 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap:
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
   skip:
-    reason: "Skip test_dhcp_relay_counter in 201911"
+    reason: "Skip test_dhcp_relay_counter in old release version"
     conditions_logical_operator: or
     conditions:
      - "'release in ['201811', '201911','202012']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
   skip:
-    reason: "Skip test_dhcp_relay_default on dualtor in 201911"
-    conditions_logical_operator: or
+    reason: "Skip test_dhcp_relay_default in dualtor and old release version"    conditions_logical_operator: or
     conditions:
      - "'release in ['201811', '201911']"
 
@@ -531,16 +530,16 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled:
   skip:
-    reason: "Skip test_dhcp_relay_with_source_port_ip_in_relay_enabled on dualtor in 201911"
+    reason: "Skip test_dhcp_relay_with_source_port_ip_in_relay_enabled in be dualtor and old release version"
     conditions_logical_operator: or
     conditions:
       - "'release in ['201811', '201911']"
 
 dhcp_relay/test_dhcp_relay.py::test_interface_binding:
   skip:
-    reason: "Skip test_interface_binding in 201911"
+    reason: "Skip test_interface_binding in old release version"
     conditions:
-      - "'release in ['201811', '201911','202126']"
+      - "'release in ['201811', '201911','202106']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:
@@ -584,31 +583,33 @@ dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
   skip:
-    reason: "Skip test_dhcp_relay_after_link_flap in 201911"
+    reason: "Skip test_dhcp_relay_after_link_flap in old release version"
     conditions:
       - "'release in ['201811','201911', '202106']"
+      - "'dualtor-aa' in topo_name"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
   skip:
-    reason: "Skip test_dhcp_relay_default in 201911"
+    reason: "Skip test_dhcp_relay_default in old release version"
     conditions:
      - "'release in ['201811','201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
-    reason: "Skip test_dhcp_relay_start_with_uplinks_down in 201911"
+    reason: "Skip test_dhcp_relay_start_with_uplinks_down in old release version"
     conditions:
       - "'release in ['201811','201911', '202106']"
+      - "'dualtor' in topo_name"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
   skip:
-    reason: "Skip test_dhcpv6_relay_counter in 201911"
+    reason: "Skip test_dhcpv6_relay_counter in old release version"
     conditions:
       - "'release in ['201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
   skip:
-    reason: "Skip test_interface_binding in 201911"
+    reason: "Skip test_interface_binding in old release version"
     conditions:
        - "'release in ['201911', '202106']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -515,13 +515,6 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
-dhcp_relay/test_dhcp_relay.py::dhcp_ready:
-skip:
- reason: "Skip dhcp_ready on dualtor in 201911"
- conditions_logical_operator: or
-     conditions:
-      - "'dualtor' in topo_name and release in ['201811', '201911']"
-
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
   skip:
     reason: "Skip test_dhcp_relay_default on dualtor in 201911"
@@ -539,6 +532,10 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enab
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
   skip:
     reason: "Skip test_dhcp_relay_counter in 201911"
+
+dhcp_relay/test_dhcp_relay.py::test_interface_binding:
+  skip:
+    reason: "Skip test_interface_binding in 201911"
     conditions:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
 
@@ -587,30 +584,35 @@ dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
     reason: "Skip test_interface_binding on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
   skip:
     reason: "Skip test_dhcpv6_relay_counter on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
   skip:
     reason: "Skip test_dhcp_relay_default on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
   skip:
     reason: "Skip test_dhcp_relay_after_link_flap on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
     reason: "Skip test_dhcp_relay_start_with_uplinks_down on dualtor or 201911"
     conditions:
       - "'dualtor' in topo_name"
+      - "'201911' in duthost.os_version"     
 
 #######################################
 #####         drop_packets        #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -496,14 +496,14 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
     reason: "Skip test_dhcp_relay_counter in old release version"
     conditions_logical_operator: or
     conditions:
-     - "'release in ['201811', '201911','202012']"
+      - "'release in ['201811', '201911', '202012']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
   skip:
     reason: "Skip test_dhcp_relay_default in dualtor and old release version"    
     conditions_logical_operator: or
     conditions:
-     - "'release in ['201811', '201911']"
+      - "'release in ['201811', '201911']"
 
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport:
   skip:
@@ -540,7 +540,7 @@ dhcp_relay/test_dhcp_relay.py::test_interface_binding:
   skip:
     reason: "Skip test_interface_binding in old release version"
     conditions:
-      - "'release in ['201811', '201911','202106']"
+      - "'release in ['201811', '201911', '202106']"
 
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:
@@ -586,20 +586,20 @@ dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
   skip:
     reason: "Skip test_dhcp_relay_after_link_flap in old release version"
     conditions:
-      - "'release in ['201811','201911', '202106']"
+      - "'release in ['201811', '201911', '202106']"
       - "'dualtor-aa' in topo_name"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
   skip:
     reason: "Skip test_dhcp_relay_default in old release version"
     conditions:
-     - "'release in ['201811','201911', '202106']"
+      - "'release in ['201811', '201911', '202106']"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
   skip:
     reason: "Skip test_dhcp_relay_start_with_uplinks_down in old release version"
     conditions:
-      - "'release in ['201811','201911', '202106']"
+      - "'release in ['201811', '201911', '202106']"
       - "'dualtor' in topo_name"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
@@ -612,7 +612,7 @@ dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
   skip:
     reason: "Skip test_interface_binding in old release version"
     conditions:
-       - "'release in ['201911', '202106']"
+      - "'release in ['201911', '202106']"
 
 #######################################
 #####         drop_packets        #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -515,6 +515,33 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac:
       - "'dualtor' in topo_name and release in ['201811', '201911']"
       - "platform in ['x86_64-8111_32eh_o-r0']"
 
+dhcp_relay/test_dhcp_relay.py::dhcp_ready:
+skip:
+ reason: "Skip dhcp_ready on dualtor in 201911"
+ conditions_logical_operator: or
+     conditions:
+      - "'dualtor' in topo_name and release in ['201811', '201911']"
+
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
+  skip:
+    reason: "Skip test_dhcp_relay_default on dualtor in 201911"
+    conditions_logical_operator: or
+    conditions:
+      - "'dualtor' in topo_name and release in ['201811', '201911']"
+
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled:
+  skip:
+    reason: "Skip test_dhcp_relay_with_source_port_ip_in_relay_enabled on dualtor in 201911"
+    conditions_logical_operator: or
+    conditions:
+      - "'dualtor' in topo_name and release in ['201811', '201911']"
+
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
+  skip:
+    reason: "Skip test_dhcp_relay_counter in 201911"
+    conditions:
+      - "'dualtor' in topo_name and release in ['201811', '201911']"
+
 dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress:
   skip:
     reason: "Skip due to flaky issue"
@@ -554,6 +581,36 @@ dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
     reason: "skip the multiple vlan test on aa dualtor as interface state is not aa after vlan split"
     conditions:
       - "'dualtor-aa' in topo_name"
+
+dhcp_relay/test_dhcpv6_relay.py::test_interface_binding:
+  skip:
+    reason: "Skip test_interface_binding on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
+
+dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter:
+  skip:
+    reason: "Skip test_dhcpv6_relay_counter on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
+
+dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default:
+  skip:
+    reason: "Skip test_dhcp_relay_default on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
+
+dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
+  skip:
+    reason: "Skip test_dhcp_relay_after_link_flap on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
+
+dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down:
+  skip:
+    reason: "Skip test_dhcp_relay_start_with_uplinks_down on dualtor or 201911"
+    conditions:
+      - "'dualtor' in topo_name"
 
 #######################################
 #####         drop_packets        #####

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -193,7 +193,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
     """
 
     testing_mode, duthost = testing_config
-     
+
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
     try:
@@ -281,7 +281,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     testing_mode, duthost = testing_config
-    
+
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
     try:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -14,7 +14,6 @@ from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.helpers.dut_utils import check_link_status
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import skip_release
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
@@ -195,9 +194,6 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
 
     testing_mode, duthost = testing_config
 
-    if testing_mode == DUAL_TOR_MODE:
-        pass
-
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
     try:
@@ -286,8 +282,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
     """
     testing_mode, duthost = testing_config
 
-    if testing_mode == DUAL_TOR_MODE:
-        pass
+  
 
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -579,8 +579,6 @@ def test_dhcp_relay_counter(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                             setup_standby_ports_on_rand_unselected_tor,
                             toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
     testing_mode, duthost = testing_config
-
-
     # based on message types we currently support in ptftest/py3/dhcp_relay_test.py
     dhcp_message_types = ["Discover", "Offer", "Request", "Ack"]
     for dhcp_relay in dut_dhcp_relay_data:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -193,7 +193,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
     """
 
     testing_mode, duthost = testing_config
-
+     
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
     try:
@@ -281,9 +281,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     testing_mode, duthost = testing_config
-
-  
-
+    
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
     try:

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -107,7 +107,6 @@ def enable_source_port_ip_in_relay(duthosts, rand_one_dut_hostname, tbinfo):
 
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data):
     duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201811", "201911", "202106"])
     if not check_interface_status(duthost):
         config_reload(duthost)
         wait_critical_processes(duthost)
@@ -197,7 +196,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
     testing_mode, duthost = testing_config
 
     if testing_mode == DUAL_TOR_MODE:
-        skip_release(duthost, ["201811", "201911"])
+        pass
 
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
@@ -288,7 +287,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(ptfhost, dut_dhcp_relay
     testing_mode, duthost = testing_config
 
     if testing_mode == DUAL_TOR_MODE:
-        skip_release(duthost, ["201811", "201911"])
+        pass
 
     skip_dhcpmon = any(vers in duthost.os_version for vers in ["201811", "201911", "202111"])
 
@@ -588,7 +587,6 @@ def test_dhcp_relay_counter(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                             toggle_all_simulator_ports_to_rand_selected_tor_m):     # noqa F811
     testing_mode, duthost = testing_config
 
-    skip_release(duthost, ["201811", "201911", "202012"])
 
     # based on message types we currently support in ptftest/py3/dhcp_relay_test.py
     dhcp_message_types = ["Discover", "Offer", "Request", "Ack"]

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -9,7 +9,6 @@ from tests.dhcp_relay.dhcp_relay_utils import restart_dhcp_service
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.split_vlan import setup_multiple_vlans_and_teardown  # noqa F401
-from tests.common.utilities import skip_release
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -260,7 +260,6 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
     new_vlan_id = setup_and_teardown_no_servers_vlan
 
     duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201911", "202106"])
     if not check_interface_status(duthost):
         config_reload(duthost)
         wait_critical_processes(duthost)
@@ -344,7 +343,6 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
                               setup_active_active_as_active_standby):            # noqa F811
     """ Test DHCPv6 Counter """
     duthost = duthosts[rand_one_dut_hostname]
-    skip_release(duthost, ["201911", "202106"])
 
     message_types = ["Unknown", "Solicit", "Advertise", "Request", "Confirm", "Renew", "Rebind", "Reply", "Release",
                      "Decline", "Reconfigure", "Information-Request", "Relay-Forward", "Relay-Reply", "Malformed"]
@@ -413,7 +411,6 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     _, duthost = testing_config
-    skip_release(duthost, ["201811", "201911", "202106"])  # TO-DO: delete skip release on 201811 and 201911
 
     # Please note: relay interface always means vlan interface
     for dhcp_relay in dut_dhcp_relay_data:
@@ -443,7 +440,6 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
        then test whether the DHCP relay agent relays packets properly.
     """
     testing_mode, duthost = testing_config
-    skip_release(duthost, ["201811", "201911", "202106"])
 
     if testing_mode == DUAL_TOR_MODE:
         pytest.skip("skip the link flap testcase on dual tor testbeds")
@@ -490,7 +486,6 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
        relays packets properly.
     """
     testing_mode, duthost = testing_config
-    skip_release(duthost, ["201811", "201911", "202106"])
 
     if testing_mode == DUAL_TOR_MODE:
         pytest.skip("skip the uplinks down testcase on dual tor testbeds")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Remove the skip_dhcpmon in test_dhcp_relay

#### How did you do it?
Removed all skip_dhcpmon variables from test_dhcp_relay 

#### How did you verify/test it?
Tested on the testbed and verified 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
