### PR TITLE
Update VM template to support additional-paths

### DIFF
--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -109,6 +109,7 @@ router bgp {{ host['bgp']['asn'] }}
 {# set LT2/FT2 as reflector to advertise route to DUT #}
 {% if props.swrole is defined and props.swrole in ("lowerspine", "fabricspine") %}
  neighbor {{ remote_ip }} route-reflector-client
+ neighbor {{ remote_ip }} additional-paths send any
 {% endif %}
 {% if remote_ip | ipv6 %}
  address-family ipv6


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to fix a routing issue on FT2 testbed.
On FT2 testbed, both DUT and neighbor VM are set as route-reflector. Hence routes are not advertised from neighbor VM to DUT.
This PR is to workaround the issue by enabling  `additional-paths`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to fix a routing issue on FT2 testbed.

#### How did you do it?
Update VM template to enable `additional-paths`.

#### How did you verify/test it?
The change is verified by running `add-topo` on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
