### PR TITLE
Add Moby to policer unsupported list

### DIFF
--- a/tests/generic_config_updater/test_monitor_config.py
+++ b/tests/generic_config_updater/test_monitor_config.py
@@ -26,7 +26,7 @@ def is_policer_supported(duthost):
     Return True if policer is supported in MIRROR_SESSION creation on this platform, otherwise return False.
     """
     platform = duthost.facts.get('platform', '')
-    if platform.startswith("x86_64-arista_7060x6_64pe"):
+    if platform.startswith("x86_64-arista_7060x6"):
         return False
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This is a follow-up PR of #19463 
Remove the policer on the Moby platform due to hardware not supported when creating MIRROR_SESSION.
CS00012412189: [TH5-512]Error log "Platform does not support SAI_MIRROR_SESSION_ATTR_POLICER".
```
admin@str5-7060x6-moby-512-2:~$ show platform summary
Platform: x86_64-arista_7060x6_16pe_384c_b
HwSKU: Arista-7060X6-16PE-384C-B-O128S2
ASIC: broadcom
ASIC Count: 1
Serial Number: SSN25202343
Model Number: DCS-7060X6-16PE-384C-B
Hardware Revision: 03.00
admin@str5-7060x6-moby-512-2:~$ 
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202505

### Approach
#### What is the motivation for this PR?
Add Moby to policer unsupported list when creating MIRROR_SESSION.

#### How did you do it?
Check the platform before building and verifying monitor session config, remove the policer if platform startwith "x86_64-arista_7060x6".

#### How did you verify/test it?
Manually run generic_config_updater/test_monitor_config.py on Moby testbed and case can pass.
```
generic_config_updater/test_monitor_config.py::test_monitor_config_tc1_suite[None] PASSED                         [100%]
```
Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>