### PR TITLE
Increase wait_for_bgp time for virtual chassis after config reload

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -243,8 +243,9 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
 
             bgp_neighbors = filtered_bgp_neighbors
 
+        wait_time = wait + 300 if modular_chassis and sonic_host.get_facts()['asic_type'] == 'vs' else wait + 120
         pytest_assert(
-            wait_until(wait + 120, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
+            wait_until(wait_time, 10, 0, sonic_host.check_bgp_session_state_all_asics, bgp_neighbors),
             "Not all bgp sessions are established after config reload",
         )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Increase wait_for_bgp time for virtual chassis after config reload since we have seen test cases that failed on teardown because not all bgp sessions recover in 720 seconds.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
