### PR TITLE
[gNOI] Adding Tests for gNOI FactoryReset service.

### DIFF
--- a/tests/gnmi/test_gnoi_fr.py
+++ b/tests/gnmi/test_gnoi_fr.py
@@ -1,0 +1,63 @@
+import pytest
+import logging
+
+from .helper import gnoi_request
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+"""
+This module contains tests for the gNOI FactoryReset API.
+"""
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_factory_reset(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Expects 'Method FactoryReset.Start is unimplemented.' error.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    request_json = '{"factoryOs": true}'
+    ret, msg = gnoi_request(duthost, localhost, "FactoryReset", "Start", request_json)
+    pytest_assert(ret == 0, f"FactoryReset.Start RPC failed: rc = {ret}, msg = {msg}")
+
+    logging.info(f"FactoryReset.Start Response: {msg}")
+    pytest_assert("ResetError" in msg, "Expected ResetError in response")
+    pytest_assert("FactoryReset.Start" in msg, "Expected method FactoryReset.Start error")
+    pytest_assert("unsupported" in msg, "Expected method unsupported error")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_factory_reset_zero_fill(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Expects zero_fill_unsupported error in the response.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    request_json = '{"factory_os": true, "zero_fill": true}'
+    ret, msg = gnoi_request(duthost, localhost, "FactoryReset", "Start", request_json)
+    pytest_assert(ret == 0, f"FactoryReset.Start RPC failed: rc = {ret}, msg = {msg}")
+
+    logging.info(f"FactoryReset.Start Response: {msg}")
+    pytest_assert("ResetError" in msg, "Expected ResetError in response")
+    pytest_assert("zero_fill" in msg, "Expected unsupported error detail mentioning zero_fill")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_factory_reset_retain_certs(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Expects method unimplemented error.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+
+    request_json = '{"factoryOs": true, "retainCerts": true}'
+    ret, msg = gnoi_request(duthost, localhost, "FactoryReset", "Start", request_json)
+    pytest_assert(ret == 0, f"FactoryReset.Start RPC failed: rc = {ret}, msg = {msg}")
+
+    logging.info(f"FactoryReset.Start Response: {msg}")
+    pytest_assert("ResetError" in msg, "Expected ResetError in response")
+    pytest_assert("FactoryReset.Start" in msg, "Expected method FactoryReset.Start error")
+    pytest_assert("unsupported" in msg, "Expected method unimplemented error")


### PR DESCRIPTION
#### Test Summary:
```
gnmi/test_gnoi_fr.py::test_gnoi_factory_reset PASSED                     [ 33%]
gnmi/test_gnoi_fr.py::test_gnoi_factory_reset_zero_fill PASSED           [ 66%]
gnmi/test_gnoi_fr.py::test_gnoi_factory_reset_retain_certs PASSED        [100%]
 
=========================== short test summary info ============================
==== 3 passed, 1 skipped, 4627 deselected, 26 warnings in 934.98s (0:15:34) ====

```
#### For the Entire Test result please refer to the below file :-

[factory_reset_tests.log](https://github.com/user-attachments/files/21491239/factory_reset_tests.log)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
#### Description of PR

- Adding Tests for gNOI FactoryReset service.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
