### PR TITLE
[M1] Adapt stress ACL test to M1 topo

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -196,6 +196,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
         if (topo == "t1" and "T2" in neighbor["name"]) or \
                 (topo == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"])) or \
                 (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]) or \
+                (topo == "m1" and ("MA" in neighbor["name"] or "MB" in neighbor["name"])) or \
                 (topo_name in ("t1-isolated-d32", "t1-isolated-d128") and "T0" in neighbor["name"]):
             upstream_ports[neighbor['namespace']].append(interface)
             upstream_port_ids.append(port_id)


### PR DESCRIPTION

### Description of PR
Update tests/acl/test_stress_acl.py


**Summary:**
 Adding the if condition to:
   (topo == "m1" and ("MA" in neighbor["name"] or "MB" in neighbor["name"])) or \

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
**What is the motivation for this PR?**
Update tests/acl/test_stress_acl.py

**How did you do it?**
Add the if condition to:
 (topo == "m1" and ("MA" in neighbor["name"] or "MB" in neighbor["name"])) or \

**How did you verify/test it?**
Verified by PR test.
