### PR TITLE
disable test_gnmi_configdb.py::test_gnmi_configdb_full_01

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1536,7 +1536,7 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/17436"
 
-gnmi/test_gnoi_killprocess.py:
+gnmi/test_gnoi_killprocess.py::test_gnoi_killprocess_then_restart:
   skip:
     reason: "Test noisy due to restart issue not relevant to GNOI. Disabling them to rewrite."
 


### PR DESCRIPTION
## Summary
Cherry-pick commit 641393b6e from master to disable test_gnmi_configdb.py::test_gnmi_configdb_full_01 in the 202505 branch.

## Changes
- Disabled test_gnmi_configdb.py::test_gnmi_configdb_full_01 in tests_mark_conditions.yaml
- Updated gnmi/test_gnoi_killprocess.py to be more specific (test_gnoi_killprocess_then_restart)

## Test plan
- Verify that the disabled test is no longer executed
- Ensure other tests continue to run as expected