### PR TITLE
Fix buffer queue cnt test to account for different BUFFER_QUEUE configs

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -31,7 +31,7 @@ MAX_UC_CNT = 7
 
 def load_new_cfg(duthost, data):
     duthost.copy(content=json.dumps(data, indent=4), dest=CFG_DB_PATH)
-    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True, yang_validate=False)
     # config reload overrides testing telemetry config, ensure testing config exists
     setup_telemetry_forpyclient(duthost)
 
@@ -186,26 +186,49 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
 
     interface_buffer_queues = [bq for bq in buffer_queues if any(val in interface_to_check for val in bq.split('|'))]
 
+    """If all queues for that pool are in the same pool ex Ethernet0|0-9
+    We will modify to separate the first queue and the remaining such
+    that we get a separate entry for Ethernet0|0 and Ethernet0|1-9"""
+    bq_entry = interface_buffer_queues[0]
+    if len(interface_buffer_queues) == 1:
+        iface, q_range = bq_entry.split('|')
+        if '-' in q_range:  # Grouped queues
+            start, end = map(int, q_range.split('-'))
+            if start < end:
+                single_queue_entry = f"{iface}|{start}"
+                remaining_queue_entry = f"{iface}|{start + 1}-{end}"
+                profile = data['BUFFER_QUEUE'][bq_entry]['profile']
+                data['BUFFER_QUEUE'][remaining_queue_entry] = { "profile": profile }
+                data['BUFFER_QUEUE'][single_queue_entry] = { "profile": profile }
+                del data['BUFFER_QUEUE'][bq_entry]
+                bq_entry = single_queue_entry
+            else:
+                pytest.skip("Invalid buffer queue range")
+
     # Add create_only_config_db_buffers entry to device metadata to enable
     # counters optimization and get number of queue counters of Ethernet0 prior
     # to removing buffer queues
-    data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
-        = "true"
-    load_new_cfg(duthost, data)
-    pytest_assert(wait_until(120, 20, 0, check_buffer_queues_cnt_cmd_output, ptfhost, gnxi_path,
-                             dut_ip, interface_to_check, env.gnmi_port), "gnmi server not fully restarted")
-    pre_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, interface_to_check, env.gnmi_port)
+    try:
+        data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] \
+            = "true"
+        load_new_cfg(duthost, data)
+        pytest_assert(wait_until(120, 20, 0, check_buffer_queues_cnt_cmd_output, ptfhost, gnxi_path,
+                                 dut_ip, interface_to_check, env.gnmi_port), "gnmi server not fully restarted")
+        pre_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, interface_to_check, env.gnmi_port)
 
-    # Remove buffer queue and reload and get new number of queue counters
-    del data['BUFFER_QUEUE'][interface_buffer_queues[0]]
-    load_new_cfg(duthost, data)
-    pytest_assert(wait_until(120, 20, 0, check_buffer_queues_cnt_cmd_output, ptfhost, gnxi_path,
-                             dut_ip, interface_to_check, env.gnmi_port), "gnmi server not fully restarted")
-    post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, interface_to_check, env.gnmi_port)
+        # Remove buffer queue and reload and get new number of queue counters
+        del data['BUFFER_QUEUE'][bq_entry]
+        load_new_cfg(duthost, data)
+        pytest_assert(wait_until(120, 20, 0, check_buffer_queues_cnt_cmd_output, ptfhost, gnxi_path,
+                                 dut_ip, interface_to_check, env.gnmi_port), "gnmi server not fully restarted")
+        post_del_cnt = get_buffer_queues_cnt(ptfhost, gnxi_path, dut_ip, interface_to_check, env.gnmi_port)
 
