### PR TITLE
Add multi binding acl test into everflow test scope

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -846,3 +846,42 @@ def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,
             pt_assert(addr not in cmd_output,
                       f"{hostname} {cmd_desc} still with addr {addr}")
             logger.info(f"{addr} not exists in the output of {cmd_desc} which is expected")
+
+
+def is_sai_profile_multi_binding_enabled(duthost):
+    """
+    Check if SAI_ACL_MULTI_BINDING_ENABLED is enabled in syncd docker's sai.profile
+
+    Args:
+        duthost: DUT host object
+
+    Returns:
+        bool: True if SAI_ACL_MULTI_BINDING_ENABLED=1 exists in sai.profile, False otherwise
+    """
+    try:
+        # Check if sai.profile exists in syncd docker
+        result = duthost.shell(
+            "docker exec syncd ls /tmp/sai.profile", module_ignore_errors=True)
+        if result['rc'] != 0:
+            return False
+
+        # Check if SAI_ACL_MULTI_BINDING_ENABLED=1 exists in the file
+        result = duthost.shell(
+            "docker exec syncd grep 'SAI_ACL_MULTI_BINDING_ENABLED=1' /tmp/sai.profile", module_ignore_errors=True)
+        return result['rc'] == 0
+    except Exception as e:
+        logger.error("Failed to check sai.profile: %s", str(e))
+        return False
+
+
+@pytest.fixture(scope="module")
+def is_multi_binding_acl_enabled(duthosts, tbinfo):
+    """
+    Check if multi-binding ACL is enabled on the DUT
+    """
+    for duthost in duthosts:
+        if not is_sai_profile_multi_binding_enabled(duthost):
+            if is_mellanox_device(duthost) and 'dualtor' in tbinfo['topo']['name']:
+                pytest.fail(
+                    "No multi-binding ACL supported on this platform, please check the sai.profile")
+            pytest.skip("No multi-binding ACL supported on this platform")

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -12,6 +12,9 @@ import six
 
 import ptf.testutils as testutils
 import ptf.packet as packet
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import IP
+from scapy.packet import Raw
 
 from abc import abstractmethod
 from ptf.mask import Mask
@@ -21,6 +24,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.macsec.macsec_helper import MACSEC_INFO
+from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
 # TODO: Add suport for CONFIGLET mode
@@ -445,6 +449,28 @@ def skip_ipv6_everflow_tests(setup_info, erspan_ip_ver):
     """
     if erspan_ip_ver == 6 and setup_info[UP_STREAM]["everflow_dut"].facts["asic_type"] == "vs":
         pytest.skip("Skipping IPv6 Everflow tests to speed up PR test execution.")
+
+
+def validate_asic_route(duthost, prefix):
+    """
+    Check if a route exists in the routing table of the asic.
+    """
+    asicdb = AsicDbCli(duthost)
+    route_table = asicdb.dump("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+    if prefix in str(route_table):
+        return True
+    return False
+
+
+def validate_mirror_session_up(duthost, session_name):
+    """
+    Check if a mirror session is up.
+    """
+    cmd = f'sonic-db-cli STATE_DB HGET \"MIRROR_SESSION_TABLE|{session_name}\" status'
+    mirror_status = duthost.command(cmd)['stdout']
+    if 'active' in mirror_status:
+        return True
+    return False
 
 
 # TODO: This should be refactored to some common area of sonic-mgmt.
@@ -876,6 +902,47 @@ class BaseEverflowTest(object):
         """
         pass
 
