### PR TITLE
Changes to modify the config_mode value to unified for FRR version

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -98,32 +98,9 @@ class GenerateGoldenConfigDBModule(object):
                 return -1
         return 0
 
-    def generate_frr_config_mode_golden_config_db(self, config):
+    def should_use_unified_mode(self):
         frr_version = self.get_frr_version()
-
-        if not (frr_version and self.compare_frr_version(frr_version, "8.5.0") >= 0):
-            return config
-
-        if not isinstance(config, str):
-            return config
-
-        config_obj = json.loads(config)
-
-        if multi_asic.is_multi_asic():
-            for _, ns_data in config_obj.items():
-                device_metadata = ns_data.get("DEVICE_METADATA", {})
-                localhost_md = device_metadata.get("localhost")
-                if isinstance(localhost_md, dict) and \
-                   localhost_md.get("docker_routing_config_mode") != "unified":
-                    localhost_md["docker_routing_config_mode"] = "unified"
-        else:
-            device_metadata = config_obj.get("DEVICE_METADATA", {})
-            localhost_md = device_metadata.get("localhost")
-            if isinstance(localhost_md, dict) and \
-               localhost_md.get("docker_routing_config_mode") != "unified":
-                localhost_md["docker_routing_config_mode"] = "unified"
-
-        return json.dumps(config_obj, indent=4)
+        return frr_version is not None and self.compare_frr_version(frr_version, "8.5.0") >= 0
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -783,7 +760,7 @@ class GenerateGoldenConfigDBModule(object):
         config = self.update_zebra_nexthop_config(config)
 
         # update router_config_mode
