### PR TITLE
[202411] Ignore loganaylzer errors about the leapsecond file being expired

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -336,3 +336,6 @@ r, ".* NOTICE kernel:.*exe=\"/usr/bin/kill\".*"
 
 # https://msazure.visualstudio.com/One/_workitems/edit/33376635
 r, ".* ERR kernel.*audit: rate limit exceeded.*"
+
+# Ignore leapsecond file being expired, the only functional impact is that the system clock might be a second off
+r, ".* ERR ntpd.*: CLOCK: leapsecond file .* expired .*"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fixes sonic-net/sonic-buildimage#23142
Fixes sonic-net/sonic-buildimage#17653
Fixes sonic-net/sonic-buildimage#11327

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Depending on the image that is running, when it was built, and what version of packages were used, the leapsecond file might be expired. Ignore errors from ntpd about it, since the only functional impact that it might cause is that if there is a leapsecond, the system clock will be off by a second for a little bit until it gets corrected.

#### How did you do it?

Add a loganalyzer pattern to ignore such error messages.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
