### PR TITLE
Added detailed reason for assert failure for macsec,bmp

### DIFF
--- a/tests/bmp/test_bmp_configdb.py
+++ b/tests/bmp/test_bmp_configdb.py
@@ -40,7 +40,9 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_neighbor_table'
     status = check_table_status(output, table_name)
-    assert (status == 'true')
+    assert (status == 'true'), (
+        "Enabling all BMP tables by default failed for bgp_neighbor_table. Actual status: {}."
+    ).format(status)
 
     # disable bgp_neighbor_table
     logger.info('disable bmp neighbor table on dut hosts')
@@ -48,7 +50,9 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_neighbor_table'
     status = check_table_status(output, table_name)
-    assert (status == 'false')
+    assert (status == 'false'), (
+        "Disabling bgp_neighbor_table failed. Actual status: {}."
+    ).format(status)
 
     # enable bgp_neighbor_table
     logger.info('enable bmp neighbor table on dut hosts')
@@ -56,7 +60,9 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_neighbor_table'
     status = check_table_status(output, table_name)
-    assert (status == 'true')
+    assert (status == 'true'), (
+        "Enabling bgp_neighbor_table failed. Actual status: {}."
+    ).format(status)
 
     # disable bgp_rib_in_table
     logger.info('disable bmp rib-in table on dut hosts')
@@ -64,7 +70,9 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_rib_in_table'
     status = check_table_status(output, table_name)
-    assert (status == 'false')
+    assert (status == 'false'), (
+        "Disabling bgp_rib_in_table failed. Actual status: {}."
+    ).format(status)
 
     # enable bgp_rib_in_table
     logger.info('enable bmp rib-in table on dut hosts')
@@ -72,7 +80,9 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_rib_in_table'
     status = check_table_status(output, table_name)
-    assert (status == 'true')
+    assert (status == 'true'), (
+        "Enabling bgp_rib_in_table failed. Actual status: {}."
+    ).format(status)
 
     # disable bgp_rib_out_table
     logger.info('disable bmp rib-out table on dut hosts')
@@ -80,7 +90,9 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_rib_out_table'
     status = check_table_status(output, table_name)
-    assert (status == 'false')
+    assert (status == 'false'), (
+        "Disabling bgp_rib_out_table failed. Actual status: {}."
+    ).format(status)
 
     # enable bgp_rib_out_table
     logger.info('enable bmp rib-out table on dut hosts')
@@ -88,4 +100,6 @@ def test_bmp_configdb(duthosts, rand_one_dut_hostname, localhost):
     output = show_bmp_tables(duthost)
     table_name = 'bgp_rib_out_table'
     status = check_table_status(output, table_name)
-    assert (status == 'true')
+    assert (status == 'true'), (
+        "Enabling bgp_rib_out_table failed. Actual status: {}."
+    ).format(status)

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -91,8 +91,7 @@ class TestFaultHandling():
             ).format(dut_ingress_sa_table_orig, dut_ingress_sa_table_new)
             return True
         assert wait_until(30, 5, 2, check_new_mka_session), (
-            "New MKA session not established within expected time. "
-            "Result of check_new_mka_session")
+            "New MKA session not established within expected time. ")
 
         # Flap > 90 seconds
         assert wait_until(12, 1, 0, lambda: find_portchannel_from_member(
@@ -100,12 +99,10 @@ class TestFaultHandling():
             "Portchannel {} did not come up within expected time. "
             "Portchannel status: {} "
             "Find portchannel from member: {} "
-            "Get portchannel status: {} "
         ).format(
             port_name,
             find_portchannel_from_member(port_name, get_portchannel(duthost))["status"],
-            find_portchannel_from_member(port_name, get_portchannel(duthost)),
-            get_portchannel(duthost)
+            find_portchannel_from_member(port_name, get_portchannel(duthost))
         )
 
         if isinstance(nbr["host"], EosHost):
@@ -119,12 +116,10 @@ class TestFaultHandling():
             "Portchannel {} did not go down within expected time. "
             "Portchannel status: {} "
             "Find portchannel from member: {} "
-            "Get portchannel status: {} "
         ).format(
             port_name,
             find_portchannel_from_member(port_name, get_portchannel(duthost))["status"],
-            find_portchannel_from_member(port_name, get_portchannel(duthost)),
-            get_portchannel(duthost)
+            find_portchannel_from_member(port_name, get_portchannel(duthost))
         )
 
         if isinstance(nbr["host"], EosHost):
@@ -136,12 +131,10 @@ class TestFaultHandling():
             "Portchannel {} did not come up within expected time. "
             "Portchannel status: {} "
             "Find portchannel from member: {} "
