### PR TITLE
Change packet.time to float type when fetching it.

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -2062,7 +2062,7 @@ class ReloadTest(BaseTest):
                     sent_payload = int(bytes(packet[scapyall.TCP].payload))
                     if sent_payload in sent_packets:
                         flooded_pkts.append(sent_payload)
-                    sent_packets[sent_payload] = packet.time
+                    sent_packets[sent_payload] = float(packet.time)
                     sent_counter += 1
                     continue
                 if packet[scapyall.Ether].src == self.dut_mac or packet[scapyall.Ether].src == self.vlan_mac:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
issue seen on 2700 - https://dev.azure.com/mssonic/internal/_build/results?buildId=882269&view=logs&j=76acabad-01e9-5c52-6fe6-d396d63e85d2&t=55864d99-7fe9-5504-0078-bfbb010fc228&l=2136
2025-06-20T20:48:59.5475010Z File "/root/ptftests/py3/advanced-reboot.py", line 1445, in runTest 2025-06-20T20:48:59.5475841Z self.handle_advanced_reboot_health_check() 2025-06-20T20:48:59.5476850Z File "/root/ptftests/py3/advanced-reboot.py", line 1167, in handle_advanced_reboot_health_check 2025-06-20T20:48:59.5477682Z self.examine_flow() 2025-06-20T20:48:59.5478542Z File "/root/ptftests/py3/advanced-reboot.py", line 2136, in examine_flow 2025-06-20T20:48:59.5479415Z self.disruption_start = datetime.datetime.fromtimestamp( 2025-06-20T20:48:59.5480166Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2025-06-20T20:48:59.5481008Z TypeError: 'EDecimal' object cannot be interpreted as an integer

Scapy fetched packet.time and Edecimal might be used in some fields, which leads to type of “packet.time” became EDecimal. To prevent this, switch to float type when fetching it from scratch.
-->
 any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
ssue seen on 2700 - https://dev.azure.com/mssonic/internal/_build/results?buildId=882269&view=logs&j=76acabad-01e9-5c52-6fe6-d396d63e85d2&t=55864d99-7fe9-5504-0078-bfbb010fc228&l=2136
2025-06-20T20:48:59.5475010Z File "/root/ptftests/py3/advanced-reboot.py", line 1445, in runTest 2025-06-20T20:48:59.5475841Z self.handle_advanced_reboot_health_check() 2025-06-20T20:48:59.5476850Z File "/root/ptftests/py3/advanced-reboot.py", line 1167, in handle_advanced_reboot_health_check 2025-06-20T20:48:59.5477682Z self.examine_flow() 2025-06-20T20:48:59.5478542Z File "/root/ptftests/py3/advanced-reboot.py", line 2136, in examine_flow 2025-06-20T20:48:59.5479415Z self.disruption_start = datetime.datetime.fromtimestamp( 2025-06-20T20:48:59.5480166Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2025-06-20T20:48:59.5481008Z TypeError: 'EDecimal' object cannot be interpreted as an integer
#### How did you do it?
Change `packet.time` type to float when fetching it.
#### How did you verify/test it?
End to end test passed - https://dev.azure.com/mssonic/internal/_build/results?buildId=890526&view=logs&j=76acabad-01e9-5c52-6fe6-d396d63e85d2
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
