### PR TITLE
updated ipinip for active active dualtor

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -10,7 +10,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # no
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa: F401
-from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active, ptf_test_port_map
+from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active
 
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url       # noqa: F401
@@ -534,7 +534,8 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
 def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa: F811
                      hash_keys, ptfhost, ipver, tbinfo, mux_server_url,             # noqa: F811
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa: F811
-                     duts_minigraph_facts, request):                                # noqa: F811
+                     duts_minigraph_facts, mux_status_from_nic_simulator,
+                     request):                                # noqa: F811
     # Only run this test on T1 or T0 (including dualtor) topologies
     pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
     logging.info(f"Topology type: {tbinfo['topo']['type']}")
@@ -558,8 +559,10 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa: F811
                "hash_test.IPinIPHashTest",
                platform_dir="ptftests",
                params={"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "ptf_test_port_map": ptf_test_port_map_active_active(ptfhost, tbinfo, duthosts, mux_server_url,
+                                                                            duts_running_config_facts,
+                                                                            mux_status_from_nic_simulator(),
+                                                                            duts_minigraph_facts),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),


### PR DESCRIPTION
## Description of PR
Summary: Fixes # (issue)

### Type of change 
 
 Test case improvement

#### Back port request

 202505

### Approach
#### What is the motivation for this PR?

The motivation for this PR is to improve the test_ipinip_hash function in tests/fib/test_fib.py.

##How did you do it?
 modified the test_ipinip_hash function to improve its functionality so that it can use the ptf_test_port_map_active_active function to get the mux status of NIC ports

##Documentation
No documentation updates are required for this PR, as it's a test case improvement.