### PR TITLE
Removing argument expectation after option `-x`

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -417,7 +417,7 @@ for arg in "$@"; do
     fi
 done
 
-while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:n:oOp:q:rs:S:t:ux:w" opt; do
+while getopts "h?a:b:Bc:C:d:e:Ef:F:H:i:I:k:l:m:n:oOp:q:rs:S:t:uxw" opt; do
     case ${opt} in
         h|\? )
             show_help_and_exit 0


### PR DESCRIPTION
Added accidentally in https://github.com/sonic-net/sonic-mgmt/pull/19549
Fixes: https://github.com/sonic-net/sonic-mgmt/issues/19687

Without this we'll see runs with `-x` fail with:
```
sudo ./run_tests.sh -n ardut -c acl/test_acl.py -x
./run_tests.sh: option requires an argument -- x
```

Summary:
Fixes #19687 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

