### PR TITLE
Skipping test_show_chassis_module_status_after_docker_restart for voq chassis

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -906,6 +906,12 @@ platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_status:
     conditions:
       - "'t2_single_node' in topo_name"
 
+platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_status_after_docker_restart:
+  skip:
+    reason: "Restarting all dockers on supervisor leaves the system in unstable state"
+    conditions:
+      - "('voq' in switch_type)"
+
 #######################################
 #####  cli/test_show_platform.py  #####
 #######################################
@@ -947,12 +953,6 @@ platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
     conditions:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
-
-platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_status_after_docker_restart:
-  skip:
-    reason: "Restarting all dockers on supervisor leaves the system in unstable state"
-    conditions:
-      - "('voq' in switch_type)"
 
 ###############################################
 ## counterpoll/test_counterpoll_watermark.py ##

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -948,6 +948,12 @@ platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom:
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6518
 
+platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_status_after_docker_restart:
+  skip:
+    reason: "Restarting all dockers on supervisor leaves the system in unstable state"
+    conditions:
+      - "('voq' in switch_type)"
+
 ###############################################
 ## counterpoll/test_counterpoll_watermark.py ##
 ###############################################


### PR DESCRIPTION
### Description of PR
We need to skip this testcase since restarting all dockers on a supervisor will leave the chassis in unstable state. 
Restarting all dockers (sudo systemctl restart docker) on a supervisor on a voq chassis will cause the chassis database to be cleared. Issue https://github.com/sonic-net/sonic-mgmt/issues/19892
Chassis database holds the information about the linecards and will not relearn the information until linecards push 
the information via a linecard reboot, config reload or a docker restart.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To skip  test_show_chassis_module_status_after_docker_restart for voq chassis since restarting all dockers on a supervisor will leave the chassis in unstable state.

#### How did you do it?
Marked the the testcase to be skipped on voq chassis

#### How did you verify/test it?
Tested on a multi-asics voq chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
