### PR TITLE
testcase to validate mux_simulator could handle/close timeout request

### DIFF
--- a/tests/dualtor_mgmt/test_mux_simulator_timeout.py
+++ b/tests/dualtor_mgmt/test_mux_simulator_timeout.py
@@ -3,25 +3,103 @@ import time
 import requests
 import logging
 import threading
+import os
+import random
 from typing import List
 from tests.common.helpers.assertions import pytest_assert
-import random
 
-pytestmark = [
-    pytest.mark.topology("dualtor")
-]
+pytestmark = [pytest.mark.topology("dualtor")]
+
+# Environment-configurable parameters
+FLOOD_COUNT = int(os.environ.get("FLOOD_COUNT", 4000))
+OVERFLOW_THRESHOLD = int(os.environ.get("OVERFLOW_THRESHOLD", 5))
+QUEUE_CONSUME_WAIT = int(os.environ.get("QUEUE_CONSUME_WAIT", 10))
 
 
 @pytest.fixture(scope="function")
 def cleanup_mux_simulator(restart_mux_simulator):
-    """
-    Fixture to restart mux_simulator **after** test completes.
-    Ensures environment cleanup regardless of test outcome.
-    """
+    """Restart mux simulator after test completes."""
     yield
-    logging.info("Restarting mux simulator in teardown...")
+    logging.warning("Restarting mux simulator in teardown...")
     restart_mux_simulator()
     time.sleep(2)
+
+
+def log_listen_queue_metrics(stage: str, localhost):
+    """Log listen queue metrics using ss -lt."""
+    try:
+        output = localhost.shell("ss -lt")["stdout"]
+        logging.warning(f"[{stage}] Listen queue metrics from 'ss -lt':\n{output}")
+    except Exception as e:
+        logging.warning(f"Failed to get listen queue metrics: {e}")
+
+
+def check_accept_queue_overflow(localhost, threshold=OVERFLOW_THRESHOLD):
+    """Check if any socket's Recv-Q exceeds the overflow threshold."""
+    try:
+        output = localhost.shell("ss -lt")["stdout"]
+        logging.warning(f"Checking accept queue overflow with 'ss -lt':\n{output}")
+        lines = output.splitlines()
+        max_recv_q = 0
+        for line in lines[1:]:  # Skip header
+            parts = line.split()
+            if len(parts) >= 5 and parts[0].upper() == "LISTEN":
+                recv_q = int(parts[1])
+                max_recv_q = max(max_recv_q, recv_q)
+                if recv_q > threshold:
+                    logging.warning(f"Accept queue overflow detected: {line.strip()} | Recv-Q = {recv_q}")
+                    return True
+        logging.warning(f"No accept queue overflow. Max Recv-Q = {max_recv_q}")
+        return False
+    except Exception as e:
+        logging.warning(f"Error in check_accept_queue_overflow: {e}")
+        return False
+
+
+def flood_toggle_all_random_side(url):
+    """Flood mux simulator with toggle requests to random sides."""
+    toggle_url = url(action="toggle_all")
+    sides = ["upper_tor", "lower_tor", "nic"]
+    logging.warning(f"Flooding mux server at {toggle_url} with {FLOOD_COUNT} requests")
+    for i in range(FLOOD_COUNT):
+        try:
+            random_side = random.choice(sides)
+            payload = {"active_side": random_side}
+            requests.post(toggle_url, json=payload, timeout=0.05)
+        except requests.exceptions.Timeout:
+            pass
+        except requests.exceptions.RequestException as e:
+            logging.warning(f"Flood {i} - Toggle random side request exception: {e}")
+
+
+def send_drop_request_random_side(url):
+    """Send a drop request to a random side."""
+    try:
+        drop_url = url(action="drop")
+        random_side = random.choice(["upper_tor", "nic"])
+        response = requests.post(drop_url, json={"out_sides": [random_side]}, timeout=0.05)
+        return response
+    except requests.exceptions.Timeout:
+        return None
+    except requests.exceptions.RequestException as e:
+        logging.warning(f"Drop request exception: {e}")
+        return None
+
+
+def wait_until_queue_consumed(timeout=QUEUE_CONSUME_WAIT):
+    """Wait for accept queue to be consumed."""
+    logging.warning("Waiting for accept queue to be consumed...")
+    time.sleep(timeout)
+
+
+def retry_get_mux_status(get_mux_status, iface: str, retries=3, delay=1):
+    """Retry mux status retrieval with delay."""
+    for _ in range(retries):
+        status = get_mux_status(interface_name=iface)
+        if status and "active_side" in status and not status.get("stale_request", False):
+            return status
+        time.sleep(delay)
+    return None
 
 
 def test_mux_simulator_toggle_all_accept_queue_overflow(
@@ -29,117 +107,50 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
     url,
     get_mux_status,
     localhost,
-    cleanup_mux_simulator,
+    cleanup_mux_simulator
 ):
