### PR TITLE
[202505] Ignore error during config reload in BGP/QOS/FPC test cases

### DIFF
--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -145,7 +145,7 @@ def peer_links(rand_selected_dut, tbinfo, nbrhosts):
     return links
 
 
-def apply_dscp_cfg_setup(duthost, dscp_mode):
+def apply_dscp_cfg_setup(duthost, dscp_mode, loganalyzer):
     """
     Applies the DSCP decap configuration to the DUT.
 
@@ -174,10 +174,11 @@ def apply_dscp_cfg_setup(duthost, dscp_mode):
         logger.info("DSCP decap mode changed from {} to {} on asic {}".format(default_decap_mode, dscp_mode, asic_id))
 
     logger.info("SETUP: Reload required for dscp decap mode changes to take effect.")
-    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True,
+                  ignore_loganalyzer=loganalyzer)
 
 
-def apply_dscp_cfg_teardown(duthost):
+def apply_dscp_cfg_teardown(duthost, loganalyzer):
     """
     Removes the previously applied DSCP decap configuration from the DUT.
 
@@ -200,7 +201,7 @@ def apply_dscp_cfg_teardown(duthost):
 
     if reload_required:
         logger.info("TEARDOWN: Reload required for dscp decap mode changes to take effect.")
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, safe_reload=True, ignore_loganalyzer=loganalyzer)
 
 
 def find_links(duthost, tbinfo, filter):

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -69,7 +69,8 @@ def build_pkt(dest_mac, ip_addr, ttl):
     return pkt, exp_packet
 
 
-def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, ptfadapter):
+def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_frontend_hostname, tbinfo, ptfadapter,
+                                       loganalyzer):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     lag_facts = duthost.lag_facts(host=duthost.hostname)['ansible_facts']['lag_facts']
@@ -205,4 +206,4 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
                 pytest.fail("BGP is still enable on lag disable member for neighbor {}", ip)
     finally:
         duthost.shell('rm -f {}'.format(lag_member_file_dir))
-        config_reload(duthost, config_source='config_db')
+        config_reload(duthost, config_source='config_db', ignore_loganalyzer=loganalyzer)

--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -154,9 +154,10 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
     def _setup_test_params(self,
                            duthost,
                            tbinfo,
-                           downstream_links, # noqa F811
-                           upstream_links, # noqa F811
-                           decap_mode):
+                           downstream_links,  # noqa: F811
+                           upstream_links,  # noqa: F811
+                           decap_mode,
+                           loganalyzer):
         """
         Set up test parameters for the DSCP to Queue mapping test for IP-IP packets.
 
@@ -188,7 +189,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
             dst_mac = duthost.facts["router_mac"]
 
         # Setup DSCP decap config on DUT
-        apply_dscp_cfg_setup(duthost, decap_mode)
+        apply_dscp_cfg_setup(duthost, decap_mode, loganalyzer)
 
         pytest_assert(downlink is not None, "No downlink found")
         pytest_assert(uplink_ptf_ports is not None, "No uplink found")
@@ -346,35 +347,41 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
 
         pytest_assert(not failed_once, "FAIL: Test failed. Please check table for details.")
 
-    def _teardown_test(self, duthost):
+    def _teardown_test(self, duthost, loganalyzer):
         """
         Test teardown
 
         Args:
             duthost (AnsibleHost): The DUT host
         """
-        apply_dscp_cfg_teardown(duthost)
+        apply_dscp_cfg_teardown(duthost, loganalyzer)
 
     def test_dscp_to_queue_mapping_pipe_mode(self, ptfadapter, rand_selected_dut,
                                              toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
                                              setup_standby_ports_on_rand_unselected_tor,
-                                             tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
+                                             tbinfo,
+                                             downstream_links, upstream_links, dut_qos_maps_module,  # noqa: F811
+                                             loganalyzer):
         """
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "pipe" mode
         """
         duthost = rand_selected_dut
-        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "pipe")
+        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "pipe",
+                                              loganalyzer)
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "pipe")
-        self._teardown_test(duthost)
+        self._teardown_test(duthost, loganalyzer)
 
     def test_dscp_to_queue_mapping_uniform_mode(self, ptfadapter, rand_selected_dut,
                                                 toggle_all_simulator_ports_to_rand_selected_tor, # noqa F811
                                                 setup_standby_ports_on_rand_unselected_tor,
-                                                tbinfo, downstream_links, upstream_links, dut_qos_maps_module): # noqa F811
+                                                tbinfo,
+                                                downstream_links, upstream_links, dut_qos_maps_module,  # noqa: F811
+                                                loganalyzer):
         """
             Test QoS SAI DSCP to queue mapping for IP-IP packets in DSCP "uniform" mode
         """
         duthost = rand_selected_dut
-        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "uniform")
+        test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, "uniform",
+                                              loganalyzer)
         self._run_test(ptfadapter, duthost, tbinfo, test_params, dut_qos_maps_module, "uniform")
-        self._teardown_test(duthost)
+        self._teardown_test(duthost, loganalyzer)

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -2065,7 +2065,8 @@ class TestQosSai(QosSaiBase):
 
     @pytest.mark.parametrize("decap_mode", ["uniform", "pipe"])
     def testIPIPQosSaiDscpToPgMapping(
-        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode  # noqa F811
+        self, duthost, ptfhost, dutTestParams, downstream_links, upstream_links, dut_qos_maps, decap_mode,  # noqa: F811
+        loganalyzer
     ):
         """
             Test QoS SAI DSCP to PG mapping ptf test
@@ -2086,7 +2087,7 @@ class TestQosSai(QosSaiBase):
             pytest.skip("Skip this test since separated DSCP_TO_TC_MAP is applied")
 
         # Setup DSCP decap config on DUT
-        apply_dscp_cfg_setup(duthost, decap_mode)
+        apply_dscp_cfg_setup(duthost, decap_mode, loganalyzer)
 
         loopback_ip = get_ipv4_loopback_ip(duthost)
         downlink = select_random_link(downstream_links)
@@ -2128,7 +2129,7 @@ class TestQosSai(QosSaiBase):
         logger.info(tabulate(data, headers=headers))
 
         # Teardown DSCP decap config on DUT
-        apply_dscp_cfg_teardown(duthost)
+        apply_dscp_cfg_teardown(duthost, loganalyzer)
 
         if local_fail_logs:
             pytest.fail("Test Failed: {}".format(local_fail_logs))


### PR DESCRIPTION
Ignore error during config reload in BGP/QOS/FPC test cases 
Cherry-pick for https://github.com/sonic-net/sonic-mgmt/pull/19869

#### Why I did it
BGP/QOS/FPC test case failed because following error:
E               2025 Jul 28 04:41:57.469604 str2-msn2700-spy-1 ERR iptables: tac_connect_single: connection to 10.64.246.145:49 failed: Network is unreachable

These test case reload_config but not set ignore_loganalyzer parameter.
Because reload config will restart networking service, which will cause TACACS server unreachable during networking service shutdown.

##### Work item tracking
- Microsoft ADO **(number only)**: 

#### How I did it
Set reload_config ignore_loganalyzer parameter in BGP/QOS/FPC test cases.

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Ignore error during config reload in BGP/QOS/FPC test cases 

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


