### PR TITLE
Add retry for ptf nn agent intialise

### DIFF
--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -1,3 +1,4 @@
+from time import sleep
 import nnpy
 import ptf
 import ptf.platforms.nn as nn
@@ -95,7 +96,14 @@ class PtfTestAdapter(BaseTest):
             ptf_nn_sock_addr = 'tcp://{}:{}'.format(ptfagent.ptf_ip, ptfagent.ptf_nn_port)
             ptf.config['device_sockets'].append((ptfagent.device_num, ptfagent.ptf_port_set, ptf_nn_sock_addr))
 
-            if not self._check_ptf_nn_agent_availability(ptf_nn_sock_addr):
+            for attempt in range(3):
+                if self._check_ptf_nn_agent_availability(ptf_nn_sock_addr):
+                    break
+                else:
+                    logging.warning(f"PTF Adapter NN connection failed {ptf_nn_sock_addr}. Retry ({attempt + 1}/3)")
+                    sleep(5 ** attempt)
+            else:
+                # After 3 failed attempts, raise on the 4th
                 raise PtfAdapterNNConnectionError(ptf_nn_sock_addr)
 
         # update ptf.config based on NN platform and create dataplane instance


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: PTF agent sometimes flaky to initialise and need some time to be available. This PR will add an attempt check for availability to avoid the unstable issues

<img width="1584" height="417" alt="image" src="https://github.com/user-attachments/assets/395ebab5-71c5-4bed-ab8d-efccd1f3c736" />


Fixes # (issue) 3392009

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Described

#### How did you do it?
Add attempt to retry for 3 times, only raise exception if it's still not working after 3 times

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
