### PR TITLE
Ignore router advertisements in PTF

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -190,6 +190,10 @@
     command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.route.max_size=168000
     become: yes
 
+  - name: Don't accept ipv6 router advertisements for docker container ptf_{{ vm_set_name }}
+    command: docker exec -i ptf_{{ vm_set_name }} sysctl -w net.ipv6.conf.default.accept_ra=0
+    become: yes
+
   - name: Create file to store dut type in PTF
     command: docker exec -i ptf_{{ vm_set_name }} sh -c 'echo {{ hostvars[duts_name.split(',')[0]]['type'] }} > /sonic/dut_type.txt'
     when:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Ignore any router advertisements sent by a DUT, and don't set a default route or an address based on it. This could happen if a T0 testbed with radv running sends router advertisements on a VLAN interface, which may result in the PTF container adding a default route on all of the VLAN interfaces. This could result in some IPv6 test cases breaking.

#### How did you do it?

Set the `net.ipv6.conf.default.accept_ra` sysctl to 0 when creating the PTF container. All of the interfaces that get created/moved into the PTF container then inherit this setting.

#### How did you verify/test it?

Ran add-topo for vms-kvm-t0, and verified that the router advertisements sent by the T0 didn't result in a default route being learned.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
