### PR TITLE
Check for comments in sai.profile lines in the test_link_local_ip.py

### DIFF
--- a/tests/ip/link_local/test_link_local_ip.py
+++ b/tests/ip/link_local/test_link_local_ip.py
@@ -61,7 +61,7 @@ class TestLinkLocalIPacket:
         sai_settings = {}
         sai_profile = "/usr/share/sonic/device/{}/{}/sai.profile".format(platform, hwsku)
         for line in duthost.command("cat %s" % sai_profile)["stdout_lines"]:
-            if (not re.match("^#", line)) and re.search("=", line):
+            if (not re.match("^[ \t]*#", line)) and re.search("=", line):
                 # line should not a comment, and must contain the "=".
                 key, value = line.split("=")
                 sai_settings[key] = value


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The issue is the loop at:
```
        sai_profile = "/usr/share/sonic/device/{}/{}/sai.profile".format(platform, hwsku)
        for line in duthost.command("cat %s" % sai_profile)["stdout_lines"]:
            key, value = line.split("=")
            sai_settings[key] = value
```
The check in line.split() fails if there is a comment line in the sai.profile. This PR updates the loop to ignore the comment lines and lines without a = sign.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Pls see the description.