### PR TITLE
Run platform specific pfc_gen script when OS is SONiC

### DIFF
--- a/tests/common/helpers/pfc_storm.py
+++ b/tests/common/helpers/pfc_storm.py
@@ -177,7 +177,7 @@ class PFCStorm(object):
                 chip_name = get_chip_name_if_asic_pfc_storm_supported(self._get_eos_fanout_version()[0])
             elif self.peer_device.os == 'sonic':
                 chip_name = get_chip_name_if_asic_pfc_storm_supported(self._get_sonic_fanout_hwsku())
-            if self.peer_device.os == 'eos' and chip_name:
+            if self.peer_device.os in ('eos', 'sonic') and chip_name:
                 self.pfc_gen_file = "pfc_gen_brcm_xgs.py"
                 self.pfc_gen_file_test_name = "pfc_gen_brcm_xgs.py"
                 self.pfc_gen_chip_name = chip_name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enhance [pfc_storm.py](https://github.com/sonic-net/sonic-mgmt/compare/master...bingwang-ms:fix_pfc_storm?expand=1#diff-484e78c60cc240abdb6d3334458ae4f0c19d720d758b99b3d7540a6450bfc757) to use platform specific script to generate PFC pause when leaf fanout is running SONiC OS.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to enhance pfc_storm.py to use platform specific script to generate PFC pause when leaf fanout is running SONiC OS.

#### How did you do it?
Update pfc_storm.py.

#### How did you verify/test it?
The change is verified on a physical testbed.

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
