### PR TITLE
Changing 'populate_vlan_arp_entries' fixture scope from 'module' to '…

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -541,7 +541,7 @@ def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
     return request.param
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def populate_vlan_arp_entries(setup, ptfhost, duthosts, rand_one_dut_hostname, ip_version):
     """Set up the ARP responder utility in the PTF container."""
     global DOWNSTREAM_IP_PORT_MAP


### PR DESCRIPTION
### Description of PR
Testcase acl/test_acl.py::TestAclWithPortToggleacl failed as expected packet was not received.
The failure is that the sent packet was not received in the expected interface due to arp aging.L2 aging from chip is set to 600sec.
In our case since arp table is learned only at the beginning of the suite, and as this suite runs multiple classes (e.f. BasicAcl, IncrementalAcl, Reboot, PortToggle, MultiBindingAcl) and test variations (e.g. direction , stage, ip_version) after 600sec, where arp table is empty, there is still test execution and we start seeing failures, as it is not guaranteed that the packet will get out from the expected vlan interface.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/19616

### Type of change
- [ x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505


#### How did you verify/test it?
OC testcase acl/test_acl.py::TestAclWithPortToggleacl is passing after this fix.


