### PR TITLE
Add SRv6 configuration fixture for snappi tests on NUTs

### DIFF
--- a/tests/snappi_tests/srv6/conftest.py
+++ b/tests/snappi_tests/srv6/conftest.py
@@ -22,7 +22,7 @@ def get_max_number_of_parallel_links_and_neighbors(duthost):
     return max(counters.values()), counters.keys()
 
 
-@pytest.fixture(scope="mosession")
+@pytest.fixture(scope="session")
 def config_setup(duthosts, tbinfo):
     logger.info("Setting up SRv6 configuration")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This is to provide a SRv6 configuration setup fixture for snappi tests on a network under test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
