### PR TITLE
Skip swss events in telemetry/test_events.py for m* topos

### DIFF
--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -30,7 +30,7 @@ WAIT_TIME = 3
 
 
 def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang):
-    if duthost.topo_type.lower() in ["m0", "mx"]:
+    if [i for i in ["m0", "mx", "m1", "m2"] if duthost.topo_type.lower().startswith(i)]:
         logger.info("Skipping swss events test on MGFX topologies")
         return
     logger.info("Beginning to test swss events")


### PR DESCRIPTION
### Description of PR

Summary:
Skipping swss event verification in telemetry/test_events.py for m1 and m2 topos as this testing is out of scope for the deployment.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
We were seeing failures while trying to verify the pfc storm event on m1 topos. This is because there is no QoS config. After inquiring with Microsoft we decided to skip this part of the test since QoS is not needed for the deployment.

#### How did you do it?
Refactored existing skip logic in the test which was being used for mx and m0 topos to include m1 and m2.

#### How did you verify/test it?
Ran test with and without change, test was passing with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
