### PR TITLE
[test_watchdog]: Add watchdog yml for sn5640

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -61,6 +61,11 @@ x86_64-nvidia_sn5600-r0:
     greater_timeout: 100
     too_big_timeout: 66000
 
+x86_64-nvidia_sn5640-r0:
+  default:
+    greater_timeout: 100
+    too_big_timeout: 66000
+
 x86_64-nvidia_sn4280-r0:
   default:
     valid_timeout: 25


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Missing the watchdog configure in the watchdog.yml so that the case `platform_tests/test_sequential_restart.py` failed

#### How did you do it?
This pull request introduces support for the `x86_64-nvidia_sn5640-r0` platform in the watchdog API tests by adding relevant timeout settings.

#### How did you verify/test it?
Check in the sn5640 platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