-    """
-    Test mux_simulator handling of accept queue overflow using mux simulator's documented API:
-    toggling all muxes to a random side and dropping packets on a random side to cause timeouts.
-    """
+    """Test mux simulator accept queue overflow behavior."""
 
-    def log_listen_queue_metrics(stage: str):
-        try:
-            output = localhost.shell("ss -lt")["stdout"]
-            logging.info(f"[{stage}] Listen queue metrics from 'ss -lt':\n{output}")
-        except Exception as e:
-            logging.warning(f"Failed to get listen queue metrics: {e}")
+    log_listen_queue_metrics("Before toggle all random flood", localhost)
 
-    def flood_toggle_all_random_side():
-        mux_server_url = url()
-        for _ in range(2000):
-            try:
-                payload = {"active_side": "random"}
-                requests.post(mux_server_url, json=payload, timeout=0.1)
-            except requests.exceptions.Timeout:
-                pass
-            except requests.exceptions.RequestException as e:
-                logging.warning(f"Toggle all random side request exception: {e}")
-
-    def send_drop_request_random_side():
-        drop_url = url(action="drop")
-        random_side = random.choice(["upper_tor", "lower_tor", "nic"])
-        try:
-            response = requests.post(
-                drop_url,
-                json={"out_sides": [random_side]},
-                timeout=0.1,
-            )
-            return response
-        except requests.exceptions.Timeout:
-            return None
-        except requests.exceptions.RequestException as e:
-            logging.warning(f"Drop request exception: {e}")
-            return None
-
-    def check_accept_queue_overflow():
-        threshold = 5
-        try:
-            output = localhost.shell("ss -lt")["stdout"]
-            logging.info(f"Checking accept queue overflow with 'ss -lt' output:\n{output}")
-            lines = output.splitlines()
-            for line in lines[1:]:
-                parts = line.split()
-                if len(parts) >= 5 and parts[0].upper() == "LISTEN":
-                    recv_q = int(parts[1])
-                    if recv_q > threshold:
-                        logging.warning(f"Accept queue overflow detected: {line.strip()}, Recv-Q={recv_q}")
-                        return True
-            return False
-        except Exception as e:
-            logging.warning(f"Could not check accept queue overflow: {e}")
-            return False
-
-    def wait_until_queue_consumed(timeout=10):
-        logging.info("Waiting for accept queue to be consumed...")
-        time.sleep(timeout)
-
-    def retry_get_mux_status(iface: str, retries=3, delay=1):
-        for _ in range(retries):
-            status = get_mux_status(interface_name=iface)
-            if status and "active_side" in status and not status.get("stale_request", False):
-                return status
-            time.sleep(delay)
-        return None
-
-    log_listen_queue_metrics("Before toggle all random flood")
-
-    toggle_thread = threading.Thread(target=flood_toggle_all_random_side)
+    toggle_thread = threading.Thread(target=flood_toggle_all_random_side, args=(url,))
     toggle_thread.start()
     time.sleep(1)  # Allow queue to potentially overflow
 
-    pytest_assert(check_accept_queue_overflow(), "Accept queue did not overflow as expected")
+    overflow = False
+    # Retry accept queue overflow check several times with delay
+    for _ in range(5):
+        if check_accept_queue_overflow(localhost):
+            overflow = True
+            break
+        time.sleep(1)
 
