### PR TITLE
[Conditional mark] Xfail test_ser.py in 202412

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -887,6 +887,11 @@ platform_tests/broadcom/test_ser.py:
       - "asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-mgmt/issues/7546"
       - "https://github.com/sonic-net/sonic-mgmt/issues/17459 and hwsku in ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-16PE-384C-O128S2-COPPER', 'Arista-7060X6-16PE-384C-O128S2']"
 
+  xfail:
+    reason: "Testcase consistently fails, CSP raised to follow up"
+    conditions:
+      - "release in ['202412']"
+
 #######################################
 #####  cli/test_show_platform.py  #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -889,7 +889,7 @@ platform_tests/broadcom/test_ser.py:
   xfail:
     reason: "Testcase consistently fails, CSP raised to follow up"
     conditions:
-      - "release in ['202412'] and hwsku in ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-16PE-384C-O128S2-COPPER', 'Arista-7060X6-16PE-384C-O128S2', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']"
+      - "release in ['202412'] and 'Arista-7060X6' in hwsku"
 
 #######################################
 #####  cli/test_show_platform.py  #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -889,7 +889,7 @@ platform_tests/broadcom/test_ser.py:
   xfail:
     reason: "Testcase consistently fails, CSP raised to follow up"
     conditions:
-      - "release in ['202412'] and hwsku in ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-16PE-384C-O128S2-COPPER', 'Arista-7060X6-16PE-384C-O128S2']"
+      - "release in ['202412'] and hwsku in ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-16PE-384C-O128S2-COPPER', 'Arista-7060X6-16PE-384C-O128S2', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']"
 
 #######################################
 #####  cli/test_show_platform.py  #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -886,11 +886,10 @@ platform_tests/broadcom/test_ser.py:
       - "platform in ['x86_64-arista_720dt_48s']"
       - "asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-mgmt/issues/7546"
       - "https://github.com/sonic-net/sonic-mgmt/issues/17459 and hwsku in ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-16PE-384C-O128S2-COPPER', 'Arista-7060X6-16PE-384C-O128S2']"
-
   xfail:
     reason: "Testcase consistently fails, CSP raised to follow up"
     conditions:
-      - "release in ['202412']"
+      - "release in ['202412'] and hwsku in ['Arista-7060X6-64DE', 'Arista-7060X6-64DE-64x400G', 'Arista-7060X6-64DE-O128S2', 'Arista-7060X6-64DE-256x200G', 'Arista-7060X6-64PE', 'Arista-7060X6-64PE-64x400G', 'Arista-7060X6-64PE-O128S2', 'Arista-7060X6-64PE-256x200G', 'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-16PE-384C-O128S2-COPPER', 'Arista-7060X6-16PE-384C-O128S2']"
 
 #######################################
 #####  cli/test_show_platform.py  #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
test_ser.py is consistently failing on 202412. Xfail it and raise CSP to Broadcom to follow up.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202412

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
