### PR TITLE
Fix test_bgp_suppress_fib.py failure with exabgp 4.x version

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -377,7 +377,7 @@ def install_route_from_exabgp(operation, ptfip, route_list, port):
     url = "http://{}:{}".format(ptfip, port)
     for route in route_list:
         route_data.append(route)
-    command = "{} attribute next-hop self nlri {}".format(operation, ' '.join(route_data))
+    command = "{} attributes next-hop self nlri {}".format(operation, ' '.join(route_data))
     data = {"command": command}
     logger.info("url: {}".format(url))
     logger.info("command: {}".format(data))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
With exabgp version 4.x, it doesn't accept "withdraw attribute", only accepting "withdraw attributes". The issue has been fixed in https://github.com/Exa-Networks/exabgp/commit/2946f34bd3d202faaa744601b952a481fae2fda2, but it's not included in 4.2.x version yet.
When running test_bgp_suppress_fib.py test case, it will failed to withdraw the routes, and result in following failures.
```
vmhost = <EosHost VM92012>, route_list = ['91.0.1.0/24', '91.0.2.0/24']
bgp_neighbor = '10.0.0.192', vrf = 'default', ip_ver = 4, exist = False

    def validate_route_propagate_status(vmhost, route_list, bgp_neighbor, vrf=DEFAULT, ip_ver=IP_VER, exist=True):
        """
        Verify ipv4 or ipv6 route propagate status
        :param vmhost: vm host object
        :param route_list: ipv4 or ipv6 route list
        :param bgp_neighbor: ipv4 or ipv6 bgp neighbor address
        :param vrf: vrf name
        :param ip_ver: ip version number
        :param exist: route expected status
        """
        if exist:
            pytest_assert(wait_until(30, 2, 0, check_propagate_route, vmhost, route_list, bgp_neighbor, ip_ver),
                          "Vrf:{} - route:{} is not propagated to T2 VM {}".format(vrf, route_list, vmhost))
        else:
>           pytest_assert(
                wait_until(30, 2, 0, check_propagate_route, vmhost, route_list, bgp_neighbor, ip_ver, ACTION_NOT_IN),
                "Vrf:{} - route:{} is propagated to T2 VM {}".format(vrf, route_list, vmhost))
E           Failed: Vrf:default - route:['91.0.1.0/24', '91.0.2.0/24'] is propagated to T2 VM <EosHost VM92012>

```


With the recent PTF upgrade, we'd better to "withdraw attributes" to work with 4.x version instead of waiting for a new exabgp release.

Here is the output on exabgp 4.x version:
```
root@99cb0373d021:~# exabgp --version
ExaBGP : 4.2.25
Python : 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0]
Uname  : Linux 99cb0373d021 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64
Root   : /root/env-python3
root@99cb0373d021:~# 

==> exabgp-ARISTA249T0.out.log <==
......
03:46:59 | 810    | api             | command from process not understood : withdraw attribute next-hop self nlri 91.0.1.0/25
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix test_bgp_suppress_fib.py failure

#### How did you do it?
use `withdraw attributes` which works for both exabgp 3.x and 4.x version.

#### How did you verify/test it?

Result on exabgp 4.x version:
```
04:42:34 | 810    | api             | route added to neighbor 10.10.247.2 local-ip 10.10.246.254 local-as 64032 peer-as 64032 router-id 10.10.246.254 family-allowed in-open : 91.0.1.0/25 next-hop self
04:42:48 | 810    | api             | route removed from neighbor 10.10.247.2 local-ip 10.10.246.254 local-as 64032 peer-as 64032 router-id 10.10.246.254 family-allowed in-open : 91.0.1.0/25 next-hop self
```

Result on exabgp 3.x version:
```
==> exabgp-ARISTA09T0.out.log <==
Mon, 14 Jul 2025 04:42:20 | INFO     | 817    | processes     | Command from process http-api : announce attributes next-hop self nlri 91.0.1.0/25 
Mon, 14 Jul 2025 04:42:20 | INFO     | 817    | reactor       | Route added to neighbor 10.10.246.10 local-ip 10.10.246.254 local-as 64002 peer-as 64002 router-id 10.10.246.254 family-allowed in-open : 91.0.1.0/25 next-hop 10.10.246.254
Mon, 14 Jul 2025 04:42:21 | INFO     | 817    | reactor       | Performing dynamic route update
Mon, 14 Jul 2025 04:42:21 | INFO     | 817    | reactor       | Updated peers dynamic routes successfully


==> exabgp-ARISTA09T0.out.log <==
Mon, 14 Jul 2025 04:42:25 | INFO     | 817    | processes     | Command from process http-api : withdraw attributes next-hop self nlri 91.0.1.0/25 
Mon, 14 Jul 2025 04:42:25 | INFO     | 817    | reactor       | Route removed : 91.0.1.0/25 next-hop 10.10.246.254
Mon, 14 Jul 2025 04:42:26 | INFO     | 817    | reactor       | Performing dynamic route update
Mon, 14 Jul 2025 04:42:26 | INFO     | 817    | reactor       | Updated peers dynamic routes successfully
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
