### PR TITLE
Remove the duplicated sad type from the multihop upgrade test

### DIFF
--- a/tests/upgrade_path/test_multi_hop_upgrade_path.py
+++ b/tests/upgrade_path/test_multi_hop_upgrade_path.py
@@ -34,7 +34,8 @@ def pytest_generate_tests(metafunc):
                 logging.warning("Unknown SAD case ({}) - skipping it.".format(input_case))
                 continue
             input_sad_list.append(input_case)
-
+        if "multi_sad" in input_sad_list and "sad_bgp" in input_sad_list and "sad_lag" in input_sad_list:
+            input_sad_list.remove("multi_sad")
         metafunc.parametrize("sad_case_type", input_sad_list, scope="module")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
Remove the 'multi_sad' from the upgrade sad test since it has duplicate with other sad types

since multi_sad == sad_bgp + sad_lag, no need to have the multi_sad type. it will reduce the run type (3-4hrs)
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
When the sad_case_list is not specified for the test_multi_hop_warm_upgrade_sad_path, it will take the default sad type list, and in the default sad list, it will inlcude the multi_sad, sad_bgp,  sad_lag, but multi_sad == sad_bgp + sad_lag, so no need to run duplicated sad type in one pytest session, remove the multi_sad when sad_bgp and sad_lag exist.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
