### PR TITLE
[test_vnet_bgp_route_precedence] Fix VNET prefix and BGP propagation

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -420,9 +420,14 @@ class Test_VNET_BGP_route_Precedence():
                 adv = routes_adv[vnet][prefix]
                 result = tor['host'].run_command("show run | grep 'router bgp'")
                 bgp_id_cmd = result['stdout'][0]
+                # configure loopback with a host address within the network
+                if self.prefix_type == 'v4':
+                    loopback_ip = adv.rsplit('.', 1)[0] + '.1'
+                else:
+                    loopback_ip = adv.rstrip(':') + '::1'
                 cmds = ["configure",
                         "interface loopback 10",
-                        "{} address {}/{}".format(type1, prefix, self.adv_mask),
+                        "{} address {}/{}".format(type1, loopback_ip, self.adv_mask),
                         "exit",
                         bgp_id_cmd,
                         "address-family {}".format(type),
@@ -446,9 +451,13 @@ class Test_VNET_BGP_route_Precedence():
                 adv_pfx = routes_adv[vnet][prefix]
                 result = tor['host'].run_command("show run | grep 'router bgp'")
                 bgp_id_cmd = result['stdout'][0]
+                if self.prefix_type == 'v4':
+                    loopback_ip = adv_pfx.rsplit('.', 1)[0] + '.1'
+                else:
+                    loopback_ip = adv_pfx.rstrip(':') + '::1'
                 cmds = ["configure",
                         "interface loopback 10",
-                        "no {} address {}/{}".format(type1, prefix, self.prefix_mask),
+                        "no {} address {}/{}".format(type1, loopback_ip, self.prefix_mask),
                         "exit",
                         bgp_id_cmd,
                         "address-family {}".format(type),

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -312,8 +312,8 @@ class Test_VNET_BGP_route_Precedence():
         routes_prefix[vnet] = {}
         if fixed_route:
             if self.prefix_type == 'v4':
-                routes_prefix[vnet][f"{prefix_offset}.131.131.1"] = nexthops.copy()
-                routes_adv[vnet][f"{prefix_offset}.131.131.1"] = f"{prefix_offset}.131.131.0"
+                routes_prefix[vnet][f"{prefix_offset}.131.131.0"] = nexthops.copy()
+                routes_adv[vnet][f"{prefix_offset}.131.131.0"] = f"{prefix_offset}.131.131.0"
                 return routes_adv, routes_prefix
             else:
                 routes_prefix[vnet][f"dcfa:{prefix_offset}:131::"] = nexthops.copy()
@@ -322,19 +322,17 @@ class Test_VNET_BGP_route_Precedence():
         count = 0
         if self.prefix_type == 'v4':
             for i in range(1, 250):
-                key1 = f"{prefix_offset}.{i}.0.{postfix}" if postfix != "" else f"{prefix_offset}.{i}.0.0"
-                key2 = f"{prefix_offset}.{i}.0.0"
-                routes_prefix[vnet][key1] = nexthops.copy()
-                routes_adv[vnet][key1] = key2
+                key = f"{prefix_offset}.{i}.0.0"
+                routes_prefix[vnet][key] = nexthops.copy()
+                routes_adv[vnet][key] = key
                 count = count + 1
                 if count >= num_routes:
                     return routes_adv, routes_prefix
         else:
             for i in range(1, 250):
-                key1 = f"dc4a:{prefix_offset}:{i}::{postfix}" if postfix != "" else f"dc4a:{prefix_offset}:{i}::"
-                key2 = f"dc4a:{prefix_offset}:{i}::"
-                routes_prefix[vnet][key1] = nexthops.copy()
-                routes_adv[vnet][key1] = key2
+                key = f"dc4a:{prefix_offset}:{i}::"
+                routes_prefix[vnet][key] = nexthops.copy()
+                routes_adv[vnet][key] = key
                 count = count + 1
                 if count >= num_routes:
                     return routes_adv, routes_prefix


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixed VNET BGP route precedence test failures by correcting route generation logic and BGP propagation configuration.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix Route Generation Problems: The test was generating host addresses (e.g., 21.131.131.1/24) instead of proper network addresses (e.g., 21.131.131.0/24) for VNET routes, causing `missed_in_asic_db_routes` errors and route validation failures.
Fix BGP Propagation Failures: TOR EOS devices were being configured with invalid loopback interface addresses (network addresses instead of host addresses), preventing BGP routes from being properly advertised to neighboring devices.

#### How did you do it?
Fixed VNET BGP route precedence test failures by correcting route generation logic and loopback interfaces with valid host addresses.

#### How did you verify/test it?
```
---------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/vxlan/test_vnet_bgp_route_precedence.xml ----------------------
--------------------------------------------------------- live log sessionfinish ---------------------------------------------------------
11:13:15 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================== short test summary info =========================================================
SKIPPED [2] vxlan/test_vnet_bgp_route_precedence.py:654: Test not required for custom monitor and initially up nexthop state.
SKIPPED [2] vxlan/test_vnet_bgp_route_precedence.py:766: Test not required for custom monitor and initially up nexthop state.
SKIPPED [2] vxlan/test_vnet_bgp_route_precedence.py:862: Test not required for custom monitor and initially up nexthop state.
SKIPPED [2] vxlan/test_vnet_bgp_route_precedence.py:1062: Test not supported for custom monitor and initially up nexthop state.
======================================== 28 passed, 8 skipped, 685 warnings in 3769.98s (1:02:49) ========================================
```

#### Any platform specific information?
str4-sn5640-3
#### Supported testbed topology if it's a new test case?
t1-isolated-d56u1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
