### PR TITLE
Check supervisor-proc-exit-listener process by full path or filename only

### DIFF
--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -72,14 +72,14 @@ def pause_orchagent(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_as
 
 def check_process_status(duthost, process, asic_id):
     result = duthost.shell(
-                        r"docker exec -i swss{} sh -c 'ps -au | grep {}".format(asic_id, process),
+                        r"docker exec -i swss{} sh -c 'pgrep -f {}".format(asic_id, process),
                         module_ignore_errors=True)['stdout']
-    logger.info('Check supervisor-proc-exit-listener running: {}'.format(result))
+    logger.info('Check the process({}) running inside swss{}: {}'.format(process, asic_id, result))
     return result
 
 
 def make_ut_fail_if_process_not_running(duthost, asic_id):
-    result = check_process_status(duthost, "/usr/bin/supervisor-proc-exit-listener'", asic_id)
+    result = check_process_status(duthost, "supervisor-proc-exit-listener", asic_id)
     if not result:
         pytest.fail("Watchfog process is not running.")
 

--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -77,12 +77,14 @@ def check_process_status(duthost, process, asic_id):
     logger.info('Check the process({}) running inside swss{}: {}'.format(process, asic_id, result))
     return result
 
+
 def pgrep_swss_process(duthost, process, asic_id):
     result = duthost.shell(
                         r"docker exec -i swss{} pgrep -f {}".format(asic_id, process),
                         module_ignore_errors=True)['stdout']
     logger.info('Pgrep the process({}) running inside swss{}: {}'.format(process, asic_id, result))
     return result
+
 
 def make_ut_fail_if_process_not_running(duthost, asic_id):
     result = pgrep_swss_process(duthost, "supervisor-proc-exit-listener", asic_id)

--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -72,14 +72,20 @@ def pause_orchagent(duthosts, enum_rand_one_per_hwsku_hostname, enum_rand_one_as
 
 def check_process_status(duthost, process, asic_id):
     result = duthost.shell(
-                        r"docker exec -i swss{} sh -c 'pgrep -f {}".format(asic_id, process),
+                        r"docker exec -i swss{} sh -c 'ps -au | grep {}".format(asic_id, process),
                         module_ignore_errors=True)['stdout']
     logger.info('Check the process({}) running inside swss{}: {}'.format(process, asic_id, result))
     return result
 
+def pgrep_swss_process(duthost, process, asic_id):
+    result = duthost.shell(
+                        r"docker exec -i swss{} pgrep -f {}".format(asic_id, process),
+                        module_ignore_errors=True)['stdout']
+    logger.info('Pgrep the process({}) running inside swss{}: {}'.format(process, asic_id, result))
+    return result
 
 def make_ut_fail_if_process_not_running(duthost, asic_id):
-    result = check_process_status(duthost, "supervisor-proc-exit-listener", asic_id)
+    result = pgrep_swss_process(duthost, "supervisor-proc-exit-listener", asic_id)
     if not result:
         pytest.fail("Watchdog process is not running.")
 

--- a/tests/system_health/test_watchdog.py
+++ b/tests/system_health/test_watchdog.py
@@ -81,7 +81,7 @@ def check_process_status(duthost, process, asic_id):
 def make_ut_fail_if_process_not_running(duthost, asic_id):
     result = check_process_status(duthost, "supervisor-proc-exit-listener", asic_id)
     if not result:
-        pytest.fail("Watchfog process is not running.")
+        pytest.fail("Watchdog process is not running.")
 
     # if orchagent not running, alert will never been triggered
     result = check_process_status(duthost, "/usr/bin/orchagent'", asic_id)


### PR DESCRIPTION
### Description of PR
This relax is needed for https://github.com/sonic-net/sonic-buildimage/pull/23513. Since that PR will change the installation path of supervisor-proc-exit-listener.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
