### PR TITLE
[dualtor-io] Fix test_active_link_admin_down_config_reload_link_up_downstream_standby on Cisco/MLNX

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -500,7 +500,8 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
 @pytest.mark.skip_active_standby
 def test_active_link_admin_down_config_reload_link_up_downstream_standby(
     upper_tor_host, lower_tor_host, send_t1_to_server_with_action,      # noqa F811
-    cable_type, active_active_ports, setup_loganalyzer                  # noqa F811
+    cable_type, active_active_ports, setup_loganalyzer,                 # noqa F811
+    link_down_downstream_active_duplication_setting                     # noqa F811
 ):
     """
     Send traffic from T1 to standby ToR and unshut the active-active mux ports.
@@ -533,12 +534,17 @@ def test_active_link_admin_down_config_reload_link_up_downstream_standby(
 
             # after config reload, it takes time to setup the zero-mac tunnel routes for
             # the mux server ips, so there will be disruption before traffic.
+            allowed_duplication, merge_duplications = \
+                link_down_downstream_active_duplication_setting
             send_t1_to_server_with_action(
                 upper_tor_host,
                 verify=True,
                 allowed_disruption=0,
                 action=lambda: config_interface_admin_status(upper_tor_host, active_active_ports, "up"),
-                allow_disruption_before_traffic=True
+                allow_disruption_before_traffic=True,
+                allowed_duplication=allowed_duplication,
+                merge_duplications_into_disruptions=merge_duplications,
+                delay=MUX_SIM_ALLOWED_DISRUPTION_SEC
             )
 
             verify_tor_states(


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/18829 into 202505

Signed-off-by: Longxiang Lyu [lolv@microsoft.com](mailto:lolv@microsoft.com)

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
