### PR TITLE
use safe_reboot in test_check_reset_status

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -95,7 +95,7 @@ def check_reset_status_after_reboot(reboot_type, pre_reboot_status, post_reboot_
     if reboot_type == 'warm':
         wait_warmboot_finalizer = True
     reboot(duthost, localhost, reboot_type,
-           wait_warmboot_finalizer=wait_warmboot_finalizer)
+           wait_warmboot_finalizer=wait_warmboot_finalizer, safe_reboot=True)
     apply_cert_config(duthost)
     r = restapi.get_reset_status(construct_url)
     pytest_assert(r.status_code == 200)


### PR DESCRIPTION
The motivation is to avoid a high switch load when performing a restart of the restapi.
This high load can be caused by starting some services after a reboot, so we want to wait for the switch to become stable and finish loading, and perform the restapi restart only after that.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
