### PR TITLE
Skip SRv6 test_srv6_static_config.py::test_uDT46_config test on mellanox platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2435,6 +2435,12 @@ srv6/test_srv6_static_config.py:
     conditions:
       - "release not in ['202412']"
 
+srv6/test_srv6_static_config.py::test_uDT46_config:
+  skip:
+    reason: "Unsupported platform"
+    conditions:
+      - "asic_type in ['mellanox']"
+
 srv6/test_srv6_vlan_forwarding.py:
   skip:
     reason: "Only target mellanox/brcm platform with 202412 image at this time"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Skip SRv6 uDT46 test on mellanox platform
Due to not support in design

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip SRv6 uDT46 test on mellanox platform
Due to not support in design

#### How did you do it?
Skip SRv6 uDT46 test on mellanox platform
#### How did you verify/test it?
Added it into skip list locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
