### PR TITLE
Skipped packet trimming tests on non-supported platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2119,17 +2119,11 @@ override_config_table/test_override_config_table.py:
 ########################################
 packet_trimming/test_packet_trimming.py:
   skip:
-    reason: "KVM do not support the feature"
+    reason: "Packet-trimming tests are only supported on certain Mellanox SN5640 and Arista 7060X6 SKUs."
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
-
-packet_trimming/test_packet_trimming.py:
-  skip:
-    reason: "Packet-trimming tests are only supported on Mellanox 5640 and Broadcom 7060x6 platforms."
-    conditions_logical_operator: and
-    conditions:
-      - "'7060x6' not in platform"
-      - "'sn5640' not in platform"
+      - "hwsku not in ['Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-64PE-B-C512S2', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2']"
 
 #######################################
 #####           pc               #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2123,6 +2123,14 @@ packet_trimming/test_packet_trimming.py:
     conditions:
       - "asic_type in ['vs']"
 
+packet_trimming/test_packet_trimming.py:
+  skip:
+    reason: "Packet-trimming tests are only supported on Mellanox 5640 and Broadcom 7060x6 platforms."
+    conditions_logical_operator: and
+    conditions:
+      - "'7060x6' not in platform"
+      - "'sn5640' not in platform"
+
 #######################################
 #####           pc               #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skipped packet trimming tests on non-supported platforms. Packet trimming is only supported on certain Mellanox SN5640 and Arista 7060X6 SKUs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Packet trimming nightly tests fail on non-supported platforms.

#### How did you do it?
Skipped packet trimming tests on all non-supported SKUs.

#### How did you verify/test it?
Verified that packet trimming tests are not skipped on Mellanox-SN5640-C512S2.
Verified that packet trimming tests are skipped on a SN4600 device.

#### Any platform specific information?
Skipped on all SKUs except Arista-7060X6-64PE-B-C448O16, Arista-7060X6-64PE-B-C512S2, Mellanox-SN5640-C448O16, and Mellanox-SN5640-C512S2.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A