### PR TITLE
Fix qos/test_qos_sai.py for active-active dualtor

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -557,7 +557,7 @@ class QosSaiBase(QosBase):
 
         return {"schedProfile": schedProfile, "schedWeight": schedWeight}
 
-    def __assignTestPortIps(self, mgFacts, topo, lower_tor_host):
+    def __assignTestPortIps(self, mgFacts, topo, lower_tor_host):  # noqa: F811
         """
             Assign IPs to test ports of DUT host
 
@@ -601,7 +601,7 @@ class QosSaiBase(QosBase):
             for i in range(len(testVlanMembers)):
                 portIndex = mgFacts["minigraph_ptf_indices"][testVlanMembers[i]]
                 peer_addr = config_facts['MUX_CABLE'][testVlanMembers[i]]['server_ipv4'].split('/')[0] \
-                            if 'dualtor' in topo else testVlanIp + portIndex + 1
+                    if 'dualtor' in topo else testVlanIp + portIndex + 1
                 portIpMap = {'peer_addr': str(peer_addr)}
                 if vlan_id is not None:
                     portIpMap['vlan_id'] = vlan_id
@@ -2382,7 +2382,6 @@ class QosSaiBase(QosBase):
 
             lower_tor_host.shell(f"sudo iptables -D OUTPUT -p tcp --dport {port} -j DROP")
             lower_tor_host.shell(f"sudo iptables -D INPUT -p tcp --sport {port} -j DROP")
-
 
     @pytest.fixture(scope='class')
     def dualtor_ports_for_duts(request, get_src_dst_asic_and_duts):

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -557,7 +557,7 @@ class QosSaiBase(QosBase):
 
         return {"schedProfile": schedProfile, "schedWeight": schedWeight}
 
-    def __assignTestPortIps(self, mgFacts, topo):
+    def __assignTestPortIps(self, mgFacts, topo, lower_tor_host):
         """
             Assign IPs to test ports of DUT host
 
@@ -596,9 +596,13 @@ class QosSaiBase(QosBase):
                 if vlan_type is not None and "Tagged" in vlan_type:
                     vlan_id = mgFacts["minigraph_vlans"][testVlan]['vlanid']
 
+            config_facts = lower_tor_host.config_facts(host=lower_tor_host.hostname, source="running")['ansible_facts']
+
             for i in range(len(testVlanMembers)):
                 portIndex = mgFacts["minigraph_ptf_indices"][testVlanMembers[i]]
-                portIpMap = {'peer_addr': str(testVlanIp + portIndex + 1)}
+                peer_addr = config_facts['MUX_CABLE'][testVlanMembers[i]]['server_ipv4'].split('/')[0] \
+                            if 'dualtor' in topo else testVlanIp + portIndex + 1
+                portIpMap = {'peer_addr': str(peer_addr)}
                 if vlan_id is not None:
                     portIpMap['vlan_id'] = vlan_id
                 dutPortIps.update({portIndex: portIpMap})
@@ -1070,7 +1074,7 @@ class QosSaiBase(QosBase):
                 dualTorPortIndexes = testPortIds
 
             testPortIps[src_dut_index] = {}
-            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts, topo)
+            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts, topo, lower_tor_host)
 
             # restore currently assigned IPs
             if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
@@ -1135,7 +1139,7 @@ class QosSaiBase(QosBase):
 
             # Need to fix this
             testPortIps[src_dut_index] = {}
-            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts, topo)
+            testPortIps[src_dut_index][src_asic_index] = self.__assignTestPortIps(src_mgFacts, topo, lower_tor_host)
 
             # restore currently assigned IPs
             if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
@@ -2350,6 +2354,35 @@ class QosSaiBase(QosBase):
         for dut_asic in get_src_dst_asic_and_duts['all_asics']:
             dut_asic.command("counterpoll watermark disable")
             dut_asic.command("counterpoll queue disable")
+
+    @pytest.fixture
+    def blockGrpcTraffic(self, tbinfo, lower_tor_host, nic_simulator_info):   # noqa F811
+
+        """
+            Block all gRPC traffic on active-active dualtor
+
+            Args:
+                tbinfo: Testbed info
+                lower_tor_host: DUT in t0 / dualtor topologies
+
+            Returns:
+                None
+        """
+
+        _, port, _ = nic_simulator_info
+        if port is None:
+            yield
+
+        else:
+
+            lower_tor_host.shell(f"sudo iptables -A OUTPUT -p tcp --dport {port} -j DROP")
+            lower_tor_host.shell(f"sudo iptables -A INPUT -p tcp --sport {port} -j DROP")
+
+            yield
+
+            lower_tor_host.shell(f"sudo iptables -D OUTPUT -p tcp --dport {port} -j DROP")
+            lower_tor_host.shell(f"sudo iptables -D INPUT -p tcp --sport {port} -j DROP")
+
 
     @pytest.fixture(scope='class')
     def dualtor_ports_for_duts(request, get_src_dst_asic_and_duts):

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -1709,7 +1709,7 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("pgProfile", ["wm_pg_shared_lossless", "wm_pg_shared_lossy"])
     def testQosSaiPgSharedWatermark(
         self, pgProfile, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, skip_src_dst_different_asic, change_lag_lacp_timer
+        resetWatermark, skip_src_dst_different_asic, change_lag_lacp_timer, blockGrpcTraffic
     ):
         """
             Test QoS SAI PG shared watermark test for lossless/lossy traffic
@@ -1929,7 +1929,8 @@ class TestQosSai(QosSaiBase):
     @pytest.mark.parametrize("queueProfile", ["wm_q_shared_lossless", "wm_q_shared_lossy"])
     def testQosSaiQSharedWatermark(
         self, get_src_dst_asic_and_duts, queueProfile, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-        resetWatermark, skip_src_dst_different_asic, skip_pacific_dst_asic, change_lag_lacp_timer
+        resetWatermark, skip_src_dst_different_asic, skip_pacific_dst_asic, change_lag_lacp_timer,
+        blockGrpcTraffic
     ):
         """
             Test QoS SAI Queue shared watermark test for lossless/lossy traffic


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix `qos/test_qos_sai.py` for active-active dualtor
Fixes [#636](https://github.com/aristanetworks/sonic-qual.msft/issues/636), [#670](https://github.com/aristanetworks/sonic-qual.msft/issues/670)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The following testcases fail on active-active dualtor 

1. testQosSaiPgSharedWatermark
2. testQosSaiQSharedWatermark

These tests involve shutting down the Tx on the egress interface and then fill up the buffers to get the reading of shared watermark. In case of active-active DualToR there is gRPC traffic flowing between the DUT and the NIC SImulator which fills up the buffers earlier than expected leading to incorrect results and test failures.

Also the test is selecting invalid destination IP addresses

#### How did you do it?
The proposed fix is as follows -
1. Fix host address selection/assignment by referring to mux_config rather than using a continuous range.
2. Block gRPC traffic for active-active/mixed dualtor using iptables as it interferes with the testcases that involve shutting down Tx on egress interface. The gRPC traffic fills up the the buffers early leading to inconsistent results.

#### How did you verify/test it?

Ran `qos/test_qos_sai.py` on Arista-7260CX3 and Arista-7050CX3 with dualtor topologies with 202505 images.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
