### PR TITLE
Handle Multi-port portchannel member case in ECMP member flap TC

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -169,7 +169,9 @@ def filter_ports(all_port_indices, tbinfo):
 
     return host_ptf_ports_all
 
-def get_port_and_portchannel_members(port_name, all_port_indices, duts_minigraph_facts, upstream_lc, tbinfo):
+
+def get_port_and_portchannel_members(port_name, all_port_indices, duts_minigraph_facts,
+                                     upstream_lc, tbinfo):
     """
     Get PTF port indices for a port and all its port channel members (if applicable).
 
@@ -198,7 +200,8 @@ def get_port_and_portchannel_members(port_name, all_port_indices, duts_minigraph
         for pc_name, pc_info in mg_facts['minigraph_portchannels'].items():
             if port_name in pc_info.get('members', []):
                 portchannel_members = pc_info['members']
-                logging.info(f"Port {port_name} is a member of port channel {pc_name}, adding all members: {portchannel_members}")
+                logging.info("Port {} is a member of port channel {}, adding all members: {}".format(
+                    port_name, pc_name, portchannel_members))
                 break
 
     # Find PTF port indices for all port channel members
@@ -207,7 +210,7 @@ def get_port_and_portchannel_members(port_name, all_port_indices, duts_minigraph
         for ptf_port, (asic_id, dut_port) in all_port_indices.items():
             if dut_port == member_port:
                 ptf_ports_to_filter.append(ptf_port)
-                logging.info(f"Found PTF port {ptf_port} for port channel member {member_port}")
+                logging.info("Found PTF port {} for port channel member {}".format(ptf_port, member_port))
                 break
 
     return ptf_ports_to_filter
@@ -788,7 +791,6 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                qlen=PTF_QLEN,
                socket_recv_size=16384,
                is_python3=True)
-
 
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, False, 1514)])

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -169,6 +169,49 @@ def filter_ports(all_port_indices, tbinfo):
 
     return host_ptf_ports_all
 
+def get_port_and_portchannel_members(port_name, all_port_indices, duts_minigraph_facts, upstream_lc, tbinfo):
+    """
+    Get PTF port indices for a port and all its port channel members (if applicable).
+
+    Args:
+        port_name: The DUT port name to check
+        all_port_indices: Dictionary mapping PTF port indices to (asic_id, port_name)
+        duts_minigraph_facts: Minigraph facts containing port channel information
+        upstream_lc: The upstream line card hostname
+
+    Returns:
+        List of PTF port indices for the port and all its port channel members
+    """
+
+    # for T2(except UT2) topologies, no need to append, as we are already filtering out the whole upstream lc ports
+    if tbinfo['topo']['type'] == 't2' and 't2_single_node' not in tbinfo['topo']['name']:
+        return []
+
+    mg_facts = None
+    for asic_id, asic_data in duts_minigraph_facts[upstream_lc]:
+        mg_facts = asic_data
+        break  # Use first ASIC's facts for port channel lookup
+
+    # Check if the port is a member of any port channel
+    portchannel_members = [port_name]  # Default is just the single port
+    if mg_facts and 'minigraph_portchannels' in mg_facts:
+        for pc_name, pc_info in mg_facts['minigraph_portchannels'].items():
+            if port_name in pc_info.get('members', []):
+                portchannel_members = pc_info['members']
+                logging.info(f"Port {port_name} is a member of port channel {pc_name}, adding all members: {portchannel_members}")
+                break
+
+    # Find PTF port indices for all port channel members
+    ptf_ports_to_filter = []
+    for member_port in portchannel_members:
+        for ptf_port, (asic_id, dut_port) in all_port_indices.items():
+            if dut_port == member_port:
+                ptf_ports_to_filter.append(ptf_port)
+                logging.info(f"Found PTF port {ptf_port} for port channel member {member_port}")
+                break
+
+    return ptf_ports_to_filter
+
 
 def fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts, tbinfo, request):
     """Get FIB info from database and store to text files on PTF host.