-    new_response = send_drop_request_random_side()
-    pytest_assert(
-        new_response is None or (new_response.status_code != 200),
-        "New drop request unexpectedly accepted during overflow"
-    )
+    pytest_assert(overflow, "Accept queue overflow expected")
+
+    # During overflow, new drop requests should not be accepted
+    new_response = send_drop_request_random_side(url)
+    pytest_assert(new_response is None or new_response.status_code != 200,
+                  "New request unexpectedly accepted during overflow")
 
     toggle_thread.join()
-
     wait_until_queue_consumed()
 
-    post_response = send_drop_request_random_side()
-    pytest_assert(
-        post_response is not None and post_response.status_code == 200,
-        "New drop request not accepted after queue consumption"
-    )
+    # After queue consumption, drop requests should again be accepted
+    post_response = send_drop_request_random_side(url)
+    pytest_assert(post_response is not None and post_response.status_code == 200,
+                  "New drop request not accepted after queue consumption")
 
-    log_listen_queue_metrics("After toggle all & drop flood and queue consumption")
+    log_listen_queue_metrics("After toggle & drop flood queue consumption", localhost)
 
     test_ports = active_standby_ports[:3] if len(active_standby_ports) >= 3 else active_standby_ports
     for iface in test_ports:
-        status = retry_get_mux_status(iface)
+        status = retry_get_mux_status(get_mux_status, iface)
         pytest_assert(status is not None, f"Could not retrieve mux status for interface {iface}")
-        pytest_assert("active_side" in status, f"'active_side' key missing in mux status for {iface}")
+        pytest_assert("active_side" in status, f"Expected 'active_side' key missing in mux status for {iface}")
         pytest_assert(not status.get("stale_request", False), f"Stale request detected for {iface}")
 
-    mux_server_url = url()
-    response = requests.post(
-        mux_server_url,
-        json={"active_side": "random"},
-        timeout=3,
-    )
-    pytest_assert(
-        response.status_code == 200,
-        "Simulator did not accept normal toggle all request after timeouts and cleanup"
-    )
+    # Verify simulator accepts normal toggle all request after timeouts and cleanup
+    toggle_url = url(action="toggle_all")
+    response = requests.post(toggle_url, json={"active_side": "random"}, timeout=3)
+    pytest_assert(response.status_code == 200,
+                  "Simulator did not accept normal toggle all request after timeouts and cleanup")

--- a/tests/dualtor_mgmt/test_mux_simulator_timeout.py
+++ b/tests/dualtor_mgmt/test_mux_simulator_timeout.py
@@ -2,72 +2,141 @@ import pytest
 import time
 import requests
 import logging
+import threading
 from typing import List
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
     pytest.mark.topology("dualtor")
 ]
 
 
-def test_mux_simulator_timeout_cleanup(
-    duthosts,
-    tbinfo,
+@pytest.fixture(scope="function")
+def cleanup_mux_simulator(restart_mux_simulator):
+    """
+    Fixture to restart mux_simulator **after** test completes.
+    Ensures environment cleanup regardless of test outcome.
+    """
+    yield
+    logging.info("Restarting mux simulator in teardown...")
+    restart_mux_simulator()
+    time.sleep(2)
+
+
+def test_mux_simulator_toggle_all_accept_queue_overflow(
     active_standby_ports: List[str],
     url,
     get_mux_status,
-    restart_mux_simulator
-) -> None:
+    localhost,
+    cleanup_mux_simulator,
+):
     """
-    Validate that mux_simulator correctly handles and cleans up timeout requests.
-
-    Test steps:
-    1. Restart mux_simulator to begin with a clean state.
-    2. Flood mux_simulator with multiple requests designed to timeout.
-    3. Allow mux_simulator time to clean up timed-out requests.
-    4. Assert no stale requests remain in mux_simulator’s state.
-    5. Verify mux_simulator accepts new valid requests post-timeout flooding.
+    Test mux_simulator handling of accept queue overflow using toggle all API timeout flood.
     """
 
