### PR TITLE
Skip IPv4 tests on IPv6-only topology in test_crm_route

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -484,12 +484,22 @@ def get_nh_ip(duthost, asichost, crm_interface, ip_ver):
                                                                 "{} -6 route del 2001:{}::/126 via {}")],
                          ids=["ipv4", "ipv6"])
 def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                   crm_interface, ip_ver, route_add_cmd, route_del_cmd):
+                   crm_interface, ip_ver, route_add_cmd, route_del_cmd, tbinfo):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_frontend_asic_index)
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_route".format(ip_ver=ip_ver)
+
+    # will be changed to use is_ipv6_only_topology from tests.common.utilities
+    # once PR #19639 is merged
+    is_ipv6_only_topology = (
+        "-v6-" in tbinfo["topo"]["name"]
+        if tbinfo and "topo" in tbinfo and "name" in tbinfo["topo"]
+        else False
+    )
+    if is_ipv6_only_topology and ip_ver == "4":
+        pytest.skip("Skipping IPv4 test on IPv6-only topology")
 
     # Template used to speedup execution of many similar commands on DUT
     del_template = """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19640 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To support IPv6 only topo.
Remove unnecessary fail and reduce total test run time.

#### How did you do it?
Topo check when it tries to run IPv4 test.
If topo is IPv6 but test is IPv4, the test will skip.

#### How did you verify/test it?
Local IPv6 only topo testbed test:
<img width="831" height="69" alt="image" src="https://github.com/user-attachments/assets/a2da0cb9-c1f0-49ae-a3ff-1a54b1512be8" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