-            "Get portchannel status: {} "
         ).format(
             port_name,
             find_portchannel_from_member(port_name, get_portchannel(duthost))["status"],
-            find_portchannel_from_member(port_name, get_portchannel(duthost)),
-            get_portchannel(duthost)
+            find_portchannel_from_member(port_name, get_portchannel(duthost))
         )
 
     @pytest.mark.disable_loganalyzer

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -24,7 +24,10 @@ class TestFaultHandling():
     @pytest.mark.disable_loganalyzer
     def test_link_flap(self, duthost, ctrl_links, wait_mka_establish):
         # Only pick one link for link flap test
-        assert ctrl_links
+        assert ctrl_links, (
+            "No control links found. Expected at least one control link, but got {}. "
+        ).format(len(ctrl_links))
+
         port_name, nbr = list(ctrl_links.items())[0]
         nbr_eth_port = get_eth_ifname(
             nbr["host"], nbr["port"])
@@ -43,8 +46,13 @@ class TestFaultHandling():
                         nbr["port"], nbr["port"]))
                     _, _, _, dut_egress_sa_table_new, dut_ingress_sa_table_new = get_appl_db(
                         duthost, port_name, nbr["host"], nbr["port"])
-                    assert dut_egress_sa_table_orig == dut_egress_sa_table_new
-                    assert dut_ingress_sa_table_orig == dut_ingress_sa_table_new
+                    assert dut_egress_sa_table_orig == dut_egress_sa_table_new, (
+                        "DUT egress SA table mismatch. Original table: {}, New table: {}. "
+                    ).format(dut_egress_sa_table_orig, dut_egress_sa_table_new)
+
+                    assert dut_ingress_sa_table_orig == dut_ingress_sa_table_new, (
+                        "DUT ingress SA table mismatch. Original table: {}, New table: {}. "
+                    ).format(dut_ingress_sa_table_orig, dut_ingress_sa_table_new)
                     break
                 except AssertionError as e:
                     if retry == 0:
@@ -66,16 +74,40 @@ class TestFaultHandling():
         def check_new_mka_session():
             _, _, _, dut_egress_sa_table_new, dut_ingress_sa_table_new = get_appl_db(
                 duthost, port_name, nbr["host"], nbr["port"])
-            assert dut_egress_sa_table_new
-            assert dut_ingress_sa_table_new
-            assert dut_egress_sa_table_orig != dut_egress_sa_table_new
-            assert dut_ingress_sa_table_orig != dut_ingress_sa_table_new
+            assert dut_egress_sa_table_new, (
+                "DUT egress SA table is empty. Expected non-empty table, but got {}. "
+            ).format(dut_egress_sa_table_new)
+            assert dut_ingress_sa_table_new, (
+                "DUT ingress SA table is empty. Expected non-empty table, but got {}. "
+            ).format(dut_ingress_sa_table_new)
+            assert dut_egress_sa_table_orig != dut_egress_sa_table_new, (
+                "DUT egress SA table remains the same. Original table: {}, New table: {}. "
+                "Expected tables to be different, but they are identical. "
+            ).format(dut_egress_sa_table_orig, dut_egress_sa_table_new)
+            assert dut_ingress_sa_table_orig != dut_ingress_sa_table_new, (
+                "DUT ingress SA table remains the same. Original table: {}, New table: {}. "
+                "Expected tables to be different, but they are identical. "
+            ).format(dut_ingress_sa_table_orig, dut_ingress_sa_table_new)
             return True
-        assert wait_until(30, 5, 2, check_new_mka_session)
+        assert wait_until(30, 5, 2, check_new_mka_session), (
+            "New MKA session not established within expected time. "
+            "Result of check_new_mka_session: {}".format(check_new_mka_session())
+        )
 
         # Flap > 90 seconds
         assert wait_until(12, 1, 0, lambda: find_portchannel_from_member(
-            port_name, get_portchannel(duthost))["status"] == "Up")
+            port_name, get_portchannel(duthost))["status"] == "Up"), (
+            "Portchannel {} did not come up within expected time. "
+            "Portchannel status: {} "
+            "Find portchannel from member: {} "
+            "Get portchannel status: {} "
+        ).format(
+            port_name,
+            find_portchannel_from_member(port_name, get_portchannel(duthost))["status"],
+            find_portchannel_from_member(port_name, get_portchannel(duthost)),
+            get_portchannel(duthost)
+        )
+
         if isinstance(nbr["host"], EosHost):
             nbr["host"].shutdown(nbr_eth_port)
             sleep(TestFaultHandling.LACP_TIMEOUT)
