### PR TITLE
`test_intf_fec.py` skip ports that are link down

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -153,6 +153,9 @@ def test_verify_fec_stats_counters(duthosts, enum_rand_one_per_hwsku_frontend_ho
     for intf in intf_status:
         intf_name = intf['iface']
         speed = duthost.get_speed(intf_name)
+        # Speed is a empty string if the port isn't up
+        if speed == '':
+            continue
         # Convert the speed to gbps format
         speed_gbps = f"{int(speed) // 1000}G"
         if speed_gbps not in SUPPORTED_SPEEDS:


### PR DESCRIPTION
`test_verify_fec_stats_counters` iterates over all ports in `intf_status` (up and down)
A down port is going to return an empty string for it's speed from STATE_DB.
If we try to cast that into an int we'll get the following error:
```
        for intf in intf_status:
            intf_name = intf['iface']
            speed = duthost.get_speed(intf_name)
            # Convert the speed to gbps format
>           speed_gbps = f"{int(speed) // 1000}G"
E           ValueError: invalid literal for int() with base 10: ''
```

Summary:
Fixes #20104 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
