### PR TITLE
Fix exceptions when processing testbeds without PTF.

### DIFF
--- a/ansible/devutil/testbed.py
+++ b/ansible/devutil/testbed.py
@@ -96,7 +96,7 @@ class TestBed(object):
         self.duts = raw_dict.get("duts", raw_dict.get("dut", []))
 
         # Create a PTF node object
-        if "ptf" in raw_dict:
+        if "ptf" in raw_dict and raw_dict["ptf"]:
             self.ptf_node = DeviceInfo(
                 hostname=self.ptf,
                 management_ip=self.ptf_ip.split("/")[0],


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

When generating the testbeds, we will run into exceptions because some testbed and topologies doesn't require PTF to be set, such as PTP.

#### How did you do it?

Ignores these PTF nodes when creating the testbed sessions.

#### How did you verify/test it?

Run locally and works.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
