### PR TITLE
[dualtor][cisco] Fix `test_encap_with_mirror_session`

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -269,7 +269,13 @@ def setup_mirror_session(rand_selected_dut, setup_uplink):
     """
     session_name = "dummy_session"
     # Nvidia platforms support only the gre_type 0x8949, which is 35145 in decimal.
-    gre_type = 35145 if "mellanox" == rand_selected_dut.facts['asic_type'] else 1234
+    asic_type = rand_selected_dut.facts['asic_type']
+    if asic_type == "mellanox":
+        gre_type = 35145
+    elif asic_type == "cisco-8000":
+        gre_type = 35006
+    else:
+        gre_type = 1234
     cmd = "config mirror_session add {} 25.192.243.243 20.2.214.125 8 100 {} 0".format(session_name, gre_type)
     rand_selected_dut.shell(cmd=cmd)
     uplink_port_id = setup_uplink


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix the mirror session add error due to the incorrect GRE type on Cisco platform.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Use `0x88BE` for cisco 8100.

#### How did you verify/test it?
test is passing on cisco 8101 with the fix.
```
dualtor/test_ipinip.py::test_encap_with_mirror_session PASSED                                                                                                                                                                                                          [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
