### PR TITLE
Skip to check mgmt ports on Arista-7060X6-64PE platform

### DIFF
--- a/tests/snmp/test_snmp_pfc_counters.py
+++ b/tests/snmp/test_snmp_pfc_counters.py
@@ -17,12 +17,23 @@ def test_snmp_pfc_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
         duthost, localhost, host=hostip, version="v2c",
         community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
 
+    # Get the hardware SKU of the DUT
+    hwsku = duthost.facts.get('hwsku', '')
+
     # Check PFC counters
     # Ignore management ports, assuming the names starting with 'eth', eg. eth0
-    for k, v in list(snmp_facts['snmp_interfaces'].items()):
-        if "Ethernet" in v['description']:
-            if 'cpfcIfRequests' not in v or \
-               'cpfcIfIndications' not in v or \
-               'requestsPerPriority' not in v or \
-               'indicationsPerPriority' not in v:
-                pytest.fail("port %s does not have pfc counters" % v['name'])
+    for _, v in list(snmp_facts['snmp_interfaces'].items()):
+        desc = v.get('description', '')
+        name = v.get('name', '')
+
+        if 'Ethernet' not in desc:
+            continue
+
+        # Skip management ports for Arista 7060x6 platforms
+        if 'Arista-7060X6-64PE' in hwsku and 'PT0' in desc:
+            continue
+
+        # Check for required PFC counters
+        required_keys = ['cpfcIfRequests', 'cpfcIfIndications', 'requestsPerPriority', 'indicationsPerPriority']
+        if not all(key in v for key in required_keys):
+            pytest.fail(f"Port {name} (desc: '{desc}') missing PFC counters: {required_keys}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
To fix the snmp/test_snmp_pfc_counters.py failure on Arista 7060x6 platform.
```
Failed: port etp65 does not have pfc counters
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
On Arista 7060X6 platforms, mgmt ports don't have pfc counter so the case would fail. To fix that, skipping the pfc counter check on the mgmt ports.

#### How did you do it?
Skip checking the ports with 'PT0' in its description on Arista 7060X6 platforms.
#### How did you verify/test it?
Run snmp.test_snmp_pfc_counters case locally and case passed.
```
snmp/test_snmp_pfc_counters.py::test_snmp_pfc_counters[str4-7060x6-512-1] PASSED                                                   [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
