### PR TITLE
Increase timeout for test_memory_exhaustion.py for multi-asic duts

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -12,7 +12,7 @@ from tests.common.utilities import wait_until, get_plt_reboot_ctrl
 logger = logging.getLogger(__name__)
 
 
-def reset_timeout(duthost):
+def reset_timeout(duthost, reset_timeout=300):
     """
     return: if timeout is specified in inventory file for this dut, return new timeout
             if not specified, return 300 sec as default timeout
@@ -21,7 +21,6 @@ def reset_timeout(duthost):
           timeout: 400
           wait: 60
     """
-    reset_timeout = 300
     plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'processes_utils.py', 'cold')
     if plt_reboot_ctrl:
         reset_timeout = plt_reboot_ctrl.get('timeout', 300)
@@ -63,12 +62,12 @@ def check_critical_processes(dut, watch_secs=0):
         watch_secs = watch_secs - 5
 
 
-def wait_critical_processes(dut):
+def wait_critical_processes(dut, timeout=300):
     """
     @summary: wait until all critical processes are healthy.
     @param dut: The AnsibleHost object of DUT. For interacting with DUT.
     """
-    timeout = reset_timeout(dut)
+    timeout = reset_timeout(dut, timeout)
     # No matter what we set in inventory file, we always set sup timeout to 900
     # because most SUPs have 10+ dockers that need to come up
     if dut.is_supervisor_node():

--- a/tests/platform_tests/test_memory_exhaustion.py
+++ b/tests/platform_tests/test_memory_exhaustion.py
@@ -72,7 +72,10 @@ class TestMemoryExhaustion:
         # Verify DUT triggered OOM reboot.
         self.wait_until_reboot(duthost, datetime_before_reboot)
         # Wait until all critical processes are healthy.
-        wait_critical_processes(duthost)
+        timeout = 300
+        if len(duthost.frontend_asics) > 1:
+            timeout = 400
+        wait_critical_processes(duthost, timeout)
         self.wait_lc_healthy_if_sup(duthost, duthosts, localhost)
 
     def wait_until_reboot(self, duthost, datetime_before_reboot, timeout=600):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This change increases the stabilization timeout in `test_memory_exhaustion.py` from 300 to 400 seconds.

The default timeout of 300 seconds is occasionally insufficient for multi-ASIC platforms to fully stabilize after the test concludes. These devices run multiple instances of services (e.g., `swss0`, `swss1`), and the increased number of Docker containers requires more time to settle. This adjustment prevents flaky test failures on these specific platforms.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202503

### Approach
#### What is the motivation for this PR?
The `test_memory_exhaustion.py` test was observed to be flaky on DUTs with multiple ASICs. The root cause is that the post-test stabilization period of 300 seconds is not long enough for the increased number of services on these devices to recover, leading to false negatives.

#### How did you do it?
The timeout value within the `test_memory_exhaustion.py` script was increased from 300 to 400 seconds. This provides an additional buffer for all services across all ASICs to return to a stable state post-test.

#### How did you verify/test it?
Verified the fix by running the `test_memory_exhaustion.py` test case on multi-asic DUT where it was previously failing. With the increased timeout, the test now passes consistently.

#### Any platform specific information?
This change primarily affects multi-ASIC platforms, which require more time for system stabilization due to running multiple instances of daemons like `swss`.

#### Supported testbed topology if it's a new test case?
N/A. This is an improvement to an existing test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A. This change modifies a test parameter and does not require a documentation update.