### PR TITLE
Update restapi test to invoke apply_cert_config in smartswitch and isolated topology

### DIFF
--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -135,3 +135,17 @@ def vlan_members(duthosts, rand_one_dut_hostname, tbinfo):
         if vlan_interfaces is not None:
             return vlan_interfaces
     return []
+
+
+@pytest.fixture
+def is_support_warm_fast_reboot(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    support_warm_fast_reboot = True
+    if 'isolated' in duthosts.tbinfo['topo']['name'] or \
+            duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+        support_warm_fast_reboot = False
+        logging.info("Skipping warm and fast reboot tests for isolated topology or smartswitch")
+        logging.info("Applying cert config")
+        apply_cert_config(duthost)
+
+    yield support_warm_fast_reboot

--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -27,7 +27,7 @@ This test checks for reset status and sets it
 '''
 
 
-def test_check_reset_status(construct_url, duthosts, rand_one_dut_hostname, localhost):
+def test_check_reset_status(construct_url, duthosts, rand_one_dut_hostname, localhost, is_support_warm_fast_reboot):
     duthost = duthosts[rand_one_dut_hostname]
     # Set reset status
     logger.info("Checking for RESTAPI reset status")
@@ -56,14 +56,8 @@ def test_check_reset_status(construct_url, duthosts, rand_one_dut_hostname, loca
     response = r.json()
     pytest_assert(response['reset_status'] == "true")
 
-    support_warm_fast_reboot = True
-    if 'isolated' in duthosts.tbinfo['topo']['name'] or \
-            duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
-        support_warm_fast_reboot = False
-        logger.info("Skipping warm and fast reboot tests for isolated topology or smartswitch")
-
     # Check reset status post fast reboot
-    if support_warm_fast_reboot:
+    if is_support_warm_fast_reboot:
         check_reset_status_after_reboot(
             'fast', "false", "true", duthost, localhost, construct_url)
 
@@ -72,7 +66,7 @@ def test_check_reset_status(construct_url, duthosts, rand_one_dut_hostname, loca
         'cold', "false", "true", duthost, localhost, construct_url)
 
     # Check reset status post warm reboot
-    if support_warm_fast_reboot:
+    if is_support_warm_fast_reboot:
         check_reset_status_after_reboot(
             'warm', "false", "false", duthost, localhost, construct_url)
 
@@ -396,7 +390,7 @@ def test_data_path(construct_url, vlan_members, cleanup_after_testing):
         "Routes with incorrect CIDR addresses with vnid: 7036002 to VNET vnet-guid-3 have not been added successfully")
 
 
-def test_data_path_sad(construct_url, vlan_members, cleanup_after_testing):
+def test_data_path_sad(construct_url, vlan_members, cleanup_after_testing, is_support_warm_fast_reboot):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
@@ -673,7 +667,7 @@ This test creates a default VxLAN Tunnel and two VNETs. It adds VLAN, VLAN membe
 '''
 
 
-def test_create_interface(construct_url, vlan_members, cleanup_after_testing):
+def test_create_interface(construct_url, vlan_members, cleanup_after_testing, is_support_warm_fast_reboot):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'
@@ -803,7 +797,7 @@ def test_create_interface(construct_url, vlan_members, cleanup_after_testing):
     logger.info("VNET with vnet_id: vnet-guid-4 has been successfully deleted")
 
 
-def test_create_interface_sad(construct_url, vlan_members):
+def test_create_interface_sad(construct_url, vlan_members, is_support_warm_fast_reboot):
     # Create Default VxLan Tunnel
     if restapi.get_config_tunnel_decap_tunnel_type(construct_url, 'vxlan').status_code == 404:
         params = '{"ip_addr": "10.1.0.32"}'


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update restapi test to invoke apply_cert_config in smartswitch and isolated topology

The configuration needed for the restapi server is added directly to the running config using sonic-db-cli commands: https://git-nbu-sw.nvidia.com/r/gitweb?p=switchx/sonic/sonic-mgmt.git;a=blob;f=tests/restapi/test_restapi.py;h=5be4008d7d4d353e69ff8f032faf2b0badf15a75;hb=refs/heads/develop#l52 And we perform warm-reboot:
https://git-nbu-sw.nvidia.com/r/gitweb?p=switchx/sonic/sonic-mgmt.git;a=blob;f=tests/restapi/test_restapi.py;h=5be4008d7d4d353e69ff8f032faf2b0badf15a75;hb=refs/heads/develop#l75 Which saves the running configuration to the config_db.json as part of the warmboot-finalizer.service script finalize-warmboot.sh https://github.com/nvidia-sonic/sonic-buildimage/blob/0bd8460a403b77ba399a2f4f48e8aaff6c317932/files/image_config/warmboot-finalizer/finalize-warmboot.sh#L208 This causes all subsequent tests to pass as the restapi configuration is saved. In case of smartswitch the running configuration is not saved since warm-reboot is skipped. So add a fixture to invoke apply_cert_config for smartswitch and isolated topology

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Case test_data_path_sad/ test_create_interface / test_create_interface_sad could not run pass at mellanox smartswitch.
#### How did you do it?
Update restapi test to invoke apply_cert_config in smartswitch and isolated topology
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
