### PR TITLE
[202305] Cherry pick the change of adding -e for setup-container to fix github api rate limit issue

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -38,6 +38,7 @@ declare -r VERBOSE_MIN="${VERBOSE_ERROR}"
 # Arguments -----------------------------------------------------------------------------------------------------------
 #
 
+ENV_VARS=""
 CONTAINER_NAME=""
 IMAGE_ID=""
 LINK_DIR=""
@@ -96,6 +97,7 @@ function show_help_and_exit() {
     echo "  -n <container_name>  set the name of the Docker container"
     echo
     echo "Other options:"
+    echo "  -e <VAR=value>      set environment variable inside the container (can be used multiple times)"
     echo "  -i <image_id>        specify Docker image to use. This can be an image ID (hashed value) or an image name."
     echo "                       If no value is provided, defaults to the following images in the specified order:"
     echo "                         1. The local image named \"docker-sonic-mgmt\""
@@ -298,7 +300,7 @@ EOF
 function start_local_container() {
     log_info "creating a container: ${CONTAINER_NAME} ..."
 
-    eval "docker run -d -t ${PUBLISH_PORTS} -h ${CONTAINER_NAME} \
+    eval "docker run -d -t ${PUBLISH_PORTS} ${ENV_VARS} -h ${CONTAINER_NAME} \
     -v \"$(dirname "${SCRIPT_DIR}"):${LINK_DIR}:rslave\" ${MOUNT_POINTS} \
     --name \"${CONTAINER_NAME}\" \"${LOCAL_IMAGE}\" /bin/bash ${SILENT_HOOK}" || \
     exit_failure "failed to start a container: ${CONTAINER_NAME}"
@@ -339,10 +341,13 @@ if [[ $# -eq 0 ]]; then
     show_help_and_exit "${EXIT_SUCCESS}"
 fi
 
-while getopts "n:i:d:m:p:fvxh" opt; do
+while getopts "e:n:i:d:m:p:fvxh" opt; do
     case "${opt}" in
         n )
             CONTAINER_NAME="${OPTARG}"
+            ;;
+        e )
+            ENV_VARS+=" -e ${OPTARG}"
             ;;
         i )
             IMAGE_ID="${OPTARG}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The PR https://github.com/sonic-net/sonic-mgmt/pull/19116 adds -e args for setup-container.sh for all PR test pipelines.

This PR is to cherry pick the change of adding -e for setup-container to fix github api rate limit issue.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
