### PR TITLE
[Snappi] Fix tx/rx port sequence in test_pfc_port_congestion.py

### DIFF
--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -102,6 +102,9 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
         testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
                                                                                   snappi_ports,
                                                                                   snappi_api)
+    enable_pfcwd = True
+    if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
+        enable_pfcwd = False
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -116,7 +119,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_diff_dist_'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': False,
+                'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,
@@ -237,6 +240,9 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
         testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
                                                                                   snappi_ports,
                                                                                   snappi_api)
+    enable_pfcwd = True
+    if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
+        enable_pfcwd = False
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -252,7 +258,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_uni_dist_full'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': False,
+                'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,
@@ -375,6 +381,9 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
         testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
                                                                                   snappi_ports,
                                                                                   snappi_api)
+    enable_pfcwd = True
+    if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
+        enable_pfcwd = False
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -390,7 +399,7 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_equal_dist'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': False,
+                'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,
@@ -514,6 +523,9 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
         testbed_config, port_config_list, snappi_ports = snappi_multi_base_config(duthosts,
                                                                                   snappi_ports,
                                                                                   snappi_api)
+    enable_pfcwd = True
+    if duthosts[0].facts["platform_asic"] == 'cisco-8000' and duthosts[0].get_facts().get("modular_chassis"):
+        enable_pfcwd = False
 
     # Percentage drop expected for lossless and lossy traffic.
     # speed_tol is speed tolerance between egress link speed and actual speed.
@@ -529,7 +541,7 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_non_cngstn_'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': False,
+                'enable_pfcwd': enable_pfcwd,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,

--- a/tests/snappi_tests/pfc/test_pfc_port_congestion.py
+++ b/tests/snappi_tests/pfc/test_pfc_port_congestion.py
@@ -73,8 +73,8 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
     pkt_size = 1024
 
     for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
+        rx_port_count = port_map[0]
+        tx_port_count = port_map[2]
         tmp_snappi_port_list = get_snappi_ports
         snappi_port_list = []
         for item in tmp_snappi_port_list:
@@ -116,7 +116,7 @@ def test_multiple_prio_diff_dist(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_diff_dist_'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': True,
+                'enable_pfcwd': False,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,
@@ -208,8 +208,8 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
     pkt_size = 1024
 
     for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
+        rx_port_count = port_map[0]
+        tx_port_count = port_map[2]
         tmp_snappi_port_list = get_snappi_ports
         snappi_port_list = []
         for item in tmp_snappi_port_list:
@@ -252,7 +252,7 @@ def test_multiple_prio_uni_dist(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_uni_dist_full'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': True,
+                'enable_pfcwd': False,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,
@@ -346,8 +346,8 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
     pkt_size = 1024
 
     for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
+        rx_port_count = port_map[0]
+        tx_port_count = port_map[2]
         tmp_snappi_port_list = get_snappi_ports
         snappi_port_list = []
         for item in tmp_snappi_port_list:
@@ -390,7 +390,7 @@ def test_multiple_prio_equal_dist(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_equal_dist'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': True,
+                'enable_pfcwd': False,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,
@@ -485,8 +485,8 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
     pkt_size = 1024
 
     for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = port_map[0]
-        rx_port_count = port_map[2]
+        rx_port_count = port_map[0]
+        tx_port_count = port_map[2]
         tmp_snappi_port_list = get_snappi_ports
         snappi_port_list = []
         for item in tmp_snappi_port_list:
@@ -529,7 +529,7 @@ def test_multiple_prio_non_cngtn(snappi_api,                   # noqa: F811
                 'test_type': '/tmp/Two_Ingress_Single_Egress_non_cngstn_'+str(port_map[1])+'Gbps',
                 'line_card_choice': testbed_subtype,
                 'port_map': port_map,
-                'enable_pfcwd': True,
+                'enable_pfcwd': False,
                 'enable_credit_wd': True,
                 'stats_interval': 60,
                 'background_traffic': True,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the following issues in test_pfc_port_congestion.py:
1. Fixed the rx/tx port sequence,  the currnet port_map is defined as [total egress port, egress port speed, total ingress ports, ingress port speed]. So get the rx port info from the first two elements.
2. pfcwd will be triggered on cisco platform as we are sending oversubscribed traffic, so disabling it during the test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Adopt this test case for 400G speed

#### How did you do it?
Fixed the case to use correct RX/TX port_map sequence. and disable pfcwd inside the test case.

#### How did you verify/test it?
```
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_diff_dist[multidut_port_info0-port_map0] SKIPPED [  6%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_diff_dist[multidut_port_info0-port_map1] 
-------------------------------- live log call ---------------------------------
05:07:37 connection._warn                         L0332 WARNING| Verification of certificates is disabled
05:07:37 connection._warn                         L0332 WARNING| Unable to connect to http://10.206.144.17:443.
PASSED                                                                   [ 12%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_diff_dist[multidut_port_info1-port_map0] SKIPPED [ 18%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_diff_dist[multidut_port_info1-port_map1] PASSED [ 25%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_uni_dist[multidut_port_info0-port_map0] SKIPPED [ 31%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_uni_dist[multidut_port_info0-port_map1] PASSED [ 37%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_uni_dist[multidut_port_info1-port_map0] SKIPPED [ 43%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_uni_dist[multidut_port_info1-port_map1] PASSED [ 50%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_equal_dist[multidut_port_info0-port_map0] SKIPPED [ 56%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_equal_dist[multidut_port_info0-port_map1] PASSED [ 62%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_equal_dist[multidut_port_info1-port_map0] SKIPPED [ 68%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_equal_dist[multidut_port_info1-port_map1] PASSED [ 75%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_non_cngtn[multidut_port_info0-port_map0] SKIPPED [ 81%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_non_cngtn[multidut_port_info0-port_map1] PASSED [ 87%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_non_cngtn[multidut_port_info1-port_map0] SKIPPED [ 93%]
snappi_tests/pfc/test_pfc_port_congestion.py::test_multiple_prio_non_cngtn[multidut_port_info1-port_map1] PASSED [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
