### PR TITLE
Add missing current_password_hash option in multi_passwd_ssh plugin configuration

### DIFF
--- a/ansible/plugins/connection/multi_passwd_ssh.py
+++ b/ansible/plugins/connection/multi_passwd_ssh.py
@@ -55,6 +55,8 @@ DOCUMENTATION += """
           description: IPv6 address
           vars:
               - name: ansible_hostv6
+      current_password_hash:
+          description: The hash of currently used password
 """.lstrip("\n")
 
 # Sample error messages that host unreachable:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When attempting to run an Ansible module in a newer environment (Ansible [core 2.18.6] with Python 3.12), the following error occurs:
```
yutongzhang@sonic_mgmt:/data/sonic-mgmt/ansible$ ansible -i veos_vtb vlab-01 -m config_facts -a 'source=running host=vlab-01'
vlab-01 | FAILED! => {
    "msg": "Requested entry (plugin_type: connection plugin: multi_passwd_ssh setting: current_password_hash ) was not defined in configuration."
}
```
This issue is caused by the multi_passwd_ssh connection plugin referencing an option named current_password_hash, which was not defined in its configuration schema.
This PR resolves the issue by explicitly adding current_password_hash to the plugin’s configuration documentation.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
When attempting to run an Ansible module in a newer environment (Ansible [core 2.18.6] with Python 3.12), the following error occurs:
```
yutongzhang@sonic_mgmt:/data/sonic-mgmt/ansible$ ansible -i veos_vtb vlab-01 -m config_facts -a 'source=running host=vlab-01'
vlab-01 | FAILED! => {
    "msg": "Requested entry (plugin_type: connection plugin: multi_passwd_ssh setting: current_password_hash ) was not defined in configuration."
}
```
This issue is caused by the multi_passwd_ssh connection plugin referencing an option named current_password_hash, which was not defined in its configuration schema.
This PR resolves the issue by explicitly adding current_password_hash to the plugin’s configuration documentation.

#### How did you do it?
This PR resolves the issue by explicitly adding current_password_hash to the plugin’s configuration documentation.

#### How did you verify/test it?
We need to make sure that this change won't affect current test firstly -- test by pipeline itself. And then, we need to make sure that this change works in the new version -- test locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
