### PR TITLE
Fix default route test for t1-isolated-d128/32

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -48,6 +48,18 @@ def is_in_neighbor(neigh_types, neigh_name):
     return False
 
 
+def get_default_route_upstream_neigh_type(tb):
+    if tb["topo"]["name"] in ["t1-isolated-d128", "t1-isolated-d32"]:
+        return "T0"
+    return get_upstream_neigh_type(tb["topo"]["type"])
+
+
+def get_default_route_all_upstream_neigh_type(tb):
+    if tb["topo"]["name"] in ["t1-isolated-d128", "t1-isolated-d32"]:
+        return "T0"
+    return get_all_upstream_neigh_type(tb["topo"]["type"])
+
+
 def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     """
     Get the information for upstream neighbors present in the testbed
@@ -55,7 +67,7 @@ def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     returns dict: {"upstream_neigh_name" : (ipv4_intf_ip, ipv6_intf_ip)}
     """
     upstream_neighbors = {}
-    neigh_types = get_all_upstream_neigh_type(tb['topo']['type'])
+    neigh_types = get_default_route_all_upstream_neigh_type(tb)
     logging.info("testbed topo {} upstream neigh types {}".format(
         tb['topo']['name'], neigh_types))
 
@@ -88,7 +100,7 @@ def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
 
 
 def get_uplink_ns(tbinfo, bgp_name_to_ns_mapping, device_neigh_metadata):
-    neigh_types = get_all_upstream_neigh_type(tbinfo['topo']['type'])
+    neigh_types = get_default_route_all_upstream_neigh_type(tbinfo)
     asics = set()
     for name, asic in list(bgp_name_to_ns_mapping.items()):
         if not is_in_neighbor(neigh_types, name):
@@ -146,7 +158,7 @@ def test_default_route_set_src(duthosts, tbinfo):
 
     """
     duthost = find_duthost_on_role(
-        duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+        duthosts, get_default_route_upstream_neigh_type(tbinfo), tbinfo)
     asichost = duthost.asic_instance(0 if duthost.is_multi_asic else None)
 
     config_facts = asichost.config_facts(
@@ -187,7 +199,7 @@ def test_default_ipv6_route_next_hop_global_address(duthosts, tbinfo):
 
     """
     duthost = find_duthost_on_role(
-        duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+        duthosts, get_default_route_upstream_neigh_type(tbinfo), tbinfo)
     asichost = duthost.asic_instance(0 if duthost.is_multi_asic else None)
 
     rtinfo = asichost.get_ip_route_info(ipaddress.ip_network("::/0"))
@@ -249,7 +261,7 @@ def test_default_route_with_bgp_flap(duthosts, tbinfo):
                    .format(tbinfo['topo']['name']))
 
     duthost = find_duthost_on_role(
-        duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+        duthosts, get_default_route_upstream_neigh_type(tbinfo), tbinfo)
 
     config_facts = duthost.config_facts(
         host=duthost.hostname, source="running")['ansible_facts']
@@ -295,7 +307,7 @@ def test_ipv6_default_route_table_enabled_for_mgmt_interface(duthosts, tbinfo):
 
     """
     duthost = find_duthost_on_role(
-        duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+        duthosts, get_default_route_upstream_neigh_type(tbinfo), tbinfo)
 
     # When management-vrf enabled, IPV6 route of management interface will not add to 'default' route table
     if is_mgmt_vrf_enabled(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202503

### Approach
#### What is the motivation for this PR?

Fix route/test_default_route.py by setting the appropriate upstream t0 neighbour for t1-isolated-d128/32 topologies

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
