### PR TITLE
Add  is_ipv6_only_topology utilities and IPv6 topology check to skip …

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -984,6 +984,19 @@ def get_all_downstream_neigh_type(topo_type, is_upper=True):
     return DOWNSTREAM_ALL_NEIGHBOR_MAP.get(topo_type, [])
 
 
+def is_ipv6_only_topology(tbinfo):
+    """
+    @summary: Check if the current topology is IPv6-only based on testbed info.
+    @param tbinfo: Testbed information dictionary
+    @return: bool - True if topology is IPv6-only, False otherwise
+    """
+    return (
+        "-v6-" in tbinfo["topo"]["name"]
+        if tbinfo and "topo" in tbinfo and "name" in tbinfo["topo"]
+        else False
+    )
+
+
 def run_until(interval, delay, retry, condition, function, *args, **kwargs):
     """
     @summary: Execute function until condition or retry number met.

--- a/tests/generic_config_updater/test_ip_bgp.py
+++ b/tests/generic_config_updater/test_ip_bgp.py
@@ -8,6 +8,7 @@ from tests.common.gu_utils import apply_patch, expect_op_success, expect_op_fail
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
 from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+from tests.common.utilities import is_ipv6_only_topology
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +212,11 @@ def delete_ip_neighbor(duthost, namespace=None, ip_version=6):
 
 
 @pytest.mark.parametrize("ip_version", [6, 4])
-def test_ip_suite(duthost, ensure_dut_readiness, ip_version, enum_rand_one_frontend_asic_index):
+def test_ip_suite(duthost, ensure_dut_readiness, ip_version, enum_rand_one_frontend_asic_index, tbinfo):
+    # Check if this is an IPv6-only topology and skip IPv4 tests
+    if ip_version == 4 and is_ipv6_only_topology(tbinfo):
+        pytest.skip("Skipping IPv4 test on IPv6-only topology")
+
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     add_deleted_ip_neighbor(duthost, asic_namespace, ip_version)


### PR DESCRIPTION
…IPv4 tests in test_ip_suite

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19638 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To support IPv6 only topo.
Remove unnecessary fail and reduce total test run time.

#### How did you do it?
Enable topo check when it tries to run IPv4 test.
Added the is_ipv6_only_topology in utilities.
If topo is IPv6 but test is IPv4, the test will skip.

#### How did you verify/test it?
Local run on IPv6 only testbed:
<img width="829" height="52" alt="image" src="https://github.com/user-attachments/assets/d7ab4e05-6e10-410f-84d1-8e63a54954fb" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
