### PR TITLE
Extend Yang validation wait time after config reload for low-perf platform.

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -196,6 +196,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
         if (topo == "t1" and "T2" in neighbor["name"]) or \
                 (topo == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"])) or \
                 (topo == "m0" and "M1" in neighbor["name"]) or (topo == "mx" and "M0" in neighbor["name"]) or \
+                (topo == "m1" and ("MA" in neighbor["name"] or "MB" in neighbor["name"])) or \
                 (topo_name in ("t1-isolated-d32", "t1-isolated-d128") and "T0" in neighbor["name"]):
             upstream_ports[neighbor['namespace']].append(interface)
             upstream_port_ids.append(port_id)

--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -253,6 +253,6 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
 
     if yang_validate:
         pytest_assert(
-            wait_until(60, 15, 0, sonic_host.yang_validate),
+            wait_until(120, 30, 0, sonic_host.yang_validate),
             "Yang validation failed after config_reload"
         )


### PR DESCRIPTION

### Description of PR
<!--
Extend Yang validation wait time after config reload for low-perf platform.
-->

**Summary:**
Repair Yang validation flaky failure after config reload on Nokia-7215.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Repair Yang validation flaky failure after config reload on Nokia-7215.
#### How did you do it?
Extend the wait time to 120s.
#### How did you verify/test it?
Verified on Nokia-7215 testbed.

