### PR TITLE
Fix loganalyzer crash with `Exception: pop from empty list`

### DIFF
--- a/tests/common/plugins/loganalyzer/utils.py
+++ b/tests/common/plugins/loganalyzer/utils.py
@@ -21,11 +21,12 @@ def support_ignore_loganalyzer(func):
             for _, dut_loganalyzer in list(loganalyzer.items()):
                 dut_loganalyzer.add_start_ignore_mark()
 
-        res = func(*args, **kwargs)
-
-        if loganalyzer:
-            for _, dut_loganalyzer in list(loganalyzer.items()):
-                dut_loganalyzer.add_end_ignore_mark()
+        try:
+            res = func(*args, **kwargs)
+        finally:
+            if loganalyzer:
+                for _, dut_loganalyzer in list(loganalyzer.items()):
+                    dut_loganalyzer.add_end_ignore_mark()
 
         return res
 


### PR DESCRIPTION
Fixing `support_ignore_loganalyzer` wrapper to add `end_ignore_mark` in case of exceptions as well.
for example: In `config_reload`, if we get any pytest_assert failure, which will cause `end_ignore_marker` to not get added, leading to this crash during further processing in loganalyzer.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix loganalyzer crash with `Exception: pop from empty list`
Fixes #19632 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
loganalyzer is crashing in case `config_reload` raising any exceptions.

#### How did you do it?
`support_ignore_loganalyzer` wrapper was not handling the addition of `end_ignore_marker` in case of wrapped function raised exceptions, added try and finally block to add `end_ignore_marker`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
