### PR TITLE
[Snappi]: Modified PFCWD testcases with tgen-port-info support

### DIFF
--- a/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
@@ -1,76 +1,62 @@
 import pytest
 import random
 import logging
-from tests.common.helpers.assertions import pytest_require                               # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                              # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
-    fanout_graph_facts_multidut     # noqa: F401
+    fanout_graph_facts_multidut                                                                         # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
-    get_snappi_ports_multi_dut, is_snappi_multidut, \
-    snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,\
-    lossless_prio_list, lossy_prio_list     # noqa: F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+    get_snappi_ports_multi_dut, is_snappi_multidut, snappi_port_selection, tgen_port_info, \
+    snappi_api, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config                             # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, \
+    lossless_prio_list, lossy_prio_list                                                                 # noqa: F401
 from tests.snappi_tests.pfcwd.files.pfcwd_burst_storm_helper import run_pfcwd_burst_storm_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,             # noqa: F811
-                                                conn_graph_facts,       # noqa: F811
-                                                fanout_graph_facts_multidut,     # noqa: F811
+@pytest.fixture(autouse=True, scope='module')
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
+def test_pfcwd_burst_storm_single_lossless_prio(snappi_api,                     # noqa: F811
+                                                conn_graph_facts,               # noqa: F811
+                                                fanout_graph_facts_multidut,    # noqa: F811
                                                 duthosts,
-                                                lossless_prio_list,    # noqa: F811
-                                                get_snappi_ports,    # noqa: F811
-                                                tbinfo,      # noqa: F811
-                                                multidut_port_info,
-                                                prio_dscp_map,               # noqa: F811
+                                                lossless_prio_list,             # noqa: F811
+                                                get_snappi_ports,               # noqa: F811
+                                                tbinfo,                         # noqa: F811
+                                                tgen_port_info,                 # noqa: F811
+                                                number_of_tx_rx_ports,          # noqa: F811
+                                                prio_dscp_map,                  # noqa: F811
                                                 ):
 
     """
-    Test PFC watchdog under bursty PFC storms on a single lossless priority
+    Test PFC watchdog under bursty PFC storms on a single lossless priority.
+    PFC storms are sent for duration of half of the PFCWD detection interval.
+    PFC storms are spaced at twice the PFCWD detection interval.
+    Expectation is that PFCWD Storm will not be set as PFC duration is less than detection interval.
+    Packets of lossless priorities will be queued on DUT due to PFCs and sent to egress once PFC storm stops.
 
     Args:
         snappi_api (pytest fixture): SNAPPI session
         conn_graph_facts (pytest fixture): connection graph
         fanout_graph_facts_multidut (pytest fixture): fanout graph
         duthosts (pytest fixture): list of DUTs
-        rand_one_dut_lossless_prio (str): name of lossless priority to test, e.g., 's6100-1|3'
-        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority)
-        lossy_prio_list (pytest fixture): list of lossy priorities
-        tbinfo (pytest fixture): fixture provides information about testbed
+        lossless_prio_list (pytest fixture): list of lossless priorities.
         get_snappi_ports (pytest fixture): gets snappi ports and connected DUT port info and returns as a list
+        tbinfo (pytest fixture): fixture provides information about testbed
+        tgen_port_info (pytest fixture): fixture provides list of interfaces of appropriate speed and sub-type.
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority)
 
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    for port in snappi_ports:
+        logger.info('Snappi ports selected for test:{}'.format(port['peer_port']))
 
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])

--- a/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
@@ -1,35 +1,39 @@
 import pytest
 import random
 import logging
-from tests.common.helpers.assertions import pytest_require                                # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                  # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
-    fanout_graph_facts_multidut     # noqa: F401
+    fanout_graph_facts_multidut                                                             # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
-    get_snappi_ports_single_dut, snappi_testbed_config, \
-    get_snappi_ports_multi_dut, is_snappi_multidut, \
-    snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list,\
-    lossless_prio_list, lossy_prio_list     # noqa: F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+    get_snappi_ports_single_dut, snappi_testbed_config, snappi_dut_base_config, \
+    get_snappi_ports_multi_dut, is_snappi_multidut, snappi_port_selection, tgen_port_info, \
+    snappi_api, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config                 # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, \
+    lossless_prio_list, lossy_prio_list                                                     # noqa: F401
 from tests.snappi_tests.pfcwd.files.pfcwd_multi_node_helper import run_pfcwd_multi_node_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
+@pytest.fixture(autouse=True, scope='module')
+def number_of_tx_rx_ports():
+    yield (2, 1)
+
+
 @pytest.mark.parametrize("trigger_pfcwd", [True, False])
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_pfcwd_many_to_one(snappi_api,              # noqa: F811
-                           conn_graph_facts,        # noqa: F811
-                           fanout_graph_facts_multidut,      # noqa: F811
+def test_pfcwd_many_to_one(snappi_api,                      # noqa: F811
+                           conn_graph_facts,                # noqa: F811
+                           fanout_graph_facts_multidut,     # noqa: F811
                            duthosts,
-                           lossless_prio_list,    # noqa: F811
-                           get_snappi_ports,    # noqa: F811
-                           tbinfo,      # noqa: F811
-                           multidut_port_info,
+                           lossless_prio_list,              # noqa: F811
+                           get_snappi_ports,                # noqa: F811
+                           tgen_port_info,                  # noqa: F811
+                           tbinfo,                          # noqa: F811
                            trigger_pfcwd,
-                           prio_dscp_map,               # noqa: F811
-                           lossy_prio_list,):           # noqa: F811
+                           prio_dscp_map,                   # noqa: F811
+                           number_of_tx_rx_ports,           # noqa: F811
+                           lossy_prio_list,):               # noqa: F811
 
     """
     Run multidut PFC watchdog test under many to one traffic pattern
