### PR TITLE
Refactor DPU check in device_utils and test_watchdog

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1148,7 +1148,7 @@ def add_platform_api_server_port_nat_for_dpu(
     The NAT rule is added before the test and removed after the test.
     '''
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    if duthost.is_dpu():
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
         ip_interface_status = duthost.show_and_parse('show ip interface')
         for item in ip_interface_status:
             if item['interface'] == "eth0-midplane":
@@ -1162,7 +1162,7 @@ def add_platform_api_server_port_nat_for_dpu(
 
     yield
 
-    if duthost.is_dpu():
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
         npu_host.command(
             f'sudo iptables -t nat -D PREROUTING -i eth0 -p tcp --dport \
                 {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -138,7 +138,8 @@ class TestWatchdogApi(PlatformApiTestBase):
             self.expect(remaining_time is -1,
                         "Watchdog remaining_time {} seconds is wrong for disarmed state".format(remaining_time))
 
-        ansible_ssh_port = get_ansible_ssh_port(duthost, ansible_adhoc) if duthost.is_dpu() else 22
+        is_dpu = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")
+        ansible_ssh_port = get_ansible_ssh_port(duthost, ansible_adhoc) if is_dpu else 22
         res = localhost.wait_for(host=duthost.mgmt_ip, port=ansible_ssh_port, state="stopped", delay=5,
                                  timeout=watchdog_timeout + TIMEOUT_DEVIATION, module_ignore_errors=True)
 

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -89,7 +89,7 @@ def skip_on_dpu(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     When dut is dpu, skip the case
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if duthost.get_facts().get('is_dpu'):
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
         pytest.skip("Skip the test, as it is not supported on DPU.")
 
 

--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -620,7 +620,7 @@ def test_techsupport_on_dpu(duthosts, enum_rand_one_per_hwsku_frontend_hostname)
     :param duthosts: DUT host
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    if not duthost.get_facts().get('is_dpu'):
+    if not duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
         pytest.skip("Skip the test, as it is supported only on DPU.")
 
     since = str(randint(1, 5)) + " minute ago"


### PR DESCRIPTION
This changes is because is_dpu method was removed
by below PR
[smartswitch]: Add is_smartswitch and is_dpu facts to simplify platform-specific test handling (#19313)

The way to check if is dpu should use `duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")` instead of `duthost.get_facts().get('is_dpu')` becasue PR #19313 added the facts into dut_basic_facts
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19573 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix bugs that cause test failure
#### How did you do it?
update tests that calls method that does not exist
#### How did you verify/test it?
run test before and after the PR to verify it works as expected
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
