### PR TITLE
Replace deprecated `collections.Iterable` with `collections.abc.Iterable`

### DIFF
--- a/tests/common/dualtor/control_plane_utils.py
+++ b/tests/common/dualtor/control_plane_utils.py
@@ -1,11 +1,11 @@
 """Contains functions used to verify control plane(APP_DB, STATE_DB) values."""
-import collections
 import json
 import logging
 
 from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ def verify_tor_states(
     Verifies that the expected states for active and standby ToRs are
     reflected in APP_DB and STATE_DB on each device
     """
-    if not isinstance(expected_active_host, collections.Iterable):
+    if not isinstance(expected_active_host, Iterable):
         expected_active_host = [] if expected_active_host is None else [expected_active_host]
     for duthost in expected_active_host:
         db_checker = DBChecker(duthost, 'active', 'healthy',
@@ -282,7 +282,7 @@ def verify_tor_states(
         if not skip_tunnel_route:
             db_checker.verify_tunnel_route(standalone_tunnel_route)
 
-    if not isinstance(expected_standby_host, collections.Iterable):
+    if not isinstance(expected_standby_host, Iterable):
         expected_standby_host = [] if expected_standby_host is None else [expected_standby_host]
     for duthost in expected_standby_host:
         db_checker = DBChecker(duthost, 'standby', expected_standby_health,

--- a/tests/common/dualtor/nic_simulator_control.py
+++ b/tests/common/dualtor/nic_simulator_control.py
@@ -2,7 +2,6 @@
 import grpc
 import pytest
 import time
-import collections
 import logging
 
 from tests.common import utilities
@@ -15,6 +14,7 @@ from tests.common.dualtor.dual_tor_common import CableType
 from tests.common.dualtor.nic_simulator import nic_simulator_grpc_service_pb2
 from tests.common.dualtor.nic_simulator import nic_simulator_grpc_mgmt_service_pb2
 from tests.common.dualtor.nic_simulator import nic_simulator_grpc_mgmt_service_pb2_grpc
+from collections.abc import Iterable
 
 
 __all__ = [
@@ -210,7 +210,7 @@ def nic_simulator_url(nic_simulator_info):
 def toggle_ports(duthosts, intf_name, state):
     """Toggle port from cmd line"""
 
-    if not isinstance(duthosts, collections.Iterable):
+    if not isinstance(duthosts, Iterable):
         duthosts = [duthosts]
 
     toggled_intfs = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Starting with Python 3.3, `collections.Iterable` was deprecated in favor of `collections.abc.Iterable`, though it remained temporarily supported for backward compatibility. However, as of Python 3.10, the old reference has been officially removed. [Doc](https://docs.python.org/3.9/library/collections.html)
<img width="613" alt="image" src="https://github.com/user-attachments/assets/30277db2-d2a4-44c0-9323-0f745978e1ff" />

Since we are upgrading Python from 3.8 to 3.12—where `collections.Iterable` is no longer supported—we will update all such references to use `collections.abc.Iterable` to ensure compatibility and prevent runtime errors.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Starting with Python 3.3, `collections.Iterable` was deprecated in favor of `collections.abc.Iterable`, though it remained temporarily supported for backward compatibility. However, as of Python 3.10, the old reference has been officially removed. [Doc](https://docs.python.org/3.9/library/collections.html)
<img width="613" alt="image" src="https://github.com/user-attachments/assets/30277db2-d2a4-44c0-9323-0f745978e1ff" />

Since we are upgrading Python from 3.8 to 3.12—where `collections.Iterable` is no longer supported—we will update all such references to use `collections.abc.Iterable` to ensure compatibility and prevent runtime errors.

#### How did you do it?
We will update all such references to use `collections.abc.Iterable` to ensure compatibility and prevent runtime errors.

#### How did you verify/test it?
We need to make sure that this change won't affect current test firstly -- test by pipeline itself. And then, we need to make sure that this change works in the new version -- test locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
