### PR TITLE
[Mellanox] Adjust margin to 2% of share buffer size for testQosSaiLossyQueue for spc4 above platform

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -291,3 +291,8 @@ class QosParamMellanox(object):
                             update_dict_value(sub_qos_config_value, qos_params_dict[sub_qos_config_key])
                     else:
                         qos_params_dict[sub_qos_config_key] = sub_qos_config_value
+
+        if int(self.asic_type.split('spc')[1]) >= 4:
+            margin_ratio = 0.02
+            self.qos_params_mlnx['lossy_queue_1']['pkts_num_margin'] = int(
+                self.qos_params_mlnx['lossy_queue_1']['pkts_num_trig_egr_drp'] * margin_ratio)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
To set the margin to a reasonable value and stabilize the testQosSaiLossyQueue for mellanox spc4 above platform, adjust margin to 2% of share buffer size for testQosSaiLossyQueue

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To set the margin to a reasonable value and stabilize the testQosSaiLossyQueue for mellanox spc4 above platform.

#### How did you do it?
adjust margin to 2% of share buffer size for testQosSaiLossyQueue

#### How did you verify/test it?
Run testQosSaiLossyQueue on spc4 above platform 

#### Any platform specific information?
spc4 above 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
