### PR TITLE
[lldp] Increase a wait timeout to 360 sec after a cold reboot for lldp syncd test

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -413,7 +413,8 @@ def test_lldp_entry_table_after_reboot(
 
     # Wait till we have all lldp entries in the DB after reboot. It's found in scaling
     # setup this may take some time to happen.
-    keys_match = wait_until(90, 5, 30, check_lldp_table_keys, duthost, db_instance)
+    MAX_TIME_TO_REBOOT = 360
+    keys_match = wait_until(MAX_TIME_TO_REBOOT, 5, 30, check_lldp_table_keys, duthost, db_instance)
     if not keys_match:
         assert keys_match, "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output"
     lldp_entry_keys = get_lldp_entry_keys(db_instance)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To avoid the `lldp/test_lldp_syncd.py` flakiness.

#### How did you do it?
Increase a wait timeout after a cold reboot, the same as community did for the platform_tests - https://github.com/sonic-net/sonic-mgmt/pull/18900

#### How did you verify/test it?
Run the `lldp/test_lldp_syncd.py`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
