### PR TITLE
Fix test_config_reload by checking for redis-db running status

### DIFF
--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -131,6 +131,30 @@ def check_database_status(duthost):
     return True
 
 
+def check_redis_db_is_reachable(duthost, asic_index=None):
+    if asic_index is not None:
+        cmd = f"sonic-db-cli -n asic{asic_index} PING"
+    else:
+        cmd = "sonic-db-cli PING"
+
+    out = duthost.shell(cmd, module_ignore_errors=True)
+    if "PONG" not in out['stdout']:
+        return False
+    return True
+
+
+def check_redis_db_status(duthost):
+    # For multi-asic check each asics database
+    if duthost.is_multi_asic:
+        for asic in duthost.asics:
+            if not check_redis_db_is_reachable(duthost, asic.asic_index):
+                return False
+    else:
+        if not check_redis_db_is_reachable(duthost):
+            return False
+    return True
+
+
 def execute_config_reload_cmd(duthost, timeout=120, check_interval=5):
     start_time = time.time()
     _, res = duthost.shell("sudo config reload -y",
@@ -183,10 +207,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
 
     reboot(duthost, localhost, reboot_type="cold", return_after_reconnect=True)
 
-    # Check if all database containers have started
-    # Some device after reboot may take some longer time to have database container started up
-    # we must give it a little longer or else it may falsely fail the test.
-    wait_until(360, 1, 0, check_database_status, duthost)
+    # check if redis-db is reachable before attempting to run any command.
+    wait_until(360, 1, 0, check_redis_db_status, duthost)
 
     logging.info("Reload configuration check")
 


### PR DESCRIPTION
### Check redis-ping before attempting any config commands

config-reload-test intends to run config-reload immediately after reboot, but sometimes it runs even before connection to redis is established.

This test relies on database container to assume that config commands can be run successfully. Ideally running status of database container does not guarantee that connection to Redis-db is established .

I've added a fix to check redis-ping before attempting any config command.

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/727

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
test_reload_config:test_reload_configuration_checks fails

#### How did you do it?
Check redis-ping before attempting any config commands

#### How did you verify/test it?
Ran the test repeatedly over 20 times.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
