### PR TITLE
Disable memory utilization checks for `platform_tests/api/test_watchdog.py`

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,  # disable automatic loganalyzer
+    pytest.mark.disable_memory_utilization,
     pytest.mark.topology('any'),
     pytest.mark.device_type('physical')
 ]


### PR DESCRIPTION
Current memory utilization checks are taking longer time that leads to watchdog getting triggered before disarm.
since all tests in `platform_tests/api/test_watchdog.py` focuses on precision of watchdog timeout , its better to disable memory utilization check for these tests

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix platform_tests/api/test_watchdog.py failure
Fixes #19302 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
multiple test cases from platform_tests/api/test_watchdog.py are failing with `exceptiongroup.ExceptionGroup: errors while tearing down`.

#### How did you do it?
disabled memory utilization check for these tests, as all tests here focuses on precision of watchdog timeout.

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
