### PR TITLE
Generate new npu-dpu ports Ethernet224 To Ethernet280 for cisco smartswicth "Cisco-8102-28FH-DPU-O"

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -9,6 +9,7 @@ import copy
 import logging
 import json
 import re
+import os
 
 from ansible.module_utils.basic import AnsibleModule
 from sonic_py_common import device_info, multi_asic
@@ -30,6 +31,15 @@ TEMP_SMARTSWITCH_CONFIG_PATH = "/tmp/smartswitch.json"
 DUMMY_QUOTA = "dummy_single_quota"
 
 logger = logging.getLogger(__name__)
+smartswitch_hwsku_config = {
+    "Cisco-8102-28FH-DPU-O": {
+         "dpu_num": {},
+         "port_key": "Ethernet{}",
+         "interface_key": "Ethernet{}|18.{}.202.0/31",
+         "base": 224,
+         "step": 8
+        }
+    }
 
 
 class GenerateGoldenConfigDBModule(object):
@@ -199,25 +209,66 @@ class GenerateGoldenConfigDBModule(object):
         ori_config_db = json.loads(out)
         if "DEVICE_METADATA" not in ori_config_db or "localhost" not in ori_config_db["DEVICE_METADATA"]:
             return "{}"
-
         ori_config_db["DEVICE_METADATA"]["localhost"]["subtype"] = "SmartSwitch"
+        hwsku = ori_config_db["DEVICE_METADATA"]["localhost"].get("hwsku", None)
+        platform = ori_config_db["DEVICE_METADATA"]["localhost"].get("platform", None)
+
+        if "FEATURE" not in ori_config_db \
+                or "dhcp_relay" not in ori_config_db["FEATURE"]:
+            return "{}"
+        ori_config_db["FEATURE"]["dhcp_relay"]["state"] = "disabled"
+
+        # Generate INTERFACE table for backplane interfaces
+        if "PORT" not in ori_config_db or "INTERFACE" not in ori_config_db:
+            return "{}"
+
+        if hwsku not in smartswitch_hwsku_config:
+            return "{}"
+
+        if "CHASSIS_MODULE" not in ori_config_db:
+            ori_config_db["CHASSIS_MODULE"] = {}
+            skudir = "/usr/share/sonic/device/{}/{}/".format(platform, hwsku)
+            config_file_path = os.path.join(skudir, "config_db.json")
+            if os.path.exists(config_file_path):
+                with open(config_file_path, "r") as f:
+                    config_data = json.load(f)
+                if "CHASSIS_MODULE" in config_data:
+                    ori_config_db["CHASSIS_MODULE"].update(config_data["CHASSIS_MODULE"])
+        hwsku_config = smartswitch_hwsku_config[hwsku]
+        dpu_num = len(ori_config_db["CHASSIS_MODULE"].keys())
+        smartswitch_hwsku_config[hwsku]['dpu_num'] = int(format(dpu_num))
+        for i in range(smartswitch_hwsku_config[hwsku]["dpu_num"]):
+            if "base" in hwsku_config and "step" in hwsku_config:
+                port_key = hwsku_config["port_key"].format(hwsku_config["base"] + i * hwsku_config["step"])
+            else:
+                port_key = hwsku_config["port_key"].format(i)
+            if "interface_key" in hwsku_config:
+                interface_key = hwsku_config["interface_key"].format(hwsku_config["base"] + i * hwsku_config["step"], i)
+
+            if port_key in ori_config_db["PORT"]:
+                ori_config_db["PORT"][port_key]["admin_status"] = "down"
+                ori_config_db["PORT"][port_key]["role"] = "Dpc"
+                if "interface_key" in hwsku_config:
+                    ori_config_db["INTERFACE"][port_key] = {}
+                    ori_config_db["INTERFACE"][interface_key] = {}
+
+            ori_config_db["CHASSIS_MODULE"]["DPU{}".format(i)] = {"admin_status": "down"}
+
         gold_config_db = {
-            "DEVICE_METADATA": copy.deepcopy(ori_config_db["DEVICE_METADATA"])
+            "DEVICE_METADATA": copy.deepcopy(ori_config_db["DEVICE_METADATA"]),
+            "FEATURE": copy.deepcopy(ori_config_db["FEATURE"]),
+            "INTERFACE": copy.deepcopy(ori_config_db["INTERFACE"]),
+            "PORT": copy.deepcopy(ori_config_db["PORT"]),
+            "CHASSIS_MODULE": copy.deepcopy(ori_config_db["CHASSIS_MODULE"]),
         }
 
-        # Generate dhcp_server related configuration
-        rc, out, err = self.module.run_command("cat {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))
-        if rc != 0:
-            self.module.fail_json(msg="Failed to get smartswitch config: {}".format(err))
-        smartswitch_config_obj = json.loads(out)
-        gold_config_db.update(smartswitch_config_obj)
         return json.dumps(gold_config_db, indent=4)
 
     def generate(self):
         # topo check
         if self.topo_name == "mx" or "m0" in self.topo_name:
             config = self.generate_mgfx_golden_config_db()
-        elif self.topo_name == "t1-28-lag":
+        elif self.topo_name in ["t1-28-lag", "t0-28"]:
             config = self.generate_smartswitch_golden_config_db()
         else:
             config = "{}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Generate new npu-dpu ports Ethernet224 To Ethernet280 for cisco smartswicth "Cisco-8102-28FH-DPU-O-T1"
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ X] 202405
- [X ] 202411
- [ ] 202505

Approach

used existing file generate_golden_config_db.py to generate the config

What is the motivation for this PR?

The fix is to generate npu-dpu ports for the cisco platform Cisco-8102-28FH-DPU-O-T1.
These ports stay in dark mode.

How did you do it?

Using generate_golden_config_db.py generated new config for npu-dpu ports.

How did you verify/test it?

Deployed the minigraph tool, cross-verified the config_db.json file, and ensured that ports Ethernet224 to Ethernet280 appear in the configuration.

Any platform specific information?

"Cisco-8102-28FH-DPU-O"

Supported testbed topology if it's a new test case?

t1-28-lag

Documentation