### PR TITLE
[PR Test] Pass BUILD_BRANCH to get-impacted-area.yml

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -36,6 +36,8 @@ jobs:
     pool: sonic-ubuntu-1c
     steps:
       - template: impacted_area_testing/get-impacted-area.yml
+        parameters:
+          BUILD_BRANCH: $(BUILD_BRANCH)
 
   - job: impacted_area_kvmtest
     displayName: " "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
PR https://github.com/sonic-net/sonic-mgmt/pull/20002 improved the PR test templates. However, parameter BUILD_BRANCH was not passed down to the template impacted_area_testing/get-impacted-area.yml as before.

#### How did you do it?
This change added code to pass down $(BUILD_BRANCH) as parameter BUILD_BRANCH to the tempate impacted_area_testing/get-impacted-area.yml.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
