### PR TITLE
Enable orch_northbond_route_zmq_enabled feature in sonic-mgmt test.

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -406,10 +406,10 @@ class GenerateGoldenConfigDBModule(object):
 
         # Older version image may not support ZMQ feature flag
         rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
-        if "orch_northbond_dash_zmq_enabled" in out: 
+        if "orch_northbond_dash_zmq_enabled" in out:
             ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_dash_zmq_enabled"] = "true"
 
-        if "orch_northbond_route_zmq_enabled" in out: 
+        if "orch_northbond_route_zmq_enabled" in out:
             ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
 
         return json.dumps(ori_config_db, indent=4)

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -483,9 +483,6 @@ class GenerateGoldenConfigDBModule(object):
                 }
             })
 
-        # enable orch_northbond_route_zmq_enabled feature
-        config = self.update_zmq_config(config)
-
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)
         with open(GOLDEN_CONFIG_DB_PATH_ORI, "w") as temp_file:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -403,9 +403,15 @@ class GenerateGoldenConfigDBModule(object):
             ori_config_db["DEVICE_METADATA"] = {}
         if "localhost" not in ori_config_db["DEVICE_METADATA"]:
             ori_config_db["DEVICE_METADATA"]["localhost"] = {}
-        if "orch_northbond_route_zmq_enabled" not in ori_config_db["DEVICE_METADATA"]["localhost"]:
-            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = {}
-        ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
+
+        # Older version image may not support ZMQ feature flag
+        rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
+        if "orch_northbond_dash_zmq_enabled" in out: 
+            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_dash_zmq_enabled"] = "true"
+
+        if "orch_northbond_route_zmq_enabled" in out: 
+            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
+
         return json.dumps(ori_config_db, indent=4)
 
     def generate_lt2_ft2_golden_config_db(self):

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -448,6 +448,9 @@ class GenerateGoldenConfigDBModule(object):
                 }
             })
 
+        # enable orch_northbond_route_zmq_enabled feature
+        golden_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
+            
         with open(GOLDEN_CONFIG_DB_PATH, "w") as temp_file:
             temp_file.write(config)
         with open(GOLDEN_CONFIG_DB_PATH_ORI, "w") as temp_file:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -383,7 +383,7 @@ class GenerateGoldenConfigDBModule(object):
         else:
             return config
 
-    def generate_default_golden_config_db(self):
+    def generate_default_init_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
         if rc != 0:
             self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
@@ -451,7 +451,7 @@ class GenerateGoldenConfigDBModule(object):
             module_msg = module_msg + " for full lossy hwsku"
             config = self.generate_full_lossy_golden_config_db()
         else:
-            config = self.generate_default_golden_config_db()
+            config = self.generate_default_init_config_db()
 
         # update ZMQ config
         config = self.update_zmq_config(config)

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -404,6 +404,10 @@ class GenerateGoldenConfigDBModule(object):
         if "localhost" not in ori_config_db["DEVICE_METADATA"]:
             ori_config_db["DEVICE_METADATA"]["localhost"] = {}
 
+        # hack docker_routing_config_mode issue, multiasic test failed because this field is 'None', which break yang validation.
+        if "docker_routing_config_mode" not in ori_config_db["DEVICE_METADATA"]["localhost"]:
+                ori_config_db["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"
+
         # Older version image may not support ZMQ feature flag
         rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
         if "orch_northbond_dash_zmq_enabled" in out:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -395,11 +395,6 @@ class GenerateGoldenConfigDBModule(object):
         if "DEVICE_METADATA" in ori_config_db:
             golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
 
-        if "DEVICE_METADATA" not in golden_config_db:
-            golden_config_db["DEVICE_METADATA"] = {}
-        if "localhost" not in golden_config_db["DEVICE_METADATA"]:
-            golden_config_db["DEVICE_METADATA"]["localhost"] = {}
-
         return json.dumps(golden_config_db, indent=4)
 
     def update_zmq_config(self, config):
@@ -409,15 +404,8 @@ class GenerateGoldenConfigDBModule(object):
         if "localhost" not in ori_config_db["DEVICE_METADATA"]:
             ori_config_db["DEVICE_METADATA"]["localhost"] = {}
 
-        # multiasic test failed because this field is 'None', which break yang validation.
-        if "docker_routing_config_mode" not in ori_config_db["DEVICE_METADATA"]["localhost"]:
-            ori_config_db["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"
-
         # Older version image may not support ZMQ feature flag
         rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
-        if "orch_northbond_dash_zmq_enabled" in out:
-            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_dash_zmq_enabled"] = "true"
-
         if "orch_northbond_route_zmq_enabled" in out:
             ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
 
@@ -464,6 +452,9 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_full_lossy_golden_config_db()
         else:
             config = self.generate_default_golden_config_db()
+
+        # update ZMQ config
+        config = self.update_zmq_config(config)
 
         # update dns config
         config = self.update_dns_config(config)

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -404,9 +404,9 @@ class GenerateGoldenConfigDBModule(object):
         if "localhost" not in ori_config_db["DEVICE_METADATA"]:
             ori_config_db["DEVICE_METADATA"]["localhost"] = {}
 
-        # hack docker_routing_config_mode issue, multiasic test failed because this field is 'None', which break yang validation.
+        # multiasic test failed because this field is 'None', which break yang validation.
         if "docker_routing_config_mode" not in ori_config_db["DEVICE_METADATA"]["localhost"]:
-                ori_config_db["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"
+            ori_config_db["DEVICE_METADATA"]["localhost"]["docker_routing_config_mode"] = "unified"
 
         # Older version image may not support ZMQ feature flag
         rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -396,7 +396,7 @@ class GenerateGoldenConfigDBModule(object):
             golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
 
         return json.dumps(golden_config_db, indent=4)
-    
+
     def update_zmq_config(self, config):
         ori_config_db = json.loads(config)
         if "DEVICE_METADATA" not in ori_config_db:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -395,6 +395,11 @@ class GenerateGoldenConfigDBModule(object):
         if "DEVICE_METADATA" in ori_config_db:
             golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
 
+        if "DEVICE_METADATA" not in golden_config_db:
+            golden_config_db["DEVICE_METADATA"] = {}
+        if "localhost" not in golden_config_db["DEVICE_METADATA"]:
+            golden_config_db["DEVICE_METADATA"]["localhost"] = {}
+
         return json.dumps(golden_config_db, indent=4)
 
     def update_zmq_config(self, config):


### PR DESCRIPTION
Enable orch_northbond_route_zmq_enabled feature in sonic-mgmt test.

#### Why I did it
Test orch_northbond_route_zmq_enabled in PR validation and nightly test.

##### Work item tracking
- Microsoft ADO **(number only)**: 32582830

#### How I did it
Enable orch_northbond_route_zmq_enabled in golden config.

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Enable orch_northbond_route_zmq_enabled feature in sonic-mgmt test.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


