### PR TITLE
Remove default alternating between ipv4 and ipv6 packets in SRv6 generate packets

### DIFF
--- a/tests/common/helpers/srv6_helper.py
+++ b/tests/common/helpers/srv6_helper.py
@@ -222,10 +222,6 @@ class SRv6Packets():
                 packet['exp_outer_dscp_uniform'] = packet['outer_dscp'] = i % 64
                 packet['exp_inner_dscp_pipe'] = packet['inner_dscp'] = (packet['outer_dscp'] + 8) % 64
 
-            # Alternate between IPv4 and IPv6 for inner packet
-            if i % 2 == 1:
-                packet['inner_pkt_ver'] = '4'
-
             srv6_packets.append(packet)
 
         return srv6_packets


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In the past, the srv6 generate packets function by default alternate between ipv4 and ipv6 inner packets. This hidden behavior is not good for users with ipv6 only topology, so we should remove it.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202412
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