-    pytest_assert(pre_del_cnt > post_del_cnt,
-                  "Number of queue counters count differs from expected")
-
+        pytest_assert(pre_del_cnt > post_del_cnt,
+                      "Number of queue counters count differs from expected")
+    finally:
+        data = json.loads(duthost.shell("cat {}".format(ORIG_CFG_DB),
+                                        verbose=False)['stdout'])
+        load_new_cfg(duthost, data)
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_osbuild_version(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19201 
MSADO: 33479698

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Currently this test does not account for BUFFER_QUEUE configs to have only entry for an interface.

In some SKU's and config

BUFFER_QUEUE may have config such as

    "BUFFER_QUEUE": {
        "Ethernet0|0-2": {
            "profile": "egress_lossy_profile"
        },      
        "Ethernet0|3-4": {
            "profile": "egress_lossless_profile"
        },      
        "Ethernet0|5-7": {
            "profile": "egress_lossy_profile"
        }, 

or even

    "BUFFER_QUEUE": {
        "Ethernet0|0": {
            "profile": "egress_lossy_profile"
        },      
        "Ethernet0|1": {
            "profile": "egress_lossless_profile"
        },      
        "Ethernet0|2": {
            "profile": "egress_lossy_profile"
        },  ... etc

The test works fine for the above configs.

However if the BUFFER_QUEUE was configured such as

    "BUFFER_QUEUE": {
        "Ethernet0|0-9": {
            "profile": "egress_lossy_profile"
        },      
        "Ethernet100|0-9": {
            "profile": "egress_lossless_profile"
        },      
        "Ethernet200|0-9": {
            "profile": "egress_lossy_profile"
        },  

When we delete Ethernet0|0-9 as part of del data['BUFFER_QUEUE'][ interface_buffer_queues[0] ] we end up deleting all queues for that interface from COUNTERS_QUEUE_NAME_MAP which causes check_buffer_queues_cnt_cmd_output to always return false.

This test checks for such edge case and we split the BUFFER_QUEUE config such that we can delete an entry without deleting all entries in the map.

#### How did you do it?

Code change

#### How did you verify/test it?

Test on 20241110

```
01/07/2025 19:00:48 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"failed": true, "changed": true, "end": "2025-07-01 19:00:48.806079", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:0\"\n}\n]\nGRPC error\n redis: nil", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:0             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "delta": "0:00:00.199525", "stderr": "", "rc": 1, "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:0             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "start": "2025-07-01 19:00:48.606554", "msg": "non-zero return code", "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:0\"", "}", "]", "GRPC error", " redis: nil"], "stderr_lines": [], "_ansible_no_log": false}
01/07/2025 19:00:48 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell, args=["python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:1             -xt COUNTERS_DB -o \"xxxxxxxxx\"             "], kwargs={"module_ignore_errors": true}                                                                                                                                                                                                                                                                                                                          01/07/2025 19:00:49 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"changed": true, "end": "2025-07-01 19:00:49.227872", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:1\"\n}\n]\nThe GetResponse is below\n-------------------------\n\noid:0x15000000000679", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:1             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "rc": 0, "start": "2025-07-01 19:00:48.981566", "stderr": "", "delta": "0:00:00.246306", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:1             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:1\"", "}", "]", "The GetResponse is below", "-------------------------", "", "oid:0x15000000000679"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
01/07/2025 19:00:49 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell, args=["python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:2             -xt COUNTERS_DB -o \"xxxxxxxxx\"             "], kwargs={"module_ignore_errors": true}                                                                                                                                                                                                                                                                                                                          01/07/2025 19:00:49 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"changed": true, "end": "2025-07-01 19:00:49.614484", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:2\"\n}\n]\nThe GetResponse is below\n-------------------------\n\noid:0x1500000000067a", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:2             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "rc": 0, "start": "2025-07-01 19:00:49.411463", "stderr": "", "delta": "0:00:00.203021", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:2             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:2\"", "}", "]", "The GetResponse is below", "-------------------------", "", "oid:0x1500000000067a"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
01/07/2025 19:00:49 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell, args=["python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:3             -xt COUNTERS_DB -o \"xxxxxxxxx\"             "], kwargs={"module_ignore_errors": true}                                                                                                                                                                                                                                                                                                                          01/07/2025 19:00:50 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"changed": true, "end": "2025-07-01 19:00:49.997748", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:3\"\n}\n]\nThe GetResponse is below\n-------------------------\n\noid:0x1500000000067b", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:3             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "rc": 0, "start": "2025-07-01 19:00:49.798159", "stderr": "", "delta": "0:00:00.199589", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:3             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:3\"", "}", "]", "The GetResponse is below", "-------------------------", "", "oid:0x1500000000067b"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
01/07/2025 19:00:50 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell, args=["python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:4             -xt COUNTERS_DB -o \"xxxxxxxxx\"             "], kwargs={"module_ignore_errors": true}                                                                                                                                                                                                                                                                                                                          01/07/2025 19:00:50 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"changed": true, "end": "2025-07-01 19:00:50.381489", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:4\"\n}\n]\nThe GetResponse is below\n-------------------------\n\noid:0x1500000000067c", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:4             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "rc": 0, "start": "2025-07-01 19:00:50.177327", "stderr": "", "delta": "0:00:00.204162", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:4             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:4\"", "}", "]", "The GetResponse is below", "-------------------------", "", "oid:0x1500000000067c"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
01/07/2025 19:00:50 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell, args=["python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:5             -xt COUNTERS_DB -o \"xxxxxxxxx\"             "], kwargs={"module_ignore_errors": true}                                                                                                                                                                                                                                                                                                                          01/07/2025 19:00:50 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"changed": true, "end": "2025-07-01 19:00:50.771962", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:5\"\n}\n]\nThe GetResponse is below\n-------------------------\n\noid:0x1500000000067d", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:5             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "rc": 0, "start": "2025-07-01 19:00:50.566323", "stderr": "", "delta": "0:00:00.205639", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:5             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "chdir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:5\"", "}", "]", "The GetResponse is below", "-------------------------", "", "oid:0x1500000000067d"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
01/07/2025 19:00:50 base._run                                L0071 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell, args=["python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:6             -xt COUNTERS_DB -o \"xxxxxxxxx\"             "], kwargs={"module_ignore_errors": true}                                                                                                                                                                                                                                                                                                                          01/07/2025 19:00:51 base._run                                L0108 DEBUG  | /var/src/sonic-mgmt-int/tests/telemetry/test_telemetry.py::get_buffer_queues_cnt#47: [xxxxx-x] AnsibleModule::shell Result => {"changed": true, "end": "2025-07-01 19:00:51.236571", "stdout": "Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path\n ------------------------- \n [elem {\n  name: \"COUNTERS_QUEUE_NAME_MAP\"\n}\nelem {\n  name: \"Ethernet0:6\"\n}\n]\nThe GetResponse is below\n-------------------------\n\noid:0x1500000000067e", "cmd": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:6             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "rc": 0, "start": "2025-07-01 19:00:50.951268", "stderr": "", "delta": "0:00:00.285303", "invocation": {"module_args": {"creates": null, "executable": null, "_uses_shell": true, "strip_empty_ends": true, "_raw_params": "python /root/gnxi/gnmi_cli_py/py_gnmicli.py -g -t xx.xx.xxx.xxx             -p 50051 -m get -x COUNTERS_QUEUE_NAME_MAP/Ethernet0:6             -xt COUNTERS_DB -o \"xxxxxxxxx\"             ", "removes": null, "argv": null, "warn": true, "choir": null, "stdin_add_newline": true, "stdin": null}}, "stdout_lines": ["Performing GetRequest, encoding=JSON_IETF to xx.xx.xxx.xxx  with the following gNMI Path", " ------------------------- ", " [elem {", "  name: \"COUNTERS_QUEUE_NAME_MAP\"", "}", "elem {", "  name: \"Ethernet0:6\"", "}", "]", "The GetResponse is below", "-------------------------", "", "oid:0x1500000000067e"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
