### PR TITLE
[dualotr] Fix disruptions after config reload

### DIFF
--- a/tests/dualtor_io/test_link_failure.py
+++ b/tests/dualtor_io/test_link_failure.py
@@ -421,7 +421,7 @@ def test_active_link_admin_down_config_reload_downstream(
             config_interface_admin_status(upper_tor_host, active_active_ports, "down")
 
             upper_tor_host.shell("config save -y")
-            config_reload(upper_tor_host, wait=60)
+            config_reload(upper_tor_host, safe_reload=True, wait_for_bgp=True)
 
             verify_tor_states(
                 expected_active_host=lower_tor_host,
@@ -433,7 +433,7 @@ def test_active_link_admin_down_config_reload_downstream(
 
             send_t1_to_server_with_action(
                 upper_tor_host, verify=True,
-                stop_after=180,
+                stop_after=60,
                 allowed_disruption=0,
                 allow_disruption_before_traffic=True
             )
@@ -467,7 +467,7 @@ def test_active_link_admin_down_config_reload_link_up_upstream(
             )
 
             upper_tor_host.shell("config save -y")
-            config_reload(upper_tor_host, wait=60)
+            config_reload(upper_tor_host, safe_reload=True, wait_for_bgp=True)
 
             verify_tor_states(
                 expected_active_host=lower_tor_host,
@@ -521,7 +521,7 @@ def test_active_link_admin_down_config_reload_link_up_downstream_standby(
             )
 
             upper_tor_host.shell("config save -y")
-            config_reload(upper_tor_host, wait=60)
+            config_reload(upper_tor_host, safe_reload=True, wait_for_bgp=True)
 
             verify_tor_states(
                 expected_active_host=lower_tor_host,


### PR DESCRIPTION
The device could be unstable after config reload, which results in possible packet drop and test failure.
Let's wait for more time after config reload.
And decrease the I/O verification time to 60s to reduce the test runtime.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The device could be unstable after config reload, which results in
possible packet drop and test failure.
Let's wait for more time after config reload.
And decrease the I/O verification time to 60s to reduce the test runtime.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com

#### How did you do it?
Reload with `safe_reload` and `wait_for_bgp` to allow the DUT to recover.

#### How did you verify/test it?
```
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-1-10] PASSED                         [ 10%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-2-10] PASSED                         [ 20%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-3-10] PASSED                         [ 30%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-4-10] PASSED                         [ 40%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-5-10] PASSED                         [ 50%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-6-10] PASSED                         [ 60%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-7-10] PASSED                         [ 70%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-8-10] PASSED                                                  [ 80%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-9-10] PASSED                         [ 90%]
dualtor_io/test_link_failure.py::test_active_link_admin_down_config_reload_downstream[active-active-10-10] PASSED                        [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
