### PR TITLE
Fixing key error in test_bgp_with_loopback

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1039,7 +1039,7 @@ class TestVrfLoopbackIntf():
 
         # vrf1 args, vrf2 use the same as vrf1
         peer_range = IPNetwork(
-            cfg_facts['BGP_PEER_RANGE']['BGPSLBPassive']['ip_range'][0])
+            cfg_facts['BGP_PEER_RANGE']['Vrf1|BGPSLBPassive']['ip_range'][0])
         ptf_speaker_ip = IPNetwork(
             "{}/{}".format(peer_range[1], peer_range.prefixlen))
         vlan_port = get_vlan_members('Vlan1000', cfg_facts)[0]
@@ -1088,7 +1088,7 @@ class TestVrfLoopbackIntf():
                          dest="%s/%s" % (exabgp_dir, 'start.sh'), mode="u+rwx")
 
         # kill exabgp if any
-        ptfhost.shell("pkill exabgp || true")
+        ptfhost.shell("ps -ef | grep -v grep | grep exabgp | grep config | awk {'print $2'} | xargs -r kill -9")
 
         # start exabgp instance
         ptfhost.shell("bash %s/start.sh" % exabgp_dir)
@@ -1111,7 +1111,7 @@ class TestVrfLoopbackIntf():
                 peer_range, ips['ipv4'][0], vrf))
 
         # kill exabgp
-        ptfhost.shell("pkill exabgp || true")
+        ptfhost.shell("ps -ef | grep -v grep | grep exabgp | grep config | awk {'print $2'} | xargs -r kill -9")
 
         # del speaker ips from ptf ports
         for vrf, vlan_peer_port in g_vars['vlan_peer_ips']:
@@ -1126,7 +1126,7 @@ class TestVrfLoopbackIntf():
     def test_bgp_with_loopback(self, duthosts, rand_one_dut_hostname, cfg_facts):
         duthost = duthosts[rand_one_dut_hostname]
         peer_range = IPNetwork(
-            cfg_facts['BGP_PEER_RANGE']['BGPSLBPassive']['ip_range'][0])
+            cfg_facts['BGP_PEER_RANGE']['Vrf1|BGPSLBPassive']['ip_range'][0])
         ptf_speaker_ip = IPNetwork(
             "{}/{}".format(peer_range[1], peer_range.prefixlen))
 

--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -27,7 +27,8 @@
             "ip_range": [
                 "10.255.0.0/25"
             ],
-            "name": "BGPSLBPassive"
+            "name": "BGPSLBPassive",
+            "src_address": "10.1.0.32"
         },
         "Vrf1|BGPVac": {
             "ip_range": [
@@ -39,7 +40,8 @@
             "ip_range": [
                 "10.255.0.0/25"
             ],
-            "name": "BGPSLBPassive2"
+            "name": "BGPSLBPassive2",
+            "src_address": "10.1.0.32"
         },
         "Vrf2|BGPVac2": {
             "ip_range": [


### PR DESCRIPTION

### Description of PR
Test vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback is failing as invalid keys are accessed. Also this test case is killing existing exabgp sessions , which is impacting other testcases. Since existing sessions are killed and restarted, PTF is not re advertising bgp routes to container VMs. We should only cleanup sessions which are created as a part of this testcase.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/19651

### Type of change
- [x ] Bug fix


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### How did you verify/test it?
OC testcase is passing - vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback 

