### PR TITLE
Update topo definition lt2-o128

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -121,7 +121,7 @@ hw_port_cfg = {
                              'skip_ports': [13, 16, 17, 44, 45, 48, 49],
                              "panel_port_step": 1},
     'o128lt2':          {"ds_breakout": 2, "us_breakout": 2, "ds_link_step": 1, "us_link_step": 1,
-                         'uplink_ports': PortList(LagPort(45), 46, 47, 48, LagPort(49), 50, 51, 52),
+                         'uplink_ports': PortList(45, 46, 47, 48, 49, 50, 51, 52),
                          'peer_ports': [],
                          'skip_ports': PortList(63),
                          "panel_port_step": 1},

--- a/ansible/vars/topo_lt2-o128.yml
+++ b/ansible/vars/topo_lt2-o128.yml
@@ -363,141 +363,147 @@ topology:
     ARISTA01UT2:
       vlans:
         - 90
-        - 91
       vm_offset: 90
     ARISTA02UT2:
       vlans:
-        - 92
+        - 91
       vm_offset: 91
     ARISTA03UT2:
       vlans:
-        - 93
+        - 92
       vm_offset: 92
     ARISTA04UT2:
       vlans:
-        - 94
+        - 93
       vm_offset: 93
     ARISTA05UT2:
       vlans:
-        - 95
+        - 94
       vm_offset: 94
     ARISTA06UT2:
       vlans:
-        - 96
+        - 95
       vm_offset: 95
     ARISTA07UT2:
       vlans:
-        - 97
+        - 96
       vm_offset: 96
     ARISTA08UT2:
       vlans:
-        - 98
-        - 99
+        - 97
       vm_offset: 97
     ARISTA09UT2:
       vlans:
-        - 100
+        - 98
       vm_offset: 98
     ARISTA10UT2:
       vlans:
-        - 101
+        - 99
       vm_offset: 99
     ARISTA11UT2:
       vlans:
-        - 102
+        - 100
       vm_offset: 100
     ARISTA12UT2:
       vlans:
-        - 103
+        - 101
       vm_offset: 101
     ARISTA13UT2:
       vlans:
-        - 104
+        - 102
       vm_offset: 102
     ARISTA14UT2:
       vlans:
-        - 105
+        - 103
       vm_offset: 103
+    ARISTA15UT2:
+      vlans:
+        - 104
+      vm_offset: 104
+    ARISTA16UT2:
+      vlans:
+        - 105
+      vm_offset: 105
     ARISTA91T1:
       vlans:
         - 106
-      vm_offset: 104
+      vm_offset: 106
     ARISTA92T1:
       vlans:
         - 107
-      vm_offset: 105
+      vm_offset: 107
     ARISTA93T1:
       vlans:
         - 108
-      vm_offset: 106
+      vm_offset: 108
     ARISTA94T1:
       vlans:
         - 109
-      vm_offset: 107
+      vm_offset: 109
     ARISTA95T1:
       vlans:
         - 110
-      vm_offset: 108
+      vm_offset: 110
     ARISTA96T1:
       vlans:
         - 111
-      vm_offset: 109
+      vm_offset: 111
     ARISTA97T1:
       vlans:
         - 112
-      vm_offset: 110
+      vm_offset: 112
     ARISTA98T1:
       vlans:
         - 113
-      vm_offset: 111
+      vm_offset: 113
     ARISTA99T1:
       vlans:
         - 114
-      vm_offset: 112
+      vm_offset: 114
     ARISTA100T1:
       vlans:
         - 115
-      vm_offset: 113
+      vm_offset: 115
     ARISTA101T1:
       vlans:
         - 116
-      vm_offset: 114
+      vm_offset: 116
     ARISTA102T1:
       vlans:
         - 117
-      vm_offset: 115
+      vm_offset: 117
     ARISTA103T1:
       vlans:
         - 118
-      vm_offset: 116
+      vm_offset: 118
     ARISTA104T1:
       vlans:
         - 119
-      vm_offset: 117
+      vm_offset: 119
     ARISTA105T1:
       vlans:
         - 120
-      vm_offset: 118
+      vm_offset: 120
     ARISTA106T1:
       vlans:
         - 121
-      vm_offset: 119
+      vm_offset: 121
     ARISTA107T1:
       vlans:
         - 122
-      vm_offset: 120
+      vm_offset: 122
     ARISTA108T1:
       vlans:
         - 123
-      vm_offset: 121
+      vm_offset: 123
     ARISTA109T1:
       vlans:
         - 124
-      vm_offset: 122
+      vm_offset: 124
     ARISTA110T1:
       vlans:
         - 125
