### PR TITLE
[routes] Add sorting vms in announce_routes for t0 and t1

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -537,7 +537,8 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
     vms_len = len(vms)
     current_routes_offset = 0
     last_suffix = 0
-    for index, (vm_name, vm) in enumerate(vms.items()):
+    for index, vm_name in enumerate(sorted(vms.keys())):
+        vm = vms[vm_name]
         router_type = "leaf"
         if 'tor' in topo['configuration'][vm_name]['properties']:
             router_type = 'tor'
@@ -671,7 +672,8 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         tor_number = len([k for k, v in vms_config.items() if 'tor' in v['properties']])
         lov6_address_pattern = ipv6_address_pattern.split("/")[0] + "/128"
         current_routes_offset = last_suffix
-        for index, (k, v) in enumerate(vms_config.items()):
+        for index, k in enumerate(sorted(vms_config.keys())):
+            v = vms_config[k]
             if dpus and k in dpus:
                 continue
             vm_offset = vms[k]['vm_offset']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Below PRs added support to advertise different route sets from BGP neighbors for T0 / T1, it's based on vm index. But loading dict from yml cannot guarantee the sort always be the same. If we re-announce routes or withdraw routes after order changing, the result would be incorrect.
https://github.com/sonic-net/sonic-mgmt/pull/19117
https://github.com/sonic-net/sonic-mgmt/pull/19041

#### How did you do it?
Add sorted in vm index to make sure order of vm dict would always be the same

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
