### PR TITLE
Skip advanced_reboot test for non warm-reboot platform.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1941,9 +1941,9 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
 #######################################
 platform_tests/test_advanced_reboot.py:
   skip:
-    reason: "Skip 4600 and 4700 reason"
-    condition: 
-      - "'platform' in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0']"
+    reason: "Skip on all platforms except 2700, 7050cx3, 7260, and 7060 for no warm reboot usecase."
+    conditions:
+      - "all(x not in hwsku for x in ['2700', '7050cx3', '7260', '7060'])"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1943,7 +1943,7 @@ platform_tests/test_advanced_reboot.py:
   skip:
     reason: "Skip on all platforms except 2700, 7050cx3, 7260, and 7060 for no warm reboot usecase."
     conditions:
-      - "all(x not in hwsku for x in ['2700', '7050cx3', '7260', '7060'])"
+      - "all(x not in hwsku for x in ['2700', '7050CX3', '7260', '7060'])"
 
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1939,6 +1939,12 @@ pfcwd/test_pfcwd_warm_reboot.py::TestPfcwdWb::test_pfcwd_wb[async_storm:
 #######################################
 #####     platform_tests          #####
 #######################################
+platform_tests/test_advanced_reboot.py:
+  skip:
+    reason: "Skip 4600 and 4700 reason"
+    condition: 
+      - "'platform' in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0']"
+
 platform_tests/test_reload_config.py::test_reload_configuration_checks:
   skip:
     reason: "Skip test_reload_configuration_checks on Cisco platform due to unstable results"


### PR DESCRIPTION
Skip advanced_reboot test for platform that doesn't feature warm reboot.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) Microsoft ADO 33002054

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Warm reboot test still run for not warm reboot platform.

#### How did you do it?
Skip the test for not warm-reboot platform.

#### How did you verify/test it?
Run on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
