### PR TITLE
T2:snappi-tests:Add deviation modification for cisco-8000.

### DIFF
--- a/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
+++ b/tests/snappi_tests/pfcwd/files/pfcwd_basic_helper.py
@@ -88,6 +88,9 @@ def run_pfcwd_basic_test(api,
     # Set appropriate pfcwd loss deviation - these values are based on empirical testing
     DEVIATION = 0.35 if egress_duthost.facts['asic_type'] in ["broadcom"] or \
         ingress_duthost.facts['asic_type'] in ["broadcom"] else 0.3
+    if "cisco-8000" in (egress_duthost.facts['asic_type'],
+                        ingress_duthost.facts['asic_type']):
+        DEVIATION = 0.5
 
     poll_interval_sec = get_pfcwd_poll_interval(egress_duthost, rx_port['asic_value']) / 1000.0
     detect_time_sec = get_pfcwd_detect_time(host_ans=egress_duthost, intf=dut_port,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
pfcwd_basic tests have to be tuned on platform basis. Since they are timer-sensitive, and can fail in corner cases with the symptom as below:
```

>           pytest_assert(loss_rate <= max_loss_rate and loss_rate >= min_loss_rate,
                          'Loss rate of {} ({}) should be in [{}, {}]'.format(
                              data_flow_name_list[i], loss_rate, min_loss_rate, max_loss_rate))
E           Failed: Loss rate of Data Flow 1 (0.5811225531621866) should be in [0.7, 1]
```

In this PR, we are increasing the deviation for cisco-8000 to 0.5 instead of the original 0.3.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Cisco-8000 runs keep hitting flaky test fails due to above signature.

#### How did you do it?
Updated the deviation for cisco-8000 to 0.5.

#### How did you verify/test it?
Run in progress for entire pfcwd_basic. Will update the PR once it is done.

#### Any platform specific information?
Specific to cisco-8000.