### PR TITLE
Fix snappi convergence import missing 202405

### DIFF
--- a/.azure-pipelines/pytest-collect-only.yml
+++ b/.azure-pipelines/pytest-collect-only.yml
@@ -23,11 +23,11 @@ steps:
 - script: |
     set -x
 
-    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
+    sudo docker pull sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:py3only
     sudo docker rm -f sonic-mgmt-collect || true
     sudo docker run --rm -dt --name sonic-mgmt-collect \
       -v $(System.DefaultWorkingDirectory):/var/src/sonic-mgmt \
-      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest \
+      sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:py3only \
       /bin/bash
   displayName: 'Prepare sonic-mgmt docker container'
 


### PR DESCRIPTION
user@host:~$ docker run --rm -it sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:py3only pip list | grep snappi
snappi                           0.9.1
snappi-convergence               0.4.1
snappi-ixnetwork                 0.9.1

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
