### PR TITLE
Skip packet trim tests on all SKUs except TH5

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1556,9 +1556,11 @@ generic_config_updater/test_multiasic_linkcrc.py:
 
 generic_config_updater/test_packet_trimming_config.py:
   skip:
-    reason: "KVM do not support the feature"
+    reason: "KVM and non TH5 platforms do not support the feature"
+    conditions_logical_operator: "OR"
     conditions:
       - "asic_type in ['vs']"
+      - "'Arista-7060X6' not in hwsku"
 
 generic_config_updater/test_pfcwd_interval.py:
   skip:


### PR DESCRIPTION
### Description of PR
packet trim feature is supported only on TH5 hence skipping it for all other platforms.

Summary:
Fixes # 
https://github.com/aristanetworks/sonic-qual.msft/issues/713
https://github.com/aristanetworks/sonic-qual.msft/issues/728

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Loganalyzer fails the test because of these error messages.

#### How did you do it?
packet trim feature is supported only on TH5 hence skipping it for all other platforms.

#### How did you verify/test it?
Scheduling the full run.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
