### PR TITLE
[CACL]Increase timeout when waiting for original ACLs to be restored

### DIFF
--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -109,7 +109,7 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                                  state='started',
                                  search_regex=SONIC_SSH_REGEX,
                                  delay=0,
-                                 timeout=90,
+                                 timeout=110,
                                  module_ignore_errors=True)
 
         pytest_assert(not res.is_failed, "SSH did not start working when expected. {}".format(res.get('msg', '')))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix the cacl.test_cacl_function failure by increasing the timeout:
```
Failed: SSH did not start working when expected.
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
In cacl.test_cacl_function case, the test ACLs config will wait for 150s to test the impact. On some testbeds, the test acl took effect very quickly, so after about 40s, the test started checking via SSH to see if the original ACL had been restored. So increase the timeout to 110s to make sure the SSH can work.

#### How did you do it?
Increase timeout to 110s when waiting for original ACLs to be restored
#### How did you verify/test it?
Run cacl.test_cacl_function.py locally and the case can pass.
```
cacl/test_cacl_function.py::test_cacl_function[str4-7060x6-512-1] 
------------------------------------------------------------- live log call --------------------------------------------------------------
06:12:32 test_cacl_function.test_cacl_function    L0034 WARNING| Will not check NTP connection. ntplib is not installed.
PASSED                                                                                                                             [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>