### PR TITLE
Ensure get_db_dump is not called on rebooting DUT

### DIFF
--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -172,8 +172,9 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
             logging.info("Rebooting dut {}".format(duthost))
             reboot(duthost, localhost, wait_for_ssh=False)
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="stopped", delay=1, timeout=60)
-            pytest_assert(check_db_consistency(duthosts, duthost, post_change_db_dump),
-                          "DB_Consistency Failed During Reboot")
+            if len(duthosts) > 1:
+                pytest_assert(check_db_consistency(duthosts, duthost, post_change_db_dump),
+                              "DB_Consistency Failed During Reboot")
             localhost.wait_for(host=duthost.mgmt_ip, port=22, state="started", delay=10, timeout=300)
             pytest_assert(wait_until(330, 20, 0, duthost.critical_services_fully_started),
                           "All critical services should fully started!")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #19980 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
`test_voq_chassis_app_db_consisitency.py` reboot_dut case on dT2 would fail with `Timeout (62s) waiting for privilege escalation prompt:` as it would try to perform `get_db_dump` on the rebooting dut. Not a problem for T2 as the DUT rebooting is always a frontend node and `get_db_dump` is always called on a supervisor node.
#### How did you do it?
Made a change so test would only `check_db_consistency` on a rebooting DUT if there are more than 1 DUT (basically if it's T2)
#### How did you verify/test it?
Ran the test, didn't see the same failure.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A