### PR TITLE
Added multi-asic support missing in interface_util

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -226,7 +226,7 @@ def get_physical_port_indices(duthost, logical_intfs=None):
             key, index = line.split(':')
             intf_name = key.split('|')[1].strip()
             cmd_out_dict[intf_name] = int(index.strip())
-        for logical_intf in logical_intfs:
+        for logical_intf in interfaces_per_asic:
             physical_port_index_dict[logical_intf] = cmd_out_dict.get(logical_intf, None)
 
     return physical_port_index_dict


### PR DESCRIPTION

### Description of PR
PR for issue https://github.com/sonic-net/sonic-mgmt/issues/19795

Added multi-asics support missing in PR #19170

A change in test_common/platform/interface_utils.py (get_physical_port_indices)
is causing all testcases in platform_tests/api/test_sfp.py::TestSfpApi to error out with the message:
TypeError: '<' not supported between instances of 'NoneType' and 'int'

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To add multi-asics support to interface_util.py (get_physical_port_indices)

#### How did you do it?
In test_common/platform/interface_utils.py (get_physical_port_indices):
Modified  logical_intfs to interface_per_asic.

#### How did you verify/test it?
Tested on a multi-asics voq chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
