### PR TITLE
Fall back to config_db if running_golden_config not exists in recovery

### DIFF
--- a/tests/common/plugins/sanity_check/recover.py
+++ b/tests/common/plugins/sanity_check/recover.py
@@ -229,7 +229,13 @@ def adaptive_recover(ptfhost, dut, localhost, fanouthosts, nbrhosts, tbinfo, che
         method = constants.RECOVER_METHODS[outstanding_action]
         wait_time = method['recover_wait']
         if method["reload"]:
-            config_reload(dut, config_source='running_golden_config',
+            running_golden_config_file_check = dut.shell("[ -f /etc/sonic/running_golden_config.json ]",
+                                                         module_ignore_errors=True)
+            if running_golden_config_file_check.get('rc') == 0:
+                config_source = 'running_golden_config'
+            else:
+                config_source = 'config_db'
+            config_reload(dut, config_source=config_source,
                           safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
         elif method["reboot"]:
             reboot_dut(dut, localhost, method["cmd"], reboot_with_running_golden_config=True)
@@ -245,10 +251,6 @@ def recover(ptfhost, dut, localhost, fanouthosts, nbrhosts, tbinfo, check_result
     if method["adaptive"]:
         adaptive_recover(ptfhost, dut, localhost, fanouthosts, nbrhosts, tbinfo, check_results, wait_time)
     elif method["reload"]:
-        # Fall back to config_db if running_golden_config not exists,
-        # For example: golden config is generated after first sanity check
-        # if the recover happens on the pre-sanity of pretest
-        # no running golden config exists
         running_golden_config_file_check = dut.shell("[ -f /etc/sonic/running_golden_config.json ]",
                                                      module_ignore_errors=True)
         if running_golden_config_file_check.get('rc') == 0:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes 33680685
Recover with golden config in pretest always fail.

In sanity check recover, the recover requires running golden config.
But running golden config is generated after sanity check.
Hence the recover in pre-sanity in pretest will always fail because of running golden config doesn't exist:
Image
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix PR test instability.
#### How did you do it?
Fall back to config_db.json if running golden config file not exists.
#### How did you verify/test it?
Verified on physical testbeds
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
