### PR TITLE
[test_hash] Skip ip-proto hash key for topology with service port

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -499,9 +499,8 @@ def test_hash(add_default_route_to_dut, duthosts, tbinfo, setup_vlan,      # noq
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
 
-    if updated_tbinfo['topo']['name'] in ['t0-d18u8s4', 't0-isolated-d32u32s2'] and \
-            'ip-proto' in hash_keys:
-        # For t0-d18u8s4 and t0-isolated-d32u32s2, use ip-proto as hash key cause traffic unbalance issue.
+    if re.match(r"t0-.*s\d+", updated_tbinfo["topo"]["name"]) and 'ip-proto' in hash_keys:
+        # For t0 topology type with service ports, use ip-proto as hash key cause traffic unbalance issue.
         hash_keys.remove('ip-proto')
 
     ptf_runner(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Using ip-proto as a hash key caused traffic to be unbalanced on the topology with the service port. Remove it from the hash_keys.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix the fib/test_fib.py::test_hash case on t0-d18u8s4 and t0-isolated-d32u32s2.

#### How did you do it?
Remove ip-proto from hash_keys when running test_hash case on t0-d18u8s4 and t0-isolated-d32u32s2 topology.

#### How did you verify/test it?
Run fib/test_fib.py::testh_hash locally with the change and case can pass.
```
fib/test_fib.py::test_hash[ipv4] 
----------------------------- live log call --------------------
07:36:26 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
PASSED                           [ 50%]
fib/test_fib.py::test_hash[ipv6] 
----------------------------- live log call --------------------
07:43:27 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
PASSED                           [ 100%]
```

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
