### PR TITLE
[dhcp_relay] Add sleep for stress dhcpmon test

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -2,6 +2,7 @@
 import pytest
 import ptf.packet as scapy
 import logging
+import time
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -75,6 +76,8 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             return not output['rc'] and output['stdout'].strip() == "exists"
 
         def _verify_server_packets(pkts, dhcp_type):
+            # Default DB update timer for dhcpmon is 20s, hence wait for it to write DB
+            time.sleep(25)
             actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0]) * num_dhcp_servers
             expected_uplink_counter = {
                 "RX": {},
@@ -92,6 +95,8 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
                                                 {}, {}, 0)
 
         def _verify_client_packets(pkts, dhcp_type):
+            # Default DB update timer for dhcpmon is 20s, hence wait for it to write DB
+            time.sleep(25)
             actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
             expected_uplink_counter = {
                 "RX": {dhcp_type.capitalize(): actual_count},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
There is not waiting in dhcpmon stress test, which would flaky fail the test due to verification happens before DB update

#### How did you do it?
Add sleep before verification

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
