### PR TITLE
Remove kill exabgp on PTF in remove topo step

### DIFF
--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -36,14 +36,6 @@
     vars:
       ptf_portchannel_action: stop
 
-  - name: Kill exabgp and ptf_nn_agent processes in PTF container
-    ptf_control:
-      ctn_name: "ptf_{{ vm_set_name }}"
-      command: kill
-    when:
-      - topo != 'fullmesh'
-      - not 'ptf' in topo
-
   - name: Get duts ports
     include_tasks: get_dut_port.yml
     loop: "{{ duts_name.split(',') }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove kill exabgp on PTF in remove topo step
Fixes # 
In the `remove_topo.yml` file, there is a step "Kill exabgp and ptf_nn_agent processes in PTF container". This step stops exabgp on the PTF containers one by one.
In the remove topo process, the PTF container will be deleted at the end, so there is no need to kill exabgp on the PTF container.
On the other hand, on the 512 scale setup, there are 512 exabgp on the PTF container. This step takes nearly 1 hour. If remove this step, it can save more time

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
