### PR TITLE
Fix typo in PR19199 in the test name

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -892,15 +892,15 @@ platform_tests/broadcom/test_ser.py:
       - "release in ['202412','202503'] and 'Arista-7060X6' in hwsku"
 
 ##############################################
-#####  cli/test_show_chassis_modules.py  #####
+#####  cli/test_show_chassis_module.py  #####
 ##############################################
-platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_midplane_status:
+platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_midplane_status:
   skip:
     reason: "Not supported on T2 single node topology"
     conditions:
       - "'t2_single_node' in topo_name"
 
-platform_tests/cli/test_show_chassis_modules.py::test_show_chassis_module_status:
+platform_tests/cli/test_show_chassis_module.py::test_show_chassis_module_status:
   skip:
     reason: "Not supported on T2 single node topology"
     conditions:


### PR DESCRIPTION
In PR19199 we added skips for `platform_tests/cli/test_show_chassis_module.py` but accidentally added a `s` on the end of the test name.
Fixing that here.

https://github.com/sonic-net/sonic-mgmt/pull/19199

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202503
- [x] 202505
