### PR TITLE
bmp: Fix docker restart test for multi-asic

### DIFF
--- a/tests/bmp/test_docker_restart.py
+++ b/tests/bmp/test_docker_restart.py
@@ -12,11 +12,13 @@ pytestmark = [
 
 
 def test_restart_bmp_docker(duthosts,
-                            enum_rand_one_per_hwsku_frontend_hostname):
+                            enum_rand_one_per_hwsku_frontend_hostname,
+                            enum_rand_one_frontend_asic_index):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
 
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
-    duthost.command("systemctl restart {}".format("bmp.service"))
+    asichost.restart_service("bmp")
     logger.info(duthost.shell(cmd="docker ps", module_ignore_errors=True)['stdout'])
 
     logger.info("Wait until the system is stable")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

There is a bmp container per ASIC so we need to use the correct per-ASIC names if we are on a multi-ASIC DUT.

#### How did you do it?

I updated the restart command to use the correct API for restarting a per-ASIC service.

#### How did you verify/test it?

We ran the test locally on an Arista multi-ASIC DUT.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
