### PR TITLE
[vm_topology] Fix pid=0 issue if ptf docker is not running

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1813,7 +1813,13 @@ class VMTopology(object):
         except Exception:
             return None
 
-        return ctn.attrs['State']['Pid']
+        if ctn.attrs['State']['Running']:
+            # If the container is running, return its PID
+            return ctn.attrs['State']['Pid']
+        else:
+            # If the container is not running, return None
+            logging.error('!!! Container %s is not running' % ptf_name)
+            return None
 
     @staticmethod
     def brctl_show(bridge=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In vm_topology.py code, lots of the code check if the PTF container pid is 'None'. For example:

```
    if self.pid is None
```

In case PTF container is stopped, the current code would store PTF container pid "0" in `self.pid`.

Consequently, some of the logic is incorrect. For example, remove-topo while PTF container is stopped, the unbind topology step would fail if the host device happens to have a "eth0" interface.

#### How did you do it?
The fix is to check the Running states of PTF container. If the container is not running, explicitly set `self.pid` to `None`.

#### How did you verify/test it?
Run 'add-topo' and 'remove-topo'.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
