### PR TITLE
ERSPAN meter is not supported for Cisco-8000 ASICs so need to Skip this testcase

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1539,6 +1539,12 @@ generic_config_updater/test_mmu_dynamic_threshold_config_update.py::test_dynamic
     conditions:
       - "asic_type in ['broadcom', 'cisco-8000'] and release in ['202211']"
 
+generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite:
+  skip:
+    reason: "This test is not run on this asic type or version currently / ERSPAN meter is not supported for Cisco Platform"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+
 generic_config_updater/test_multiasic_addcluster.py:
   skip:
     reason: "Only supported on multi-asic system."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
ERSPAN meter is not supported for Cisco-8000 ASICs so need to Skip this testcase

Summary:
Fixes # Failure due to Error thrown by SDK due to unsupported feature.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
