### PR TITLE
Update qos margin

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -223,6 +223,8 @@ class QosParamMellanox(object):
         wm_pg_shared_lossless['pkts_num_trig_pfc'] = pkts_num_dismiss_pfc
         wm_pg_shared_lossless['cell_size'] = self.cell_size
         wm_pg_shared_lossless["pkts_num_margin"] = 3
+        if self.asic_type == 'spc1':
+            wm_pg_shared_lossless["pkts_num_margin"] = 4
 
         wm_q_shared_lossless = self.qos_params_mlnx[self.speed_cable_len]['wm_q_shared_lossless']
         wm_q_shared_lossless['pkts_num_trig_ingr_drp'] = pkts_num_trig_ingr_drp


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update qos margin in case wm_pg_shared_lossless according to lower layer implementation 
The shared buffer would have 1 packet left sometimes, and for Mellanox sn2700 the cell size is much smaller than other platforms 
So update the margin for sn2700 to cover this scenario


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Update qos margin in case wm_pg_shared_lossless according to lower layer implementation 
#### How did you do it?
The shared buffer would have 1 packet left sometimes, and for Mellanox sn2700 the cell size is much smaller than other platforms, so increase the margin for sn2700
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
