### PR TITLE
Imporve DHCP relay counter stress test

### DIFF
--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -263,13 +263,33 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
             uplink_interfaces.append(portchannel_name)
 
     vlan_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [])
+
+    # uplink_portchannels_interfaces means the item can be the portchannel or the interface
+    # Example:
+    #   If there are 4 uplink portchannels, the uplink_portchannels_or_interfaces will be
+    #   ['PortChannel101', 'PortChannel103', 'PortChannel105', 'PortChannel106']
+    #   If there is no portchannel, the uplink_portchannels_or_interfaces will be
+    #   ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
     uplink_portchannels_interfaces_counter = query_and_sum_dhcpcom_relay_counters(
         duthost, downlink_vlan_iface, uplink_portchannels_or_interfaces
     )
+
+    """
+    Example:
+    Discover counter for PortChannels:
+    {'TX': {'Unknown': 0, 'Discover': 141216, 'Offer': 0, 'Request': 0, 'Decline': 0, 'Ack': 0, 'Nak': 0, 'Release': 0,
+    'Inform': 0, 'Bootp': 0},
+    'RX': {'Unknown': 0, 'Discover': 0, 'Offer': 0, 'Request': 0, 'Decline': 0, 'Ack': 0, 'Nak': 0,
+    'Release': 0, 'Inform': 0, 'Bootp': 0}}
+    """
+    # Query the counters for uplink portchannels interfaces such as:
+    # ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
     uplink_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, uplink_interfaces)
 
     vlan_interface_counter_from_pkts = all_pkt_counters.get(interface_name_index_mapping[downlink_vlan_iface],
                                                             {"RX": {}, "TX": {}})
