### PR TITLE
Fix flakiness with poll mode tests when client has not connected yet or default route has not populated yet

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -55,8 +55,8 @@ def skip_201911_and_older(duthost):
 
 def check_gnmi_cli_running(duthost, ptfhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    rc = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"")["rc"]
-    return rc == "0"
+    res = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"")
+    return res and res["rc"] == 0
 
 
 def parse_gnmi_output(gnmi_output, match_no, find_data):

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -53,7 +53,7 @@ def skip_201911_and_older(duthost):
         pytest.skip("Test not supported for 201911 images. Skipping the test")
 
 
-def check_gnmi_cli_running(ptfhost):
+def check_gnmi_cli_running(duthost, ptfhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     rc = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"")["rc"]
     return rc == "0"

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -54,8 +54,9 @@ def skip_201911_and_older(duthost):
 
 
 def check_gnmi_cli_running(ptfhost):
-    program_list = ptfhost.shell("pgrep -f 'python /root/gnxi/gnmi_cli_py/py_gnmicli.py'")["stdout"]
-    return len(program_list) > 0
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+    rc = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"")["rc"]
+    return rc == "0"
 
 
 def parse_gnmi_output(gnmi_output, match_no, find_data):

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -345,7 +345,7 @@ def test_on_change_updates(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, 
     client_thread = threading.Thread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, callback,))
     client_thread.start()
 
-    wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
+    wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
     cmd = "sonic-db-cli STATE_DB HSET \"NEIGH_STATE_TABLE|{}\" \"state\" {}".format(bgp_neighbor,
                                                                                     new_state)
     cmd = duthost.get_cli_cmd_for_namespace(cmd, ns)

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -189,9 +189,9 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     pytest_assert(len(update_responses_match) == 5, "Missing update responses")
 
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
-                              subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
+                              subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=10,
                               xpath="\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/0.0.0.0\/0\"",  # noqa: W605
-                              target="APPL_DB", max_sync_count=-1, update_count=0, timeout=120, namespace=namespace)
+                              target="APPL_DB", max_sync_count=-1, update_count=10, timeout=120, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -103,7 +103,7 @@ def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_h
     client_thread = InterruptableThread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, callback,))
     client_thread.start()
 
-    wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
+    wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
     modify_fake_appdb_table(duthost, True, 2)  # Add second table data
     client_thread.join(30)
@@ -148,7 +148,7 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     client_thread = InterruptableThread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, callback,))
     client_thread.start()
 
-    wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
+    wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
     modify_fake_appdb_table(duthost, False, 2)  # Remove all added tables
     client_thread.join(30)
@@ -202,14 +202,14 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     client_thread = InterruptableThread(target=invoke_py_cli_from_ptf, args=(ptfhost, cmd, callback,))
     client_thread.start()
 
-    wait_until(5, 1, 0, check_gnmi_cli_running, ptfhost)
+    wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
     # Add back default route
     duthost.shell("config bgp startup all")
     pytest_assert(wait_until(60, 5, 0, verify_route_table_status, duthost, namespace, "1"),
                   "ROUTE_TABLE default route missing")
 
-    # Give 60 seconds for client to connect to server and then another 60 for default route to populate after bgp sessions start
+    # Give 60 seconds for client to connect to server and then 60 for default route to populate after bgp session start
     client_thread.join(120)
 
     modify_fake_appdb_table(duthost, False, 1)  # Remove all added tables

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -191,7 +191,7 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/0.0.0.0\/0\"",  # noqa: W605
-                              target="APPL_DB", max_sync_count=-1, update_count=10, timeout=60, namespace=namespace)
+                              target="APPL_DB", max_sync_count=-1, update_count=0, timeout=120, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)
@@ -209,7 +209,8 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     pytest_assert(wait_until(60, 5, 0, verify_route_table_status, duthost, namespace, "1"),
                   "ROUTE_TABLE default route missing")
 
-    client_thread.join(60)
+    # Give 60 seconds for client to connect to server and then another 60 for default route to populate after bgp sessions start
+    client_thread.join(120)
 
     modify_fake_appdb_table(duthost, False, 1)  # Remove all added tables
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
MS ADO: 33256194

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

This PR does the following:

1) Uses netstat to ensure that there is an established TCP connection between the client and server which is a more reliable check instead of pid check. This new check will help ensure that client is connected and can receive all notifications.

2) Ensures that we are giving enough time for default route to populate in APPL_DB after bgp sessions have been restored. There are some situations where we grab 10 updates, but default route has not been populated yet, so we miss the update. We will let the query run for longer and check less frequently to ensure that we see the default route entries after restoring bgp sessions.

#### How did you do it?

Code change

#### How did you verify/test it?

202411 test

```
telemetry/test_telemetry_poll.py::test_poll_mode_default_route[xxxxxxxx-False] PASSED  

2025-07-01 23:11:48.341175 response received:
sync_response: true

2025-07-01 23:11:58.355388 response received:
update {
  timestamp: 1751411518201902684
  prefix {
    target: "APPL_DB/"
  }
  update {
    path {
      elem {
        name: "ROUTE_TABLE"
      }
      elem {
        name: "0.0.0.0/0"
      }
    }
    val {                                                                                                                                                                                                                                                                                                                                                                                       json_ietf_val: "{\"ifname\":\"PortChannel101,PortChannel102,PortChannel103,PortChannel104\",\"nexthop\":\"xxxx,xxxx,xxxx,xxxx\",\"protocol\":\"bgp\",\"weight\":\"1,1,1,1\"}"
    }
  }
}

2025-07-01 23:11:58.356885 response received:
update {
  timestamp: 1751411518206189131
  prefix {
    target: "APPL_DB/"
  }
  update {
    path {                                                                                                                                                                                                                                                                                                                                                                                      elem {                                                                                                                                                                                                                                                                                                                                                                                      name: "FAKE_APPL_DB_TABLE_0"                                                                                                                                                                                                                                                                                                                                                            }
    }
    val {                                                                                                                                                                                                                                                                                                                                                                                       json_ietf_val: "{\"fake_key0\":{\"dummy0\":\"val\"}}"
    }
  }
}

Max update count reached 10
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
