### PR TITLE
XonHyst test case tuning for Cisco 8101 with dynamic threshold 0 or more

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -69,10 +69,12 @@ class QosParamCisco(object):
              self.lossless_drop_tuning_pkts) = asic_params[dutAsic]
 
             self.flow_config = self.get_expected_flow_config()
+            self.dynamic_th = None
 
             # Calculate attempted pause threshold
             if "dynamic_th" in lossless_prof:
                 dynamic_th = int(lossless_prof["dynamic_th"])
+                self.dynamic_th = dynamic_th
                 alpha = 2 ** dynamic_th
                 if dutAsic == "gr2":
                     attempted_pause = int((self.ingress_pool_size - self.ingress_pool_headroom) * alpha / (1. + alpha))
@@ -850,8 +852,20 @@ class QosParamCisco(object):
 
             else:  # 8101/Q200
 
+                # Dynamic Threshold change from -2 to 0 change:
+                # ---------------------------------------------
+                #
+                # The last port in each of these MB-fill lists below is checked to trigger
+                # XOFF. The other ports at 5MB are not intended to trigger XOFF, but
+                # merely to fill the SQG or counterA without dropping traffic due to the
+                # pause threshold at 5MB. If the pause threshold increases for the last
+                # port from a reduced threshold to 5MB due to the alpha change, set the
+                # number of packets to send on the last port to 5.1MB to trigger
+                # XOFF. Required for parametrizations 1, 2, 3, and 6.
+                is_maxed = self.dynamic_th is not None and self.dynamic_th >= 0
+
                 # 5*10 + 4 = 54 MB
-                sq_occupancies_mb = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4]
+                sq_occupancies_mb = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5.1 if is_maxed else 4]
                 params_1 = {"packet_size": packet_size,
                             "ecn": 1,
                             "dscps":      [3, 4, 3, 4, 3,  4,  3,  4,  3,  4,  3],
@@ -863,7 +877,7 @@ class QosParamCisco(object):
                 self.write_params("xon_hysteresis_1", params_1)
 
                 # 3 + 2 + 5*9 + 3(3) = 59 MB
-                sq_occupancies_mb = [3, 2, 5, 5, 5, 5, 5, 5, 5, 5, 5, 3, 3, 3]
+                sq_occupancies_mb = [3, 2, 5, 5, 5, 5, 5, 5, 5, 5, 5, 3, 3, 5.1 if is_maxed else 3]
                 params_2 = {"packet_size": packet_size,
                             "ecn": 1,
                             "dscps":      [3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
@@ -877,7 +891,7 @@ class QosParamCisco(object):
                 # Total: 67.5 MB
                 # lossy: 5(5) = 25
                 # lossless: 3 + 2 + 5(5) + 4 + 3(2) + 2.5 = 42.5
-                sq_occupancies_mb = [3, 5, 5, 5, 5, 5, 2, 5, 5, 5, 5, 5, 4, 3, 3, 2.5]
+                sq_occupancies_mb = [3, 5, 5, 5, 5, 5, 2, 5, 5, 5, 5, 5, 4, 3, 3, 5.1 if is_maxed else 2.5]
                 params_3 = {"packet_size": packet_size,
                             "ecn": 1,
                             "dscps":      [3, self.dscp_queue1, self.dscp_queue0,
@@ -926,7 +940,7 @@ class QosParamCisco(object):
                 # Total: 64MB MB
                 # lossy: 5 MB
                 # lossless: 3 + 2 + 5(9) + 3(3) = 59MB
-                sq_occupancies_mb = [3, 2, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 3, 3, 3]
+                sq_occupancies_mb = [3, 2, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 3, 3, 5.1 if is_maxed else 3]
                 params_6 = {"packet_size": packet_size,
                             "ecn": 1,
                             "dscps":      [3, 4, self.dscp_queue1, 3, 4, 3, 4, 3, 4, 3,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enables test_qos_sai.py tuning for Cisco-8101 when alpha is >=0. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Validated XonHyst test parametrizations all pass when dynamic thr is 0 and -2 on Cisco-8101. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
