### PR TITLE
Increase memory threshold for pmon container

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -73,7 +73,7 @@
         "pmon": {
           "memory_increase_threshold": {
             "type": "value",
-            "value": 2
+            "value": 4
           },
           "memory_high_threshold": {
             "type": "value",


### PR DESCRIPTION
### Description of PR
Changing the memory increase threshold of the pmon container from 2 MB to 4 MB as some of our SKUs have been failing sonic-mgmt tests on tear down due to memory usage in the 3 MB range. I believe these thresholds are being determined empirically, therefore it seems reasonable to increase it.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Failing sonic-mgmt tests on some Arista SKUs due to memory increase threshold being exceeded for the pmon container

#### How did you do it?
Modified `memory_utilization_dependence.json` to use a higher threshold value (4 MB)

#### How did you verify/test it?
Ran the test with and without the change, the tests in question all pass with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
