### PR TITLE
fix import errors in test_pfc_pause_single_lossless_prio_reboot

### DIFF
--- a/tests/snappi_tests/files/helper.py
+++ b/tests/snappi_tests/files/helper.py
@@ -433,12 +433,12 @@ def get_npu_voq_queue_counters(duthost, interface, priority, clear=False):
 
 
 @pytest.fixture(params=['warm', 'cold', 'fast'])
-def reboot_duts_and_disable_wd(setup_ports_and_dut, localhost, request):
+def reboot_duts_and_disable_wd(tgen_port_info, localhost, request):
     '''
     Purpose of the function is to have reboot_duts and disable watchdogs.
     '''
     reboot_type = request.param
-    _, _, snappi_ports = setup_ports_and_dut
+    _, _, snappi_ports = tgen_port_info
     skip_warm_reboot(snappi_ports[0]['duthost'], reboot_type)
     skip_warm_reboot(snappi_ports[1]['duthost'], reboot_type)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the following import error.

```
  def test_pfc_pause_single_lossless_prio_reboot(snappi_api,                   # noqa: F811
file /data/tests/snappi_tests/files/helper.py, line 127
  @pytest.fixture(autouse=True)
  def setup_ports_and_dut(
E       fixture 'multidut_port_info' not found
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Update to use tgen_port_info

#### How did you do it?

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
