### PR TITLE
[multi_asic]: Add wrapper for is_dpu() function

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -418,6 +418,9 @@ class MultiAsicSonicHost(object):
 
         return True
 
+    def is_dpu(self):
+        return self.sonichost.is_dpu()
+
     def get_asic_index_for_portchannel(self, portchannel):
         for asic in self.asics:
             if asic.portchannel_on_asic(portchannel):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Watchdog tests fail in setup due to recent DPU functionality (https://github.com/sonic-net/sonic-mgmt/pull/18189) - there is no is_dpu() function for multi asic hosts, so these tests fail in startup when trying to call it. 

Add a wrapper for this in multiasic host. 

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/pull/18189


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/6880573463c9607f286ff116
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
