### PR TITLE
[GCU] Enhance test_eth_interface

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -300,6 +300,7 @@ def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
+    intf_init_status = duthost.get_interfaces_status()
     port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
     json_patch = [
         {
@@ -322,8 +323,9 @@ def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
                           "Failed to properly configure interface FEC to requested value {}".format(fec))
 
             # The rollback after the test cannot revert the fec, when fec is not configured in config_db.json
-            if duthost.facts['platform'] in ['x86_64-arista_7050_qx32s']:
-                config_reload(duthost, safe_reload=True)
+            if intf_init_status[port].get("fec", "N/A") == "N/A":
+                out = duthost.command("config interface fec {} none".format(port))
+                pytest_assert(out["rc"] == 0, "Failed to set {} fec to none. Error: {}".format(port, out["stderr"]))
         else:
             expect_op_failure(output)
     finally:

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -3,7 +3,6 @@ import pytest
 import re
 import random
 
-from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_failure
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When interface FEC is not configured (N/A or none). The GCU rollback fails and port become operational down due to incorrect FEC.
Enhance the testcase to set FEC back to N/A (none).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
When interface FEC is not configured (N/A or none). The GCU rollback fails and port become operational down due to incorrect FEC.
Enhance the testcase to set FEC back to N/A (none).

#### How did you do it?
Enhance the testcase to set FEC back to N/A (none).

#### How did you verify/test it?
Verified by run test on Arista-7050CX3 M1 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
