### PR TITLE
Update topology definition ft2-64

### DIFF
--- a/ansible/vars/topo_ft2-64.yml
+++ b/ansible/vars/topo_ft2-64.yml
@@ -1,4 +1,6 @@
 topology:
+  disabled_host_interfaces:
+    - 63
   VMs:
     ARISTA01LT2:
       vlans:
@@ -252,10 +254,6 @@ topology:
       vlans:
         - 62
       vm_offset: 62
-    ARISTA64LT2:
-      vlans:
-        - 63
-      vm_offset: 63
 
 configuration_properties:
   common:
@@ -1468,22 +1466,3 @@ configuration:
     bp_interface:
       ipv4: 10.10.246.64/24
       ipv6: fc0a::40/64
-  ARISTA64LT2:
-    properties:
-    - common
-    bgp:
-      asn: 4200100000
-      peers:
-        4200100000:
-          - 10.0.0.126
-          - fc01::1
-    interfaces:
-      Loopback0:
-        ipv4: 100.1.0.64/32
-        ipv6: 2064:100:0:40::/128
-      Ethernet1:
-        ipv4: 10.0.0.127/31
-        ipv6: fc01::2/126
-    bp_interface:
-      ipv4: 10.10.246.65/24
-      ipv6: fc0a::41/64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to update topo definition of ft2-64.

Change list
1. Remove ARISTA64LT2. The number of LT2 is 63 after this change.
2. Disable port etp64


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to update topo definition of ft2-64.

#### How did you do it?
Update ansible/vars/topo_ft2-64.yml.

#### How did you verify/test it?
The change is verified by deploying the topo on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
