### PR TITLE
Enable generic_config_updater/test_eth_interface.py

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -197,7 +197,6 @@ def test_remove_lanes(duthosts, rand_one_dut_front_end_hostname,
         delete_tmpfile(duthost, tmpfile)
 
 
-@pytest.mark.skip(reason="Bypass as it is blocking submodule update")
 def test_replace_lanes(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
                        enum_rand_one_frontend_asic_index):
     duthost = duthosts[rand_one_dut_front_end_hostname]
@@ -330,7 +329,6 @@ def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
         delete_tmpfile(duthost, tmpfile)
 
 
-@pytest.mark.skip(reason="Bypass as this is not a production scenario")
 def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
                               enum_rand_one_frontend_asic_index):
     duthost = duthosts[rand_one_dut_front_end_hostname]
@@ -357,7 +355,6 @@ def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_
         delete_tmpfile(duthost, tmpfile)
 
 
-@pytest.mark.skip(reason="Bypass as this is not a production scenario")
 def test_update_valid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
                             enum_rand_one_frontend_asic_index):
     duthost = duthosts[rand_one_dut_front_end_hostname]


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Several testcases in this test are disabled. One testcase was bypassed back in 2022 for a suspected test bug, and two others were bypassed for "not being a production scenario". Both testcases seem valid to me, so we should reenable them.

Fixes #19197

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Improve test coverage.

#### How did you do it?

Removed `pytest.mark.skip()` statements.

#### How did you verify/test it?

Ran the test without the skips and verified that it passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
