### PR TITLE
Fix everflow_per_interface test on LT2/FT2

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -189,8 +189,8 @@ def generate_testing_packet(ptfadapter, duthost, mirror_session_info, router_mac
         )
 
     dec_ttl = 0
-
-    if 't2' in setup['topo']:
+    # Only need to decrement TTL for chassis T2
+    if setup['topo'].startswith('t2'):
         dec_ttl = 1
     elif duthost.is_multi_asic:
         dec_ttl = 2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix [test_everflow_per_interface.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:fix_everflow_per_interface_on_lt2?expand=1#diff-6d0768046d4041cf91f44c70f9910c4f782d20c768315ddf2ec663a878ef69e1) on LT2 and FT2.

The test can't pass on LT2/FT2 because TTL is decrease by 1 mistakenly. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR is to fix [test_everflow_per_interface.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:fix_everflow_per_interface_on_lt2?expand=1#diff-6d0768046d4041cf91f44c70f9910c4f782d20c768315ddf2ec663a878ef69e1) on LT2 and FT2.

#### How did you do it?
Only decrease TTL on chassis T2.

#### How did you verify/test it?
Change is verified on LT2 testbed.
```
collected 4 items                                                                                                                                                                                                             

everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv4-default] PASSED                                                                                                                   [ 25%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv4-default] PASSED                                                                                                                   [ 50%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv6-default] PASSED                                                                                                                   [ 75%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv6-default] PASSED                                                                                                                   [100%]

```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
