### PR TITLE
Adding fixes for bfd_responder, it is giving a bunch of failures.

### DIFF
--- a/ansible/roles/test/files/helpers/bfd_responder.py
+++ b/ansible/roles/test/files/helpers/bfd_responder.py
@@ -1,4 +1,3 @@
-import binascii
 import socket
 import struct
 import select
@@ -19,16 +18,20 @@ BFD_FLAG_F_BIT = 4
 UDP_BFD_PKT_LEN = 32
 
 
-def get_if(iff, cmd):
-    s = socket.socket()
-    ifreq = ioctl(s, cmd, struct.pack("16s16x", iff))
-    s.close()
-    return ifreq
-
-
-def get_mac(iff):
-    SIOCGIFHWADDR = 0x8927          # Get hardware address
-    return get_if(iff, SIOCGIFHWADDR)[18:24]
+def get_mac(ifname):
+    """
+    Retrieves the MAC address for a given network interface name on a Linux system.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # Create a socket.
+    # Use fcntl.ioctl to make the SIOCGIFHWADDR request.
+    # '0x8927' is the numerical value of SIOCGIFHWADDR.
+    # struct.pack prepares the interface name string for the request.
+    info = ioctl(s.fileno(), 0x8927, struct.pack('256s', bytes(ifname, 'utf-8')[:15]))
+    # The MAC address is contained in the response data, bytes 18-24.
+    # We format it as a colon-separated hex string.
+    value = ':'.join('%02x' % b for b in info[18:24])
+    print(f"mac = {value}")
+    return value
 
 
 class Interface(object):
@@ -52,9 +55,7 @@ class Interface(object):
     def recv(self):
         sniffed = self.socket.recv()
         pkt = sniffed[0]
-        str_pkt = str(pkt).encode("HEX")
-        binpkt = binascii.unhexlify(str_pkt)
-        return binpkt
+        return pkt
 
     def send(self, data):
         scapy2.sendp(data, iface=self.iface)
@@ -121,7 +122,7 @@ class BFDResponder(object):
 
     def extract_bfd_info(self, data):
         # remote_mac, remote_ip, request_ip, op_type
-        ether = scapy2.Ether(data)
+        ether = data
         mac_src = ether.src
         mac_dst = ether.dst
         ip_src = ether.payload.src
@@ -132,7 +133,7 @@ class BFDResponder(object):
         ip_version = str(ether.payload.version)
         ip_priority_field = 'tos' if ip_version == IPv4 else 'tc'
         ip_priority = getattr(ether.payload, ip_priority_field)
-        bfdpkt = BFD(bytes(ether.payload.payload.payload.load))
+        bfdpkt = BFD(str(ether.payload.payload.payload).encode("utf-8"))
         bfd_remote_disc = bfdpkt.my_discriminator
         bfd_state = bfdpkt.sta
         bfd_flags = bfdpkt.flags
@@ -142,8 +143,8 @@ class BFDResponder(object):
         return mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state, bfd_flags
 
     def craft_bfd_packet(self, session, data, mac_src, mac_dst, ip_src, ip_dst, bfd_remote_disc, bfd_state):
-        ethpart = scapy2.Ether(data)
-        bfdpart = BFD(bytes(ethpart.payload.payload.payload.load))
+        ethpart = data
+        bfdpart = BFD(str(ethpart.payload.payload.payload).encode("utf-8"))
         bfdpart.my_discriminator = session["my_disc"]
         bfdpart.your_discriminator = bfd_remote_disc
         bfdpart.sta = bfd_state


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
bfd_responder (used by bfd/test_bfd.py) is failing to start in the PTF container with the following error:
```
Traceback (most recent call last):
File "/opt/bfd_responder.py", line 213, in <module>
main()
File "/opt/bfd_responder.py", line 190, in main
curr_session["mac"] = get_mac(str(bfd["ptf_intf"]))
File "/opt/bfd_responder.py", line 31, in get_mac
return get_if(iff, SIOCGIFHWADDR)[18:24]
File "/opt/bfd_responder.py", line 24, in get_if
ifreq = ioctl(s, cmd, struct.pack("16s16x", iff))
struct.error: argument for 's' must be a bytes object
```

After adding the modifications, in this PR, the test is finally passing:
![Screenshot 2025-07-08 at 9 56 34 AM](https://github.com/user-attachments/assets/89cb02f1-f520-4a41-87d0-16c2b431cb89)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Pls see description. The bfd_responder was not able to start in the ptf container.

#### How did you do it?
Updated the script with more recent python functions.

#### How did you verify/test it?
Ran it on a TB, pls see description for the test result.

#### Any platform specific information?
Generic change.