### PR TITLE
[202505]Added detailed reason for assert failure for snmp

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -252,8 +252,7 @@ def test_fan_drawer_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physic
         assert expect_oid in snmp_physical_entity_info, (
             "Expected OID for fabric card not found in SNMP physical entity MIB.\n"
             "Expected OID: {}\n"
-            "SNMP physical entity info: {}"
-        ).format(expect_oid, snmp_physical_entity_info)
+        ).format(expect_oid)
 
         drawer_snmp_fact = snmp_physical_entity_info[expect_oid]
         assert drawer_snmp_fact['entPhysDescr'] == name, (
@@ -371,8 +370,7 @@ def test_fan_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_enti
         assert expect_oid in snmp_physical_entity_info, (
             "Expected OID for fabric card not found in SNMP physical entity MIB.\n"
             "Expected OID: {}\n"
-            "SNMP physical entity info: {}"
-        ).format(expect_oid, snmp_physical_entity_info)
+        ).format(expect_oid)
 
         fan_snmp_fact = snmp_physical_entity_info[expect_oid]
         assert fan_snmp_fact['entPhysDescr'] == name, (


### PR DESCRIPTION

 **Description of PR**

Added detailed Reason for Assert failure

**This PR is the cherry pick PR to 202505**
https://github.com/sonic-net/sonic-mgmt/pull/19188

**Type of change**
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


**Back port request**

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Summary:**

Enhanced assertion messages in selected test cases to provide clearer failure context. This improves debuggability and speeds up issue resolution when tests fail.
Added detailed assertion failure messages in test scripts to make it easier to understand why tests fails.

**What is the motivation for this PR?**
The motivation is to improve test debuggability by adding detailed failure reasons in assertions for selected test cases. This enhancement makes it easier to identify the root cause of test failures in logs, thereby reducing triage time and simplifying test maintenance

**How did you do it?**
I updated the assertion statements in the following test files to include descriptive error messages:
tests/snmp/test_snmp_phy_entity.py

**How did you verify/test it?**
Verified that the updated assertion messages are correctly reflected in the test code by reviewing the changes locally.

