### PR TITLE
[sanity] Fix sanity check bgp not ready after restart

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -193,7 +193,12 @@ def check_bgp(duthosts, tbinfo):
 
         def _check_bgp_status_helper():
             asic_check_results = []
-            bgp_facts = dut.bgp_facts(asic_index='all')
+            try:
+                bgp_facts = dut.bgp_facts(asic_index='all')
+            except Exception as e:
+                logger.error("Failed to get BGP status on host %s: %s", dut.hostname, repr(e))
+                check_result['failed'] = True
+                return False
 
             # Conditions to fail BGP check
             #   1. No BGP neighbor.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix the following error:

```
tests.common.errors.RunAnsibleModuleFail: run module bgp_facts failed, Ansible Results =>
failed = True
msg = Command failed rc=1, out=, err=Exiting: failed to connect to any daemons.

invocation = {'module_args': {'num_npus': 1, 'instance_id': None}}
_ansible_no_log = None
changed = False
stdout =
stderr =

, error:run module bgp_facts failed, Ansible Results =>
failed = True
msg = Command failed rc=1, out=, err=Exiting: failed to connect to any daemons.

invocation = {'module_args': {'num_npus': 1, 'instance_id': None}}
_ansible_no_log = None
changed = False
stdout =
stderr =
```

This issue is due to that, if the first `_check_bgp_status_helper` fails, the recover tries to restart `bgp` on the DUT; but bgpd takes time to startup, so the vtysh is not responsive.

https://github.com/sonic-net/sonic-mgmt/blob/1b3006fb611c1b72e8b1f675bf13a530158d45d2/tests/common/plugins/sanity_check/checks.py#L282-L286

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
catch any exception raised by the `bgp_facts` and return `False` in this case.


#### How did you verify/test it?
Run testcase with no default route, verify no complain that vtysh is not responsive:

```
bgp/test_bgp_fact.py::test_bgp_facts[str2-7050cx3-acs-06-None] PASSED                                                                                                                                                                                                  [ 50%]
bgp/test_bgp_fact.py::test_bgp_facts[str2-7050cx3-acs-07-None] PASSED                                                                                                                                                                                                  [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
