### PR TITLE
Improve test to support user_auth mode

### DIFF
--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 import re
 
-from spytest.spytest import env
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.utilities import get_mgmt_ipv6, check_output, run_show_features

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -233,14 +233,14 @@ def test_telemetry_output_ipv6_only(request, duthosts_ipv6_mgmt_only, localhost,
         with setup_streaming_telemetry_context(True, dut, localhost, ptfhost, gnxi_path):
             env = GNMIEnvironment(dut, GNMIEnvironment.TELEMETRY_MODE)
             dut.shell('sonic-db-cli CONFIG_DB hset "%s|gnmi" user_auth none' % (env.gnmi_config_table),
-                  module_ignore_errors=False)
+                      module_ignore_errors=False)
             dut_ip = get_mgmt_ipv6(dut)
             cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
                 [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
             show_gnmi_out = dut.shell(cmd)['stdout']
             result = str(show_gnmi_out)
             dut.shell('sonic-db-cli CONFIG_DB hdel "%s|gnmi" user_auth' % (env.gnmi_config_table),
-                        module_ignore_errors=False)
+                      module_ignore_errors=False)
             inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
             pytest_assert(inerrors_match is not None,
                           "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import re
 
+from spytest.spytest import env
 from tests.common.helpers.constants import DEFAULT_ASIC_ID
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.utilities import get_mgmt_ipv6, check_output, run_show_features
@@ -232,11 +233,15 @@ def test_telemetry_output_ipv6_only(request, duthosts_ipv6_mgmt_only, localhost,
     def verify_telemetry_output_ipv6_only(dut):
         with setup_streaming_telemetry_context(True, dut, localhost, ptfhost, gnxi_path):
             env = GNMIEnvironment(dut, GNMIEnvironment.TELEMETRY_MODE)
+            dut.shell('sonic-db-cli CONFIG_DB hset "%s|gnmi" user_auth none' % (env.gnmi_config_table),
+                  module_ignore_errors=False)
             dut_ip = get_mgmt_ipv6(dut)
             cmd = "~/gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr \
                 [%s]:%s -logtostderr -insecure" % (dut_ip, env.gnmi_port)
             show_gnmi_out = dut.shell(cmd)['stdout']
             result = str(show_gnmi_out)
+            dut.shell('sonic-db-cli CONFIG_DB hdel "%s|gnmi" user_auth' % (env.gnmi_config_table),
+                        module_ignore_errors=False)
             inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
             pytest_assert(inerrors_match is not None,
                           "SAI_PORT_STAT_IF_IN_ERRORS not found in gnmi output")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Microsoft ADO: 33257886

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We will enable user_auth by default, and then telemetry test will be blocked.

#### How did you do it?
Set user_auth as none before the telemetry test, and recover user_auth after the telemetry test.

#### How did you verify/test it?
Run ip/test_mgmt_ipv6_only.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
