### PR TITLE
Fix retry count test case to properly teardown in case of failure

### DIFF
--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -78,13 +78,13 @@ def higher_retry_count_on_peers(request, duthost, nbrhosts):
     if request.config.getoption("neighbor_type") != "sonic":
         pytest.skip("Only supported with SONiC neighbor")
 
-    featureCheckResult = nbrhosts[list(nbrhosts.keys())[0]]['host'].shell(
+    featureCheckResult = nbrhosts[list(nbrhosts.keys())[0]]['host'].command(
             "sudo config portchannel retry-count get PortChannel1", module_ignore_errors=True)
     if featureCheckResult["rc"] != 0:
         pytest.skip("SONiC neighbor isn't running supported version of SONiC")
 
     for nbr in list(nbrhosts.keys()):
-        nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count set PortChannel1 5")
+        nbrhosts[nbr]['host'].command("sudo config portchannel retry-count set PortChannel1 5")
 
     # Wait for retry count info to be updated
     pytest_assert(wait_until(5, 1, 0, verify_retry_count, [duthost], 5),
@@ -93,7 +93,7 @@ def higher_retry_count_on_peers(request, duthost, nbrhosts):
     yield
 
     for nbr in list(nbrhosts.keys()):
-        nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count set PortChannel1 3")
+        nbrhosts[nbr]['host'].command("sudo config portchannel retry-count set PortChannel1 3")
 
     # Wait for retry count info to be updated
     pytest_assert(wait_until(90, 5, 0, verify_retry_count, [duthost], 3),
@@ -107,13 +107,13 @@ def higher_retry_count_on_dut(request, duthost, nbrhosts):
 
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
 
-    featureCheckResult = duthost.shell("sudo config portchannel retry-count get {}".format(
+    featureCheckResult = duthost.command("sudo config portchannel retry-count get {}".format(
         list(cfg_facts["PORTCHANNEL"].keys())[0]), module_ignore_errors=True)
     if featureCheckResult["rc"] != 0:
         pytest.skip("SONiC DUT isn't running supported version of SONiC")
 
     for port_channel in list(cfg_facts["PORTCHANNEL"].keys()):
-        duthost.shell("sudo config portchannel retry-count set {} 5".format(port_channel))
+        duthost.command("sudo config portchannel retry-count set {} 5".format(port_channel))
 
     # Wait for retry count info to be updated
     pytest_assert(wait_until(5, 1, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 5),
@@ -122,7 +122,7 @@ def higher_retry_count_on_dut(request, duthost, nbrhosts):
     yield
 
     for port_channel in list(cfg_facts["PORTCHANNEL"].keys()):
-        duthost.shell("sudo config portchannel retry-count set {} 3".format(port_channel))
+        duthost.command("sudo config portchannel retry-count set {} 3".format(port_channel))
 
     # Wait for retry count info to be updated
     pytest_assert(wait_until(90, 5, 0, verify_retry_count, [nbrhosts[nbr]['host'] for nbr in nbrhosts], 3),
@@ -137,7 +137,7 @@ def config_reload_on_cleanup(request, nbrhosts, duthost):
     yield
 
     for nbr in list(nbrhosts.keys()):
-        nbrhosts[nbr]['host'].shell("sudo config reload -y")
+        nbrhosts[nbr]['host'].command("sudo config reload -y")
     config_reload(duthost, safe_reload=True)
 
 
@@ -202,24 +202,24 @@ def check_lacpdu_packet_version(duthost):
 @pytest.fixture(scope="function")
 def disable_retry_count_on_peer(duthost, nbrhosts, higher_retry_count_on_peers, collect_techsupport_all_nbrs):
     for nbr in list(nbrhosts.keys()):
-        nbrhosts[nbr]['host'].shell("teamdctl PortChannel1 state item set runner.enable_retry_count_feature false")
+        nbrhosts[nbr]['host'].command("teamdctl PortChannel1 state item set runner.enable_retry_count_feature false")
 
     yield
 
     for nbr in list(nbrhosts.keys()):
-        nbrhosts[nbr]['host'].shell("teamdctl PortChannel1 state item set runner.enable_retry_count_feature true")
+        nbrhosts[nbr]['host'].command("teamdctl PortChannel1 state item set runner.enable_retry_count_feature true")
 
 
 @pytest.fixture(scope="function")
 def disable_retry_count_on_dut(duthost, nbrhosts, higher_retry_count_on_dut, collect_techsupport_all_nbrs):
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     for port_channel in list(cfg_facts["PORTCHANNEL"].keys()):
-        duthost.shell("teamdctl {} state item set runner.enable_retry_count_feature false".format(port_channel))
+        duthost.command("teamdctl {} state item set runner.enable_retry_count_feature false".format(port_channel))
 
     yield
 
     for port_channel in list(cfg_facts["PORTCHANNEL"].keys()):
-        duthost.shell("teamdctl {} state item set runner.enable_retry_count_feature true".format(port_channel))
+        duthost.command("teamdctl {} state item set runner.enable_retry_count_feature true".format(port_channel))
 
 
 class TestNeighborRetryCount:
@@ -257,7 +257,7 @@ class TestNeighborRetryCount:
         Test that the lag remains up for 150 seconds after killing teamd on the peer
         """
         for nbr in list(nbrhosts.keys()):
-            nbrhosts[nbr]['host'].shell("sudo pkill -USR1 -x teamd")
+            nbrhosts[nbr]['host'].command("sudo pkill -USR1 -x teamd")
 
         # Give ourselves 15 seconds to check before the LAG goes down.
         time.sleep(135)
@@ -294,7 +294,7 @@ def test_peer_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_peer
                   "Retry count on one or more neighbors has not been reset to 3.")
 
     for nbr in list(nbrhosts.keys()):
-        processRc = nbrhosts[nbr]['host'].shell("sudo config portchannel retry-count get PortChannel1",
+        processRc = nbrhosts[nbr]['host'].command("sudo config portchannel retry-count get PortChannel1",
                                                 module_ignore_errors=True)
         pytest_assert(processRc["failed"], "Expected failure for getting retry count, but instead it succeeded")
 
@@ -330,7 +330,7 @@ class TestDutRetryCount:
         """
         Test that the lag remains up for 150 seconds after killing teamd on the DUT
         """
-        duthost.shell("docker exec teamd pkill -USR1 -x teamd")
+        duthost.command("docker exec teamd pkill -USR1 -x teamd")
 
         # Give ourselves 15 seconds to check before the LAG goes down.
         time.sleep(135)
@@ -364,6 +364,6 @@ def test_dut_retry_count_disabled(duthost, nbrhosts, higher_retry_count_on_dut, 
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
     port_channels = cfg_facts["PORTCHANNEL"].keys()
     for port_channel in port_channels:
-        processRc = duthost.shell("sudo config portchannel retry-count get {}".format(port_channel),
+        processRc = duthost.command("sudo config portchannel retry-count get {}".format(port_channel),
                                   module_ignore_errors=True)
         pytest_assert(processRc["failed"], "Expected failure for getting retry count, but instead it succeeded")

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -257,16 +257,13 @@ class TestNeighborRetryCount:
         Test that the lag remains up for 150 seconds after killing teamd on the peer
         """
 
-        # Add random command to make sure SSH connection is alive, for
-        # timing purposes
-        for nbr in list(nbrhosts.keys()):
-            nbrhosts[nbr]['host'].command("ps")
+        start_timestamp = int(time.monotonic())
 
         for nbr in list(nbrhosts.keys()):
             nbrhosts[nbr]['host'].command("sudo pkill -USR1 -x teamd")
 
-        # Give ourselves 15 seconds to check before the LAG goes down.
-        time.sleep(135)
+        # Give ourselves 45 seconds to check before the LAG goes down.
+        time.sleep(150 - 45 - (int(time.monotonic()) - start_timestamp))
 
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
         port_channels = cfg_facts["PORTCHANNEL"].keys()
@@ -278,8 +275,8 @@ class TestNeighborRetryCount:
                               "partner retry count is incorrect; expected 5, but is {}"
                               .format(status["runner"]["partner_retry_count"]))
 
-        # Wait 20 seconds (total of 155 seconds) to verify that the LAG did go down.
-        time.sleep(20)
+        # Wait 50 seconds to verify that the LAG did go down (total of 155 seconds since killing teamd).
+        time.sleep(50)
 
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
         port_channels = cfg_facts["PORTCHANNEL"].keys()

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -256,6 +256,12 @@ class TestNeighborRetryCount:
         """
         Test that the lag remains up for 150 seconds after killing teamd on the peer
         """
+
+        # Add random command to make sure SSH connection is alive, for
+        # timing purposes
+        for nbr in list(nbrhosts.keys()):
+            nbrhosts[nbr]['host'].command("ps -ef | grep teamd")
+
         for nbr in list(nbrhosts.keys()):
             nbrhosts[nbr]['host'].command("sudo pkill -USR1 -x teamd")
 

--- a/tests/pc/test_retry_count.py
+++ b/tests/pc/test_retry_count.py
@@ -260,7 +260,7 @@ class TestNeighborRetryCount:
         # Add random command to make sure SSH connection is alive, for
         # timing purposes
         for nbr in list(nbrhosts.keys()):
-            nbrhosts[nbr]['host'].command("ps -ef | grep teamd")
+            nbrhosts[nbr]['host'].command("ps")
 
         for nbr in list(nbrhosts.keys()):
             nbrhosts[nbr]['host'].command("sudo pkill -USR1 -x teamd")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This PR contains the following changes to the retry count test cases:
1. Use `command` instead of `shell` to avoid needing to start a shell where it's not needed.
2. Fix some Python style issues.
3. Rework the retry count test case logic to do a proper tear down by not having an assertion in a fixture. Instead, move the assertion to the test case itself. That makes sure that the teardown part of a fixture runs.
4. Fix the teamd kill test cases failing when running them individually in Elastictest, due to commands taking more time to run there.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

Tested via running `pc/test_retry_count.py` 20 times [here](https://elastictest.org/scheduler/testplan/689cc5be133795c925d9077e). There are only a couple passes, but the failures are because of loganalyzer failures not related to this test case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
