### PR TITLE
Golden config support for t1-48-lag topo and Mellanox-SN4280-O8C40 hwsku

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -624,7 +624,7 @@
               dest=/tmp/smartswitch.json
         become: true
         # t1-28-lag is smartswitch topo only
-        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
+        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"]
 
       - name: Create dns config
         template: src=templates/dns_config.j2
@@ -803,7 +803,7 @@
               dest=/tmp/dpu_extra.json
         become: true
         # t1-28-lag is smartswitch topo only
-        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
+        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"]
 
       - name: Load DPU config in smartswitch
         load_extra_dpu_config:
@@ -812,7 +812,7 @@
           host_passwords: "{{ sonic_default_passwords }}"
         become: true
         # t1-28-lag is smartswitch topo only
-        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1"]
+        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"]
 
       - name: Configure TACACS
         become: true

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -407,7 +407,7 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_mgfx_golden_config_db()
             module_msg = module_msg + " for mgfx"
             self.module.run_command("sudo rm -f {}".format(TEMP_DHCP_SERVER_CONFIG_PATH))
-        elif self.topo_name in ["t1-smartswitch-ha", "t1-28-lag", "smartswitch-t1"]:
+        elif self.topo_name in ["t1-smartswitch-ha", "t1-28-lag", "smartswitch-t1", "t1-48-lag"]:
             config = self.generate_smartswitch_golden_config_db()
             module_msg = module_msg + " for smartswitch"
             self.module.run_command("sudo rm -f {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))

--- a/ansible/module_utils/smartswitch_utils.py
+++ b/ansible/module_utils/smartswitch_utils.py
@@ -12,5 +12,13 @@ smartswitch_hwsku_config = {
         "base": 224,
         "step": 8,
         "dpu_key": "dpu{}"
+    },
+    "Mellanox-SN4280-O8C40": {
+        "dpu_num": 4,
+        "port_key": "Ethernet{}",
+        "interface_key": "Ethernet{}|18.{}.202.0/31",
+        "base": 224,
+        "step": 8,
+        "dpu_key": "dpu{}"
     }
 }


### PR DESCRIPTION
Summary:
Updated sonic-mgmt code to add support for t1-48-lag topo and Mellanox-SN4280-O8C40 hwsku.

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
New hwsku request

#### How did you do it?
Included new topo to the logic

#### How did you verify/test it?
Deployed on multiple community test beds

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