+    def remove_outer_ip(self, packet_data):
+        """
+        The mirror packet from IP in IP tunnel would take an external IP header.
+        Remove the outer IP header from the IPinIP packet and keeps the original Ethernet header.
+
+        Args:
+            packet_data: Original IPinIP packet
+
+        Returns:
+            scapy.Ether: Original Ethernet header + Inner IP header + payload
+        """
+        if isinstance(packet_data, bytes):
+            outer_pkt = Ether(packet_data)
+        else:
+            outer_pkt = packet_data
+
+        if not outer_pkt.haslayer(IP):
+            return None
+
+        outer_ip = outer_pkt[IP]
+
+        if outer_ip.proto != 4:
+            return None
+
+        # Extract the original Ethernet header
+        original_eth = outer_pkt[Ether]
+        eth_dst = original_eth.dst
+        eth_src = original_eth.src
+        eth_type = 0x0800
+
+        inner_payload = outer_ip.payload
+
+        # If the payload is Raw type, we need to re-parse it as IP
+        if isinstance(inner_payload, Raw):
+            inner_ip_packet = IP(bytes(inner_payload))
+        else:
+            inner_ip_packet = inner_payload
+        new_packet = Ether(dst=eth_dst, src=eth_src, type=eth_type) / inner_ip_packet
+
+        return new_packet
+
     def send_and_check_mirror_packets(self,
                                       setup,
                                       mirror_session,
@@ -887,7 +954,8 @@ class BaseEverflowTest(object):
                                       dest_ports=None,
                                       expect_recv=True,
                                       valid_across_namespace=True,
-                                      erspan_ip_ver=4):
+                                      erspan_ip_ver=4,
+                                      multi_binding_acl=False):
 
         # In Below logic idea is to send traffic in such a way so that mirror traffic
         # will need to go across namespaces and within namespace. If source and mirror destination
@@ -932,7 +1000,8 @@ class BaseEverflowTest(object):
                                                                                  direction,
                                                                                  mirror_packet,
                                                                                  src_port_metadata_map[src_port][1],
-                                                                                 erspan_ip_ver)
+                                                                                 erspan_ip_ver,
+                                                                                 multi_binding_acl=multi_binding_acl)
             # Avoid changing the original packet
             mirror_packet_sent = mirror_packet.copy()
             if src_port_metadata_map[src_port][0]:
@@ -953,7 +1022,8 @@ class BaseEverflowTest(object):
                 _, received_packet = result
                 logging.info("Received packet: %s", packet.Ether(received_packet).summary())
 
-                inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet_sent), erspan_ip_ver)
+                inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet_sent), erspan_ip_ver,
+                                                            multi_binding_acl=multi_binding_acl)
                 logging.info("Received inner packet: %s", inner_packet.summary())
 
                 inner_packet = Mask(inner_packet)
@@ -981,6 +1051,12 @@ class BaseEverflowTest(object):
                     inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
                     inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
 
+                if multi_binding_acl:
+                    inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
+                    inner_packet.set_do_not_care_scapy(packet.Ether, "src")
+                    inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
+                    inner_packet.set_do_not_care_scapy(packet.IP, "ttl")
+
                 logging.info("Expected inner packet: %s", mirror_packet_sent.summary())
                 pytest_assert(inner_packet.pkt_match(mirror_packet_sent),
                               "Mirror payload does not match received packet")
@@ -988,15 +1064,23 @@ class BaseEverflowTest(object):
                 testutils.verify_no_packet_any(ptfadapter, expected_mirror_packet, dest_ports)
 
     @staticmethod
-    def copy_and_pad(pkt, asic_type, platform_asic, hwsku):
+    def copy_and_pad(pkt, asic_type, platform_asic, hwsku, multi_binding_acl=False):
         padded = pkt.copy()
 
         # Add vendor specific padding to the packet
         if asic_type == "mellanox":
             if six.PY2:
-                padded = binascii.unhexlify("0" * 44) + str(padded)
+                if multi_binding_acl:
+                    padded = binascii.unhexlify("0" * 44) + str(padded)[:24] + binascii.unhexlify("0" * 40) + \
+                        str(padded)[24:]
+                else:
+                    padded = binascii.unhexlify("0" * 44) + str(padded)
             else:
-                padded = binascii.unhexlify("0" * 44) + bytes(padded)
+                if multi_binding_acl:
+                    padded = binascii.unhexlify("0" * 44) + bytes(padded)[:24] + binascii.unhexlify("0" * 40) + \
+                        bytes(padded)[24:]
+                else:
+                    padded = binascii.unhexlify("0" * 44) + bytes(padded)
         if asic_type in ["barefoot", "cisco-8000", "marvell-teralynx"] \
            or platform_asic == "broadcom-dnx" \
            or hwsku in ["rd98DX35xx", "rd98DX35xx_cn9131", "Nokia-7215-A1"]:
@@ -1007,11 +1091,13 @@ class BaseEverflowTest(object):
         return padded
 
     @staticmethod
-    def get_expected_mirror_packet_ipv4(mirror_session, setup, duthost, direction, mirror_packet, ttl_dec):
+    def get_expected_mirror_packet_ipv4(mirror_session, setup, duthost, direction, mirror_packet, ttl_dec,
+                                        multi_binding_acl=False):
         asic_type = duthost.facts["asic_type"]
         platform_asic = duthost.facts.get("platform_asic")
         hwsku = duthost.facts["hwsku"]
