### PR TITLE
Qos_yaml updated for j2c+ topo-t2_single_node_min

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -375,6 +375,113 @@ qos_params:
             hdrm_pool_wm_multiplier: 1
             cell_size: 4096
         topo-t2_single_node_min:
+            100000_120000m:
+                pkts_num_leak_out: 5
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_trig_ingr_drp: 566603
+                    pkts_num_margin: 100
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_trig_ingr_drp: 566603
+                    pkts_num_margin: 100
+                hdrm_pool_size:
+                    dscps: [ 3, 4 ]
+                    ecn: 1
+                    pgs: [ 3, 4 ]
+                    src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
+                    dst_port_id: 18
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_hdrm_full: 178614
+                    pkts_num_hdrm_partial: 178514
+                    margin: 100
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_trig_ingr_drp: 566603
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_dismiss_pfc: 3245
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_dismiss_pfc: 3245
+                    pkts_num_margin: 150
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_margin: 200
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 387989
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 566603
+                    cell_size: 4096
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_pfc: 28160
+                    pkts_num_trig_ingr_drp: 566603
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    cell_size: 4096
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 4096
             400000_50m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Continuation of PR https://github.com/sonic-net/sonic-mgmt/pull/18458
Update qos_params for 100G_120k profile for min topology

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Verify sonic-mgmt qos test with new buffer-profile

#### How did you do it?

#### How did you verify/test it?
Executed sonic-mgmt qos tests & verified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
