### PR TITLE
Change ip_opt_action in vrf test case from drop to deny

### DIFF
--- a/tests/vrf/vrf_attr_ip_opt_action.json
+++ b/tests/vrf/vrf_attr_ip_opt_action.json
@@ -1,7 +1,7 @@
 {
     "VRF": {
         "Vrf1": {
-            "ip_opt_action": "drop"
+            "ip_opt_action": "deny"
         },
         "Vrf2": {
             "ip_opt_action": "forward"


### PR DESCRIPTION

### Description of PR
Fixing the vrf/test_vrf_attr.py::TestVrfAttrIpAction::test_vrf1_drop_pkts_with_ip_opt, which was failing due to wrong usage of SAI attribute.

Summary:
Fixes # [(issue)](https://github.com/sonic-net/sonic-mgmt/issues/10165)

### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The case vrf/test_vrf_attr.py::TestVrfAttrIpAction::test_vrf1_drop_pkts_with_ip_opt should apply "deny" instead of "drop".

This is because according to [SAI](https://github.com/opencomputeproject/SAI/blob/683d72720b3318f83c54074edfa501ea6812550d/inc/saivirtualrouter.h#L96) the default ip_opt_action is "trap" which means [COPY and DROP](https://github.com/opencomputeproject/SAI/blob/683d72720b3318f83c54074edfa501ea6812550d/inc/saiswitch.h#L114). So if apply "drop" again, the CPU path are still COPY.

#### How did you do it?
Modify the tests/vrf/vrf_attr_ip_opt_action.json to change "ip_opt_action": "drop" to "ip_opt_action": "deny"

#### How did you verify/test it?
Run the test : vrf/test_vrf_attr.py::TestVrfAttrIpAction::test_vrf1_drop_pkts_with_ip_opt

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
