### PR TITLE
Fix invalid vars format in playbook for Ansible compatibility.

### DIFF
--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -151,8 +151,8 @@
       commands: show version
       wait_for: result[0] contains IOS-XR
     vars:
-      - ansible_connection: 'network_cli'
-      - ansible_network_os: 'iosxr'
+      ansible_connection: 'network_cli'
+      ansible_network_os: 'iosxr'
     register: version
     delegate_to: "{{ cisco_vmhost }}"
     ignore_errors: yes
@@ -169,8 +169,8 @@
         commands: show version
         wait_for: result[0] contains IOS-XR
       vars:
-        - ansible_connection: 'network_cli'
-        - ansible_network_os: 'iosxr'
+        ansible_connection: 'network_cli'
+        ansible_network_os: 'iosxr'
       register: respin_version
       delegate_to: "{{ cisco_vmhost }}"
       ignore_errors: yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In an Ansible playbook, the `vars` field must be defined as a dictionary (i.e., a set of key-value pairs), not as a list prefixed with -. When upgrading to a newer version of Ansible, the parser may enforce stricter validation on playbook syntax, which can result in errors like the following:
```
TASK [vm_set : Kickstart VMs] **************************************************
ERROR! Vars in a Task must be specified as a dictionary. 

The error appears to be in '/var/src/sonic-mgmt/ansible/roles/vm_set/tasks/kickstart_vm.yml': line 154, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    vars:
      - ansible_connection: 'network_cli'
      ^ here
```
This PR fixes the issue by correcting the structure of the vars section in the playbook to use the proper dictionary format, ensuring compatibility with newer Ansible versions and preventing similar errors in the future.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In an Ansible playbook, the `vars` field must be defined as a dictionary (i.e., a set of key-value pairs), not as a list prefixed with -. When upgrading to a newer version of Ansible, the parser may enforce stricter validation on playbook syntax, which can result in errors like the following:
```
TASK [vm_set : Kickstart VMs] **************************************************
ERROR! Vars in a Task must be specified as a dictionary. 

The error appears to be in '/var/src/sonic-mgmt/ansible/roles/vm_set/tasks/kickstart_vm.yml': line 154, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    vars:
      - ansible_connection: 'network_cli'
      ^ here
```
This PR fixes the issue by correcting the structure of the vars section in the playbook to use the proper dictionary format, ensuring compatibility with newer Ansible versions and preventing similar errors in the future.

#### How did you do it?
This PR fixes the issue by correcting the structure of the vars section in the playbook to use the proper dictionary format, ensuring compatibility with newer Ansible versions and preventing similar errors in the future.

#### How did you verify/test it?
We need to make sure that this change won't affect current test firstly -- test by pipeline itself. And then, we need to make sure that this change works in the new version -- test locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
