### PR TITLE
test_bfd.py, check length before accessing the list

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -236,7 +236,7 @@ def check_dut_bfd_status(duthost, neighbor_addr, expected_state, max_attempts=12
         bfd_state = duthost.shell("sonic-db-cli STATE_DB HGET 'BFD_SESSION_TABLE|default|default|{}' 'state'"
                                   .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']
         logger.info(f'Query state of BFD_SESSION_TABLE|default|default|{neighbor_addr} = {bfd_state}')
-        assert (bfd_state and len(bfd_state)>0), "no bfd session found"
+        assert (bfd_state and len(bfd_state) > 0), "no bfd session found"
         logger.info("BFD state check: {} - {}".format(neighbor_addr, bfd_state[0]))
 
         if expected_state in bfd_state[0]:

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -236,6 +236,7 @@ def check_dut_bfd_status(duthost, neighbor_addr, expected_state, max_attempts=12
         bfd_state = duthost.shell("sonic-db-cli STATE_DB HGET 'BFD_SESSION_TABLE|default|default|{}' 'state'"
                                   .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']
         logger.info(f'Query state of BFD_SESSION_TABLE|default|default|{neighbor_addr} = {bfd_state}')
+        assert (bfd_state and len(bfd_state)>0), "no bfd session found"
         logger.info("BFD state check: {} - {}".format(neighbor_addr, bfd_state[0]))
 
         if expected_state in bfd_state[0]:


### PR DESCRIPTION
test_bfd.py, avoid list index out of range error in the case of bfd session creation failure -- catch it by assertion instead of long crash call stack

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
test_bfd.py, check length before accessing the list

Summary:
Fixes # (issue)
There is "list index out of range" error when bfd session creation fails.
```
 def check_dut_bfd_status(duthost, neighbor_addr, expected_state, max_attempts=12, retry_interval=10):

        for i in range(max_attempts + 1):

            bfd_state = duthost.shell("sonic-db-cli STATE_DB HGET 'BFD_SESSION_TABLE|default|default|{}' 'state'"

                                      .format(neighbor_addr), module_ignore_errors=False)['stdout_lines']

&gt;           http://logger.info ("BFD state check: {} - {}".format(neighbor_addr, bfd_state[0]))

E           IndexError: list index out of range
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
to give a clear failure reason instead of testcase crash log when bfd session creation fails.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
