### PR TITLE
Move dualtor log cleanup to post-test after log collection

### DIFF
--- a/tests/test_posttest.py
+++ b/tests/test_posttest.py
@@ -104,3 +104,4 @@ def test_collect_dualtor_logs(request, vmhost, tbinfo, active_active_ports, acti
         log_files = vmhost.shell('ls {}'.format(log_name))['stdout'].split()
         for log_file in log_files:
             vmhost.fetch(src=log_file, dest="logs/server", fail_on_missing=False)
+            vmhost.shell("rm -f {}".format(log_file))

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -580,27 +580,3 @@ def test_generate_running_golden_config(duthosts):
     with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
         for duthost in duthosts:
             executor.submit(generate_running_golden_config, duthost)
-
-
-def test_clean_dualtor_logs(request, vmhost, tbinfo, active_active_ports, active_standby_ports):
-    """
-    Clean mux/nic simulator logs from /tmp/ on the server before test run.
-    """
-    if 'dualtor' not in tbinfo['topo']['name']:
-        return
-
-    log_name = None
-    if active_standby_ports:
-        server = tbinfo['server']
-        tbname = tbinfo['conf-name']
-        inv_files = utilities.get_inventory_files(request)
-        http_port = utilities.get_group_visible_vars(inv_files, server).get('mux_simulator_http_port')[tbname]
-        log_name = '/tmp/mux_simulator_{}.log*'.format(http_port)
-    elif active_active_ports:
-        vm_set = tbinfo['group-name']
-        log_name = "/tmp/nic_simulator_{}.log*".format(vm_set)
-
-    if log_name:
-        log_files = vmhost.shell('ls {}'.format(log_name))['stdout'].split()
-        for log_file in log_files:
-            vmhost.shell("rm -f {}".format(log_file))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The original implementation https://github.com/sonic-net/sonic-mgmt/pull/19657 was to clean the dualtor logs before each test run. However, this caused issues when tests were re-executed during the pipeline run (like redeploys).

#### How did you do it?
Move the cleanup to the end of the test session.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
