### PR TITLE
Skip snmp pfc counter check on Moby

### DIFF
--- a/tests/snmp/test_snmp_pfc_counters.py
+++ b/tests/snmp/test_snmp_pfc_counters.py
@@ -30,7 +30,7 @@ def test_snmp_pfc_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             continue
 
         # Skip management ports for Arista 7060x6 platforms
-        if 'Arista-7060X6-64PE' in hwsku and 'PT0' in desc:
+        if 'Arista-7060X6' in hwsku and 'PT0' in desc:
             continue
 
         # Check for required PFC counters


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is a follow-up PR of #19610.
Fix the condition to include the Moby platform.
```
admin@str5-7060x6-moby-512-2:~$ show platform summary
Platform: x86_64-arista_7060x6_16pe_384c_b
HwSKU: Arista-7060X6-16PE-384C-B-O128S2
ASIC: broadcom
ASIC Count: 1
Serial Number: SSN25202343
Model Number: DCS-7060X6-16PE-384C-B
Hardware Revision: 03.00
admin@str5-7060x6-moby-512-2:~$ 
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202505

### Approach
#### What is the motivation for this PR?
On Arista 7060X6 platforms, mgmt ports don't have pfc counter so the case would fail. To fix that, skipping the pfc counter check on the mgmt ports.

#### How did you do it?
Skip checking the ports with 'PT0' in its description on Arista 7060X6 platforms.

#### How did you verify/test it?
Manually run test_snmp_pfc_counters.py on Moby testbed and case can pass.
```

snmp/test_snmp_pfc_counters.py::test_snmp_pfc_counters[str5-7060x6-moby-512-3] PASSED                           [100%]
```

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
