### PR TITLE
[202411] Adapt test_neighbor_mac_noptf.py to platforms with backplane ports

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -74,9 +74,6 @@ class TestNeighborMacNoPtf:
         localv4 = sum(self.count_routes(asichost, prefix) for prefix in localv4_prefixes)
         # these routes are present only on multi asic device, on single asic platform they will be zero
         internal_prefixes = ["8.", "2603"]
-        if asichost.sonichost.facts['switch_type'] == 'voq':
-            # voq inband_ip's
-            internal_prefixes.append("3")
         internal = sum(self.count_routes(asichost, prefix) for prefix in internal_prefixes)
         # custom filtered ips
         filter = {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  The PR is a cherry-pick and  please check below master PR link
https://github.com/sonic-net/sonic-mgmt/pull/17857
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ X] 202411
- [ ] 202505

### Approach
This PR fixes this issue by filtering out these types of routes when counting them in _get_bgp_routes_asic.
#### What is the motivation for this PR?
test_neighbor_mac_noptf.py errors out on Cisco-8000 SmartSwitch platforms.
#### How did you do it?
During the test, if the duthost asic_type is "cisco-8000", the backplane interface IPs are extracted from the configuration and added to a filter list, which is ignored when counting routes in _get_bgp_routes_asic. The backplane interfaces are identified by their "dpc" role in the port configuration.
#### How did you verify/test it?
ran the tests on t1 topo and tests passed.
arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf
#### Any platform specific information?
The fix in test_neighbor_mac_noptf.py only applies when duthost.facts["asic_type"] == "cisco-8000". Additional platforms with backplane ports can be added in the future as needed.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
