### PR TITLE
[SNAPPI] `pfc/test_pfc_pause_lossless_with_snappi.py` failed to configure ports

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -181,9 +181,6 @@ def __l3_intf_config(config, port_config_list, duthost, snappi_ports, setup=True
 
         port_config_list.append(port_config)
 
-    if len(port_config_list) != len(snappi_ports):
-        return False
-
     return True
 
 
@@ -262,9 +259,6 @@ def __vlan_intf_config(config, port_config_list, duthost, snappi_ports):
 
             port_config_list.append(port_config)
 
-        if duthost.get_facts().get("modular_chassis") and len(port_config_list) != len(snappi_ports):
-            return False
-
     return True
 
 
@@ -306,6 +300,16 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
         prefix = str(pc_intf[pc]['prefixlen'])
         pc_ip_addr = str(pc_intf[pc]['peer_addr'])
 
+        """
+        Do not create a PC LAG object in config if no interfaces
+        are present for that PortChannel group
+        """
+        port_ids = [id for id, snappi_port in enumerate(snappi_ports)
+                    for phy_intf in phy_intfs
+                    if snappi_port['peer_port'] == phy_intf]
+        if len(port_ids) == 0:
+            continue
+
         lag = config.lags.lag(name='Lag {}'.format(pc))[-1]
         lag.protocol.lacp.actor_system_id = '00:00:00:00:00:01'
         lag.protocol.lacp.actor_system_priority = 1
@@ -317,7 +321,7 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
             port_ids = [id for id, snappi_port in enumerate(snappi_ports)
                         if snappi_port['peer_port'] == phy_intf]
             if len(port_ids) != 1:
-                return False
+                continue
 
             port_id = port_ids[0]
             mac = __gen_mac(port_id)
@@ -741,6 +745,8 @@ def setup_dut_ports(
                                              snappi_ports=snappi_ports,
                                              setup=setup)
             pytest_assert(config_result is True, 'Fail to configure L3 interfaces')
+
+    pytest_assert(len(port_config_list) == len(snappi_ports), 'Failed to configure DUT ports')
 
     return config, port_config_list, snappi_ports
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

There are a few different errors but all are part of the function `setup_dut_ports` when trying to configure ports using dynamic port selection. There are 3 main issues to deal with here:

ISSUE 1
The assumption from the 3 functions written (`__vlan_intf_config`, ` __portchannel_intf_config`, `__l3_intf_config`) is that they would run independently of each other, which is not the case looking at the function `setup_dut_ports`. `port_config_list`, an initially empty list is passed to all three functions and then used by the caller. In such a case, such a comparison (`len(port_config_list) != len(snappi_ports)`) within each function is wrong. It should be ideally done under `setup_dut_ports` after all 3 configuration functions are run.

ISSUE 2 - ` __portchannel_intf_config`
Port channel LAG groups are initialized under the _SnappiObject_ `config` before looking at whether any ports are meant for such configuration. This results in IXIA API trying to read into empty lists and printing an error `No ports assigned to topology 'Topology Lag PortChannel2001'. Please connect Ixia hardware.`

ISSUE 3 - ` __portchannel_intf_config`
If a certain port `phy_intf` is not part of the `snappi_ports` list, continue to the next port / port channel instead of returning False.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/aristanetworks/sonic-qual.msft/issues/690
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Using dynamic port selection resulted in many issues in port configuration for L3, VLAN and PortChannel under `setup_dut_ports`. 

#### How did you do it?
3 functions are used for port configuration:
1. `__vlan_intf_config`, 
2. ` __portchannel_intf_config`, 
3. `__l3_intf_config`

Updated them to handle dynamic port selection as mentioned in PR description. Added an assert to `setup_dut_ports` where it compares configured ports to available ports after it tries to configure through all 3 functions instead of checking within the config functions.

#### How did you verify/test it?
Ran the entire test `pfc/test_pfc_pause_lossless_with_snappi.py`

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
