### PR TITLE
[snappi-T2] Fix pfcwd/test_pfcwd_actions.py to consider asic value

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_actions_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_actions_helper.py
@@ -100,22 +100,24 @@ def run_pfc_test(api,
 
     pytest_assert(testbed_config is not None, 'Fail to get L2/3 testbed config')
 
+    rx_port_asic_value = rx_port['asic_value'] if egress_duthost.is_multi_asic else None
+    tx_port_asic_value = tx_port['asic_value'] if ingress_duthost.is_multi_asic else None
     if (test_def['enable_pfcwd_drop']):
-        start_pfcwd(egress_duthost)
-        start_pfcwd(ingress_duthost)
+        start_pfcwd(egress_duthost, rx_port_asic_value)
+        start_pfcwd(ingress_duthost, tx_port_asic_value)
     elif (test_def['enable_pfcwd_fwd']):
-        start_pfcwd_fwd(egress_duthost)
-        start_pfcwd_fwd(ingress_duthost)
+        start_pfcwd_fwd(egress_duthost, rx_port_asic_value)
+        start_pfcwd_fwd(ingress_duthost, tx_port_asic_value)
     else:
-        stop_pfcwd(egress_duthost)
-        stop_pfcwd(ingress_duthost)
+        stop_pfcwd(egress_duthost, rx_port_asic_value)
+        stop_pfcwd(ingress_duthost, tx_port_asic_value)
 
     if (test_def['enable_credit_wd']):
-        enable_packet_aging(egress_duthost, rx_port['asic_value'])
-        enable_packet_aging(ingress_duthost, tx_port['asic_value'])
+        enable_packet_aging(egress_duthost, rx_port_asic_value)
+        enable_packet_aging(ingress_duthost, tx_port_asic_value)
     else:
-        disable_packet_aging(egress_duthost, rx_port['asic_value'])
-        disable_packet_aging(ingress_duthost, tx_port['asic_value'])
+        disable_packet_aging(egress_duthost, rx_port_asic_value)
+        disable_packet_aging(ingress_duthost, tx_port_asic_value)
 
     rx_port_id = 0
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [snappi-T2] Fix pfcwd/test_pfcwd_actions.py to consider asic value
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/19591

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] msft-202405 

### Approach
#### What is the motivation for this PR?
Helper method `run_pfc_test` is not passing `asic_value` of the port for enabling/disabling of pfcwd on the dut. This causes config to be not applied for multi-asic devices, where config command needs to be run on asic namespace. And test is failing with `No Tx PFCs from DUT after receiving PFCs`.

#### How did you do it?
Updated helper method to pass `asic_value` correctly.

#### How did you verify/test it?
Test is passing with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
