### PR TITLE
Config counter poll interval to 100ms for test_link_local_ip.py

### DIFF
--- a/tests/ip/link_local/test_link_local_ip.py
+++ b/tests/ip/link_local/test_link_local_ip.py
@@ -135,6 +135,18 @@ class TestLinkLocalIPacket:
         vtysh_cmd_for_namespace = duthost.get_vtysh_cmd_for_namespace(tag_route_cmd, ptf_port_idx_namespace)
         duthost.shell(vtysh_cmd_for_namespace)
 
+    @pytest.fixture(scope='class', autouse=True)
+    def config_counter_poll_interval(self, duthost):
+        """
+        Set counter poll interval to 100ms to ensure that the counters are updated in time
+        """
+        origin_queue_interval = duthost.get_counter_poll_status()['PORT_STAT']['interval']
+        duthost.set_counter_poll_interval('PORT_STAT', 100)
+
+        yield
+
+        duthost.set_counter_poll_interval('PORT_STAT', origin_queue_interval)
+
     @staticmethod
     def remove_ips_form_downlink_ifaces(duthost, mg_facts, rx_iface, tx_iface):
         for addr_dict in mg_facts['minigraph_interfaces']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Config counter poll interval to 100ms for test_link_local_ip.py
Fixes # 
Test case `test_link_local_ip.py` sends packets and sleep 1 second, then verify the counter. But the default `PORT_STAT` counter poll interval is still 1 second, which might lead to the case unstable. Add a fixture to config `PORT_STAT` counter poll interval to 100 ms.
```python
  testutils.send(ptfadapter, ptf_idx, pkt, PKT_NUM)
  time.sleep(1)
  self.validate_counters(duthost, ptfadapter, exp_pkt, dut_rx_iface, rif_rx_iface,
                         out_ptf_indices, out_ifaces, out_rif_ifaces, rif_support)
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Add a fixture to config `PORT_STAT` counter poll interval to 100 ms.

#### How did you verify/test it?
Run the test, pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
