### PR TITLE
Fix NTP test failures due to unsynchronized clock

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -40,6 +40,12 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     ptfhost.lineinfile(
         path=ntp_conf_path, line="#pool 3.debian.pool.ntp.org iburst", regexp="^pool.*3.debian.*pool.*ntp.*org.*")
 
+    # Comment out the tos minclock minsane option line
+    # Having this option enabled can cause the NTP server to not synchronize
+    # with the PTF host, which can lead to test failures.
+    ptfhost.lineinfile(
+        path=ntp_conf_path, line="#tos minclock 4 minsane 3", regexp="^tos.*minclock.*minsane.*")
+
     ptfhost.lineinfile(path=ntp_conf_path, line="server 127.127.1.0 prefer")
 
     # restart ntp server


### PR DESCRIPTION
### Description of PR

The PR contains fix for failed NTP testcases on Bookworm based PTF image. The NTPSec daemon on Bookworm has "tos minclock 4 minsane 3" configuration line which requires at least 4 clocks to be available before `ntpstat` reports synchronized status. Since we use local clock, the line is commented.

Applicable only to `docker-ptf` images that are based on Bookworm.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Fix NTP test failures.

#### How did you do it?

See description

#### How did you verify/test it?

Manually in VS test testbed.

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA