### PR TITLE
[Arista] Ignore SRV6 ERR log on Arista platforms

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -344,6 +344,10 @@ r, ".*ERR swss\d*#orchagent:.*handlePortStatusChangeNotification: Failed to get 
 # Ignore SAI_NEXT_HOP_GROUP_ATTR_TYPE unsupported
 r, ".* ERR swss#orchagent:.*queryAttributeEnumValuesCapability:.*returned value \d+ is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE"
 
+# Ignore SRV6 error
+r, ".* ERR syncd#syncd: \[none\] SAI_API_SRV6:_brcm_sai_srv6_config_get:\d+ SRV6 unsupported or not enabled on this device"
+r, ".* ERR syncd#syncd: \[none\] SAI_API_SWITCH:sai_object_type_get_availability:\d+ availablity my_sid failed with error -2."
+
 # https://github.com/sonic-net/sonic-buildimage/issues/22346
 r, ".* ERR hostcfgd: \['sonic-kdump-config'[^]]*\] - failed.*"
 

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -345,8 +345,8 @@ r, ".*ERR swss\d*#orchagent:.*handlePortStatusChangeNotification: Failed to get 
 r, ".* ERR swss#orchagent:.*queryAttributeEnumValuesCapability:.*returned value \d+ is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE"
 
 # Ignore SRV6 error
-r, ".* ERR syncd#syncd: \[none\] SAI_API_SRV6:_brcm_sai_srv6_config_get:\d+ SRV6 unsupported or not enabled on this device"
-r, ".* ERR syncd#syncd: \[none\] SAI_API_SWITCH:sai_object_type_get_availability:\d+ availablity my_sid failed with error -2."
+r, ".* ERR syncd#syncd: .* SAI_API_SRV6:_brcm_sai_srv6_config_get:\d+ SRV6 unsupported or not enabled on this device"
+r, ".* ERR syncd#syncd: .* SAI_API_SWITCH:sai_object_type_get_availability:\d+ availablity my_sid failed with error -2."
 
 # https://github.com/sonic-net/sonic-buildimage/issues/22346
 r, ".* ERR hostcfgd: \['sonic-kdump-config'[^]]*\] - failed.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

We got below loganalyzer failure on latest Arista images. Since this ERR log is only for SRV6, I ignore them in loganalyzer:

```
E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost 720dt-3>" exit code:"1"
E               match: 2
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2025 Aug  2 17:59:33.069264 720dt-3 ERR syncd#syncd: [none] SAI_API_SRV6:_brcm_sai_srv6_config_get:1309 SRV6 unsupported or not enabled on this device
E               
E               2025 Aug  2 17:59:33.069264 720dt-3 ERR syncd#syncd: [none] SAI_API_SWITCH:sai_object_type_get_availability:1002 availablity my_sid failed with error -2.
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Ignore SRV6 ERR in loganalyzer.

#### How did you do it?
Ignore SRV6 ERR in loganalyzer.

#### How did you verify/test it?
Verified by testcase `test_lldp_syncd.py` on Arista-720DT Mx:

```
lldp/test_lldp_syncd.py::test_lldp_entry_table_content[720dt-1] PASSED                                                                                                                                                   [ 20%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_syncd_orchagent[720dt-1] PASSED                                                                                                                                     [ 40%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_flap[720dt-1] PASSED                                                                                                                                                [ 60%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_lldp_restart[720dt-1] PASSED                                                                                                                                        [ 80%]
lldp/test_lldp_syncd.py::test_lldp_entry_table_after_reboot[720dt-1] PASSED                                                                                                                                              [100%]
=============================================================================================== 5 passed, 1 warning in 1014.52s (0:16:54) ===============================================================================================
```

#### Any platform specific information?
Arista.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
