### PR TITLE
Enable generic_config_updater/test_bgpl.py for T1 topologies

### DIFF
--- a/tests/generic_config_updater/test_bgpl.py
+++ b/tests/generic_config_updater/test_bgpl.py
@@ -11,7 +11,7 @@ from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0', 'mx', "m1", 't2'),
+    pytest.mark.topology('t0', 't1', 'm0', 'mx', "m1", 't2'),
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This test has been extended to support T1 topologies.

Fixes #19196

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Improve test coverage.

#### How did you do it?

Add `t1` to the `pytest.mark.topology()` statement at the beginning of the test.

#### How did you verify/test it?

Ran the test against a non-Mellanox T1 device after the change and verified that it passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
