### PR TITLE
[sanity_check] Fix bgp recovery for multi-asic devices

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -185,7 +185,12 @@ def check_bgp(duthosts, tbinfo):
         def _restart_bgp(dut):
             # Restart BGP service
             try:
-                dut.command("systemctl restart bgp.service")
+                if dut.is_multi_asic:
+                    with SafeThreadPoolExecutor(max_workers=8) as executor:
+                        for asic in range(dut.num_asics()):
+                            executor.submit(dut.command, f"systemctl restart bgp@{asic}.service")
+                else:
+                    dut.command("systemctl restart bgp.service")
             except RunAnsibleModuleFail as e:
                 logger.error("Failed to restart BGP service on %s: %s" % (dut.hostname, str(e)))
                 return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #33668010
systemctl restart bgp.service fails on multi-asic devices.
Enhacne and add compatible logic for multi-asic devices.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
systemctl restart bgp.service fails on multi-asic devices.

#### How did you do it?
Enhacne and add compatible logic for multi-asic devices.
#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/686a3db4c452a23450444da8?testcase=test_pretest.py%7C%7C%7Cvms-kvm-four-asic-t1-lag_219086&type=log
![image](https://github.com/user-attachments/assets/0cd28ad5-c4fe-4c33-88d3-629c8cc1f306)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
