### PR TITLE
Fix incorrect break indent in macsec dut selection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -625,7 +625,7 @@ def macsec_duthost(duthosts, tbinfo):
         for duthost in duthosts:
             if duthost.is_macsec_capable_node():
                 macsec_dut = duthost
-            break
+                break
     else:
         return duthosts[0]
     return macsec_dut


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
- current logic of "macsec_duthost" not selecting macsec capabale dut due to incorrect break indent
- Ref: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/conftest.py#L628
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/19370

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
"macsec_duthost" should find macsec capabale linecard to run macsec sonic-mgmt tests

#### How did you do it?
correction made to incorrect break indent

#### How did you verify/test it?
verified the fix, able to select macsec capable dut irrespective to position of linecard.

#### Any platform specific information?
generic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
