### PR TITLE
Update test_clock.py with new testcase "test_config_ntp"

### DIFF
--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -21,6 +21,7 @@ class ClockConsts:
     DATE = "date"
     TIME = "time"
     TIMEZONE = "timezone"
+    
     TEST_TIMEZONE = "Asia/Jerusalem"
     TIME_MARGIN = 6
     TIME_MARGIN_MODULAR = 16
@@ -458,8 +459,6 @@ def test_config_ntp(duthosts, init_timezone):
         2. Verify NTP server added
         3. Delete the added NTP server
         4. Verify NTP server deleted
-        5. Try to add an invalid NTP server
-        6. Verify error and that NTP server hasn't changed
     """
     with allure.step(f'Add the NTP server {ClockConsts.NTP_SERVER_IP}'):
         output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_ADD, ClockConsts.NTP_SERVER_IP)
@@ -478,4 +477,3 @@ def test_config_ntp(duthosts, init_timezone):
     with allure.step('Verify command success'):
         assert output == ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(ClockConsts.NTP_SERVER_IP), \
             f'Expected: "{output}" == "{ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(ClockConsts.NTP_SERVER_IP)}"'
-

--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -21,11 +21,11 @@ class ClockConsts:
     DATE = "date"
     TIME = "time"
     TIMEZONE = "timezone"
-
     TEST_TIMEZONE = "Asia/Jerusalem"
     TIME_MARGIN = 6
     TIME_MARGIN_MODULAR = 16
     RANDOM_NUM = 6
+    NTP_SERVER_IP = '10.230.70.8'
 
     # sonic commands
     CMD_SHOW_CLOCK = "show clock"
@@ -446,3 +446,36 @@ def test_config_clock_date(duthosts, init_timezone, restore_time, tbinfo):
                         actual=datetime_after,
                         allowed_margin=time_margin
                     )
+
+
+def test_config_ntp(duthosts, init_timezone):
+    """ 
+    @summary:
+        Check that 'config ntp' commands work correctly
+
+        Steps:
+        1. Add a new valid NTP server
+        2. Verify NTP server added
+        3. Delete the added NTP server
+        4. Verify NTP server deleted
+        5. Try to add an invalid NTP server
+        6. Verify error and that NTP server hasn't changed
+    """
+    with allure.step(f'Add the NTP server {ClockConsts.NTP_SERVER_IP}'):
+        output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_ADD, ClockConsts.NTP_SERVER_IP)
+
+    with allure.step('Verify command success'):
+        assert output == ClockConsts.OUTPUT_CMD_NTP_ADD_SUCCESS.format(ClockConsts.NTP_SERVER_IP), \
+            f'Expected: "{output}" == "{ClockConsts.OUTPUT_CMD_NTP_ADD_SUCCESS.format(ClockConsts.NTP_SERVER_IP)}"'
+
+    with allure.step(f'Verify NTP server {ClockConsts.NTP_SERVER_IP} added'):
+        ntp_output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_SHOW_NTP)
+        assert ClockConsts.NTP_SERVER_IP in ntp_output, f'Expected: "{ClockConsts.NTP_SERVER_IP}" in "{ntp_output}"'
+
+    with allure.step(f'Delete the NTP server {ClockConsts.NTP_SERVER_IP}'):
+        output = ClockUtils.run_cmd(duthosts, ClockConsts.CMD_CONFIG_NTP_DEL, ClockConsts.NTP_SERVER_IP)
+
+    with allure.step('Verify command success'):
+        assert output == ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(ClockConsts.NTP_SERVER_IP), \
+            f'Expected: "{output}" == "{ClockConsts.OUTPUT_CMD_NTP_DEL_SUCCESS.format(ClockConsts.NTP_SERVER_IP)}"'
+


### PR DESCRIPTION
        Steps:
        1. Add a new valid NTP server
        2. Verify NTP server added
        3. Delete the added NTP server
        4. Verify NTP server deleted
        5. Try to add an invalid NTP server
        6. Verify error and that NTP server hasn't changed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