+
+    # calculate the sum of uplink portchannels interfaces counters from pkts
     uplink_portchannels_interfaces_counter_from_pkts = {
                 "RX": {},
                 "TX": {}
@@ -277,6 +297,8 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
     for iface in uplink_portchannels_or_interfaces:
         merge_counters(uplink_portchannels_interfaces_counter_from_pkts,
                        all_pkt_counters.get(interface_name_index_mapping[iface], {"RX": {}, "TX": {}}))
+
+    # calculate the sum of uplink interface counters from pkts
     uplink_interface_counter_from_pkts = {
                 "RX": {},
                 "TX": {}

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -231,7 +231,7 @@ def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_
             # sum the counters from pkts for each member of the portchannel
             for member in portchannels[portchannel_name]['members']:
                 merge_counters(members_counter_from_pkts, all_pkt_counters.get(interface_name_index_mapping[member],
-                                                                              {"RX": {}, "TX": {}}))
+                                                                               {"RX": {}, "TX": {}}))
 
             ''' Compare the counters from pkts with the counters from the DB for portchannel and its members'''
             compare_dhcpcom_relay_counters_with_warning(

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -2,10 +2,12 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 import json
 import logging
+import ptf.packet as scapy
+
 
 logger = logging.getLogger(__name__)
 SUPPORTED_DHCPV4_TYPE = [
-    "Unknown", "Discover", "Offer", "Request", "Decline", "Ack", "Nak", "Release", "Inform", "Bootp"
+     "Discover", "Offer", "Request", "Decline", "Ack", "Nak", "Release", "Inform", "Bootp", "Unknown"
 ]
 SUPPORTED_DIR = ["TX", "RX"]
 
@@ -145,10 +147,162 @@ def validate_dhcpcom_relay_counters(dhcp_relay, duthost, expected_uplink_counter
         compare_warning_msg.format(uplink_portchannels_or_interfaces, uplink_interfaces, duthost.hostname),
         error_in_percentage)
     compare_dhcpcom_relay_counters_with_warning(
-        vlan_interface_counter, expected_downlink_counter,
-        compare_warning_msg.format(downlink_vlan_iface, "expected_downlink_counter", duthost.hostname),
+        client_interface_counter, expected_downlink_counter,
+        compare_warning_msg.format(client_iface, "expected_downlink_counter", duthost.hostname),
         error_in_percentage)
     compare_dhcpcom_relay_counters_with_warning(
         uplink_interface_counter, expected_uplink_counter,
         compare_warning_msg.format(uplink_interfaces, "expected_uplink_counter", duthost.hostname),
         error_in_percentage)
+
+
+def calculate_counters_per_pkts(pkts):
+    """
+    Calculate the counters for each interface index based on the packets.
+    Return the counters for each interface index.
+    """
+    all_counters = {}
+    for pkt in pkts:
+        if hasattr(pkt, 'ifindex'):
+            counter = all_counters.setdefault(pkt.ifindex, {
+                "RX": {},
+                "TX": {}
+            })
+            message_type_int = pkt[scapy.DHCP].options[0][1] if pkt.haslayer(scapy.DHCP) else None
+            message_type_str = SUPPORTED_DHCPV4_TYPE[message_type_int - 1] \
+                if message_type_int is not None and message_type_int > 0 else "Unknown"
+            sport = pkt[scapy.UDP].sport if pkt.haslayer(scapy.UDP) else None
+            dport = pkt[scapy.UDP].dport if pkt.haslayer(scapy.UDP) else None
+            # For DHCP Discover or Request, dport can only be 67, sport can be 68 or 67
+            # All other packets are skipped
+            if dport == 67 and (message_type_str == "Discover" or message_type_str == "Request"):
+                if sport == 68:
+                    counter["RX"][message_type_str] = counter["RX"].get(message_type_str, 0) + 1
+                elif sport == 67:
+                    counter["TX"][message_type_str] = counter["TX"].get(message_type_str, 0) + 1
+            # DHCP Offer or Ack, sport can only be 67, dport can be 68 or 67
+            # All other packets are skipped
+            elif sport == 67 and (message_type_str == "Offer" or message_type_str == "Ack"):
+                if dport == 67:
+                    counter["RX"][message_type_str] = counter["RX"].get(message_type_str, 0) + 1
+                elif dport == 68:
+                    counter["TX"][message_type_str] = counter["TX"].get(message_type_str, 0) + 1
+
+    return all_counters
+
+
+def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping, local_ip,
+                                           error_in_percentage=0.0):
+    """Validate the dhcpcom relay counters and packets consistence"""
+    downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
+    # it can be portchannel or interface, it depends on the topology
+    uplink_portchannels_or_interfaces = dhcp_relay['uplink_interfaces']
+    client_iface = dhcp_relay['client_iface']['name']
+    portchannels = dhcp_relay['portchannels']
+
+    '''
+    If the uplink_portchannels_or_interfaces are portchannels,
+        uplink_interfaces will contains the members of the portchannels
+    If the uplink_portchannels_or_interfaces are not portchannels,
+        uplink_interfaces will equal to uplink_portchannels_or_interfaces
+    '''
+    uplink_interfaces = []
+    compare_warning_msg = "Warning for comparing {} counters and {} counters, hostname:{}. "
+    all_pkt_counters = calculate_counters_per_pkts(pkts)
+    for portchannel_name in uplink_portchannels_or_interfaces:
+        if portchannel_name in portchannels.keys():
+            uplink_interfaces.extend(portchannels[portchannel_name]['members'])
+            portchannel_counters = query_and_sum_dhcpcom_relay_counters(duthost,
+                                                                        downlink_vlan_iface,
+                                                                        [portchannel_name])
+            members_counters = query_and_sum_dhcpcom_relay_counters(duthost,
+                                                                    downlink_vlan_iface,
+                                                                    portchannels[portchannel_name]['members'])
+
+            # If the portchannel counters and its members' counters are not equal, yield a warning message
+
+            portchannel_counter_from_pkts = all_pkt_counters.get(interface_name_index_mapping[portchannel_name],
+                                                                 {"RX": {}, "TX": {}})
+
+            members_counter_from_pkts = {
+                "RX": {},
+                "TX": {}
+            }
+            # sum the counters from pkts for each member of the portchannel
+            for member in portchannels[portchannel_name]['members']:
+                merge_counters(members_counter_from_pkts, all_pkt_counters.get(interface_name_index_mapping[member],
+                                                                              {"RX": {}, "TX": {}}))
+
+            ''' Compare the counters from pkts with the counters from the DB for portchannel and its members'''
+            compare_dhcpcom_relay_counters_with_warning(
+                portchannel_counters, portchannel_counter_from_pkts,
+                compare_warning_msg.format(portchannel_name, portchannel_name + " from pkts", duthost.hostname),
+                error_in_percentage)
+            compare_dhcpcom_relay_counters_with_warning(
+                members_counters, members_counter_from_pkts,
+                compare_warning_msg.format(portchannels[portchannel_name]['members'],
+                                           str(portchannels[portchannel_name]['members']) + " from pkts",
+                                           duthost.hostname),
+                error_in_percentage)
+            compare_dhcpcom_relay_counters_with_warning(
+                portchannel_counters, members_counters,
+                compare_warning_msg.format(portchannel_name,
+                                           portchannels[portchannel_name]['members'], duthost.hostname),
+                error_in_percentage)
+        else:
+            uplink_interfaces.append(portchannel_name)
+
+    vlan_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [])
+    client_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, [client_iface])
+    uplink_portchannels_interfaces_counter = query_and_sum_dhcpcom_relay_counters(
+        duthost, downlink_vlan_iface, uplink_portchannels_or_interfaces
+    )
+    uplink_interface_counter = query_and_sum_dhcpcom_relay_counters(duthost, downlink_vlan_iface, uplink_interfaces)
+
+    vlan_interface_counter_from_pkts = all_pkt_counters.get(interface_name_index_mapping[downlink_vlan_iface],
+                                                            {"RX": {}, "TX": {}})
+    client_interface_counter_from_pkts = all_pkt_counters.get(interface_name_index_mapping[client_iface],
+                                                              {"RX": {}, "TX": {}})
+    uplink_portchannels_interfaces_counter_from_pkts = {
+                "RX": {},
+                "TX": {}
+            }
+    for iface in uplink_portchannels_or_interfaces:
+        merge_counters(uplink_portchannels_interfaces_counter_from_pkts,
+                       all_pkt_counters.get(interface_name_index_mapping[iface], {"RX": {}, "TX": {}}))
+    uplink_interface_counter_from_pkts = {
+                "RX": {},
+                "TX": {}
+            }
+    for iface in uplink_interfaces:
+        merge_counters(uplink_interface_counter_from_pkts,
+                       all_pkt_counters.get(interface_name_index_mapping[iface], {"RX": {}, "TX": {}}))
+
+    compare_dhcpcom_relay_counters_with_warning(
+        vlan_interface_counter, vlan_interface_counter_from_pkts,
+        compare_warning_msg.format(downlink_vlan_iface, downlink_vlan_iface + " from pkts", duthost.hostname),
+        error_in_percentage)
+    compare_dhcpcom_relay_counters_with_warning(
+        uplink_portchannels_interfaces_counter, uplink_portchannels_interfaces_counter_from_pkts,
+        compare_warning_msg.format(uplink_portchannels_or_interfaces,
+                                   str(uplink_portchannels_or_interfaces) + " from pkts", duthost.hostname),
+        error_in_percentage)
+    compare_dhcpcom_relay_counters_with_warning(
+        uplink_portchannels_interfaces_counter, uplink_interface_counter,
+        compare_warning_msg.format(uplink_portchannels_or_interfaces, uplink_interfaces, duthost.hostname),
+        error_in_percentage)
+    compare_dhcpcom_relay_counters_with_warning(
+        client_interface_counter, client_interface_counter_from_pkts,
+        compare_warning_msg.format(client_iface, client_iface + " from pkts", duthost.hostname),
+        error_in_percentage)
+    compare_dhcpcom_relay_counters_with_warning(
+        uplink_interface_counter, uplink_interface_counter_from_pkts,
+        compare_warning_msg.format(uplink_interfaces, str(uplink_interfaces) + " from pkts", duthost.hostname),
+        error_in_percentage)
+
+
+def merge_counters(source_counter, merge_counter):
+    for dir in SUPPORTED_DIR:
+        for dhcp_type in SUPPORTED_DHCPV4_TYPE:
+            source_counter[dir][dhcp_type] = source_counter.get(dir, {}).get(dhcp_type, 0) + \
+                                                                    merge_counter.get(dir, {}).get(dhcp_type, 0)

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -191,7 +191,7 @@ def calculate_counters_per_pkts(pkts):
     return all_counters
 
 
