### PR TITLE
cherry pick for the PR#17101

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -199,3 +199,9 @@ x86_64-8101_32fh_o_c01-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+
+x86_64-8102_28fh_dpu_o-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Adding Cisco 8122 platforms to platform_tests/api/watchdog.yml file. This is needed for testcase platform_tests/api/test_watchdog.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X ] 202411
- [X ] 202505

What is the motivation for this PR?

Adding Cisco 8122 platforms to platform_tests/api/watchdog.yml file. This is needed for testcase platform_tests/api/test_watchdog.py

How did you do it?

Added the details for 8102 platforms to watchdog.yml file

How did you verify/test it?

Made sure that testcase platform_tests/api/test_watchdog.py passes on 8122 platforms after adding adding them to watchdog.yml file

Any platform specific information?

root@MtFuji-dut:/home/cisco# show platform summary
Platform: x86_64-8102_28fh_dpu_o-r0
HwSKU: Cisco-8102-28FH-DPU-O-T1
ASIC: cisco-8000
ASIC Count: 1
Serial Number: FLM2824083H
Model Number: 8102-28FH-DPU-O
Hardware Revision: 0.20

Supported testbed topology if it's a new test case?
t-28-lag