### PR TITLE
Add T2 checker to baseline test

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.template.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.template.yml
@@ -18,38 +18,30 @@ jobs:
           TESTBED_PREP_TOPOLOGY: t0
           CHECKER: t0_checker
           TOPOLOGY: t0
-          PREPARE_TIME: 30
         impacted-area-kvmtest-t0-2vlans:
           TESTBED_PREP_TOPOLOGY: t0-2vlans
           CHECKER: t0-2vlans_checker
           DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a "
           TOPOLOGY: t0
-          PREPARE_TIME: 30
         impacted-area-kvmtest-t1-lag:
           TESTBED_PREP_TOPOLOGY: t1
           CHECKER: t1_checker
           TOPOLOGY: t1-lag
-          # 50 mins for preparing testbed, 30 mins for pre-test and post-test
-          PREPARE_TIME: 80
         impacted-area-kvmtest-dualtor:
           TESTBED_PREP_TOPOLOGY: dualtor
           CHECKER: dualtor_checker
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
           TOPOLOGY: dualtor
-          # 30 mins for preparing testbed, 30 mins for pre-test and 20 mins for post-test
-          PREPARE_TIME: 80
         impacted-area-kvmtest-multi-asic-t1:
           TESTBED_PREP_TOPOLOGY: t1-multi-asic
           CHECKER: t1-multi-asic_checker
           TOPOLOGY: t1-8-lag
           NUM_ASIC: 4
-          PREPARE_TIME: 30
         impacted-area-kvmtest-t0-sonic:
           TESTBED_PREP_TOPOLOGY: t0-sonic
           CHECKER: t0-sonic_checker
           COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
           TOPOLOGY: t0-64-32
-          PREPARE_TIME: 40
           VM_TYPE: vsonic
           SPECIFIC_PARAM: '[
             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
@@ -59,10 +51,14 @@ jobs:
           TESTBED_PREP_TOPOLOGY: dpu
           CHECKER: dpu_checker
           TOPOLOGY: dpu
-          PREPARE_TIME: 30
           SPECIFIC_PARAM: '[
             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
             ]'
+        impacted-area-kvmtest-t2:
+          TESTBED_PREP_TOPOLOGY: t2
+          CHECKER: t2_checker
+          TOPOLOGY: t2
+
     condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
@@ -79,7 +75,6 @@ jobs:
         parameters:
           TOPOLOGY: $(TESTBED_PREP_TOPOLOGY)
           BUILD_BRANCH: $(Build.SourceBranchName)
-          PREPARE_TIME: $(PREPARE_TIME)
 
       - template: ../run-test-elastictest-template.yml
         parameters:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
T2 PR checker was added by https://github.com/sonic-net/sonic-mgmt/pull/17368, need baseline test to run multiple rounds of T2 test to verify tests and fix issues.
#### How did you do it?
Add T2 PR checker to baseline test.
Remove unnecessary parameter PREPARE_TIME, it's parameter for impact area to calculate instance numbers, not KVM prepare time, and it's defined default to 30 mins in impact area yaml.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
