### PR TITLE
[sonic-mgmt]Fix flakiness in pfcwd/test_pfcwd_all_port_storm.py for active-standby topology variants

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -9,6 +9,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.helpers.pfcwd_helper import start_wd_on_ports, start_background_traffic     # noqa: F401
 from tests.common.helpers.pfcwd_helper import EXPECT_PFC_WD_DETECT_RE, EXPECT_PFC_WD_RESTORE_RE, \
     fetch_vendor_specific_diagnosis_re
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m # noqa F401, E501
 from tests.common.helpers.pfcwd_helper import send_background_traffic
 from tests.common import config_reload
 
@@ -227,9 +228,12 @@ class TestPfcwdAllPortStorm(object):
                 storm_hndle.stop_pfc_storm()
             time.sleep(5)
 
-    def test_all_port_storm_restore(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                                    storm_test_setup_restore, setup_pfc_test, ptfhost,
-                                    set_pfc_time_cisco_8000):
+    def test_all_port_storm_restore(
+            self, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+            storm_test_setup_restore, setup_pfc_test, ptfhost,
+            setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally,     # noqa: F811
+            toggle_all_simulator_ports_to_enum_rand_one_per_hwsku_frontend_host_m,                  # noqa: F811
+            set_pfc_time_cisco_8000):
         """
         Tests PFC storm/restore on all ports
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([709](https://github.com/aristanetworks/sonic-qual.msft/issues/709))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
- The test will pick a ToR randomly for the test without ascertaining if it's an active ToR
- In such cases, when the selected ToR is the standby, resolve_arp(which sends out a docker exec swss arping <>) would fail since the downstream facing interface is in standby mode, and the test will not proceed

#### How did you do it?
This fix ensures the selected ToR will be set to be the active ToR

#### How did you verify/test it?
Verified on Arista-7050CX3 running dualtor topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
