### PR TITLE
Enhance test_vxlan_bfd_tsa test

### DIFF
--- a/tests/vxlan/test_vxlan_bfd_tsa.py
+++ b/tests/vxlan/test_vxlan_bfd_tsa.py
@@ -535,7 +535,8 @@ class Test_VxLAN_BFD_TSA():
         # readd routes as they are removed by config reload
         ecmp_utils.configure_vxlan_switch(duthost, vxlan_port=4789, dutmac=self.vxlan_test_setup['dut_mac'])
         dest, ep_list = self.create_vnet_route(encap_type)
-        wait_until(20, 2, 0, is_vnet_route_configured_on_asic, duthost, dest)
+        pytest_assert(wait_until(40, 2, 0, is_vnet_route_configured_on_asic, duthost, dest),
+                      "Vnet route not configured on ASIC")
 
         self.dump_self_info_and_run_ptf("test4b", encap_type, True, [])
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add assert when checking vnet route asic installation

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
When using wait until function, it would not fail the case when it exit wait until function due to timeout.
#### How did you do it?
Add assert when checking vnet route asic installation. 
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
