### PR TITLE
[sonic-mgmt][202505] Fix for no_v6_default_route error

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -686,6 +686,13 @@ def skip_traffic_test(request):
 
 
 @pytest.fixture(scope='function')
+def iptables_drop_ipv6_tx(ptfhost):
+    ptfhost.shell("ip6tables -P OUTPUT DROP")
+    yield
+    ptfhost.shell("ip6tables -P OUTPUT ACCEPT")
+
+
+@pytest.fixture(scope='function')
 def disable_ipv6(ptfhost):
     default_ipv6_status = ptfhost.shell("sysctl -n net.ipv6.conf.all.disable_ipv6")["stdout"]
     changed = False

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -34,7 +34,7 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory         
 from tests.common.fixtures.ptfhost_utils import copy_saitests_directory                     # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses                        # noqa F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                            # noqa F401
-from tests.common.fixtures.ptfhost_utils import disable_ipv6                                # noqa F401
+from tests.common.fixtures.ptfhost_utils import iptables_drop_ipv6_tx                       # noqa F401
 from tests.common.dualtor.dual_tor_utils import dualtor_ports, is_tunnel_qos_remap_enabled  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.pfc_storm import PFCStorm
@@ -849,7 +849,7 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiHeadroomPoolSize(
         self, get_src_dst_asic_and_duts, ptfhost, dutTestParams, dutConfig, dutQosConfig,
-            ingressLosslessProfile, disable_ipv6, change_lag_lacp_timer):                # noqa F811
+            ingressLosslessProfile, iptables_drop_ipv6_tx, change_lag_lacp_timer):                # noqa F811
         # NOTE: cisco-8800 will skip this test since there are no headroom pool
         """
             Test QoS SAI Headroom pool size


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Backport of #19709 with merge conflict resolution for the 202505

This PR is dependent on the PR (https://github.com/sonic-net/sonic-buildimage/pull/23382) and should be merged only after that PR.

A new fixture, iptables_drop_ipv6_tx, has been created to use ip6tables to drop IPv6 traffic. This fixture is being used in place of disable_ipv6, which uses sysctl.

Using sysctl to disable IPv6 caused interfaces to lose their configured addresses, resulting in connectivity issues with the PTF container. Using ip6tables fulfills the requirement to block IPv6 traffic while the scenario is running without affecting the interfaces.

#### How did you do it?
Created a new fixture iptables_drop_ipv6_tx

#### How did you verify/test it?
Verified on Arista-7260CX3 running dualtor-120 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
