### PR TITLE
Add t0-56-o8v48 into reboot test supported topology

### DIFF
--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -259,7 +259,7 @@ testcases:
 
     reboot:
       filename: reboot.yml
-      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-48-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
+      topologies: [dualtor, dualtor-64-breakout, dualtor-aa-64-breakout, t0, t0-28, t0-52, t0-56, t0-56-po2vlan, t0-56-o8v48, t0-64, t0-64-32, t0-116, t0-118, t0-120, t1, t1-lag, t1-28-lag, t1-48-lag, t1-64-lag, t1-64-lag-clet, t1-56-lag, ptf32, ptf64]
 
     repeat_harness:
       filename: repeat_harness.yml


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add t0-56-o8v48 into reboot test supported topology

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Add t0-56-o8v48 into reboot test supported topology
#### How did you do it?
Add t0-56-o8v48 into reboot test supported topology
#### How did you verify/test it?
Run the test in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
