### PR TITLE
Add options to by pass cache cleanup before running the tests.

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -417,7 +417,7 @@ for arg in "$@"; do
     fi
 done
 
-while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:n:oOp:q:rs:S:t:ux" opt; do
+while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:n:oOp:q:rs:S:t:ux:w" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

RunTest CLI will always clean up the cache before running the tests, which will take time when we have multiple DUTs in the testbed.

Here is an example of cache load after initial cleanup:
<img width="1914" height="546" alt="image" src="https://github.com/user-attachments/assets/1a32e1a6-24ff-4702-a7eb-55702bf085a0" />


#### How did you do it?

This PR adds an option `-w` to skip the cache clear and save time for test preparation.

#### How did you verify/test it?

Finished locally.

<img width="1900" height="86" alt="image" src="https://github.com/user-attachments/assets/3a007d73-d064-43b2-af0d-8473e3307c65" />

After this change, local cache will be used directly:
<img width="1199" height="390" alt="image" src="https://github.com/user-attachments/assets/bf8b6603-317d-44cd-8e7e-13646d88923f" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
