### PR TITLE
[dualtor] Fix sniffer not capture packets

### DIFF
--- a/tests/scripts/dual_tor_sniffer.py
+++ b/tests/scripts/dual_tor_sniffer.py
@@ -3,17 +3,37 @@ import logging
 import socket
 
 import scapy.all as scapyall
+import scapy.arch.linux as scapyarchlinux
+from scapy.config import conf
+from scapy.data import MTU
 
 
-class L2ListenAllSocket(scapyall.conf.L2listen):
+class L2ListenAllSocket(scapyarchlinux.L2ListenSocket):
     """Read packets at layer2 using Linux PF_PACKET sockets on all ports."""
 
     def __init__(self, *args, **kwargs):
         # HACK: Set the socket bind to NOOP, so the packet sockets created
         # will not bind to any interface and it will listen on all interfaces
         # by default.
-        socket.bind = lambda _: None
+        socket.socket.bind = lambda *_: None
         super(L2ListenAllSocket, self).__init__(*args, **kwargs)
+
+    def recv_raw(self, x=MTU):
+        # NOTE: override the L2ListenSocket.recv_raw to map to correct
+        # packet layer type.
+        pkt, sa_ll, ts = self._recv_raw(self.ins, x)
+        if ts is None:
+            ts = scapyarchlinux.get_last_packet_timestamp(self.ins)
+        if sa_ll[3] in conf.l2types:
+            cls = conf.l2types[sa_ll[3]]
+        elif sa_ll[1] in conf.l3types:
+            cls = conf.l3types[sa_ll[1]]
+        else:
+            cls = conf.default_l2
+            logging.warning("Unable to guess type (interface=%s "
+                            "protocol=%#x family=%i). Using %s" % (
+                                sa_ll[0], sa_ll[1], sa_ll[3], cls.name))
+        return cls, pkt, ts
 
 
 class Sniffer(object):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Fix the dualtor sniffer not capture any packets:
```
dualtor_io/test_normal_op.py::test_normal_op_upstream[active-active] 
-------------------------------- live log call ---------------------------------
03:52:04 dual_tor_io.examine_flow                 L0691 ERROR  | self.all_packets not defined.
PASSED  
```
```
14/07/2025 05:12:15 dual_tor_io.examine_flow                 L0706 INFO   | Number of filtered packets captured: 0
14/07/2025 05:12:15 dual_tor_io.examine_flow                 L0708 ERROR  | Sniffer failed to capture any traffic
```

**Why `dual_tor_sniffer cannot capture any I/O?**

For scapy 2.5.0 and above, the `L2ListenSocket` uses `getsockname()` to retrieve the socket hardware type [1], and the socket hardware type is used to build the packet [2] [3].
As we are using `PACKET` socket without binding to any interface,  `getsockname()` will return 0 for the hardware type, `scapy` will use the wrong layer2 packet type to build the packet.

[1]: https://github.com/secdev/scapy/blob/7fb32a173f8567a498e25282da79569b5bf802bb/scapy/arch/linux/__init__.py#L259-L270
[2]: https://github.com/secdev/scapy/blob/7fb32a173f8567a498e25282da79569b5bf802bb/scapy/arch/linux/__init__.py#L291
[3]: https://github.com/secdev/scapy/blob/7fb32a173f8567a498e25282da79569b5bf802bb/scapy/supersocket.py#L205-L209

Signed-off-by: Longxiang Lyu lolv@microsoft.com

#### How did you do it?
Use the hardware type returned by `recvfrom` to build the packet.

#### How did you verify/test it?
Run any dualtor-io case and check the packet capture:
```
14/07/2025 06:32:54 dual_tor_io.fetch_captured_packets       L0627 INFO   | Number of all packets captured: 10734
14/07/2025 06:32:54 dual_tor_io.examine_flow                 L0689 INFO   | Packet flow examine started 2025-07-14 06:32:54.501871
14/07/2025 06:32:54 dual_tor_io.examine_flow                 L0706 INFO   | Number of filtered packets captured: 10734
14/07/2025 06:32:55 dual_tor_io.examine_flow                 L0731 INFO   | Measuring traffic disruptions...
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