-    # Restart mux_simulator to ensure a clean start
-    restart_mux_simulator()
-    time.sleep(2)  # wait for simulator to fully restart
+    def log_listen_queue_metrics(stage: str):
+        cmd = "netstat -s | grep -i listen"
+        output = localhost.shell(cmd)["stdout"]
+        logging.info(f"[{stage}] Listen queue metrics:\n{output}")
 
-    # Select up to 3 active ports to run timeout tests on
-    test_ports = active_standby_ports[:3] if len(active_standby_ports) >= 3 else active_standby_ports
-
-    # Flood mux_simulator with timeout-inducing requests
-    for iface in test_ports:
-        timeout_request_url = url(interface_name=iface, action="drop")  # 'drop' action triggers timeout simulation
-        for _ in range(10):
+    def flood_toggle_all_timeouts():
+        toggle_all_url = url(action="toggle_all", toggle_action="drop")
+        for _ in range(2000):
             try:
                 requests.post(
-                    timeout_request_url,
-                    json={"out_sides": ["upper_tor", "lower_tor", "nic"]},
-                    timeout=0.1,  # very short timeout to force client-side timeout
+                    toggle_all_url,
+                    json={"action": "toggle", "out_sides": ["upper_tor", "lower_tor", "nic"]},
+                    timeout=0.1,
                 )
             except requests.exceptions.Timeout:
-                # Expected timeout; no action needed
+                # Expected timeout, ignore
                 pass
             except requests.exceptions.RequestException as e:
-                # Optional: log unexpected exceptions for debugging
-                logging.warning(f"Non-timeout request exception on {iface}: {e}")
+                logging.warning(f"Toggle all request exception: {e}")
 
-    # Allow mux_simulator time to process and clear timed-out requests
-    time.sleep(3.5)
+    def send_timeout_request():
+        try:
+            toggle_all_url = url(action="toggle_all", toggle_action="drop")
+            response = requests.post(
+                toggle_all_url,
+                json={"action": "toggle", "out_sides": ["upper_tor", "lower_tor", "nic"]},
+                timeout=0.1,
+            )
+            return response
+        except requests.exceptions.Timeout:
+            return None
+        except requests.exceptions.RequestException as e:
+            logging.warning(f"Request exception: {e}")
+            return None
 
-    # Check that mux_simulator has cleaned up stale requests
+    def check_accept_queue_overflow():
+        cmd = "netstat -s | grep -i 'listen queue overflow'"
+        output = localhost.shell(cmd)["stdout"]
+        logging.info(f"Accept queue overflow check output:\n{output}")
+        return "listen queue overflow" in output.lower()
+
+    def wait_until_queue_consumed(timeout=10):
+        logging.info("Waiting for accept queue to be consumed...")
+        time.sleep(timeout)
+
+    def retry_get_mux_status(iface: str, retries=3, delay=1):
+        for _ in range(retries):
+            status = get_mux_status(interface_name=iface)
+            if status and "active_side" in status and not status.get("stale_request", False):
+                return status
+            time.sleep(delay)
+        return None
+
+    # Log listen queue metrics before flooding
+    log_listen_queue_metrics("Before Toggle All Flood")
+
+    # Start flooding toggle all timeout requests in a separate thread
+    toggle_thread = threading.Thread(target=flood_toggle_all_timeouts)
+    toggle_thread.start()
+
+    time.sleep(1)  # short delay to let accept queue potentially overflow
+
+    # Step 1: Check accept queue overflow
+    pytest_assert(check_accept_queue_overflow(), "Accept queue did not overflow as expected")
+
+    # Step 2: Attempt sending a new request during overflow
+    new_response = send_timeout_request()
+    pytest_assert(
+        new_response is None or (new_response.status_code != 200),
+        "New request unexpectedly accepted during overflow"
+    )
+
+    toggle_thread.join()
+
+    # Step 3: Wait for accept queue to be consumed
+    wait_until_queue_consumed()
+
+    # Step 4: Send new request after consumption, expect acceptance
+    post_response = send_timeout_request()
+    pytest_assert(
+        post_response is not None and post_response.status_code == 200,
+        "New request not accepted after queue consumption"
+    )
+
+    # Log listen queue metrics after flooding & consumption
+    log_listen_queue_metrics("After Toggle All Flood & Queue Consumption")
+
+    # Validate per-port mux status for stale requests
+    test_ports = active_standby_ports[:3] if len(active_standby_ports) >= 3 else active_standby_ports
     for iface in test_ports:
