### PR TITLE
Skip IPv4 BGP network command test in IPv6 topology

### DIFF
--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -32,16 +32,16 @@ def test_bgp_network_command(
     if it matches the output of "docker exec -i bgp vtysh -c show bgp ipv4 all" command
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    # Determine if we are on IPv6 topology
-    ipv6_topo = (
+    # Determine if we are on IPv6 only topology
+    ipv6_only_topo = (
         "-v6-" in tbinfo["topo"]["name"]
         if tbinfo and "topo" in tbinfo and "name" in tbinfo["topo"]
         else False
     )
 
     if ip_version == "ipv4":
-        if ipv6_topo:
-            pytest.skip("Skipping IPv4 BGP network command test in IPv6 topology")
+        if ipv6_only_topo:
+            pytest.skip("Skipping IPv4 BGP network command test in IPv6 only topology")
         bgp_network_cmd = "show ip bgp network"
         bgp_docker_cmd = 'docker exec -i bgp vtysh -c "show bgp ipv4 all"'
     elif ip_version == "ipv6":

--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -25,14 +25,23 @@ def parse_routes_and_paths(output):
 
 @pytest.mark.parametrize("ip_version", ["ipv4", "ipv6"])
 def test_bgp_network_command(
-    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ip_version
+    duthosts, enum_rand_one_per_hwsku_frontend_hostname, ip_version, tbinfo
 ):
     """
     @summary: This test case is to verify the output of "show ip bgp network" command
     if it matches the output of "docker exec -i bgp vtysh -c show bgp ipv4 all" command
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    # Determine if we are on IPv6 topology
+    ipv6_topo = (
+        "-v6-" in tbinfo["topo"]["name"]
+        if tbinfo and "topo" in tbinfo and "name" in tbinfo["topo"]
+        else False
+    )
+
     if ip_version == "ipv4":
+        if ipv6_topo:
+            pytest.skip("Skipping IPv4 BGP network command test in IPv6 topology")
         bgp_network_cmd = "show ip bgp network"
         bgp_docker_cmd = 'docker exec -i bgp vtysh -c "show bgp ipv4 all"'
     elif ip_version == "ipv6":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19605 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To support IPv6 topo. 
Remove unnecessary fail and reduce total test run time.

#### How did you do it?
Enable topo check when it tries to run IPv4 test.
If topo is IPv6 but test is IPv4, the test will skip.

#### How did you verify/test it?
Ran on local testbed to verify.
<img width="1044" height="65" alt="image" src="https://github.com/user-attachments/assets/17ea6295-7297-48b3-8c32-5684b295660f" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
