### PR TITLE
[Mellanox] Update spf test related to error status when sw control is enabled

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -5,7 +5,8 @@ import logging
 from tests.common.mellanox_data import is_mellanox_device
 from .args.counterpoll_cpu_usage_args import add_counterpoll_cpu_usage_args
 from tests.common.helpers.mellanox_thermal_control_test_helper import suspend_hw_tc_service, resume_hw_tc_service
-from tests.common.platform.transceiver_utils import get_ports_with_flat_memory
+from tests.common.platform.transceiver_utils import get_ports_with_flat_memory, \
+    get_passive_cable_port_list, get_cmis_cable_ports_and_ver
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -208,3 +209,21 @@ def port_list_with_flat_memory(duthosts):
         ports_with_flat_memory.update({dut.hostname: get_ports_with_flat_memory(dut)})
     logging.info(f"port list with flat memory: {ports_with_flat_memory}")
     return ports_with_flat_memory
+
+
+@pytest.fixture(scope="module")
+def passive_cable_ports(duthosts):
+    passive_cable_ports = {}
+    for dut in duthosts:
+        passive_cable_ports.update({dut.hostname: get_passive_cable_port_list(dut)})
+    logging.info(f"passive_cable_ports: {passive_cable_ports}")
+    return passive_cable_ports
+
+
+@pytest.fixture(scope="module")
+def cmis_cable_ports_and_ver(duthosts):
+    cmis_cable_ports_and_ver = {}
+    for dut in duthosts:
+        cmis_cable_ports_and_ver.update({dut.hostname: get_cmis_cable_ports_and_ver(dut)})
+    logging.info(f"cmis_cable_ports_and_ver: {cmis_cable_ports_and_ver}")
+    return cmis_cable_ports_and_ver

--- a/tests/platform_tests/sfp/test_sfputil.py
+++ b/tests/platform_tests/sfp/test_sfputil.py
@@ -18,6 +18,10 @@ from tests.common.fixtures.duthost_utils import shutdown_ebgp   # noqa F401
 from tests.common.port_toggle import default_port_toggle_wait_time
 from tests.common.platform.transceiver_utils import I2C_WAIT_TIME_AFTER_SFP_RESET
 from tests.common.platform.interface_utils import get_physical_port_indices
+from tests.common.mellanox_data import is_mellanox_device
+from tests.common.platform.transceiver_utils import is_sw_control_enabled,\
+    get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled
+
 
 cmd_sfp_presence = "sudo sfputil show presence"
 cmd_sfp_eeprom = "sudo sfputil show eeprom"
@@ -335,10 +339,12 @@ def test_check_sfputil_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostn
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 
+@pytest.mark.device_type('physical')
 @pytest.mark.parametrize("cmd_sfp_error_status",
                          ["sudo sfputil show error-status", "sudo sfputil show error-status --fetch-from-hardware"])
 def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                    enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list):
+                                    enum_frontend_asic_index, conn_graph_facts, cmd_sfp_error_status, xcvr_skip_list,
+                                    passive_cable_ports, cmis_cable_ports_and_ver):
     """
     @summary: Check SFP error status using 'sfputil show error-status'
               and 'sfputil show error-status --fetch-from-hardware'
@@ -355,14 +361,22 @@ def test_check_sfputil_error_status(duthosts, enum_rand_one_per_hwsku_frontend_h
     if "NOT implemented" in sfp_error_status['stdout']:
         pytest.skip("Skip test as error status isn't supported")
     parsed_presence = parse_output(sfp_error_status["stdout_lines"][2:])
+    physical_port_index_map = get_physical_port_indices(duthost, conn_graph_facts["device_conn"][duthost.hostname])
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            if "Not supported" in sfp_error_status['stdout']:
-                logger.warning("test_check_sfputil_error_status: Skipping transceiver {} as error status not "
-                               "supported on this port)".format(intf))
+            expected_state = 'OK'
+            intf_index = physical_port_index_map[intf]
+            if cmd_sfp_error_status == "sudo sfputil show error-status --fetch-from-hardware"\
+                    and is_mellanox_device(duthost) and is_sw_control_enabled(duthost, intf_index):
+                expected_state = get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled(
+                    intf, passive_cable_ports[duthost.hostname], cmis_cable_ports_and_ver[duthost.hostname])
+            elif "Not supported" in sfp_error_status['stdout']:
+                logger.warning("test_check_sfputil_error_status: Skipping transceiver {} as error status "
+                               "not supported on this port)".format(intf))
                 continue
-            assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
-            assert parsed_presence[intf] == "OK", "Interface error status is not 'OK'"
+            assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_error_status)
+            assert parsed_presence[intf] == expected_state, \
+                f"Interface {intf}'s error status is not {expected_state}, actual state is:{parsed_presence[intf]}."
 
 
 def test_check_sfputil_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostname,

--- a/tests/platform_tests/sfp/util.py
+++ b/tests/platform_tests/sfp/util.py
@@ -12,9 +12,9 @@ def parse_output(output_lines):
     res = {}
     for line in output_lines:
         fields = line.split()
-        if len(fields) != 2:
+        if len(fields) < 2:
             continue
-        res[fields[0]] = fields[1]
+        res[fields[0]] = line.replace(fields[0], '').strip()
     return res
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update spf platform test related to error status, due to PR: https://github.com/sonic-net/sonic-buildimage/pull/20964
When software control is enabled, the port error status is as follows:
1. For active module, the expected state is OK
2. For cmis passive module, when cmis ver is 3.0, the expected state is ModuleLowPwr, else it is OK
3. For non cmis passive module, the expected state is 'Not supported'

When software control is disabled, the port error status keeps the original behaviour

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
 - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411

### Approach
#### What is the motivation for this PR?
Update spf test related to error status when sw control is enabled

#### How did you do it?
When sw control is enabled, check the error stats as the following logic:
1. For active module, the expected state is OK
2. For cmis passive module, the expected state is ModuleLowPwr
3. For non cmis passive module, the expected state is 'Not supported'

#### How did you verify/test it?
Run test_get_error_description and  test_check_sfputil_error_status when sw control is enabled

#### Any platform specific information?
Mellanox 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