-        status = get_mux_status(interface_name=iface)
-        assert status is not None, f"Could not retrieve mux status for interface {iface}"
-        assert "active_side" in status, f"Expected 'active_side' key missing in mux status for {iface}"
-        assert not status.get("stale_request", False), f"Stale request detected for {iface}"
+        status = retry_get_mux_status(iface)
+        pytest_assert(status is not None, f"Could not retrieve mux status for interface {iface}")
+        pytest_assert("active_side" in status, f"Expected 'active_side' key missing in mux status for {iface}")
+        pytest_assert(not status.get("stale_request", False), f"Stale request detected for {iface}")
 
-    # Verify mux_simulator accepts new valid requests after timeout cleanup
-    for iface in test_ports:
-        normal_request_url = url(interface_name=iface, action="output")
-        response = requests.post(
-            normal_request_url,
-            json={"out_sides": ["upper_tor"]},
-            timeout=3,
-        )
-        assert response.status_code == 200, f"Failed to accept new request on {iface} after timeouts"
+    # Final check: mux simulator accepts a new normal toggle all request
+    toggle_all_url = url(action="toggle_all")
+    response = requests.post(
+        toggle_all_url,
+        json={"action": "toggle", "out_sides": ["upper_tor"]},
+        timeout=3,
+    )
+    pytest_assert(
+        response.status_code == 200,
+        "Simulator did not accept normal toggle all request after timeouts and cleanup"
+    )

--- a/tests/dualtor_mgmt/test_mux_simulator_timeout.py
+++ b/tests/dualtor_mgmt/test_mux_simulator_timeout.py
@@ -3,9 +3,9 @@ import time
 import requests
 import logging
 import threading
-import random
 from typing import List
 from tests.common.helpers.assertions import pytest_assert
+import random
 
 pytestmark = [
     pytest.mark.topology("dualtor")
@@ -32,25 +32,51 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
     cleanup_mux_simulator,
 ):
     """
-    Test mux_simulator handling of accept queue overflow using toggle all API timeout flood,
-    with toggling to random sides for each request.
+    Test mux_simulator handling of accept queue overflow using mux simulator's documented API:
+    toggling all muxes to a random side and dropping packets on a random side to cause timeouts.
     """
 
     def log_listen_queue_metrics(stage: str):
-        # Placeholder for listen queue metrics logging
         try:
             output = localhost.shell("ss -lt")["stdout"]
             logging.info(f"[{stage}] Listen queue metrics from 'ss -lt':\n{output}")
         except Exception as e:
             logging.warning(f"Failed to get listen queue metrics: {e}")
 
+    def flood_toggle_all_random_side():
+        mux_server_url = url()
+        for _ in range(2000):
+            try:
+                payload = {"active_side": "random"}
+                requests.post(mux_server_url, json=payload, timeout=0.1)
+            except requests.exceptions.Timeout:
+                pass
+            except requests.exceptions.RequestException as e:
+                logging.warning(f"Toggle all random side request exception: {e}")
+
+    def send_drop_request_random_side():
+        drop_url = url(action="drop")
+        random_side = random.choice(["upper_tor", "lower_tor", "nic"])
+        try:
+            response = requests.post(
+                drop_url,
+                json={"out_sides": [random_side]},
+                timeout=0.1,
+            )
+            return response
+        except requests.exceptions.Timeout:
+            return None
+        except requests.exceptions.RequestException as e:
+            logging.warning(f"Drop request exception: {e}")
+            return None
+
     def check_accept_queue_overflow():
-        threshold = 5  # Adjust threshold based on environment
+        threshold = 5
         try:
             output = localhost.shell("ss -lt")["stdout"]
             logging.info(f"Checking accept queue overflow with 'ss -lt' output:\n{output}")
             lines = output.splitlines()
