### PR TITLE
Add support for ft2 bgp neighbor bgp.test_bgp_update_timer

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -100,8 +100,11 @@ def common_setup_teardown(
 
     if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter", "LowerSpineRouter"]:
         neigh_type = "LeafRouter"
-    elif dut_type == "UpperSpineRouter":
+    elif dut_type in ["UpperSpineRouter", "FabricSpineRouter"]:
         neigh_type = "LowerSpineRouter"
+        if dut_type == "FabricSpineRouter":
+            global NEIGHBOR_ASN0, NEIGHBOR_ASN1
+            NEIGHBOR_ASN0 = NEIGHBOR_ASN1 = dut_asn
     else:
         neigh_type = "ToRRouter"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The test pseudo bgp neighbors in the test cannot be established in FT2 because FT2 only accept either LowerSpineRouter or SpineRouter as the candidate. Neighbor will not have address family unicast since the peer-group is not correctly set

This will change the type of pseudo neighbors for FT2 to be LowerSpineRouter (simulate an LT2). For this to work, the ASN need to be the same as FT2

Fixes # (issue) 3392019

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<img width="1281" height="64" alt="image" src="https://github.com/user-attachments/assets/eda4484b-696d-42f6-948c-c4678a324edf" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
