### PR TITLE
Add topology support for NUT testbeds.

### DIFF
--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -13,6 +13,10 @@
   - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
     when: inventory_hostname not in testbed_facts['duts']
 
+- name: output testbed facts
+  debug:
+    var: testbed_facts
+
 - name: get connection graph if defined for dut
   conn_graph_facts:
     hosts: "{{ testbed_facts['duts'] + testbed_facts['tgs'] }}"

--- a/ansible/vars/nut_topos/nut-2tiers-backend.yml
+++ b/ansible/vars/nut_topos/nut-2tiers-backend.yml
@@ -15,4 +15,8 @@ dut_templates:
     asn_step: 0
     p2p_v4: "10.0.0.0/16"
     p2p_v6: "fc0a::/64"
-tg_template: { type: "BackEndToRRouter", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }
+tg_template:
+  type: "BackEndToRRouter"
+  asn_base: 60001
+  p2p_v4: "10.0.0.0/16"
+  p2p_v6: "fc0a::/64"

--- a/ansible/vars/nut_topos/nut-2tiers-backend.yml
+++ b/ansible/vars/nut_topos/nut-2tiers-backend.yml
@@ -1,0 +1,18 @@
+dut_templates:
+  - name: ".*-t0-.*"
+    type: "BackEndToRRouter"
+    loopback_v4: "10.1.0.0/24"
+    loopback_v6: "2064:100:0:0::/64"
+    asn_base: 64001
+    asn_step: 1
+    p2p_v4: "10.0.0.0/16"
+    p2p_v6: "fc0a::/64"
+  - name: ".*-t1-.*"
+    type: "BackEndLeafRouter"
+    loopback_v4: "10.1.1.0/24"
+    loopback_v6: "2064:100:0:1::/64"
+    asn_base: 65001
+    asn_step: 0
+    p2p_v4: "10.0.0.0/16"
+    p2p_v6: "fc0a::/64"
+tg_template: { type: "BackEndToRRouter", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }

--- a/ansible/vars/nut_topos/nut-2tiers.yml
+++ b/ansible/vars/nut_topos/nut-2tiers.yml
@@ -1,5 +1,5 @@
 dut_templates:
-  - name: "-t0-"
+  - name: ".*-t0-.*"
     type: "ToRRouter"
     loopback_v4: "10.1.0.0/24"
     loopback_v6: "2064:100:0:0::/64"
@@ -7,7 +7,7 @@ dut_templates:
     asn_step: 1
     p2p_v4: "10.0.0.0/16"
     p2p_v6: "fc0a::/64"
-  - name: "-t1-"
+  - name: ".*-t1-.*"
     type: "LeafRouter"
     loopback_v4: "10.1.1.0/24"
     loopback_v6: "2064:100:0:1::/64"
@@ -15,4 +15,8 @@ dut_templates:
     asn_step: 0
     p2p_v4: "10.0.0.0/16"
     p2p_v6: "fc0a::/64"
-tg_template: { type: "ToRRouter", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }
+tg_template:
+  type: "ToRRouter"
+  asn_base: 60001
+  p2p_v4: "10.0.0.0/16"
+  p2p_v6: "fc0a::/64"

--- a/ansible/vars/nut_topos/nut-2tiers.yml
+++ b/ansible/vars/nut_topos/nut-2tiers.yml
@@ -1,0 +1,18 @@
+dut_templates:
+  - name: "-t0-"
+    type: "ToRRouter"
+    loopback_v4: "10.1.0.0/24"
+    loopback_v6: "2064:100:0:0::/64"
+    asn_base: 64001
+    asn_step: 1
+    p2p_v4: "10.0.0.0/16"
+    p2p_v6: "fc0a::/64"
+  - name: "-t1-"
+    type: "LeafRouter"
+    loopback_v4: "10.1.1.0/24"
+    loopback_v6: "2064:100:0:1::/64"
+    asn_base: 65001
+    asn_step: 0
+    p2p_v4: "10.0.0.0/16"
+    p2p_v6: "fc0a::/64"
+tg_template: { type: "ToRRouter", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }

--- a/ansible/vars/nut_topos/nut-single-dut.yml
+++ b/ansible/vars/nut_topos/nut-single-dut.yml
@@ -1,0 +1,10 @@
+dut_templates:
+  - name: ".*"
+    type: "ToRRouter"
+    loopback_v4: "10.1.0.0/24"
+    loopback_v6: "2064:100:0:0::/64"
+    asn_base: 64001
+    asn_step: 1
+    p2p_v4: "10.0.0.0/16"
+    p2p_v6: "fc0a::/64"
+tg_template: { type: "ToRRouter", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }

--- a/ansible/vars/nut_topos/nut-single-dut.yml
+++ b/ansible/vars/nut_topos/nut-single-dut.yml
@@ -7,4 +7,8 @@ dut_templates:
     asn_step: 1
     p2p_v4: "10.0.0.0/16"
     p2p_v6: "fc0a::/64"
-tg_template: { type: "ToRRouter", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }
+tg_template:
+  type: "ToRRouter"
+  asn_base: 60001
+  p2p_v4: "10.0.0.0/16"
+  p2p_v6: "fc0a::/64"


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

When defining the testbeds, it turns to be many testbeds will share the same topology. Repeating this info in all the testbeds is not ideal.

#### How did you do it?

Extracted DUT template and TG template out of the testbed definition and make them a topology for NUT.

#### How did you verify/test it?

Yes, deployed the testbed locally and all passing.

```
./testbed-cli.sh -t testbed.nut.yaml gen-cfg nut-sn5640-stress-1 ixia ../../password.txt
```

![image](https://github.com/user-attachments/assets/d82c0fa7-498c-4d49-a8af-c2b37af50cd7)


#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

NUT testbeds.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Included in PR.
