### PR TITLE
Fix generic_config_updater/test_srv6 to use the correct fixture to select dut

### DIFF
--- a/tests/generic_config_updater/test_srv6.py
+++ b/tests/generic_config_updater/test_srv6.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
-def setup_and_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
+def setup_and_cleanup(duthosts, rand_one_dut_hostname, enum_frontend_asic_index):
     """
     Setup/teardown fixture for SRv6 config
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     create_checkpoint(duthost)
 
     asic_index = enum_frontend_asic_index
@@ -43,11 +43,11 @@ def setup_and_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         delete_checkpoint(duthost)
 
 
-def test_srv6_config_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
+def test_srv6_config_update(duthosts, rand_one_dut_hostname, enum_frontend_asic_index):
     """
     Test adding SRv6 configuration.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     asic_namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
     json_patch = [
         {
@@ -90,11 +90,11 @@ def test_srv6_config_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_srv6_config_remove(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
+def test_srv6_config_remove(duthosts, rand_one_dut_hostname, enum_frontend_asic_index):
     """
     Test removing SRv6 configuration.
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    duthost = duthosts[rand_one_dut_hostname]
     asic_index = enum_frontend_asic_index
     asic_namespace = duthost.get_namespace_from_asic_id(asic_index)
     if duthost.is_multi_asic:


### PR DESCRIPTION
Summary:

test_srv6 uses _enum_rand_one_per_hwsku_frontend_hostname_ fixture to select the dut, which is different from the one used by _ignore_expected_loganalyzer_exceptions_ fixture in conftest.

This results in 2 different duts to be selected sometimes. This leads us to the issue where errors of the pattern "ERR sonic_yang." are not ignored by loganalyzer.

This is not seen consistently beacuse there is a probability that same device might be randomly be selected in some scenarios where it wont fail.

Fixes # 
[(issue)](https://github.com/sonic-net/sonic-mgmt/issues/19411)
https://github.com/aristanetworks/sonic-qual.msft/issues/664

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Failure of test_srv6.py

#### How did you do it?
I've added fix to use _rand_one_dut_hostname_ in the test_srv6 which is also used by _ignore_expected_loganalyzer_exceptions_ fixture.

#### How did you verify/test it?
I've tested this by running the tests 20 times without fix, where it fails 9 times. With fix it never failed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
