### PR TITLE
[Dualtor][Qos SAI] Fix qos sai test for dualtor

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -103,22 +103,22 @@ class QosBase:
         elif dut_test_params_qos["topo"] in self.SUPPORTED_T0_TOPOS:
             dut_test_params_qos["basicParams"]["router_mac"] = ''
 
-        elif "dualtor" in tbinfo["topo"]["name"]:
-            # For dualtor qos test scenario, DMAC of test traffic is default vlan interface's MAC address.
-            # To reduce duplicated code, put "is_dualtor" and "def_vlan_mac" into dutTestParams['basicParams'].
-            dut_test_params_qos["basicParams"]["is_dualtor"] = True
+            if "dualtor" in tbinfo["topo"]["name"]:
+                # For dualtor qos test scenario, DMAC of test traffic is default vlan interface's MAC address.
+                # To reduce duplicated code, put "is_dualtor" and "def_vlan_mac" into dutTestParams['basicParams'].
+                dut_test_params_qos["basicParams"]["is_dualtor"] = True
 
-            vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
-            if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
-                default_vlan_name = vlan_cfgs['default_vlan_config']
-                if default_vlan_name:
-                    for vlan in vlan_cfgs[default_vlan_name].values():
-                        if 'mac' in vlan and vlan['mac']:
-                            dut_test_params_qos["basicParams"]["def_vlan_mac"] = vlan['mac']
-                            break
+                vlan_cfgs = tbinfo['topo']['properties']['topology']['DUT']['vlan_configs']
+                if vlan_cfgs and 'default_vlan_config' in vlan_cfgs:
+                    default_vlan_name = vlan_cfgs['default_vlan_config']
+                    if default_vlan_name:
+                        for vlan in vlan_cfgs[default_vlan_name].values():
+                            if 'mac' in vlan and vlan['mac']:
+                                dut_test_params_qos["basicParams"]["def_vlan_mac"] = vlan['mac']
+                                break
 
-            pytest_assert(dut_test_params_qos["basicParams"]["def_vlan_mac"] is not None,
-                          "Dual-TOR miss default VLAN MAC address")
+                pytest_assert(dut_test_params_qos["basicParams"]["def_vlan_mac"] is not None,
+                              "Dual-TOR miss default VLAN MAC address")
         else:
             try:
                 duthost = get_src_dst_asic_and_duts['src_dut']
@@ -1366,7 +1366,7 @@ class QosSaiBase(QosBase):
             "srcDutInstance": src_dut,
             "dstDutInstance": dst_dut,
             "dualTor": request.config.getoption("--qos_dual_tor"),
-            "dualTorScenario": len(dualtor_ports_for_duts) != 0
+            "dualTorScenario": len(dualtor_ports_for_duts) != 0 and "dualtor" not in tbinfo["topo"]["name"]
         }
 
     @pytest.fixture(scope='class')

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3266,7 +3266,9 @@ class HdrmPoolSizeTest(sai_base_test.ThriftInterfaceDataPlane):
         self.src_port_macs = [self.dataplane.get_mac(
             0, ptid) for ptid in self.src_port_ids]
 
-        if self.testbed_type in ['dualtor', 'dualtor-56', 't0', 't0-28', 't0-64', 't0-116', 't0-118', 't0-120']:
+        if self.testbed_type in [
+                'dualtor', 'dualtor-56', 'dualtor-aa-64-breakout',
+                't0', 't0-28', 't0-64', 't0-116', 't0-118', 't0-120']:
             # populate ARP
             # sender's MAC address is corresponding PTF port's MAC address
             # sender's IP address is caculated in tests/qos/qos_sai_base.py::QosSaiBase::__assignTestPortIps()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There are 2 issue in the Qos sai test on dualtor testbed.
1. The dualTorScenario is only for mocked dualtor testbed(This is introduced in https://github.com/sonic-net/sonic-mgmt/pull/5947). It changes the configuration in some tests. It should be False when it's real dualtor topo.
2. def_vlan_mac for dualtor should be the mac of vlan interface(00:aa:bb:cc:dd:ee), but the logic to update mac for dualtor was broken in PR(https://github.com/sonic-net/sonic-mgmt/pull/7716). The mac update logic is not executed because it's in a "elif" and the dualtor topo is also in SUPPORTED_T0_TOPOS.

The test case qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize fails due the the above issues.
```
======================================================================
ERROR: sai_qos_tests.HdrmPoolSizeTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "saitests/py3/sai_qos_tests.py", line 3177, in runTest
    sys.exit("Too many pkts needed to trigger pfc: %d" % (pkt_cnt))
SystemExit: Too many pkts needed to trigger pfc: 10

----------------------------------------------------------------------
Ran 1 test in 282.847s
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix qos sai test for dualtor
#### How did you do it?
See the summary.
#### How did you verify/test it?
Run the test with dualtor-aa-64-breakout topo on sn4700, all passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
