### PR TITLE
[7215] Skip unsupported everflow testcases

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1140,7 +1140,7 @@ everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan
     reason: "Skip everflow packet integrity IPv6 test on unsupported platforms"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['cisco-8000', 'marvell', 'mellanox'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
+      - "asic_type in ['cisco-8000', 'marvell', 'mellanox', 'marvell-prestera'] or (asic_subtype in ['broadcom-dnx'] and https://github.com/sonic-net/sonic-swss/issues/2204)"
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
@@ -1150,7 +1150,7 @@ everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-m0_l3_
     reason: "Skip m0 everflow packet integrity IPv6 test on unsupported platforms"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['marvell']"
+      - "asic_type in ['marvell', 'marvell-prestera']"
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"
@@ -1160,7 +1160,7 @@ everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-m0_vla
     reason: "Skip m0 everflow packet integrity IPv6 test on unsupported platforms"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['marvell']"
+      - "asic_type in ['marvell', 'marvell-prestera']"
       - "'dualtor' in topo_name"
       - "platform in ['x86_64-8800_lc_48h_o-r0', 'x86_64-8800_lc_48h-r0']"
       - "(is_multi_asic==True) and https://github.com/sonic-net/sonic-buildimage/issues/11776"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip unsupported everflow testcases on Nokia-7215.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip unsupported everflow testcases on Nokia-7215.

#### How did you do it?
Skip testcase via condition mark.

#### How did you verify/test it?

Verified on Nokia-7215 M0:

```
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv4-m0_vlan_scenario] PASSED                                                        [  6%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv4-m0_vlan_scenario] PASSED                                                        [ 12%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv4-m0_l3_scenario] PASSED                                                          [ 18%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv4-m0_l3_scenario] PASSED                                                          [ 25%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv4-m0_vlan_scenario] SKIPPED (Skip everflow per interface IPv6 test on unsuppo...) [ 31%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv4-m0_vlan_scenario] SKIPPED (Skip everflow packet integrity IPv6 test on unsu...) [ 37%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv4-m0_l3_scenario] SKIPPED (Skip everflow per interface IPv6 test on unsupport...) [ 43%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv4-m0_l3_scenario] SKIPPED (Skip everflow packet integrity IPv6 test on unsupp...) [ 50%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv6-m0_vlan_scenario] SKIPPED (Skip everflow per interface IPv6 test on unsuppo...) [ 56%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv6-m0_vlan_scenario] SKIPPED (Skip everflow packet integrity IPv6 test on unsu...) [ 62%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv6-m0_l3_scenario] SKIPPED (Skip everflow per interface IPv6 test on unsupport...) [ 68%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv6-m0_l3_scenario] SKIPPED (Skip everflow packet integrity IPv6 test on unsupp...) [ 75%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv6-m0_vlan_scenario] PASSED                                                        [ 81%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv6-m0_vlan_scenario] PASSED                                                        [ 87%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv6-m0_l3_scenario] PASSED                                                          [ 93%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv6-m0_l3_scenario] PASSED                                                          [100%]
========================================================================== short test summary info ==========================================================================
SKIPPED [4] everflow/test_everflow_per_interface.py: Skip everflow per interface IPv6 test on unsupported platforms
SKIPPED [4] everflow/test_everflow_per_interface.py: Skip everflow packet integrity IPv6 test on unsupported platforms
=========================================================== 8 passed, 8 skipped, 4 warnings in 1474.15s (0:24:34) ===========================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