-        payload = BaseEverflowTest.copy_and_pad(mirror_packet, asic_type, platform_asic, hwsku)
+        payload = BaseEverflowTest.copy_and_pad(mirror_packet, asic_type, platform_asic, hwsku,
+                                                multi_binding_acl=multi_binding_acl)
 
         expected_packet = testutils.simple_gre_packet(
             eth_src=setup[direction]["egress_router_mac"],
@@ -1047,11 +1133,13 @@ class BaseEverflowTest(object):
         return expected_packet
 
     @staticmethod
-    def get_expected_mirror_packet_ipv6(mirror_session, setup, duthost, direction, mirror_packet, hlim_dec):
+    def get_expected_mirror_packet_ipv6(mirror_session, setup, duthost, direction, mirror_packet, hlim_dec,
+                                        multi_binding_acl=False):
         asic_type = duthost.facts["asic_type"]
         platform_asic = duthost.facts.get("platform_asic")
         hwsku = duthost.facts["hwsku"]
-        payload = BaseEverflowTest.copy_and_pad(mirror_packet, asic_type, platform_asic, hwsku)
+        payload = BaseEverflowTest.copy_and_pad(mirror_packet, asic_type, platform_asic, hwsku,
+                                                multi_binding_acl=multi_binding_acl)
 
         expected_packet = testutils.simple_grev6_packet(
             eth_src=setup[direction]["egress_router_mac"],
@@ -1081,20 +1169,30 @@ class BaseEverflowTest(object):
         return expected_packet
 
     @staticmethod
-    def get_expected_mirror_packet(mirror_session, setup, duthost, direction, mirror_packet, ttl_dec, erspan_ip_ver=4):
+    def get_expected_mirror_packet(mirror_session, setup, duthost, direction, mirror_packet, ttl_dec, erspan_ip_ver=4,
+                                   multi_binding_acl=False):
         if erspan_ip_ver == 4:
             return BaseEverflowTest.get_expected_mirror_packet_ipv4(mirror_session, setup, duthost,
-                                                                    direction, mirror_packet, ttl_dec)
+                                                                    direction, mirror_packet, ttl_dec,
+                                                                    multi_binding_acl=multi_binding_acl)
         else:
             return BaseEverflowTest.get_expected_mirror_packet_ipv6(mirror_session, setup, duthost,
-                                                                    direction, mirror_packet, ttl_dec)
+                                                                    direction, mirror_packet, ttl_dec,
+                                                                    multi_binding_acl=multi_binding_acl)
 
-    def _extract_mirror_payload(self, encapsulated_packet, payload_size, erspan_ip_ver=4):
+    def _extract_mirror_payload(self, encapsulated_packet, payload_size, erspan_ip_ver=4, multi_binding_acl=False):
         outer_header_size = OUTER_HEADER_SIZE if erspan_ip_ver == 4 else OUTER_HEADER_SIZE_V6
+        if multi_binding_acl:
+            outer_header_size += 20
         pytest_assert(len(encapsulated_packet) >= outer_header_size,
                       f"Incomplete packet, expected at least {outer_header_size} header bytes")
 
         inner_frame = encapsulated_packet[-payload_size:]
+        if multi_binding_acl:
+            inner_frame = encapsulated_packet[-(payload_size + 20):]
+            inner_frame = self.remove_outer_ip(inner_frame)
+            return inner_frame
+
         return packet.Ether(inner_frame)
 
     @staticmethod


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add multi binding acl test into everflow test scope
1. Toggle dualtor setup to AS mode
2. Only send packet from upstream to standby downstream side
3. Match the bounce back ipinip tunnel packet my multi binding acl at active downstream side
4. Mirror the match result
5. Validate the inner packet

Run pass at local setup:
<img width="998" height="118" alt="image" src="https://github.com/user-attachments/assets/d45d6c44-0b41-4dd7-a617-36d1230e7fe2" />


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Add multi binding acl test into everflow test scope
#### How did you do it?
1. Toggle dualtor setup to AS mode
2. Only send packet from upstream to standby downstream side
3. Match the bounce back ipinip tunnel packet my multi binding acl at active downstream side
4. Mirror the match result
5. Validate the inner packet
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
