### PR TITLE
Add autoneg config for sonic 202505 fanout

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -22,6 +22,18 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "400000", "800000"] %}
             "fec" : "rs",
     {% endif %}
+    {% if port_name in device_conn[inventory_hostname] %}
+        {% if 'autoneg' in device_conn[inventory_hostname][port_name] %}
+                {% if 'on' in device_conn[inventory_hostname][port_name]['autoneg']%}
+                    "autoneg": "on",
+                    {% if msft_an_enabled is defined %}
+                        "fec": "none",
+                    {% endif %}
+                {% else %}
+                    "autoneg": "off",
+                {% endif %}
+        {% endif %}
+    {% endif %}
     {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] or 'mellanox' in fanout_sonic_version["asic_type"] %}
         {% if port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"].lower() == "access" %}
             "tpid": "0x9100",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add autoneg config for sonic 202505 fanout. Set the autoneg according to the data in device_conn.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Add autoneg config for sonic 202505 fanout. Set the autoneg according to the data in device_conn.

#### How did you do it?
Add autoneg config to sonic_deploy_202405.j2

#### How did you verify/test it?
deploy fanout with 202405 image

#### Any platform specific information?
Sonic switch

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