@@ -83,14 +115,34 @@ class TestFaultHandling():
             nbr["host"].shell("ifconfig {} down && sleep {}".format(
                 nbr_eth_port, TestFaultHandling.LACP_TIMEOUT))
         assert wait_until(6, 1, 0, lambda: find_portchannel_from_member(
-            port_name, get_portchannel(duthost))["status"] == "Dw")
+                    port_name, get_portchannel(duthost))["status"] == "Dw"), (
+            "Portchannel {} did not go down within expected time. "
+            "Portchannel status: {} "
+            "Find portchannel from member: {} "
+            "Get portchannel status: {} "
+        ).format(
+            port_name,
+            find_portchannel_from_member(port_name, get_portchannel(duthost))["status"],
+            find_portchannel_from_member(port_name, get_portchannel(duthost)),
+            get_portchannel(duthost)
+        )
 
         if isinstance(nbr["host"], EosHost):
             nbr["host"].no_shutdown(nbr_eth_port)
         else:
             nbr["host"].shell("ifconfig {} up".format(nbr_eth_port))
         assert wait_until(12, 1, 0, lambda: find_portchannel_from_member(
-            port_name, get_portchannel(duthost))["status"] == "Up")
+            port_name, get_portchannel(duthost))["status"] == "Up"), (
+            "Portchannel {} did not come up within expected time. "
+            "Portchannel status: {} "
+            "Find portchannel from member: {} "
+            "Get portchannel status: {} "
+        ).format(
+            port_name,
+            find_portchannel_from_member(port_name, get_portchannel(duthost))["status"],
+            find_portchannel_from_member(port_name, get_portchannel(duthost)),
+            get_portchannel(duthost)
+        )
 
     @pytest.mark.disable_loganalyzer
     def test_mismatch_macsec_configuration(self, duthost, unctrl_links,
@@ -124,7 +176,10 @@ class TestFaultHandling():
             return dut_ingress_sc_table or dut_egress_sa_table or dut_ingress_sa_table
         # The mka should be establishing or established
         # To check whether the MKA establishment happened within 90 seconds
-        assert not wait_until(90, 1, 12, check_mka_establishment)
+        assert not wait_until(90, 1, 12, check_mka_establishment), (
+            "MKA establishment failed. Expected MKA to not establish within expected time, but it did. "
+            "Result of check_mka_establishment: {}"
+        ).format(check_mka_establishment())
 
         # Teardown
         disable_macsec_port(duthost, port_name)

--- a/tests/macsec/test_fault_handling.py
+++ b/tests/macsec/test_fault_handling.py
@@ -25,8 +25,9 @@ class TestFaultHandling():
     def test_link_flap(self, duthost, ctrl_links, wait_mka_establish):
         # Only pick one link for link flap test
         assert ctrl_links, (
-            "No control links found. Expected at least one control link, but got {}. "
-        ).format(len(ctrl_links))
+            "No control links found. Expected at least one control link, but got {}.\n"
+            "Actual ctrl_links: {}"
+        ).format(len(ctrl_links), ctrl_links)
 
         port_name, nbr = list(ctrl_links.items())[0]
         nbr_eth_port = get_eth_ifname(
@@ -91,8 +92,7 @@ class TestFaultHandling():
             return True
         assert wait_until(30, 5, 2, check_new_mka_session), (
             "New MKA session not established within expected time. "
-            "Result of check_new_mka_session: {}".format(check_new_mka_session())
-        )
+            "Result of check_new_mka_session")
 
         # Flap > 90 seconds
         assert wait_until(12, 1, 0, lambda: find_portchannel_from_member(
@@ -178,8 +178,7 @@ class TestFaultHandling():
         # To check whether the MKA establishment happened within 90 seconds
         assert not wait_until(90, 1, 12, check_mka_establishment), (
             "MKA establishment failed. Expected MKA to not establish within expected time, but it did. "
-            "Result of check_mka_establishment: {}"
-        ).format(check_mka_establishment())
+        )
 
         # Teardown
         disable_macsec_port(duthost, port_name)


### PR DESCRIPTION

 **Description of PR**

 **Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

**Back port request**

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Summary:**

Enhanced assertion messages in selected test cases to provide clearer failure context. This improves debuggability and speeds up issue resolution when tests fail.
Added detailed assertion failure messages in test scripts to make it easier to understand why tests fails.

 **What is the motivation for this PR?**
The motivation is to improve test debuggability by adding detailed failure reasons in assertions for selected test cases. This enhancement makes it easier to identify the root cause of test failures in logs, thereby reducing triage time and simplifying test maintenance.

**How did you do it?**
I updated the assertion statements in the following test files to include descriptive error messages:
tests/macsec/test_fault_handling.py
tests/bmp/test_bmp_configdb.py

**How did you verify/test it?**
Verified that the updated assertion messages are correctly reflected in the test code by reviewing the changes locally.