### PR TITLE
[dualtor-io] Fix sniffer no capture issue

### DIFF
--- a/tests/scripts/dual_tor_sniffer.py
+++ b/tests/scripts/dual_tor_sniffer.py
@@ -12,7 +12,7 @@ class L2ListenAllSocket(scapyall.conf.L2listen):
         # HACK: Set the socket bind to NOOP, so the packet sockets created
         # will not bind to any interface and it will listen on all interfaces
         # by default.
-        socket.bind = lambda _: None
+        socket.socket.bind = lambda *_: None
         super(L2ListenAllSocket, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix the dualtor sniffer not capture any packets:
```
dualtor_io/test_normal_op.py::test_normal_op_upstream[active-active] 
-------------------------------- live log call ---------------------------------
03:52:04 dual_tor_io.examine_flow                 L0691 ERROR  | self.all_packets not defined.
PASSED                                                                   [  5%]
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
scapy defaults to listen to `mgmt` port if not interface is provided to the sniffer.

```
```

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
