### PR TITLE
[ssw][ha] add loopback0 config to DUT in topo file

### DIFF
--- a/ansible/vars/topo_t1-smartswitch-ha.yml
+++ b/ansible/vars/topo_t1-smartswitch-ha.yml
@@ -61,6 +61,14 @@ topology:
         - "0.11@22"
         - "1.11@23"
       vm_offset: 11
+  DUT:
+    loopback:
+      ipv4:
+        - 10.1.0.32/32
+        - 10.1.0.33/32
+      ipv6:
+        - FC00:1:0:32::/128
+        - FC00:1:0:33::/128
 
 
 configuration_properties:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Default loopback address is identical on all DUTs. Need to explicitly set it to a different value on 2 DUTs, otherwise tunnel won't work. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Tested on internal testbed with deploy-mg. Loopback0 was configured as expected. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
