### PR TITLE
Fix the console log fetching, to prevent a race condition

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -355,9 +355,15 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
     if not wait_for_ssh:
         pool.terminate()
         return
+    dut_console = None
     try:
         wait_for_startup(duthost, localhost, delay, timeout)
-        dut_console = console_thread_res.get()
+        try:
+            dut_console = console_thread_res.get()
+        except Exception as console_err:
+            logger.warning(f'Failed to get console thread result: {console_err}')
+            dut_console = None
+    
     except Exception as err:
         if dut_console:
             dut_console.disconnect()

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -363,7 +363,7 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         except Exception as console_err:
             logger.warning(f'Failed to get console thread result: {console_err}')
             dut_console = None
-    
+
     except Exception as err:
         if dut_console:
             dut_console.disconnect()

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -671,6 +671,7 @@ def collect_console_log(duthost, localhost, timeout):
         logger.warning("dut console is not ready, we cannot get log by console")
         return None
 
+
 def collect_mgmt_config_by_console(duthost, localhost):
     logger.info("check if dut is pingable")
     localhost.shell(f"ping -c 5 {duthost.mgmt_ip}", module_ignore_errors=True)
@@ -686,3 +687,4 @@ def collect_mgmt_config_by_console(duthost, localhost):
         logger.info('End: collect mgmt config by  console  ...')
     else:
         logger.warning("dut console is not ready, we can get mgmt config by console")
+

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -670,8 +670,6 @@ def collect_console_log(duthost, localhost, timeout):
     if dut_console:
         if dut_console:
             logger.info("start: collect console log")
-            logger.info(f"sleep {timeout} to collect console log....")
-            time.sleep(timeout)
             return dut_console
     else:
         logger.warning("dut console is not ready, we cannot get log by console")

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -353,10 +353,15 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
 
     # if wait_for_ssh flag is False, do not wait for dut to boot up
     if not wait_for_ssh:
+        pool.terminate()
         return
     try:
         wait_for_startup(duthost, localhost, delay, timeout)
+        dut_console = console_thread_res.get()
     except Exception as err:
+        if dut_console:
+            dut_console.disconnect()
+            logger.info('end: collect console log')
         logger.error('collecting console log thread result: {} on {}'.format(console_thread_res.get(), hostname))
         pool.terminate()
         raise Exception(f"dut not start: {err}")
@@ -400,6 +405,9 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
 
     DUT_ACTIVE.set()
     logger.info('{} reboot finished on {}'.format(reboot_type, hostname))
+    if dut_console:
+        dut_console.disconnect()
+        logger.info('end: collect console log')
     pool.terminate()
     dut_uptime = duthost.get_up_time(utc_timezone=True)
     logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
@@ -650,18 +658,18 @@ def try_create_dut_console(duthost, localhost, conn_graph_facts, creds):
 
 
 def collect_console_log(duthost, localhost, timeout):
-    logger.info("start: collect console log")
     creds = creds_on_dut(duthost)
     conn_graph_facts = get_graph_facts(duthost, localhost, [duthost.hostname])
     dut_console = try_create_dut_console(duthost, localhost, conn_graph_facts, creds)
     if dut_console:
-        logger.info(f"sleep {timeout} to collect console log....")
-        time.sleep(timeout)
-        dut_console.disconnect()
-        logger.info('end: collect console log')
+        if dut_console:
+            logger.info("start: collect console log")
+            logger.info(f"sleep {timeout} to collect console log....")
+            time.sleep(timeout)
+            return dut_console
     else:
         logger.warning("dut console is not ready, we cannot get log by console")
-
+        return None
 
 def collect_mgmt_config_by_console(duthost, localhost):
     logger.info("check if dut is pingable")

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -687,4 +687,3 @@ def collect_mgmt_config_by_console(duthost, localhost):
         logger.info('End: collect mgmt config by  console  ...')
     else:
         logger.warning("dut console is not ready, we can get mgmt config by console")
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the console log fetching, to prevent a race condition between the disconnection of the console session, to the system boot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The "disconnect" function of console session is sending "exit" command to console, and in some occasions,  this command is sent exactly when the system is booting, causing system to be sent to grub edit mode, due to the "e" letter in "exit" which initiated this mode.
The fix ensures the disconnection happens only after system is fully booted.

#### How did you do it?
Move the "disconnect" function to run after system finished boot.

#### How did you verify/test it?
Ran the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
