### PR TITLE
[ZMQ] improve ZMQ test to prevent data drop during orchagent down.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3506,3 +3506,4 @@ zmq/test_gnmi_zmq.py:
     conditions:
       - "'arista' in platform"
       - "'isolated' in topo_name"
+      - https://github.com/sonic-net/sonic-buildimage/issues/23622

--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -18,12 +18,13 @@ def get_pid(duthost, process_name):
     return duthost.shell("pgrep {}".format(process_name), module_ignore_errors=True)["stdout"]
 
 
-def save_reload_config(duthost):
+def check_process_ready(duthost, process_name, old_pid):
+    new_pid = get_pid(duthost, process_name)
+    logger.debug("_check_orchagent_ready: {} PID {}".format(process_name, new_pid))
+    return new_pid != "" and new_pid != old_pid
 
-    def _check_process_ready(duthost, process_name, old_pid):
-        new_pid = get_pid(duthost, process_name)
-        logger.debug("_check_orchagent_ready: {} PID {}".format(process_name, new_pid))
-        return new_pid != "" and new_pid != old_pid
+
+def save_reload_config(duthost):
 
     orchagent_pid = get_pid(duthost, "orchagent")
     telemetry_pid = get_pid(duthost, "telemetry")
@@ -33,36 +34,57 @@ def save_reload_config(duthost):
     result = duthost.shell("sudo config reload -y -f", module_ignore_errors=True)
     logger.debug("Reload config: {}".format(result))
 
