### PR TITLE
Add nexthop threshold for arista-7050cx3-32s-c6s104

### DIFF
--- a/tests/crm/test_crm_available.py
+++ b/tests/crm/test_crm_available.py
@@ -18,6 +18,7 @@ SKU_NEXTHOP_THRESHOLDS = {
     'arista-7050cx3-32s-c28s4': 255,
     'Arista-7050CX3-32S-C32': 255,
     'arista-7050cx3-32s-s128': 255,
+    'arista-7050cx3-32s-c6s104': 255,
 }
 
 DEFAULT_NEXTHOP_THRESHOLD = 256


### PR DESCRIPTION
### Description of PR

Summary:
Fix crm/test_crm_available.py by adding the nexthop threshold for arista-7050cx3-32s-c6s104 to the test.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
There was an assert failure in test_crm_available.py for this SKU because it defaults to a nexthop threshold of 256 which is higher than the threshold the chip actually supports.

#### How did you do it?
Added an entry under SKU_NEXTHOP_THRESHOLDS dictionary to set the nexthop threshold to 255 which is in line with other SKUs that have the same switch ASIC.

#### How did you verify/test it?
Ran the test with and without the change. Passing with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
