### PR TITLE
chore: change the type LT2 to LowerSpineRouter

### DIFF
--- a/ansible/templates/minigraph_meta.j2
+++ b/ansible/templates/minigraph_meta.j2
@@ -38,13 +38,6 @@
 {% endif %}
         </a:DeviceProperty>
 {% endif %}
-{% if 'lt2' in topo %}
-          <a:DeviceProperty>
-            <a:Name>SubRole</a:Name>
-            <a:Reference i:nil="true"/>
-            <a:Value>LowerSpineRouter</a:Value>
-          </a:DeviceProperty>
-{% endif %}
 {% endif %}
 {% if 'dualtor' in topo %}
           <a:DeviceProperty>

--- a/ansible/templates/minigraph_png.j2
+++ b/ansible/templates/minigraph_png.j2
@@ -204,7 +204,7 @@
 {% elif 'T1' in dev %}
 {% set dev_type = 'LeafRouter' %}
 {% elif 'LT2' in dev %}
-{% set dev_type = 'SpineRouter' %}
+{% set dev_type = 'LowerSpineRouter' %}
 {% elif 'FT2' in dev %}
 {% set dev_type = 'FabricSpineRouter' %}
 {% elif 'UT2' in dev %}

--- a/ansible/templates/topo_lt2_128.j2
+++ b/ansible/templates/topo_lt2_128.j2
@@ -12,7 +12,7 @@ topology:
 configuration_properties:
   common:
     dut_asn: {{ dut.asn }}
-    dut_type: SpineRouter
+    dut_type: LowerSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200

--- a/ansible/templates/topo_lt2_p32o64.j2
+++ b/ansible/templates/topo_lt2_p32o64.j2
@@ -12,7 +12,7 @@ topology:
 configuration_properties:
   common:
     dut_asn: {{ dut.asn }}
-    dut_type: SpineRouter
+    dut_type: LowerSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200

--- a/ansible/vars/topo_lt2-o128.yml
+++ b/ansible/vars/topo_lt2-o128.yml
@@ -502,7 +502,7 @@ topology:
 configuration_properties:
   common:
     dut_asn: 4200100000
-    dut_type: SpineRouter
+    dut_type: LowerSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200

--- a/ansible/vars/topo_lt2-p32o64.yml
+++ b/ansible/vars/topo_lt2-p32o64.yml
@@ -356,7 +356,7 @@ topology:
 configuration_properties:
   common:
     dut_asn: 4200100000
-    dut_type: SpineRouter
+    dut_type: LowerSpineRouter
     nhipv4: 10.10.246.254
     nhipv6: FC0A::FF
     podset_number: 200

--- a/tests/bgp/test_bgp_peer_shutdown.py
+++ b/tests/bgp/test_bgp_peer_shutdown.py
@@ -51,10 +51,10 @@ def common_setup_teardown(
         if k == duthost.hostname:
             dut_type = v["type"]
 
-    if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"]:
+    if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter", "LowerSpineRouter"]:
         neigh_type = "LeafRouter"
     elif dut_type == "UpperSpineRouter":
-        neigh_type = "SpineRouter"
+        neigh_type = "LowerSpineRouter"
     else:
         neigh_type = "ToRRouter"
     logging.info(

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -136,10 +136,10 @@ def setup_bgp_peers(
 
     dut_asn = mg_facts["minigraph_bgp_asn"]
     dut_type = mg_facts["minigraph_devices"][duthost.hostname]["type"]
-    if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"]:
+    if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter", "LowerSpineRouter"]:
         neigh_type = "LeafRouter"
     elif dut_type == "UpperSpineRouter":
-        neigh_type = "SpineRouter"
+        neigh_type = "LowerSpineRouter"
     else:
         neigh_type = "ToRRouter"
 

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -98,10 +98,10 @@ def common_setup_teardown(
         if k == duthost.hostname:
             dut_type = v["type"]
 
-    if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter"]:
+    if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter", "LowerSpineRouter"]:
         neigh_type = "LeafRouter"
     elif dut_type == "UpperSpineRouter":
-        neigh_type = "SpineRouter"
+        neigh_type = "LowerSpineRouter"
     else:
         neigh_type = "ToRRouter"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adjust the LT2 type to `LowerSpineRouter` and its VM neighbors. 

Also updated some test cases to include LowerSpineRouter

Fixes # (issue) 33894729


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
