### PR TITLE
Remove config reload in test_config_interface_speed_40G_100G

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -4,7 +4,6 @@ import re
 import ipaddress
 
 from tests.common.devices.base import AnsibleHostBase
-from tests.common.config_reload import config_reload
 from tests.common.platform.device_utils import fanout_switch_port_lookup
 from tests.common.utilities import wait, wait_until
 from netaddr import IPAddress


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/19467
Remove config reload in test_config_interface_speed_40G_100G. Port aliases are required by later test and config reload resets them.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The config reload resets port alias, which cause failures in "test_show_interfaces_neighbor_expected". This is to remove the unnecessary reload.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
