### PR TITLE
Rename VMs to correct portchannel interfaces' order

### DIFF
--- a/ansible/vars/topo_t1-smartswitch-ha.yml
+++ b/ansible/vars/topo_t1-smartswitch-ha.yml
@@ -41,22 +41,22 @@ topology:
         - "0.7@14"
         - "1.7@15"
       vm_offset: 7
-    ARISTA01T0:
+    ARISTA11T0:
       vlans:
         - "0.8@16"
         - "1.8@17"
       vm_offset: 8
-    ARISTA02T0:
+    ARISTA12T0:
       vlans:
         - "0.9@18"
         - "1.9@19"
       vm_offset: 9
-    ARISTA03T0:
+    ARISTA13T0:
       vlans:
         - "0.10@20"
         - "1.10@21"
       vm_offset: 10
-    ARISTA04T0:
+    ARISTA14T0:
       vlans:
         - "0.11@22"
         - "1.11@23"
@@ -344,7 +344,7 @@ configuration:
       ipv4: 10.10.246.8/24
       ipv6: fc0a::11/64
 
-  ARISTA01T0:
+  ARISTA11T0:
     properties:
     - common
     - tor
@@ -382,7 +382,7 @@ configuration:
       ipv4: 10.10.246.17/24
       ipv6: fc0a::22/64
 
-  ARISTA02T0:
+  ARISTA12T0:
     properties:
     - common
     - tor
@@ -420,7 +420,7 @@ configuration:
       ipv4: 10.10.246.18/24
       ipv6: fc0a::25/64
 
-  ARISTA03T0:
+  ARISTA13T0:
     properties:
     - common
     - tor
@@ -458,7 +458,7 @@ configuration:
       ipv4: 10.10.246.19/24
       ipv6: fc0a::26/64
 
-  ARISTA04T0:
+  ARISTA14T0:
     properties:
     - common
     - tor


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

In minigraph template, VM list will be sorted by alphabet, which then causes portchannel interfaces rendering in a wrong order. Renaming the VMs to make sure  the ordering is correct.

https://github.com/sonic-net/sonic-mgmt/blob/d525ae19d6581d9581003f8673adf70b517002be/ansible/templates/minigraph_template.j2#L3

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run `deploy-mg` against lab testbeds. Order is corrected. 

```
~$ show ip int
Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ------------  --------------  -------------
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
PortChannel101             10.0.0.0/31          up/up         ARISTA01T2      10.0.0.1
PortChannel102             10.0.0.2/31          up/up         ARISTA02T2      10.0.0.3
PortChannel103             10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
PortChannel104             10.0.0.6/31          up/up         ARISTA04T2      10.0.0.7
PortChannel105             10.0.0.8/31          up/up         ARISTA05T2      10.0.0.9
PortChannel106             10.0.0.10/31         up/up         ARISTA06T2      10.0.0.11
PortChannel107             10.0.0.12/31         up/up         ARISTA07T2      10.0.0.13
PortChannel108             10.0.0.14/31         up/up         ARISTA08T2      10.0.0.15
PortChannel109             10.0.0.32/31         up/up         ARISTA11T0      10.0.0.33
PortChannel110             10.0.0.34/31         up/up         ARISTA12T0      10.0.0.35
PortChannel111             10.0.0.36/31         up/up         ARISTA13T0      10.0.0.37
PortChannel112             10.0.0.38/31         up/up         ARISTA14T0      10.0.0.39
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
