### PR TITLE
[test_cont_link_flap] Get correct frr daemon memory usage

### DIFF
--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -45,7 +45,7 @@ class TestContLinkFlap(object):
             output = duthost.shell(duthost.get_vtysh_cmd_for_namespace(
                 f'vtysh -c "show memory {daemon}" | grep "Used ordinary blocks"', asic.namespace))["stdout"]
             frr_daemon_memory = output.split()[-2]
-            frr_daemon_memory_per_asics[asic.index] = frr_daemon_memory
+            frr_daemon_memory_per_asics[asic.asic_index] = frr_daemon_memory
 
         return frr_daemon_memory_per_asics
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
FRR daemon memory usage obtained in test_cont_link_flap.py is incorrect because grep cannot be run in the vtysh shell.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202505

### Approach
#### What is the motivation for this PR?
To get the correct FRR daemon memory usage.

#### How did you do it?
Run 'vtysh -c "show memory bgpd" | grep "Used ordinary blocks" ' on duthost shell instead of in vtysh shell.

#### How did you verify/test it?
Run test_cont_link_flap.py manually on DUT and check the log to verify it get the correct memory usage and cass can pass.
```
12/08/2025 03:17:20 base._run                                L0071 DEBUG  | /home/zitingguo/workspace/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [str4-7050cx3-c28s4-1] AnsibleModule::shell, args=["vtysh -c \"show memory bgpd\" | grep \"Used ordinary blocks\""], kwargs={}
12/08/2025 03:17:21 base._run                                L0108 DEBUG  | /home/zitingguo/workspace/sonic-mgmt-int/tests/common/devices/multi_asic.py::_run_on_asics#136: [str4-7050cx3-c28s4-1] AnsibleModule::shell Result => {"cmd": "vtysh -c \"show memory bgpd\" | grep \"Used ordinary blocks\"", "stdout": "  Used ordinary blocks:  112 MiB", "stderr": "", "rc": 0, "start": "2025-08-12 03:17:21.101018", "end": "2025-08-12 03:17:21.364380", "delta": "0:00:00.263362", "changed": true, "invocation": {"module_args": {"_raw_params": "vtysh -c \"show memory bgpd\" | grep \"Used ordinary blocks\"", "_uses_shell": true, "warn": true, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["  Used ordinary blocks:  112 MiB"], "stderr_lines": [], "_ansible_no_log": false, "failed": false}
12/08/2025 03:17:21 test_cont_link_flap.test_cont_link_flap  L0181 INFO   | bgpd memory usage at end: 
{0: '112'}

platform_tests/link_flap/test_cont_link_flap.py::TestContLinkFlap::test_cont_link_flap[str4-7050cx3-c28s4-1] PASSED    [100%]
```

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
