### PR TITLE
xfail test_ser on 202503 branch

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -889,7 +889,7 @@ platform_tests/broadcom/test_ser.py:
   xfail:
     reason: "Testcase consistently fails, CSP raised to follow up"
     conditions:
-      - "release in ['202412'] and 'Arista-7060X6' in hwsku"
+      - "release in ['202412','202503'] and 'Arista-7060X6' in hwsku"
 
 #######################################
 #####  cli/test_show_platform.py  #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to xfail `test_ser` in 202503 release on th5 as it's not supported.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR is to xfail `test_ser` in 202503 release on th5 as it's not supported.

#### How did you do it?
Add `202503` into release list.

#### How did you verify/test it?
The change is veried by running `test_ser` on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