-def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping, local_ip,
+def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping,
                                            error_in_percentage=0.0):
     """Validate the dhcpcom relay counters and packets consistence"""
     downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -163,7 +163,7 @@ def calculate_counters_per_pkts(pkts):
     """
     all_counters = {}
     for pkt in pkts:
-        if hasattr(pkt, 'ifindex') and pkt.haslayer(scapy.DHCP):
+        if hasattr(pkt, 'ifindex') and pkt.haslayer(scapy.DHCP) and pkt[scapy.BOOTP].xid == 0:
             counter = all_counters.setdefault(pkt.ifindex, {
                 "RX": {},
                 "TX": {}

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -477,6 +477,12 @@ decap/test_subnet_decap.py::test_vlan_subnet_decap:
 #######################################
 #####         dhcp_relay        #####
 #######################################
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress:
+  xfail:
+    reason: "7215 has low performance, and can only take low stress (about 5 pps)"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+
 dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[discover]:
   xfail:
     reason: "Need to skip for discover test cases on dualtor"
@@ -490,12 +496,6 @@ dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[reque
     conditions:
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
-
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress:
-  xfail:
-    reason: "7215 has low performance, and can only take low stress (about 5 pps)"
-    conditions:
-      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 dhcp_relay/test_dhcp_relay.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -491,6 +491,12 @@ dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[reque
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
 
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress:
+  xfail:
+    reason: "7215 has low performance, and can only take low stress (about 5 pps)"
+    conditions:
+      - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+
 dhcp_relay/test_dhcp_relay.py:
   skip:
     reason: "Need to skip for Cisco backend platform"

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1221,7 +1221,8 @@ def capture_and_check_packet_on_dut(
     pkts_validator=lambda pkts: pytest_assert(len(pkts) > 0, "No packets captured"),
     pkts_validator_args=[],
     pkts_validator_kwargs={},
-    wait_time=1
+    wait_time=1,
+    tcpdump_buffer_size=102400
 ):
     """
     Capture packets on DUT and check if the packet is expected
