### PR TITLE
SRv6: Update SRv6 test case to align with 16-bit locator function length

### DIFF
--- a/ansible/vars/configdb_jsons/7nodes_cisco/PE1.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/PE1.json
@@ -7,7 +7,7 @@
             "load_balance_mp_relax" : "true",
             "keepalive" : "10",
             "holdtime" : "30",
-            "sid_vpn_per_vrf_export_explicit": "fd00:201:201:fff1:1::"
+            "sid_vpn_per_vrf_export_explicit": "fd00:201:201:1::"
         },
         "default" : {
             "local_asn" : "64600",
@@ -444,17 +444,17 @@
         "lsid1": {
             "argu_len": "48",
             "block_len": "32",
-            "func_len": "32",
+            "func_len": "16",
             "node_len": "16",
             "prefix": "fd00:201:201::/48"
         }
     },
     "SRV6_MY_SIDS": {
-        "lsid1|fd00:201:201:fff1:1::/80": {
+        "lsid1|fd00:201:201:1::/64": {
             "action": "uDT46",
             "decap_vrf": "Vrf1"
         },
-        "lsid1|fd00:201:201:fff1:11::/80": {
+        "lsid1|fd00:201:201:11::/64": {
             "action": "uDT46",
             "decap_vrf": "Vrf2"
         }

--- a/ansible/vars/configdb_jsons/7nodes_cisco/PE2.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/PE2.json
@@ -7,7 +7,7 @@
             "load_balance_mp_relax" : "true",
             "keepalive" : "10",
             "holdtime" : "30",
-            "sid_vpn_per_vrf_export_explicit": "fd00:202:202:fff2:2::"
+            "sid_vpn_per_vrf_export_explicit": "fd00:202:202:2::"
         },
         "default" : {
             "local_asn" : "64601",
@@ -444,17 +444,17 @@
         "lsid1": {
             "argu_len": "48",
             "block_len": "32",
-            "func_len": "32",
+            "func_len": "16",
             "node_len": "16",
             "prefix": "fd00:202:202::/48"
         }
     },
     "SRV6_MY_SIDS": {
-        "lsid1|fd00:202:202:fff2:2::/80": {
+        "lsid1|fd00:202:202:2::/64": {
             "action": "uDT46",
             "decap_vrf": "Vrf1"
         },
-        "lsid1|fd00:202:202:fff2:22::/80": {
+        "lsid1|fd00:202:202:22::/64": {
             "action": "uDT46",
             "decap_vrf": "Vrf2"
         }

--- a/ansible/vars/configdb_jsons/7nodes_cisco/PE3.json
+++ b/ansible/vars/configdb_jsons/7nodes_cisco/PE3.json
@@ -7,7 +7,7 @@
             "load_balance_mp_relax" : "true",
             "keepalive" : "10",
             "holdtime" : "30",
-            "sid_vpn_per_vrf_export_explicit": "fd00:203:203:fff3:3::"
+            "sid_vpn_per_vrf_export_explicit": "fd00:203:203:3::"
         },
         "default" : {
             "local_asn" : "64602",
@@ -443,17 +443,17 @@
         "lsid1": {
             "argu_len": "48",
             "block_len": "32",
-            "func_len": "32",
+            "func_len": "16",
             "node_len": "16",
             "prefix": "fd00:203:203::/48"
         }
     },
     "SRV6_MY_SIDS": {
-        "lsid1|fd00:203:203:fff3:3::/80": {
+        "lsid1|fd00:203:203:3::/64": {
             "action": "uDT46",
             "decap_vrf": "Vrf1"
         },
-        "lsid1|fd00:203:203:fff3:33::/80": {
+        "lsid1|fd00:203:203:33::/64": {
             "action": "uDT46",
             "decap_vrf": "Vrf2"
         }

--- a/tests/srv6/test_srv6_basic_sanity.py
+++ b/tests/srv6/test_srv6_basic_sanity.py
@@ -204,7 +204,7 @@ def test_check_routes(duthosts, rand_one_dut_hostname, nbrhosts):
     check_routes(nbrhost, dut2_ips, ["10.10.246.254"], "Vrf1")
     # Check core routes
     check_routes(
-        nbrhost, ["fd00:201:201:fff1:11::", "fd00:202:202:fff2:22::"],
+        nbrhost, ["fd00:201:201:11::", "fd00:202:202:22::"],
         ["fc08::2", "fc06::2"], global_route, is_v6
     )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update the test case for srv6 based on 7nodes_cisco.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Currently FRR limits the function length up to 20 bits for a srv6 locator, but the configuration in 7nodes_cisco topology is 32 bits. Let's change it as 16 (less than 20).

#### How did you do it?
Update the configuration for locator and SID in 7nodes_cisco, and update the test case for srv6 according to the new value.

#### How did you verify/test it?
This test case is a part of project Phoenix Wing, and the changes have been verified on its vSONiC testbed.
