### PR TITLE
[LA] Add LA ignore for 'auditd queue full reporting limit reached' message

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -416,3 +416,9 @@ r, ".*ERR pmon.*Failed to freeze VDM stats in contextmanager for port.*"
 r, ".*ERR pmon.*Failed to freeze VDM stats for port.*"
 r, ".*ERR pmon.*Failed to confirm VDM unfreeze status for port.*"
 r, ".*ERR pmon.*Failed to unfreeze VDM stats in contextmanager for port.*"
+
+# https://github.com/sonic-net/sonic-mgmt/issues/19347
+r, ".* ERR auditd.*: queue to plugins is full - dropping event"
+r, ".* ERR auditd.*: message repeated .*: \[ queue to plugins is full - dropping event\]"
+r, ".* ERR auditd.*: auditd queue full reporting limit reached - ending dropped event notifications"
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#19347 Enhancement: Log Analyzer should add the pattern of "auditd queue full reporting limit reached" from test_tc1_aaa_suite](https://github.com/sonic-net/sonic-mgmt/issues/19347)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To eliminate test failure when such messages are in DUT syslog:
```
Match Messages:
2025 May 11 02:55:58.050391 dut ERR auditd[618]: queue to plugins is full - dropping event
2025 May 11 02:55:58.219484 dut ERR auditd[618]: queue to plugins is full - dropping event
2025 May 11 02:55:58.244281 dut ERR auditd[618]: message repeated 3 times: [ queue to plugins is full - dropping event]
2025 May 11 02:55:58.244402 dut ERR auditd[618]: auditd queue full reporting limit reached - ending dropped event notifications
```

#### How did you do it?
Add the regex to the `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt` ignore list file.

#### How did you verify/test it?
Run the `sonic-mgmt/tests/generic_config_updater/test_aaa.py::test_tc1_aaa_suite` test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