-            for line in lines[1:]:  # Skip header
+            for line in lines[1:]:
                 parts = line.split()
                 if len(parts) >= 5 and parts[0].upper() == "LISTEN":
                     recv_q = int(parts[1])
@@ -61,38 +87,6 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
         except Exception as e:
             logging.warning(f"Could not check accept queue overflow: {e}")
             return False
-
-    def flood_toggle_all_timeouts():
-        toggle_all_url = url(action="toggle_all")
-        sides = ["upper_tor", "lower_tor", "nic"]
-        for _ in range(2000):
-            try:
-                random_side = random.choice(sides)
-                requests.post(
-                    toggle_all_url,
-                    json={"action": "toggle", "toggle_action": "drop", "out_sides": [random_side]},
-                    timeout=0.1,
-                )
-            except requests.exceptions.Timeout:
-                pass
-            except requests.exceptions.RequestException as e:
-                logging.warning(f"Toggle all request exception: {e}")
-
-    def send_timeout_request():
-        try:
-            toggle_all_url = url(action="toggle_all")
-            random_side = random.choice(["upper_tor", "lower_tor", "nic"])
-            response = requests.post(
-                toggle_all_url,
-                json={"action": "toggle", "toggle_action": "drop", "out_sides": [random_side]},
-                timeout=0.1,
-            )
-            return response
-        except requests.exceptions.Timeout:
-            return None
-        except requests.exceptions.RequestException as e:
-            logging.warning(f"Request exception: {e}")
-            return None
 
     def wait_until_queue_consumed(timeout=10):
         logging.info("Waiting for accept queue to be consumed...")
@@ -106,45 +100,43 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
             time.sleep(delay)
         return None
 
-    # Log metrics before flood
-    log_listen_queue_metrics("Before Toggle All Flood")
+    log_listen_queue_metrics("Before toggle all random flood")
 
-    toggle_thread = threading.Thread(target=flood_toggle_all_timeouts)
+    toggle_thread = threading.Thread(target=flood_toggle_all_random_side)
     toggle_thread.start()
-    time.sleep(1)  # Allow queue to possibly overflow
+    time.sleep(1)  # Allow queue to potentially overflow
 
     pytest_assert(check_accept_queue_overflow(), "Accept queue did not overflow as expected")
 
-    new_response = send_timeout_request()
+    new_response = send_drop_request_random_side()
     pytest_assert(
         new_response is None or (new_response.status_code != 200),
-        "New request unexpectedly accepted during overflow"
+        "New drop request unexpectedly accepted during overflow"
     )
 
     toggle_thread.join()
 
     wait_until_queue_consumed()
 
-    post_response = send_timeout_request()
+    post_response = send_drop_request_random_side()
     pytest_assert(
         post_response is not None and post_response.status_code == 200,
-        "New request not accepted after queue consumption"
+        "New drop request not accepted after queue consumption"
     )
 
-    log_listen_queue_metrics("After Toggle All Flood & Queue Consumption")
+    log_listen_queue_metrics("After toggle all & drop flood and queue consumption")
 
     test_ports = active_standby_ports[:3] if len(active_standby_ports) >= 3 else active_standby_ports
-
     for iface in test_ports:
         status = retry_get_mux_status(iface)
         pytest_assert(status is not None, f"Could not retrieve mux status for interface {iface}")
         pytest_assert("active_side" in status, f"'active_side' key missing in mux status for {iface}")
         pytest_assert(not status.get("stale_request", False), f"Stale request detected for {iface}")
 
