### PR TITLE
[sonic-mgmt]Fix for fdb/test_fdb_mac_move.py KeyError on Arista-7260CX3 dualtor topology variants

### DIFF
--- a/tests/fdb/test_fdb_mac_move.py
+++ b/tests/fdb/test_fdb_mac_move.py
@@ -130,7 +130,7 @@ def test_fdb_mac_move(ptfadapter, duthosts, fanouthosts, rand_one_dut_hostname, 
             port_index = port_list[(port_index_start + i) % len(port_list)]
             dummy_mac_set = dummy_mac_list[(port_index_start + i) % len(port_list)]
             for dummy_mac in dummy_mac_set:
-                send_arp_request(ptfadapter, port_index, dummy_mac, router_mac, vlan_id)
+                send_arp_request(ptfadapter, port_list[port_index], dummy_mac, router_mac, vlan_id)
 
         time.sleep(FDB_POPULATE_SLEEP_TIMEOUT)
         pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) > vlan_member_count),


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([660](https://github.com/aristanetworks/sonic-qual.msft/issues/660))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
- In this test, we are sending ARP request to all available downstream ports using the function
  send_arp_request(ptfadapter, port_index, dummy_mac, router_mac, vlan_id) inside a for loop.
- But this is failing because we are passing the port_index(index of the actual value in port_list) instead of the port number from the port list

#### How did you do it?
Fixed this by supplying the corresponding port number from the port list

#### How did you verify/test it?
Verified on Arista-7260CX3 running dualtor-120 and dualtor-active-active-56 topologies 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
