### PR TITLE
[logrotate] Fix the issue that no logs will be consider as non-zero return in grep

### DIFF
--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -97,7 +97,8 @@ def get_syslog_file_count(duthost):
     :return: file number value
     """
     logger.info('Check rotated syslog file number')
-    num = duthost.shell('sudo ls -l /var/log | grep -Ec "syslog\\.[0-9]{1,4}[\\.gz]{0,1}"')['stdout']
+    num = duthost.shell('sudo ls -l /var/log | grep -Ec "syslog\\.[0-9]{1,4}[\\.gz]{0,1}"',
+                        module_ignore_errors=True)['stdout']
     logger.debug('There are {} rotated syslog files'.format(num))
     return int(num)
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #33258706
[logrotate] Fix the issue that no logs will be consider as non-zero return in grep
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix the issue that no logs will be consider as non-zero return in grep

#### How did you do it?
Ignore errors of grep return
#### How did you verify/test it?
Tested on physical testbeds and it works well
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
