### PR TITLE
[dualtor] Skip toggle failure introduced by `setup_dualtor_mux_ports`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3473,6 +3473,12 @@ def setup_dualtor_mux_ports(active_active_ports, duthost, duthosts, tbinfo, requ
         except KeyError:
             continue
     logging.debug("dualtor mux port setup config: %s", dualtor_setup_config)
+
+    if dualtor_setup_config & DualtorMuxPortSetupConfig.DUALTOR_SKIP_SETUP_MUX_PORTS:
+        logging.info("skip setup dualtor mux cables")
+        yield False
+        return
+
     is_test_func_parametrized = hasattr(request.node, "callspec")
     is_enum = is_test_func_parametrized and \
         any(param.startswith("enum_") for param in request.node.callspec.params.keys())

--- a/tests/ip/test_mgmt_ipv6_only.py
+++ b/tests/ip/test_mgmt_ipv6_only.py
@@ -22,7 +22,8 @@ from tests.conftest import get_hosts_per_hwsku
 pytestmark = [
     pytest.mark.disable_loganalyzer,
     pytest.mark.topology('any'),
-    pytest.mark.device_type('vs')
+    pytest.mark.device_type('vs'),
+    pytest.mark.dualtor_skip_setup_mux_ports
 ]
 
 _cached_nodes_per_hwsku = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

`test_mgmt_ipv6_only` will disable ipv4 mgmt address in its setup, which will cause the self-acting toggle from `setup_dualtor_mux_ports` failing as DUT cannot talk to `mux_simulator`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add the unsupported mark `pytest.mark.dualtor_skip_setup_mux_ports`.
Skip setup mux ports for `test_mgmt_ipv6_only`

#### How did you verify/test it?
```
ip/test_mgmt_ipv6_only.py::test_bgp_facts_ipv6_only PASSED                                                                                                                                                                                                             [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
