### PR TITLE
Add instances to shorten PR test time

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -69,7 +69,7 @@ steps:
     pip install azure-kusto-data
     pip install azure-kusto-data azure-identity
 
-    INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }})
+    INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
 
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Get instances number fails."

--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -64,7 +64,7 @@ def get_access_token():
         raise Exception(f"Failed to get token after {MAX_GET_TOKEN_RETRY_TIMES} attempts")
 
 
-def main(scripts, topology, branch, prepare_time):
+def main(scripts, topology, branch, prepare_time, target_pr_test_time):
     ingest_cluster = os.getenv("TEST_REPORT_QUERY_KUSTO_CLUSTER_BACKUP")
     access_token = get_access_token()
 
@@ -125,7 +125,7 @@ def main(scripts, topology, branch, prepare_time):
     # As we need some time to prepare testbeds, the prepare time should be subtracted.
     # Obtain the number of instances by rounding up the calculation.
     # To prevent unexpected situations, we set the maximum number of instance
-    print(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER))
+    print(min(math.ceil(total_running_time / 60 / (target_pr_test_time - prepare_time)), MAX_INSTANCE_NUMBER))
 
 
 if __name__ == '__main__':
@@ -134,10 +134,12 @@ if __name__ == '__main__':
     parser.add_argument("--scripts", help="Test scripts to be executed", type=str, default="")
     parser.add_argument("--branch", help="Test branch", type=str, default="")
     parser.add_argument("--prepare_time", help="Time for preparing testbeds", type=int, default=30)
+    parser.add_argument("--target_pr_test_time", help="Target PR test time", type=int, default=120)
     args = parser.parse_args()
 
     scripts = args.scripts
     topology = args.topology
     branch = args.branch
     prepare_time = args.prepare_time
-    main(scripts, topology, branch, prepare_time)
+    target_pr_test_time = args.target_pr_test_time
+    main(scripts, topology, branch, prepare_time, target_pr_test_time)

--- a/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
+++ b/.azure-pipelines/impacted_area_testing/calculate_instance_number.py
@@ -125,7 +125,7 @@ def main(scripts, topology, branch, prepare_time):
     # As we need some time to prepare testbeds, the prepare time should be subtracted.
     # Obtain the number of instances by rounding up the calculation.
     # To prevent unexpected situations, we set the maximum number of instance
-    print(min(math.ceil(total_running_time / 60 / (180 - prepare_time)), MAX_INSTANCE_NUMBER))
+    print(min(math.ceil(total_running_time / 60 / (120 - prepare_time)), MAX_INSTANCE_NUMBER))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Our goal is limit PR test into 120 mins, previously due to lack of PR test instances and Elastictest limitation, we set it to 180 mins, but now we have enough instances and Elastictest limitation was fixed, we can use more instances to lower PR test time.
#### How did you do it?
Set target PR test time to 120 mins in library, and import from group, then we don't need to change it in code.
#### How did you verify/test it?
Before change:
2025-08-07T05:18:29.0819937Z INFO:root:Total running time: 112067.61339999993
2025-08-07T05:18:29.1170502Z + INSTANCE_NUMBER=13
After change:
2025-08-07T07:27:51.3542401Z INFO:root:Total running time: 112067.61339999993
2025-08-07T07:27:51.3974217Z + INSTANCE_NUMBER=21
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
