### PR TITLE
Enable generic_config_updater/test_pfcwd_interval.py on TH5 skus

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -19,7 +19,7 @@ from tests.common.utilities import get_duts_from_host_pattern
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONDITIONS_FILE = 'common/plugins/conditional_mark/tests_mark_conditions*.yaml'
-ASIC_NAME_PATH = '/../../../../ansible/group_vars/sonic/variables'
+GROUP_VARS_PATH = '/../../../../ansible/group_vars/sonic/variables'
 MARK_CONDITIONS_CONSTANTS = {
     "QOS_SAI_TOPO": ['t0', 't0-64', 't0-116', 't0-118', 't0-35', 't0-56', 't0-80',
                      't0-standalone-32', 't0-standalone-64', 't0-standalone-128', 't0-standalone-256',
@@ -119,7 +119,7 @@ def read_asic_name(hwsku):
         str or None: Return the asic generation name or None if something went wrong or nothing found in the file.
 
     '''
-    asic_name_file = os.path.dirname(__file__) + ASIC_NAME_PATH
+    asic_name_file = os.path.dirname(__file__) + GROUP_VARS_PATH
     try:
         with open(asic_name_file) as f:
             asic_name = yaml.safe_load(f)
@@ -136,6 +136,24 @@ def read_asic_name(hwsku):
 
     except IOError:
         return None
+
+
+def load_group_vars():
+    '''
+    Load group vars from the ansible file.
+
+    Returns:
+        dict: Return the group_vars dict.
+    '''
+    results = {}
+    logger.info('Loading group_vars')
+    group_vars_file = os.path.dirname(__file__) + GROUP_VARS_PATH
+    try:
+        with open(group_vars_file) as f:
+            results = yaml.safe_load(f)
+    except IOError:
+        pass
+    return results
 
 
 def load_dut_basic_facts(inv_name, dut_name):
@@ -419,6 +437,9 @@ def load_basic_facts(dut_name, session):
 
     # Check if the testrun has enable_macsec parameter set
     results['macsec_en'] = session.config.getoption("--enable_macsec", False)
+
+    # Load group_vars so they can be used in condition evaluation
+    results['group_vars'] = load_group_vars()
 
     return results
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2818,11 +2818,11 @@ generic_config_updater/test_packet_trimming_config_symmetric:
       - "release in ['202505']"
 
 generic_config_updater/test_pfcwd_interval.py:
-  skip:
-    reason: "This test can only support mellanox platforms. This test is not run on this hwsku currently"
+  xfail:
+    reason: "This test can only support mellanox and Broadcom TH5 platforms. This test is not run on this hwsku currently"
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['mellanox', 'cisco-8000']"
+      - "asic_type not in ['mellanox', 'cisco-8000'] and hwsku not in group_vars['broadcom_th5_hwskus']"
       - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2',
                    'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
 

--- a/tests/generic_config_updater/test_pfcwd_interval.py
+++ b/tests/generic_config_updater/test_pfcwd_interval.py
@@ -11,7 +11,7 @@ from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 from tests.common.gu_utils import is_valid_platform_and_version
 
 pytestmark = [
-    pytest.mark.asic('cisco-8000', 'mellanox', 'marvell-teralynx'),
+    pytest.mark.asic('cisco-8000', 'mellanox', 'marvell-teralynx', 'broadcom'),
     pytest.mark.topology('any'),
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This test is skipped for all ASICs besides Mellanox. It runs fine on Broadcom TH5 devices, so we should enable it for TH5.

Fixes #19190 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Increase test coverage.

#### How did you do it?

Add Broadcom TH5 sku to the list of accepted devices in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`

#### How did you verify/test it?

Before the change, the test is skipped on TH5 devices. After the change, the test runs and passes on TH5 devices.

#### Any platform specific information?

This change is specific to Broadcom TH5.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
