### PR TITLE
Stabilize hash_test on FT2 topology

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -527,10 +527,15 @@ class HashTest(BaseTest):
         '''
         percentage = (actual - expected) / float(expected)
         balancing_range = self.balancing_range
-        if hash_key == 'ip-proto' and 't2' in self.topo_name:
-            # ip-protocol only has 8-bits of entropy which results in poor hashing distributions on topologies with
-            # a large number of ecmp paths so relax the hashing requirements
-            balancing_range = self.RELAXED_BALANCING_RANGE
+        if hash_key == 'ip-proto':
+            # For FT2 topologies, there is not enough entropy in ip-proto to achieve good balancing
+            # So we just check if there are packets received on each expected port
+            if 'ft2' in self.topo_name:
+                return (percentage, actual >= expected * 0.2)
+            elif 't2' in self.topo_name:
+                # ip-protocol only has 8-bits of entropy which results in poor hashing distributions on topologies with
+                # a large number of ecmp paths so relax the hashing requirements
+                balancing_range = self.RELAXED_BALANCING_RANGE
         return (percentage, abs(percentage) <= balancing_range)
 
     def check_same_asic(self, src_port, exp_port_list):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize `test_hash` on FT2 topology.
The test is flaky on FT2 because of the insufficient entropy and enormous number of neighbors.
The PR stabilized the test by loosing the balance check criteria.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_hash` on FT2 topology.

#### How did you do it?
Loose balance check criteria. Test is considered as passing if all ports received over 20% expected packets.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 2 items                                                                                                                                                                                                             

fib/test_fib.py::test_hash[ipv4] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
22:07:39 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^H ^H ^H ^H ^H ^H ^HPASSED                                                                                                                                                                                                                  [ 50%]
fib/test_fib.py::test_hash[ipv6] 
-------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------
22:48:27 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
 ^H ^H ^H ^H ^H
 ^H ^H ^H
PASSED                                                                                  
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
