### PR TITLE
support dynamic saithrift URL generation

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -402,17 +402,34 @@ def test_update_saithrift_ptf(request, ptfhost, duthosts, enum_dut_hostname):
         else:
             pytest.fail("Unable to parse or recognize version format: {}".format(version))
 
-    debian_codename = "bookworm"
-    if branch_name.startswith("internal-") and branch_name < "internal-202505":
+    # Get debian codename from syncd container (not host OS)
+    try:
+        # Try to get codename from syncd container
+        syncd_codename_result = duthost.shell("docker exec syncd grep VERSION_CODENAME /etc/os-release | cut -d= -f2 | tr -d '\"'", module_ignore_errors=True)
+        if syncd_codename_result['rc'] == 0 and syncd_codename_result['stdout'].strip():
+            debian_codename = syncd_codename_result['stdout'].strip()
+        else:
+            pytest.fail("Failed to get debian codename from syncd container. RC: {}, Output: '{}'".format(
+                syncd_codename_result['rc'], syncd_codename_result['stdout']))
+    except Exception as e:
+        pytest.fail("Exception while getting debian codename from syncd container: {}".format(str(e)))
+
+    # Apply special codename overrides for specific internal branches
+    if branch_name == "internal-202411":
+        # internal-202411 has saithrift URL hardcoded to bullseye
         debian_codename = "bullseye"
 
     pkg_name = py_saithrift_url.split("/")[-1]
     ip_addr = py_saithrift_url.split("/")[2]
     ptfhost.shell("rm -f {}".format(pkg_name))
 
-    if branch_name == "master":
+    if branch_name.startswith("internal-") and branch_name < "internal-202405":
+        # For internal branches older than 202405, use the original URL without modification
+        pass
+    elif branch_name == "master":
         py_saithrift_url = f"http://{ip_addr}/mssonic-public-pipelines/Azure.sonic-buildimage.official.{asic}/master/{asic}/latest/target/debs/{debian_codename}/{pkg_name}"
     else:
+        # For internal branches newer than 202405 and other branches
         py_saithrift_url = f"http://{ip_addr}/pipelines/Networking-acs-buildimage-Official/{asic}/{branch_name}/latest/target/debs/{debian_codename}/{pkg_name}"
 
     # Retry download of saithrift library


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

When the Debian codename changes, the saithrift package URL must be updated accordingly outside the test code. Otherwise, the package download may silently fail, leading to QoS SAI test failures.

This change dynamically generates the correct saithrift package URL based on the current Debian codename and explicitly reports test failure if the download fails.

#### How did you do it?

This change dynamically generates the correct saithrift package URL based on the current Debian codename and explicitly reports test failure if the download fails.

#### How did you verify/test it?

passed local tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
