### PR TITLE
Fixed test_cold_reboot_dpus test

### DIFF
--- a/tests/smartswitch/common/reboot.py
+++ b/tests/smartswitch/common/reboot.py
@@ -23,7 +23,7 @@ def log_and_perform_reboot(duthost, reboot_type, dpu_name):
     hostname = duthost.hostname
 
     if reboot_type == REBOOT_TYPE_COLD:
-        if duthost.facts['is_smartswitch']:
+        if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
             if dpu_name is None:
                 logger.info("Sync reboot cause history queue with DUT reboot cause history queue")
                 sync_reboot_history_queue_with_dut(duthost)

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -236,18 +236,12 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
 
     logging.info("Executing pre test check")
     ip_address_list, dpu_on_list, dpu_off_list = pre_test_check(duthost, platform_api_conn, num_dpu_modules)
-
-    def reboot_dpu(duthost, platform_api_conn, index):
-        try:
-            dpu_name = module.get_name(platform_api_conn, index)
-            perform_reboot(duthost, REBOOT_TYPE_COLD, dpu_name)
-        except Exception as e:
-            logging.error(f"Failed to reboot DPU at index {index}: {e}")
+    dpu_names = [module.get_name(platform_api_conn, index) for index in range(num_dpu_modules)]
 
     with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
         logging.info("Rebooting all DPUs in parallel")
-        for index in range(num_dpu_modules):
-            executor.submit(reboot_dpu, duthost, platform_api_conn, index)
+        for dpu_name in dpu_names:
+            executor.submit(perform_reboot, duthost, REBOOT_TYPE_COLD, dpu_name)
 
     logging.info("Executing post test dpu check")
     post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules, "Non-Hardware")


### PR DESCRIPTION
### Description of PR
Fixed  test_cold_reboot_dpus
Summary:
The test was not handling the exceptions correctly, as the result it passed even and the DPUs were not rebooted.
Exceptions were caused by the incorrect access to duthost facts and using the platform API in multiple threads concurrently.


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
False pass on test_cold_reboot_dpus tests

#### How did you do it?
Updated logic access to the duthost facts to match the recent change.
Inquired the DPU names in the main thread, before rebooting them in parallel

#### How did you verify/test it?
Ran both positive (test PASS as expected) and negative scenario (test FAIL because of the exception)