-    toggle_all_url = url(action="toggle_all")
+    mux_server_url = url()
     response = requests.post(
-        toggle_all_url,
-        json={"action": "toggle", "out_sides": ["upper_tor"]},
+        mux_server_url,
+        json={"active_side": "random"},
         timeout=3,
     )
     pytest_assert(

--- a/tests/dualtor_mgmt/test_mux_simulator_timeout.py
+++ b/tests/dualtor_mgmt/test_mux_simulator_timeout.py
@@ -13,10 +13,7 @@ pytestmark = [
 
 @pytest.fixture(scope="function")
 def cleanup_mux_simulator(restart_mux_simulator):
-    """
-    Fixture to restart mux_simulator **after** test completes.
-    Ensures environment cleanup regardless of test outcome.
-    """
+    """Fixture to restart mux_simulator **after** test completes."""
     yield
     logging.info("Restarting mux simulator in teardown...")
     restart_mux_simulator()
@@ -31,13 +28,13 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
     cleanup_mux_simulator,
 ):
     """
-    Test mux_simulator handling of accept queue overflow using toggle all API timeout flood.
+    Test mux_simulator handling of accept queue overflow using toggle all API timeout flood,
+    without dependency on netstat.
     """
 
     def log_listen_queue_metrics(stage: str):
-        cmd = "netstat -s | grep -i listen"
-        output = localhost.shell(cmd)["stdout"]
-        logging.info(f"[{stage}] Listen queue metrics:\n{output}")
+        # Placeholder: If you want to log metrics, parse output of 'ss -s', or just log the test stage.
+        logging.info(f"[{stage}] Listen queue metrics logging is not implemented without netstat/ss parser.")
 
     def flood_toggle_all_timeouts():
         toggle_all_url = url(action="toggle_all", toggle_action="drop")
@@ -49,7 +46,6 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
                     timeout=0.1,
                 )
             except requests.exceptions.Timeout:
-                # Expected timeout, ignore
                 pass
             except requests.exceptions.RequestException as e:
                 logging.warning(f"Toggle all request exception: {e}")
@@ -70,10 +66,9 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
             return None
 
     def check_accept_queue_overflow():
-        cmd = "netstat -s | grep -i 'listen queue overflow'"
-        output = localhost.shell(cmd)["stdout"]
-        logging.info(f"Accept queue overflow check output:\n{output}")
-        return "listen queue overflow" in output.lower()
+        # Placeholder: Implement your overflow check here if you have a sim API/log, else return True/False as needed
+        logging.info("Checking accept queue overflow (logic skipped, no netstat/ss)")
+        return True  # For demonstration, assume overflow occurs
 
     def wait_until_queue_consumed(timeout=10):
         logging.info("Waiting for accept queue to be consumed...")
@@ -87,16 +82,15 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
             time.sleep(delay)
         return None
 
-    # Log listen queue metrics before flooding
+    # Log listen queue metrics before flooding (placeholder)
     log_listen_queue_metrics("Before Toggle All Flood")
 
-    # Start flooding toggle all timeout requests in a separate thread
+    # Flood toggle all timeout requests in separate thread
     toggle_thread = threading.Thread(target=flood_toggle_all_timeouts)
     toggle_thread.start()
+    time.sleep(1)  # Let queue potentially overflow
 
-    time.sleep(1)  # short delay to let accept queue potentially overflow
-
-    # Step 1: Check accept queue overflow
+    # Step 1: Check accept queue overflow (simulated)
     pytest_assert(check_accept_queue_overflow(), "Accept queue did not overflow as expected")
 
     # Step 2: Attempt sending a new request during overflow
@@ -118,7 +112,7 @@ def test_mux_simulator_toggle_all_accept_queue_overflow(
         "New request not accepted after queue consumption"
     )
 
-    # Log listen queue metrics after flooding & consumption
+    # Log after flooding (placeholder)
     log_listen_queue_metrics("After Toggle All Flood & Queue Consumption")
 
     # Validate per-port mux status for stale requests

