### PR TITLE
Support pulling original cEOS docker image from remote registry

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -1,3 +1,10 @@
+- name: Pull original cEOS docker image from remote registry
+  docker_image:
+    name: "{{ ceos_image_orig }}"
+    source: pull
+  become: yes
+  when: "'/' in ceos_image_orig"
+
 - name: Check if cEOS docker image exists or not
   docker_image_info:
     name:


### PR DESCRIPTION
### Description of PR

Support the case when cEOS image is kept in a remote docker registry.
Add a step to pull the docker image if it is a non-local image (image name contains a `/`).

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Change enables centralized distribution of cEOS images to testbeds using a docker registry instead of a HTTP file download. This simplifies deployment of new testbeds.

#### How did you do it?

Added a new task in `add_ceos_list.yml` that is a no-op when `ceos_image_orig` points to a local image. This is a default configuration for a new testbed.

If the `ceos_image_orig` points to a remote docker image, as detected by checking if the name contains a slash `/`, Ansible will pull the image for the registry.

#### How did you verify/test it?

Tested the image is pulled only when `ceos_image_orig` points to remote image.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

No changes to documentation.