@@ -1235,8 +1236,8 @@ def capture_and_check_packet_on_dut(
         wait_time: the time to wait before stopping the packet capture, default is 1 second
     """
     pcap_save_path = "/tmp/func_capture_and_check_packet_on_dut_%s.pcap" % (str(uuid.uuid4()))
-    cmd_capture_pkts = "nohup tcpdump --immediate-mode -U -i %s -w %s >/dev/null 2>&1 %s & echo $!" \
-        % (interface, pcap_save_path, pkts_filter)
+    cmd_capture_pkts = ("nohup tcpdump --buffer-size=%s --immediate-mode -U -i %s -w %s" +
+                        ">/dev/null 2>&1 %s & echo $!") % (tcpdump_buffer_size, interface, pcap_save_path, pkts_filter)
     tcpdump_pid = duthost.shell(cmd_capture_pkts)["stdout"]
     cmd_check_if_process_running = "ps -p %s | grep %s |grep -v grep | wc -l" % (tcpdump_pid, tcpdump_pid)
     pytest_assert(duthost.shell(cmd_check_if_process_running)["stdout"] == "1",

--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -68,7 +68,6 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
     for vlan_iface_name, vlan_info_dict in list(vlan_dict.items()):
         # Filter(remove) PortChannel interfaces from VLAN members list
         vlan_members = [port for port in vlan_info_dict['members'] if 'PortChannel' not in port]
-
         # Gather information about the downlink VLAN interface this relay agent is listening on
         downlink_vlan_iface = {}
         downlink_vlan_iface['name'] = vlan_iface_name
@@ -136,6 +135,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, ptfhost, tbinfo):
         dhcp_relay_data['uplink_port_indices'] = uplink_port_indices
         dhcp_relay_data['switch_loopback_ip'] = str(switch_loopback_ip)
         dhcp_relay_data['portchannels'] = mg_facts['minigraph_portchannels']
+        dhcp_relay_data['vlan_members'] = vlan_members
 
         # Obtain MAC address of an uplink interface because vlan mac may be different than that of physical interfaces
         res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -12,6 +12,10 @@ from tests.dhcp_relay.dhcp_relay_utils import check_dhcp_stress_status
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
+pytestmark = [
+    pytest.mark.topology('t0', 'm0')
+]
+
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -1,17 +1,21 @@
-
 import pytest
 import ptf.packet as scapy
 import logging
 import time
+import re
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters
+from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters, \
+                                          validate_counters_and_pkts_consistency
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.dhcp_relay.dhcp_relay_utils import check_dhcp_stress_status
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
+pytestmark = [
+    pytest.mark.topology('t0', 'm0')
+]
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
@@ -37,12 +41,9 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
     logger.info("Testing mode: {}, client packets per second: {}, error margin: {}".format(
         testing_mode, client_packets_per_sec, error_margin))
     for dhcp_relay in dut_dhcp_relay_data:
-        client_port_name = str(dhcp_relay['client_iface']['name'])
         client_port_id = dhcp_relay['client_iface']['port_idx']
-        client_mac = ptfadapter.dataplane.get_mac(0, client_port_id).decode('utf-8')
-        server_port_name = dhcp_relay['uplink_interfaces'][0]
-        server_mac = ptfadapter.dataplane.get_mac(0, dhcp_relay['uplink_port_indices'][0]).decode('utf-8')
-        num_dhcp_servers = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
+        vlan_ip = dhcp_relay['downlink_vlan_iface']['addr']
+
         init_dhcpcom_relay_counters(duthost)
         if testing_mode == DUAL_TOR_MODE:
             standby_duthost = rand_unselected_dut
@@ -75,57 +76,38 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             output = ptfhost.shell(command)
             return not output['rc'] and output['stdout'].strip() == "exists"
 
-        def _verify_server_packets(pkts, dhcp_type):
+        def _verify_packets(pkts):
             # Default DB update timer for dhcpmon is 20s, hence wait for it to write DB
             time.sleep(25)
-            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0]) * num_dhcp_servers
-            expected_uplink_counter = {
-                "RX": {},
-                "TX": {dhcp_type.capitalize(): actual_count}
-            }
-            expected_downlink_counter = {
-                "RX": {dhcp_type.capitalize(): actual_count / num_dhcp_servers},
-                "TX": {}
-            }
-            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                            expected_uplink_counter,
-                                            expected_downlink_counter, error_margin)
+            validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_dict, vlan_ip,
+                                                   error_in_percentage=error_margin)
             if testing_mode == DUAL_TOR_MODE:
                 validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
                                                 {}, {}, 0)
 
-        def _verify_client_packets(pkts, dhcp_type):
-            # Default DB update timer for dhcpmon is 20s, hence wait for it to write DB
-            time.sleep(25)
-            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
-            expected_uplink_counter = {
-                "RX": {dhcp_type.capitalize(): actual_count},
-                "TX": {}
-            }
-            expected_downlink_counter = {
-                "RX": {},
-                "TX": {dhcp_type.capitalize(): actual_count}
-            }
-            validate_dhcpcom_relay_counters(dhcp_relay, duthost,
-                                            expected_uplink_counter,
-                                            expected_downlink_counter, error_margin)
-            if testing_mode == DUAL_TOR_MODE:
-                validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
-                                                {}, {}, 0)
+        def get_ip_link_result(duthost):
+            # Get the output of 'ip link' command and parse it to a dictionary of index: name
+            cmd_res = duthost.shell('ip link')
+            if cmd_res['rc'] != 0:
+                pytest.fail("Failed to get ip link result: {}".format(cmd_res['stderr']))
 
-        if dhcp_type in ['discover', 'request']:
-            interface = client_port_name
-            eth_src = client_mac
-            pkts_validator = _verify_server_packets
-        else:
-            interface = server_port_name
-            eth_src = server_mac
-            pkts_validator = _verify_client_packets
+            pattern = re.compile(r'^(\d+):\s+([^\s@:]+)')
+            interface_dict = {}
+
+            for line in cmd_res['stdout'].splitlines():
+                match = pattern.match(line)
+                if match:
+                    index = int(match.group(1))
+                    name = match.group(2)
+                    interface_dict[name] = index
+
+            return interface_dict
+
         with capture_and_check_packet_on_dut(
-            duthost=duthost, interface=interface,
-            pkts_filter="ether src %s and udp dst port %s" % (eth_src, DEFAULT_DHCP_SERVER_PORT),
-            pkts_validator=pkts_validator,
-            pkts_validator_args=[dhcp_type]
+            duthost=duthost, interface='any',
+            pkts_filter="udp dst port %s or udp dst port %s" % (DEFAULT_DHCP_SERVER_PORT,
+                                                                DEFAULT_DHCP_CLIENT_PORT),
+            pkts_validator=_verify_packets
         ):
             ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
                        platform_dir="ptftests", params=params,
@@ -134,3 +116,7 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             check_dhcp_stress_status(duthost, packets_send_duration)
             pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
             ptfhost.shell('rm -f {}'.format(count_file))
+            if testing_mode == DUAL_TOR_MODE:
+                interface_dict = get_ip_link_result(standby_duthost)
+            else:
+                interface_dict = get_ip_link_result(duthost)

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -12,10 +12,6 @@ from tests.dhcp_relay.dhcp_relay_utils import check_dhcp_stress_status
 from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
-pytestmark = [
-    pytest.mark.topology('t0', 'm0')
-]
-
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
@@ -41,7 +37,6 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
         testing_mode, client_packets_per_sec, error_margin))
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_id = dhcp_relay['client_iface']['port_idx']
-        vlan_ip = dhcp_relay['downlink_vlan_iface']['addr']
 
         init_dhcpcom_relay_counters(duthost)
         if testing_mode == DUAL_TOR_MODE:
@@ -78,7 +73,7 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
         def _verify_packets(pkts):
             # Default DB update timer for dhcpmon is 20s, hence wait for it to write DB
             time.sleep(25)
-            validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_dict, vlan_ip,
+            validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_dict,
                                                    error_in_percentage=error_margin)
             if testing_mode == DUAL_TOR_MODE:
                 validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
@@ -115,7 +110,4 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             check_dhcp_stress_status(duthost, packets_send_duration)
             pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))
             ptfhost.shell('rm -f {}'.format(count_file))
-            if testing_mode == DUAL_TOR_MODE:
-                interface_dict = get_ip_link_result(standby_duthost)
-            else:
-                interface_dict = get_ip_link_result(duthost)
+            interface_dict = get_ip_link_result(duthost)

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -1,5 +1,4 @@
 import pytest
-import ptf.packet as scapy
 import logging
 import time
 import re

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -13,7 +13,8 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.ptf_runner import ptf_runner
 
 pytestmark = [
-    pytest.mark.topology('t0', 'm0')
+    pytest.mark.topology('t0', 'm0'),
+    pytest.mark.device_type('physical')
 ]
 
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Previous counter stress tests only checked 2 interfaces (port channel interface for  discover and request, client interface for offer and ack). In some cases, the packet count of testbed received and relayed are not equal, it may due to dhcy relay issue instead of dhcy relay counter. The test cases should distinguish this scenario.
#### How did you do it?
Catch packets from both directly for the four request types and compare the cached packet number and counter value.
#### How did you verify/test it?
run the stress test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
