### PR TITLE
Add Redis service check after reboot

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -379,6 +379,8 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         # Update critical service list after rebooting in case critical services changed after rebooting
         pytest_assert(wait_until(200, 10, 0, duthost.is_critical_processes_running_per_asic_or_host, "database"),
                       "Database not start.")
+        pytest_assert(wait_until(20, 5, 0, duthost.is_service_running, "redis", "database"), "Redis DB not start")
+
         duthost.critical_services_tracking_list()
         pytest_assert(wait_until(wait + 400, 20, 0, duthost.critical_services_fully_started),
                       "{}: All critical services should be fully started!".format(hostname))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add Redis service check after reboot to avoid duthost.critical_services_tracking_list failure due to redis not start

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Sometimes, after reboot, even database docker is UP, there would be some chance that Redis DB is under initialization.
In this scenario, the test would failed due to duthost.critical_services_tracking_list() failure:
https://github.com/sonic-net/sonic-mgmt/blob/005c92029ca963161400bb26723c67082a1b09d6/tests/common/reboot.py#L382
#### How did you do it?
Add Redis service check after reboot
#### How did you verify/test it?
Run it at local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
