### PR TITLE
conditional_mark: Evaluate github issues lazily

### DIFF
--- a/tests/common/plugins/conditional_mark/README.md
+++ b/tests/common/plugins/conditional_mark/README.md
@@ -79,6 +79,18 @@ folder3:
     reason: "Skip all the test scripts under subfolder 'folder3'"
 ```
 
+## Evaluation order of conditions
+
+Conditions are evaluated top to bottom, left to right.
+As soon as a value of a condition can be determined, the terms are left unevaluated.
+This matters when issue URLs are involved, because checking issue involves sending a HTTP request.
+To avoid unnecessary checks, prefer putting the issue URLs at the right or bottom of the condition.
+
+For example, prefer `release in ['master'] and https://github.com/sonic-net/sonic-mgmt/issues/1234`
+over `https://github.com/sonic-net/sonic-mgmt/issues/1234 and release in ['master']`.
+In the first case, the state of the issue will be checked only for master release.
+In the second case, the state of the issue will always be checked, regardless of the release.
+
 ## Match rule
 
 This plugin process each expanded (for parametrized test cases) test cases one by one.

--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -13,7 +13,7 @@ import glob
 import pytest
 
 from tests.common.testbed import TestbedInfo
-from .issue import check_issues
+from .issue import check_issue
 from tests.common.utilities import get_duts_from_host_pattern
 
 logger = logging.getLogger(__name__)
@@ -492,48 +492,10 @@ def find_all_matches(nodeid, conditions, session, dynamic_update_skip_reason, ba
     return matches
 
 
-def update_issue_status(condition_str, session):
-    """Replace issue URL with 'True' or 'False' based on its active state.
-
-    If there is an issue URL is found, this function will try to query state of the issue and replace the URL
-    in the condition string with 'True' or 'False' based on its active state.
-
-    The issue URL may be Github, Jira, Redmine, etc.
-
-    Args:
-        condition_str (str): Condition string that may contain issue URLs.
-        session (obj): Pytest session object, for getting cached data.
-
-    Returns:
-        str: New condition string with issue URLs already replaced with 'True' or 'False'.
-    """
-    issues = re.findall('https?://[^ )]+', condition_str)
-    if not issues:
-        logger.debug('No issue specified in condition')
-        return condition_str
-
-    issue_status_cache = session.config.cache.get('ISSUE_STATUS', {})
-    proxies = session.config.cache.get('PROXIES', {})
-
-    unknown_issues = [issue_url for issue_url in issues if issue_url not in issue_status_cache]
-    if unknown_issues:
-        results = check_issues(unknown_issues, proxies=proxies)
-        issue_status_cache.update(results)
-        session.config.cache.set('ISSUE_STATUS', issue_status_cache)
-
-    for issue_url in issues:
-        if issue_url in issue_status_cache:
-            replace_str = str(issue_status_cache[issue_url])
-        else:
-            # Consider the issue as active anyway if unable to get issue state
-            replace_str = 'True'
-
-        condition_str = condition_str.replace(issue_url, replace_str)
-    return condition_str
-
-
 def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basic_facts, session):
     """Evaluate a condition string based on supplied basic facts.
+
+    URLs in the condition will be checked only when required for evaluation of the condition.
 
     Args:
         dynamic_update_skip_reason(bool): Dynamically update the skip reason based on the conditions, if it is true,
@@ -551,9 +513,21 @@ def evaluate_condition(dynamic_update_skip_reason, mark_details, condition, basi
     if condition is None or condition.strip() == '':
         return True    # Empty condition item will be evaluated as True. Equivalent to be ignored.
 
-    condition_str = update_issue_status(condition, session)
+    # Replace each issue url with a call to _check('url').
+    condition_str = re.sub('https?://[^ )]+', lambda m: "_check(%r)" % m.group(0), condition)
+
+    def _check(issue_url):
+        issue_status_cache = session.config.cache.get('ISSUE_STATUS', {})
+        if issue_url in issue_status_cache:
+            return issue_status_cache[issue_url]
+        proxies = session.config.cache.get('PROXIES', {})
+        result = check_issue(issue_url, proxies=proxies)
+        issue_status_cache.update(result)
+        session.config.cache.set('ISSUE_STATUS', issue_status_cache)
+        return issue_status_cache[issue_url]
+
     try:
-        condition_result = bool(eval(condition_str, basic_facts))
+        condition_result = bool(eval(condition_str, {**basic_facts, '_check': _check}))
         if condition_result and dynamic_update_skip_reason:
             mark_details['reason'].append(condition)
         return condition_result


### PR DESCRIPTION
### Description of PR

This change reduces number of github api calls required for deciding if a test case should be skipped or not.
Checking each issue is deferred to the moment its status is needed for evaluation of the logical condition.
When condition can be evaluated regardless of the state of the issue, no github api request is made.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach

#### What is the motivation for this PR?

Reduce number of requests to github REST api.

#### How did you do it?

Instead of replacing issue url in the condition text with `True` or `False`, replace it with a function call that will check the status of the issue. This way requests are made only for issues required for evaluation of the condition. If the condition short-circuits, the function call does not happen and no api request is made.

Replaced `check_issues` with `check_issue` and removed multiprocessing code, as issues are now checked one by one.

#### How did you verify/test it?

Verified the conditions before and after the change result in the same set of skipped tests.
Verified the number of api calls is reduced by 15%-30%.

#### Any platform specific information?

N/A.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

Updated `README.md` in the conditional_mark directory.
