### PR TITLE
correct PT0 ASN number in t0-isolated-v6 and full topo.

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -41,7 +41,7 @@ roles_cfg = {
         "asn_v6": 4200000000,
         "downlink": None,
         "uplink": {"role": "t1", "asn": 64600, "asn_v6": 4200100000, "asn_increment": 0},
-        "peer": {"role": "pt0", "asn": 65100, "asn_v6": 4200000000, "asn_increment": 1},
+        "peer": {"role": "pt0", "asn": 65100, "asn_v6": 64620, "asn_increment": 1},
     },
     "t1": {
         "asn": 65100,

--- a/ansible/vars/topo_t0-isolated-d128u128s2.yml
+++ b/ansible/vars/topo_t0-isolated-d128u128s2.yml
@@ -700,7 +700,7 @@ topology:
 
 configuration_properties:
   common:
-    dut_asn: 65100
+    dut_asn: 4200000000
     dut_type: ToRRouter
     swrole: leaf
     nhipv4: 10.10.246.254
@@ -720,9 +720,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.64
           - fc00::81
     interfaces:
@@ -733,15 +733,15 @@ configuration:
         ipv4: 10.0.0.65/31
         ipv6: fc00::82/126
     bp_interface:
-      ipv4: 10.10.246.34/24
+      ipv4: 10.10.246.34/22
       ipv6: fc0a::22/64
   ARISTA02T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.66
           - fc00::85
     interfaces:
@@ -752,15 +752,15 @@ configuration:
         ipv4: 10.0.0.67/31
         ipv6: fc00::86/126
     bp_interface:
-      ipv4: 10.10.246.35/24
+      ipv4: 10.10.246.35/22
       ipv6: fc0a::23/64
   ARISTA03T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.68
           - fc00::89
     interfaces:
@@ -771,15 +771,15 @@ configuration:
         ipv4: 10.0.0.69/31
         ipv6: fc00::8a/126
     bp_interface:
-      ipv4: 10.10.246.36/24
+      ipv4: 10.10.246.36/22
       ipv6: fc0a::24/64
   ARISTA04T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.70
           - fc00::8d
     interfaces:
@@ -790,15 +790,15 @@ configuration:
         ipv4: 10.0.0.71/31
         ipv6: fc00::8e/126
     bp_interface:
-      ipv4: 10.10.246.37/24
+      ipv4: 10.10.246.37/22
       ipv6: fc0a::25/64
   ARISTA05T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.72
           - fc00::91
     interfaces:
@@ -809,15 +809,15 @@ configuration:
         ipv4: 10.0.0.73/31
         ipv6: fc00::92/126
     bp_interface:
-      ipv4: 10.10.246.38/24
+      ipv4: 10.10.246.38/22
       ipv6: fc0a::26/64
   ARISTA06T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.74
           - fc00::95
     interfaces:
@@ -828,15 +828,15 @@ configuration:
         ipv4: 10.0.0.75/31
         ipv6: fc00::96/126
     bp_interface:
-      ipv4: 10.10.246.39/24
+      ipv4: 10.10.246.39/22
       ipv6: fc0a::27/64
   ARISTA07T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.76
           - fc00::99
     interfaces:
@@ -847,15 +847,15 @@ configuration:
         ipv4: 10.0.0.77/31
         ipv6: fc00::9a/126
     bp_interface:
-      ipv4: 10.10.246.40/24
+      ipv4: 10.10.246.40/22
       ipv6: fc0a::28/64
   ARISTA08T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.78
           - fc00::9d
     interfaces:
@@ -866,15 +866,15 @@ configuration:
         ipv4: 10.0.0.79/31
         ipv6: fc00::9e/126
     bp_interface:
-      ipv4: 10.10.246.41/24
+      ipv4: 10.10.246.41/22
       ipv6: fc0a::29/64
   ARISTA09T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.80
           - fc00::a1
     interfaces:
@@ -885,15 +885,15 @@ configuration:
         ipv4: 10.0.0.81/31
         ipv6: fc00::a2/126
     bp_interface:
-      ipv4: 10.10.246.42/24
+      ipv4: 10.10.246.42/22
       ipv6: fc0a::2a/64
   ARISTA10T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.82
           - fc00::a5
     interfaces:
@@ -904,15 +904,15 @@ configuration:
         ipv4: 10.0.0.83/31
         ipv6: fc00::a6/126
     bp_interface:
-      ipv4: 10.10.246.43/24
+      ipv4: 10.10.246.43/22
       ipv6: fc0a::2b/64
   ARISTA11T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.84
           - fc00::a9
     interfaces:
@@ -923,15 +923,15 @@ configuration:
         ipv4: 10.0.0.85/31
         ipv6: fc00::aa/126
     bp_interface:
-      ipv4: 10.10.246.44/24
+      ipv4: 10.10.246.44/22
       ipv6: fc0a::2c/64
   ARISTA12T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.86
           - fc00::ad
     interfaces:
@@ -942,15 +942,15 @@ configuration:
         ipv4: 10.0.0.87/31
         ipv6: fc00::ae/126
     bp_interface:
-      ipv4: 10.10.246.45/24
+      ipv4: 10.10.246.45/22
       ipv6: fc0a::2d/64
   ARISTA13T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.88
           - fc00::b1
     interfaces:
@@ -961,15 +961,15 @@ configuration:
         ipv4: 10.0.0.89/31
         ipv6: fc00::b2/126
     bp_interface:
-      ipv4: 10.10.246.46/24
+      ipv4: 10.10.246.46/22
       ipv6: fc0a::2e/64
   ARISTA14T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.90
           - fc00::b5
     interfaces:
@@ -980,15 +980,15 @@ configuration:
         ipv4: 10.0.0.91/31
         ipv6: fc00::b6/126
     bp_interface:
-      ipv4: 10.10.246.47/24
+      ipv4: 10.10.246.47/22
       ipv6: fc0a::2f/64
   ARISTA15T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.92
           - fc00::b9
     interfaces:
@@ -999,15 +999,15 @@ configuration:
         ipv4: 10.0.0.93/31
         ipv6: fc00::ba/126
     bp_interface:
-      ipv4: 10.10.246.48/24
+      ipv4: 10.10.246.48/22
       ipv6: fc0a::30/64
   ARISTA16T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.94
           - fc00::bd
     interfaces:
@@ -1018,15 +1018,15 @@ configuration:
         ipv4: 10.0.0.95/31
         ipv6: fc00::be/126
     bp_interface:
-      ipv4: 10.10.246.49/24
+      ipv4: 10.10.246.49/22
       ipv6: fc0a::31/64
   ARISTA17T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.96
           - fc00::c1
     interfaces:
@@ -1037,15 +1037,15 @@ configuration:
         ipv4: 10.0.0.97/31
         ipv6: fc00::c2/126
     bp_interface:
-      ipv4: 10.10.246.50/24
+      ipv4: 10.10.246.50/22
       ipv6: fc0a::32/64
   ARISTA18T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.98
           - fc00::c5
     interfaces:
@@ -1056,15 +1056,15 @@ configuration:
         ipv4: 10.0.0.99/31
         ipv6: fc00::c6/126
     bp_interface:
-      ipv4: 10.10.246.51/24
+      ipv4: 10.10.246.51/22
       ipv6: fc0a::33/64
   ARISTA19T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.100
           - fc00::c9
     interfaces:
@@ -1075,15 +1075,15 @@ configuration:
         ipv4: 10.0.0.101/31
         ipv6: fc00::ca/126
     bp_interface:
-      ipv4: 10.10.246.52/24
+      ipv4: 10.10.246.52/22
       ipv6: fc0a::34/64
   ARISTA20T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.102
           - fc00::cd
     interfaces:
@@ -1094,15 +1094,15 @@ configuration:
         ipv4: 10.0.0.103/31
         ipv6: fc00::ce/126
     bp_interface:
-      ipv4: 10.10.246.53/24
+      ipv4: 10.10.246.53/22
       ipv6: fc0a::35/64
   ARISTA21T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.104
           - fc00::d1
     interfaces:
@@ -1113,15 +1113,15 @@ configuration:
         ipv4: 10.0.0.105/31
         ipv6: fc00::d2/126
     bp_interface:
-      ipv4: 10.10.246.54/24
+      ipv4: 10.10.246.54/22
       ipv6: fc0a::36/64
   ARISTA22T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.106
           - fc00::d5
     interfaces:
@@ -1132,15 +1132,15 @@ configuration:
         ipv4: 10.0.0.107/31
         ipv6: fc00::d6/126
     bp_interface:
-      ipv4: 10.10.246.55/24
+      ipv4: 10.10.246.55/22
       ipv6: fc0a::37/64
   ARISTA23T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.108
           - fc00::d9
     interfaces:
@@ -1151,15 +1151,15 @@ configuration:
         ipv4: 10.0.0.109/31
         ipv6: fc00::da/126
     bp_interface:
-      ipv4: 10.10.246.56/24
+      ipv4: 10.10.246.56/22
       ipv6: fc0a::38/64
   ARISTA24T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.110
           - fc00::dd
     interfaces:
@@ -1170,15 +1170,15 @@ configuration:
         ipv4: 10.0.0.111/31
         ipv6: fc00::de/126
     bp_interface:
-      ipv4: 10.10.246.57/24
+      ipv4: 10.10.246.57/22
       ipv6: fc0a::39/64
   ARISTA25T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.112
           - fc00::e1
     interfaces:
@@ -1189,15 +1189,15 @@ configuration:
         ipv4: 10.0.0.113/31
         ipv6: fc00::e2/126
     bp_interface:
-      ipv4: 10.10.246.58/24
+      ipv4: 10.10.246.58/22
       ipv6: fc0a::3a/64
   ARISTA26T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.114
           - fc00::e5
     interfaces:
@@ -1208,15 +1208,15 @@ configuration:
         ipv4: 10.0.0.115/31
         ipv6: fc00::e6/126
     bp_interface:
-      ipv4: 10.10.246.59/24
+      ipv4: 10.10.246.59/22
       ipv6: fc0a::3b/64
   ARISTA27T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.116
           - fc00::e9
     interfaces:
@@ -1227,15 +1227,15 @@ configuration:
         ipv4: 10.0.0.117/31
         ipv6: fc00::ea/126
     bp_interface:
-      ipv4: 10.10.246.60/24
+      ipv4: 10.10.246.60/22
       ipv6: fc0a::3c/64
   ARISTA28T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.118
           - fc00::ed
     interfaces:
@@ -1246,15 +1246,15 @@ configuration:
         ipv4: 10.0.0.119/31
         ipv6: fc00::ee/126
     bp_interface:
-      ipv4: 10.10.246.61/24
+      ipv4: 10.10.246.61/22
       ipv6: fc0a::3d/64
   ARISTA29T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.120
           - fc00::f1
     interfaces:
@@ -1265,15 +1265,15 @@ configuration:
         ipv4: 10.0.0.121/31
         ipv6: fc00::f2/126
     bp_interface:
-      ipv4: 10.10.246.62/24
+      ipv4: 10.10.246.62/22
       ipv6: fc0a::3e/64
   ARISTA30T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.122
           - fc00::f5
     interfaces:
@@ -1284,15 +1284,15 @@ configuration:
         ipv4: 10.0.0.123/31
         ipv6: fc00::f6/126
     bp_interface:
-      ipv4: 10.10.246.63/24
+      ipv4: 10.10.246.63/22
       ipv6: fc0a::3f/64
   ARISTA31T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.124
           - fc00::f9
     interfaces:
@@ -1303,15 +1303,15 @@ configuration:
         ipv4: 10.0.0.125/31
         ipv6: fc00::fa/126
     bp_interface:
-      ipv4: 10.10.246.64/24
+      ipv4: 10.10.246.64/22
       ipv6: fc0a::40/64
   ARISTA32T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.126
           - fc00::fd
     interfaces:
@@ -1322,15 +1322,15 @@ configuration:
         ipv4: 10.0.0.127/31
         ipv6: fc00::fe/126
     bp_interface:
-      ipv4: 10.10.246.65/24
+      ipv4: 10.10.246.65/22
       ipv6: fc0a::41/64
   ARISTA33T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.128
           - fc00::101
     interfaces:
@@ -1341,15 +1341,15 @@ configuration:
         ipv4: 10.0.0.129/31
         ipv6: fc00::102/126
     bp_interface:
-      ipv4: 10.10.246.66/24
+      ipv4: 10.10.246.66/22
       ipv6: fc0a::42/64
   ARISTA34T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.130
           - fc00::105
     interfaces:
@@ -1360,15 +1360,15 @@ configuration:
         ipv4: 10.0.0.131/31
         ipv6: fc00::106/126
     bp_interface:
-      ipv4: 10.10.246.67/24
+      ipv4: 10.10.246.67/22
       ipv6: fc0a::43/64
   ARISTA35T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.132
           - fc00::109
     interfaces:
@@ -1379,15 +1379,15 @@ configuration:
         ipv4: 10.0.0.133/31
         ipv6: fc00::10a/126
     bp_interface:
-      ipv4: 10.10.246.68/24
+      ipv4: 10.10.246.68/22
       ipv6: fc0a::44/64
   ARISTA36T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.134
           - fc00::10d
     interfaces:
@@ -1398,15 +1398,15 @@ configuration:
         ipv4: 10.0.0.135/31
         ipv6: fc00::10e/126
     bp_interface:
-      ipv4: 10.10.246.69/24
+      ipv4: 10.10.246.69/22
       ipv6: fc0a::45/64
   ARISTA37T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.136
           - fc00::111
     interfaces:
@@ -1417,15 +1417,15 @@ configuration:
         ipv4: 10.0.0.137/31
         ipv6: fc00::112/126
     bp_interface:
-      ipv4: 10.10.246.70/24
+      ipv4: 10.10.246.70/22
       ipv6: fc0a::46/64
   ARISTA38T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.138
           - fc00::115
     interfaces:
@@ -1436,15 +1436,15 @@ configuration:
         ipv4: 10.0.0.139/31
         ipv6: fc00::116/126
     bp_interface:
-      ipv4: 10.10.246.71/24
+      ipv4: 10.10.246.71/22
       ipv6: fc0a::47/64
   ARISTA39T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.140
           - fc00::119
     interfaces:
@@ -1455,15 +1455,15 @@ configuration:
         ipv4: 10.0.0.141/31
         ipv6: fc00::11a/126
     bp_interface:
-      ipv4: 10.10.246.72/24
+      ipv4: 10.10.246.72/22
       ipv6: fc0a::48/64
   ARISTA40T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.142
           - fc00::11d
     interfaces:
@@ -1474,15 +1474,15 @@ configuration:
         ipv4: 10.0.0.143/31
         ipv6: fc00::11e/126
     bp_interface:
-      ipv4: 10.10.246.73/24
+      ipv4: 10.10.246.73/22
       ipv6: fc0a::49/64
   ARISTA41T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.144
           - fc00::121
     interfaces:
@@ -1493,15 +1493,15 @@ configuration:
         ipv4: 10.0.0.145/31
         ipv6: fc00::122/126
     bp_interface:
-      ipv4: 10.10.246.74/24
+      ipv4: 10.10.246.74/22
       ipv6: fc0a::4a/64
   ARISTA42T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.146
           - fc00::125
     interfaces:
@@ -1512,15 +1512,15 @@ configuration:
         ipv4: 10.0.0.147/31
         ipv6: fc00::126/126
     bp_interface:
-      ipv4: 10.10.246.75/24
+      ipv4: 10.10.246.75/22
       ipv6: fc0a::4b/64
   ARISTA43T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.148
           - fc00::129
     interfaces:
@@ -1531,15 +1531,15 @@ configuration:
         ipv4: 10.0.0.149/31
         ipv6: fc00::12a/126
     bp_interface:
-      ipv4: 10.10.246.76/24
+      ipv4: 10.10.246.76/22
       ipv6: fc0a::4c/64
   ARISTA44T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.150
           - fc00::12d
     interfaces:
@@ -1550,15 +1550,15 @@ configuration:
         ipv4: 10.0.0.151/31
         ipv6: fc00::12e/126
     bp_interface:
-      ipv4: 10.10.246.77/24
+      ipv4: 10.10.246.77/22
       ipv6: fc0a::4d/64
   ARISTA45T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.152
           - fc00::131
     interfaces:
@@ -1569,15 +1569,15 @@ configuration:
         ipv4: 10.0.0.153/31
         ipv6: fc00::132/126
     bp_interface:
-      ipv4: 10.10.246.78/24
+      ipv4: 10.10.246.78/22
       ipv6: fc0a::4e/64
   ARISTA46T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.154
           - fc00::135
     interfaces:
@@ -1588,15 +1588,15 @@ configuration:
         ipv4: 10.0.0.155/31
         ipv6: fc00::136/126
     bp_interface:
-      ipv4: 10.10.246.79/24
+      ipv4: 10.10.246.79/22
       ipv6: fc0a::4f/64
   ARISTA47T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.156
           - fc00::139
     interfaces:
@@ -1607,15 +1607,15 @@ configuration:
         ipv4: 10.0.0.157/31
         ipv6: fc00::13a/126
     bp_interface:
-      ipv4: 10.10.246.80/24
+      ipv4: 10.10.246.80/22
       ipv6: fc0a::50/64
   ARISTA48T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.158
           - fc00::13d
     interfaces:
@@ -1626,15 +1626,15 @@ configuration:
         ipv4: 10.0.0.159/31
         ipv6: fc00::13e/126
     bp_interface:
-      ipv4: 10.10.246.81/24
+      ipv4: 10.10.246.81/22
       ipv6: fc0a::51/64
   ARISTA49T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.160
           - fc00::141
     interfaces:
@@ -1645,15 +1645,15 @@ configuration:
         ipv4: 10.0.0.161/31
         ipv6: fc00::142/126
     bp_interface:
-      ipv4: 10.10.246.82/24
+      ipv4: 10.10.246.82/22
       ipv6: fc0a::52/64
   ARISTA50T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.162
           - fc00::145
     interfaces:
@@ -1664,15 +1664,15 @@ configuration:
         ipv4: 10.0.0.163/31
         ipv6: fc00::146/126
     bp_interface:
-      ipv4: 10.10.246.83/24
+      ipv4: 10.10.246.83/22
       ipv6: fc0a::53/64
   ARISTA51T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.164
           - fc00::149
     interfaces:
@@ -1683,15 +1683,15 @@ configuration:
         ipv4: 10.0.0.165/31
         ipv6: fc00::14a/126
     bp_interface:
-      ipv4: 10.10.246.84/24
+      ipv4: 10.10.246.84/22
       ipv6: fc0a::54/64
   ARISTA52T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.166
           - fc00::14d
     interfaces:
@@ -1702,15 +1702,15 @@ configuration:
         ipv4: 10.0.0.167/31
         ipv6: fc00::14e/126
     bp_interface:
-      ipv4: 10.10.246.85/24
+      ipv4: 10.10.246.85/22
       ipv6: fc0a::55/64
   ARISTA53T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.168
           - fc00::151
     interfaces:
@@ -1721,15 +1721,15 @@ configuration:
         ipv4: 10.0.0.169/31
         ipv6: fc00::152/126
     bp_interface:
-      ipv4: 10.10.246.86/24
+      ipv4: 10.10.246.86/22
       ipv6: fc0a::56/64
   ARISTA54T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.170
           - fc00::155
     interfaces:
@@ -1740,15 +1740,15 @@ configuration:
         ipv4: 10.0.0.171/31
         ipv6: fc00::156/126
     bp_interface:
-      ipv4: 10.10.246.87/24
+      ipv4: 10.10.246.87/22
       ipv6: fc0a::57/64
   ARISTA55T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.172
           - fc00::159
     interfaces:
@@ -1759,15 +1759,15 @@ configuration:
         ipv4: 10.0.0.173/31
         ipv6: fc00::15a/126
     bp_interface:
-      ipv4: 10.10.246.88/24
+      ipv4: 10.10.246.88/22
       ipv6: fc0a::58/64
   ARISTA56T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.174
           - fc00::15d
     interfaces:
@@ -1778,15 +1778,15 @@ configuration:
         ipv4: 10.0.0.175/31
         ipv6: fc00::15e/126
     bp_interface:
-      ipv4: 10.10.246.89/24
+      ipv4: 10.10.246.89/22
       ipv6: fc0a::59/64
   ARISTA57T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.176
           - fc00::161
     interfaces:
@@ -1797,15 +1797,15 @@ configuration:
         ipv4: 10.0.0.177/31
         ipv6: fc00::162/126
     bp_interface:
-      ipv4: 10.10.246.90/24
+      ipv4: 10.10.246.90/22
       ipv6: fc0a::5a/64
   ARISTA58T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.178
           - fc00::165
     interfaces:
@@ -1816,15 +1816,15 @@ configuration:
         ipv4: 10.0.0.179/31
         ipv6: fc00::166/126
     bp_interface:
-      ipv4: 10.10.246.91/24
+      ipv4: 10.10.246.91/22
       ipv6: fc0a::5b/64
   ARISTA59T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.180
           - fc00::169
     interfaces:
@@ -1835,15 +1835,15 @@ configuration:
         ipv4: 10.0.0.181/31
         ipv6: fc00::16a/126
     bp_interface:
-      ipv4: 10.10.246.92/24
+      ipv4: 10.10.246.92/22
       ipv6: fc0a::5c/64
   ARISTA60T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.182
           - fc00::16d
     interfaces:
@@ -1854,15 +1854,15 @@ configuration:
         ipv4: 10.0.0.183/31
         ipv6: fc00::16e/126
     bp_interface:
-      ipv4: 10.10.246.93/24
+      ipv4: 10.10.246.93/22
       ipv6: fc0a::5d/64
   ARISTA61T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.184
           - fc00::171
     interfaces:
@@ -1873,15 +1873,15 @@ configuration:
         ipv4: 10.0.0.185/31
         ipv6: fc00::172/126
     bp_interface:
-      ipv4: 10.10.246.94/24
+      ipv4: 10.10.246.94/22
       ipv6: fc0a::5e/64
   ARISTA62T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.186
           - fc00::175
     interfaces:
@@ -1892,15 +1892,15 @@ configuration:
         ipv4: 10.0.0.187/31
         ipv6: fc00::176/126
     bp_interface:
-      ipv4: 10.10.246.95/24
+      ipv4: 10.10.246.95/22
       ipv6: fc0a::5f/64
   ARISTA63T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.188
           - fc00::179
     interfaces:
@@ -1911,15 +1911,15 @@ configuration:
         ipv4: 10.0.0.189/31
         ipv6: fc00::17a/126
     bp_interface:
-      ipv4: 10.10.246.96/24
+      ipv4: 10.10.246.96/22
       ipv6: fc0a::60/64
   ARISTA64T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.190
           - fc00::17d
     interfaces:
@@ -1930,15 +1930,15 @@ configuration:
         ipv4: 10.0.0.191/31
         ipv6: fc00::17e/126
     bp_interface:
-      ipv4: 10.10.246.97/24
+      ipv4: 10.10.246.97/22
       ipv6: fc0a::61/64
   ARISTA65T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.64
           - fc00::281
     interfaces:
@@ -1949,15 +1949,15 @@ configuration:
         ipv4: 10.0.1.65/31
         ipv6: fc00::282/126
     bp_interface:
-      ipv4: 10.10.246.162/24
+      ipv4: 10.10.246.162/22
       ipv6: fc0a::a2/64
   ARISTA66T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.66
           - fc00::285
     interfaces:
@@ -1968,15 +1968,15 @@ configuration:
         ipv4: 10.0.1.67/31
         ipv6: fc00::286/126
     bp_interface:
-      ipv4: 10.10.246.163/24
+      ipv4: 10.10.246.163/22
       ipv6: fc0a::a3/64
   ARISTA67T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.68
           - fc00::289
     interfaces:
@@ -1987,15 +1987,15 @@ configuration:
         ipv4: 10.0.1.69/31
         ipv6: fc00::28a/126
     bp_interface:
-      ipv4: 10.10.246.164/24
+      ipv4: 10.10.246.164/22
       ipv6: fc0a::a4/64
   ARISTA68T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.70
           - fc00::28d
     interfaces:
@@ -2006,15 +2006,15 @@ configuration:
         ipv4: 10.0.1.71/31
         ipv6: fc00::28e/126
     bp_interface:
-      ipv4: 10.10.246.165/24
+      ipv4: 10.10.246.165/22
       ipv6: fc0a::a5/64
   ARISTA69T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.72
           - fc00::291
     interfaces:
@@ -2025,15 +2025,15 @@ configuration:
         ipv4: 10.0.1.73/31
         ipv6: fc00::292/126
     bp_interface:
-      ipv4: 10.10.246.166/24
+      ipv4: 10.10.246.166/22
       ipv6: fc0a::a6/64
   ARISTA70T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.74
           - fc00::295
     interfaces:
@@ -2044,15 +2044,15 @@ configuration:
         ipv4: 10.0.1.75/31
         ipv6: fc00::296/126
     bp_interface:
-      ipv4: 10.10.246.167/24
+      ipv4: 10.10.246.167/22
       ipv6: fc0a::a7/64
   ARISTA71T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.76
           - fc00::299
     interfaces:
@@ -2063,15 +2063,15 @@ configuration:
         ipv4: 10.0.1.77/31
         ipv6: fc00::29a/126
     bp_interface:
-      ipv4: 10.10.246.168/24
+      ipv4: 10.10.246.168/22
       ipv6: fc0a::a8/64
   ARISTA72T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.78
           - fc00::29d
     interfaces:
@@ -2082,15 +2082,15 @@ configuration:
         ipv4: 10.0.1.79/31
         ipv6: fc00::29e/126
     bp_interface:
-      ipv4: 10.10.246.169/24
+      ipv4: 10.10.246.169/22
       ipv6: fc0a::a9/64
   ARISTA73T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.80
           - fc00::2a1
     interfaces:
@@ -2101,15 +2101,15 @@ configuration:
         ipv4: 10.0.1.81/31
         ipv6: fc00::2a2/126
     bp_interface:
-      ipv4: 10.10.246.170/24
+      ipv4: 10.10.246.170/22
       ipv6: fc0a::aa/64
   ARISTA74T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.82
           - fc00::2a5
     interfaces:
@@ -2120,15 +2120,15 @@ configuration:
         ipv4: 10.0.1.83/31
         ipv6: fc00::2a6/126
     bp_interface:
-      ipv4: 10.10.246.171/24
+      ipv4: 10.10.246.171/22
       ipv6: fc0a::ab/64
   ARISTA75T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.84
           - fc00::2a9
     interfaces:
@@ -2139,15 +2139,15 @@ configuration:
         ipv4: 10.0.1.85/31
         ipv6: fc00::2aa/126
     bp_interface:
-      ipv4: 10.10.246.172/24
+      ipv4: 10.10.246.172/22
       ipv6: fc0a::ac/64
   ARISTA76T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.86
           - fc00::2ad
     interfaces:
@@ -2158,15 +2158,15 @@ configuration:
         ipv4: 10.0.1.87/31
         ipv6: fc00::2ae/126
     bp_interface:
-      ipv4: 10.10.246.173/24
+      ipv4: 10.10.246.173/22
       ipv6: fc0a::ad/64
   ARISTA77T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.88
           - fc00::2b1
     interfaces:
@@ -2177,15 +2177,15 @@ configuration:
         ipv4: 10.0.1.89/31
         ipv6: fc00::2b2/126
     bp_interface:
-      ipv4: 10.10.246.174/24
+      ipv4: 10.10.246.174/22
       ipv6: fc0a::ae/64
   ARISTA78T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.90
           - fc00::2b5
     interfaces:
@@ -2196,15 +2196,15 @@ configuration:
         ipv4: 10.0.1.91/31
         ipv6: fc00::2b6/126
     bp_interface:
-      ipv4: 10.10.246.175/24
+      ipv4: 10.10.246.175/22
       ipv6: fc0a::af/64
   ARISTA79T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.92
           - fc00::2b9
     interfaces:
@@ -2215,15 +2215,15 @@ configuration:
         ipv4: 10.0.1.93/31
         ipv6: fc00::2ba/126
     bp_interface:
-      ipv4: 10.10.246.176/24
+      ipv4: 10.10.246.176/22
       ipv6: fc0a::b0/64
   ARISTA80T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.94
           - fc00::2bd
     interfaces:
@@ -2234,15 +2234,15 @@ configuration:
         ipv4: 10.0.1.95/31
         ipv6: fc00::2be/126
     bp_interface:
-      ipv4: 10.10.246.177/24
+      ipv4: 10.10.246.177/22
       ipv6: fc0a::b1/64
   ARISTA81T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.96
           - fc00::2c1
     interfaces:
@@ -2253,15 +2253,15 @@ configuration:
         ipv4: 10.0.1.97/31
         ipv6: fc00::2c2/126
     bp_interface:
-      ipv4: 10.10.246.178/24
+      ipv4: 10.10.246.178/22
       ipv6: fc0a::b2/64
   ARISTA82T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.98
           - fc00::2c5
     interfaces:
@@ -2272,15 +2272,15 @@ configuration:
         ipv4: 10.0.1.99/31
         ipv6: fc00::2c6/126
     bp_interface:
-      ipv4: 10.10.246.179/24
+      ipv4: 10.10.246.179/22
       ipv6: fc0a::b3/64
   ARISTA83T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.100
           - fc00::2c9
     interfaces:
@@ -2291,15 +2291,15 @@ configuration:
         ipv4: 10.0.1.101/31
         ipv6: fc00::2ca/126
     bp_interface:
-      ipv4: 10.10.246.180/24
+      ipv4: 10.10.246.180/22
       ipv6: fc0a::b4/64
   ARISTA84T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.102
           - fc00::2cd
     interfaces:
@@ -2310,15 +2310,15 @@ configuration:
         ipv4: 10.0.1.103/31
         ipv6: fc00::2ce/126
     bp_interface:
-      ipv4: 10.10.246.181/24
+      ipv4: 10.10.246.181/22
       ipv6: fc0a::b5/64
   ARISTA85T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.104
           - fc00::2d1
     interfaces:
@@ -2329,15 +2329,15 @@ configuration:
         ipv4: 10.0.1.105/31
         ipv6: fc00::2d2/126
     bp_interface:
-      ipv4: 10.10.246.182/24
+      ipv4: 10.10.246.182/22
       ipv6: fc0a::b6/64
   ARISTA86T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.106
           - fc00::2d5
     interfaces:
@@ -2348,15 +2348,15 @@ configuration:
         ipv4: 10.0.1.107/31
         ipv6: fc00::2d6/126
     bp_interface:
-      ipv4: 10.10.246.183/24
+      ipv4: 10.10.246.183/22
       ipv6: fc0a::b7/64
   ARISTA87T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.108
           - fc00::2d9
     interfaces:
@@ -2367,15 +2367,15 @@ configuration:
         ipv4: 10.0.1.109/31
         ipv6: fc00::2da/126
     bp_interface:
-      ipv4: 10.10.246.184/24
+      ipv4: 10.10.246.184/22
       ipv6: fc0a::b8/64
   ARISTA88T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.110
           - fc00::2dd
     interfaces:
@@ -2386,15 +2386,15 @@ configuration:
         ipv4: 10.0.1.111/31
         ipv6: fc00::2de/126
     bp_interface:
-      ipv4: 10.10.246.185/24
+      ipv4: 10.10.246.185/22
       ipv6: fc0a::b9/64
   ARISTA89T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.112
           - fc00::2e1
     interfaces:
@@ -2405,15 +2405,15 @@ configuration:
         ipv4: 10.0.1.113/31
         ipv6: fc00::2e2/126
     bp_interface:
-      ipv4: 10.10.246.186/24
+      ipv4: 10.10.246.186/22
       ipv6: fc0a::ba/64
   ARISTA90T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.114
           - fc00::2e5
     interfaces:
@@ -2424,15 +2424,15 @@ configuration:
         ipv4: 10.0.1.115/31
         ipv6: fc00::2e6/126
     bp_interface:
-      ipv4: 10.10.246.187/24
+      ipv4: 10.10.246.187/22
       ipv6: fc0a::bb/64
   ARISTA91T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.116
           - fc00::2e9
     interfaces:
@@ -2443,15 +2443,15 @@ configuration:
         ipv4: 10.0.1.117/31
         ipv6: fc00::2ea/126
     bp_interface:
-      ipv4: 10.10.246.188/24
+      ipv4: 10.10.246.188/22
       ipv6: fc0a::bc/64
   ARISTA92T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.118
           - fc00::2ed
     interfaces:
@@ -2462,15 +2462,15 @@ configuration:
         ipv4: 10.0.1.119/31
         ipv6: fc00::2ee/126
     bp_interface:
-      ipv4: 10.10.246.189/24
+      ipv4: 10.10.246.189/22
       ipv6: fc0a::bd/64
   ARISTA93T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.120
           - fc00::2f1
     interfaces:
@@ -2481,15 +2481,15 @@ configuration:
         ipv4: 10.0.1.121/31
         ipv6: fc00::2f2/126
     bp_interface:
-      ipv4: 10.10.246.190/24
+      ipv4: 10.10.246.190/22
       ipv6: fc0a::be/64
   ARISTA94T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.122
           - fc00::2f5
     interfaces:
@@ -2500,15 +2500,15 @@ configuration:
         ipv4: 10.0.1.123/31
         ipv6: fc00::2f6/126
     bp_interface:
-      ipv4: 10.10.246.191/24
+      ipv4: 10.10.246.191/22
       ipv6: fc0a::bf/64
   ARISTA95T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.124
           - fc00::2f9
     interfaces:
@@ -2519,15 +2519,15 @@ configuration:
         ipv4: 10.0.1.125/31
         ipv6: fc00::2fa/126
     bp_interface:
-      ipv4: 10.10.246.192/24
+      ipv4: 10.10.246.192/22
       ipv6: fc0a::c0/64
   ARISTA96T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.126
           - fc00::2fd
     interfaces:
@@ -2538,15 +2538,15 @@ configuration:
         ipv4: 10.0.1.127/31
         ipv6: fc00::2fe/126
     bp_interface:
-      ipv4: 10.10.246.193/24
+      ipv4: 10.10.246.193/22
       ipv6: fc0a::c1/64
   ARISTA97T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.128
           - fc00::301
     interfaces:
@@ -2557,15 +2557,15 @@ configuration:
         ipv4: 10.0.1.129/31
         ipv6: fc00::302/126
     bp_interface:
-      ipv4: 10.10.246.194/24
+      ipv4: 10.10.246.194/22
       ipv6: fc0a::c2/64
   ARISTA98T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.130
           - fc00::305
     interfaces:
@@ -2576,15 +2576,15 @@ configuration:
         ipv4: 10.0.1.131/31
         ipv6: fc00::306/126
     bp_interface:
-      ipv4: 10.10.246.195/24
+      ipv4: 10.10.246.195/22
       ipv6: fc0a::c3/64
   ARISTA99T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.132
           - fc00::309
     interfaces:
@@ -2595,15 +2595,15 @@ configuration:
         ipv4: 10.0.1.133/31
         ipv6: fc00::30a/126
     bp_interface:
-      ipv4: 10.10.246.196/24
+      ipv4: 10.10.246.196/22
       ipv6: fc0a::c4/64
   ARISTA100T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.134
           - fc00::30d
     interfaces:
@@ -2614,15 +2614,15 @@ configuration:
         ipv4: 10.0.1.135/31
         ipv6: fc00::30e/126
     bp_interface:
-      ipv4: 10.10.246.197/24
+      ipv4: 10.10.246.197/22
       ipv6: fc0a::c5/64
   ARISTA101T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.136
           - fc00::311
     interfaces:
@@ -2633,15 +2633,15 @@ configuration:
         ipv4: 10.0.1.137/31
         ipv6: fc00::312/126
     bp_interface:
-      ipv4: 10.10.246.198/24
+      ipv4: 10.10.246.198/22
       ipv6: fc0a::c6/64
   ARISTA102T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.138
           - fc00::315
     interfaces:
@@ -2652,15 +2652,15 @@ configuration:
         ipv4: 10.0.1.139/31
         ipv6: fc00::316/126
     bp_interface:
-      ipv4: 10.10.246.199/24
+      ipv4: 10.10.246.199/22
       ipv6: fc0a::c7/64
   ARISTA103T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.140
           - fc00::319
     interfaces:
@@ -2671,15 +2671,15 @@ configuration:
         ipv4: 10.0.1.141/31
         ipv6: fc00::31a/126
     bp_interface:
-      ipv4: 10.10.246.200/24
+      ipv4: 10.10.246.200/22
       ipv6: fc0a::c8/64
   ARISTA104T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.142
           - fc00::31d
     interfaces:
@@ -2690,15 +2690,15 @@ configuration:
         ipv4: 10.0.1.143/31
         ipv6: fc00::31e/126
     bp_interface:
-      ipv4: 10.10.246.201/24
+      ipv4: 10.10.246.201/22
       ipv6: fc0a::c9/64
   ARISTA105T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.144
           - fc00::321
     interfaces:
@@ -2709,15 +2709,15 @@ configuration:
         ipv4: 10.0.1.145/31
         ipv6: fc00::322/126
     bp_interface:
-      ipv4: 10.10.246.202/24
+      ipv4: 10.10.246.202/22
       ipv6: fc0a::ca/64
   ARISTA106T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.146
           - fc00::325
     interfaces:
@@ -2728,15 +2728,15 @@ configuration:
         ipv4: 10.0.1.147/31
         ipv6: fc00::326/126
     bp_interface:
-      ipv4: 10.10.246.203/24
+      ipv4: 10.10.246.203/22
       ipv6: fc0a::cb/64
   ARISTA107T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.148
           - fc00::329
     interfaces:
@@ -2747,15 +2747,15 @@ configuration:
         ipv4: 10.0.1.149/31
         ipv6: fc00::32a/126
     bp_interface:
-      ipv4: 10.10.246.204/24
+      ipv4: 10.10.246.204/22
       ipv6: fc0a::cc/64
   ARISTA108T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.150
           - fc00::32d
     interfaces:
@@ -2766,15 +2766,15 @@ configuration:
         ipv4: 10.0.1.151/31
         ipv6: fc00::32e/126
     bp_interface:
-      ipv4: 10.10.246.205/24
+      ipv4: 10.10.246.205/22
       ipv6: fc0a::cd/64
   ARISTA109T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.152
           - fc00::331
     interfaces:
@@ -2785,15 +2785,15 @@ configuration:
         ipv4: 10.0.1.153/31
         ipv6: fc00::332/126
     bp_interface:
-      ipv4: 10.10.246.206/24
+      ipv4: 10.10.246.206/22
       ipv6: fc0a::ce/64
   ARISTA110T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.154
           - fc00::335
     interfaces:
@@ -2804,15 +2804,15 @@ configuration:
         ipv4: 10.0.1.155/31
         ipv6: fc00::336/126
     bp_interface:
-      ipv4: 10.10.246.207/24
+      ipv4: 10.10.246.207/22
       ipv6: fc0a::cf/64
   ARISTA111T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.156
           - fc00::339
     interfaces:
@@ -2823,15 +2823,15 @@ configuration:
         ipv4: 10.0.1.157/31
         ipv6: fc00::33a/126
     bp_interface:
-      ipv4: 10.10.246.208/24
+      ipv4: 10.10.246.208/22
       ipv6: fc0a::d0/64
   ARISTA112T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.158
           - fc00::33d
     interfaces:
@@ -2842,15 +2842,15 @@ configuration:
         ipv4: 10.0.1.159/31
         ipv6: fc00::33e/126
     bp_interface:
-      ipv4: 10.10.246.209/24
+      ipv4: 10.10.246.209/22
       ipv6: fc0a::d1/64
   ARISTA113T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.160
           - fc00::341
     interfaces:
@@ -2861,15 +2861,15 @@ configuration:
         ipv4: 10.0.1.161/31
         ipv6: fc00::342/126
     bp_interface:
-      ipv4: 10.10.246.210/24
+      ipv4: 10.10.246.210/22
       ipv6: fc0a::d2/64
   ARISTA114T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.162
           - fc00::345
     interfaces:
@@ -2880,15 +2880,15 @@ configuration:
         ipv4: 10.0.1.163/31
         ipv6: fc00::346/126
     bp_interface:
-      ipv4: 10.10.246.211/24
+      ipv4: 10.10.246.211/22
       ipv6: fc0a::d3/64
   ARISTA115T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.164
           - fc00::349
     interfaces:
@@ -2899,15 +2899,15 @@ configuration:
         ipv4: 10.0.1.165/31
         ipv6: fc00::34a/126
     bp_interface:
-      ipv4: 10.10.246.212/24
+      ipv4: 10.10.246.212/22
       ipv6: fc0a::d4/64
   ARISTA116T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.166
           - fc00::34d
     interfaces:
@@ -2918,15 +2918,15 @@ configuration:
         ipv4: 10.0.1.167/31
         ipv6: fc00::34e/126
     bp_interface:
-      ipv4: 10.10.246.213/24
+      ipv4: 10.10.246.213/22
       ipv6: fc0a::d5/64
   ARISTA117T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.168
           - fc00::351
     interfaces:
@@ -2937,15 +2937,15 @@ configuration:
         ipv4: 10.0.1.169/31
         ipv6: fc00::352/126
     bp_interface:
-      ipv4: 10.10.246.214/24
+      ipv4: 10.10.246.214/22
       ipv6: fc0a::d6/64
   ARISTA118T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.170
           - fc00::355
     interfaces:
@@ -2956,15 +2956,15 @@ configuration:
         ipv4: 10.0.1.171/31
         ipv6: fc00::356/126
     bp_interface:
-      ipv4: 10.10.246.215/24
+      ipv4: 10.10.246.215/22
       ipv6: fc0a::d7/64
   ARISTA119T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.172
           - fc00::359
     interfaces:
@@ -2975,15 +2975,15 @@ configuration:
         ipv4: 10.0.1.173/31
         ipv6: fc00::35a/126
     bp_interface:
-      ipv4: 10.10.246.216/24
+      ipv4: 10.10.246.216/22
       ipv6: fc0a::d8/64
   ARISTA120T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.174
           - fc00::35d
     interfaces:
@@ -2994,15 +2994,15 @@ configuration:
         ipv4: 10.0.1.175/31
         ipv6: fc00::35e/126
     bp_interface:
-      ipv4: 10.10.246.217/24
+      ipv4: 10.10.246.217/22
       ipv6: fc0a::d9/64
   ARISTA121T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.176
           - fc00::361
     interfaces:
@@ -3013,15 +3013,15 @@ configuration:
         ipv4: 10.0.1.177/31
         ipv6: fc00::362/126
     bp_interface:
-      ipv4: 10.10.246.218/24
+      ipv4: 10.10.246.218/22
       ipv6: fc0a::da/64
   ARISTA122T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.178
           - fc00::365
     interfaces:
@@ -3032,15 +3032,15 @@ configuration:
         ipv4: 10.0.1.179/31
         ipv6: fc00::366/126
     bp_interface:
-      ipv4: 10.10.246.219/24
+      ipv4: 10.10.246.219/22
       ipv6: fc0a::db/64
   ARISTA123T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.180
           - fc00::369
     interfaces:
@@ -3051,15 +3051,15 @@ configuration:
         ipv4: 10.0.1.181/31
         ipv6: fc00::36a/126
     bp_interface:
-      ipv4: 10.10.246.220/24
+      ipv4: 10.10.246.220/22
       ipv6: fc0a::dc/64
   ARISTA124T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.182
           - fc00::36d
     interfaces:
@@ -3070,15 +3070,15 @@ configuration:
         ipv4: 10.0.1.183/31
         ipv6: fc00::36e/126
     bp_interface:
-      ipv4: 10.10.246.221/24
+      ipv4: 10.10.246.221/22
       ipv6: fc0a::dd/64
   ARISTA125T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.184
           - fc00::371
     interfaces:
@@ -3089,15 +3089,15 @@ configuration:
         ipv4: 10.0.1.185/31
         ipv6: fc00::372/126
     bp_interface:
-      ipv4: 10.10.246.222/24
+      ipv4: 10.10.246.222/22
       ipv6: fc0a::de/64
   ARISTA126T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.186
           - fc00::375
     interfaces:
@@ -3108,15 +3108,15 @@ configuration:
         ipv4: 10.0.1.187/31
         ipv6: fc00::376/126
     bp_interface:
-      ipv4: 10.10.246.223/24
+      ipv4: 10.10.246.223/22
       ipv6: fc0a::df/64
   ARISTA127T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.188
           - fc00::379
     interfaces:
@@ -3127,15 +3127,15 @@ configuration:
         ipv4: 10.0.1.189/31
         ipv6: fc00::37a/126
     bp_interface:
-      ipv4: 10.10.246.224/24
+      ipv4: 10.10.246.224/22
       ipv6: fc0a::e0/64
   ARISTA128T1:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.190
           - fc00::37d
     interfaces:
@@ -3146,15 +3146,15 @@ configuration:
         ipv4: 10.0.1.191/31
         ipv6: fc00::37e/126
     bp_interface:
-      ipv4: 10.10.246.225/24
+      ipv4: 10.10.246.225/22
       ipv6: fc0a::e1/64
   ARISTA01PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 64621
       peers:
-        65100:
+        4200000000:
           - 10.0.2.0
           - fc00::401
     interfaces:
@@ -3165,15 +3165,15 @@ configuration:
         ipv4: 10.0.2.1/31
         ipv6: fc00::402/126
     bp_interface:
-      ipv4: 10.10.247.2/24
+      ipv4: 10.10.247.2/22
       ipv6: fc0a::102/64
   ARISTA02PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 64622
       peers:
-        65100:
+        4200000000:
           - 10.0.2.2
           - fc00::405
     interfaces:
@@ -3184,5 +3184,5 @@ configuration:
         ipv4: 10.0.2.3/31
         ipv6: fc00::406/126
     bp_interface:
-      ipv4: 10.10.247.3/24
+      ipv4: 10.10.247.3/22
       ipv6: fc0a::103/64

--- a/ansible/vars/topo_t0-isolated-d256u256s2.yml
+++ b/ansible/vars/topo_t0-isolated-d256u256s2.yml
@@ -1340,7 +1340,7 @@ topology:
 
 configuration_properties:
   common:
-    dut_asn: 65100
+    dut_asn: 4200000000
     dut_type: ToRRouter
     swrole: leaf
     nhipv4: 10.10.246.254
@@ -1360,9 +1360,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.128
           - fc00::101
     interfaces:
@@ -1379,9 +1379,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.130
           - fc00::105
     interfaces:
@@ -1398,9 +1398,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.132
           - fc00::109
     interfaces:
@@ -1417,9 +1417,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.134
           - fc00::10d
     interfaces:
@@ -1436,9 +1436,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.136
           - fc00::111
     interfaces:
@@ -1455,9 +1455,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.138
           - fc00::115
     interfaces:
@@ -1474,9 +1474,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.140
           - fc00::119
     interfaces:
@@ -1493,9 +1493,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.142
           - fc00::11d
     interfaces:
@@ -1512,9 +1512,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.144
           - fc00::121
     interfaces:
@@ -1531,9 +1531,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.146
           - fc00::125
     interfaces:
@@ -1550,9 +1550,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.148
           - fc00::129
     interfaces:
@@ -1569,9 +1569,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.150
           - fc00::12d
     interfaces:
@@ -1588,9 +1588,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.152
           - fc00::131
     interfaces:
@@ -1607,9 +1607,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.154
           - fc00::135
     interfaces:
@@ -1626,9 +1626,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.156
           - fc00::139
     interfaces:
@@ -1645,9 +1645,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.158
           - fc00::13d
     interfaces:
@@ -1664,9 +1664,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.160
           - fc00::141
     interfaces:
@@ -1683,9 +1683,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.162
           - fc00::145
     interfaces:
@@ -1702,9 +1702,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.164
           - fc00::149
     interfaces:
@@ -1721,9 +1721,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.166
           - fc00::14d
     interfaces:
@@ -1740,9 +1740,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.168
           - fc00::151
     interfaces:
@@ -1759,9 +1759,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.170
           - fc00::155
     interfaces:
@@ -1778,9 +1778,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.172
           - fc00::159
     interfaces:
@@ -1797,9 +1797,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.174
           - fc00::15d
     interfaces:
@@ -1816,9 +1816,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.176
           - fc00::161
     interfaces:
@@ -1835,9 +1835,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.178
           - fc00::165
     interfaces:
@@ -1854,9 +1854,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.180
           - fc00::169
     interfaces:
@@ -1873,9 +1873,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.182
           - fc00::16d
     interfaces:
@@ -1892,9 +1892,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.184
           - fc00::171
     interfaces:
@@ -1911,9 +1911,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.186
           - fc00::175
     interfaces:
@@ -1930,9 +1930,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.188
           - fc00::179
     interfaces:
@@ -1949,9 +1949,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.190
           - fc00::17d
     interfaces:
@@ -1968,9 +1968,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.192
           - fc00::181
     interfaces:
@@ -1987,9 +1987,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.194
           - fc00::185
     interfaces:
@@ -2006,9 +2006,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.196
           - fc00::189
     interfaces:
@@ -2025,9 +2025,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.198
           - fc00::18d
     interfaces:
@@ -2044,9 +2044,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.200
           - fc00::191
     interfaces:
@@ -2063,9 +2063,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.202
           - fc00::195
     interfaces:
@@ -2082,9 +2082,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.204
           - fc00::199
     interfaces:
@@ -2101,9 +2101,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.206
           - fc00::19d
     interfaces:
@@ -2120,9 +2120,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.208
           - fc00::1a1
     interfaces:
@@ -2139,9 +2139,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.210
           - fc00::1a5
     interfaces:
@@ -2158,9 +2158,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.212
           - fc00::1a9
     interfaces:
@@ -2177,9 +2177,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.214
           - fc00::1ad
     interfaces:
@@ -2196,9 +2196,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.216
           - fc00::1b1
     interfaces:
@@ -2215,9 +2215,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.218
           - fc00::1b5
     interfaces:
@@ -2234,9 +2234,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.220
           - fc00::1b9
     interfaces:
@@ -2253,9 +2253,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.222
           - fc00::1bd
     interfaces:
@@ -2272,9 +2272,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.224
           - fc00::1c1
     interfaces:
@@ -2291,9 +2291,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.226
           - fc00::1c5
     interfaces:
@@ -2310,9 +2310,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.228
           - fc00::1c9
     interfaces:
@@ -2329,9 +2329,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.230
           - fc00::1cd
     interfaces:
@@ -2348,9 +2348,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.232
           - fc00::1d1
     interfaces:
@@ -2367,9 +2367,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.234
           - fc00::1d5
     interfaces:
@@ -2386,9 +2386,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.236
           - fc00::1d9
     interfaces:
@@ -2405,9 +2405,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.238
           - fc00::1dd
     interfaces:
@@ -2424,9 +2424,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.240
           - fc00::1e1
     interfaces:
@@ -2443,9 +2443,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.242
           - fc00::1e5
     interfaces:
@@ -2462,9 +2462,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.244
           - fc00::1e9
     interfaces:
@@ -2481,9 +2481,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.246
           - fc00::1ed
     interfaces:
@@ -2500,9 +2500,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.248
           - fc00::1f1
     interfaces:
@@ -2519,9 +2519,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.250
           - fc00::1f5
     interfaces:
@@ -2538,9 +2538,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.252
           - fc00::1f9
     interfaces:
@@ -2557,9 +2557,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.0.254
           - fc00::1fd
     interfaces:
@@ -2576,9 +2576,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.0
           - fc00::201
     interfaces:
@@ -2595,9 +2595,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.2
           - fc00::205
     interfaces:
@@ -2614,9 +2614,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.4
           - fc00::209
     interfaces:
@@ -2633,9 +2633,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.6
           - fc00::20d
     interfaces:
@@ -2652,9 +2652,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.8
           - fc00::211
     interfaces:
@@ -2671,9 +2671,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.10
           - fc00::215
     interfaces:
@@ -2690,9 +2690,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.12
           - fc00::219
     interfaces:
@@ -2709,9 +2709,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.14
           - fc00::21d
     interfaces:
@@ -2728,9 +2728,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.16
           - fc00::221
     interfaces:
@@ -2747,9 +2747,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.18
           - fc00::225
     interfaces:
@@ -2766,9 +2766,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.20
           - fc00::229
     interfaces:
@@ -2785,9 +2785,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.22
           - fc00::22d
     interfaces:
@@ -2804,9 +2804,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.24
           - fc00::231
     interfaces:
@@ -2823,9 +2823,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.26
           - fc00::235
     interfaces:
@@ -2842,9 +2842,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.28
           - fc00::239
     interfaces:
@@ -2861,9 +2861,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.30
           - fc00::23d
     interfaces:
@@ -2880,9 +2880,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.32
           - fc00::241
     interfaces:
@@ -2899,9 +2899,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.34
           - fc00::245
     interfaces:
@@ -2918,9 +2918,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.36
           - fc00::249
     interfaces:
@@ -2937,9 +2937,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.38
           - fc00::24d
     interfaces:
@@ -2956,9 +2956,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.40
           - fc00::251
     interfaces:
@@ -2975,9 +2975,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.42
           - fc00::255
     interfaces:
@@ -2994,9 +2994,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.44
           - fc00::259
     interfaces:
@@ -3013,9 +3013,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.46
           - fc00::25d
     interfaces:
@@ -3032,9 +3032,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.48
           - fc00::261
     interfaces:
@@ -3051,9 +3051,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.50
           - fc00::265
     interfaces:
@@ -3070,9 +3070,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.52
           - fc00::269
     interfaces:
@@ -3089,9 +3089,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.54
           - fc00::26d
     interfaces:
@@ -3108,9 +3108,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.56
           - fc00::271
     interfaces:
@@ -3127,9 +3127,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.58
           - fc00::275
     interfaces:
@@ -3146,9 +3146,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.60
           - fc00::279
     interfaces:
@@ -3165,9 +3165,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.62
           - fc00::27d
     interfaces:
@@ -3184,9 +3184,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.64
           - fc00::281
     interfaces:
@@ -3203,9 +3203,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.66
           - fc00::285
     interfaces:
@@ -3222,9 +3222,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.68
           - fc00::289
     interfaces:
@@ -3241,9 +3241,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.70
           - fc00::28d
     interfaces:
@@ -3260,9 +3260,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.72
           - fc00::291
     interfaces:
@@ -3279,9 +3279,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.74
           - fc00::295
     interfaces:
@@ -3298,9 +3298,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.76
           - fc00::299
     interfaces:
@@ -3317,9 +3317,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.78
           - fc00::29d
     interfaces:
@@ -3336,9 +3336,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.80
           - fc00::2a1
     interfaces:
@@ -3355,9 +3355,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.82
           - fc00::2a5
     interfaces:
@@ -3374,9 +3374,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.84
           - fc00::2a9
     interfaces:
@@ -3393,9 +3393,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.86
           - fc00::2ad
     interfaces:
@@ -3412,9 +3412,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.88
           - fc00::2b1
     interfaces:
@@ -3431,9 +3431,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.90
           - fc00::2b5
     interfaces:
@@ -3450,9 +3450,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.92
           - fc00::2b9
     interfaces:
@@ -3469,9 +3469,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.94
           - fc00::2bd
     interfaces:
@@ -3488,9 +3488,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.96
           - fc00::2c1
     interfaces:
@@ -3507,9 +3507,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.98
           - fc00::2c5
     interfaces:
@@ -3526,9 +3526,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.100
           - fc00::2c9
     interfaces:
@@ -3545,9 +3545,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.102
           - fc00::2cd
     interfaces:
@@ -3564,9 +3564,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.104
           - fc00::2d1
     interfaces:
@@ -3583,9 +3583,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.106
           - fc00::2d5
     interfaces:
@@ -3602,9 +3602,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.108
           - fc00::2d9
     interfaces:
@@ -3621,9 +3621,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.110
           - fc00::2dd
     interfaces:
@@ -3640,9 +3640,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.112
           - fc00::2e1
     interfaces:
@@ -3659,9 +3659,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.114
           - fc00::2e5
     interfaces:
@@ -3678,9 +3678,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.116
           - fc00::2e9
     interfaces:
@@ -3697,9 +3697,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.118
           - fc00::2ed
     interfaces:
@@ -3716,9 +3716,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.120
           - fc00::2f1
     interfaces:
@@ -3735,9 +3735,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.122
           - fc00::2f5
     interfaces:
@@ -3754,9 +3754,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.124
           - fc00::2f9
     interfaces:
@@ -3773,9 +3773,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.1.126
           - fc00::2fd
     interfaces:
@@ -3792,9 +3792,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.128
           - fc00::501
     interfaces:
@@ -3811,9 +3811,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.130
           - fc00::505
     interfaces:
@@ -3830,9 +3830,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.132
           - fc00::509
     interfaces:
@@ -3849,9 +3849,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.134
           - fc00::50d
     interfaces:
@@ -3868,9 +3868,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.136
           - fc00::511
     interfaces:
@@ -3887,9 +3887,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.138
           - fc00::515
     interfaces:
@@ -3906,9 +3906,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.140
           - fc00::519
     interfaces:
@@ -3925,9 +3925,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.142
           - fc00::51d
     interfaces:
@@ -3944,9 +3944,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.144
           - fc00::521
     interfaces:
@@ -3963,9 +3963,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.146
           - fc00::525
     interfaces:
@@ -3982,9 +3982,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.148
           - fc00::529
     interfaces:
@@ -4001,9 +4001,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.150
           - fc00::52d
     interfaces:
@@ -4020,9 +4020,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.152
           - fc00::531
     interfaces:
@@ -4039,9 +4039,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.154
           - fc00::535
     interfaces:
@@ -4058,9 +4058,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.156
           - fc00::539
     interfaces:
@@ -4077,9 +4077,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.158
           - fc00::53d
     interfaces:
@@ -4096,9 +4096,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.160
           - fc00::541
     interfaces:
@@ -4115,9 +4115,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.162
           - fc00::545
     interfaces:
@@ -4134,9 +4134,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.164
           - fc00::549
     interfaces:
@@ -4153,9 +4153,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.166
           - fc00::54d
     interfaces:
@@ -4172,9 +4172,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.168
           - fc00::551
     interfaces:
@@ -4191,9 +4191,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.170
           - fc00::555
     interfaces:
@@ -4210,9 +4210,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.172
           - fc00::559
     interfaces:
@@ -4229,9 +4229,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.174
           - fc00::55d
     interfaces:
@@ -4248,9 +4248,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.176
           - fc00::561
     interfaces:
@@ -4267,9 +4267,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.178
           - fc00::565
     interfaces:
@@ -4286,9 +4286,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.180
           - fc00::569
     interfaces:
@@ -4305,9 +4305,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.182
           - fc00::56d
     interfaces:
@@ -4324,9 +4324,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.184
           - fc00::571
     interfaces:
@@ -4343,9 +4343,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.186
           - fc00::575
     interfaces:
@@ -4362,9 +4362,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.188
           - fc00::579
     interfaces:
@@ -4381,9 +4381,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.190
           - fc00::57d
     interfaces:
@@ -4400,9 +4400,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.192
           - fc00::581
     interfaces:
@@ -4419,9 +4419,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.194
           - fc00::585
     interfaces:
@@ -4438,9 +4438,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.196
           - fc00::589
     interfaces:
@@ -4457,9 +4457,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.198
           - fc00::58d
     interfaces:
@@ -4476,9 +4476,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.200
           - fc00::591
     interfaces:
@@ -4495,9 +4495,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.202
           - fc00::595
     interfaces:
@@ -4514,9 +4514,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.204
           - fc00::599
     interfaces:
@@ -4533,9 +4533,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.206
           - fc00::59d
     interfaces:
@@ -4552,9 +4552,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.208
           - fc00::5a1
     interfaces:
@@ -4571,9 +4571,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.210
           - fc00::5a5
     interfaces:
@@ -4590,9 +4590,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.212
           - fc00::5a9
     interfaces:
@@ -4609,9 +4609,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.214
           - fc00::5ad
     interfaces:
@@ -4628,9 +4628,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.216
           - fc00::5b1
     interfaces:
@@ -4647,9 +4647,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.218
           - fc00::5b5
     interfaces:
@@ -4666,9 +4666,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.220
           - fc00::5b9
     interfaces:
@@ -4685,9 +4685,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.222
           - fc00::5bd
     interfaces:
@@ -4704,9 +4704,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.224
           - fc00::5c1
     interfaces:
@@ -4723,9 +4723,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.226
           - fc00::5c5
     interfaces:
@@ -4742,9 +4742,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.228
           - fc00::5c9
     interfaces:
@@ -4761,9 +4761,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.230
           - fc00::5cd
     interfaces:
@@ -4780,9 +4780,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.232
           - fc00::5d1
     interfaces:
@@ -4799,9 +4799,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.234
           - fc00::5d5
     interfaces:
@@ -4818,9 +4818,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.236
           - fc00::5d9
     interfaces:
@@ -4837,9 +4837,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.238
           - fc00::5dd
     interfaces:
@@ -4856,9 +4856,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.240
           - fc00::5e1
     interfaces:
@@ -4875,9 +4875,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.242
           - fc00::5e5
     interfaces:
@@ -4894,9 +4894,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.244
           - fc00::5e9
     interfaces:
@@ -4913,9 +4913,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.246
           - fc00::5ed
     interfaces:
@@ -4932,9 +4932,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.248
           - fc00::5f1
     interfaces:
@@ -4951,9 +4951,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.250
           - fc00::5f5
     interfaces:
@@ -4970,9 +4970,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.252
           - fc00::5f9
     interfaces:
@@ -4989,9 +4989,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.2.254
           - fc00::5fd
     interfaces:
@@ -5008,9 +5008,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.0
           - fc00::601
     interfaces:
@@ -5027,9 +5027,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.2
           - fc00::605
     interfaces:
@@ -5046,9 +5046,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.4
           - fc00::609
     interfaces:
@@ -5065,9 +5065,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.6
           - fc00::60d
     interfaces:
@@ -5084,9 +5084,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.8
           - fc00::611
     interfaces:
@@ -5103,9 +5103,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.10
           - fc00::615
     interfaces:
@@ -5122,9 +5122,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.12
           - fc00::619
     interfaces:
@@ -5141,9 +5141,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.14
           - fc00::61d
     interfaces:
@@ -5160,9 +5160,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.16
           - fc00::621
     interfaces:
@@ -5179,9 +5179,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.18
           - fc00::625
     interfaces:
@@ -5198,9 +5198,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.20
           - fc00::629
     interfaces:
@@ -5217,9 +5217,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.22
           - fc00::62d
     interfaces:
@@ -5236,9 +5236,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.24
           - fc00::631
     interfaces:
@@ -5255,9 +5255,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.26
           - fc00::635
     interfaces:
@@ -5274,9 +5274,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.28
           - fc00::639
     interfaces:
@@ -5293,9 +5293,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.30
           - fc00::63d
     interfaces:
@@ -5312,9 +5312,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.32
           - fc00::641
     interfaces:
@@ -5331,9 +5331,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.34
           - fc00::645
     interfaces:
@@ -5350,9 +5350,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.36
           - fc00::649
     interfaces:
@@ -5369,9 +5369,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.38
           - fc00::64d
     interfaces:
@@ -5388,9 +5388,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.40
           - fc00::651
     interfaces:
@@ -5407,9 +5407,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.42
           - fc00::655
     interfaces:
@@ -5426,9 +5426,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.44
           - fc00::659
     interfaces:
@@ -5445,9 +5445,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.46
           - fc00::65d
     interfaces:
@@ -5464,9 +5464,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.48
           - fc00::661
     interfaces:
@@ -5483,9 +5483,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.50
           - fc00::665
     interfaces:
@@ -5502,9 +5502,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.52
           - fc00::669
     interfaces:
@@ -5521,9 +5521,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.54
           - fc00::66d
     interfaces:
@@ -5540,9 +5540,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.56
           - fc00::671
     interfaces:
@@ -5559,9 +5559,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.58
           - fc00::675
     interfaces:
@@ -5578,9 +5578,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.60
           - fc00::679
     interfaces:
@@ -5597,9 +5597,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.62
           - fc00::67d
     interfaces:
@@ -5616,9 +5616,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.64
           - fc00::681
     interfaces:
@@ -5635,9 +5635,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.66
           - fc00::685
     interfaces:
@@ -5654,9 +5654,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.68
           - fc00::689
     interfaces:
@@ -5673,9 +5673,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.70
           - fc00::68d
     interfaces:
@@ -5692,9 +5692,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.72
           - fc00::691
     interfaces:
@@ -5711,9 +5711,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.74
           - fc00::695
     interfaces:
@@ -5730,9 +5730,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.76
           - fc00::699
     interfaces:
@@ -5749,9 +5749,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.78
           - fc00::69d
     interfaces:
@@ -5768,9 +5768,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.80
           - fc00::6a1
     interfaces:
@@ -5787,9 +5787,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.82
           - fc00::6a5
     interfaces:
@@ -5806,9 +5806,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.84
           - fc00::6a9
     interfaces:
@@ -5825,9 +5825,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.86
           - fc00::6ad
     interfaces:
@@ -5844,9 +5844,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.88
           - fc00::6b1
     interfaces:
@@ -5863,9 +5863,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.90
           - fc00::6b5
     interfaces:
@@ -5882,9 +5882,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.92
           - fc00::6b9
     interfaces:
@@ -5901,9 +5901,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.94
           - fc00::6bd
     interfaces:
@@ -5920,9 +5920,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.96
           - fc00::6c1
     interfaces:
@@ -5939,9 +5939,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.98
           - fc00::6c5
     interfaces:
@@ -5958,9 +5958,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.100
           - fc00::6c9
     interfaces:
@@ -5977,9 +5977,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.102
           - fc00::6cd
     interfaces:
@@ -5996,9 +5996,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.104
           - fc00::6d1
     interfaces:
@@ -6015,9 +6015,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.106
           - fc00::6d5
     interfaces:
@@ -6034,9 +6034,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.108
           - fc00::6d9
     interfaces:
@@ -6053,9 +6053,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.110
           - fc00::6dd
     interfaces:
@@ -6072,9 +6072,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.112
           - fc00::6e1
     interfaces:
@@ -6091,9 +6091,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.114
           - fc00::6e5
     interfaces:
@@ -6110,9 +6110,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.116
           - fc00::6e9
     interfaces:
@@ -6129,9 +6129,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.118
           - fc00::6ed
     interfaces:
@@ -6148,9 +6148,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.120
           - fc00::6f1
     interfaces:
@@ -6167,9 +6167,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.122
           - fc00::6f5
     interfaces:
@@ -6186,9 +6186,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.124
           - fc00::6f9
     interfaces:
@@ -6205,9 +6205,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 64600
+      asn: 4200100000
       peers:
-        65100:
+        4200000000:
           - 10.0.3.126
           - fc00::6fd
     interfaces:
@@ -6224,9 +6224,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65101
+      asn: 64621
       peers:
-        65100:
+        4200000000:
           - 10.0.4.0
           - fc00::801
     interfaces:
@@ -6243,9 +6243,9 @@ configuration:
     properties:
     - common
     bgp:
-      asn: 65102
+      asn: 64622
       peers:
-        65100:
+        4200000000:
           - 10.0.4.2
           - fc00::805
     interfaces:

--- a/ansible/vars/topo_t0-isolated-v6-d16u16s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d16u16s2.yml
@@ -412,7 +412,7 @@ configuration:
     - common
     bgp:
       router-id: 100.1.1.1
-      asn: 4200000000
+      asn: 64621
       peers:
         4200000000:
           - fc00::401
@@ -428,7 +428,7 @@ configuration:
     - common
     bgp:
       router-id: 100.1.1.2
-      asn: 4200000000
+      asn: 64622
       peers:
         4200000000:
           - fc00::405

--- a/ansible/vars/topo_t0-isolated-v6-d256u256s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d256u256s2.yml
@@ -5452,7 +5452,7 @@ configuration:
     - common
     bgp:
       router-id: 100.1.2.1
-      asn: 4200000001
+      asn: 64621
       peers:
         4200000000:
           - fc00::801
@@ -5468,7 +5468,7 @@ configuration:
     - common
     bgp:
       router-id: 100.1.2.2
-      asn: 4200000002
+      asn: 64622
       peers:
         4200000000:
           - fc00::805

--- a/ansible/vars/topo_t0-isolated-v6-d32u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d32u32s2.yml
@@ -748,7 +748,7 @@ configuration:
     - common
     bgp:
       router-id: 100.1.2.1
-      asn: 4200000000
+      asn: 64621
       peers:
         4200000000:
           - fc00::801
@@ -764,7 +764,7 @@ configuration:
     - common
     bgp:
       router-id: 100.1.2.2
-      asn: 4200000000
+      asn: 64622
       peers:
         4200000000:
           - fc00::805


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Peer T0 is using 2 bytes ASN in t0-isolated-v6 topo. Update the topo file with correct settings.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Update t0-isolated-v6 topo with correct PT0 ASN settings.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
