### PR TITLE
[test_pfcwd_status] skipped generic_config_updater.test_pfcwd_status for non-supported hwsku SN5640 and Arista7060X6PE 

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1490,6 +1490,8 @@ generic_config_updater/test_pfcwd_status.py:
     conditions:
       - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
+      - "hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5600-C224O8',
+                   'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']"
 
 generic_config_updater/test_pg_headroom_update.py:
   skip:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: skipped generic_config_updater.test_pfcwd_status for non-supported hwsku SN5640 and Arista7060X6PE 
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skipped generic_config_updater.test_pfcwd_status for non-supported hwsku SN5640 and Arista7060X6PE 
#### How did you do it?
Add non-supported hwsku to conditional markers
#### How did you verify/test it?
Veried it in sonic mgmt test generic_config_updater.test_pfcwd_status
#### Any platform specific information?
str4-sn5640-3
#### Supported testbed topology if it's a new test case?
t1-isolated-d56u1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
