### PR TITLE
Skip IPv4 tests on IPv6 topologies in Everflow tests

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -90,6 +90,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
     @staticmethod
     def _is_ipv6_only_topology(tbinfo):
         """Helper function to determine if this is an IPv6 topology."""
+        # will be changed to use is_ipv6_only_topology from tests.common.utilities
+        # once PR #19639 is merged
         return (
             "-v6-" in tbinfo["topo"]["name"]
             if tbinfo and "topo" in tbinfo and "name" in tbinfo["topo"]
@@ -99,6 +101,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
     @pytest.fixture(autouse=True)
     def skip_ipv4_on_ipv6_only_topo(self, tbinfo, erspan_ip_ver):        # noqa F811
         """Skip IPv4 tests if running on IPv6 only topology."""
+        # will be changed to use is_ipv6_only_topology from tests.common.utilities
+        # once PR #19639 is merged
         # Only skip if it's an IPv6 only topology AND we're running IPv4 tests
         if self._is_ipv6_only_topology(tbinfo) and erspan_ip_ver == 4:
             pytest.skip("Skipping IPv4 test on IPv6 only topology")
@@ -109,6 +113,12 @@ class EverflowIPv4Tests(BaseEverflowTest):
         This fixture parametrize  dest_port_type and can perform action based
         on that. As of now cleanup is being done here.
         """
+        # will be changed to use is_ipv6_only_topology from tests.common.utilities
+        # once PR #19639 is merged
+        if self._is_ipv6_topology(tbinfo) and erspan_ip_ver == 4:
+            # return
+            pytest.skip("Skipping IPv4 test on IPv6 topology")
+
         remote_dut = setup_info[request.param]['remote_dut']
 
         ip = "ipv4" if erspan_ip_ver == 4 else "ipv6"
@@ -121,10 +131,6 @@ class EverflowIPv4Tests(BaseEverflowTest):
             pytest.skip("Skipping DOWN_STREAM test on FT2 topology.")
 
         yield request.param
-
-        # Skip cleanup only when IPv4 tests run on IPv6 only topologies (which shouldn't happen due to skip logic)
-        if self._is_ipv6_only_topology(tbinfo) and erspan_ip_ver == 4:
-            return
 
         session_prefixes = setup_mirror_session["session_prefixes"] if erspan_ip_ver == 4 \
             else setup_mirror_session["session_prefixes_ipv6"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19603 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To remove unnecessary Fails in test, and reduce total runtime.
Since IPv6 topo, shouldn't run IPv4 test.

#### How did you do it?
By implementing a check for topo and the test.
Now:
IPv6 topology + IPv4 test (erspan_ip_ver == 4): Skip the test entirely
IPv6 topology + IPv6 test (erspan_ip_ver == 6): Run the test and do proper cleanup
IPv4 topology + IPv4 test: Run the test and do proper cleanup

#### How did you verify/test it?
Ran test locally:
<img width="1360" height="201" alt="image" src="https://github.com/user-attachments/assets/8c43d2dc-81f6-40d1-8e45-2052eaed68f9" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
