### PR TITLE
Skip PSUs listed under skip_modules

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -87,19 +87,20 @@ def get_dut_psu_line_pattern(dut):
     elif dut.facts["asic_type"] in ["mellanox"]:
         psu_line_pattern = re.compile(r"PSU\s+(\d+).*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
     else:
-        """
-        Changed the pattern to match space (s+) and non-space (S+) only.
-        w+ cannot match following examples properly:
-
-        example 1:
-            psu1   PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
-            psu2   PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
-        example 2:
-            psutray0.psu0  N/A      N/A               12.05           3.38        40.62  OK        green
-            psutray0.psu1  N/A      N/A               12.01           4.12        49.50  OK        green
-
-        """
-        psu_line_pattern = re.compile(r"^(\S+)\s+.*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
+        # Changed the pattern to match different PSU name formats and status patterns.
+        # Supports various PSU naming conventions:
+        #
+        # example 1:
+        #     psu1   PWR-500AC-R  L8180S01HTAVP  N/A            N/A            N/A          OK        green
+        #     psu2   PWR-500AC-R  L8180S01HFAVP  N/A            N/A            N/A          OK        green
+        # example 2:
+        #     psutray0.psu0  N/A      N/A               12.05           3.38        40.62  OK        green
+        #     psutray0.psu1  N/A      N/A               12.01           4.12        49.50  OK        green
+        # example 3:
+        #     PSU 9  PSU6.3KW-20A-HV  DTM273501QU      1.00  55.052         11.359         626.386      OK        green
+        #
+        psu_line_pattern = re.compile(
+            r"^(PSU\s+\d+|\S+)\s+.*?(OK|NOT OK|NOT PRESENT|WARNING)\s+(green|amber|red|off|N/A)")
     return psu_line_pattern
 
 

--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -15,6 +15,7 @@ from tests.common.helpers.psu_helpers import turn_on_all_outlets, get_grouped_pd
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 from tests.common.utilities import wait_until, get_sup_node_or_random_node
 from tests.common.platform.device_utils import get_dut_psu_line_pattern
+from tests.platform_tests.cli.util import get_skip_mod_list
 from tests.common.helpers.thermal_control_test_helper import ThermalPolicyFileContext,\
     check_cli_output_with_mocker, restart_thermal_control_daemon, check_thermal_algorithm_status, \
     mocker_factory, disable_thermal_policy  # noqa: F401
@@ -220,18 +221,49 @@ def check_vendor_specific_psustatus(dut, psu_status_line, psu_line_pattern):
         check_psu_sysfs(dut, psu_id, psu_status)
 
 
+def get_psu_name_and_check_skip(psu_identifier, skip_psu_list):
+    """
+    @summary: Convert PSU identifier to standardized name and check if it should be skipped
+    @param psu_identifier: Raw PSU identifier from platform (e.g., "1", "psu1", "psutray0.psu0")
+    @param skip_psu_list: List of PSU names to skip
+    @return: Tuple of (psu_name, should_skip)
+    """
+    # Handle different PSU identifier formats:
+    # 1. "psu1" - already contains psu prefix
+    # 2. "1" - just a number, needs PSU prefix
+    # 3. "psutray0.psu0" - complex format with psu in it
+    if 'psu' in psu_identifier.lower():
+        psu_name = psu_identifier
+    else:
+        psu_name = "PSU {}".format(psu_identifier)
+
+    # Check if PSU should be skipped (case-insensitive comparison)
+    should_skip = any(psu_name.lower() == skip_psu.lower() for skip_psu in skip_psu_list)
+    logging.info(f"PSU name '{psu_name}' should be skipped: {should_skip}")
+
+    return psu_name, should_skip
+
+
 def check_all_psu_on(dut, psu_test_results):
     """
-        @summary: check all PSUs are in 'OK' status.
+        @summary: Check that all non-skipped PSUs are in 'OK' status.
         @param dut: dut host instance.
         @param psu_test_results: dictionary of all PSU names, values are not important.
+        @return: True if all non-skipped PSUs are on (no powered off PSUs), otherwise False.
     """
     power_off_psu_list = []
+
+    # Get list of PSUs to skip from inventory configuration
+    skip_psu_list = get_skip_mod_list(dut, ['psus'])
 
     if "201811" in dut.os_version or "201911" in dut.os_version:
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS)
         for line in cli_psu_status["stdout_lines"][2:]:
             fields = line.split()
+            # Skip PSUs that are in the skip list
+            if fields[1] in skip_psu_list:
+                logging.info("Skip PSU {} as it is in skip list".format(fields[1]))
+                continue
             if " ".join(fields[2:]) != 'NOT PRESENT':
                 psu_test_results[fields[1]] = line
             if " ".join(fields[2:]) == "NOT OK":
@@ -241,14 +273,18 @@ def check_all_psu_on(dut, psu_test_results):
         cli_psu_status = dut.command(CMD_PLATFORM_PSUSTATUS_JSON)
         psu_info_list = json.loads(cli_psu_status["stdout"])
         for psu_info in psu_info_list:
+            if psu_info["name"] in skip_psu_list:
+                logging.info("Skip PSU {} as it is in skip list".format(psu_info["name"]))
+                continue
             if psu_info["status"] != 'NOT PRESENT':
                 psu_test_results[psu_info['name']] = psu_info
             if psu_info["status"] == "NOT OK":
-                power_off_psu_list.append(psu_info["index"])
+                power_off_psu_list.append(psu_info["name"])
 
     if power_off_psu_list:
         logging.warning('Powered off PSUs: {}'.format(power_off_psu_list))
 
+    # Return True if all PSUs are on (no powered off PSUs), otherwise False
     return len(power_off_psu_list) == 0
 
 
@@ -306,8 +342,19 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
     # Group outlets/PDUs by PSU and toggle PDUs by PSU
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
 
+    # Get list of PSUs to skip from inventory configuration
+    skip_psu_list = get_skip_mod_list(duthost, ['psus'])
+    logging.info(f"PSUs to skip during PDU testing: {skip_psu_list}")
+    logging.info(f"PSUs to check: {psu_to_pdus.keys()}")
+
     try:
         for psu in psu_to_pdus.keys():
+            logging.info(f"Checking PSU identifier: {psu}")
+            # Skip PSUs that are in the skip list
+            if psu in skip_psu_list:
+                logging.info(f"Skipping PSU {psu} as it's in the skip list")
+                continue
+
             outlets = psu_to_pdus[psu]
             psu_under_test = None
 
@@ -322,6 +369,11 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
             for line in cli_psu_status["stdout_lines"][2:]:
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")
+                # Skip PSUs that are in the skip list
+                psu_name, should_skip = get_psu_name_and_check_skip(psu_match.group(1), skip_psu_list)
+                if should_skip:
+                    logging.info(f"Skipping PSU {psu_name} as it's in the skip list")
+                    continue
                 # also make sure psustatus is not 'NOT PRESENT', which cannot be turned on/off
                 if psu_match.group(2) != "OK" and psu_match.group(2) != "NOT PRESENT":
                     psu_under_test = psu_match.group(1)
@@ -337,6 +389,12 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
             for line in cli_psu_status["stdout_lines"][2:]:
                 psu_match = psu_line_pattern.match(line)
                 pytest_assert(psu_match, "Unexpected PSU status output")
+                # Skip PSUs that are in the skip list
+                psu_name, should_skip = get_psu_name_and_check_skip(psu_match.group(1), skip_psu_list)
+                # Skip PSUs that are in the skip list when checking status
+                if should_skip:
+                    logging.info(f"Skipping PSU {psu_name} as it's in the skip list")
+                    continue
                 if psu_match.group(1) == psu_under_test:
                     pytest_assert(psu_match.group(2) == "OK",
                                   "Unexpected PSU status after turned it on")
@@ -347,8 +405,12 @@ def test_turn_on_off_psu_and_check_psustatus(duthosts, enum_rand_one_per_hwsku_h
         turn_on_all_outlets(pdu_ctrl)
 
     for psu in psu_test_results:
-        pytest_assert(psu_test_results[psu],
-                      "Test psu status of PSU %s failed" % psu)
+        pytest_assert(
+            psu_test_results[psu],
+            "Test psu status failed for PSU '{}'. Observed status: {}".format(
+                psu, psu_test_results[psu] if psu_test_results[psu] is not True else "OK"
+            )
+        )
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION
### Description of PR
Skip PSUs listed under skip_modules, to avoid false alarms during test_platform_info.py tests
For Cisco 8808 chassis, PSUs are installed by rows and not by single PSU. 
Therefore, when row of PSU is installed and if any PSU in that row is not plugged in with PDU, status of PSU will be displayed as 'NOT OK'.
currently, if we have "NOT OK" status, test_platform_info will automatically skip the test and resulting a failure. 

This PR is to address this issue, by skipping PSUs based on inventory file declaration. 
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This pull request enhances the PSU testing framework by introducing the ability to skip specific PSUs based on an inventory configuration. The changes ensure that skipped PSUs are excluded from status checks and power toggle tests, improving test reliability and configurability.

### Enhancements to PSU Testing:

* **Inventory-based PSU skipping**:
  - Added `get_skip_mod_list` import to retrieve the list of PSUs to skip from the inventory configuration. (`tests/platform_tests/test_platform_info.py`)
  - Integrated the skip list into `check_all_psu_on` to exclude skipped PSUs from status checks. (`tests/platform_tests/test_platform_info.py`)
  - Updated `test_turn_on_off_psu_and_check_psustatus` to skip PSUs during PDU testing and status validation. (`tests/platform_tests/test_platform_info.py`) [[1]](diffhunk://#diff-1383f65336ddb625108da5f83322a2415be7b70f05ecaaf6ddecb6e81b1fd37aR322-R334) [[2]](diffhunk://#diff-1383f65336ddb625108da5f83322a2415be7b70f05ecaaf6ddecb6e81b1fd37aR349-R354) [[3]](diffhunk://#diff-1383f65336ddb625108da5f83322a2415be7b70f05ecaaf6ddecb6e81b1fd37aR370-R376)

* **Improved logging and assertions**:
  - Added detailed logging for skipped PSUs to enhance test traceability. (`tests/platform_tests/test_platform_info.py`) [[1]](diffhunk://#diff-1383f65336ddb625108da5f83322a2415be7b70f05ecaaf6ddecb6e81b1fd37aR322-R334) [[2]](diffhunk://#diff-1383f65336ddb625108da5f83322a2415be7b70f05ecaaf6ddecb6e81b1fd37aR349-R354)
  - Enhanced assertion error messages to provide more informative feedback when PSU status tests fail. (`tests/platform_tests/test_platform_info.py`)<!--

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
False alarm on test_platform_info
#### How did you do it?
adding skip mechanism based on skip_modules declared in inventory file
#### How did you verify/test it?
tested on Cisco T2 8800 devices
<img width="1193" height="31" alt="image" src="https://github.com/user-attachments/assets/e3535329-7e07-40db-abe3-fce1afe99bfa" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
