### PR TITLE
Add common param in baseline to support SafeThreadPoolExecutor for Ubuntu 24.04 upgrade

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.template.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.template.yml
@@ -47,7 +47,7 @@ jobs:
         impacted-area-kvmtest-t0-sonic:
           TESTBED_PREP_TOPOLOGY: t0-sonic
           CHECKER: t0-sonic_checker
-          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation"
+          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
           TOPOLOGY: t0-64-32
           PREPARE_TIME: 40
           VM_TYPE: vsonic

--- a/.azure-pipelines/baseline_test/baseline.test.template.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.template.yml
@@ -47,7 +47,7 @@ jobs:
         impacted-area-kvmtest-t0-sonic:
           TESTBED_PREP_TOPOLOGY: t0-sonic
           CHECKER: t0-sonic_checker
-          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic "
+          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation"
           TOPOLOGY: t0-64-32
           PREPARE_TIME: 40
           VM_TYPE: vsonic
@@ -68,7 +68,7 @@ jobs:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
-      COMMON_EXTRA_PARAMS: ""
+      COMMON_EXTRA_PARAMS: "--disable_sai_validation "
       DEPLOY_MG_EXTRA_PARAMS: ""
       SPECIFIC_PARAM: "[]"
     timeoutInMinutes: 300


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/19263 added new SafeThreadPoolExecutor for Ubuntu 24.04 upgrade and common param in PR test, but we also need the param in baseline test
#### How did you do it?
Add common param in baseline to support SafeThreadPoolExecutor for Ubuntu 24.04 upgrade
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
