### PR TITLE
[Snappi] Fixes for snappi reboot cases

### DIFF
--- a/tests/snappi_tests/reboot/files/reboot_helper.py
+++ b/tests/snappi_tests/reboot/files/reboot_helper.py
@@ -254,12 +254,13 @@ def __tgen_bgp_config(snappi_api, ):
     num_of_devices = 1000
     conf_values['server_1_ipv4'] = get_ip_addresses("192.168.1.2", 2000)[::2]
     conf_values['server_2_ipv4'] = get_ip_addresses("192.168.1.2", 2000)[1::2]
-    conf_values['server_1_ipv6'] = get_ip_addresses("5000::2", 2000,
+    conf_values['server_1_ipv6'] = get_ip_addresses("5001::2", 2000,
                                                     'ipv6')[::2]
-    conf_values['server_2_ipv6'] = get_ip_addresses("5000::2", 2000,
+    conf_values['server_2_ipv6'] = get_ip_addresses("5001::2", 2000,
                                                     'ipv6')[1::2]
     conf_values['server_1_mac'] = get_macs("001700000011", num_of_devices)
     conf_values['server_2_mac'] = get_macs("001600000011", num_of_devices)
+
     for i in range(1, num_of_devices + 1):
         # server1
         d1 = config.devices.device(name='Server_1_{}'.format(i - 1))[-1]
@@ -276,7 +277,7 @@ def __tgen_bgp_config(snappi_api, ):
         ipv6_1.name = 'IPv6 1_{}'.format(i - 1)
         ipv6_1.address = conf_values['server_1_ipv6'][i - 1]
         ipv6_1.gateway = '5001::1'
-        ipv6_1.prefix = 128
+        ipv6_1.prefix = 64
         # server2
         d2 = config.devices.device(name='Server_2_{}'.format(i - 1))[-1]
         eth_2 = d2.ethernets.add()
@@ -292,7 +293,7 @@ def __tgen_bgp_config(snappi_api, ):
         ipv6_2.name = 'IPv6 2_{}'.format(i - 1)
         ipv6_2.address = conf_values['server_2_ipv6'][i - 1]
         ipv6_2.gateway = '5001::1'
-        ipv6_2.prefix = 128
+        ipv6_2.prefix = 64
 
     # T1
     d3 = config.devices.device(name="T1")[-1]
@@ -309,7 +310,7 @@ def __tgen_bgp_config(snappi_api, ):
     ipv6_3.name = 'IPv6 3'
     ipv6_3.address = temp_tg_port[1]['ipv6']
     ipv6_3.gateway = temp_tg_port[1]['peer_ipv6']
-    ipv6_3.prefix = 128
+    ipv6_3.prefix = 64
 
     bgpv4_stack = d3.bgp
     bgpv4_stack.router_id = temp_tg_port[1]['peer_ip']
@@ -336,7 +337,7 @@ def __tgen_bgp_config(snappi_api, ):
     bgpv6_peer.as_type = BGP_TYPE
     bgpv6_peer.peer_address = temp_tg_port[1]['peer_ipv6']
     bgpv6_peer.as_number = int(TGEN_AS_NUM)
-    route_range2 = bgpv4_peer.v6_routes.add(name="Network Group 2")
+    route_range2 = bgpv6_peer.v6_routes.add(name="Network Group 2")
     route_range2.addresses.add(address='3000::1', prefix=128, count=3000)
     as_path = route_range2.as_path
     as_path_segment = as_path.segments.add()
@@ -409,7 +410,7 @@ def wait_for_bgp_and_lb_soft(snappi_api, ping_req, ):
     found_lb_state = False
     while True:
         responses = ping_loopback_if(snappi_api, ping_req)
-        if not found_lb_state and not responses[-1].result in "success":
+        if not found_lb_state and not responses[-1].result == "succeeded":
             loopback_down_start_timer = time.time()
             found_lb_state = True
             logger.info('!!!!!!! 1. loopback timer started {} !!!!!!'.format(
@@ -421,7 +422,7 @@ def wait_for_bgp_and_lb_soft(snappi_api, ping_req, ):
     found_lb_state = False
     while True:
         responses = ping_loopback_if(snappi_api, ping_req)
-        if not found_lb_state and responses[-1].result in "success":
+        if not found_lb_state and responses[-1].result == "succeeded":
             loopback_up_start_timer = time.time()
             # found_lb_state = True
             logger.info('\n Ping Successfull \n!!!!!!! 2. loopback up end time {} !!!!!!'.format(
@@ -457,13 +458,13 @@ def wait_for_bgp_and_lb(snappi_api, ping_req, ):
             found_bgp_state = True
             logger.info('!!! 1. bgp is down time started {} !!!'.format(
                 bgp_down_start_timer))
-        if not found_lb_state and not responses[-1].result in "success":
+        if not found_lb_state and not responses[-1].result == "succeeded":
             loopback_down_start_timer = time.time()
             found_lb_state = True
             logger.info('!!! 1. loopback timer started {} !!!'.format(
                 loopback_down_start_timer))
         if bgpv4_metrics[-1].session_state in "down" and not \
-                responses[-1].result in "success" and found_bgp_state and \
+                responses[-1].result == "succeeded" and found_bgp_state and \
                 found_lb_state:
             logger.info('BGP Control And LoopBack I/F Down')
             break
@@ -481,14 +482,14 @@ def wait_for_bgp_and_lb(snappi_api, ping_req, ):
             logger.info(' ')
             logger.info('^^ 2. bgp is up end time {} ^^^'.format(
                 bgp_up_start_timer))
-        if not found_lb_state and responses[-1].result in "success":
+        if not found_lb_state and responses[-1].result == "succeeded":
             loopback_up_start_timer = time.time()
             found_lb_state = True
             logger.info(' ')
             logger.info('2. loopback up end time {} !!!'.format(
                 loopback_up_start_timer))
-        if bgpv4_metrics[-1].session_state in "up" and responses[-1].result \
-                in "success" and found_bgp_state and found_lb_state:
+        if bgpv4_metrics[-1].session_state in "up" and responses[-1].result == "succeeded" \
+                and found_bgp_state and found_lb_state:
             logger.info('BGP Control And LoopBack I/F Up')
             break
 
@@ -580,7 +581,7 @@ def get_convergence_for_reboot_test(duthost,
                             '{}'.format(i, 0))
         else:
             request.flow.flow_names = [i]
-            flow = snappi_api.get_metrics(request).flow_metric
+            flow = snappi_api.get_metrics(request).flow_metrics
             assert int(flow[0].frames_tx_rate) != 0, \
                 "No Frames sent for traffic item: {}".format(i)
             assert flow[0].frames_tx_rate == flow[0].frames_tx_rate, \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixes for snappi reboot cases
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202305
- [ ] 202205
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We found some issues related to ipv6 stack addressing , flow metrics typo and loop back ping condition check string
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### OUTPUT

------------------------------------------------------------------------------------------------------ live log call ------------------------------------------------------------------------------------------------------
22:23:02 reboot_helper.duthost_bgp_config         L0077 INFO   | Removing configured IP and IPv6 Address from Ethernet8
22:23:04 reboot_helper.duthost_bgp_config         L0077 INFO   | Removing configured IP and IPv6 Address from Ethernet16
22:23:05 reboot_helper.duthost_bgp_config         L0077 INFO   | Removing configured IP and IPv6 Address from Ethernet24
22:23:07 reboot_helper.duthost_bgp_config         L0088 INFO   | Adding Ethernet24 and Ethernet16 to Vlan 1000
22:23:10 reboot_helper.duthost_bgp_config         L0101 INFO   | Configuring Ethernet8 to PortChannel1
22:23:10 reboot_helper.duthost_bgp_config         L0103 INFO   | Portchannel1 (IPv4,IPv6)  : (22.1.1.1,2002::1)
22:23:12 reboot_helper.duthost_bgp_config         L0109 INFO   | Configuring 1.1.1.1/32 on the loopback interface
22:23:13 reboot_helper.duthost_bgp_config         L0111 INFO   | Saving Interface, Vlan and Portchannel configuration in config_db.json
22:23:14 reboot_helper.duthost_bgp_config         L0114 INFO   | Configuring BGP in config_db.json
22:23:16 reboot_helper.duthost_bgp_config         L0178 INFO   | Reloading config_db.json to apply IP and BGP configuration on sonic-s6100-dut1
22:23:51 reboot_helper.duthost_bgp_config         L0181 INFO   | Config Reload Successful in sonic-s6100-dut1 !!!
22:23:53 connection._warn                         L0336 WARNING| Verification of certificates is disabled
22:23:53 connection._info                         L0333 INFO   | Determining the platform and rest_port using the 10.36.79.8 address...
22:23:53 connection._warn                         L0336 WARNING| Unable to connect to http://10.36.79.8:443.
22:23:53 connection._info                         L0333 INFO   | Connection established to `https://10.36.79.8:443 on linux`
22:24:12 connection._info                         L0333 INFO   | Using IxNetwork api server version 10.80.2411.172
22:24:12 connection._info                         L0333 INFO   | User info IxNetwork/ixnetworkweb/admin-15-22225
22:24:13 snappi_api.info                          L1488 INFO   | snappi-1.32.0
22:24:13 snappi_api.info                          L1488 INFO   | snappi_ixnetwork-1.31.2
22:24:13 snappi_api.info                          L1488 INFO   | ixnetwork_restpy-1.7.0
22:24:15 snappi_api.info                          L1488 INFO   | Config validation 0.797s
22:24:17 snappi_api.info                          L1488 INFO   | Ports configuration 1.586s
22:24:17 snappi_api.info                          L1488 INFO   | Captures configuration 0.189s
22:24:20 snappi_api.info                          L1488 INFO   | Add location hosts [10.36.79.8] 3.032s
22:24:23 snappi_api.info                          L1488 INFO   | Location hosts ready [10.36.79.8] 2.316s
22:24:23 snappi_api.info                          L1488 INFO   | Speed conversion is not require for (port.name, speed) : [('t1', 'aresOneOneByFourHundredGigNonFanOut'), ('server2', 'aresOneOneByFourHundredGigNonFanOut'), ('server1', 'aresOneOneByFourHundredGigNonFanOut')]
22:24:23 snappi_api.info                          L1488 INFO   | Aggregation mode speed change 0.331s
22:24:24 snappi_api.info                          L1488 INFO   | Location preemption [10.36.79.8;1;6, 10.36.79.8;1;7, 10.36.79.8;1;8] 0.113s
22:24:38 snappi_api.info                          L1488 INFO   | Location connect [t1, server2, server1] 14.368s
22:24:38 snappi_api.info                          L1488 INFO   | Location state check [t1, server2, server1] 0.205s
22:24:38 snappi_api.info                          L1488 INFO   | Location configuration 21.453s
22:24:39 snappi_api.info                          L1488 INFO   | Layer1 configuration 0.273s
22:24:39 snappi_api.info                          L1488 INFO   | Lag Configuration 0.756s
22:24:40 snappi_api.info                          L1488 INFO   | Lag Ethernet Configuration 0.803s
22:24:41 snappi_api.info                          L1488 INFO   | Lag Protocol Configuration 1.067s
22:24:43 snappi_api.info                          L1488 INFO   | Convert device config : 1.477s
22:24:43 snappi_api.info                          L1488 INFO   | Create IxNetwork device config : 0.001s
22:24:46 snappi_api.warning                       L1494 WARNING|  kError invalidCommit Unable to set attributes for  /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:3
22:24:46 snappi_api.warning                       L1494 WARNING|  kError invalidCommit Unable to set attributes for  /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:4
22:24:46 snappi_api.warning                       L1494 WARNING| [SDMObjId: /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:4/bgpAsPathSegmentList:1] cannot be expressed as an xpath statement as not all instance ids can be resolved kError invalidCommit Change request operation failed: No type information for object /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:4/bgpAsPathSegmentList:1
22:24:46 snappi_api.warning                       L1494 WARNING|  kError invalidCommit Unable to set attributes for  /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:5
22:24:46 snappi_api.warning                       L1494 WARNING|  kError invalidCommit Unable to set attributes for  /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:6
22:24:46 snappi_api.warning                       L1494 WARNING|  kError invalidCommit Unable to set attributes for  /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:7
22:24:46 snappi_api.warning                       L1494 WARNING|  kError invalidCommit Unable to set attributes for  /topology:3/deviceGroup:1/networkGroup:2/ipv6PrefixPools:1/bgpV6IPRouteProperty:24
22:24:46 snappi_api.info                          L1488 INFO   | Push IxNetwork device config : 3.259s
22:24:46 snappi_api.info                          L1488 INFO   | Devices configuration 4.810s
22:24:49 snappi_api.info                          L1488 INFO   | Flows configuration 3.085s
22:24:51 snappi_api.info                          L1488 INFO   | Start interfaces 1.809s
22:24:57 snappi_api.info                          L1488 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
22:24:57 snappi_api.info                          L1488 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
22:24:57 reboot_helper.get_convergence_for_reboot L0523 INFO   | Starting Protocol
22:25:15 utilities.wait                           L0119 INFO   | Pause 30 seconds, reason: For Protocols To start
22:25:45 reboot_helper.get_convergence_for_reboot L0528 INFO   | Starting Traffic
22:26:07 snappi_api.info                          L1488 INFO   | Flows generate/apply 20.282s
22:26:21 snappi_api.info                          L1488 INFO   | Flows clear statistics 12.988s
22:26:21 snappi_api.info                          L1488 INFO   | Captures start 0.000s
22:26:26 snappi_api.info                          L1488 INFO   | Flows start 5.026s
22:26:26 snappi_api.info                          L1488 INFO   | IxNet - If ports in a lag are down, please enable Transmit Ignore Link Status port property in order to successfully start traffic or clear statistics.
22:26:26 snappi_api.info                          L1488 INFO   | IxNet - The Rate Monitoring Jitter Window Size was decreased to support the incoming frame rate
22:26:26 utilities.wait                           L0119 INFO   | Pause 30 seconds, reason: For Traffic To start
22:27:01 reboot_helper.check_bgp_state            L0540 INFO   | BGP v4 Session State is UP
22:27:07 reboot_helper.check_bgp_state            L0545 INFO   | BGP v6 Session State is UP
22:27:07 reboot_helper.get_convergence_for_reboot L0551 INFO   | Issuing a cold reboot on the dut sonic-s6100-dut1
22:27:07 reboot.reboot                            L0329 INFO   | Reboot sonic-s6100-dut1: wait[120], timeout[300]
22:27:07 reboot.reboot                            L0331 INFO   | DUT sonic-s6100-dut1 create a file /dev/shm/test_reboot before rebooting
22:27:08 reboot.reboot                            L0334 INFO   | DUT OS Version: Edgecore-SONiC_20241018_041000_ec202211_ecsonic_431
22:27:08 reboot.collect_console_log               L0667 INFO   | start: collect console log
22:27:08 dut_utils.creds_on_dut                   L0487 INFO   | dut sonic-s6100-dut1 belongs to groups ['snappi-sonic', 'sonic', 'sonic_dell64_40', 'fanout']
22:27:08 dut_utils.creds_on_dut                   L0512 INFO   | skip empty var file /var/AzDevOps/sonic-mgmt/tests/common/helpers/../../../ansible/group_vars/all/corefile_uploader.yml
22:27:08 dut_utils.creds_on_dut                   L0512 INFO   | skip empty var file /var/AzDevOps/sonic-mgmt/tests/common/helpers/../../../ansible/group_vars/all/env.yml
22:27:08 transport._log                           L1873 INFO   | Connected (version 2.0, client OpenSSH_8.4p1)
22:27:08 transport._log                           L1873 INFO   | Authentication (password) successful!
22:27:08 reboot.try_create_dut_console            L0660 WARNING| Fail to create dut console. Please check console config or if console works ro not. 'ManagementIp'
22:27:08 reboot.collect_console_log               L0677 WARNING| dut console is not ready, we cannot get log by console
22:27:10 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:10 snappi_api.info                          L1488 INFO   | Ping requests completed in 0.440s
22:27:13 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:14 snappi_api.info                          L1488 INFO   | Ping requests completed in 0.426s
22:27:14 reboot.wait_for_shutdown                 L0184 INFO   | waiting for ssh to drop on sonic-s6100-dut1
22:27:14 reboot.execute_reboot_command            L0228 INFO   | rebooting sonic-s6100-dut1 with command "reboot"
22:27:16 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:16 snappi_api.info                          L1488 INFO   | Ping requests completed in 0.392s
22:27:19 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:22 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.377s
22:27:22 reboot_helper.wait_for_bgp_and_lb        L0465 INFO   | !!! 1. loopback timer started 1753914442.8494968 !!!
22:27:25 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:25 reboot.wait_for_startup                  L0205 INFO   | waiting for ssh to startup on sonic-s6100-dut1
22:27:25 reboot.ssh_connection_with_retry         L0717 INFO   | Checking ssh connection using the following params: {'host_ip': '10.36.78.28', 'port': 22, 'delay': 10, 'timeout': 300, 'search_regex': 'OpenSSH_[\\w\\.]+ Debian'}
22:27:28 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.401s
22:27:31 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:34 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.384s
22:27:37 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:40 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.447s
22:27:43 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:46 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.402s
22:27:49 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:52 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.399s
22:27:55 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:27:58 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.398s
22:28:01 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:04 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.373s
22:28:08 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:11 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.491s
22:28:14 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:17 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.400s
22:28:21 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:24 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.375s
22:28:26 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:29 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.370s
22:28:38 reboot.ssh_connection_with_retry         L0723 INFO   | Connection succeeded
22:28:38 reboot.wait_for_startup                  L0220 INFO   | ssh has started up on sonic-s6100-dut1
22:28:38 reboot.reboot                            L0370 INFO   | waiting for switch sonic-s6100-dut1 to initialize
22:28:38 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:41 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.449s
22:28:44 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:47 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.419s
22:28:51 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:28:54 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.419s
22:28:54 reboot_helper.wait_for_bgp_and_lb        L0460 INFO   | !!! 1. bgp is down time started 1753914534.206218 !!!
22:28:54 reboot_helper.wait_for_bgp_and_lb        L0470 INFO   | BGP Control And LoopBack I/F Down
22:28:57 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:29:00 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.531s
22:29:05 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:29:09 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.604s
22:29:12 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:29:12 snappi_api.info                          L1488 INFO   | Ping requests completed in 0.407s
22:29:12 reboot_helper.wait_for_bgp_and_lb        L0489 INFO   |  
22:29:12 reboot_helper.wait_for_bgp_and_lb        L0490 INFO   | 2. loopback up end time 1753914552.9336414 !!!
22:29:16 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:29:19 snappi_api.info                          L1488 INFO   | Ping requests completed in 3.524s
22:29:22 snappi_api.info                          L1488 INFO   | Sending ping to 1.1.1.1
22:29:23 snappi_api.info                          L1488 INFO   | Ping requests completed in 0.487s
22:29:23 reboot_helper.wait_for_bgp_and_lb        L0483 INFO   |  
22:29:23 reboot_helper.wait_for_bgp_and_lb        L0484 INFO   | ^^ 2. bgp is up end time 1753914563.0929067 ^^^
22:29:23 reboot_helper.wait_for_bgp_and_lb        L0494 INFO   | BGP Control And LoopBack I/F Up
22:29:23 reboot_helper.get_convergence_for_reboot L0562 INFO   | Wait until the system is stable
22:30:38 reboot.reboot                            L0410 INFO   | cold reboot finished on sonic-s6100-dut1
22:30:40 reboot.reboot                            L0413 INFO   | DUT sonic-s6100-dut1 up since 2025-03-01 01:16:46.500000
22:32:11 snappi_api.info                          L1488 INFO   | event is not reflected in stat
22:33:28 reboot_helper.get_convergence_for_reboot L0587 INFO   | No Loss Observed in Traffic Item IPv4_1-IPv4_2
22:33:28 reboot_helper.get_convergence_for_reboot L0587 INFO   | DP/DP Convergence Time (ms) of IPv4_1-IPv4_2 : 8982.732
22:33:31 reboot_helper.get_convergence_for_reboot L0586 INFO   | No Loss Observed in Traffic Item IPv6_2-IPv6_1
22:33:31 reboot_helper.get_convergence_for_reboot L0586 INFO   | DP/DP Convergence Time (ms) of IPv6_2-IPv6_1 : 8731.067
22:33:34 reboot_helper.get_convergence_for_reboot L0587 INFO   | No Loss Observed in Traffic Item IPv4_1-T1
22:33:34 reboot_helper.get_convergence_for_reboot L0587 INFO   | DP/DP Convergence Time (ms) of IPv4_1-T1 : 20414.749
22:33:38 reboot_helper.get_convergence_for_reboot L0586 INFO   | No Loss Observed in Traffic Item IPv6_2-T1
22:33:38 reboot_helper.get_convergence_for_reboot L0586 INFO   | DP/DP Convergence Time (ms) of IPv6_2-T1 : 0.0
22:33:41 reboot_helper.get_convergence_for_reboot L0587 INFO   | No Loss Observed in Traffic Item T1-IPv4_1
22:33:41 reboot_helper.get_convergence_for_reboot L0587 INFO   | DP/DP Convergence Time (ms) of T1-IPv4_1 : 134282.99
22:33:45 reboot_helper.get_convergence_for_reboot L0586 INFO   | No Loss Observed in Traffic Item T1-IPv6_2
22:33:45 reboot_helper.get_convergence_for_reboot L0586 INFO   | DP/DP Convergence Time (ms) of T1-IPv6_2 : 134660.465
22:33:45 reboot_helper.get_convergence_for_reboot L0586 INFO   | 
+---------------+-------------------------------+------------------------------------+-------------+
| Reboot Type   | Traffic Item Name             |   Data Plane Convergence Time (ms) |   Time (ms) |
|---------------+-------------------------------+------------------------------------+-------------|
| cold          | Server IPv4_1 - Server IPv4_2 |                            8982.73 |         0   |
| cold          | Server IPv6_2 - Server IPv6_1 |                            8731.07 |         0   |
| cold          | Server IPv4_1 - T1            |                           20414.7  |         0   |
| cold          | Server IPv6_2 - T1            |                               0    |         0   |
| cold          | T1 - Server IPv4_1            |                          134283    |         0   |
| cold          | T1 - Server IPv6_2            |                          134660    |         0   |
| cold          | BGP Control Plane Up Time     |                               0    |     28886.7 |
| cold          | Loopback Up Time              |                               0    |    110084   |
+---------------+-------------------------------+------------------------------------+-------------+
PASSED                    