### PR TITLE
[TH5] update t0-isolated-d96u32s2 topo

### DIFF
--- a/ansible/generate_topo.py
+++ b/ansible/generate_topo.py
@@ -504,6 +504,7 @@ def main(role: str, keyword: str, template: str, port_count: int, uplinks: str, 
     - ./generate_topo.py -r t1 -k isolated -t t1-isolated -c 64 -u 12,16,44,48 -l 'c224o8'
     - ./generate_topo.py -r t1 -k isolated -t t1-isolated -c 64 -u 12,16,44,48 -l 'c224o8-sparse' -s 16,44,48
     - ./generate_topo.py -r t0 -k isolated -t t0-isolated -c 64 -u 25,26,27,28,29,30,31,32 -l 'o128'
+    - ./generate_topo.py -r t0 -k isolated -t t0-isolated -c 64 -l 'o128t0'
     - ./generate_topo.py -r t0 -k isolated-v6 -t t0-isolated-v6 -c 64 -l 'c256'
     - ./generate_topo.py -r t0 -k isolated-v6 -t t0-isolated-v6 -c 64 -l 'c256-sparse'
     - ./generate_topo.py -r t0 -k isolated-v6 -t t0-isolated-v6 -c 64 -p 64 -l 'c256-sparse'

--- a/ansible/vars/topo_t0-isolated-d96u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-d96u32s2.yml
@@ -317,7 +317,7 @@ configuration:
         ipv4: 10.0.0.1/31
         ipv6: fc00::2/126
     bp_interface:
-      ipv4: 10.10.246.2/24
+      ipv4: 10.10.246.2/22
       ipv6: fc0a::2/64
   ARISTA02T1:
     properties:
@@ -336,7 +336,7 @@ configuration:
         ipv4: 10.0.0.3/31
         ipv6: fc00::6/126
     bp_interface:
-      ipv4: 10.10.246.3/24
+      ipv4: 10.10.246.3/22
       ipv6: fc0a::3/64
   ARISTA03T1:
     properties:
@@ -355,7 +355,7 @@ configuration:
         ipv4: 10.0.0.5/31
         ipv6: fc00::a/126
     bp_interface:
-      ipv4: 10.10.246.4/24
+      ipv4: 10.10.246.4/22
       ipv6: fc0a::4/64
   ARISTA04T1:
     properties:
@@ -374,7 +374,7 @@ configuration:
         ipv4: 10.0.0.7/31
         ipv6: fc00::e/126
     bp_interface:
-      ipv4: 10.10.246.5/24
+      ipv4: 10.10.246.5/22
       ipv6: fc0a::5/64
   ARISTA05T1:
     properties:
@@ -393,7 +393,7 @@ configuration:
         ipv4: 10.0.0.9/31
         ipv6: fc00::12/126
     bp_interface:
-      ipv4: 10.10.246.6/24
+      ipv4: 10.10.246.6/22
       ipv6: fc0a::6/64
   ARISTA06T1:
     properties:
@@ -412,7 +412,7 @@ configuration:
         ipv4: 10.0.0.11/31
         ipv6: fc00::16/126
     bp_interface:
-      ipv4: 10.10.246.7/24
+      ipv4: 10.10.246.7/22
       ipv6: fc0a::7/64
   ARISTA07T1:
     properties:
@@ -431,7 +431,7 @@ configuration:
         ipv4: 10.0.0.13/31
         ipv6: fc00::1a/126
     bp_interface:
-      ipv4: 10.10.246.8/24
+      ipv4: 10.10.246.8/22
       ipv6: fc0a::8/64
   ARISTA08T1:
     properties:
@@ -450,7 +450,7 @@ configuration:
         ipv4: 10.0.0.15/31
         ipv6: fc00::1e/126
     bp_interface:
-      ipv4: 10.10.246.9/24
+      ipv4: 10.10.246.9/22
       ipv6: fc0a::9/64
   ARISTA09T1:
     properties:
@@ -469,7 +469,7 @@ configuration:
         ipv4: 10.0.0.17/31
         ipv6: fc00::22/126
     bp_interface:
-      ipv4: 10.10.246.10/24
+      ipv4: 10.10.246.10/22
       ipv6: fc0a::a/64
   ARISTA10T1:
     properties:
@@ -488,7 +488,7 @@ configuration:
         ipv4: 10.0.0.19/31
         ipv6: fc00::26/126
     bp_interface:
-      ipv4: 10.10.246.11/24
+      ipv4: 10.10.246.11/22
       ipv6: fc0a::b/64
   ARISTA11T1:
     properties:
@@ -507,7 +507,7 @@ configuration:
         ipv4: 10.0.0.21/31
         ipv6: fc00::2a/126
     bp_interface:
-      ipv4: 10.10.246.12/24
+      ipv4: 10.10.246.12/22
       ipv6: fc0a::c/64
   ARISTA12T1:
     properties:
@@ -526,7 +526,7 @@ configuration:
         ipv4: 10.0.0.23/31
         ipv6: fc00::2e/126
     bp_interface:
-      ipv4: 10.10.246.13/24
+      ipv4: 10.10.246.13/22
       ipv6: fc0a::d/64
   ARISTA13T1:
     properties:
@@ -545,7 +545,7 @@ configuration:
         ipv4: 10.0.0.25/31
         ipv6: fc00::32/126
     bp_interface:
-      ipv4: 10.10.246.14/24
+      ipv4: 10.10.246.14/22
       ipv6: fc0a::e/64
   ARISTA14T1:
     properties:
@@ -564,7 +564,7 @@ configuration:
         ipv4: 10.0.0.27/31
         ipv6: fc00::36/126
     bp_interface:
-      ipv4: 10.10.246.15/24
+      ipv4: 10.10.246.15/22
       ipv6: fc0a::f/64
   ARISTA15T1:
     properties:
@@ -583,7 +583,7 @@ configuration:
         ipv4: 10.0.0.29/31
         ipv6: fc00::3a/126
     bp_interface:
-      ipv4: 10.10.246.16/24
+      ipv4: 10.10.246.16/22
       ipv6: fc0a::10/64
   ARISTA16T1:
     properties:
@@ -602,7 +602,7 @@ configuration:
         ipv4: 10.0.0.31/31
         ipv6: fc00::3e/126
     bp_interface:
-      ipv4: 10.10.246.17/24
+      ipv4: 10.10.246.17/22
       ipv6: fc0a::11/64
   ARISTA17T1:
     properties:
@@ -621,7 +621,7 @@ configuration:
         ipv4: 10.0.0.33/31
         ipv6: fc00::42/126
     bp_interface:
-      ipv4: 10.10.246.18/24
+      ipv4: 10.10.246.18/22
       ipv6: fc0a::12/64
   ARISTA18T1:
     properties:
@@ -640,7 +640,7 @@ configuration:
         ipv4: 10.0.0.35/31
         ipv6: fc00::46/126
     bp_interface:
-      ipv4: 10.10.246.19/24
+      ipv4: 10.10.246.19/22
       ipv6: fc0a::13/64
   ARISTA19T1:
     properties:
@@ -659,7 +659,7 @@ configuration:
         ipv4: 10.0.0.37/31
         ipv6: fc00::4a/126
     bp_interface:
-      ipv4: 10.10.246.20/24
+      ipv4: 10.10.246.20/22
       ipv6: fc0a::14/64
   ARISTA20T1:
     properties:
@@ -678,7 +678,7 @@ configuration:
         ipv4: 10.0.0.39/31
         ipv6: fc00::4e/126
     bp_interface:
-      ipv4: 10.10.246.21/24
+      ipv4: 10.10.246.21/22
       ipv6: fc0a::15/64
   ARISTA21T1:
     properties:
@@ -697,7 +697,7 @@ configuration:
         ipv4: 10.0.0.41/31
         ipv6: fc00::52/126
     bp_interface:
-      ipv4: 10.10.246.22/24
+      ipv4: 10.10.246.22/22
       ipv6: fc0a::16/64
   ARISTA22T1:
     properties:
@@ -716,7 +716,7 @@ configuration:
         ipv4: 10.0.0.43/31
         ipv6: fc00::56/126
     bp_interface:
-      ipv4: 10.10.246.23/24
+      ipv4: 10.10.246.23/22
       ipv6: fc0a::17/64
   ARISTA23T1:
     properties:
@@ -735,7 +735,7 @@ configuration:
         ipv4: 10.0.0.45/31
         ipv6: fc00::5a/126
     bp_interface:
-      ipv4: 10.10.246.24/24
+      ipv4: 10.10.246.24/22
       ipv6: fc0a::18/64
   ARISTA24T1:
     properties:
@@ -754,7 +754,7 @@ configuration:
         ipv4: 10.0.0.47/31
         ipv6: fc00::5e/126
     bp_interface:
-      ipv4: 10.10.246.25/24
+      ipv4: 10.10.246.25/22
       ipv6: fc0a::19/64
   ARISTA25T1:
     properties:
@@ -773,7 +773,7 @@ configuration:
         ipv4: 10.0.0.49/31
         ipv6: fc00::62/126
     bp_interface:
-      ipv4: 10.10.246.26/24
+      ipv4: 10.10.246.26/22
       ipv6: fc0a::1a/64
   ARISTA26T1:
     properties:
@@ -792,7 +792,7 @@ configuration:
         ipv4: 10.0.0.51/31
         ipv6: fc00::66/126
     bp_interface:
-      ipv4: 10.10.246.27/24
+      ipv4: 10.10.246.27/22
       ipv6: fc0a::1b/64
   ARISTA27T1:
     properties:
@@ -811,7 +811,7 @@ configuration:
         ipv4: 10.0.0.53/31
         ipv6: fc00::6a/126
     bp_interface:
-      ipv4: 10.10.246.28/24
+      ipv4: 10.10.246.28/22
       ipv6: fc0a::1c/64
   ARISTA28T1:
     properties:
@@ -830,7 +830,7 @@ configuration:
         ipv4: 10.0.0.55/31
         ipv6: fc00::6e/126
     bp_interface:
-      ipv4: 10.10.246.29/24
+      ipv4: 10.10.246.29/22
       ipv6: fc0a::1d/64
   ARISTA29T1:
     properties:
@@ -849,7 +849,7 @@ configuration:
         ipv4: 10.0.0.57/31
         ipv6: fc00::72/126
     bp_interface:
-      ipv4: 10.10.246.30/24
+      ipv4: 10.10.246.30/22
       ipv6: fc0a::1e/64
   ARISTA30T1:
     properties:
@@ -868,7 +868,7 @@ configuration:
         ipv4: 10.0.0.59/31
         ipv6: fc00::76/126
     bp_interface:
-      ipv4: 10.10.246.31/24
+      ipv4: 10.10.246.31/22
       ipv6: fc0a::1f/64
   ARISTA31T1:
     properties:
@@ -887,7 +887,7 @@ configuration:
         ipv4: 10.0.0.61/31
         ipv6: fc00::7a/126
     bp_interface:
-      ipv4: 10.10.246.32/24
+      ipv4: 10.10.246.32/22
       ipv6: fc0a::20/64
   ARISTA32T1:
     properties:
@@ -906,13 +906,13 @@ configuration:
         ipv4: 10.0.0.63/31
         ipv6: fc00::7e/126
     bp_interface:
-      ipv4: 10.10.246.33/24
+      ipv4: 10.10.246.33/22
       ipv6: fc0a::21/64
   ARISTA01PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65101
       peers:
         65100:
           - 10.0.1.0
@@ -925,13 +925,13 @@ configuration:
         ipv4: 10.0.1.1/31
         ipv6: fc00::202/126
     bp_interface:
-      ipv4: 10.10.246.130/24
+      ipv4: 10.10.246.130/22
       ipv6: fc0a::82/64
   ARISTA02PT0:
     properties:
     - common
     bgp:
-      asn: 65100
+      asn: 65102
       peers:
         65100:
           - 10.0.1.2
@@ -944,5 +944,5 @@ configuration:
         ipv4: 10.0.1.3/31
         ipv6: fc00::206/126
     bp_interface:
-      ipv4: 10.10.246.131/24
+      ipv4: 10.10.246.131/22
       ipv6: fc0a::83/64

--- a/ansible/vars/topo_t0-isolated-v6-d96u32s2.yml
+++ b/ansible/vars/topo_t0-isolated-v6-d96u32s2.yml
@@ -290,13 +290,16 @@ configuration_properties:
     tor_asn_start: 4200000000
     failure_rate: 0
     nhipv6: FC0A::FF
+    ipv6_address_pattern: 2064:100:0::%02X%02X:%02X%02X:0/120
+    enable_ipv4_routes_generation: false
+    enable_ipv6_routes_generation: true
 
 configuration:
   ARISTA01T1:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.1
+      router-id: 100.1.0.1
       asn: 4200100000
       peers:
         4200000000:
@@ -312,7 +315,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.2
+      router-id: 100.1.0.2
       asn: 4200100000
       peers:
         4200000000:
@@ -328,7 +331,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.3
+      router-id: 100.1.0.3
       asn: 4200100000
       peers:
         4200000000:
@@ -344,7 +347,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.4
+      router-id: 100.1.0.4
       asn: 4200100000
       peers:
         4200000000:
@@ -360,7 +363,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.5
+      router-id: 100.1.0.5
       asn: 4200100000
       peers:
         4200000000:
@@ -376,7 +379,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.6
+      router-id: 100.1.0.6
       asn: 4200100000
       peers:
         4200000000:
@@ -392,7 +395,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.7
+      router-id: 100.1.0.7
       asn: 4200100000
       peers:
         4200000000:
@@ -408,7 +411,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.8
+      router-id: 100.1.0.8
       asn: 4200100000
       peers:
         4200000000:
@@ -424,7 +427,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.9
+      router-id: 100.1.0.9
       asn: 4200100000
       peers:
         4200000000:
@@ -440,7 +443,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.10
+      router-id: 100.1.0.10
       asn: 4200100000
       peers:
         4200000000:
@@ -456,7 +459,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.11
+      router-id: 100.1.0.11
       asn: 4200100000
       peers:
         4200000000:
@@ -472,7 +475,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.12
+      router-id: 100.1.0.12
       asn: 4200100000
       peers:
         4200000000:
@@ -488,7 +491,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.13
+      router-id: 100.1.0.13
       asn: 4200100000
       peers:
         4200000000:
@@ -504,7 +507,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.14
+      router-id: 100.1.0.14
       asn: 4200100000
       peers:
         4200000000:
@@ -520,7 +523,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.15
+      router-id: 100.1.0.15
       asn: 4200100000
       peers:
         4200000000:
@@ -536,7 +539,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.16
+      router-id: 100.1.0.16
       asn: 4200100000
       peers:
         4200000000:
@@ -552,7 +555,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.17
+      router-id: 100.1.0.17
       asn: 4200100000
       peers:
         4200000000:
@@ -568,7 +571,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.18
+      router-id: 100.1.0.18
       asn: 4200100000
       peers:
         4200000000:
@@ -584,7 +587,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.19
+      router-id: 100.1.0.19
       asn: 4200100000
       peers:
         4200000000:
@@ -600,7 +603,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.20
+      router-id: 100.1.0.20
       asn: 4200100000
       peers:
         4200000000:
@@ -616,7 +619,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.21
+      router-id: 100.1.0.21
       asn: 4200100000
       peers:
         4200000000:
@@ -632,7 +635,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.22
+      router-id: 100.1.0.22
       asn: 4200100000
       peers:
         4200000000:
@@ -648,7 +651,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.23
+      router-id: 100.1.0.23
       asn: 4200100000
       peers:
         4200000000:
@@ -664,7 +667,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.24
+      router-id: 100.1.0.24
       asn: 4200100000
       peers:
         4200000000:
@@ -680,7 +683,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.25
+      router-id: 100.1.0.25
       asn: 4200100000
       peers:
         4200000000:
@@ -696,7 +699,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.26
+      router-id: 100.1.0.26
       asn: 4200100000
       peers:
         4200000000:
@@ -712,7 +715,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.27
+      router-id: 100.1.0.27
       asn: 4200100000
       peers:
         4200000000:
@@ -728,7 +731,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.28
+      router-id: 100.1.0.28
       asn: 4200100000
       peers:
         4200000000:
@@ -744,7 +747,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.29
+      router-id: 100.1.0.29
       asn: 4200100000
       peers:
         4200000000:
@@ -760,7 +763,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.30
+      router-id: 100.1.0.30
       asn: 4200100000
       peers:
         4200000000:
@@ -776,7 +779,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.31
+      router-id: 100.1.0.31
       asn: 4200100000
       peers:
         4200000000:
@@ -792,7 +795,7 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.32
+      router-id: 100.1.0.32
       asn: 4200100000
       peers:
         4200000000:
@@ -808,8 +811,8 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.129
-      asn: 4200000000
+      router-id: 100.1.0.129
+      asn: 64621
       peers:
         4200000000:
           - fc00::201
@@ -824,8 +827,8 @@ configuration:
     properties:
     - common
     bgp:
-      router_id: 100.1.0.130
-      asn: 4200000000
+      router-id: 100.1.0.130
+      asn: 64622
       peers:
         4200000000:
           - fc00::205

--- a/ansible/veos
+++ b/ansible/veos
@@ -68,6 +68,7 @@ all:
           - t0-isolated-d32u32s2
           - t0-isolated-v6-d256u256s2
           - t0-isolated-v6-d32u32s2
+          - t0-isolated-d96u32s2
           - dualtor
           - dualtor-56
           - cable-test


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
update topo t0-isolated-d96u32s2 with the following:
1. use /22 for bp_interfaces
2. correct typo for router-id in ipv6 only topo
3. update PT0 ASN to 2 bytes in ipv6 only topo
4. Add d96u32s2 support into veos


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
update topo t0-isolated-d96u32s2 with the following

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
