### PR TITLE
Reduced sleep during snmp_cpu test

### DIFF
--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -49,7 +49,7 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
             duthost.shell("nohup yes > /dev/null 2>&1 & sleep 1")
 
         # Wait for load to reflect in SNMP
-        time.sleep(20)
+        time.sleep(5)
 
         # Gather facts with SNMP version 2
         snmp_facts = get_snmp_facts(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test runs all 16 cores to 100% for more than 20 seconds , and we are hitting timeout in our bulk counters. This is causes expected behavior of-
```
ERR syncd#SDK: [SAI_OBJECT.ERR] ./src/mlnx_sai_object.c[1036]- mlnx_wait_for_bulk_read_event: Failed to wait for an event: Connection timed out, status: -1.
ERR syncd#SDK: [SAI_PORT.ERR] ./src/mlnx_sai_port.c[15367]- mlnx_sai_bulk_port_stats_get: Failed to prepare bulk counter for shared buffer stats.
```

In this PR I Reduced the stress of cpu to 5 seconds, it will keep test functionality while avoiding the expected errors.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?


#### How did you do it?
Reduced stress time to 5 seconds

#### How did you verify/test it?
Ran the test multiple times and verified it passed without the errors in log.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
