### PR TITLE
[wol] remove restart monit routeCheck

### DIFF
--- a/tests/wol/conftest.py
+++ b/tests/wol/conftest.py
@@ -72,7 +72,6 @@ def random_intf_pair_to_remove_under_vlan(duthost, random_vlan, random_intf_pair
 
 
 def setup_ip_on_ptf(duthost, ptfhost, ip, intf_pairs):
-    duthost.command('monit stop routeCheck', module_ignore_errors=True)
     ptfhost.remove_ip_addresses()
     ip = ipaddress.ip_address(ip)
     if isinstance(ip, ipaddress.IPv4Address):
@@ -109,7 +108,6 @@ def remove_ip_on_ptf(duthost, ptfhost):
     duthost.command("sonic-clear fdb all")
     duthost.command("sonic-clear arp")
     duthost.command("sonic-clear ndp")
-    duthost.command('monit start routeCheck', module_ignore_errors=True)
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Remove restart monit as there will be a delay of 5 minutes, which cause monit check to fail for the next 5 minutes.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Restarting monit routeCheck cause 5 minute delay which causes monit check to fail for the next 5 minutes

#### How did you do it?
Remove restart monit routeCheck

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
