### PR TITLE
Tune memory utilization limits specific to ARISTA SKUs

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -1,6 +1,12 @@
 {
   "HWSKU": {
-    "Arista-7050QX": ["Arista-7050-QX-32S", "Arista-7050-QX32", "Arista-7050QX-32S-S4Q31", "Arista-7050QX32S-Q32"]
+    "Arista-7050QX": ["Arista-7050-QX-32S", "Arista-7050-QX32", "Arista-7050QX-32S-S4Q31", "Arista-7050QX32S-Q32"],
+    "Arista-free": ["Arista-7050CX3-32S-C32", "Arista-7260CX3-D108C8"],
+    "Arista-frr_bgp": ["Arista-7050CX3-32S", "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-C28S4",
+        "Arista-7060CX-32S-C32", "Arista-7060DX5-32", "Arista-7060DX5-64S", "Arista-7060X6-64DE-64x400G",
+        "Arista-7260CX3-C64", "Arista-7260CX3-D108C8"],
+    "Arista-frr_zebra": ["Arista-7060CX-32S-C32", "Arista-7260CX3-D108C8"],
+    "Arista-monit": ["Arista-720DT-48S", "Arista-7050CX3-32S-C32", "Arista-7260CX3-C64", "Arista-7260CX3-D108C8"]
   },
   "COMMON": [
     {
@@ -210,6 +216,77 @@
           "memory_high_threshold": {
             "type": "value",
             "value": 85
+          }
+        }
+      },
+      "memory_check": "parse_monit_status_output"
+    }
+  ],
+  "Arista-free": [
+    {
+      "name": "free",
+      "cmd": "free -m",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": {
+            "type": "percentage",
+            "value": "120%"
+          },
+          "memory_high_threshold": null
+        }
+      },
+      "memory_check": "parse_free_output"
+    }
+  ],
+  "Arista-frr_bgp": [
+    {
+      "name": "frr_bgp",
+      "cmd": "vtysh -c \"show memory bgp\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "value", "value": 64}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 200
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
+    }
+  ],
+  "Arista-frr_zebra": [
+    {
+      "name": "frr_zebra",
+      "cmd": "vtysh -c \"show memory zebra\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "value", "value": 48}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 128
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
+    }
+  ],
+  "Arista-monit": [
+    {
+      "name": "monit",
+      "cmd": "sudo monit status",
+      "memory_params": {
+        "memory_usage": {
+          "memory_increase_threshold": {
+            "type": "value",
+            "value": 30
+          },
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 70
           }
         }
       },


### PR DESCRIPTION
### Description of PR
https://github.com/sonic-net/sonic-mgmt/pull/14642 has introduced threshold values for memory utilization, which is causing failures of various tests.
We have fine-tuned the memory high/increase threshold to appropriate baseline values based on test results for ARISTA SKUs.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/18991
https://github.com/aristanetworks/sonic-qual.msft/issues/621

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/14642 has introduced threshold values for memory utilization, which is causing failures of various tests.

#### How did you do it?
Overriding the memory high/increase threshold to appropriate baseline values based on test results for ARISTA SKUs.

#### How did you verify/test it?
By running sonic-mgmt tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