@@ -747,6 +790,7 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                is_python3=True)
 
 
+
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, False, 1514)])
 def test_ecmp_group_member_flap(
     duthosts, ptfhost, tbinfo, ipv4, ipv6, mtu,
@@ -840,8 +884,14 @@ def test_ecmp_group_member_flap(
     logging.info("Shutting down port {}".format(nh_dut_ports[port_index_to_shut][1]))
     duthosts[0].shell("sudo config interface {} shutdown {}".format(asic_ns, nh_dut_ports[port_index_to_shut][1]))
 
-    time.sleep(10)  # Allow time for the state to stabilize
-    filtered_ports.append(nh_ptf_ports[port_index_to_shut])
+    time.sleep(60)  # Allow time for the state to stabilize
+
+    # Get all PTF ports for the port and its port channel members (if applicable)
+    ptf_ports_to_filter = get_port_and_portchannel_members(
+        nh_dut_ports[port_index_to_shut][1], all_port_indices, duts_minigraph_facts, upstream_lc, tbinfo)
+
+    # Add them to filtered_ports
+    filtered_ports.extend(ptf_ports_to_filter)
 
     # --- Re-run the PTF test after member down ---
     logging.info("Verifying ECMP behavior after member down.")
@@ -885,7 +935,11 @@ def test_ecmp_group_member_flap(
 
     logging.info("Enabling port {}".format(nh_dut_ports[port_index_to_shut][1]))
     duthosts[0].shell("sudo config interface {} startup {}".format(asic_ns, nh_dut_ports[port_index_to_shut][1]))
-    filtered_ports.pop()
+
+    # Remove the PTF ports that were added earlier
+    for ptf_port in ptf_ports_to_filter:
+        if ptf_port in filtered_ports:
+            filtered_ports.remove(ptf_port)
 
     time.sleep(60)  # Allow time for the state to stabilize
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/17887

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This fixes issue mentioned in https://github.com/sonic-net/sonic-mgmt/issues/17887. 
For pizza box DUTs, multi-port portchannel scenario was not handled, which caused issue on certain specific topologies.

#### How did you do it?
Add all members of PORT_CHANNEL (if the port being shutdown is part of PORT_CHANNEL) to the filtered ports list, so that during fib_test, these ports are not randomly picked as src port.

#### How did you verify/test it?
Verified on t1-lag topology. the testcase passes.
Logs:
```
07/08/2025 20:31:13 test_fib.test_ecmp_group_member_flap     L0864 INFO   | Shutting down one uplink port.
07/08/2025 20:31:13 test_fib.test_ecmp_group_member_flap     L0869 INFO   | Shutting down port Ethernet0
07/08/2025 20:31:31 test_fib.get_port_and_portchannel_member L0764 INFO   | Port Ethernet0 is a member of port channel PortChannel102, adding all members: ['Ethernet0', 'Ethernet8']
07/08/2025 20:31:31 test_fib.get_port_and_portchannel_member L0773 INFO   | Found PTF port 0 for port channel member Ethernet0
07/08/2025 20:31:31 test_fib.get_port_and_portchannel_member L0773 INFO   | Found PTF port 1 for port channel member Ethernet8
07/08/2025 20:31:31 test_fib.test_ecmp_group_member_flap     L0881 INFO   | Verifying ECMP behavior after member down.
["/root/env-python3/bin/ptf --test-dir ptftests/py3 fib_test.FibTest --platform-dir ptftests --qlen=20000 --platform remote -t 'fib_info_files=['\"'\"'/root/fib_info_dut_test_ecmp_group_member_flap[True-False-1514]_0.txt'\"'\"'];
ptf_test_port_map='\"'\"'/root/ptf_test_port_map.json'\"'\"';ipv4=True;ipv6=False;testbed_mtu=1514;test_balancing=True;ignore_ttl=False;single_fib_for_duts='\"'\"'multiple-fib'\"'\"';switch_type='\"'\"''\"'\"';;
skip_src_ports=[**0, 1]**' --relax --debug info --log-file /tmp/fib_test.ecmp_member_flap.member_down.ipv4.True.ipv6.False.2025-08-07-20:26:22.log --socket-recv-size 16384"], kwargs={"chdir": "/root", "module_ignore_errors": false, "module_async": false}
```
#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
