### PR TITLE
[Snappi-RDMA] Adding CRC error check warning message in run_traffic a…

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -412,6 +412,22 @@ def clear_pfc_counter_after_storm(dut, port, pri):
     return False
 
 
+def check_for_crc_errors(api):
+    """
+    Check for CRC errors in port statistics.
+    Args:
+        api (obj): snappi session
+    Returns:
+        None
+    """
+    ixnetwork = api._ixnetwork
+    port_metrics = StatViewAssistant(ixnetwork, 'Port Statistics')
+    for row in port_metrics.Rows:
+        if int(row['CRC Errors']) > 0:
+            logger.warning("CRC Errors detected on port {}: {}".format(
+                row['Port Name'], row['CRC Errors']))
+
+
 def run_traffic(duthost,
                 api,
                 config,
@@ -551,7 +567,7 @@ def run_traffic(duthost,
     cs = api.control_state()
     cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.STOP
     api.set_control_state(cs)
-
+    check_for_crc_errors(api)
     return flow_metrics, switch_device_results, in_flight_flow_metrics
 
 
@@ -1337,7 +1353,7 @@ def run_traffic_and_collect_stats(rx_duthost,
     fname = fname + '.csv'
     logger.info('Writing statistics to file : {}'.format(fname))
     df_t.to_csv(fname, index=False)
-
+    check_for_crc_errors(api)
     return flow_metrics, switch_device_results, test_stats
 
 


### PR DESCRIPTION
…nd run_traffic_and_collect_stats fixtures

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding a warning message in case if the ports encounter CRC errors during RDMA test run
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
to fix https://github.com/sonic-net/sonic-mgmt/issues/19812
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
