### PR TITLE
Xfail case test_lag and test_bgp_dual_asn_v4 due to github issue #22855

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -149,6 +149,12 @@ bgp/test_bgp_bbr.py:
       - "platform in ['x86_64-8111_32eh_o-r0', 'x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/17598"
 
+bgp/test_bgp_dual_asn.py::test_bgp_dual_asn_v4:
+  xfail:
+    reason: "Testcase skipped due to https://github.com/sonic-net/sonic-buildimage/issues/22855"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/22855
+
 bgp/test_bgp_gr_helper.py:
   skip:
     reason: 'bgp graceful restarted is not a supported feature for T2 and skip in KVM for failing with new cEOS image'
@@ -2171,6 +2177,12 @@ packet_trimming/test_packet_trimming.py:
 #######################################
 #####           pc               #####
 #######################################
+pc/test_lag_2.py::test_lag:
+  xfail:
+    reason: "Testcase skipped due to https://github.com/sonic-net/sonic-buildimage/issues/22855"
+    conditions:
+      - https://github.com/sonic-net/sonic-buildimage/issues/22855
+
 pc/test_lag_2.py::test_lag_db_status_with_po_update:
   skip:
     reason: "Only support t1-lag, t1-56-lag, t1-28-lag, t1-64-lag and t2 topology"


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Xfail case test_lag of pc/test_lag_2.py and test_bgp_dual_asn_v4 of bgp/test_bgp_dual_asn.py due to github issue https://github.com/sonic-net/sonic-buildimage/issues/22855

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Xfail case test_lag of pc/test_lag_2.py and test_bgp_dual_asn_v4 of bgp/test_bgp_dual_asn.py due to github issue https://github.com/sonic-net/sonic-buildimage/issues/22855
#### How did you do it?
Add the xfail conditions
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
