### PR TITLE
[202505]Add detailed reason for Assertfailure for bfd,sfp,route

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -236,7 +236,10 @@ def check_dut_bfd_status(duthost, neighbor_addr, expected_state, max_attempts=12
         if i < max_attempts:
             time.sleep(retry_interval)
 
-    assert expected_state in bfd_state[0]  # If all attempts fail, raise an assertion error
+    assert expected_state in bfd_state[0], (
+        "BFD session state verification failed: expected '{}', got '{}'."
+        .format(expected_state, bfd_state[0] if bfd_state else "No state found")
+    )
 
 
 def create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs, dut_init_first, scale_test=False):

--- a/tests/platform_tests/sfp/test_sfpshow.py
+++ b/tests/platform_tests/sfp/test_sfpshow.py
@@ -37,7 +37,10 @@ def test_check_sfp_presence(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     parsed_presence = parse_output(sfp_presence["stdout_lines"][2:])
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            assert intf in parsed_presence, "Interface is not in output of '{}'".format(cmd_sfp_presence)
+            assert intf in parsed_presence, (
+                "Interface '{}' is not in the output of '{}'. "
+                "Parsed presence output: {}".format(intf, cmd_sfp_presence, parsed_presence)
+            )
             assert parsed_presence[intf] == "Present", "Interface presence is not 'Present'"
 
 
@@ -56,5 +59,11 @@ def test_check_sfpshow_eeprom(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     parsed_eeprom = parse_eeprom(sfp_eeprom["stdout_lines"])
     for intf in dev_conn:
         if intf not in xcvr_skip_list[duthost.hostname]:
-            assert intf in parsed_eeprom, "Interface is not in output of 'sfputil show eeprom'"
-            assert parsed_eeprom[intf] == "SFP EEPROM detected"
+            assert intf in parsed_eeprom, "Interface '{}' not found in 'sfputil show eeprom' output.".format(intf)
+            assert parsed_eeprom[intf] == "SFP EEPROM detected", (
+                (
+                    "The EEPROM information for interface '{}' is not as expected. "
+                    "Expected: 'SFP EEPROM detected', but got: '{}'. "
+                    "Full parsed EEPROM output: {}"
+                ).format(intf, parsed_eeprom.get(intf, "No data found"), parsed_eeprom)
+            )

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -164,10 +164,9 @@ def check_route_redistribution(duthost, prefix, ipv6, removed=False):
                 return False
         return True
 
-    pytest_assert(
-        wait_until(60, 15, 0, _check_routes),
-        f"Route {prefix} advertisement state does not match expected 'removed={removed}' on all neighbors"
-    )
+    assert wait_until(60, 15, 0, _check_routes), (
+        "Route {} advertisement state does not match expected 'removed={}' on all neighbors"
+    ).format(prefix, removed)
 
 
 # output example of ip [-6] route show


### PR DESCRIPTION
**Description of PR**

Added detailed Reason for Assert failure
This PR is the cherry pick PR to 202505
[Added detailed reason for assertfailure by bachalla · Pull Request #18426 · sonic-net/sonic-mgmt](https://github.com/sonic-net/sonic-mgmt/pull/18426)

**Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


 **Back port request**

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Summary:**

Enhanced assertion messages in selected test cases to provide clearer failure context. This improves debuggability and speeds up issue resolution when tests fail.
Added detailed assertion failure messages in test scripts to make it easier to understand why tests fails.

**What is the motivation for this PR?**
The motivation is to improve test debuggability by adding detailed failure reasons in assertions for selected test cases. This enhancement makes it easier to identify the root cause of test failures in logs, thereby reducing triage time and simplifying test maintenance.

**How did you do it?**
I updated the assertion statements in the following test files to include descriptive error messages:
tests/route/test_static_route.py
tests/bfd/test_bfd.py
tests/platform_tests/sfp/test_sfpshow.py
These changes provide clear context when a test fails, such as the expected vs actual values or relevant system states.

**How did you verify/test it?**
Verified that the updated assertion messages are correctly reflected in the test code by reviewing the changes locally.

