### PR TITLE
fix: metadata not generate for ixia/tgen topology

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -219,8 +219,12 @@ def test_update_snappi_testbed_metadata(duthosts, tbinfo, request):
     """
     Prepare metadata json for snappi tests, will be stored in metadata/snappi_tests/<tb>.json
     """
-    pytest_require(("tgen" in (request.config.getoption("--topology") or "")),
+    is_ixia_testbed = "tgen" in (request.config.getoption("--topology") or "") \
+        or "tgen" in tbinfo["topo"]["name"] or "ixia" in tbinfo["topo"]["name"]
+
+    pytest_require(is_ixia_testbed,
                    "Skip snappi metadata generation for non-tgen testbed")
+
     metadata = {}
     tbname = tbinfo['conf-name']
     pytest_require(tbname, "skip test due to lack of testbed name.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Since [prepare_dut](https://github.com/sonic-net/sonic-mgmt/blob/202505/tests/run_tests.sh#L306) does not pass in the `--topology tgen`, we need an alternative way to determine if it's tgen or not.

Fixes # (issue) #19277 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Described above
#### How did you do it?
Add extra condition based on topology name to validate if it's ixia/tgen topo
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
