### PR TITLE
Fix test_bgp_suppress_fib failure with ExaBGP4

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -373,22 +373,20 @@ def install_route_from_exabgp(operation, ptfip, route_list, port):
     """
     Install or withdraw ipv4 or ipv6 route by exabgp
     """
-    route_data = []
     url = "http://{}:{}".format(ptfip, port)
     for route in route_list:
-        route_data.append(route)
-    command = "{} attribute next-hop self nlri {}".format(operation, ' '.join(route_data))
-    data = {"command": command}
-    logger.info("url: {}".format(url))
-    logger.info("command: {}".format(data))
-    r = requests.post(url, data=data, timeout=90, proxies={"http": None, "https": None})
-    assert r.status_code == 200, (
-        "HTTP request to ExaBGP API failed with status code {}. URL: {}. Data: {}"
-    ).format(
-        r.status_code,
-        url,
-        data
-    )
+        command = "{} route {} next-hop self".format(operation, route)
+        data = {"command": command}
+        logger.info("url: {}".format(url))
+        logger.info("command: {}".format(data))
+        r = requests.post(url, data=data, timeout=90, proxies={"http": None, "https": None})
+        assert r.status_code == 200, (
+            "HTTP request to ExaBGP API failed with status code {}. URL: {}. Data: {}"
+        ).format(
+            r.status_code,
+            url,
+            data
+        )
 
 
 def announce_route(ptfip, route_list, port, action=ANNOUNCE):


### PR DESCRIPTION
### Description of PR

The PR modifies the ExaBGP announce/withdraw message format to fix the `test_bgp_suppress_fib` failure with ExaBGP4.

Summary:
Fixes #18998 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Fix test that fails on branches that use ExaBGP v4.

#### How did you do it?

See description above.

#### How did you verify/test it?

Manually verified on `Arista-7050CX3-32S-C32`.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA