### PR TITLE
Fix k8s node join time not enough issue

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -361,11 +361,13 @@ def trigger_join_and_check(duthost, vmhost):
     logger.info("Start to join duthost to k8s cluster and check the status")
     duthost.shell(f"sudo config kube server ip {vmhost.mgmt_ip}")
     duthost.shell("sudo config kube server disable off")
-    time.sleep(60)
-    nodes = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get nodes {duthost.hostname}", module_ignore_errors=True)
-    pytest_assert(duthost.hostname in nodes["stdout"], "Failed to join duthost to k8s cluster")
-    pytest_assert("NotReady" not in nodes["stdout"], "The status of duthost in k8s cluster is not ready")
-    logger.info(f"Successfully joined duthost {duthost.hostname} to k8s cluster")
+    for _ in range(12):
+        time.sleep(5)
+        nodes = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get nodes {duthost.hostname}", module_ignore_errors=True)
+        if duthost.hostname in nodes["stdout"] and "NotReady" not in nodes["stdout"]:
+            logger.info("Duthost is successfully joined to k8s cluster")
+            return
+    pytest_assert(False, "Failed to join duthost to k8s cluster")
 
 
 def trigger_disjoin_and_check(duthost, vmhost):

--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -362,7 +362,7 @@ def trigger_join_and_check(duthost, vmhost):
     duthost.shell(f"sudo config kube server ip {vmhost.mgmt_ip}")
     duthost.shell("sudo config kube server disable off")
     for _ in range(12):
-        time.sleep(5)
+        time.sleep(10)
         nodes = vmhost.shell(f"{NO_PROXY} minikube kubectl -- get nodes {duthost.hostname}", module_ignore_errors=True)
         if duthost.hostname in nodes["stdout"] and "NotReady" not in nodes["stdout"]:
             logger.info("Duthost is successfully joined to k8s cluster")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: It's an improvement for testbed vms75-t0-7050cx3-1. For this SKU, the kubelet needs more time(around 70s) to join the minikube cluster, so increased the wait time for joining node to cluster.
Fixes # (33976122)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
It's an improvement for testbed vms75-t0-7050cx3-1. For this SKU, the kubelet needs more time(around 70s) to join the minikube cluster.
#### How did you do it?
Increased the wait time for joining node to cluster.
#### How did you verify/test it?
Run this test in testbed vms75-t0-7050cx3-1 to see if it passes.
#### Any platform specific information?
None
#### Supported testbed topology if it's a new test case?
None
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
