### PR TITLE
[advanced-reboot] Set max_allowed_lacp_session_wait based on test_params

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1751,7 +1751,24 @@ class ReloadTest(BaseTest):
 
         # in the list of all LACPDUs received by T1, find the largest time gap between two consecutive LACPDUs
         max_lacp_session_wait = None
-        max_allowed_lacp_session_wait = 150
+
+        # Initialize max_allowed_lacp_session_wait
+        LACP_SLOW_PERIOD_SEC = 30
+
+        if self.test_params['neighbor_type'] == "eos":
+            if 'ceos_neighbor_lacp_multiplier' in self.test_params and self.test_params['ceos_neighbor_lacp_multiplier']:
+                lacp_multiplier = self.test_params['ceos_neighbor_lacp_multiplier']
+            else:
+                lacp_multiplier = 3
+        elif self.test_params['neighbor_type'] == "sonic":
+            lacp_multiplier = 5 # SONiC negotiates multiplier 5 with SONiC peer
+        else:
+            lacp_multiplier = 3
+
+        max_allowed_lacp_session_wait = lacp_multiplier * LACP_SLOW_PERIOD_SEC
+        self.log('max_allowed_lacp_session_wait is set to {} sec for neighbor {}, neighbor_type {}'.format(
+            max_allowed_lacp_session_wait, ip, self.test_params['neighbor_type']))
+
         if lacp_pdu_all_times and len(lacp_pdu_all_times) > 1:
             lacp_pdu_all_times.sort()
             max_lacp_session_wait = 0

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1757,7 +1757,7 @@ class ReloadTest(BaseTest):
 
         if self.test_params['neighbor_type'] == "eos":
             if 'ceos_neighbor_lacp_multiplier' in self.test_params \
-                and self.test_params['ceos_neighbor_lacp_multiplier']:
+                    and self.test_params['ceos_neighbor_lacp_multiplier']:
                 lacp_multiplier = self.test_params['ceos_neighbor_lacp_multiplier']
             else:
                 lacp_multiplier = 3

--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1756,12 +1756,13 @@ class ReloadTest(BaseTest):
         LACP_SLOW_PERIOD_SEC = 30
 
         if self.test_params['neighbor_type'] == "eos":
-            if 'ceos_neighbor_lacp_multiplier' in self.test_params and self.test_params['ceos_neighbor_lacp_multiplier']:
+            if 'ceos_neighbor_lacp_multiplier' in self.test_params \
+                and self.test_params['ceos_neighbor_lacp_multiplier']:
                 lacp_multiplier = self.test_params['ceos_neighbor_lacp_multiplier']
             else:
                 lacp_multiplier = 3
         elif self.test_params['neighbor_type'] == "sonic":
-            lacp_multiplier = 5 # SONiC negotiates multiplier 5 with SONiC peer
+            lacp_multiplier = 5  # SONiC negotiates multiplier 5 with SONiC peer
         else:
             lacp_multiplier = 3
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Fix max_allowed_lacp_session_wait, needs to be set according to LACP multiplier used in test.

#### How did you do it?

Set max_allowed_lacp_session_wait based on neighbor type and multiplier configuration

#### How did you verify/test it?

Ran test without providing ceos_neighbor_lacp_multiplier and setting ceos_neighbor_lacp_multiplier = 5. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
