### PR TITLE
[Mellanox] Updated SN5600 section in sku-sensors-data.yml

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -6152,11 +6152,11 @@ sensors_checks:
       - dps460-i2c-4-5a/PSU-2(R) 220V Rail (in)/in1_lcrit_alarm
       - dps460-i2c-4-5a/PSU-2(R) 220V Rail (in)/in1_crit_alarm
       - dps460-i2c-4-5a/PSU-2(R) 220V Rail Pwr (in)/power1_alarm
-      - dps460-i2c-4-5a/PSU-2(R) 12V Rail Pwr (out)/power2_max_alarm
-      - dps460-i2c-4-5a/PSU-2(R) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-5a/PSU-2(R) 54V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-5a/PSU-2(R) 54V Rail Pwr (out)/power2_crit_alarm
       - dps460-i2c-4-5a/PSU-2(R) 220V Rail Curr (in)/curr1_max_alarm
-      - dps460-i2c-4-5a/PSU-2(R) 12V Rail Curr (out)/curr2_max_alarm
-      - dps460-i2c-4-5a/PSU-2(R) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-5a/PSU-2(R) 54V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-5a/PSU-2(R) 54V Rail Curr (out)/curr2_crit_alarm
 
       - mp2975-i2c-5-68/PMIC-7 PSU 13V5 Rail (in1)/in1_crit_alarm
       - mp2975-i2c-5-68/PMIC-7 DVDD_T2 ADJ Rail (out1)/in2_lcrit_alarm
@@ -6229,11 +6229,11 @@ sensors_checks:
       - dps460-i2c-4-59/PSU-1(L) 220V Rail (in)/in1_lcrit_alarm
       - dps460-i2c-4-59/PSU-1(L) 220V Rail (in)/in1_crit_alarm
       - dps460-i2c-4-59/PSU-1(L) 220V Rail Pwr (in)/power1_alarm
-      - dps460-i2c-4-59/PSU-1(L) 12V Rail Pwr (out)/power2_max_alarm
-      - dps460-i2c-4-59/PSU-1(L) 12V Rail Pwr (out)/power2_crit_alarm
+      - dps460-i2c-4-59/PSU-1(L) 54V Rail Pwr (out)/power2_max_alarm
+      - dps460-i2c-4-59/PSU-1(L) 54V Rail Pwr (out)/power2_crit_alarm
       - dps460-i2c-4-59/PSU-1(L) 220V Rail Curr (in)/curr1_max_alarm
-      - dps460-i2c-4-59/PSU-1(L) 12V Rail Curr (out)/curr2_max_alarm
-      - dps460-i2c-4-59/PSU-1(L) 12V Rail Curr (out)/curr2_crit_alarm
+      - dps460-i2c-4-59/PSU-1(L) 54V Rail Curr (out)/curr2_max_alarm
+      - dps460-i2c-4-59/PSU-1(L) 54V Rail Curr (out)/curr2_crit_alarm
 
       - mp2975-i2c-5-67/PMIC-6 PSU 13V5 Rail (in1)/in1_crit_alarm
       - mp2975-i2c-5-67/PMIC-6 DVDD_T0 ADJ Rail (out1)/in2_lcrit_alarm
@@ -6244,15 +6244,15 @@ sensors_checks:
       - mp2975-i2c-5-67/PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)/curr1_alarm
       - mp2975-i2c-5-67/PMIC-6 DVDD_T0 Rail Curr (out1)/curr2_alarm
 
-      - mp2975-i2c-39-6b/PMIC-6 PSU 12V Rail (vin)/in1_crit_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX VCORE (out1)/in2_lcrit_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX VCORE (out1)/in2_crit_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX VCCSA (out2)/in3_lcrit_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX VCCSA (out2)/in3_crit_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX Pwr (pin)/power1_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX Curr (iin)/curr1_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX VCORE Rail Curr (out1)/curr2_alarm
-      - mp2975-i2c-39-6b/PMIC-6 COMEX VCCSA Rail Curr (out2)/curr6_alarm
+      - mp2975-i2c-39-6b/PMIC-12 PSU 13V5 Rail (vin)/in1_crit_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX VCORE (out1)/in2_lcrit_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX VCORE (out1)/in2_crit_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX VCCSA (out2)/in3_lcrit_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX VCCSA (out2)/in3_crit_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX Pwr (pin)/power1_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX Curr (iin)/curr1_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX VCORE Rail Curr (out1)/curr2_alarm
+      - mp2975-i2c-39-6b/PMIC-12 COMEX VCCSA Rail Curr (out2)/curr6_alarm
 
       - mp2975-i2c-5-64/PMIC-3 PSU 13V5 Rail (in1)/in1_crit_alarm
       - mp2975-i2c-5-64/PMIC-3 VDD_T2 ADJ Rail (out1)/in2_lcrit_alarm
@@ -6332,8 +6332,8 @@ sensors_checks:
       - mp2975-i2c-5-67/PMIC-6 DVDD_T0 ADJ Temp 1/temp1_max_alarm
       - mp2975-i2c-5-67/PMIC-6 DVDD_T0 ADJ Temp 1/temp1_crit_alarm
 
