### PR TITLE
Revert "Add ignore_analyzer to config reloads in voq/test_voq_intfs.py"

### DIFF
--- a/tests/voq/test_voq_intfs.py
+++ b/tests/voq/test_voq_intfs.py
@@ -50,7 +50,6 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         if intf_config_facts['BGP_NEIGHBOR'][a_bgp_neighbor]['local_addr'] in portchannel_ips:
             bgp_nbrs_to_portchannel.append(a_bgp_neighbor.lower())
 
-    ignore_loganalyzer = True if duthost.get_facts()['asic_type'] == 'vs' else False
     try:
         logger.info("remove ethernet from a portchannel to use for interface create")
         intf = portchannel_members[0]
@@ -68,8 +67,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         logger.info("Save and reload config")
 
         duthost.shell_cmds(cmds=["config save -y"])
-        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True,
-                      ignore_loganalyzer=ignore_loganalyzer)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts, bgp_nbrs_to_portchannel),
                       "All BGP's are not established after ports removed from LAG and IP added to one of them")
         logger.info("Check interfaces after add.")
@@ -99,8 +97,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
         logger.info("Save and reload config")
 
         duthost.shell_cmds(cmds=["config save -y"])
-        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True,
-                      ignore_loganalyzer=ignore_loganalyzer)
+        config_reload(duthost, config_source='config_db', safe_reload=True, check_intf_up_ports=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts, bgp_nbrs_to_portchannel),
                       "All BGP's are not established after added IP removed from a LAG member")
         logger.info("check interface is gone after config reload")
@@ -116,8 +113,7 @@ def test_cycle_voq_intf(duthosts, all_cfg_facts, nbrhosts, nbr_macs):
     finally:
         # restore interface from minigraph
         logger.info("Restore config from minigraph.")
-        config_reload(duthost, config_source='minigraph', override_config=True, safe_reload=True,
-                      check_intf_up_ports=True, ignore_loganalyzer=ignore_loganalyzer)
+        config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True)
         pytest_assert(wait_until(300, 10, 0, check_bgp_neighbors, duthosts),
                       "All BGP's are not established after config reload from original minigraph")
         duthost.shell_cmds(cmds=["config save -y"])


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#19982 since it did not resolve the problem and instead it caused persistent failures that affect other T2 test cases