### PR TITLE
Use monit validate to get live data

### DIFF
--- a/tests/common/plugins/memory_utilization/README.md
+++ b/tests/common/plugins/memory_utilization/README.md
@@ -12,7 +12,7 @@
   - [Enabling and Disabling](#enabling-and-disabling)
   - [Configuration Examples](#configuration-examples)
 - [Supported Memory Monitors](#supported-memory-monitors)
-  - [Monit Status Monitor](#monit-status-monitor)
+  - [Monit Validate Monitor](#monit-validate-monitor)
   - [Free Memory Monitor](#free-memory-monitor)
   - [Docker Stats Monitor](#docker-stats-monitor)
   - [Top Monitor](#top-monitor)
@@ -176,12 +176,12 @@ Memory utilization checking is enabled by default for all tests. To disable it:
 
 ## Supported Memory Monitors and Configuration Examples
 
-### Monit Status Monitor
+### Monit Validate Monitor
 
 Monitors system memory usage via Monit.
 
-- **Command**: `sudo monit status`
-- **Parser Function**: `parse_monit_status_output`
+- **Command**: `sudo monit validate`
+- **Parser Function**: `parse_monit_validate_output`
 - **Monitored Parameters**:
   - `memory_usage`: System memory utilization percentage
 
@@ -189,7 +189,7 @@ Example configuration:
 ```json
 {
   "name": "monit",
-  "cmd": "sudo monit status",
+  "cmd": "sudo monit validate",
   "memory_params": {
     "memory_usage": {
       "memory_increase_threshold": {
@@ -202,7 +202,7 @@ Example configuration:
       }
     }
   },
-  "memory_check": "parse_monit_status_output"
+  "memory_check": "parse_monit_validate_output"
 }
 ```
 
@@ -359,7 +359,7 @@ Example:
   "Arista-7050QX": [
     {
       "name": "monit",
-      "cmd": "sudo monit status",
+      "cmd": "sudo monit validate",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -372,7 +372,7 @@ Example:
           }
         }
       },
-      "memory_check": "parse_monit_status_output"
+      "memory_check": "parse_monit_validate_output"
     }
   ]
 }

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -478,7 +478,7 @@ def parse_free_output(output, memory_params):
     return memory_values
 
 
-def parse_monit_status_output(output, memory_params):
+def parse_monit_validate_output(output, memory_params):
     """Parse the 'monit validate' command output to extract memory usage information."""
     memory_values = {}
 

--- a/tests/common/plugins/memory_utilization/memory_utilization_common.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_common.json
@@ -2,7 +2,7 @@
   "COMMON": [
     {
       "name": "monit",
-      "cmd": "sudo monit status",
+      "cmd": "sudo monit validate",
       "memory_params": {
         "memory_usage": {
           "memory_increase_threshold": {
@@ -15,7 +15,7 @@
           }
         }
       },
-      "memory_check": "parse_monit_status_output"
+      "memory_check": "parse_monit_validate_output"
     }
   ]
 }

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -54,7 +54,7 @@
           }
         }
       },
-      "memory_check": "parse_monit_status_output"
+      "memory_check": "parse_monit_validate_output"
     },
     {
       "name": "docker",
@@ -216,7 +216,7 @@
           }
         }
       },
-      "memory_check": "parse_monit_status_output"
+      "memory_check": "parse_monit_validate_output"
     }
   ],
   "Mellanox-SN4600C": [
@@ -235,7 +235,7 @@
           }
         }
       },
-      "memory_check": "parse_monit_status_output"
+      "memory_check": "parse_monit_validate_output"
     },
     {
       "name": "docker",


### PR DESCRIPTION
### Description of PR
Summary:
'monit status' provides a stale 60 secs old data, this is not ideal in certain scenarios. 
We should use the live data , 'monit validate' provides the live data.

Fixes # (issue)
https://github.com/aristanetworks/sonic-qual.msft/issues/718

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
disk/test_disk_exhaustion.py creates a 1.7G file in the test and deletes it at the end of the test.
But "monit status" is configured to check only once every 60 secs in /etc/monit/monitrc.
This provides a stale data resulting in memory high threshold getting breached.

#### How did you do it?
We should use "monit validate" instead of "monit status"
#### How did you verify/test it?
verified by running the test 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