-      - mp2975-i2c-39-6b/PMIC-6 Temp/temp1_max_alarm
-      - mp2975-i2c-39-6b/PMIC-6 Temp/temp1_crit_alarm
+      - mp2975-i2c-39-6b/PMIC-12 Temp/temp1_max_alarm
+      - mp2975-i2c-39-6b/PMIC-12 Temp/temp1_crit_alarm
 
       - mp2975-i2c-5-64/PMIC-3 VDD_T2 ADJ Temp 1/temp1_max_alarm
       - mp2975-i2c-5-64/PMIC-3 VDD_T2 ADJ Temp 1/temp1_crit_alarm
@@ -6390,8 +6390,8 @@ sensors_checks:
       - - drivetemp-scsi-0-0/SSD Temp/temp1_input
         - drivetemp-scsi-0-0/SSD Temp/temp1_crit
 
-      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_input
-        - tmp102-i2c-7-4a/Ambient Port Side Temp (air exhaust)/temp1_max
+      - - tmp102-i2c-7-4a/Ambient Port Side Temp (air intake)/temp1_input
+        - tmp102-i2c-7-4a/Ambient Port Side Temp (air intake)/temp1_max
 
       - - mp2975-i2c-5-63/PMIC-2 VDD_T0 ADJ Temp 1/temp1_input
         - mp2975-i2c-5-63/PMIC-2 VDD_T0 ADJ Temp 1/temp1_crit
@@ -6426,11 +6426,11 @@ sensors_checks:
       - - mp2975-i2c-5-67/PMIC-6 DVDD_T0 ADJ Temp 1/temp1_input
         - mp2975-i2c-5-67/PMIC-6 DVDD_T0 ADJ Temp 1/temp1_crit
 
-      - - tmp102-i2c-6-49/Ambient Fan Side Temp (air intake)/temp1_input
-        - tmp102-i2c-6-49/Ambient Fan Side Temp (air intake)/temp1_max
+      - - tmp102-i2c-6-49/Ambient Fan Side Temp (air exhaust)/temp1_input
+        - tmp102-i2c-6-49/Ambient Fan Side Temp (air exhaust)/temp1_max
 
-      - - mp2975-i2c-39-6b/PMIC-6 Temp/temp1_input
-        - mp2975-i2c-39-6b/PMIC-6 Temp/temp1_crit
+      - - mp2975-i2c-39-6b/PMIC-12 Temp/temp1_input
+        - mp2975-i2c-39-6b/PMIC-12 Temp/temp1_crit
 
       - - mp2975-i2c-5-64/PMIC-3 VDD_T2 ADJ Temp 1/temp1_input
         - mp2975-i2c-5-64/PMIC-3 VDD_T2 ADJ Temp 1/temp1_crit

--- a/tests/platform_tests/sensors_utils/psu_data.yaml
+++ b/tests/platform_tests/sensors_utils/psu_data.yaml
@@ -210,13 +210,13 @@ sensors_checks:
           - dps460-i2c-*-*/PSU-* 220V Rail (in)/in1_max_alarm
           - dps460-i2c-*-*/PSU-* 220V Rail (in)/in1_lcrit_alarm
           - dps460-i2c-*-*/PSU-* 220V Rail (in)/in1_crit_alarm
-          - dps460-i2c-*-*/PSU-* 12V Rail (out)/in3_alarm
+          - dps460-i2c-*-*/PSU-* 54V Rail (out)/in3_alarm
           - dps460-i2c-*-*/PSU-* 220V Rail Pwr (in)/power1_alarm
-          - dps460-i2c-*-*/PSU-* 12V Rail Pwr (out)/power2_max_alarm
-          - dps460-i2c-*-*/PSU-* 12V Rail Pwr (out)/power2_crit_alarm
+          - dps460-i2c-*-*/PSU-* 54V Rail Pwr (out)/power2_max_alarm
+          - dps460-i2c-*-*/PSU-* 54V Rail Pwr (out)/power2_crit_alarm
           - dps460-i2c-*-*/PSU-* 220V Rail Curr (in)/curr1_max_alarm
-          - dps460-i2c-*-*/PSU-* 12V Rail Curr (out)/curr2_max_alarm
-          - dps460-i2c-*-*/PSU-* 12V Rail Curr (out)/curr2_crit_alarm
+          - dps460-i2c-*-*/PSU-* 54V Rail Curr (out)/curr2_max_alarm
+          - dps460-i2c-*-*/PSU-* 54V Rail Curr (out)/curr2_crit_alarm
         temp:
           - dps460-i2c-*-*/PSU-* Temp 1/temp1_max_alarm
           - dps460-i2c-*-*/PSU-* Temp 1/temp1_crit_alarm


### PR DESCRIPTION
### Description of PR

Summary:
Updates for SN5600 sensors data, reflect the changes in https://github.com/sonic-net/sonic-buildimage/pull/23613

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Align the sensors data in sku-sensors-data.yml and psu_data.yml according to the sensors.conf updates.

#### How did you do it?
Updated the relevant sensors labels

#### How did you verify/test it?
tested test_sensors.py on SN5600 platform

#### Any platform specific information?
Mellanox