-      vm_offset: 123
+      vm_offset: 125
 
 configuration_properties:
   common:
@@ -2601,16 +2607,32 @@ configuration:
         ipv4: 100.1.0.91/32
         ipv6: 2064:100:0:5b::/128
       Ethernet1:
-        lacp: 1
-      Ethernet2:
-        lacp: 1
-      Port-Channel1:
         ipv4: 10.0.0.181/31
         ipv6: fc00::16a/126
     bp_interface:
       ipv4: 10.10.246.92/24
       ipv6: fc0a::5c/64
   ARISTA02UT2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 4200200000
+      peers:
+        4200100000:
+          - 10.0.0.182
+          - fc00::16d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.92/32
+        ipv6: 2064:100:0:5c::/128
+      Ethernet1:
+        ipv4: 10.0.0.183/31
+        ipv6: fc00::16e/126
+    bp_interface:
+      ipv4: 10.10.246.93/24
+      ipv6: fc0a::5d/64
+  ARISTA03UT2:
     properties:
     - common
     - spine
@@ -2630,7 +2652,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.94/24
       ipv6: fc0a::5e/64
-  ARISTA03UT2:
+  ARISTA04UT2:
     properties:
     - common
     - spine
@@ -2650,7 +2672,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.95/24
       ipv6: fc0a::5f/64
-  ARISTA04UT2:
+  ARISTA05UT2:
     properties:
     - common
     - spine
@@ -2670,7 +2692,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.96/24
       ipv6: fc0a::60/64
-  ARISTA05UT2:
+  ARISTA06UT2:
     properties:
     - common
     - spine
@@ -2690,7 +2712,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.97/24
       ipv6: fc0a::61/64
-  ARISTA06UT2:
+  ARISTA07UT2:
     properties:
     - common
     - spine
@@ -2710,7 +2732,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.98/24
       ipv6: fc0a::62/64
-  ARISTA07UT2:
+  ARISTA08UT2:
     properties:
     - common
     - spine
@@ -2730,7 +2752,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.99/24
       ipv6: fc0a::63/64
-  ARISTA08UT2:
+  ARISTA09UT2:
     properties:
     - common
     - spine
@@ -2745,16 +2767,32 @@ configuration:
         ipv4: 100.1.0.99/32
         ipv6: 2064:100:0:63::/128
       Ethernet1:
-        lacp: 1
-      Ethernet2:
-        lacp: 1
-      Port-Channel1:
         ipv4: 10.0.0.197/31
         ipv6: fc00::18a/126
     bp_interface:
       ipv4: 10.10.246.100/24
       ipv6: fc0a::64/64
-  ARISTA09UT2:
+  ARISTA10UT2:
+    properties:
+    - common
+    - spine
+    bgp:
+      asn: 4200200000
+      peers:
+        4200100000:
+          - 10.0.0.198
+          - fc00::18d
+    interfaces:
+      Loopback0:
+        ipv4: 100.1.0.100/32
+        ipv6: 2064:100:0:64::/128
+      Ethernet1:
+        ipv4: 10.0.0.199/31
+        ipv6: fc00::18e/126
+    bp_interface:
+      ipv4: 10.10.246.101/24
+      ipv6: fc0a::65/64
+  ARISTA11UT2:
     properties:
     - common
     - spine
@@ -2774,7 +2812,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.102/24
       ipv6: fc0a::66/64
-  ARISTA10UT2:
+  ARISTA12UT2:
     properties:
     - common
     - spine
@@ -2794,7 +2832,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.103/24
       ipv6: fc0a::67/64
-  ARISTA11UT2:
+  ARISTA13UT2:
     properties:
     - common
     - spine
@@ -2814,7 +2852,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.104/24
       ipv6: fc0a::68/64
-  ARISTA12UT2:
+  ARISTA14UT2:
     properties:
     - common
     - spine
@@ -2834,7 +2872,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.105/24
       ipv6: fc0a::69/64
-  ARISTA13UT2:
+  ARISTA15UT2:
     properties:
     - common
     - spine
@@ -2854,7 +2892,7 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.106/24
       ipv6: fc0a::6a/64
-  ARISTA14UT2:
+  ARISTA16UT2:
     properties:
     - common
     - spine


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to update the topo definition for LT2-O128.
Change list
- Remove LAG between LT2 and UT2
- Add two VMs for UT2

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR is to update the topo definition for LT2-O128.

#### How did you do it?
- Remove LAG between LT2 and UT2
- Add two VMs for UT2

#### How did you verify/test it?
The change is verified by deploying it on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
