### PR TITLE
Add test case for BGP weight attribute verification (Issue #18208)

### DIFF
--- a/tests/bgp/test_bgp_route_weight_attribute.py
+++ b/tests/bgp/test_bgp_route_weight_attribute.py
@@ -1,0 +1,138 @@
+import pytest
+import logging
+import json
+import re
+import time
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+def parse_bgp_summary(text_output):
+    neighbors = []
+    in_table = False
+
+    for line in text_output.splitlines():
+        if re.match(r"^Neighbor\s+V\s+AS\s+", line):
+            in_table = True
+            continue
+        if not in_table or line.strip() == "":
+            continue
+        cols = re.split(r'\s+', line.strip())
+        if len(cols) < 10:
+            continue
+        neighbor_ip = cols[0]
+        state_or_pfx = cols[9]
+        try:
+            pfxRcd = int(state_or_pfx)
+            state = "Established"
+        except ValueError:
+            state = state_or_pfx
+            try:
+                pfxRcd = int(cols[10]) if len(cols) > 10 else 0
+            except (IndexError, ValueError):
+                pfxRcd = 0
+        neighbors.append({
+            "neighbor": neighbor_ip,
+            "state": state,
+            "pfxRcd": pfxRcd,
+        })
+    return neighbors
+
+
+@pytest.mark.bgp_ft
+@pytest.mark.community
+def test_bgp_route_weight_attribute(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
+
+    topo = tbinfo["topo"]["type"]
+    if topo not in ["t0", "t1", "dualtor", "any"]:
+        pytest.skip(f"Unsupported topology: {topo}")
+
+    logger.info("Fetching current BGP summary")
+    summary = duthost.shell("vtysh -c 'show ip bgp summary'")["stdout"]
+    neighbors = parse_bgp_summary(summary)
+
+    # Run this BEFORE assigning test_nbr
+    raw = duthost.shell("vtysh -c 'show bgp ipv4 unicast 0.0.0.0/0 json'")["stdout"]
+    default_route_data = json.loads(raw)
+    advertising_peers = {p["peer"]["peerId"] for p in default_route_data.get("paths", [])}
+
+    valid_nbrs = [
+        n for n in neighbors
+        if n["neighbor"].startswith("10.0.0.")
+        and n["state"] == "Established"
+        and n["pfxRcd"] > 0
+        and n["neighbor"] in advertising_peers
+    ]
+
+    if not valid_nbrs:
+        pytest.skip("No suitable IPv4 BGP neighbors found")
+
+    test_nbr = valid_nbrs[0]["neighbor"]
+    logger.info(f"Testing neighbor: {test_nbr}")
+
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    local_asn = mg_facts.get("minigraph_bgp_asn")
+    if not local_asn:
+        pytest.skip("Local BGP ASN not found in minigraph")
+
+    expected_weight = 200
+    try:
+        logger.info(f"Applying weight={expected_weight} to {test_nbr}")
+        duthost.shell(
+            f'vtysh -c "configure terminal" '
+            f'-c "router bgp {local_asn}" '
+            f'-c "address-family ipv4 unicast" '
+            f'-c "neighbor {test_nbr} weight {expected_weight}" '
+            f'-c "end"'
+        )
+
+        logger.debug("Sleeping 10 seconds to allow session reset...")
+        time.sleep(10)
+
+        def session_established():
+            output = duthost.shell("vtysh -c 'show ip bgp summary'")["stdout"]
+            for line in output.splitlines():
+                if test_nbr in line:
+                    logger.debug(f"BGP summary line: {line}")
+                    match = re.search(
+                        rf"{re.escape(test_nbr)}\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+[\d:]+?\s+(\S+)", line)
+                    if match:
+                        state_or_pfx = match.group(1)
+                        try:
+                            return int(state_or_pfx) > 0
+                        except ValueError:
+                            return state_or_pfx == "Established"
+            return False
+
+        logger.info("Waiting for BGP session to re-establish...")
+        pytest_assert(wait_until(180, 5, 0, session_established),
+                      f"BGP did not reach Established with {test_nbr} after applying weight")
+
+        logger.info("Verifying route weight in default route (0.0.0.0/0)")
+        raw = duthost.shell("vtysh -c 'show bgp ipv4 unicast 0.0.0.0/0 json'")["stdout"]
+        data = json.loads(raw)
+        for path in data.get("paths", []):
+            if path.get("peer", {}).get("peerId") == test_nbr:
+                pytest_assert(path.get("weight") == expected_weight,
+                              f"Weight mismatch: expected {expected_weight},"
+                              f"got {path.get('weight')}")
+                logger.info("Weight correctly applied and used for best path")
+                break
+        else:
+            pytest.fail(f"Route via neighbor {test_nbr} not found in paths")
+
+    finally:
+        logger.info(f"Removing weight configuration for {test_nbr}")
+        duthost.shell(
+            f'vtysh -c "configure terminal" '
+            f'-c "router bgp {local_asn}" '
+            f'-c "address-family ipv4 unicast" '
+            f'-c "no neighbor {test_nbr} weight" '
+            f'-c "end"',
+            module_ignore_errors=True
+        )
+        logger.info("Cleanup completed")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR

his PR addresses GitHub Issue #18208 by adding a PTF test case that verifies BGP-learned routes include the weight attribute and that it is correctly applied in best path selection.

Summary:
Fixes #18208

#### Motivation and Context: 
During regression testing for the Arlo+ release, it was observed that routes learned via BGP did not always carry the configured weight attribute into SONiC’s routing table, potentially breaking weighted ECMP behavior. This test ensures that when a neighbor is configured with a weight, the DUT’s BGP summary and JSON route outputs reflect that weight and that it influences the best-path decision.

Dependencies: Relies on SONiC’s PTF framework and duthost shell access to FRR’s vtysh.

#### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To ensure BGP weight attributes are verified in SONiC’s BGP summary and route JSON outputs, preventing regressions in weighted ECMP.

#### How did you do it?
##Neighbor Discovery: Parses show ip bgp summary text to select an established IPv4 neighbor advertising routes.

##Weight Configuration: Uses vtysh commands to apply neighbor <IP> weight 200 under the DUT’s BGP router context.

##Session Stabilization: Waits for the neighbor to show received routes in the summary.

##Weight Verification:

Checks the default route JSON (show bgp ipv4 unicast 0.0.0.0/0 json) for the configured neighbor’s weight.

Parses neighbor-specific route output to confirm weight presence.

##Cleanup: Removes the weight setting to restore original configuration.

#### How did you verify/test it?
Ran the test on a T1 topology DUT with multiple IPv4 BGP peers. The test successfully:

Detected an established neighbor with received routes.

Applied weight 200 and confirmed it in both BGP JSON and text outputs.

Ensured the neighbor’s path was selected as best due to weight.

Cleaned up the configuration after test completion.
#### Any platform specific information?
None. The test skips unsupported topologies and requires FRR/BGP support.

#### Supported testbed topology if it's a new test case?
Topologies: t0, t1, dualtor, and any

Requires at least one IPv4 BGP neighbor on DUT.


