### PR TITLE
Added Testcases for gNOI File Service

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -390,7 +390,7 @@ def gnoi_reboot(duthost, method, delay, message):
         return 0, output['stdout']
 
 
-def gnoi_request(duthost, localhost, module, rpc, request_json_data):
+def gnoi_request(duthost, localhost, module, rpc, request_json_data, input_data=None):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
@@ -400,12 +400,26 @@ def gnoi_request(duthost, localhost, module, rpc, request_json_data):
     cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
     cmd += "-logtostderr -module {} -rpc {} ".format(module, rpc)
     cmd += f'-jsonin \'{request_json_data}\''
+    if input_data:
+        cmd += input_data
+
     output = duthost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
         logger.error(output['stderr'])
         return -1, output['stderr']
     else:
         return 0, output['stdout']
+
+
+def gnoi_exec(duthost, cmd):
+    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    dut_cmd = "docker exec %s %s" % (env.gnmi_container, cmd)
+    output = duthost.shell(dut_cmd, module_ignore_errors=True)
+    if output['stderr']:
+        logger.error(output['stderr'])
+        return -1
+    else:
+        return 0
 
 
 def extract_gnoi_response(output):

--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -1,0 +1,148 @@
+import logging
+import pytest
+
+from .helper import gnoi_request, extract_gnoi_response, gnoi_exec
+from tests.common.helpers.assertions import pytest_assert
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+
+"""
+This module contains tests for the gNOI File API.
+"""
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_file_get(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify gNOI File.Get returns method unimplemented error as expected.
+
+    """
+
+    duthost = duthosts[rand_one_dut_hostname]
+    request_json = '{"remote_file": "/etc/hostfile.txt"}'
+    ret, msg = gnoi_request(duthost, localhost, "File", "Get", request_json)
+    pytest_assert(ret == -1, "File.Get RPC failed: rc = {}, msg = {}".format(ret, msg))
+    if not msg:
+        pytest.fail("Failed to extract gnoi response for File.Get RPC")
+
+    logging.info("File.Get Response: {}" .format(msg))
+    pytest_assert("Method file.Get is unimplemented" in msg, "Expected Method Unimplemented error")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_file_stat(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify gNOI File.Stat returns the statistcis of the specified file as follows
+    {stats : {<path, lastmodified, size(in bytes), permissions, umask> }}
+
+    """
+
+    duthost = duthosts[rand_one_dut_hostname]
+    request_json = '{"path": "/etc/hostname"}'
+    ret, msg = gnoi_request(duthost, localhost, "File", "Stat", request_json)
+    pytest_assert(ret == 0, "File.Stat RPC failed: rc = {}, msg = {}".format(ret, msg))
+
+    msg_json = extract_gnoi_response(msg)
+    if not msg_json:
+        pytest.fail("Failed to extract gnoi response for File.Stat RPC")
+
+    logging.info("File.stat Response: {}" .format(msg_json))
+    pytest_assert("File Stat" in msg, "Expected File Stat")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_file_remove_invalid_file(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify gNOI File.Remove returns file not found error for invalid files.
+    """
+
+    duthost = duthosts[rand_one_dut_hostname]
+    request_json = '{"remote_file":"/tmp/test_remove"}'
+    ret, msg = gnoi_request(duthost, localhost, "File", "Remove", request_json)
+    pytest_assert(ret == -1, "File.Remove RPC failed: rc = {}, msg = {}".format(ret, msg))
+
+    if not msg:
+        pytest.fail("Failed to extract gnoi response for File.Remove RPC")
+
+    logging.info("File.Remove Response: {}" .format(msg))
+    pytest_assert('File not found' in msg, "No such file. Failed to remove'")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_file_transfertoremote(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify gNOI File.TransferToRemote returns method unimplemented error as expected.
+    """
+
+    duthost = duthosts[rand_one_dut_hostname]
+    request_json = (
+        '{'
+        '"local_path": "/etc/config.txt", '
+        '"remote_download": {'
+        '"protocol": 1, '
+        '"remote_url": "scp://user@remotehost:/path/to/destination", '
+        '"username": "********", '
+        '"password": "********"'
+        '}'
+        '}'
+    )
+
+    ret, msg = gnoi_request(duthost, localhost, "File", "TransferToRemote", request_json)
+    pytest_assert(ret == -1, "File.TransferToRemote RPC failed: rc = {}, msg = {}".format(ret, msg))
+
+    if not msg:
+        pytest.fail("Failed to extract gnoi response for File.TransferToRemote RPC")
+
+    logging.info("File.TransferToRemote Response: {}" .format(msg))
+    pytest_assert('unimplemented' in msg, "Expected Method Unimplemented error")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_file_remove(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify gNOI File.Remove removes the specified file on the target successfully.
+    """
+
+    duthost = duthosts[rand_one_dut_hostname]
+    dut_cmd = "touch /tmp/test_remove"
+    duthost.shell(dut_cmd, module_ignore_errors=True)
+
+    request_json = '{"remote_file":"/tmp/test_remove"}'
+    ret, msg = gnoi_request(duthost, localhost, "File", "Remove", request_json)
+
+    pytest_assert(ret == 0, "File.Remove RPC failed: rc = {}, msg = {}".format(ret, msg))
+
+    if not msg:
+        pytest.fail("Failed to extract gnoi response for File.Remove RPC")
+
+    logging.info("File.Remove Response: {}" .format(msg))
+    pytest_assert('File Remove' in msg, "Expected 'File Remove' message not found in response")
+
+
+@pytest.mark.disable_loganalyzer
+def test_gnoi_file_put(duthosts, rand_one_dut_hostname, localhost):
+    """
+    Verify gNOI File.Put returns method unimplemented error as expected.
+    """
+
+    duthost = duthosts[rand_one_dut_hostname]
+    val = gnoi_exec(duthost, "touch /tmp/sample.bin")
+    pytest_assert(val == 0, "Failed to open the file")
+
+    request_json = '{"remote_file":"/tmp/test.bin","permissions":644}'
+    input_data = ' -input_file="/tmp/sample.bin"'
+
+    ret, msg = gnoi_request(duthost, localhost, "File", "Put", request_json, input_data)
+    pytest_assert(ret == -1, "File.Put RPC failed: rc = {}, msg = {}".format(ret, msg))
+
+    val = gnoi_exec(duthost, "rm -rf /tmp/sample.bin")
+    pytest_assert(val == 0, "Failed to remove the file")
+
+    if not msg:
+        pytest.fail("Failed to extract gnoi response for File.Put RPC")
+
+    logging.info("File.Put Response: {}" .format(msg))
+    pytest_assert('unimplemented' in msg, "Expected Method Unimplemented error")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
## [UMF] gNOI File Service Test Scenario's
Test Summary :

```
gnmi/test_gnoi_file.py::test_gnoi_file_get 
-------------------------------- live log call ---------------------------------
18:15:16 helper.gnoi_request                      L0487 ERROR  | Error receiving stream: rpc error: code = Unimplemented desc = Method file.Get is unimplemented.
PASSED                                                                   [ 16%]
gnmi/test_gnoi_file.py::test_gnoi_file_stat PASSED                       [ 33%]
gnmi/test_gnoi_file.py::test_gnoi_file_remove_invalid_file 
-------------------------------- live log call ---------------------------------
18:15:44 helper.gnoi_request                      L0487 ERROR  | Remove RPC failed: rpc error: code = Unknown desc = File not found: /tmp/test_remove
PASSED                                                                   [ 50%]
gnmi/test_gnoi_file.py::test_gnoi_file_transfertoremote 
-------------------------------- live log call ---------------------------------
18:15:57 helper.gnoi_request                      L0487 ERROR  | TransferToRemote RPC failed: rpc error: code = Unimplemented desc = Method file.TransferToRemote is unimplemented.
PASSED                                                                   [ 66%]
gnmi/test_gnoi_file.py::test_gnoi_file_remove PASSED                     [ 83%]
gnmi/test_gnoi_file.py::test_gnoi_file_put 
-------------------------------- live log call ---------------------------------
18:16:26 helper.gnoi_request                      L0487 ERROR  | Put RPC error on close: rpc error: code = Unimplemented desc = Method file.Put is unimplemented.
PASSED                                                                   [100%]

```

**For Entire Test result please refer to the below file** :-
[File_Service_test.log](https://github.com/user-attachments/files/21579119/File_Service_test.log)






### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
