### PR TITLE
[Dash] Fix the tests for VM Mode

### DIFF
--- a/tests/dash/configs/privatelink_config.py
+++ b/tests/dash/configs/privatelink_config.py
@@ -49,8 +49,7 @@ APPLIANCE_CONFIG = {
     f"DASH_APPLIANCE_TABLE:{APPLIANCE_ID}": {
         "sip": APPLIANCE_VIP,
         "vm_vni": VM_VNI,
-        "local_region_id": LOCAL_REGION_ID,
-        "outbound_direction_lookup": OUTBOUND_DIR_LOOKUP
+        "local_region_id": LOCAL_REGION_ID
     }
 }
 

--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -145,8 +145,8 @@ def inbound_pl_packets(config, use_pkt_alt_attrs=False, inner_packet_type='udp',
 def outbound_pl_packets(config, outer_encap, use_pkt_alt_attrs=False,
                         inner_packet_type='udp', vxlan_udp_dport=4789, vxlan_udp_sport=1234):
     inner_packet = generate_inner_packet(inner_packet_type)(
-        eth_src=pl.ENI_MAC
-        eth_dst=pl.REMOTE_MAC
+        eth_src=pl.ENI_MAC,
+        eth_dst=pl.REMOTE_MAC,
         ip_src=pl.VM1_CA,
         ip_dst=pl.PE_CA,
     )

--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -108,8 +108,8 @@ def inbound_pl_packets(config, use_pkt_alt_attrs=False, inner_packet_type='udp',
     )
 
     exp_inner_packet = generate_inner_packet(inner_packet_type)(
-        eth_src=pl.REMOTE_MAC if use_pkt_alt_attrs else pl.ENI_MAC,
-        eth_dst=pl.ENI_MAC if use_pkt_alt_attrs else pl.VM_MAC,
+        eth_src=pl.REMOTE_MAC,
+        eth_dst=pl.ENI_MAC,
         ip_src=pl.PE_CA,
         ip_dst=pl.VM1_CA,
         ip_id=0,
@@ -145,8 +145,8 @@ def inbound_pl_packets(config, use_pkt_alt_attrs=False, inner_packet_type='udp',
 def outbound_pl_packets(config, outer_encap, use_pkt_alt_attrs=False,
                         inner_packet_type='udp', vxlan_udp_dport=4789, vxlan_udp_sport=1234):
     inner_packet = generate_inner_packet(inner_packet_type)(
-        eth_src=pl.ENI_MAC if use_pkt_alt_attrs else pl.VM_MAC,
-        eth_dst=pl.REMOTE_MAC if use_pkt_alt_attrs else pl.ENI_MAC,
+        eth_src=pl.ENI_MAC
+        eth_dst=pl.REMOTE_MAC
         ip_src=pl.VM1_CA,
         ip_dst=pl.PE_CA,
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

From this PR, https://github.com/sonic-net/sonic-swss/pull/3763 outbound_direction_lookup of 'dst_mac' would be for FNIC scenario. setting this for VM mode operation would fail. Thus update the test 

Remove the outbound_dir_lookup from the DASH_APPLIANCE_TABLE and modify the packets to have the correct INNER_MAC attributes.



#### How did you verify/test it?

Ran the tests and verified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
