### PR TITLE
[test_lag_member_forwarding] skip one LAG scenario

### DIFF
--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -75,6 +75,8 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
     lag_facts = duthost.lag_facts(host=duthost.hostname)['ansible_facts']['lag_facts']
     if not len(lag_facts['lags'].keys()):
         pytest.skip("No Lag found in this topology")
+    if len(lag_facts['lags'].keys()) == 1:
+        pytest.skip("Only one Lag found in this topology, skipping test")
     portchannel_name = list(lag_facts['lags'].keys())[0]
     portchannel_dest_name = None
     recv_port = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip one LAG scenario since this test is designed to verify that when LAG members are disabled, traffic forwarding between different LAGs stops working properly. With only one LAG, the test cannot verify inter-LAG forwarding - there's no second LAG to forward traffic to.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip one lag scenario since this test is designed to verify that when LAG members are disabled, traffic forwarding between different LAGs stops working properly.

#### How did you do it?
Skip one lag scenario when the number of LAG is equal to 1.

#### How did you verify/test it?
```
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
04:59:56 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================================================== short test summary info ===========================================================================================
SKIPPED [1] pc/test_lag_member_forwarding.py:79: Only one Lag found in this topology, skipping test
================================================================================= 1 skipped, 1 warning in 104.44s (0:01:44) ==================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_lag_member_forwarding_packets[str4-sn5640-3]>
```
#### Any platform specific information?
str4-sn5640-3
#### Supported testbed topology if it's a new test case?
t1-isolated-d56u1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
