### PR TITLE
Fix devutils ModuleNotFoundError

### DIFF
--- a/ansible/module_utils/graph_utils.py
+++ b/ansible/module_utils/graph_utils.py
@@ -7,7 +7,10 @@ from operator import itemgetter
 from itertools import groupby
 from natsort import natsorted
 
-from ansible.module_utils.port_utils import get_port_alias_to_name_map
+try:
+    from ansible.module_utils.port_utils import get_port_alias_to_name_map
+except (ImportError, ModuleNotFoundError):
+    from module_utils.graph_utils import get_port_alias_to_name_map
 
 
 class LabGraph(object):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Running the devutils tool for power cycle fails with ModuleNotFoundError. The issue was introduced by the metadata validator PR #19720. That PR moved the LabGraph tool to ansible/module_utils/graph_utils.

If run the ansible module conn_graph_facts, ansible can prepare the dependent ansible.module_utils.port_utils module.

If run the devutils, the conn_graph_facts was imported directly, ansible doesn't have a chance to prepare the dependent module_utils modules. That's why devutils tool fails after this change.

#### How did you do it?
The fix is to enhance the importing of port_utils in graph_utils.py. When ModuleNotFoundError is hit, try to directly import from module_utils.port_utils.

#### How did you verify/test it?
Run the devutils tool.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
