### PR TITLE
Increase vpp vcpu to 10.

### DIFF
--- a/ansible/roles/vm_set/templates/sonic.xml.j2
+++ b/ansible/roles/vm_set/templates/sonic.xml.j2
@@ -39,10 +39,10 @@
 {% elif asic_type == 'vpp' %}
   <memory unit='GiB'>8</memory>
   <currentMemory unit='GiB'>8</currentMemory>
-  <vcpu placement='static'>6</vcpu>
+  <vcpu placement='static'>10</vcpu>
   <cpu mode='host-model'>
     <model fallback='forbid'/>
-    <topology sockets='1' dies='1' cores='6' threads='1'/>
+    <topology sockets='1' dies='1' cores='10' threads='1'/>
   </cpu>
 {% else %}
   <memory unit='GiB'>6</memory>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

VPP shown to require higher VCPU for testcase stability, increasing from 6 to 10.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Some tests were unstable due to resource limitations when running sonic-mgmt with vpp

#### How did you do it?
Increased vcpu until test results were stable.

#### How did you verify/test it?
Ran sonic-mgmt and consistent results were seen with 10 vcpu.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