-    pytest_assert(wait_until(360, 2, 0, _check_process_ready, duthost, "orchagent", orchagent_pid),
+    pytest_assert(wait_until(360, 2, 0, check_process_ready, duthost, "orchagent", orchagent_pid),
                   "The orchagent not start after change subtype")
 
-    pytest_assert(wait_until(360, 2, 0, _check_process_ready, duthost, "telemetry", telemetry_pid),
+    pytest_assert(wait_until(360, 2, 0, check_process_ready, duthost, "telemetry", telemetry_pid),
                   "The telemetry not start after change subtype")
 
 
 @pytest.fixture
 def enable_zmq(duthost):
+
+    # backup orchagent
+    command = 'docker exec swss cp /usr/bin/orchagent.sh /usr/bin/orchagent.sh_backup'
+    duthost.shell(command, module_ignore_errors=True)
+
+    # In default address space, GNMI need connect to local address, but bash table bind to mgmt_ip
+    command = r'docker exec swss sed -i "s|-q tcp:\/\/\${mgmt_ip}|-q tcp:\/\/127.0.0.1|g" /usr/bin/orchagent.sh'
+    result = duthost.shell(command, module_ignore_errors=True)
+    logger.warning("Replace ZMQ address in orchagent.sh: {}".format(result))
+
+    command = 'docker exec swss cat /usr/bin/orchagent.sh'
+    result = duthost.shell(command, module_ignore_errors=True)
+    logger.warning("Fixed orchagent.sh: {}".format(result))
+
+    # enable ZMQ
     command = 'sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" subtype'
     subtype = duthost.shell(command, module_ignore_errors=True)["stdout"]
     logger.debug("subtype: {}".format(subtype))
 
     # the device already enable SmartSwitch
-    if subtype == "SmartSwitch":
-        yield
-        return
+    if subtype != "SmartSwitch":
+        command = 'sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" subtype SmartSwitch'
+        result = duthost.shell(command, module_ignore_errors=True)
+        logger.debug("set subtype subtype: {}".format(result))
 
-    # enable ZMQ
-    command = 'sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" subtype SmartSwitch'
-    result = duthost.shell(command, module_ignore_errors=True)
-    logger.debug("set subtype subtype: {}".format(result))
     save_reload_config(duthost)
 
     yield
 
+    # retore orchagent
+    command = 'docker exec swss cp /usr/bin/orchagent.sh_backup /usr/bin/orchagent.sh'
+    duthost.shell(command, module_ignore_errors=True)
+
     # revert change
-    command = 'sonic-db-cli CONFIG_DB hdel "DEVICE_METADATA|localhost" subtype'
-    result = duthost.shell(command, module_ignore_errors=True)
-    logger.debug("revert subtype subtype: {}".format(result))
+    if subtype != "SmartSwitch":
+        if not subtype:
+            command = 'sonic-db-cli CONFIG_DB hdel "DEVICE_METADATA|localhost" subtype'
+        else:
+            command = 'sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" subtype {}'.format(subtype)
+        result = duthost.shell(command, module_ignore_errors=True)
+        logger.debug("revert subtype subtype: {}".format(result))
+
     save_reload_config(duthost)
 
 
@@ -97,12 +119,8 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list):
     cmd += '--xpath ' + xpath
     cmd += ' '
     cmd += '--value ' + xvalue
-    output = ptfhost.shell(cmd, module_ignore_errors=True)
-    error = "GRPC error\n"
-    if error in output['stdout']:
-        result = output['stdout'].split(error, 1)
-        raise Exception("GRPC error:" + result[1])
-    return
+    logger.warning("gnmi_set command: {}".format(cmd))
+    return ptfhost.shell(cmd, module_ignore_errors=True)['stdout']
 
 
 def test_gnmi_zmq(duthosts,
@@ -111,19 +129,33 @@ def test_gnmi_zmq(duthosts,
                   enable_zmq):
     duthost = duthosts[rand_one_dut_hostname]
 
-    command = 'ps -auxww | grep "/usr/sbin/telemetry -logtostderr --noTLS --port 8080"'
-    gnmi_process = duthost.shell(command, module_ignore_errors=True)["stdout"]
-    logger.debug("gnmi_process: {}".format(gnmi_process))
-
     file_name = "vnet.txt"
     vnet_key = "Vnet{}".format(random.randint(0, 1000))
     text = "{\"" + vnet_key + "\": {\"vni\": \"1000\", \"guid\": \"559c6ce8-26ab-4193-b946-ccc6e8f930b2\"}}"
     with open(file_name, 'w') as file:
         file.write(text)
     ptfhost.copy(src=file_name, dest='/root')
-    # Add DASH_VNET_TABLE
     update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
-    gnmi_set(duthost, ptfhost, [], update_list, [])
+
+    orchagent_pid = get_pid(duthost, "orchagent")
+
+    # stop orchagent make set operation failed
+    command = 'docker exec swss supervisorctl stop orchagent'
+    duthost.shell(command, module_ignore_errors=True)
+
+    result = gnmi_set(duthost, ptfhost, [], update_list, [])
+    logger.warning("gnmi_set result when orch stop: {}".format(result))
+    assert "Resource temporarily unavailable" in result
+
+    # start orchagent make set operation success
+    command = 'docker exec swss supervisorctl start orchagent'
+    duthost.shell(command, module_ignore_errors=True)
+
+    pytest_assert(wait_until(360, 2, 0, check_process_ready, duthost, "orchagent", orchagent_pid),
+                  "The orchagent not start")
+
+    result = gnmi_set(duthost, ptfhost, [], update_list, [])
+    logger.warning("gnmi_set result when orch start: {}".format(result))
 
     command = 'sonic-db-cli APPL_DB keys "*" | grep "DASH_VNET_TABLE:{}"'.format(vnet_key)
     appl_db_key = duthost.shell(command, module_ignore_errors=True)["stdout"]


### PR DESCRIPTION
Improve ZMQ test to prevent data drop during orchagent down.

#### Why I did it
This PR will break zmq/test_gnmi_zmq.py: https://github.com/sonic-net/sonic-swss-common/pull/1059
That PR is fix for: https://github.com/sonic-net/sonic-buildimage/issues/23110
So zmq/test_gnmi_zmq.py need update to handle the change and cover orchagent down scenario

##### Work item tracking
- Microsoft ADO **(number only)**: 33995986

#### How I did it
Ignore zmq/test_gnmi_zmq.py with https://github.com/sonic-net/sonic-buildimage/issues/23622
Improve test case to cover orchagent down scenario。

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Improve ZMQ test to prevent data drop during orchagent down.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


