### PR TITLE
Fix undefined veos image filename variables in kickstart_vm.yml

### DIFF
--- a/ansible/roles/vm_set/tasks/kickstart_vm.yml
+++ b/ansible/roles/vm_set/tasks/kickstart_vm.yml
@@ -30,9 +30,9 @@
   - name: Respin failed vm
     include_tasks: respin_vm.yml
     vars:
-      src_disk_image: "{{ root_path }}/images/{{ hdd_image_filename }}"
+      src_disk_image: "{{ root_path }}/images/{{ veos_hdd_image_filename }}"
       disk_image: "{{ root_path }}/disks/{{ vm_name }}_hdd.vmdk"
-      cdrom_image: "{{ root_path }}/images/{{ cd_image_filename }}"
+      cdrom_image: "{{ root_path }}/images/{{ veos_cd_image_filename }}"
     when: '"kickstart_code" in kickstart_output and kickstart_output.kickstart_code != 0'
     ignore_errors: true
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
As part of the commit [`56cf79b`](https://github.com/sonic-net/sonic-mgmt/commit/56cf79bddfad388d1b7919745a1673a4cd43ebe2), where image filename variables were moved from `ansible/group_vars/vm_host/main.yml` to platform-specific group vars (`vm_host/veos.yml`, `vm_host/vsonic.yml`,`vm_host/vcisco.yml` etc.) but `kickstart_vm.yml` was not updated accordingly for veos testbeds. 

So, when deploying virtual or KVM testbeds for veos VMs, the `kickstart_vm.yml` playbook fails with an undefined variable error during the `Respin failed vm` task:
`hdd_image_filename` is undefined or 
`cd_image_filename` is undefined

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
`Respin failed vm` task in kickstart_vm.yml fails with 'hdd_image_filename' variable is undefined for veos VMs in virtual testbeds. Similarly for the `cd_image_filename` variable. 

#### How did you do it?
Fixed the correct variable names for veos platforms which should be : 
- `veos_hdd_image_filename` instead of `hdd_image_filename`
- `veos_cd_image_filename` instead of `cd_image_filename`

#### How did you verify/test it?
Verified in my local testbed

#### Any platform specific information?
Virtual or KVM testbeds using vEOS VMs

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
