### PR TITLE
MIGSMSFT-1146 Use queue occupancy to determine whether oq/voq watchdog is triggered

### DIFF
--- a/tests/qos/test_oq_watchdog.py
+++ b/tests/qos/test_oq_watchdog.py
@@ -105,6 +105,11 @@ class TestOqWatchdog(QosSaiBase):
             "oq_watchdog_enabled": True,
         })
 
+        # Run TrafficSanityTest to verify the system in good state before starting the test
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.TrafficSanityTest",
+            testParams=testParams)
+
         try:
             # Block voq7
             original_pir_voq7 = self.block_queue(dst_dut, dst_port, 7, "voq", dst_asic_index)

--- a/tests/qos/test_oq_watchdog.py
+++ b/tests/qos/test_oq_watchdog.py
@@ -84,20 +84,6 @@ class TestOqWatchdog(QosSaiBase):
                 RunAnsibleModuleFail if ptf test fails
         """
 
-        # Block voq7
-        dst_dut = get_src_dst_asic_and_duts['dst_dut']
-        dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
-        dst_port = dutConfig['dutInterfaces'][dutConfig["testPorts"]["dst_port_id"]]
-        original_pir_voq7 = self.block_queue(dst_dut, dst_port, 7, "voq", dst_asic_index)
-        # Fill leakout of Q7 by ping
-        cmd_opt = "sudo ip netns exec asic{}".format(dst_asic_index)
-        if not dst_dut.sonichost.is_multi_asic:
-            cmd_opt = ""
-        dst_dut.shell("{} ping -I {} -c 50 1.1.1.1 -i 0 -w 0 || true".format(cmd_opt, dst_port))
-
-        # Block oq0
-        original_pir_oq0 = self.block_queue(dst_dut, dst_port, 0, "oq", dst_asic_index)
-
         testParams = dict()
         testParams.update(dutTestParams["basicParams"])
         testParams.update({
@@ -112,14 +98,50 @@ class TestOqWatchdog(QosSaiBase):
             "oq_watchdog_enabled": True,
         })
 
-        self.runPtfTest(
-            ptfhost, testCase="sai_qos_tests.OqWatchdogTest",
-            testParams=testParams)
-
-        # Unblock voq7 and oq0 to restore the system state
-        self.unblock_queue(dst_dut, dst_port, 7, "voq", original_pir_voq7, dst_asic_index)
-        self.unblock_queue(dst_dut, dst_port, 0, "oq", original_pir_oq0, dst_asic_index)
-
+        # Run TrafficSanityTest to verify the system state is good before starting the test
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.TrafficSanityTest",
             testParams=testParams)
+
+        try:
+            dst_dut = get_src_dst_asic_and_duts['dst_dut']
+            dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
+            dst_port = dutConfig['dutInterfaces'][dutConfig["testPorts"]["dst_port_id"]]
+
+            # Block voq7
+            original_pir_voq7 = self.block_queue(dst_dut, dst_port, 7, "voq", dst_asic_index)
+            # Fill leakout of Q7 by ping
+            cmd_opt = "sudo ip netns exec asic{}".format(dst_asic_index)
+            if not dst_dut.sonichost.is_multi_asic:
+                cmd_opt = ""
+            dst_dut.shell("{} ping -I {} -c 50 1.1.1.1 -i 0 -w 0 || true".format(cmd_opt, dst_port))
+
+            # Block oq0
+            original_pir_oq0 = self.block_queue(dst_dut, dst_port, 0, "oq", dst_asic_index)
+
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.OqWatchdogTest",
+                testParams=testParams)
+
+        except Exception as e:
+            # Print extra debug information
+            cmd_list = [
+                "df -hl",
+                "show interface portchannel",
+                "show ip interface",
+                "show queue counters",
+            ]
+            for cmd in cmd_list:
+                logger.info("Running command on {}: {}".format(dst_dut.hostname, cmd))
+                dst_dut.shell(cmd)
+            logger.error("OQ watchdog test failed: {}".format(e))
+            raise e
+
+        finally:
+            # Unblock voq7 and oq0 to restore the system state
+            self.unblock_queue(dst_dut, dst_port, 7, "voq", original_pir_voq7, dst_asic_index)
+            self.unblock_queue(dst_dut, dst_port, 0, "oq", original_pir_oq0, dst_asic_index)
+
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.TrafficSanityTest",
+                testParams=testParams)

--- a/tests/qos/test_voq_watchdog.py
+++ b/tests/qos/test_voq_watchdog.py
@@ -86,6 +86,7 @@ class TestVoqWatchdog(QosSaiBase):
             testParams.update(dutTestParams["basicParams"])
             testParams.update({
                 "dscp": 8,
+                "queue_idx": 0,
                 "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
                 "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
                 "src_port_id": dutConfig["testPorts"]["src_port_id"],
@@ -94,6 +95,8 @@ class TestVoqWatchdog(QosSaiBase):
                 "packet_size": 1350,
                 "pkts_num": PKTS_NUM,
                 "voq_watchdog_enabled": voq_watchdog_enabled,
+                "dutInterfaces": dutConfig["dutInterfaces"],
+                "testPorts": dutConfig["testPorts"],
             })
 
             self.runPtfTest(

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -129,6 +129,12 @@ PG_TOLERANCE = 2
 # Constants for voq/oq watchdog test
 WATCHDOG_TIMEOUT_SECONDS = {"voq": 60,
                             "oq": 5}
+SAI_LOG_TO_CHECK = {"voq": ["HARDWARE_WATCHDOG", "soft_reset"],
+                    "oq": ["HARDWARE_WATCHDOG", "soft_reset"]}
+SDK_LOG_TO_CHECK = {"voq": ["VOQ Appears to be stuck"],
+                    "oq": []}
+SAI_LOG = "/var/log/sai.log"
+SDK_LOG = "/var/log/syslog"
 
 
 def log_message(message, level='info', to_stderr=False):
@@ -674,6 +680,46 @@ def get_peer_addresses(data):
     addresses = set()
     get_peer_addr(data, addresses)
     return list(addresses)
+
+
+def init_log_check(test_case):
+    pre_offsets = []
+    for logfile in [SAI_LOG, SDK_LOG]:
+        offset_cmd = "stat -c %s {}".format(logfile)
+        stdout, err, ret = test_case.exec_cmd_on_dut(
+            test_case.dst_server_ip,
+            test_case.test_params['dut_username'],
+            test_case.test_params['dut_password'],
+            offset_cmd)
+        pre_offsets.append(int(stdout[0]))
+    return pre_offsets
+
+
+def verify_log(test_case, pre_offsets, watchdog_enabled=True, watchdog_type='voq'):
+    qos_test_assert(test_case, watchdog_type in ['voq', 'oq'],
+                    "Invalid watchdog type: {}".format(watchdog_type))
+    found_list = []
+    for pre_offset, logfile, str_to_check in zip(pre_offsets, [SAI_LOG, SDK_LOG],
+                                                 [SAI_LOG_TO_CHECK[watchdog_type], SDK_LOG_TO_CHECK[watchdog_type]]):
+        egrep_str = '|'.join(str_to_check)
+        check_cmd = "sudo tail -c +{} {} | egrep '{}' || true".format(pre_offset + 1, logfile, egrep_str)
+        stdout, err, ret = test_case.exec_cmd_on_dut(
+            test_case.dst_server_ip,
+            test_case.test_params['dut_username'],
+            test_case.test_params['dut_password'],
+            check_cmd)
+        log_message("Log for {}: {}".format(egrep_str, stdout), level='info', to_stderr=True)
+        for string in str_to_check:
+            if string in "".join(stdout):
+                found_list.append(True)
+            else:
+                found_list.append(False)
+    if watchdog_enabled:
+        qos_test_assert(test_case, all(found is True for found in found_list),
+                        "{} watchdog trigger log not detected".format(watchdog_type))
+    else:
+        qos_test_assert(test_case, all(found is False for found in found_list),
+                        "unexpected {} watchdog trigger log".format(watchdog_type))
 
 
 def verify_queue_occupancy(test_case, dst_port_id, queue_idx, expect_queue_empty=True, timeout=0):
@@ -6756,6 +6802,7 @@ class VoqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
         log_message("dst_port_name: {}".format(dst_port_name), to_stderr=True)
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        pre_offsets = init_log_check(self)
 
         try:
             # send packets
@@ -6768,6 +6815,9 @@ class VoqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
             log_message("Waiting for VOQ watchdog to trigger", level='info', to_stderr=True)
             verify_queue_occupancy(self, dst_port_id, queue_idx, voq_watchdog_enabled,
                                    timeout=WATCHDOG_TIMEOUT_SECONDS["voq"])
+
+            log_message("Verify log after VOQ watchdog timeout", level='info', to_stderr=True)
+            verify_log(self, pre_offsets, voq_watchdog_enabled, "voq")
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
@@ -6789,6 +6839,7 @@ class OqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
         src_port_ip = self.test_params['src_port_ip']
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
+        oq_watchdog_enabled = self.test_params['oq_watchdog_enabled']
         pkts_num = int(self.test_params['pkts_num'])
         queue_id = int(self.test_params['queue_id'])
 
@@ -6820,6 +6871,8 @@ class OqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
         log_message("test dst_port_id: {}, src_port_id: {}, src_vlan: {}".format(
             dst_port_id, src_port_id, src_port_vlan), to_stderr=True)
 
+        pre_offsets = init_log_check(self)
+
         try:
             log_message("Verify OQ is empty before send packets", level='info', to_stderr=True)
             verify_tx_cgm_state(self, dst_interfaces, queue_id, True)
@@ -6835,6 +6888,9 @@ class OqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
 
             log_message("Verify OQ is empty after watchdog timeout", level='info', to_stderr=True)
             verify_tx_cgm_state(self, dst_interfaces, queue_id, True)
+
+            log_message("Verify log after OQ watchdog timeout", level='info', to_stderr=True)
+            verify_log(self, pre_offsets, oq_watchdog_enabled, "oq")
 
         finally:
             print("END OF TEST")

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1,6 +1,7 @@
 """
 SONiC Dataplane Qos tests
 """
+import re
 import time
 import logging
 import ptf.packet as scapy
@@ -128,12 +129,6 @@ PG_TOLERANCE = 2
 # Constants for voq/oq watchdog test
 WATCHDOG_TIMEOUT_SECONDS = {"voq": 60,
                             "oq": 5}
-SAI_LOG_TO_CHECK = {"voq": ["HARDWARE_WATCHDOG", "soft_reset"],
-                    "oq": ["HARDWARE_WATCHDOG", "soft_reset"]}
-SDK_LOG_TO_CHECK = {"voq": ["VOQ Appears to be stuck"],
-                    "oq": []}
-SAI_LOG = "/var/log/sai.log"
-SDK_LOG = "/var/log/syslog"
 
 
 def log_message(message, level='info', to_stderr=False):
@@ -681,44 +676,72 @@ def get_peer_addresses(data):
     return list(addresses)
 
 
-def init_log_check(test_case):
-    pre_offsets = []
-    for logfile in [SAI_LOG, SDK_LOG]:
-        offset_cmd = "stat -c %s {}".format(logfile)
-        stdout, err, ret = test_case.exec_cmd_on_dut(
-            test_case.dst_server_ip,
-            test_case.test_params['dut_username'],
-            test_case.test_params['dut_password'],
-            offset_cmd)
-        pre_offsets.append(int(stdout[0]))
-    return pre_offsets
+def verify_queue_occupancy(test_case, dst_port_id, queue_idx, expect_queue_empty=True, timeout=0):
+    time_elapsed = 0
+    while True:
+        queue_counters = sai_thrift_read_queue_occupancy(test_case.dst_client, "dst", dst_port_id)
+        if expect_queue_empty and queue_counters[queue_idx] == 0:
+            break
+        elif not expect_queue_empty and queue_counters[queue_idx] > 0:
+            break
+        time.sleep(5)
+        time_elapsed += 5
+        if time_elapsed > timeout * 2:
+            break
+
+    if expect_queue_empty:
+        qos_test_assert(test_case, queue_counters[queue_idx] == 0,
+                        "Queue {} is not empty: queue_occupancy={}".format(queue_idx, queue_counters[queue_idx]))
+    elif not queue_counters[queue_idx]:
+        qos_test_assert(test_case, False,
+                        "Queue {} is expected to be not empty, but it is empty".format(queue_idx))
+    log_message("voq occupancy verified after {} seconds".format(time_elapsed), level='info', to_stderr=True)
+    qos_test_assert(test_case, time_elapsed <= timeout * 1.3,
+                    "voq occupancy verification took too long: {} seconds".format(time_elapsed))
 
 
-def verify_log(test_case, pre_offsets, watchdog_enabled=True, watchdog_type='voq'):
-    qos_test_assert(test_case, watchdog_type in ['voq', 'oq'],
-                    "Invalid watchdog type: {}".format(watchdog_type))
-    found_list = []
-    for pre_offset, logfile, str_to_check in zip(pre_offsets, [SAI_LOG, SDK_LOG],
-                                                 [SAI_LOG_TO_CHECK[watchdog_type], SDK_LOG_TO_CHECK[watchdog_type]]):
-        egrep_str = '|'.join(str_to_check)
-        check_cmd = "sudo tail -c +{} {} | egrep '{}' || true".format(pre_offset + 1, logfile, egrep_str)
-        stdout, err, ret = test_case.exec_cmd_on_dut(
-            test_case.dst_server_ip,
-            test_case.test_params['dut_username'],
-            test_case.test_params['dut_password'],
-            check_cmd)
-        log_message("Log for {}: {}".format(egrep_str, stdout))
-        for string in str_to_check:
-            if string in "".join(stdout):
-                found_list.append(True)
-            else:
-                found_list.append(False)
-    if watchdog_enabled:
-        qos_test_assert(test_case, all(found is True for found in found_list),
-                        "{} watchdog trigger not detected".format(watchdog_type))
-    else:
-        qos_test_assert(test_case, all(found is False for found in found_list),
-                        "unexpected {} watchdog trigger".format(watchdog_type))
+def get_queue_ptrs(test_case, interface, queue_idx):
+    """
+    Get queue read and write pointers for the given interface.
+    """
+    cmd = "sudo show platform npu tx cgm_state -i {}".format(interface)
+    stdout, err, ret = test_case.exec_cmd_on_dut(
+        test_case.dst_server_ip,
+        test_case.test_params['dut_username'],
+        test_case.test_params['dut_password'],
+        cmd)
+    log_message("{}: {}".format(cmd, stdout), level='info', to_stderr=True)
+    for line in stdout:
+        if "queue {} rd_ptr".format(queue_idx) in line:
+            pattern = r"queue {} rd_ptr (\d+) wr_ptr (\d+)".format(queue_idx)
+            result = re.search(pattern, line)
+            if result:
+                rd_ptr = int(result.group(1))
+                wr_ptr = int(result.group(2))
+                log_message("{} Queue {}: rd_ptr={}, wr_ptr={}".format(interface, queue_idx, rd_ptr, wr_ptr),
+                            level='info', to_stderr=True)
+                return rd_ptr, wr_ptr
+    raise RuntimeError(
+        "Queue {} not found in CGM state for interface {}".format(queue_idx, interface))
+
+
+def verify_tx_cgm_state(test_case, dst_interfaces, queue_idx, expect_queue_empty=True):
+    """
+    Verify TX CGM state for the given interfaces.
+    """
+    pkts_in_queue = False
+    for interface in dst_interfaces:
+        rd_ptr, wr_ptr = get_queue_ptrs(test_case, interface, queue_idx)
+        if expect_queue_empty:
+            qos_test_assert(test_case, rd_ptr == wr_ptr,
+                            "Queue {} is not empty: rd_ptr={}, wr_ptr={}".format(queue_idx, rd_ptr, wr_ptr))
+        elif rd_ptr != wr_ptr:
+            pkts_in_queue = True
+            log_message("Queue {} is not empty: rd_ptr={}, wr_ptr={}".format(queue_idx, rd_ptr, wr_ptr),
+                        level='warning', to_stderr=True)
+    if not expect_queue_empty and not pkts_in_queue:
+        qos_test_assert(test_case, False,
+                        "Queue {} is expected to be not empty, but it is empty".format(queue_idx))
 
 
 class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
@@ -6680,6 +6703,7 @@ class VoqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
 
         # Parse input parameters
         dscp = int(self.test_params['dscp'])
+        queue_idx = int(self.test_params['queue_idx'])
         router_mac = self.test_params['router_mac']
         sonic_version = self.test_params['sonic_version']
         dst_port_id = int(self.test_params['dst_port_id'])
@@ -6692,6 +6716,8 @@ class VoqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
         voq_watchdog_enabled = self.test_params['voq_watchdog_enabled']
         asic_type = self.test_params['sonic_asic_type']
         pkts_num = int(self.test_params['pkts_num'])
+        dutInterfaces = self.test_params['dutInterfaces']
+        testPorts = self.test_params['testPorts']
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # get counter names to query
@@ -6726,19 +6752,22 @@ class VoqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
             self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan
         )
         log_message("actual dst_port_id: {}".format(dst_port_id), to_stderr=True)
+        dst_port_name = dutInterfaces[testPorts["dst_port_id"]]
+        log_message("dst_port_name: {}".format(dst_port_name), to_stderr=True)
 
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
-        pre_offsets = init_log_check(self)
 
         try:
             # send packets
             send_packet(self, src_port_id, pkt, pkts_num)
 
-            # allow enough time to trigger voq watchdog
-            time.sleep(WATCHDOG_TIMEOUT_SECONDS["voq"] * 1.3)
+            # Verify that voq is not empty
+            verify_queue_occupancy(self, dst_port_id, queue_idx, expect_queue_empty=False)
 
-            # verify voq watchdog is triggered
-            verify_log(self, pre_offsets, voq_watchdog_enabled, "voq")
+            # Verify that voq is empty after watchdog timeout
+            log_message("Waiting for VOQ watchdog to trigger", level='info', to_stderr=True)
+            verify_queue_occupancy(self, dst_port_id, queue_idx, voq_watchdog_enabled,
+                                   timeout=WATCHDOG_TIMEOUT_SECONDS["voq"])
 
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
@@ -6755,12 +6784,13 @@ class OqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
         dst_port_id = int(self.test_params['dst_port_id'])
         dst_port_ip = self.test_params['dst_port_ip']
         dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
+        dst_interfaces = self.test_params.get('dst_interfaces', [])
         src_port_id = int(self.test_params['src_port_id'])
         src_port_ip = self.test_params['src_port_ip']
         src_port_vlan = self.test_params['src_port_vlan']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
-        oq_watchdog_enabled = self.test_params['oq_watchdog_enabled']
         pkts_num = int(self.test_params['pkts_num'])
+        queue_id = int(self.test_params['queue_id'])
 
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # get counter names to query
@@ -6790,17 +6820,21 @@ class OqWatchdogTest(sai_base_test.ThriftInterfaceDataPlane):
         log_message("test dst_port_id: {}, src_port_id: {}, src_vlan: {}".format(
             dst_port_id, src_port_id, src_port_vlan), to_stderr=True)
 
-        pre_offsets = init_log_check(self)
-
         try:
+            log_message("Verify OQ is empty before send packets", level='info', to_stderr=True)
+            verify_tx_cgm_state(self, dst_interfaces, queue_id, True)
+
             # send packets
             send_packet(self, src_port_id, pkt, pkts_num)
+
+            log_message("Verify OQ is not empty after send packets", level='info', to_stderr=True)
+            verify_tx_cgm_state(self, dst_interfaces, queue_id, False)
 
             # allow enough time to trigger oq watchdog
             time.sleep(WATCHDOG_TIMEOUT_SECONDS["oq"] * 1.3)
 
-            # verify voq watchdog is triggered
-            verify_log(self, pre_offsets, oq_watchdog_enabled, "oq")
+            log_message("Verify OQ is empty after watchdog timeout", level='info', to_stderr=True)
+            verify_tx_cgm_state(self, dst_interfaces, queue_id, True)
 
         finally:
             print("END OF TEST")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Use voq occupancy to determine whether voq watchdog is triggered.
Use oq occupancy to determine whether oq watchdog is triggered.

Summary:
Fixes # (issue)
https://migsonic.atlassian.net/browse/MIGSMSFT-1146

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To identify the failure reason of oq watchdog test case.

#### How did you do it?
Add some CLI output in script to capture more information when test case fails.

#### How did you verify/test it?
Verified on T2 testbed.

OQ watchdog:
```
----------------------------- generated xml file: /run_logs/qos/test_oq_watchdog_2025-07-28-05-53-07.xml ------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
06:56:18 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog[single_asic]
PASSED qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog[single_dut_multi_asic]
PASSED qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog[multi_dut_longlink_to_shortlink]
PASSED qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog[multi_dut_shortlink_to_shortlink]
PASSED qos/test_oq_watchdog.py::TestOqWatchdog::testOqWatchdog[multi_dut_shortlink_to_longlink]
============================================== 5 passed, 1 warning in 3789.73s (1:03:09) ==============================================
sonic@sonic-ucs-m6-4:/data/tests$ 
```

VOQ watchdog:
```
----------------------------- generated xml file: /run_logs/qos/test_voq_watchdog_2025-07-28-04-11-40.xml -----------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
05:22:43 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_asic-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_asic-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_dut_multi_asic-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[single_dut_multi_asic-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_longlink_to_shortlink-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_longlink_to_shortlink-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_shortlink-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_shortlink-False]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_longlink-True]
PASSED qos/test_voq_watchdog.py::TestVoqWatchdog::testVoqWatchdog[multi_dut_shortlink_to_longlink-False]
============================================= 10 passed, 1 warning in 4261.44s (1:11:01) ==============================================
sonic@sonic-ucs-m6-4:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
