### PR TITLE
Fix announce_route for DT2

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1235,7 +1235,7 @@ def fib_ft2_routes(topo, ptf_ip, action="announce"):
 
     vms = sorted(topo['topology']['VMs'])
 
-    group_number = len(vms) // GROUP_SIZE
+    group_number = int(math.ceil(float(len(vms)) / GROUP_SIZE))
     routes_per_group = ROUTE_NUMBER // group_number  # Number of routes per group
     subnets_ipv4 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_NETWORK_V4)).subnets(new_prefix=PREFIX_LEN_V4))
     subnets_ipv6 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_NETWORK_V6)).subnets(new_prefix=PREFIX_LEN_V6))
@@ -1249,6 +1249,8 @@ def fib_ft2_routes(topo, ptf_ip, action="announce"):
         # Get the index of the VM in the group
         for lt2_index in range(GROUP_SIZE):
             vm_index = group_index * GROUP_SIZE + lt2_index
+            if vm_index >= len(vms):
+                break
             vm_name = vms[vm_index]
             vm_offset = topo['topology']['VMs'][vm_name]['vm_offset']
             port = IPV4_BASE_PORT + vm_offset
@@ -1437,7 +1439,7 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce"):
     all_subnetv4 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V4)).subnets(new_prefix=24))
     all_subnetv6 = list(ipaddress.ip_network(UNICODE_TYPE(BASE_ADDR_V6)).subnets(new_prefix=124))
 
-    group_nums = int(len(t1_vms) // T1_GROUP_SIZE)
+    group_nums = int(math.ceil(float(len(t1_vms)) / T1_GROUP_SIZE))
     t1_route_per_group = int(math.ceil(ROUTE_NUMBER_T1 / T1_GROUP_SIZE / group_nums))
 
     # 32 route each x 4 to match 110 T1
@@ -1455,6 +1457,8 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce"):
         as_path = "{} {}".format(leaf_asn_start + group, tor_asn_start + group)
 
         for vm_index in range(T1_GROUP_SIZE):
+            if group * T1_GROUP_SIZE + vm_index >= len(t1_vms):
+                break
             vm_name = t1_vms[group * T1_GROUP_SIZE + vm_index]
             vm_offset = topo['topology']['VMs'][vm_name]['vm_offset']
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve [ansible/library/announce_routes.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:fix_announce_route_for_dt2?expand=1#diff-68b518f15cfb2d75f404b5d982cd1b23244d0775494df25b73f029842c384ec0) to support scenario when the number of VMs is not exactly divisible by `GROUP_SIZE`.

Before this change: The last group doesn't have route advertised from exabgp.
After this change: All groups have routes from exabgp.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to improve ansible/library/announce_routes.py for DT2.

#### How did you do it?
Use `ceil` to get the correct number of groups.

#### How did you verify/test it?
The change is verified by running `announce_routes` on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