-        if self.generate_frr_config_mode_golden_config_db() is True:
+        if self.should_use_unified_mode():
             if ("DEVICE_METADATA" in config and "localhost" in config["DEVICE_METADATA"]):
                 if config["DEVICE_METADATA"]["localhost"].get("docker_routing_config_mode") != "unified":
                     config["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -83,7 +83,7 @@ class GenerateGoldenConfigDBModule(object):
                 return frr_version_match.group(1)
             else:
                 return None
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return None
 
     def compare_frr_version(self, version1, version2):
@@ -100,7 +100,7 @@ class GenerateGoldenConfigDBModule(object):
 
     def generate_frr_config_mode_golden_config_db(self, config):
         frr_version = self.get_frr_version()
-        
+
         if not (frr_version and self.compare_frr_version(frr_version, "8.5.0") >= 0):
             return config
 
@@ -784,8 +784,7 @@ class GenerateGoldenConfigDBModule(object):
 
         # update router_config_mode
         if self.generate_frr_config_mode_golden_config_db() is True:
-            if ("DEVICE_METADATA" in config and
-                "localhost" in config["DEVICE_METADATA"]):
+            if ("DEVICE_METADATA" in config and "localhost" in config["DEVICE_METADATA"]):
                 if config["DEVICE_METADATA"]["localhost"].get("docker_routing_config_mode") != "unified":
                     config["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"
 

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -74,6 +74,50 @@ class GenerateGoldenConfigDBModule(object):
         self.is_lit_mode = self.module.params['is_lit_mode']
         self.npu_index = self.module.params['npu_index']
 
+    def get_frr_version(self):
+        try:
+            frr_version_output = subprocess.check_output(["vtysh", "-c", "show version"]).decode("utf-8")
+            frr_version_match = re.search(r"FRRouting (\d+\.\d+\.\d+)", frr_version_output)
+            if frr_version_match:
+                return frr_version_match.group(1)
+            else:
+                return None
+        except subprocess.CalledProcessError as e:
+            return None
+
+    def compare_frr_version(self, version1, version2):
+        v1 = list(map(int, version1.split('.')))
+        v2 = list(map(int, version2.split('.')))
+        for i in range(max(len(v1), len(v2))):
+            v1_val = v1[i] if i < len(v1) else 0
+            v2_val = v2[i] if i < len(v2) else 0
+            if v1_val > v2_val:
+                return 1
+            elif v1_val < v2_val:
+                return -1
+        return 0
+
+    def generate_frr_config_mode_golden_config_db(self):
+        frr_version = self.get_frr_version()
+        if frr_version and self.compare_frr_version(frr_version, "8.5.0") >= 0:
+            rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
+            if rc != 0:
+                self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
+
+            # Generate config table from init_cfg.ini
+            ori_config_db = json.loads(out)
+
+            golden_config_db = {}
+            if "DEVICE_METADATA" in ori_config_db:
+                golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
+                if ("localhost" in golden_config_db["DEVICE_METADATA"] and
+                   "docker_routing_config_mode" in golden_config_db["DEVICE_METADATA"]["localhost"]):
+                    golden_config_db["DEVICE_METADATA"]["localhost"]["default_pfcwd_status"] = "unified"
+
+            return json.dumps(golden_config_db, indent=4)
+        else:
+            return json.dumps({})
+
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
         if rc != 0:
@@ -731,6 +775,8 @@ class GenerateGoldenConfigDBModule(object):
         # update zebra_nexthop config from minigraph
         config = self.update_zebra_nexthop_config(config)
 
+        # update router_config_mode
+        config = self.generate_frr_config_mode_golden_config_db(config)
         # To enable bmp feature when the image version is >= 202411 and the device is not supervisor
         # Note: the Chassis supervisor is not holding any BGP sessions so the BMP feature is not needed
         if self.check_version_for_bmp() is True and device_info.is_supervisor() is False:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -11,6 +11,7 @@ import logging
 import json
 import re
 import ipaddress
+import subprocess
 
 from ansible.module_utils.basic import AnsibleModule
 from sonic_py_common import device_info, multi_asic
@@ -97,26 +98,32 @@ class GenerateGoldenConfigDBModule(object):
                 return -1
         return 0
 
-    def generate_frr_config_mode_golden_config_db(self):
+    def generate_frr_config_mode_golden_config_db(self, config):
         frr_version = self.get_frr_version()
-        if frr_version and self.compare_frr_version(frr_version, "8.5.0") >= 0:
-            rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
-            if rc != 0:
-                self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
+        
+        if not (frr_version and self.compare_frr_version(frr_version, "8.5.0") >= 0):
+            return config
 
-            # Generate config table from init_cfg.ini
-            ori_config_db = json.loads(out)
+        if not isinstance(config, str):
+            return config
 
-            golden_config_db = {}
-            if "DEVICE_METADATA" in ori_config_db:
-                golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
-                if ("localhost" in golden_config_db["DEVICE_METADATA"] and
-                   "docker_routing_config_mode" in golden_config_db["DEVICE_METADATA"]["localhost"]):
-                    golden_config_db["DEVICE_METADATA"]["localhost"]["default_pfcwd_status"] = "unified"
+        config_obj = json.loads(config)
 
-            return json.dumps(golden_config_db, indent=4)
+        if multi_asic.is_multi_asic():
+            for _, ns_data in config_obj.items():
+                device_metadata = ns_data.get("DEVICE_METADATA", {})
+                localhost_md = device_metadata.get("localhost")
+                if isinstance(localhost_md, dict) and \
+                   localhost_md.get("docker_routing_config_mode") != "unified":
+                    localhost_md["docker_routing_config_mode"] = "unified"
         else:
-            return json.dumps({})
+            device_metadata = config_obj.get("DEVICE_METADATA", {})
+            localhost_md = device_metadata.get("localhost")
+            if isinstance(localhost_md, dict) and \
+               localhost_md.get("docker_routing_config_mode") != "unified":
+                localhost_md["docker_routing_config_mode"] = "unified"
+
+        return json.dumps(config_obj, indent=4)
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -776,7 +783,12 @@ class GenerateGoldenConfigDBModule(object):
         config = self.update_zebra_nexthop_config(config)
 
         # update router_config_mode
-        config = self.generate_frr_config_mode_golden_config_db(config)
+        if self.generate_frr_config_mode_golden_config_db() is True:
+            if ("DEVICE_METADATA" in config and
+                "localhost" in config["DEVICE_METADATA"]):
+                if config["DEVICE_METADATA"]["localhost"].get("docker_routing_config_mode") != "unified":
+                    config["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"
+
         # To enable bmp feature when the image version is >= 202411 and the device is not supervisor
         # Note: the Chassis supervisor is not holding any BGP sessions so the BMP feature is not needed
         if self.check_version_for_bmp() is True and device_info.is_supervisor() is False:


### PR DESCRIPTION
###Description of PR:
The changes in the below pull-requests modifies the docker_routing_config_mode value to unified .
https://github.com/sonic-net/sonic-buildimage/pull/22533

But, we see there are sonic-mgmt testcases which uses the minigraph to generate docker_routing_config_mode value to 'separated'. Post the above changes, as no longer our system will operate in separated mode, the generated docker_routing_config_mode needs to be modified to unified.

This change modifies the docker_routing_config_mode to unified by checking the FRR_VERSION.

