### PR TITLE
Adding qos test param support for platform x86_64-nokia_ixr7220_d4-r0

### DIFF
--- a/tests/qos/files/qos_params.td4.yaml
+++ b/tests/qos/files/qos_params.td4.yaml
@@ -1,0 +1,483 @@
+qos_params:
+    td4:
+        topo-t0:
+            100000_5m:
+                pkts_num_egr_mem: 270
+                pkts_num_leak_out: 0 
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99804
+                    pkts_num_trig_ingr_drp: 100041
+                    pkts_num_margin: 0
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99804
+                    pkts_num_trig_ingr_drp: 100041
+                    pkts_num_margin: 0
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [33, 34, 35]
+                    dst_port_id: 32
+                    pgs_num: 37
+                    pkts_num_trig_pfc: 1856
+                    pkts_num_hdrm_full: 1472
+                    pkts_num_hdrm_partial: 552
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99799
+                    pkts_num_trig_ingr_drp: 100036
+                    cell_size: 318
+                    pkts_num_margin: 2
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99799
+                    pkts_num_dismiss_pfc: 0
+                    pkts_num_margin: 0
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99799
+                    pkts_num_dismiss_pfc: 0
+                    pkts_num_margin: 0
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 4
+                    pkts_num_trig_pfc: 99799
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 0
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 80
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 100036
+                    pkts_num_margin: 5
+                    cell_size: 318
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 4
+                    pkts_num_trig_pfc: 99799
+                    pkts_num_trig_ingr_drp: 100039
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80
+                    cell_size: 318
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+            100000_40m:
+                pkts_num_egr_mem: 270
+                pkts_num_leak_out: 0 
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99804
+                    pkts_num_trig_ingr_drp: 100061
+                    pkts_num_margin: 0
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99804
+                    pkts_num_trig_ingr_drp: 100061
+                    pkts_num_margin: 0
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [33, 34, 35]
+                    dst_port_id: 32
+                    pgs_num: 37
+                    pkts_num_trig_pfc: 1856
+                    pkts_num_hdrm_full: 1472
+                    pkts_num_hdrm_partial: 552
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99799
+                    pkts_num_trig_ingr_drp: 100056
+                    cell_size: 318
+                    pkts_num_margin: 5
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99804
+                    pkts_num_dismiss_pfc: 0
+                    pkts_num_margin: 0
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99804
+                    pkts_num_dismiss_pfc: 0
+                    pkts_num_margin: 0
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 4
+                    pkts_num_trig_pfc: 99799
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 0
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 80
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 100056
+                    pkts_num_margin: 5
+                    cell_size: 318
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 4
+                    pkts_num_trig_pfc: 99799
+                    pkts_num_trig_ingr_drp: 100059
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80
+                    cell_size: 318
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+            400000_5m:
+                pkts_num_egr_mem: 646
+                pkts_num_leak_out: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100308
+                    pkts_num_margin: 5
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100308
+                    pkts_num_margin: 5
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [33,34,35]
+                    dst_port_id: 33
+                    pgs_num: 37
+                    pkts_num_trig_pfc: 1856
+                    pkts_num_hdrm_full: 1472
+                    pkts_num_hdrm_partial: 552
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100308
+                    cell_size: 318
+                    pkts_num_margin: 5
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_dismiss_pfc: 8
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_dismiss_pfc: 8
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80 
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 4
+                    pkts_num_trig_pfc: 99819
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 0
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 80
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 100308
+                    cell_size: 318
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 4
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100308
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80
+                    cell_size: 318
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+            400000_40m:
+                pkts_num_egr_mem: 646
+                pkts_num_leak_out: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100394
+                    pkts_num_margin: 5
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100394
+                    pkts_num_margin: 5
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [33, 34, 35]
+                    dst_port_id: 32
+                    pgs_num: 37
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_hdrm_full: 562
+                    pkts_num_hdrm_partial: 502
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99819
+                    pkts_num_trig_ingr_drp: 100387
+                    cell_size: 318
+                    pkts_num_margin: 5
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_dismiss_pfc: 8
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_dismiss_pfc: 8
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_margin: 80
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 4
+                    pkts_num_trig_pfc: 99819
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 0
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    packet_size: 64
+                    cell_size: 318
+                    pkts_num_margin: 80
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 100394
+                    cell_size: 318
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 4
+                    pkts_num_trig_pfc: 99822
+                    pkts_num_trig_ingr_drp: 100394
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    cell_size: 318
+                    pkts_num_margin: 80
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 11715
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 318
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 318
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 318
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 318
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 318
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 280
+                q1_num_of_pkts: 280
+                q2_num_of_pkts: 280
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 280
+                q6_num_of_pkts: 280
+                q7_num_of_pkts: 280
+                limit: 400
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 160
+                q1_num_of_pkts: 160
+                q2_num_of_pkts: 160
+                q3_num_of_pkts: 600
+                q4_num_of_pkts: 600
+                q5_num_of_pkts: 160
+                q6_num_of_pkts: 160
+                q7_num_of_pkts: 160
+                limit: 400
+                lossy_weight: 8
+                lossless_weight: 30
+            hdrm_pool_wm_multiplier: 1
+            cell_size: 318

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -58,7 +58,7 @@ class QosBase:
                           "t1-isolated-d448u15-lag", "t1-isolated-v6-d448u15-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "spc5",
-                           "td3", "th3", "j2c+", "jr2", "th5"]
+                           "td3", "td4", "th3", "j2c+", "jr2", "th5"]
 
     BREAKOUT_SKUS = ['Arista-7050-QX-32S']
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -198,7 +198,8 @@ class TestQosSai(QosSaiBase):
         'Arista-7260CX3-Q64',
         'Arista-7050CX3-32S-C32',
         'Arista-7050CX3-32S-C28S4',
-        'Arista-7050CX3-32S-D48C8'
+        'Arista-7050CX3-32S-D48C8',
+        'Nokia-IXR7220-D4-36D'
     ]
 
     @pytest.fixture(scope="class", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adding qos parameters to support/run sonic-mgmt qos test for platform x86_64-nokia_ixr7220_d4-r0


Summary:
Fixes #(https://github.com/sonic-net/sonic-mgmt/issues/18681)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Verify sonic-mgmt qos test for the newly introduced 86_64-nokia_ixr7220_d4-r0 platform.

#### How did you do it?
Added file qos_params.td4.yaml and updated qos_sai_base.py and test_qos_sai.py

#### How did you verify/test it?
Executed sonic-mgmt qos tests and verified.

#### Any platform specific information?
x86_64-nokia_ixr7220_d4-r0/broadcom

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
