### PR TITLE
Enhance test_disk_exhaustion with leaving some free space to avoid kernel errors

### DIFF
--- a/tests/disk/test_disk_exhaustion.py
+++ b/tests/disk/test_disk_exhaustion.py
@@ -170,18 +170,20 @@ def test_disk_exhaustion(duthost, ptfadapter, tbinfo, creds):
     # Create a shell script to do the operations like fallocate and remove file,
     # because when space is full, duthost.command() is not work
 
-    # i. First, get how much space total has in /tmp mounted partition, the output of "df /tmp" was like below:
+    # Get available space in /tmp mounted partition, the output of "df /tmp" was like below:
     #   Filesystem     1K-blocks    Used Available Use% Mounted on
     #   root-overlay    14874056 6429908   8427764  44% /
     df_rst = duthost.shell("df /tmp")["stdout_lines"][1].split()
-    total_space = df_rst[1]
+    available_kb = int(df_rst[3])
+    allocate_kb = int(available_kb * 0.95)
     used_before_test = int(df_rst[4].rstrip('%'))
+    logger.info(f"Preparing to allocate ~{allocate_kb} KB (95% of available) to simulate disk exhaustion")
 
-    # ii. Second create sh and execute
+    # Setup test.sh and execute
     duthost.shell_cmds(cmds=[
-        "echo 'fallocate -l {}K /tmp/huge_dummy_file' > /tmp/test.sh".format(total_space),
+        f"echo 'fallocate -l {allocate_kb}K /tmp/huge_dummy_file > /tmp/test.sh",
         "echo 'sleep 60' >> /tmp/test.sh",
-        "echo 'sudo rm /tmp/huge_dummy_file' >> /tmp/test.sh",
+        "echo 'sudo rm -f /tmp/huge_dummy_file' >> /tmp/test.sh",
         "chmod u+x /tmp/test.sh",
         "nohup /tmp/test.sh >/dev/null 2>&1 &"
     ], continue_on_fail=False, module_ignore_errors=True)
@@ -210,7 +212,7 @@ def test_disk_exhaustion(duthost, ptfadapter, tbinfo, creds):
         time.sleep(60)
 
         # Delete test.sh
-        duthost.shell("sudo rm /tmp/test.sh")
+        duthost.shell("sudo rm -f /tmp/test.sh")
         # Confirm disk space was released
         df_rst = duthost.shell("df /tmp")["stdout_lines"][1].split()
         used_after_test = int(df_rst[4].rstrip('%'))

--- a/tests/disk/test_disk_exhaustion.py
+++ b/tests/disk/test_disk_exhaustion.py
@@ -181,7 +181,7 @@ def test_disk_exhaustion(duthost, ptfadapter, tbinfo, creds):
 
     # Setup test.sh and execute
     duthost.shell_cmds(cmds=[
-        f"echo 'fallocate -l {allocate_kb}K /tmp/huge_dummy_file > /tmp/test.sh",
+        f"echo 'fallocate -l {allocate_kb}K /tmp/huge_dummy_file' > /tmp/test.sh",
         "echo 'sleep 60' >> /tmp/test.sh",
         "echo 'sudo rm -f /tmp/huge_dummy_file' >> /tmp/test.sh",
         "chmod u+x /tmp/test.sh",


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Enhance test_disk_exhaustion with leaving some free space to avoid kernel errors.

The allocation still appears to succeed even when it returns an error like:
`fallocate: fallocate failed: No space left on device`
```
admin@sonic:~$ df /tmp
Filesystem     1K-blocks      Used Available Use% Mounted on
root-overlay   229572940 102699796 126856760  45% /
admin@ sonic:~$ fallocate -l 229572940k /tmp/huge_dummy_file         
fallocate: fallocate failed: No space left on device
admin@ sonic:~$ 
admin@ sonic:~$ df /tmp
Filesystem     1K-blocks      Used Available Use% Mounted on
root-overlay   229572940 229556556         0 100% /
```

@kebol@nvidia.com mentioned that when allocate 100% may cause kernel errors like:
```
# loop write error
2025 Jun 18 07:12:22.363360 sonic_testbed ERR kernel: [ 1009.228833] loop: Write error at byte offset 673349632, length 4096.
07:12:32: Error while async write back metadata
2025 Jun 18 07:12:32.614365 sonic_testbed CRIT kernel: [ 1019.487101] EXT4-fs error (device loop1): ext4_check_bdev_write_error:217: comm rs:main Q:Reg: Error while async write back metadata

# remounting fs as read-only
2025 Jun 18 07:17:40.046393 sonic_testbed ERR kernel: [ 1326.758055] Aborting journal on device loop1-8.
2025 Jun 18 07:17:40.046411 sonic_testbed CRIT kernel: [ 1326.765336] EXT4-fs error (device loop1): ext4_journal_check_start:83: comm auditd: Detected aborted journal
2025 Jun 18 07:17:40.066131 sonic_testbed CRIT kernel: [ 1326.765960] EXT4-fs error (device loop1): ext4_journal_check_start:83: comm rs:main Q:Reg: Detected aborted journal
2025 Jun 18 07:17:40.066136 sonic_testbed CRIT kernel: [ 1326.775629] EXT4-fs (loop1): Remounting filesystem read-only
```

So, this PR makes enhancement to resolve the above issues with allocating slightly less than available space (e.g., 95%) to avoid triggering kernel errors.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Enhance test_disk_exhaustion with leaving some free space to avoid kernel errors.

#### How did you do it?
Allocate with available space(95%) instead of total space.

#### How did you verify/test it?
Run TC locally.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
