### PR TITLE
Roll back ceos image version since it's causing multi-asic failure in 202505

### DIFF
--- a/ansible/group_vars/vm_host/ceos.yml
+++ b/ansible/group_vars/vm_host/ceos.yml
@@ -1,11 +1,11 @@
-ceos_image_filename: cEOS64-lab-4.32.5M.tar
-ceos_image_orig: ceosimage:4.32.5M
-ceos_image: ceosimage:4.32.5M-1
+ceos_image_filename: cEOS64-lab-4.29.3M.tar
+ceos_image_orig: ceosimage:4.29.3M
+ceos_image: ceosimage:4.29.3M-1
 # Please update ceos_image_url to the actual URL of the cEOS image file in your environment. If the cEOS image file
 # is not available on test server, the cEOS image file will be downloaded from this URL.
 # The ceos_image_url can be a string as single URL or a list of strings as multiple URLs. If it is a list, the code
 # logic will automatically try each URL in the list
 ceos_image_url:
-  - "http://example1.com/cEOS64-lab-4.32.5M.tar"
-  - "http://example2.com/cEOS64-lab-4.32.5M.tar"
+  - "http://example1.com/cEOS64-lab-4.29.3M.tar"
+  - "http://example2.com/cEOS64-lab-4.29.3M.tar"
 skip_ceos_image_downloading: false

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -151,11 +151,9 @@ bgp/test_bgp_bbr.py:
 
 bgp/test_bgp_gr_helper.py:
   skip:
-    reason: 'bgp graceful restarted is not a supported feature for T2 and skip in KVM for failing with new cEOS image'
-    conditions_logical_operator: or
+    reason: 'bgp graceful restarted is not a supported feature for T2'
     conditions:
       - "'t2' in topo_name"
-      - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/18788"
 
 bgp/test_bgp_multipath_relax.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Previously we updated ceos image version to 4.32.5M to meet the needs of test server OS version upgrade to Ubuntu 24, but it may cause multi-asic failure in 202505
#### How did you do it?
Revert to see if it would help
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
