### PR TITLE
[snappi-T2] Update ecn helpers to use asic_value for fetching config_facts

### DIFF
--- a/tests/snappi_tests/ecn/files/helper.py
+++ b/tests/snappi_tests/ecn/files/helper.py
@@ -350,12 +350,14 @@ def run_ecn_test(api,
     config_result = config_wred(host_ans=egress_duthost,
                                 kmin=snappi_extra_params.ecn_params["kmin"],
                                 kmax=snappi_extra_params.ecn_params["kmax"],
-                                pmax=snappi_extra_params.ecn_params["pmax"])
+                                pmax=snappi_extra_params.ecn_params["pmax"],
+                                asic_value=rx_port['asic_value'])
     pytest_assert(config_result is True, 'Failed to configure WRED/ECN at the DUT')
     config_result = config_wred(host_ans=ingress_duthost,
                                 kmin=snappi_extra_params.ecn_params["kmin"],
                                 kmax=snappi_extra_params.ecn_params["kmax"],
-                                pmax=snappi_extra_params.ecn_params["pmax"])
+                                pmax=snappi_extra_params.ecn_params["pmax"],
+                                asic_value=tx_port['asic_value'])
     pytest_assert(config_result is True, 'Failed to configure WRED/ECN at the DUT')
 
     # Enable ECN marking
@@ -364,11 +366,13 @@ def run_ecn_test(api,
     pytest_assert(enable_ecn(host_ans=ingress_duthost, prio=lossless_prio), 'Unable to enable ecn')
 
     config_result = config_ingress_lossless_buffer_alpha(host_ans=egress_duthost,
-                                                         alpha_log2=3)
+                                                         alpha_log2=3,
+                                                         asic_value=rx_port['asic_value'])
 
     pytest_assert(config_result is True, 'Failed to configure PFC threshold to 8')
     config_result = config_ingress_lossless_buffer_alpha(host_ans=ingress_duthost,
-                                                         alpha_log2=3)
+                                                         alpha_log2=3,
+                                                         asic_value=tx_port['asic_value'])
 
     pytest_assert(config_result is True, 'Failed to configure PFC threshold to 8')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [snappi-T2] Update ecn helpers to use asic_value for fetching config_facts
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/19590

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] msft-202405 

### Approach
#### What is the motivation for this PR?
Couple of ecn config helper methods are not using `asic_value` (which refers to asic where underlying port belongs to, in case of multi-asic devices) to fetch config_facts, thus causing config_facts to be fetched from linecard namespace (instead of asic namespace) which doesn't have qos config (WRED_PROFILE, BUFFER_PROFILE etc) and causing test failures with `Failed to configure WRED/ECN at the DUT`.

#### How did you do it?
Pass `asic_value` parameter to the config helper methods.

#### How did you verify/test it?
With the fix test is not hitting `Failed to configure WRED/ECN at the DUT`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
