### PR TITLE
Increase max dpu processes up timeout from 360s to 400s

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -23,7 +23,8 @@ SWITCH_MAX_DELAY = 100
 SWITCH_MAX_TIMEOUT = 400
 INTF_MAX_TIMEOUT = 300
 INTF_TIME_INT = 5
-DPU_MAX_TIMEOUT = 360
+DPU_MAX_ONLINE_TIMEOUT = 360
+DPU_MAX_PROCESS_UP_TIMEOUT = 400
 DPU_MAX_TIME_INT = 30
 REBOOT_CAUSE_TIMEOUT = 30
 REBOOT_CAUSE_INT = 10
@@ -484,7 +485,7 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause):
 
     logging.info(f"Checking {dpu_name} is UP post test")
     pytest_assert(
-        wait_until(DPU_MAX_TIMEOUT, DPU_MAX_TIME_INT, 0,
+        wait_until(DPU_MAX_ONLINE_TIMEOUT, DPU_MAX_TIME_INT, 0,
                    check_dpu_module_status, duthost, "on", dpu_name),
         f"DPU {dpu_name} is not operationally UP post the operation"
     )
@@ -493,7 +494,7 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause):
     logging.info(f"Checking critical processes on {dpu_name}")
     pytest_assert(
         wait_until(
-            DPU_MAX_TIMEOUT, DPU_MAX_TIME_INT, 0,
+            DPU_MAX_PROCESS_UP_TIMEOUT, DPU_MAX_TIME_INT, 0,
             check_dpu_critical_processes, dpuhosts, dpu_id),
         f"Crictical process check for {dpu_name} has been failed"
     )
@@ -553,7 +554,7 @@ def dpus_shutdown_and_check(duthost, dpu_list, num_dpu_modules):
                 f"sudo config chassis modules shutdown {dpu_name}"
             )
             executor.submit(
-                wait_until, DPU_MAX_TIMEOUT, DPU_TIME_INT, 0,
+                wait_until, DPU_MAX_ONLINE_TIMEOUT, DPU_TIME_INT, 0,
                 check_dpu_module_status, duthost, "off", dpu_name
             )
 
@@ -577,6 +578,6 @@ def dpus_startup_and_check(duthost, dpu_list, num_dpu_modules):
                 f"sudo config chassis modules startup {dpu_name}"
             )
             executor.submit(
-                wait_until, DPU_MAX_TIMEOUT, DPU_TIME_INT, 0,
+                wait_until, DPU_MAX_ONLINE_TIMEOUT, DPU_TIME_INT, 0,
                 check_dpu_module_status, duthost, "on", dpu_name
             )


### PR DESCRIPTION
Summary:
Fixes the dpu_ctrl test timeout 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
DPU tests that expects processes running fail since there is not enough time (360s) to DPU to start all processes

#### How did you do it?
Created a separate timeout constant DPU_MAX_PROCESS_UP_TIMEOUT = 400 s for the processes to start.
The old boot DPU_MAX_TIMEOUT renamed to DPU_MAX_ONLINE_TIMEOUT and remains 360 s

#### How did you verify/test it?
Re-ran the test with the new timeouts
