### PR TITLE
Ignore query stats error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -356,3 +356,6 @@ r, ".* ERR kernel.*audit: rate limit exceeded.*"
 # https://msazure.visualstudio.com/One/_workitems/edit/33479668
 r, ".* ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB.*"
 r, ".* ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs.*"
+
+# Ignore query stats capability errors
+r, ".* ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_stats_capability.*stats capablity not supported for object.*"


### PR DESCRIPTION
### Description of PR
Summary:
This is a new feature implementation in SAI 13.2.1_EA. Until now the implementation was stubbed out without returning any error msg. But now the code hits a case where it returns the same error_code with an error msg.

Log-analyzer complaints about this newly added error message for the feature. Will add it to skip list until the feature is enabled.

Fixes # (issue)
https://github.com/aristanetworks/sonic-qual.msft/issues/675

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Too many new error logs are thrown due to this unsupported feature.
#### How did you do it?
Added the error pattern to list of patterns to ignore.
#### How did you verify/test it?

UT:
    verified using a python program to match on the regex.

```
    python3 /tmp/test_regex.py
    Enter a string: pc/test_lag_member_forwarding.log:2025 Jul  5 09:06:21.721018 ld496 ERR syncd#syncd: message repeated 420 times: [ [none] SAI_API_SWITCH:sai_query_stats_capability:874 stats capablity not supported for object 26]
    Matched: .* ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_stats_capability.*stats capablity not supported for object.*

    python3 /tmp/test_regex.py
    Enter a string: pc/test_lag_member_forwarding.log:2025 Jul  5 09:06:26.729108 ld496 ERR syncd#syncd: message repeated 135 times: [ [none] SAI_API_SWITCH:sai_query_stats_capability:874 stats capablity not supported for object 1]
    Matched: .* ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_stats_capability.*stats capablity not supported for object.*

    python3 /tmp/test_regex.py
    Enter a string: pc/test_lag_member_forwarding.log:2025 Jul  5 09:06:21.177644 ld496 ERR syncd#syncd: [none] SAI_API_SWITCH:sai_query_stats_capability:874 stats capablity not supported for object 24
    Matched: .* ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_stats_capability.*stats capablity not supported for object.*


```
Also verified by running thte tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
