### PR TITLE
Use ISO/UTC format when requesting the date/time from the DUT/DPUs.

### DIFF
--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -240,7 +240,8 @@ def test_npu_dpu_date(duthosts, dpuhosts,
     """
 
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    date_format = "%a %b %d %I:%M:%S %p %Z %Y"
+    # output ISO format and UTC timezone
+    date_cmd = "date --iso-8601=s -u"
 
     for index in range(num_dpu_modules):
         dpu_name = module.get_name(platform_api_conn, index)
@@ -249,13 +250,13 @@ def test_npu_dpu_date(duthosts, dpuhosts,
             continue
 
         logging.info("Checking date and time on {}".format(dpu_name))
-        dpu_date = dpuhosts[index].command("date")['stdout']
+        dpu_date = dpuhosts[index].command(date_cmd)['stdout'].strip()
 
         logging.info("Checking date and time on switch")
-        switch_date = duthost.command("date")['stdout_lines']
+        switch_date = duthost.command(date_cmd)['stdout'].strip()
 
-        date1 = datetime.strptime(switch_date[0], date_format)
-        date2 = datetime.strptime(dpu_date, date_format)
+        date1 = datetime.fromisoformat(switch_date)
+        date2 = datetime.fromisoformat(dpu_date)
 
         time_difference = abs((date1 - date2).total_seconds())
 


### PR DESCRIPTION
### Description of PR
Setting the "date" command parameters in the test to retrieve the system date/time from the DUTs in the ISO format and UTC timezone for the simpler and correct parsing in Python.

Summary:
Fixes erroneous failure of the test_npu_dpu_date 

### Type of change


- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Observed bogus test failures. Python3.8 incorrect handling of the timezones.

#### How did you do it?
Aligned/simplified the "date" output formats

#### How did you verify/test it?
Ran on the system with the synchronized and non-synchronized DPUs

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Switch+4 DPUs

### Documentation
N/A