### PR TITLE
Teamd serviceability - Testcase for validating portchannel lacp statistics 

### DIFF
--- a/tests/common/devices/sonic_asic.py
+++ b/tests/common/devices/sonic_asic.py
@@ -572,6 +572,24 @@ class SonicAsic(object):
                 return pc["ports"].split()
         return []
 
+    def clear_portchannel_statistics(self, pc_name=None, interface_name=None):
+        """
+        Clear PortChannel statistics:
+        - If both pc_name and interface_name are None: clear all.
+        - If interface_name is None: clear for the given portchannel.
+        - If both provided: clear for specific member of the portchannel.
+        """
+        base_cmd = "sudo sonic-clear {ns} portchannel statistics".format(ns=self.cli_ns_option)
+
+        if pc_name and interface_name:
+            cmd = f"{base_cmd} {pc_name} {interface_name}"
+        elif pc_name:
+            cmd = f"{base_cmd} {pc_name}"
+        else:
+            cmd = base_cmd
+
+        return self.sonichost.shell(cmd)
+
     def switch_arptable(self, *module_args, **complex_args):
         complex_args['namespace'] = self.namespace
         return self.sonichost.switch_arptable(*module_args, **complex_args)


### PR DESCRIPTION
Testing lacp statistics:

Verifying that LACP statistics counters
Testing for specific portchannel member by clearing the statistics
Testing for specific portchannel by clearing the statistics
Testing lacp statistics by clearing all portchannel
Logs:

[dependency_logs.txt](https://github.com/user-attachments/files/21146625/dependency_logs.txt)

[pre-commit-sonic-mgmt-logs.txt](https://github.com/user-attachments/files/21146558/pre-commit-sonic-mgmt-logs.txt)

[sonic-mgmt-statistics-logs.zip](https://github.com/user-attachments/files/21146559/sonic-mgmt-statistics-logs.zip)