### PR TITLE
Set VM as reflector for LT2/FT2

### DIFF
--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -106,14 +106,10 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
-<<<<<<< Updated upstream
- neighbor {{ remote_ip }} next-hop-self
-=======
 {# set LT2/FT2 as reflector to advertise route to DUT #}
 {% if props.swrole is defined and props.swrole in ("lowerspine", "fabricspine") %}
  neighbor {{ remote_ip }} route-reflector-client
 {% endif %}
->>>>>>> Stashed changes
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate

--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -106,7 +106,14 @@ router bgp {{ host['bgp']['asn'] }}
 {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+<<<<<<< Updated upstream
  neighbor {{ remote_ip }} next-hop-self
+=======
+{# set LT2/FT2 as reflector to advertise route to DUT #}
+{% if props.swrole is defined and props.swrole in ("lowerspine", "fabricspine") %}
+ neighbor {{ remote_ip }} route-reflector-client
+{% endif %}
+>>>>>>> Stashed changes
 {% if remote_ip | ipv6 %}
  address-family ipv6
   neighbor {{ remote_ip }} activate


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enhance VM template to support route reflector.

In DT2 topologies, the BGP sessions between FT2 and LT2 are IBGP. Hence, the routes learnt from exabgp, which is also IBGP session, are not advertised to DUT.
To workaround this, this PR set VM as route reflector if the VM type is `lowerspine` or `fabricspine`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR is to support route reflector in VM template.

#### How did you do it?
Check VM type and enable route reflector if  VM type is `lowerspine` or `fabricspine`.

#### How did you verify/test it?
The change is verified on a physical testbed. 

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
