### PR TITLE
Send ping to bringup IPv6 BFD sessions.

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -370,6 +370,11 @@ def verify_bfd_queue_counters(duthost, dut_intf):
     if queue_pkt_count == 0:
         pytest.fail('Queue 7 packet count is zero, no BFD traffic')
 
+def warm_up_ipv6_neighbors(duthost, neighbor_addrs):
+    for addr in neighbor_addrs:
+        logger.info(f"Warming up IPv6 neighbor {addr}")
+        duthost.shell(f"ping -6 -c 1 -W 1 {addr}", module_ignore_errors=True)
+
 
 @pytest.mark.parametrize('dut_init_first', [True, False], ids=['dut_init_first', 'ptf_init_first'])
 @pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
@@ -387,6 +392,9 @@ def test_bfd_basic(request, rand_selected_dut, ptfhost, tbinfo, ipv6, dut_init_f
         # neighborship can be resolved on PTF side.
         time.sleep(5)
         create_bfd_sessions(ptfhost, duthost, local_addrs, neighbor_addrs, dut_init_first)
+
+        if ipv6:
+            warm_up_ipv6_neighbors(duthost, neighbor_addrs)
 
         time.sleep(1)
         for idx, neighbor_addr in enumerate(neighbor_addrs):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Fixes # (issue)
IPv6 BFD sessions were not coming up when NDP was not resolved. Send ping to complete resolution and for BFD sessions to come up.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
BFD sessions were staying down due to unresolved ipv6 NDP

#### How did you do it?
Add a step to send ping which will resolve the NDP.

#### How did you verify/test it?
Ran the BFD sonic-mgmt tests for Mt Fuji and all passed with the fix.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
