### PR TITLE
update autoneg setting to support 'off' when deploy-mg

### DIFF
--- a/ansible/templates/minigraph_link_meta.j2
+++ b/ansible/templates/minigraph_link_meta.j2
@@ -5,7 +5,7 @@
 {%- endif -%}
 
 {%- if device_conn is defined and inventory_hostname in device_conn and
-      device_conn[inventory_hostname].values() | selectattr('autoneg', 'defined') | selectattr('autoneg', 'equalto', 'on') | list | length > 0 -%}
+      device_conn[inventory_hostname].values() | selectattr('autoneg', 'defined') | selectattr('autoneg', 'in', ['on', 'off']) | list | length > 0 -%}
     {% set ns.link_metadata_defined = True %}
 {%- endif -%}
 {% if ns.link_metadata_defined %}
@@ -61,13 +61,17 @@
 {% if device_conn is defined and inventory_hostname in device_conn %}
 {% for iface_name in device_conn[inventory_hostname].keys() %}
 {% if iface_name in device_conn[inventory_hostname] and 'autoneg' in device_conn[inventory_hostname][iface_name] %}
-{% if 'on' in device_conn[inventory_hostname][iface_name]['autoneg'] %}
+{% if device_conn[inventory_hostname][iface_name]['autoneg'] in ['on', 'off'] %}
         <a:LinkMetadata>
             <a:Name i:nil="true"/>
             <a:Properties>
                 <a:DeviceProperty>
                     <a:Name>AutoNegotiation</a:Name>
+{% if device_conn[inventory_hostname][iface_name]['autoneg'] in ['on'] %}
                     <a:Value>True</a:Value>
+{% else %}
+                    <a:Value>False</a:Value>
+{% endif %}
                     </a:DeviceProperty>
 {% if msft_an_enabled is defined %}
                  <a:DeviceProperty>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Current 'autoneg' column in links.csv only support 'on'.  If it's  'off' or other settings, it will default to platform.json behavior.
This PR add the support for 'off' settings.  
For  DUT which want to use the default behavior, it can leave that column empty, or use any other value, e.g. 'none'

Note: There will be a behavior change if user is using `off` in links.csv already for their DUT.
old behavior:  the autoneg settings will be derived from platform.json, which chould be `on` or `off` or not defined.
new behavior:  will be `off` always.
If users is using `off` already, they need to update their links.csv to leave autoneg field as empty if they want to use the default settings in platform.json.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
update autoneg setting to support 'off'

#### How did you do it?
Check autoneg value for both `on` and `off` in minigraph

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
