### PR TITLE
[Dualtor] Double the DROP_MARGIN in drop counters test for dualtor

### DIFF
--- a/tests/common/helpers/drop_counters/drop_counters.py
+++ b/tests/common/helpers/drop_counters/drop_counters.py
@@ -133,6 +133,10 @@ def verify_drop_counters(duthosts, asic_index, dut_iface, get_cnt_cli_cmd, colum
         DROP_MARGIN = 0 if mg_facts['minigraph_vlans'] else 10
         for vlan in mg_facts['minigraph_vlans']:
             DROP_MARGIN += len(mg_facts['minigraph_vlans'][vlan]['members'])
+            # For dualtor, we need to double the margin
+            config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+            if config_facts['DEVICE_METADATA']['localhost'].get('subtype', '') == 'DualToR':
+                DROP_MARGIN *= 2
         logger.info(f"The DROP_MARGIN is {DROP_MARGIN}")
         actual_drop = _get_drops_across_all_duthosts()
         for drop in actual_drop:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In PR(https://github.com/sonic-net/sonic-mgmt/pull/14676) , we increased the DROP_MARGIN in the drop counters test for T0 due to noisy packets in the test environment was also counted during the test.
Those packets were send to the dut Vlan and dropped, which increased the drop counter unexpectedly.
For dualtor, we need to double the DROP_MARGIN due to we have 2 duts and sometimes the noisy packets are doubled.

Here is an failure example on dualtor-aa-64-breakout topology, the expected drop counter is 1000, but we got 1046. 
An we have exact 23 interfaces in the Vlan.
```
Failed: 'RX_ERR' drop counter was not incremented on iface Vlan1000. DUT RX_ERR == [46, 1046]; Sent == 1000
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To stabilize the drop counters test on dualtor testbed.
#### How did you do it?

#### How did you verify/test it?
Run the test in regression, failure is not observer again.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
