### PR TITLE
Ignore Packet Trim feature related Errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -356,3 +356,7 @@ r, ".* ERR kernel.*audit: rate limit exceeded.*"
 # https://msazure.visualstudio.com/One/_workitems/edit/33479668
 r, ".* ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*"
 r, ".* ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs.*"
+
+# Ignore Packet Trim Feature related errors
+r, ".* ERR .*packet trim Enum Capability values get for .*"
+r, ".* ERR .*Failed to get attribute\(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE\) enum value capabilities"


### PR DESCRIPTION
### Description of PR
Summary:
Packet Trim feature is supported only on TH5-512, hence ignoring the noisy error log which results in failure of multiple tests.

Fixes # (issue)
https://github.com/aristanetworks/sonic-qual.msft/issues/676

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Log analyzer complains about these unwanted errors.

#### How did you do it?

#### How did you verify/test it?
Tested using re.search(pattern, input_string)::
    $python3 /tmp/test_regex.py
    Enter a string: 2025 Jul 5 10:16:00.917878 ld496 ERR swss#orchagent: :- queryTrimModeEnumCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE) enum value capabilities
    Matched: .* ERR .*Failed to get attribute\(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE\) enum value capabilities
    $python3 /tmp/test_regex.py
    Enter a string: 2025 Jul 5 10:16:00.917432 ld496 ERR syncd#syncd: [none] SAI_API_SWITCH:sai_query_switch_attribute_enum_values_capability:26786 packet trim Enum Capability values get for 243 failed with error -2.
    Matched: .* ERR .*packet trim Enum Capability values get for .*

Also verified by running the tests that were causing the issue.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
