### PR TITLE
show interface counters detailed

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -1197,6 +1197,32 @@ def get_interface_stats(duthost, port):
     return i_stats
 
 
+def get_interface_counters_detailed(duthost, port):
+    """
+    Runs 'show interface counters detailed <interface>' on the device and parses the output.
+    Args:
+        duthost (Ansible host instance): device under test
+        port (str): interface name, e.g., 'Ethernet0'
+    Returns:
+        counters (dict): key-value pairs of interface counters, where key is the counter name
+                            and value is the counter value as a string.
+    """
+    cmd = f"show interface counters detailed {port}"
+    output = duthost.command(cmd)["stdout"]
+
+    counters = {}
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # Split on the last space in the line
+        parts = line.rsplit(' ', 1)
+        if len(parts) == 2:
+            key, value = parts
+            counters[key.strip()] = value.strip()
+    return counters
+
+
 def get_queue_count_all_prio(duthost, port):
     """
     Get the egress queue count in packets and bytes for a given port and all priorities.

--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -12,7 +12,7 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count, pfc
     get_lossless_buffer_size, get_pg_dropped_packets, \
     sec_to_nanosec, get_pfc_frame_count, packet_capture, get_tx_frame_count, get_rx_frame_count, \
     traffic_flow_mode, get_pfc_count, clear_counters, get_interface_stats, get_queue_count_all_prio, \
-    get_pfcwd_stats
+    get_pfcwd_stats, get_interface_counters_detailed
 from tests.common.snappi_tests.port import select_ports, select_tx_port
 from tests.common.snappi_tests.snappi_helpers import wait_for_arp, fetch_snappi_flow_metrics
 from .variables import pfcQueueGroupSize, pfcQueueValueDict
@@ -1096,6 +1096,7 @@ def run_traffic_and_collect_stats(rx_duthost,
         f_stats = update_dict(m, f_stats, tgen_curr_stats(traf_metrics, flow_metrics, data_flow_names))
         for dut, port in dutport_list:
             f_stats = update_dict(m, f_stats, flatten_dict(get_interface_stats(dut, port)))
+            f_stats = update_dict(m, f_stats, flatten_dict(get_interface_counters_detailed(dut, port)))
             f_stats = update_dict(m, f_stats, flatten_dict(get_pfc_count(dut, port)))
             f_stats = update_dict(m, f_stats, flatten_dict(get_queue_count_all_prio(dut, port)))
 


### PR DESCRIPTION


### Description of PR
Printing 'show interface counters detailed' for the interfaces used in test to help with debugging

Summary:
Fixes # To help debug https://migsonic.atlassian.net/browse/MIGSMSFT-1080

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X ] Test case improvement



### Approach
#### What is the motivation for this PR?
MSFT is seeing loss at TGEN where as DUT doesnt report any loss. This command will help confirm the issue might be on the Ixia side.

#### How did you do it?
Added the code to print the command output in test logs

#### How did you verify/test it?
Manually ran the test and verified

Testlog will have this info printed
```
10/07/2025 23:30:43 base._run                                L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [yy40-mixed-short] AnsibleModule::command, args=["show interface counters detailed Ethernet128"], kwargs={}
10/07/2025 23:30:45 base._run                                L0108 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [yy40-mixed-short] AnsibleModule::command Result => {"changed": true, "stdout": "Packets Received 64 Octets..................... 0\nPackets Received 65-127 Octets................. 0\nPackets Received 128-255 Octets................ 0\nPackets Received 256-511 Octets................ 0\nPackets Received 512-1023 Octets............... 0\nPackets Received 1024-1518 Octets.............. 0\nPackets Received 1519-2047 Octets.............. 0\nPackets Received 2048-4095 Octets.............. N/A\nPackets Received 4096-9216 Octets.............. N/A\nPackets Received 9217-16383 Octets............. N/A\n\nTotal Packets Received Without Errors.......... 0\nUnicast Packets Received....................... 0\nMulticast Packets Received..................... 0\nBroadcast Packets Received..................... 0\n\nJabbers Received............................... N/A\nFragments Received............................. N/A\nUndersize Received............................. 0\nOverruns Received.............................. N/A\n\nPackets Transmitted 64 Octets.................. 0\nPackets Transmitted 65-127 Octets.............. 0\nPackets Transmitted 128-255 Octets............. 0\nPackets Transmitted 256-511 Octets............. 11\nPackets Transmitted 512-1023 Octets............ 0\nPackets Transmitted 1024-1518 Octets........... 3,275,862,060\nPackets Transmitted 1519-2047 Octets........... 0\nPackets Transmitted 2048-4095 Octets........... N/A\nPackets Transmitted 4096-9216 Octets........... N/A\nPackets Transmitted 9217-16383 Octets.......... N/A\n\nTotal Packets Transmitted Successfully......... 3,275,862,071\nUnicast Packets Transmitted.................... 3,275,862,071\nMulticast Packets Transmitted.................. 0\nBroadcast Packets Transmitted.................. 0\nTime Since Counters Last Cleared............... 2025-07-10T23:29:46.958696", "stderr": "", "rc": 0, "cmd": ["show", "interface", "counters", "detailed", "Ethernet128"], "start": "2025-07-10 23:35:36.705215", "end": "2025-07-10 23:35:38.609832", "delta": "0:00:01.904617", "msg": "", "invocation": {"module_args": {"_raw_params": "show interface counters detailed Ethernet128", "_uses_shell": false, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["Packets Received 64 Octets..................... 0", "Packets Received 65-127 Octets................. 0", "Packets Received 128-255 Octets................ 0", "Packets Received 256-511 Octets................ 0", "Packets Received 512-1023 Octets............... 0", "Packets Received 1024-1518 Octets.............. 0", "Packets Received 1519-2047 Octets.............. 0", "Packets Received 2048-4095 Octets.............. N/A", "Packets Received 4096-9216 Octets.............. N/A", "Packets Received 9217-16383 Octets............. N/A", "", "Total Packets Received Without Errors.......... 0", "Unicast Packets Received....................... 0", "Multicast Packets Received..................... 0", "Broadcast Packets Received..................... 0", "", "Jabbers Received............................... N/A", "Fragments Received............................. N/A", "Undersize Received............................. 0", "Overruns Received.............................. N/A", "", "Packets Transmitted 64 Octets.................. 0", "Packets Transmitted 65-127 Octets.............. 0", "Packets Transmitted 128-255 Octets............. 0", "Packets Transmitted 256-511 Octets............. 11", "Packets Transmitted 512-1023 Octets............ 0", "Packets Transmitted 1024-1518 Octets........... 3,275,862,060", "Packets Transmitted 1519-2047 Octets........... 0", "Packets Transmitted 2048-4095 Octets........... N/A", "Packets Transmitted 4096-9216 Octets........... N/A", "Packets Transmitted 9217-16383 Octets.......... N/A", "", "Total Packets Transmitted Successfully......... 3,275,862,071", "Unicast Packets Transmitted.................... 3,275,862,071", "Multicast Packets Transmitted.................. 0", "Broadcast Packets Transmitted.................. 0", "Time Since Counters Last Cleared............... 2025-07-10T23:29:46.958696"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
```

#### Any platform specific information?
no
