### PR TITLE
[devices/eos]: Ignore case when searching for interface speeds

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -421,7 +421,8 @@ class EosHost(AnsibleHostBase):
                     'show interface {} hardware'.format(interface_name)]
         for command in commands:
             output = self.eos_command(commands=[command])
-            found_txt = re.search("Speed/Duplex: (.+)", output['stdout'][0])
+            # Ignore case as EOS 4.23 has format of "Speed/Duplex" whereas 4.25 is "Speed/duplex"
+            found_txt = re.search("Speed/Duplex: (.+)", output['stdout'][0], flags=re.IGNORECASE)
             if found_txt is not None:
                 break
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Ignore case for speed regex when looking up interface speeds on eos. Newer versions of EOS changed the format from "Speed/Duplex" to "Speed/duplex", causing failures when working with fanouts/ devices with newer EOS versions

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ x] 202405
- [ x] 202411
- [x ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/687076b73e9a888e73a505b8

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
