### PR TITLE
fix: fix golden_config minigraph generation bug

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -169,12 +169,15 @@ class GenerateGoldenConfigDBModule(object):
 
         return out
 
+    def get_namespace_list(self):
+        return json.loads(self.get_multiasic_feature_config()).keys()
+
     def overwrite_feature_golden_config_db_multiasic(self, config, feature_key, auto_restart="enabled",
                                                      state="enabled", feature_data=None):
         full_config = json.loads(config)
         if full_config == {} or "FEATURE" not in full_config.get("localhost", {}):
-            # need dump running config FEATURE + selected feature
-            gold_config_db = json.loads(self.get_multiasic_feature_config())
+            if not full_config:
+                gold_config_db = {ns: {} for ns in self.get_namespace_list()}
         else:
             # need existing config + selected feature
             gold_config_db = full_config

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -169,15 +169,14 @@ class GenerateGoldenConfigDBModule(object):
 
         return out
 
-    def get_namespace_list(self):
-        return json.loads(self.get_multiasic_feature_config()).keys()
-
     def overwrite_feature_golden_config_db_multiasic(self, config, feature_key, auto_restart="enabled",
                                                      state="enabled", feature_data=None):
         full_config = json.loads(config)
-        if full_config == {} or "FEATURE" not in full_config.get("localhost", {}):
-            if not full_config:
-                gold_config_db = {ns: {} for ns in self.get_namespace_list()}
+        if not full_config:
+            gold_config_db = {
+                **{ns: {} for ns in multi_asic.get_namespace_list()},
+                "localhost": {}
+            }
         else:
             # need existing config + selected feature
             gold_config_db = full_config


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently doing deploy-mg, multi-asic minigraph when calling `overwrite_feature_golden_config_db_multiasic` will default load configs from `show runningconfiguration all` if there is no initial config.

However at the point of the code, doing `show runningconfiguration all` will return the old configuration and hence therefore overwrite the changes that made in minigraph.

This will fix this behavior by only make the golden_config_db has "FEATURE" field instead of all fields


Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Described above

#### How did you do it?

Initialise value with `{}` instead of `show runningconfiguration all`

#### How did you verify/test it?

on multi-asic testbed. confirmed that the features are still disabled as intended

```
$ show feature autorestart
Feature    AutoRestart
---------  -------------
dash-ha    disabled
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
