### PR TITLE
[devices/eos]: Handle no auto option for link speed

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -431,7 +431,12 @@ class EosHost(AnsibleHostBase):
 
         speed_list = found_txt.groups()[0]
         speed_list = speed_list.split(',')
-        speed_list.remove('auto')
+
+        try:
+            speed_list.remove('auto')
+        except ValueError:
+            # auto may not be in speed options for certain versions
+            pass
 
         def extract_speed_only(v):
             return re.match(r'\d+', v.strip()).group() + '000'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

missed change from https://github.com/sonic-net/sonic-mgmt/pull/19538
New versions may not have auto as an option causing a value error - handle this case 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x ] 202405
- [ x] 202411
- [x ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/687593f414a9e751813a7d03
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
