### PR TITLE
[SNAPPI] `pfc/test_pfc_pause_lossless_warm_reboot.py` Failure: `ValueError: invalid literal for int() with base 10: 'N/A'`

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -24,6 +24,8 @@ from random import getrandbits
 from tests.common.portstat_utilities import parse_portstat
 from collections import defaultdict
 from tests.conftest import parse_override
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 
 def increment_ip_address(ip, incr=1):
@@ -915,6 +917,15 @@ def sec_to_nanosec(secs):
     return secs * 1e9
 
 
+def check_pfc_counters(duthost, port, priority, is_tx=False):
+    if is_tx:
+        raw_out = duthost.shell("show pfc counters | sed -n '/Port Tx/,/^$/p' | grep {}".format(port))['stdout']
+    else:
+        raw_out = duthost.shell("show pfc counters | sed -n '/Port Rx/,/^$/p' | grep {}".format(port))['stdout']
+    if raw_out.split()[priority + 1].replace(',', '') == 'N/A':
+        return False
+    return True
+
 def get_pfc_frame_count(duthost, port, priority, is_tx=False):
     """
     Get the PFC frame count for a given port and priority from SONiC CLI
@@ -926,14 +937,16 @@ def get_pfc_frame_count(duthost, port, priority, is_tx=False):
     Returns:
         int: PFC pause frame count
     """
+    pytest_assert(wait_until(120, 5, 0, check_pfc_counters, duthost, port, priority, is_tx),
+                  "Unable to fetch PFC counters from DUT")
+
     if is_tx:
         raw_out = duthost.shell("show pfc counters | sed -n '/Port Tx/,/^$/p' | grep {}".format(port))['stdout']
     else:
         raw_out = duthost.shell("show pfc counters | sed -n '/Port Rx/,/^$/p' | grep {}".format(port))['stdout']
 
-    pause_frame_count = raw_out.split()[priority + 1]
-
-    return int(pause_frame_count.replace(',', ''))
+    pause_frame_count = raw_out.split()[priority + 1].replace(',', '')
+    return int(pause_frame_count)
 
 
 def get_all_port_stats(duthost):


### PR DESCRIPTION
Right after a reboot, the test checks for the PFC counters data. It can show up as N/A, as it requires time for initializations and fetching info from DB. In such cases, make sure that we wait for a while until the correct value is fetched instead of 'N/A'.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/692

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
Created a assert with a wait_until and checked for 60s / every 5s until PFC counters are not N/A.

#### What is the motivation for this PR?
Test case errors out with this message:
`ValueError: invalid literal for int() with base 10: 'N/A'`
The reason was PFC counters after a reboot was not available right after a reboot. An example on the table looks like this:
`' Ethernet76     N/A     N/A     N/A     N/A     N/A     N/A     N/A     N/A'`

#### How did you do it?

#### How did you verify/test it?
Ran the test case that no longer has the `N/A` value (`pfc/test_pfc_pause_lossless_warm_reboot.py`)

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
