### PR TITLE
Fix saithrift URL generation for Mellanox on internal-202411 branch

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -409,8 +409,8 @@ def test_update_saithrift_ptf(request, ptfhost, duthosts, enum_dut_hostname):
             pytest.fail("Unable to parse or recognize version format: {}".format(version))
 
     # Apply special codename overrides for specific internal branches
-    if branch_name == "internal-202411":
-        # internal-202411 has saithrift URL hardcoded to bullseye
+    if branch_name == "internal-202411" and asic != "mellanox":
+        # internal-202411 has saithrift URL hardcoded to bullseye for non-mellanox platform
         debian_codename = "bullseye"
     elif (branch_name.startswith("internal-") and branch_name < "internal-202405"):
         # For internal branches older than 202405, use the original URL without modification


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

The saithrift package download fails for Mellanox platforms on internal-202411 branch because the code was hardcoding bullseye as the Debian codename for all ASIC types, but Mellanox requires the actual Debian codename from the syncd container.

#### How did you do it?

Modified the condition to only use hardcoded bullseye for non-Mellanox platforms on internal-202411
For Mellanox on internal-202411, the code now retrieves the actual Debian codename via docker command
This ensures the correct saithrift package URL is constructed for each platform type

#### How did you verify/test it?

local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