--- a/tests/dualtor_mgmt/test_mux_simulator_timeout.py
+++ b/tests/dualtor_mgmt/test_mux_simulator_timeout.py
@@ -1,0 +1,73 @@
+import pytest
+import time
+import requests
+import logging
+from typing import List
+
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+
+def test_mux_simulator_timeout_cleanup(
+    duthosts,
+    tbinfo,
+    active_standby_ports: List[str],
+    url,
+    get_mux_status,
+    restart_mux_simulator
+) -> None:
+    """
+    Validate that mux_simulator correctly handles and cleans up timeout requests.
+
+    Test steps:
+    1. Restart mux_simulator to begin with a clean state.
+    2. Flood mux_simulator with multiple requests designed to timeout.
+    3. Allow mux_simulator time to clean up timed-out requests.
+    4. Assert no stale requests remain in mux_simulator’s state.
+    5. Verify mux_simulator accepts new valid requests post-timeout flooding.
+    """
+
+    # Restart mux_simulator to ensure a clean start
+    restart_mux_simulator()
+    time.sleep(2)  # wait for simulator to fully restart
+
+    # Select up to 3 active ports to run timeout tests on
+    test_ports = active_standby_ports[:3] if len(active_standby_ports) >= 3 else active_standby_ports
+
+    # Flood mux_simulator with timeout-inducing requests
+    for iface in test_ports:
+        timeout_request_url = url(interface_name=iface, action="drop")  # 'drop' action triggers timeout simulation
+        for _ in range(10):
+            try:
+                requests.post(
+                    timeout_request_url,
+                    json={"out_sides": ["upper_tor", "lower_tor", "nic"]},
+                    timeout=0.1,  # very short timeout to force client-side timeout
+                )
+            except requests.exceptions.Timeout:
+                # Expected timeout; no action needed
+                pass
+            except requests.exceptions.RequestException as e:
+                # Optional: log unexpected exceptions for debugging
+                logging.warning(f"Non-timeout request exception on {iface}: {e}")
+
+    # Allow mux_simulator time to process and clear timed-out requests
+    time.sleep(3.5)
+
+    # Check that mux_simulator has cleaned up stale requests
+    for iface in test_ports:
+        status = get_mux_status(interface_name=iface)
+        assert status is not None, f"Could not retrieve mux status for interface {iface}"
+        assert "active_side" in status, f"Expected 'active_side' key missing in mux status for {iface}"
+        assert not status.get("stale_request", False), f"Stale request detected for {iface}"
+
+    # Verify mux_simulator accepts new valid requests after timeout cleanup
+    for iface in test_ports:
+        normal_request_url = url(interface_name=iface, action="output")
+        response = requests.post(
+            normal_request_url,
+            json={"out_sides": ["upper_tor"]},
+            timeout=3,
+        )
+        assert response.status_code == 200, f"Failed to accept new request on {iface} after timeouts"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
--># Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

## Summary:
This PR adds a new test case `test_mux_simulator_timeout_cleanup` to validate the mux_simulator’s ability to handle and clean up timeout-induced requests under dualtor topology. It addresses the test gap described in [Issue #16544](https://github.com/sonic-net/sonic-mgmt/issues/16544), with supporting context from [Issue #16495](https://github.com/sonic-net/sonic-mgmt/issues/16495).

Fixes #16544

---

# Type of change
<!--
- Fill x for your type of change.
-->

- [ ] Bug fix  
- [ ] Testbed and Framework (new/improvement)  
- [x] New Test case  
- [ ] Skipped for non-supported platforms  
- [ ] Test case improvement  

---

# Back port request

- [ ] 202205  
- [ ] 202305  
- [ ] 202311  
- [ ] 202405  
- [ ] 202411  
- [ ] 202505  

---

# Approach

## What is the motivation for this PR?
To ensure mux_simulator can recover from timeout-induced socket leaks and listen queue overflows, and continue to accept valid requests post-recovery.

## How did you do it?
- Restarted mux_simulator for a clean state.  
- Flooded it with short-timeout requests using parallel threads.  
- Added system-level diagnostics using `netstat` to monitor listen queue health.  
- Implemented retry logic for mux status validation.  
- Verified simulator’s ability to accept valid requests after timeout cleanup.

## How did you verify/test it?
- Ran the test on dualtor topology with active standby ports.  
- Confirmed no stale requests remained.  
- Verified successful handling of new requests post-timeout flood.  
- Logged system metrics before and after flooding.

## Any platform specific information?
No platform-specific dependencies. Designed to run on dualtor topology.

## Supported testbed topology if it's a new test case?
- dualtor

---

# Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->



