### PR TITLE
Skip test_show_chassis_modules.py on T2 single node

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -891,6 +891,21 @@ platform_tests/broadcom/test_ser.py:
     conditions:
       - "release in ['202412'] and 'Arista-7060X6' in hwsku"
 
+##############################################
+#####  cli/test_show_chassis_modules.py  #####
+##############################################
+platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_midplane_status:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_status:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
 #######################################
 #####  cli/test_show_platform.py  #####
 #######################################
@@ -932,21 +947,6 @@ platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
-
-##############################################
-#####  cli/test_show_chassis_modules.py  #####
-##############################################
-platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_status:
-  skip:
-    reason: "Not supported on T2 single node topology"
-    conditions:
-      - "'t2_single_node' in topo_name"
-
-platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_midplane_status:
-  skip:
-    reason: "Not supported on T2 single node topology"
-    conditions:
-      - "'t2_single_node' in topo_name"
 
 ###############################################
 ## counterpoll/test_counterpoll_watermark.py ##

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -933,6 +933,21 @@ platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
 
+##############################################
+#####  cli/test_show_chassis_modules.py  #####
+##############################################
+platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_status:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_midplane_status:
+  skip:
+    reason: "Not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
 ###############################################
 ## counterpoll/test_counterpoll_watermark.py ##
 ###############################################


### PR DESCRIPTION
T2 single node does not run chassisd and thus does not fill in the chassis module table.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?

T2 single node does not run chassisd and thus does not fill in the chassis module table.

#### How did you do it?

I added the test to the conditional skip list.

#### How did you verify/test it?

I verified that the test was skipped on a t2-single-node-min topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
