### PR TITLE
Fix PFCWD Test port filtering

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -352,10 +352,8 @@ def select_test_ports(test_ports):
                 selected_ports[port] = port_info
         # filter out selected ports that also act as rx ports
         selected_ports = {p: pi for p, pi in list(selected_ports.items())
-                          if p not in rx_port}
-    elif len(test_ports) == 2:
-        selected_ports = test_ports
-
+                          if p not in rx_ports}
+    # if only 1 or 2 ports avail, take only one, as they are eachother's rx ports
     if not selected_ports:
         random_port = list(test_ports.keys())[0]
         selected_ports[random_port] = test_ports[random_port]


### PR DESCRIPTION
Selected test ports are not meant to include loops with their rx ports. The existing selection process did not correctly apply this, particularly in the case of only 2 test ports available.

Problem situation seen in test_pfcwd_multi_port. When there are only 2 test ports they are eachother's RX ports and so when storm is started on one, SendVerifyTraffic could not determine if the other was working correctly.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202503

### Approach
#### What is the motivation for this PR?
This bug was originally found in msft-202503 where the test failed with 
`AssertionError: Did not receive expected packet on any of ports [] for device .`

#### How did you do it?
I noticed this occurred with only 2 test ports available, so I changed the selection process.
https://github.com/sonic-net/sonic-mgmt/pull/11656

I found this PR which originally mentioned the test_pfcwd_multi_port and included a change for 2 ports. But the situation where there are only 2 test ports available is problematic as storming one will mean traffic can't be verified on the other during this test case since they are eachother's RX ports.

#### How did you verify/test it?
I re-ran the test to see that test_pfcwd_multi_port should have skipped in this situation. And also verified that when there were enough test ports available test_pfcwd_multi_port did not skip.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
