### PR TITLE
Add check to verify if portA key exists in the pick_ports method

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -225,7 +225,7 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
 
     if dutA is None:
         pytest.skip("Did not find any asic in the DUTs (linecards) \
-            that are connected to T1 VM's")
+            that are connected to T1/LT2 VM's")
 
     for asic_index, asic_cfg in enumerate(all_cfg_facts[dutA.hostname]):
         cfg_facts = asic_cfg['ansible_facts']
@@ -261,6 +261,9 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
 
         if 'portA' in intfs_to_test:
             break
+
+    if 'portA' not in intfs_to_test:
+        pytest.skip("Could not find portA that is connected to a downstream T1/LT2 VM's")
 
     if len(duthosts.frontend_nodes) == 1:
         # We are dealing with a single card, lets find the portC and portD in other asic on the same card


### PR DESCRIPTION
In pick_ports we assume portA always exists and this causes indexing errors. There may be cases where portA is not found, for example, when the test looks for a portchannel connected to downstream T1/LT2 VMs. In t2_single_node_max the downstream links do not have portchannels, and hence no intf will satisfy this condition.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19534

### Type of change
Fixes an indexing error in the pick_ports function when a PortChannel is expected but not found in the downstream links of the tested topology.

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202503

### Approach
#### What is the motivation for this PR?
The pick_ports function assumes that portA always exists after attempting to find a connection that satisfies specific criteria (e.g., a PortChannel connected to downstream T1/LT2 VMs).

In topologies like t2_single_node_max, the downstream links do not have PortChannels, meaning no interface satisfies the condition. This leads to an IndexError when the code tries to access portA, causing the test execution to fail unexpectedly. This PR fixes the pick_ports failure in these scenarios.

#### How did you do it?
Modified the pick_ports function to gracefully handle cases where no interface matching the required criteria is found, preventing the indexing error.

#### How did you verify/test it?
The changes were verified by running the affected test suite on the t2_single_node_max topology. The test no longer crashes due to the indexing error in pick_ports and are skipped as expected when downstream PortChannels are absent.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
N/A. This is a fix for an existing test framework function, not a new test case.

### Documentation
N/A

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
