### PR TITLE
Update API watchdog case for dpu because watchdog will be set to arm for dpu by default

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -51,7 +51,7 @@ class TestWatchdogApi(PlatformApiTestBase):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
-                duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
+                duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0' or duthost.is_dpu():
             duthost.shell("watchdogutil disarm")
 
         assert not watchdog.is_armed(platform_api_conn)
@@ -60,9 +60,12 @@ class TestWatchdogApi(PlatformApiTestBase):
             yield
         finally:
             watchdog.disarm(platform_api_conn)
+
             if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
                     duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
                 duthost.shell("systemctl start cpu_wdt.service")
+            if duthost.is_dpu():
+                duthost.shell("watchdogutil arm")
 
     @pytest.fixture(scope='module')
     def conf(self, request,

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -51,7 +51,8 @@ class TestWatchdogApi(PlatformApiTestBase):
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
-                duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0' or duthost.is_dpu():
+                duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0' or \
+                duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
             duthost.shell("watchdogutil disarm")
 
         assert not watchdog.is_armed(platform_api_conn)
@@ -64,7 +65,7 @@ class TestWatchdogApi(PlatformApiTestBase):
             if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
                     duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
                 duthost.shell("systemctl start cpu_wdt.service")
-            if duthost.is_dpu():
+            if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
                 duthost.shell("watchdogutil arm")
 
     @pytest.fixture(scope='module')
@@ -151,7 +152,7 @@ class TestWatchdogApi(PlatformApiTestBase):
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
     def test_remaining_time(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):    # noqa: F811
         ''' arm watchdog with a valid timeout and verify that remaining time API works correctly '''
-
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         watchdog_timeout = conf['valid_timeout']
 
         # in the begginging of the test watchdog is not armed, so
@@ -172,14 +173,18 @@ class TestWatchdogApi(PlatformApiTestBase):
         remaining_time = watchdog.get_remaining_time(platform_api_conn)
         time.sleep(TEST_WAIT_TIME_SECONDS)
         remaining_time_new = watchdog.get_remaining_time(platform_api_conn)
-        self.expect(remaining_time_new < remaining_time,
-                    "Remaining_time {} seconds should be decreased from previous remaining_time {} seconds"
-                    .format(remaining_time_new, remaining_time))
+        self.expect(
+            remaining_time_new == remaining_time
+            if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")
+            else remaining_time_new < remaining_time,
+            "Remaining_time {} seconds should be decreased from previous remaining_time {} seconds"
+            .format(remaining_time_new, remaining_time))
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
     def test_periodic_arm(self, duthosts, enum_rand_one_per_hwsku_hostname, platform_api_conn, conf):  # noqa: F811
         ''' arm watchdog several times as watchdog deamon would and verify API behaves correctly '''
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
         watchdog_timeout = conf['valid_timeout']
         actual_timeout = watchdog.arm(platform_api_conn, watchdog_timeout)
@@ -193,7 +198,9 @@ class TestWatchdogApi(PlatformApiTestBase):
                     "the previous actual watchdog timeout {} seconds"
                     .format(self.test_periodic_arm.__name__, actual_timeout_new, actual_timeout))
         self.expect(
-            remaining_time_new > remaining_time,
+            remaining_time_new == remaining_time
+            if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")
+            else remaining_time_new > remaining_time,
             "{}: new remaining timeout {} seconds should be greater than "
             "the previous remaining timeout {} seconds by {} seconds"
             .format(self.test_periodic_arm.__name__, remaining_time_new, remaining_time, TEST_WAIT_TIME_SECONDS))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
According to the following PR, the dpu watchdog will set to arm by default and the get_remaining_time api will return the same value (armed time), so update the API watchdog case accordingly
 
PR: https://github.com/sonic-net/sonic-buildimage/pull/22315

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Update the watchdog case for dpu

#### How did you do it?
Update the watchdog case for dpu according to the PR https://github.com/sonic-net/sonic-buildimage/pull/22315

#### How did you verify/test it?
Run the cases on dpu

#### Any platform specific information?
DPU

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
