### PR TITLE
[route] Fix routes announing issue in isolated T1 topo

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -659,7 +659,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         last_suffix += (256 - last_suffix % 256)
 
     for k in sorted(vms_config.keys()):
-        v = vms_config(k)
+        v = vms_config[k]
         curr_no_default_route = no_default_route
         if topo_name in BGP_SCALE_T1S and 'spine' in v['properties']:
             curr_no_default_route = True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Route announcing by neighbor groups for isolated T1 in multi server scenario is incorrect.
In previous, the route announce order for isolated is: vlans / default route (from T0) - T2s' loopback (from T2) - **other T1s' loopback (from T0)**
The third part (other T1s loopback) need to be grouped. But in muti-server scenario, the number of T0 neighbors or T2 neighbors maybe be different, which would cause start offset of third part is not aligned in each ptf.

#### How did you do it?
Modify order of announcing routes, announce other T1s' loopback routes from T0 first, then announce T2 routes and T0 vlan / loopback routes

#### How did you verify/test it?
Run test_ipv6_bgp_scale

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