@@ -49,31 +53,9 @@ def test_pfcwd_many_to_one(snappi_api,              # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 2
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 3 ports defined in ansible/files/*links.csv file")
-
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    for port in snappi_ports:
+        logger.info('Snappi port selected for test:{}'.format(port['peer_port']))
 
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])

--- a/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
@@ -1,31 +1,34 @@
 import pytest
 import logging
-from tests.common.helpers.assertions import pytest_require                           # noqa: F401
+from tests.common.helpers.assertions import pytest_require                                          # noqa: F401
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts, \
-    fanout_graph_facts_multidut     # noqa: F401
+    fanout_graph_facts_multidut                                                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
-    get_snappi_ports_multi_dut, is_snappi_multidut, \
-    snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map                                        # noqa: F401
-from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+    get_snappi_ports_multi_dut, is_snappi_multidut, snappi_port_selection, tgen_port_info, \
+    snappi_api, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config                         # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map                                    # noqa: F401
 from tests.snappi_tests.pfcwd.files.\
     pfcwd_runtime_traffic_helper import run_pfcwd_runtime_traffic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 logger = logging.getLogger(__name__)
-
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
 
 
-@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
-def test_pfcwd_runtime_traffic(snappi_api,                  # noqa: F811
-                               conn_graph_facts,            # noqa: F811
-                               fanout_graph_facts_multidut,          # noqa: F811
+@pytest.fixture(autouse=True, scope='module')
+def number_of_tx_rx_ports():
+    yield (1, 1)
+
+
+def test_pfcwd_runtime_traffic(snappi_api,                      # noqa: F811
+                               conn_graph_facts,                # noqa: F811
+                               fanout_graph_facts_multidut,     # noqa: F811
                                duthosts,
-                               prio_dscp_map,               # noqa: F811
-                               get_snappi_ports,     # noqa: F811
-                               tbinfo,      # noqa: F811
-                               multidut_port_info,   # noqa: F811
+                               prio_dscp_map,                   # noqa: F811
+                               get_snappi_ports,                # noqa: F811
+                               tbinfo,                          # noqa: F811
+                               tgen_port_info,                  # noqa: F811
+                               number_of_tx_rx_ports,           # noqa: F811
                                ):
     """
     Test PFC watchdog's impact on runtime traffic
@@ -42,31 +45,9 @@ def test_pfcwd_runtime_traffic(snappi_api,                  # noqa: F811
     Returns:
         N/A
     """
-    for testbed_subtype, rdma_ports in multidut_port_info.items():
-        tx_port_count = 1
-        rx_port_count = 1
-        snappi_port_list = get_snappi_ports
-        pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
-                       "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
-
-        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-
-        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
-                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
-                      testbed {}, subtype {} in variables.py'.
-                       format(MULTIDUT_TESTBED, testbed_subtype))
-        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
-        if is_snappi_multidut(duthosts):
-            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
-                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
-        else:
-            snappi_ports = get_snappi_ports
-        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
-                                                                                snappi_ports,
-                                                                                snappi_api)
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    for port in snappi_ports:
+        logger.info('Snappi port selected for test:{}'.format(port['peer_port']))
 
     all_prio_list = prio_dscp_map.keys()
 

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -4,14 +4,15 @@ import random
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_graph_facts_multidut, \
-    fanout_graph_facts      # noqa: F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, snappi_api, \
-    snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config, \
-    get_snappi_ports_multi_dut, get_snappi_ports_single_dut       # noqa: F401
+    fanout_graph_facts                                                                              # noqa: F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
+    get_snappi_ports_single_dut, snappi_testbed_config, snappi_dut_base_config, \
+    get_snappi_ports_multi_dut, is_snappi_multidut, tgen_port_info, \
+    snappi_api, get_snappi_ports, snappi_port_selection, get_snappi_ports_for_rdma, cleanup_config  # noqa: F401
 from tests.common.snappi_tests.port import select_ports
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list  # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
-from tests.snappi_tests.files.helper import multidut_port_info, setup_ports_and_dut  # noqa: F401
+from tests.snappi_tests.files.helper import setup_ports_and_dut                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2
@@ -92,7 +93,7 @@ def __gen_all_to_all_traffic(testbed_config,
     return testbed_config
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='module')
 def number_of_tx_rx_ports():
     yield (1, 1)
 
@@ -106,7 +107,8 @@ def test_snappi(request,
                 get_snappi_ports,             # noqa: F811
                 tbinfo,
                 prio_dscp_map,                # noqa: F811
-                setup_ports_and_dut           # noqa: F811
+                number_of_tx_rx_ports,        # noqa: F811
+                tgen_port_info,               # noqa: F811
                 ):
 
     """
@@ -123,7 +125,9 @@ def test_snappi(request,
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    for port in snappi_ports:
+        logger.info('Snappi ports selected for test:{}'.format(port['peer_port']))
 
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])

--- a/tests/snappi_tests/test_multidut_snappi.py
+++ b/tests/snappi_tests/test_multidut_snappi.py
@@ -12,7 +12,6 @@ from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi
 from tests.common.snappi_tests.port import select_ports
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list                # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp
-from tests.snappi_tests.files.helper import setup_ports_and_dut                                     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import gen_data_flow_dest_ip
 logger = logging.getLogger(__name__)
 SNAPPI_POLL_DELAY_SEC = 2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Added support for tgen-port-info for the PFCWD testcases.

Testcases modified:
```
tests/snappi_tests/pfcwd/test_pfcwd_runtime_traffic_with_snappi.py
tests/snappi_tests/pfcwd/test_pfcwd_m2o_with_snappi.py
tests/snappi_tests/pfcwd/test_pfcwd_burst_storm_with_snappi.py
tests/snappi_tests/test_multidut_snappi.py
```
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
The support for dynamic and static port selection during test execution is available. Modified the PFCWD testcases to have that support.

#### How did you do it?
1. Added the num_tx_rx_ports to ensure that test ONLY uses limited number of ports.
2. Removed old and unused imports.
3. testbed_config, port_config_list and snappi_ports are now defined using tgen_port_info.

#### How did you verify/test it?
Ran on multidut-tgen environment with both static and dynamic port selections.

Logs:
```
azureuser@7e081020c2c7:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern ixr-x3b-14 --testbed ixr-x3b-14-t2 --testbed_file ../ansible/testbed.csv --log-cli-level info --log-file-level info --kube_master unset --showlocals -ra --show-capture stdout --junit-xml=/tmp/p.xml --skip_sanity --log-file=/tmp/p.log --cache-clear --disable_loganalyzer --topology multidut-tgen snappi_tests/test_multidut_snappi_dynamic.py --pdb
Tue Jul  8 13:15:50 UTC 2025
------------- curtailed output -------------
====================================================================== 6 passed, 13 warnings in 869.14s (0:14:29) ======================================================================
INFO:root:Can not get Allure report URL. Please check logs
```

```
azureuser@7e081020c2c7:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern ixr-x3b-14 --testbed ixr-x3b-14-t2 --testbed_file ../ansible/testbed.csv --log-cli-level info --log-file-level info --kube_master unset --showlocals -ra --show-capture stdout --junit-xml=/tmp/p.xml --skip_sanity --log-file=/tmp/p.log --cache-clear --disable_loganalyzer --topology multidut-tgen --enable-snappi-dynamic-ports snappi_tests/test_multidut_snappi_dynamic.py --pdb
Tue Jul  8 13:40:10 UTC 2025
------------ curtailed output ---------------
---------------------------------------------------------------------------- generated xml file: /tmp/p.xml ----------------------------------------------------------------------------
-------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------
13:51:11 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
====================================================================== 4 passed, 11 warnings in 658.61s (0:10:58) ======================================================================
INFO:root:Can not get Allure report URL. Please check logs
```



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
