### PR TITLE
Added new code (Minigraph deployment) to support cisco hwsku Cisco-8102-28FH-DPU-O8C40

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -9,6 +9,7 @@ import copy
 import logging
 import json
 import re
+import os
 
 from ansible.module_utils.basic import AnsibleModule
 from sonic_py_common import device_info, multi_asic
@@ -30,6 +31,16 @@ TEMP_SMARTSWITCH_CONFIG_PATH = "/tmp/smartswitch.json"
 DUMMY_QUOTA = "dummy_single_quota"
 
 logger = logging.getLogger(__name__)
+
+smartswitch_hwsku_config = {
+    "Cisco-8102-28FH-DPU-O8C40": {
+         "dpu_num": {},
+         "port_key": "Ethernet{}",
+         "interface_key": "Ethernet{}|18.{}.202.0/31",
+         "base": 224,
+         "step": 8
+        }
+    }
 
 
 class GenerateGoldenConfigDBModule(object):
@@ -199,18 +210,65 @@ class GenerateGoldenConfigDBModule(object):
         ori_config_db = json.loads(out)
         if "DEVICE_METADATA" not in ori_config_db or "localhost" not in ori_config_db["DEVICE_METADATA"]:
             return "{}"
-
         ori_config_db["DEVICE_METADATA"]["localhost"]["subtype"] = "SmartSwitch"
-        gold_config_db = {
-            "DEVICE_METADATA": copy.deepcopy(ori_config_db["DEVICE_METADATA"])
-        }
+        hwsku = ori_config_db["DEVICE_METADATA"]["localhost"].get("hwsku", None)
+        platform = ori_config_db["DEVICE_METADATA"]["localhost"].get("platform", None)
 
-        # Generate dhcp_server related configuration
-        rc, out, err = self.module.run_command("cat {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))
-        if rc != 0:
-            self.module.fail_json(msg="Failed to get smartswitch config: {}".format(err))
-        smartswitch_config_obj = json.loads(out)
-        gold_config_db.update(smartswitch_config_obj)
+        if "FEATURE" not in ori_config_db \
+                or "dhcp_relay" not in ori_config_db["FEATURE"]:
+            return "{}"
+        ori_config_db["FEATURE"]["dhcp_relay"]["state"] = "disabled"
+
+        # Generate INTERFACE table for backplane interfaces
+        if "PORT" not in ori_config_db or "INTERFACE" not in ori_config_db:
+            return "{}"
+
+        if hwsku not in smartswitch_hwsku_config:
+            return "{}"
+
+        if "CHASSIS_MODULE" not in ori_config_db:
+            ori_config_db["CHASSIS_MODULE"] = {}
+            skudir = "/usr/share/sonic/device/{}/{}/".format(platform, hwsku)
+            config_file_path = os.path.join(skudir, "config_db.json")
+            if os.path.exists(config_file_path):
+                with open(config_file_path, "r") as f:
+                    config_data = json.load(f)
+                if "CHASSIS_MODULE" in config_data:
+                    ori_config_db["CHASSIS_MODULE"].update(config_data["CHASSIS_MODULE"])
+        hwsku_config = smartswitch_hwsku_config[hwsku]
+        dpu_num = len(ori_config_db["CHASSIS_MODULE"].keys())
+        smartswitch_hwsku_config[hwsku]['dpu_num'] = int(format(dpu_num))
+        for i in range(smartswitch_hwsku_config[hwsku]["dpu_num"]):
+            if "base" in hwsku_config and "step" in hwsku_config:
+                port_key = hwsku_config["port_key"].format(hwsku_config["base"] + i * hwsku_config["step"])
+            else:
+                port_key = hwsku_config["port_key"].format(i)
+            if "interface_key" in hwsku_config:
+                interface_key = hwsku_config["interface_key"].format(hwsku_config["base"] + i * hwsku_config["step"], i)
+
+            if port_key in ori_config_db["PORT"]:
+                ori_config_db["PORT"][port_key]["admin_status"] = "down"
+                ori_config_db["PORT"][port_key]["role"] = "Dpc"
+                if "interface_key" in hwsku_config:
+                    ori_config_db["INTERFACE"][port_key] = {}
+                    ori_config_db["INTERFACE"][interface_key] = {}
+            for index in range(128, 153, 8):
+                port_key = "Ethernet{}".format(index)
+                if port_key in ori_config_db["PORT"]:
+                    ori_config_db["PORT"][port_key]["admin_status"] = "up"
+            for index in range(160, 221, 4):
+                port_key = "Ethernet{}".format(index)
+                if port_key in ori_config_db["PORT"]:
+                    ori_config_db["PORT"][port_key]["admin_status"] = "up"
+
+            ori_config_db["CHASSIS_MODULE"]["DPU{}".format(i)] = {"admin_status": "down"}
+        gold_config_db = {
+            "DEVICE_METADATA": copy.deepcopy(ori_config_db["DEVICE_METADATA"]),
+            "FEATURE": copy.deepcopy(ori_config_db["FEATURE"]),
+            "INTERFACE": copy.deepcopy(ori_config_db["INTERFACE"]),
+            "PORT": copy.deepcopy(ori_config_db["PORT"]),
+            "CHASSIS_MODULE": copy.deepcopy(ori_config_db["CHASSIS_MODULE"]),
+        }
         return json.dumps(gold_config_db, indent=4)
 
     def generate(self):

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -346,6 +346,21 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "36x100Gb":
             for i in range(0, 36):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+        elif hwsku == "Cisco-8102-28FH-DPU-O8C40":
+            for i in range(0, 12):
+                base_eth = i * 8
+                port_alias_to_name_map["etp%da" % i] = "Ethernet%d" % base_eth
+                port_alias_to_name_map["etp%db" % i] = "Ethernet%d" % (base_eth + 4)
+            for i in range(12, 20):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (96 + (i - 12) * 8)
+            for i in range(20, 28):  # Update to include only up to etp27
+                base_eth = 160 + (i - 20) * 8
+                port_alias_to_name_map["etp%da" % i] = "Ethernet%d" % base_eth
+                port_alias_to_name_map["etp%db" % i] = "Ethernet%d" % (base_eth + 4)
+            start_eth = 224  # Start Ethernet port for etp28
+            for i in range(28, 36):  # Loop through etp28 to etp34
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % start_eth
+                start_eth += 8
         elif hwsku == "Cisco-8102-C64":
             for i in range(0, 64):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 4)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Added new code (Minigraph deployment) to support cisco hwsku Cisco-8102-28FH-DPU-O8C40
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X ] 202405
- [ X] 202411
- [ ] 202505

What is the motivation for this PR?
New cisco hwsku support
Added minigraph support for new cisco hwsku Cisco-8102-28FH-DPU-O8C40

How did you do it?

How did you verify/test it?
Deployed minigraph on 08C40
Any platform specific information?

Cisco-8102-28FH-DPU-O8C40

Supported testbed topology if it's a new test case?

t1-28-lag

Documentation