### PR TITLE
Skip `test_everflow_fwd_recircle_port_queue_check` on single-asic disaggt2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1273,27 +1273,30 @@ everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_eve
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclEgressMirror::test_everflow_fwd_recircle_port_queue_check:
     skip:
-      reason: "Test not supported on non broadcom-dnx and non voq platforms"
+      reason: "Test not supported on non broadcom-dnx and non voq platforms and single-asic disagg-t2"
       conditions_logical_operator: "OR"
       conditions:
         - "(asic_subtype not in ['broadcom-dnx'])"
         - "('voq' not in switch_type)"
+        - "(type in ['UpperSpineRouter'] and is_multi_asic is False)"
 
 everflow/test_everflow_testbed.py::TestEverflowV4EgressAclIngressMirror::test_everflow_fwd_recircle_port_queue_check:
   skip:
-    reason: "Test not supported on non broadcom-dnx and non voq platforms"
+    reason: "Test not supported on non broadcom-dnx and non voq platforms and single-asic disagg-t2"
     conditions_logical_operator: "OR"
     conditions:
       - "(asic_subtype not in ['broadcom-dnx'])"
       - "('voq' not in switch_type)"
+      - "(type in ['UpperSpineRouter'] and is_multi_asic is False)"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclEgressMirror::test_everflow_fwd_recircle_port_queue_check:
   skip:
-    reason: "Test not supported on non broadcom-dnx and non voq platforms"
+    reason: "Test not supported on non broadcom-dnx and non voq platforms and single-asic disagg-t2"
     conditions_logical_operator: "OR"
     conditions:
       - "(asic_subtype not in ['broadcom-dnx'])"
       - "('voq' not in switch_type)"
+      - "(type in ['UpperSpineRouter'] and is_multi_asic is False)"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_basic_forwarding[erspan_ipv6-cli-downstream-default]:
   skip:
@@ -1327,11 +1330,12 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_fwd_recircle_port_queue_check:
   skip:
-    reason: "Test not supported on non broadcom-dnx and non voq platforms"
+    reason: "Test not supported on non broadcom-dnx and non voq platforms and single-asic disagg-t2"
     conditions_logical_operator: "OR"
     conditions:
       - "(asic_subtype not in ['broadcom-dnx'])"
       - "('voq' not in switch_type)"
+      - "(type in ['UpperSpineRouter'] and is_multi_asic is False)"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_neighbor_mac_change[erspan_ipv6-cli-downstream-default]:
   skip:


### PR DESCRIPTION
single-asic disaggt2 boxes don't have an Ethernet-Rec0 port so this test doesn't make sense on those systems.

This test will fail with errors like:
```
E           Port doesn't exist! Ethernet-Rec0
```

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Skipped for non-supported platforms
- [ ] Test case improvement