### PR TITLE
skip upgrade path in T1 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5018,6 +5018,7 @@ upgrade_path:
       Skipped due to one or more unsupported conditions:
       - Upgrade path test needs base and target image lists, currently do not support on KVM.
       - Not supported on t1 topology
+    conditions_logical_operator: or
     conditions:
       - "asic_type in ['vs']"
       - "'t1' in topo_type and asic_type in ['marvell-teralynx']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Upgrade path test case skip for T1 topology on asic "marvell-teralynx"

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Upgrade_path is expecting portchannel and vlan members which are unavailable in T1 topology.

#### How did you do it?
Added skip conditions in tests_mark_conditions.yaml for upgrade_path

#### How did you verify/test it?
Run the test on marvell-teralynx asic,
upgrade_path/test_multi_hop_upgrade_path.py::test_multi_hop_upgrade_path[str-marvell-tl10-01] SKIPPED (Not supported on t1 to
upgrade_path/test_upgrade_path.py::test_double_upgrade_path[str-marvell-tl10-01] SKIPPED (Not supported on t1 topo.)
upgrade_path/test_upgrade_path.py::test_upgrade_path[str-marvell-tl10-01] SKIPPED (Not supported on t1 topo.)
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[sad-str-marvell-tl10-01] SKIPPED (Not supported on t1 topo.)
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[multi_sad-str-marvell-tl10-01] SKIPPED (Not supported on t1 top
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[sad_bgp-str-marvell-tl10-01] SKIPPED (Not supported on t1 topo.
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[sad_lag_member-str-marvell-tl10-01] SKIPPED (Not supported on t
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[sad_lag-str-marvell-tl10-01] SKIPPED (Not supported on t1 topo.
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[sad_vlan_port-str-marvell-tl10-01] SKIPPED (Not supported on t1
upgrade_path/test_upgrade_path.py::test_warm_upgrade_sad_path[sad_inboot-str-marvell-tl10-01] SKIPPED (Not supported on t1 to

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
