### PR TITLE
Extend Yang validation wait time after config reload for low-perf platform.

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -253,6 +253,6 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
 
     if yang_validate:
         pytest_assert(
-            wait_until(60, 15, 0, sonic_host.yang_validate),
+            wait_until(120, 30, 0, sonic_host.yang_validate),
             "Yang validation failed after config_reload"
         )


### PR DESCRIPTION

### Description of PR
<!--
Repair Yang validation flaky failure after config reload on Nokia-7215.
-->

**Summary:**
Extend Yang validation wait time after config reload for low-perf platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Repair Yang validation flaky failure after config reload on Nokia-7215.#### How did you do it?
#### How did you verify/test it?
Extend the wait time to 120s.
#### Any platform specific information?
Verified on Nokia-7215 testbed.

