### PR TITLE
(Pending #19429) Add NUT topology support when running the tests

### DIFF
--- a/ansible/testbed.nut.yaml
+++ b/ansible/testbed.nut.yaml
@@ -29,4 +29,5 @@
     - tgen-1
     - tgen-2
   tg_template: { type: "Server", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }
+  tg_api_server: 10.2.0.1:443
   auto_recover: 'True'

--- a/docs/testbed/README.testbed.NUT.md
+++ b/docs/testbed/README.testbed.NUT.md
@@ -21,6 +21,7 @@
 6. [6. Command references](#6-command-references)
    1. [6.1. Generate config: `gen-cfg`](#61-generate-config-gen-cfg)
    2. [6.2. Deploy config: `deploy-cfg`](#62-deploy-config-deploy-cfg)
+   3. [6.3. Run tests](#63-run-tests)
 
 ## 1. Overview
 
@@ -114,6 +115,7 @@ The current testbed yaml definition is not designed to support NUT, so we will c
   tg:
     - tg-1
   tg_template: { type: "Server", asn_base: 60001, p2p_v4: "10.0.0.0/16", p2p_v6: "fc0a::/64" }
+  tg_api_server: 10.2.0.1:443
   inv_name: lab
   auto_recover: 'True'
   comment: "Testbed for NUT with multi-tier topology"
@@ -461,4 +463,13 @@ The configuration will be generated into a few places:
 ```bash
 # ./testbed-cli.sh -t <testbed-yaml-file-path> deploy-cfg <testbed-name> <inventory-name> <password-file>
 ./testbed-cli.sh -t testbed.nut.yaml deploy-cfg nut-testbed-1 ixia ../../password.txt
+```
+
+### 6.3. Run tests
+
+We can directly use the `pytest` module to run the tests against the NUT testbed:
+
+```bash
+# Under tests directory, run:
+python3 -m pytest --inventory <inventory-file> --host-pattern all --testbed nut-testbed-1 --testbed_file ../ansible/testbed.nut.yaml --show-capture=stdout --log-cli-level info <test_file>
 ```

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -141,7 +141,7 @@ def load_dut_basic_facts(inv_name, dut_name):
         dict or None: Return the dut basic facts dict or None if something went wrong.
     """
     results = {}
-    logger.info('Getting dut basic facts')
+    logger.info('Getting dut basic facts: {}'.format(dut_name))
     try:
         inv_full_path = os.path.join(os.path.dirname(__file__), '../../../../ansible', inv_name)
         ansible_cmd = 'ansible -m dut_basic_facts -i {} {} -o'.format(inv_full_path, dut_name)
@@ -227,7 +227,7 @@ def load_minigraph_facts(inv_name, dut_name):
         dict or None: Return the minigraph basic facts dict or None if something went wrong.
     """
     results = {}
-    logger.info('Getting minigraph basic facts')
+    logger.info('Getting minigraph basic facts: {}'.format(dut_name))
     try:
         # get minigraph basic faces
         ansible_cmd = "ansible -m minigraph_facts -i ../ansible/{0} {1} -a host={1}".format(inv_name, dut_name)
@@ -259,7 +259,7 @@ def load_config_facts(inv_name, dut_name):
         dict or None: Return the minigraph basic facts dict or None if something went wrong.
     """
     results = {}
-    logger.info('Getting config basic facts')
+    logger.info('Getting config basic facts: {}'.format(dut_name))
     try:
         # get config basic faces
         ansible_cmd = ['ansible', '-m', 'config_facts', '-i', '../ansible/{}'.format(inv_name),
@@ -296,7 +296,7 @@ def load_switch_capabilities_facts(inv_name, dut_name):
         dict or None: Return the minigraph basic facts dict or None if something went wrong.
     """
     results = {}
-    logger.info('Getting switch capabilities basic facts')
+    logger.info('Getting switch capabilities basic facts: {}'.format(dut_name))
     try:
         # get switch capabilities basic faces
         ansible_cmd = "ansible -m switch_capabilities_facts -i ../ansible/{} {}".format(inv_name, dut_name)
@@ -325,7 +325,7 @@ def load_console_facts(inv_name, dut_name):
         dict or None: Return the minigraph basic facts dict or None if something went wrong.
     """
     results = {}
-    logger.info('Getting console basic facts')
+    logger.info('Getting console basic facts: {}'.format(dut_name))
     try:
         # get console basic faces
         ansible_cmd = "ansible -m console_facts -i ../ansible/{} {}".format(inv_name, dut_name)
@@ -353,6 +353,7 @@ def load_basic_facts(dut_name, session):
     Returns:
         dict: Dict of facts.
     """
+    logger.info("Loading basic facts for DUT: {}".format(dut_name))
     results = {}
 
     testbed_name = session.config.option.testbed

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -39,7 +39,7 @@ def snappi_api_serv_ip(tbinfo):
 
 
 @pytest.fixture(scope="module")
-def snappi_api_serv_port(duthosts, rand_one_dut_hostname):
+def snappi_api_serv_port(tbinfo, duthosts, rand_one_dut_hostname):
     """
     This fixture returns the TCP Port of the Snappi API server.
     Args:
@@ -47,6 +47,9 @@ def snappi_api_serv_port(duthosts, rand_one_dut_hostname):
     Returns:
         snappi API server port.
     """
+    if "tg_api_server" in tbinfo:
+        return tbinfo['tg_api_server'].split(':')[1]
+
     duthost = duthosts[rand_one_dut_hostname]
     return (duthost.host.options['variable_manager'].
             _hostvars[duthost.hostname]['snappi_api_server']['rest_port'])

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -106,16 +106,34 @@ class TestbedInfo(object):
         """Read yaml testbed info file."""
         with open(self.testbed_filename) as f:
             tb_info = yaml.safe_load(f)
-            for tb in tb_info:
-                if "ptf_ip" in tb and tb["ptf_ip"]:
-                    tb["ptf_ip"], tb["ptf_netmask"] = \
-                        self._cidr_to_ip_mask(tb["ptf_ip"])
-                if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
-                    tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
-                        self._cidr_to_ip_mask(tb["ptf_ipv6"])
-                tb["duts"] = tb.pop("dut")
-                tb["duts_map"] = {dut: i for i, dut in enumerate(tb["duts"])}
-                self.testbed_topo[tb["conf-name"]] = tb
+
+            if tb_info is None or len(tb_info) == 0:
+                raise ValueError("Testbed file {} is empty".format(self.testbed_filename))
+
+            tb_type = "regular" if "conf-name" in tb_info[0] else "nut"
+            if tb_type == "nut":
+                self._read_nut_testbed_topo_from_yaml(tb_info)
+            else:
+                self._read_regular_testbed_topo_from_yaml(tb_info)
+
+    def _read_regular_testbed_topo_from_yaml(self, tb_info):
+        for tb in tb_info:
+            if "ptf_ip" in tb and tb["ptf_ip"]:
+                tb["ptf_ip"], tb["ptf_netmask"] = \
+                    self._cidr_to_ip_mask(tb["ptf_ip"])
+            if "ptf_ipv6" in tb and tb["ptf_ipv6"]:
+                tb["ptf_ipv6"], tb["ptf_netmask_v6"] = \
+                    self._cidr_to_ip_mask(tb["ptf_ipv6"])
+            tb["duts"] = tb.pop("dut")
+            tb["duts_map"] = {dut: i for i, dut in enumerate(tb["duts"])}
+            self.testbed_topo[tb["conf-name"]] = tb
+
+    def _read_nut_testbed_topo_from_yaml(self, tb_info):
+        for tb in tb_info:
+            tb["conf-name"] = tb["name"]
+            tb["topo"] = "nut"
+            tb["ptf_ip"] = tb["tg_api_server"].split(':')[0]
+            self.testbed_topo[tb["conf-name"]] = tb
 
     def dump_testbeds_to_yaml(self, args=""):
 
@@ -256,7 +274,7 @@ class TestbedInfo(object):
 
     def get_testbed_type(self, topo_name):
         pattern = re.compile(
-            r'^(wan|t0|t1|ptf|fullmesh|dualtor|ciscovs|t2|lt2|ft2|tgen|mgmttor|m0|mc0|mx|m1|dpu|ptp|smartswitch)'
+            r'^(wan|t0|t1|ptf|fullmesh|dualtor|ciscovs|t2|lt2|ft2|tgen|mgmttor|m0|mc0|mx|m1|dpu|ptp|smartswitch|nut)'
         )
         match = pattern.match(topo_name)
         if match is None:
@@ -363,13 +381,15 @@ class TestbedInfo(object):
             tb["topo"] = defaultdict()
             tb["topo"]["name"] = topo
             tb["topo"]["type"] = self.get_testbed_type(topo)
-            topo_dir = os.path.join(os.path.dirname(__file__), self.TOPOLOGY_FILEPATH)
-            topo_file = os.path.join(topo_dir, "topo_{}.yml".format(topo))
-            with open(topo_file, 'r') as fh:
-                tb['topo']['properties'] = yaml.safe_load(fh)
-            tb['topo']['ptf_map'] = self.calculate_ptf_index_map(tb)
-            tb['topo']['ptf_map_disabled'] = self.calculate_ptf_index_map_disabled(tb)
-            tb['topo']['ptf_dut_intf_map'] = self.calculate_ptf_dut_intf_map(tb)
+
+            if topo != "nut":
+                topo_dir = os.path.join(os.path.dirname(__file__), self.TOPOLOGY_FILEPATH)
+                topo_file = os.path.join(topo_dir, "topo_{}.yml".format(topo))
+                with open(topo_file, 'r') as fh:
+                    tb['topo']['properties'] = yaml.safe_load(fh)
+                tb['topo']['ptf_map'] = self.calculate_ptf_index_map(tb)
+                tb['topo']['ptf_map_disabled'] = self.calculate_ptf_index_map_disabled(tb)
+                tb['topo']['ptf_dut_intf_map'] = self.calculate_ptf_dut_intf_map(tb)
 
 
 if __name__ == "__main__":

--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -26,6 +26,7 @@ class TestbedInfo(object):
                                   'ptf_ip', 'ptf_ipv6', 'server', 'vm_base', 'dut',
                                   'inv_name', 'auto_recover', 'is_smartswitch', 'comment')
     TOPOLOGY_FILEPATH = "../../ansible/vars/"
+    NUT_TOPOLOGY_FILEPATH = "../../ansible/vars/nut_topos"
 
     def __init__(self, testbed_file):
         if testbed_file.endswith(".csv"):
@@ -131,7 +132,6 @@ class TestbedInfo(object):
     def _read_nut_testbed_topo_from_yaml(self, tb_info):
         for tb in tb_info:
             tb["conf-name"] = tb["name"]
-            tb["topo"] = "nut"
             tb["ptf_ip"] = tb["tg_api_server"].split(':')[0]
             self.testbed_topo[tb["conf-name"]] = tb
 
@@ -382,7 +382,12 @@ class TestbedInfo(object):
             tb["topo"]["name"] = topo
             tb["topo"]["type"] = self.get_testbed_type(topo)
 
-            if topo != "nut":
+            if topo.startswith("nut-"):
+                topo_dir = os.path.join(os.path.dirname(__file__), self.NUT_TOPOLOGY_FILEPATH)
+                topo_file = os.path.join(topo_dir, "{}.yml".format(topo))
+                with open(topo_file, 'r') as fh:
+                    tb['topo']['properties'] = yaml.safe_load(fh)
+            else:
                 topo_dir = os.path.join(os.path.dirname(__file__), self.TOPOLOGY_FILEPATH)
                 topo_file = os.path.join(topo_dir, "topo_{}.yml".format(topo))
                 with open(topo_file, 'r') as fh:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -780,6 +780,8 @@ def ptfhosts(enhance_inventory, ansible_adhoc, tbinfo, duthost, request):
     _hosts = []
     if 'ptp' in tbinfo['topo']['name']:
         return None
+    if 'nut' in tbinfo['topo']['name']:
+        return None
     if "ptf_image_name" in tbinfo and "docker-keysight-api-server" in tbinfo["ptf_image_name"]:
         return None
     if "ptf" in tbinfo:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -927,13 +927,18 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
 
 
 @pytest.fixture(scope="module")
-def fanouthosts(enhance_inventory, ansible_adhoc, conn_graph_facts, creds, duthosts):      # noqa: F811
+def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, creds, duthosts):      # noqa: F811
     """
     Shortcut fixture for getting Fanout hosts
     """
 
     dev_conn = conn_graph_facts.get('device_conn', {})
     fanout_hosts = {}
+
+    if tbinfo['topo']['name'] == 'nut':
+        # Nut topology has no fanout
+        return fanout_hosts
+
     # WA for virtual testbed which has no fanout
     for dut_host, value in list(dev_conn.items()):
         duthost = duthosts[dut_host]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -780,7 +780,7 @@ def ptfhosts(enhance_inventory, ansible_adhoc, tbinfo, duthost, request):
     _hosts = []
     if 'ptp' in tbinfo['topo']['name']:
         return None
-    if 'nut' in tbinfo['topo']['name']:
+    if tbinfo['topo']['name'].startswith("nut-"):
         return None
     if "ptf_image_name" in tbinfo and "docker-keysight-api-server" in tbinfo["ptf_image_name"]:
         return None
@@ -935,7 +935,7 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
     dev_conn = conn_graph_facts.get('device_conn', {})
     fanout_hosts = {}
 
-    if tbinfo['topo']['name'] == 'nut':
+    if tbinfo['topo']['name'].startswith('nut-'):
         # Nut topology has no fanout
         return fanout_hosts
 

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -219,8 +219,9 @@ def test_update_snappi_testbed_metadata(duthosts, tbinfo, request):
     """
     Prepare metadata json for snappi tests, will be stored in metadata/snappi_tests/<tb>.json
     """
-    pytest_require(("tgen" in (request.config.getoption("--topology") or "")),
-                   "Skip snappi metadata generation for non-tgen testbed")
+    topology = request.config.getoption("--topology") or ""
+    pytest_require("tgen" in topology or "nut" in topology,
+                   "Skip snappi metadata generation for non-tgen and non-nut testbed")
     metadata = {}
     tbname = tbinfo['conf-name']
     pytest_require(tbname, "skip test due to lack of testbed name.")


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

When topology being extracted in the NUT testbed tools, the run test tool also needs to be updated for running the tests.

#### How did you do it?

Updated conftest.py and testbed.py to support the topology parsing.

#### How did you verify/test it?

Run locally.

#### Any platform specific information?

No.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Doc is already included in the add topo support.