### PR TITLE
Enhance large topology stability via sub-task splitting.

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -97,27 +97,18 @@
   when: ceos_docker_image_stat.images | length == 0
 
 - name: Create VMs network in parallel
-  become: yes
-  vm_topology:
-    cmd:          'create'
-    vm_names:     "{{ vm_name }}"
-    fp_mtu:       "{{ fp_mtu_size }}"
-    max_fp_num:   "{{ max_fp_num }}"
-    topo: "{{ topology }}"
-  async: 3600
-  poll: 0
+  include_tasks: create_vm_network.yml
   loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
     loop_var: vm_name
-  register: async_create_vm_network_results
 
 - name: Wait for create tasks to complete
   become: yes
   async_status:
-    jid: "{{ async_create_vm_network_result_item.ansible_job_id }}"
-  loop: "{{ async_create_vm_network_results.results }}"
+    jid: "{{ async_create_vm_network_results[vm_name] }}"
+  loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
-    loop_var: async_create_vm_network_result_item
+    loop_var: vm_name
   register: async_create_vm_network_poll_results
   until: async_create_vm_network_poll_results.finished
   retries: 30
@@ -159,27 +150,18 @@
   delay: 30
 
 - name: Create network for ceos container net_{{ vm_set_name }}_{{ vm_name }} in parallel
-  become: yes
-  ceos_network:
-    name: net_{{ vm_set_name }}_{{ vm_name }}
-    vm_name:    "{{ vm_name }}"
-    fp_mtu:     "{{ fp_mtu_size }}"
-    max_fp_num: "{{ max_fp_num }}"
-    mgmt_bridge: "{{ mgmt_bridge }}"
+  include_tasks: create_ceos_network.yml
   loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
     loop_var: vm_name
-  async: 3600
-  poll: 0
-  register: async_create_ceos_network_results
 
 - name: Wait for network tasks to complete
   become: yes
   async_status:
-    jid: "{{ async_create_ceos_network_result_item.ansible_job_id }}"
-  loop: "{{ async_create_ceos_network_results.results }}"
+    jid: "{{ async_create_ceos_network_results[vm_name] }}"
+  loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
-    loop_var: async_create_ceos_network_result_item
+    loop_var: vm_name
   register: async_create_ceos_network_poll_results
   until: async_create_ceos_network_poll_results.finished
   retries: 30

--- a/ansible/roles/vm_set/tasks/create_ceos_network.yml
+++ b/ansible/roles/vm_set/tasks/create_ceos_network.yml
@@ -1,0 +1,15 @@
+- name: Create network for ceos container net_{{ vm_set_name }}_{{ vm_name }}
+  become: yes
+  ceos_network:
+    name: net_{{ vm_set_name }}_{{ vm_name }}
+    vm_name:    "{{ vm_name }}"
+    fp_mtu:     "{{ fp_mtu_size }}"
+    max_fp_num: "{{ max_fp_num }}"
+    mgmt_bridge: "{{ mgmt_bridge }}"
+  async: 3600
+  poll: 0
+  register: async_create_ceos_network_result_item
+
+- name: Save job id for {{ vm_name }}
+  set_fact:
+    async_create_ceos_network_results: "{{ async_create_ceos_network_results | default({}) | combine({ vm_name: async_create_ceos_network_result_item.ansible_job_id }) }}"

--- a/ansible/roles/vm_set/tasks/create_vm_network.yml
+++ b/ansible/roles/vm_set/tasks/create_vm_network.yml
@@ -1,0 +1,15 @@
+- name: Create VM network for {{ vm_name }}
+  become: yes
+  vm_topology:
+    cmd:          'create'
+    vm_names:     "{{ vm_name }}"
+    fp_mtu:       "{{ fp_mtu_size }}"
+    max_fp_num:   "{{ max_fp_num }}"
+    topo: "{{ topology }}"
+  async: 3600
+  poll: 0
+  register: async_create_vm_network_result_item
+
+- name: Save job id for {{ vm_name }}
+  set_fact:
+    async_create_vm_network_results: "{{ async_create_vm_network_results | default({}) | combine({ vm_name: async_create_vm_network_result_item.ansible_job_id }) }}"

--- a/ansible/roles/vm_set/tasks/destroy_vm_network.yml
+++ b/ansible/roles/vm_set/tasks/destroy_vm_network.yml
@@ -1,0 +1,14 @@
+- name: Destroy VMs network {{ vm_name }}
+  vm_topology:
+    cmd: 'destroy'
+    vm_names: "{{ vm_name }}"
+  become: yes
+  async: 3600
+  poll: 0
+  throttle: 1
+  when: vm_type is defined and vm_type=="ceos"
+  register: async_destroy_vm_network_result_item
+
+- name: Save job id for {{ vm_name }}
+  set_fact:
+    async_destroy_vm_network_results: "{{ async_destroy_vm_network_results | default({}) | combine({ vm_name: async_destroy_vm_network_result_item.ansible_job_id }) }}"

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -172,25 +172,17 @@
   when: container_type == "IxANVL-CONF-TESTER"
 
 - name: Destroy VMs network in parallel
-  vm_topology:
-    cmd: 'destroy'
-    vm_names: "{{ vm_name }}"
-  become: yes
-  async: 3600
-  poll: 0
   loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
     loop_var: vm_name
-  when: vm_type is defined and vm_type=="ceos"
-  register: async_destroy_vm_network_results
 
 - name: Wait for destroy tasks to complete
   become: yes
   async_status:
-    jid: "{{ async_destroy_vm_network_result_item.ansible_job_id }}"
-  loop: "{{ async_destroy_vm_network_results.results }}"
+    jid: "{{ async_destroy_vm_network_results[vm_name] }}"
+  loop: "{{ VM_targets|flatten(levels=1) }}"
   loop_control:
-    loop_var: async_destroy_vm_network_result_item
+    loop_var: vm_name
   register: async_destroy_vm_network_poll_results
   until: async_destroy_vm_network_poll_results.finished
   retries: 30


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In PR #19484, we optimized large topology deployment by parallelizing previously serial tasks. However, we observed that in extremely large topologies, certain commands, such as `ovs-vsctl`, may conflict when executed concurrently, resulting in errors. To mitigate such conflicts across threads, we introduce a slight time gap between the start of each parallel thread. This is achieved by breaking the parallel operations into sub-tasks, invoked using `include_tasks`. Within each sub-task, we insert a follow-up task that introduces a short delay after each thread starts, helping to reduce contention and improve stability.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In PR #19484, we optimized large topology deployment by parallelizing previously serial tasks. However, we observed that in extremely large topologies, certain commands, such as `ovs-vsctl`, may conflict when executed concurrently, resulting in errors. To mitigate such conflicts across threads, we introduce a slight time gap between the start of each parallel thread. This is achieved by breaking the parallel operations into sub-tasks, invoked using `include_tasks`. Within each sub-task, we insert a follow-up task that introduces a short delay after each thread starts, helping to reduce contention and improve stability.

#### How did you do it?
To mitigate such conflicts across threads, we introduce a slight time gap between the start of each parallel thread. This is achieved by breaking the parallel operations into sub-tasks, invoked using `include_tasks`. Within each sub-task, we insert a follow-up task that introduces a short delay after each thread starts, helping to reduce contention and improve stability.

#### How did you verify/test it?
Test locally using 512 ports testbed, I have tested add-topo and remove-topo. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
