### PR TITLE
[sonic-mgmt]Fix for fib/test_fib.py::test_ipinip_hash for active-active topology variants

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -10,7 +10,7 @@ from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # no
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
 from tests.common.fixtures.ptfhost_utils import set_ptf_port_mapping_mode   # noqa: F401
-from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active, ptf_test_port_map
+from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active, ptf_test_port_map          # noqa: F401
 
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url       # noqa: F401
@@ -531,10 +531,12 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
 # used as hash keys
 
 
-def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa: F811
-                     hash_keys, ptfhost, ipver, tbinfo, mux_server_url,             # noqa: F811
-                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,    # noqa: F811
-                     duts_minigraph_facts, request):                                # noqa: F811
+def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,                                   # noqa: F811
+                     hash_keys, ptfhost, ipver, tbinfo, mux_server_url,                             # noqa: F811
+                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,                    # noqa: F811
+                     duts_minigraph_facts, toggle_all_simulator_ports_to_rand_selected_tor_m,       # noqa: F811
+                     mux_status_from_nic_simulator, setup_standby_ports_on_rand_unselected_tor,     # noqa: F811
+                     request):                                                                      # noqa: F811
     # Only run this test on T1 or T0 (including dualtor) topologies
     pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
     logging.info(f"Topology type: {tbinfo['topo']['type']}")
@@ -558,8 +560,9 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,  # noqa: F811
                "hash_test.IPinIPHashTest",
                platform_dir="ptftests",
                params={"fib_info_files": fib_files[:3],   # Test at most 3 DUTs
-                       "ptf_test_port_map": ptf_test_port_map(ptfhost, tbinfo, duthosts, mux_server_url,
-                                                              duts_running_config_facts, duts_minigraph_facts),
+                       "ptf_test_port_map": ptf_test_port_map_active_active(
+                           ptfhost, tbinfo, duthosts, mux_server_url, duts_running_config_facts,
+                           duts_minigraph_facts, mux_status_from_nic_simulator()),
                        "hash_keys": hash_keys,
                        "src_ip_range": ",".join(src_ip_range),
                        "dst_ip_range": ",".join(dst_ip_range),


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([665](https://github.com/aristanetworks/sonic-qual.msft/issues/665))

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
- test_ipinip_hash is failing because ptf_test_port_map params is fetched using “ptf_test_port_map” instead of “ptf_test_port_map_active_active”

#### How did you do it?
By using dualtor-aa supported ptf port mapping for ipinip_hash test

#### How did you verify/test it?
Tested on Arista-7050CX3 running dualtor-active-active topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
