### PR TITLE
[M1] Skip QOS check in test_techsupport

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -513,8 +513,7 @@ def commands_to_check(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
                     add_asic_arg("{}", cmds.broadcom_cmd_misc, num),
             }
         )
-        if duthost.facts["platform"] in ['x86_64-cel_e1031-r0',
-                                         'x86_64-arista_720dt_48s']:
+        if duthost.topo_type in ["mx", "m0", "m1"]:
             cmds_to_check.update(
                 {
                     "copy_config_cmds":


### PR DESCRIPTION

**Description of PR**
Update testcase test_techsupport.py

**Summary:**
The current if condition only checks for E1031 and 720DT.
So update the if condition to:
if duthost.topo_type in ["mx", "m0", "m1"]:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**### Approach**
**What is the motivation for this PR?**
Update testcase test_techsupport.py

**How did you do it?**
update the if condition to:
if duthost.topo_type in ["mx", "m0", "m1"]:

**How did you verify/test it?**
Verified by PR test.