### PR TITLE
[Log analyzer] Ignore lldp failed with 500 server error log

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -369,3 +369,6 @@ r, ".* ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_stats_capability:\d+ stats c
 
 # Ignore all audisp-tacplus Accounting logs
 r, ".* INFO audisp-tacplus: Audisp-tacplus: Accounting: user: .*, tty: .*, host: .*, command: .*, type: \d+, task ID: \d+"
+
+# Ignore lldp error log, don't have real impact
+r, ".* ERR container: docker cmd: stop for lldp failed with 500 Server Error.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Ignore lldp related error log in log analyzer.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
To ignore LLDP-related error logs in the log analyzer—such as those shown below—which are observed only on 512-port devices and have no functional impact.
```
2025 Aug  2 00:04:20.447956 str5-7060x6-512-3 ERR container: docker cmd: stop for lldp failed with 500 Server Error for http+docker://localhost/v1.43/containers/5ff64ad7a6bee49abdc2aee23b458ebfdbf457e0cecc8f5f6550d0c11eddad9a/stop: Internal Server Error ("cannot stop container: 5ff64ad7a6bee49abdc2aee23b458ebfdbf457e0cecc8f5f6550d0c11eddad9a: tried to kill container, but did not receive an exit event")
```
#### How did you do it?
Ignore lldp error log in loganalyzer.

#### How did you verify/test it?
Verify it locally.

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>