### PR TITLE
Marking Sub port interface port-in lag cases xFAIL due to community issues

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2428,6 +2428,18 @@ sub_port_interfaces/test_show_subinterface.py::test_subinterface_status[port_in_
   skip:
     reason: "Not supported port type"
 
+sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-l3-TCP-UDP-ICMP]:
+  xfail:
+    reason: "This test case may fail due to a known issue https://github.com/sonic-net/sonic-swss/issues/3498"
+    conditions:
+      - "https://github.com/sonic-net/sonic-swss/issues/3498 and 't1' in topo_name"
+
+sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-svi-TCP-UDP-ICMP]:
+  xfail:
+    reason: "This test case may fail due to a known issue https://github.com/sonic-net/sonic-swss/issues/3498"
+    conditions:
+      - "https://github.com/sonic-net/sonic-swss/issues/3498 and 't1' in topo_name"
+
 sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_unaffected_by_sub_ports_removal[port_in_lag:
   skip:
     reason: "Not supported port type"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Added conditional markers to XFAIL for Sub port interface port-in lag cases due to the open community issues

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Added conditional markers to XFAIL for Sub port interface port-in lag cases due to the open community issues

#### How did you do it?
Added xFAIL conditions in tests_mark_conditions.yaml for sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-svi-TCP-UDP-ICMP] and sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-l3-TCP-UDP-ICMP]

#### How did you verify/test it?
Run the test on marvell-teralynx asic,
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-svi-TCP-UDP-ICMP] XPASS (This test case may fail due to a known issue https://gi/...) [ 75%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-svi-TCP-UDP-ICMP] XFAIL (This test case may fail due to a known issue https://gi/...) [ 75%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-l3-TCP-UDP-ICMP] XPASS (This test case may fail due to a known issue https://git/...) [100%]
sub_port_interfaces/test_sub_port_interfaces.py::TestSubPorts::test_routing_between_sub_ports_and_port[port_in_lag-l3-TCP-UDP-ICMP] XFAIL (This test case may fail due to a known issue https://git/...) [100%]


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
