### PR TITLE
Add support to autogenerate sonicLabConsoleLinks.csv

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -263,13 +263,13 @@ def makeSonicLabConsoleLinks(data, outfile):
     # folding this line inserts unwanted spaces
     csv_columns = "StartDevice,StartPort,EndDevice,Console_type,Console_menu_type,Proxy,BaudRate"
     console_info_template = OrderedDict({
-        "start_device" : "",
-        "start_port" : "",
-        "end_device" : "",
-        "console_type" : "",
-        "console_menu_type" : "",
-        "proxy" : "",
-        "baud_rate" : "" })
+        "start_device": "",
+        "start_port": "",
+        "end_device": "",
+        "console_type": "",
+        "console_menu_type": "",
+        "proxy": "",
+        "baud_rate": ""})
     try:
         with open(csv_file, "w") as f:
             f.write(csv_columns + "\n")
@@ -278,8 +278,7 @@ def makeSonicLabConsoleLinks(data, outfile):
                 if not console_info:
                     continue
 
-                result = fill_missing_fields(console_info,
-                        console_info_template)
+                result = fill_missing_fields(console_info, console_info_template)
 
                 row = ','.join(list(result.values()))
                 f.write(row + "\n")
@@ -487,7 +486,7 @@ def makeLabSecrets(data, outfile):
                 "ansible").get("sonicadmin_initial_password")})
 
         if "serialconsole" in str(value.get("device_type")).lower():
-           result["console_login"] = value.get("console_login")
+            result["console_login"] = value.get("console_login")
 
     with open(outfile, "w") as toWrite:
         yaml.dump(result, stream=toWrite, default_flow_style=False)

--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -5,6 +5,8 @@ import yaml
 import datetime
 import os
 import argparse
+from collections import OrderedDict
+import copy
 
 """"
 Testbed Processing
@@ -54,6 +56,7 @@ vmHostCreds_file = "group_vars/vm_host/creds.yml"
 labLinks_file = "files/sonic_lab_links.csv"
 testbed_file = "testbed.yaml"
 devices_file = "files/sonic_lab_devices.csv"
+console_links_file = "files/sonic_lab_console_links.csv"
 eosCred_file = "group_vars/eos/creds.yml"
 fanoutSecrets_file = "group_vars/fanout/secrets.yml"
 labSecrets_file = "group_vars/lab/secrets.yml"
@@ -74,6 +77,7 @@ backupList.append(vmHostCreds_file)
 backupList.append(labLinks_file)
 backupList.append(testbed_file)
 backupList.append(devices_file)
+backupList.append(console_links_file)
 backupList.append(eosCred_file)
 backupList.append(fanoutSecrets_file)
 backupList.append(labSecrets_file)
@@ -233,6 +237,54 @@ def makeSonicLabDevices(data, outfile):
                 f.write(row + "\n")
     except IOError:
         print("I/O error: makeSonicLabDevices")
+
+
+"""
+makeSonicLabConsoleLinks(data, outfile)
+@:parameter data - the dictionary to look through (devices dictionary)
+@:parameter outfile - the file to write to
+generates files/sonic_lab_console_links.csv
+"""
+
+
+def makeSonicLabConsoleLinks(data, outfile):
+    def fill_missing_fields(data, template):
+        """Returns a copy of `data` with missing fields from `template` \
+                filled with empty strings."""
+        filled_data = copy.deepcopy(OrderedDict(template))  # Preserve the order
+
+        for key in template:
+            filled_data[key] = str(data.get(key)) if data.get(key) is not None else ''
+
+        return filled_data
+
+    devices = data
+    csv_file = outfile
+    # folding this line inserts unwanted spaces
+    csv_columns = "StartDevice,StartPort,EndDevice,Console_type,Console_menu_type,Proxy,BaudRate"
+    console_info_template = OrderedDict({
+        "start_device" : "",
+        "start_port" : "",
+        "end_device" : "",
+        "console_type" : "",
+        "console_menu_type" : "",
+        "proxy" : "",
+        "baud_rate" : "" })
+    try:
+        with open(csv_file, "w") as f:
+            f.write(csv_columns + "\n")
+            for device, deviceDetails in devices.items():
+                console_info = deviceDetails.get("console_info")
+                if not console_info:
+                    continue
+
+                result = fill_missing_fields(console_info,
+                        console_info_template)
+
+                row = ','.join(list(result.values()))
+                f.write(row + "\n")
+    except IOError:
+        print("I/O error: makeSonicLabConsoleLinks")
 
 
 """
@@ -433,6 +485,9 @@ def makeLabSecrets(data, outfile):
                 "ansible").get("sonicadmin_password")})
             result.update({"sonicadmin_initial_password": value.get(
                 "ansible").get("sonicadmin_initial_password")})
+
+        if "serialconsole" in str(value.get("device_type")).lower():
+           result["console_login"] = value.get("console_login")
 
     with open(outfile, "w") as toWrite:
         yaml.dump(result, stream=toWrite, default_flow_style=False)
@@ -1043,6 +1098,9 @@ def main():
     print("\tCREATING SONIC LAB DEVICES: " + args.basedir + devices_file)
     # Generate sonic_lab_devices.csv (DEVICES)
     makeSonicLabDevices(devices, args.basedir + devices_file)
+    print("\tCREATING SONIC LAB CONSOLE LINKS: " + args.basedir + console_links_file)
+    # Generate sonic_lab_console_links.csv (DEVICES)
+    makeSonicLabConsoleLinks(devices, args.basedir + console_links_file)
     print("\tCREATING TEST BED: " + args.basedir + testbed_file)
     # Generate testbed.yaml (TESTBED)
     makeTestbed(testbed, args.basedir + testbed_file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This fix will enable us to generate "sonic_lab_console_links.csv" file from the testbed.yaml file.
This is required for dut_console tests on dualtor.

Summary:
Fixes # [(662)](https://github.com/aristanetworks/sonic-qual.msft/issues/662)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Few dut console tests were failing on Dualtor testbeds, because "sonic_lab_console_links.csv" file was not created.

#### How did you do it?
Added support to generate "sonic_lab_console_links.csv" file from the testbed.yaml file.

#### How did you verify/test it?
Ran dut_console tests and verified that test_escape_character and test_idle_timeout are passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
