### PR TITLE
[dualtor] Skip warm/fast reboot cases on dualtor

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1303,9 +1303,11 @@ gnmi/test_gnoi_killprocess.py:
 
 gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
   skip:
-    reason: "Warm reboot should only run on t0 topology"
+    reason: "Warm reboot should only run on t0 topology but not on dualtor"
+    conditions_logical_operator: or
     conditions:
       - "topo_type not in ['t0']"
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 #######################################
 #####           hash              #####
@@ -1800,6 +1802,18 @@ mvrf/test_mgmtvrf.py:
       - "asic_type in ['vs']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0']"
+
+mvrf/test_mgmtvrf.py::TestReboot::test_fastboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
+mvrf/test_mgmtvrf.py::TestReboot::test_warmboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 #######################################
 #####           nat               #####
@@ -2405,6 +2419,18 @@ sflow/test_sflow.py:
     conditions:
       - "asic_type in ['vs']"
 
+sflow/test_sflow.py::TestReboot::testFastreboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
+sflow/test_sflow.py::TestReboot::testWarmreboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
 #######################################
 #####      show_techsupport       #####
 #######################################
@@ -2862,6 +2888,18 @@ vrf/test_vrf.py::TestVrfAclRedirect:
     conditions:
       - "'switch' in vars() and len([capabilities for capabilities in switch.values() if 'REDIRECT_ACTION' in capabilities]) == 0"
       - "asic_type in ['vs']"
+
+vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_swss_warm_reboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
+
+vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_system_warm_reboot:
+  skip:
+    reason: "Dualtor topology doesn't support advanced-reboot"
+    conditions:
+      - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
 
 vrf/test_vrf_attr.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip warm/fast reboot cases on dualtor.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add those cases to the conditional mark skip list.
```
vrf.test_vrf.TestVrfWarmReboot.test_vrf_swss_warm_reboot
vrf.test_vrf.TestVrfWarmReboot.test_vrf_system_warm_reboot
gnmi.test_gnoi_system_reboot.test_gnoi_system_reboot_warm
mvrf.test_mgmtvrf.TestReboot.test_warmboot
mvrf.test_mgmtvrf.TestReboot.test_fastboot
sflow.test_sflow.TestReboot.testFastreboot
sflow.test_sflow.TestReboot.testWarmreboot
```

#### How did you verify/test it?
```
mvrf/test_mgmtvrf.py::TestReboot::test_fastboot SKIPPED (Dualtor topology doesn't support warm-reboot)           [100%]
mvrf/test_mgmtvrf.py::TestReboot::test_warmboot SKIPPED (Dualtor topology doesn't support warm-reboot)           [100%]
sflow/test_sflow.py::TestReboot::testFastreboot SKIPPED (Dualtor topology doesn't support warm-reboot)           [100%]
sflow/test_sflow.py::TestReboot::testWarmreboot SKIPPED (Dualtor topology doesn't support warm-reboot)           [100%]
vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_swss_warm_reboot SKIPPED (Dualtor topology doesn't support warm-reboot)                                                                                                          [100%]
vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_system_warm_reboot SKIPPED (Dualtor topology doesn't support warm-reboot)                                                                                                          [100%]
gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm SKIPPED (Warm reboot should only run on t0 topology but not on dualtor)                                                          [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
