### PR TITLE
Ensure 'portA' and 'portB' are different in pick_ports

### DIFF
--- a/tests/voq/test_voq_ipfwd.py
+++ b/tests/voq/test_voq_ipfwd.py
@@ -243,7 +243,8 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
                     # No pos interfaces, let see if we have other ethernet ports in this asic
                     if len(eths) != 1:
                         # We have more than 1 eth interface, pick it for port B
-                        intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, eths, version, dutA, asic_index,
+                        left_eths = [eth for eth in eths if eth != intfs_to_test['portA']['port']]
+                        intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, left_eths, version, dutA, asic_index,
                                                                      nbrhosts)
         else:
             # port type is portchannel
@@ -256,7 +257,8 @@ def pick_ports(duthosts, all_cfg_facts, nbrhosts, tbinfo, port_type_a="ethernet"
                     # No eth interfaces, let see if we have other pc ports in this asic
                     if len(pos) != 1:
                         # We have more than 1 pc interface, pick it for port B
-                        intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, pos, version, dutA, asic_index,
+                        left_pos = [po for po in pos if po != intfs_to_test['portA']['port']]
+                        intfs_to_test['portB'] = get_info_for_a_port(cfg_facts, left_pos, version, dutA, asic_index,
                                                                      nbrhosts)
 
         if 'portA' in intfs_to_test:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19971 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
When using `pick_ports` function in `test_voq_ipfwd.py`, it was possible that the function chose the same port for 'portA' and 'portB' when forced to choose 2 of the same types of ports. This was causing failures in `test_voq_disrupts.py` which used the function.
#### How did you do it?
Remove 'portA' from candidates for 'portB'.
#### How did you verify/test it?
Ran the failing test a few times to make sure it no longer fails
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A