### PR TITLE
Add capability to handle when the counter has ',' in the value

### DIFF
--- a/tests/ip/ip_util.py
+++ b/tests/ip/ip_util.py
@@ -78,7 +78,7 @@ def parse_rif_counters(output_lines):
         intf = portstats[0]
         results[intf] = {}
         for idx in range(1, len(portstats)):  # Skip the first column interface name
-            results[intf][headers[idx]] = portstats[idx]
+            results[intf][headers[idx]] = portstats[idx].replace(',', '')
 
     return results
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: When the counter exceed 1000, there will be "," in it, previously, it only happen when there is cache for the counters, after the PR, there will be always "," when counter excceed 1000.  Here is the PR: https://github.com/sonic-net/sonic-utilities/pull/3902/
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
