### PR TITLE
[Mellanox] Align QoS test for Spectrum-4/5 platforms when port alpha is disabled

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -296,3 +296,10 @@ class QosParamMellanox(object):
             margin_ratio = 0.02
             self.qos_params_mlnx['lossy_queue_1']['pkts_num_margin'] = int(
                 self.qos_params_mlnx['lossy_queue_1']['pkts_num_trig_egr_drp'] * margin_ratio)
+            wm_margin_ratio = 0.001
+            self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin'] = max(
+                self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_margin'],
+                int(self.qos_params_mlnx['wm_pg_shared_lossy']['pkts_num_trig_egr_drp'] * wm_margin_ratio))
+            self.qos_params_mlnx['wm_q_shared_lossy']['pkts_num_margin'] = max(
+                self.qos_params_mlnx['wm_q_shared_lossy']['pkts_num_margin'],
+                int(self.qos_params_mlnx['wm_q_shared_lossy']['pkts_num_trig_egr_drp'] * wm_margin_ratio))

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -398,7 +398,8 @@ class QosSaiBase(QosBase):
             platform_support_nvidia_new_algorithm_cal_buffer_thr = ["x86_64-nvidia_sn5600-r0",
                                                                     "x86_64-nvidia_sn5640-r0",
                                                                     "x86_64-nvidia_sn5400-r0"]
-            if dut_asic.sonichost.facts['platform'] in platform_support_nvidia_new_algorithm_cal_buffer_thr:
+            if dut_asic.sonichost.facts['platform'] in platform_support_nvidia_new_algorithm_cal_buffer_thr \
+                    and self.is_port_alpha_enabled(dut_asic):
                 self.__compute_buffer_threshold_for_nvidia_device(dut_asic, table, port, bufferProfile)
             else:
                 self.__computeBufferThreshold(dut_asic, bufferProfile)
@@ -3021,3 +3022,10 @@ def set_queue_pir(interface, queue, rate):
         if not dut.sonichost.is_multi_asic:
             cmd_opt = ""
         dut.shell("sudo show platform npu script {} -s set_queue_pir.py".format(cmd_opt))
+
+    def is_port_alpha_enabled(self, duthost):
+        # only spc4 and above support enable or disable port alpha function
+        get_sai_profile_cmd = "sudo docker exec syncd  cat /usr/share/sonic/hwsku/sai.profile"
+        sai_profile_content = duthost.shell(get_sai_profile_cmd)['stdout']
+        logging.info(f"sai_profile_content: {sai_profile_content}")
+        return "SAI_KEY_DISABLE_PORT_ALPHA=1" not in sai_profile_content


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Align the qos test for Mellanox spectrum-4/5 platforms, according to the PR: https://github.com/sonic-net/sonic-buildimage/pull/23381.  
1. When port alpha is disabled, we use the common function to calculate the buffer threshold.
2. Update  margin for testQosSaiQSharedWatermark[wm_q_shared_lossy] and testQosSaiPgSharedWatermark[wm_pg_shared_lossy] as the following rule: When current margin is smaller share buffer * 0.001, set margin to share buffer * 0.001, otherwise keep the original one

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Align the qos test for Mellanox spc4 and  above platform, according to the PR: https://github.com/sonic-net/sonic-buildimage/pull/23381.  

#### How did you do it?
1. When port alpha is disabled, we use the common function to calculate the buffer threshold.
2. Update  margin for testQosSaiQSharedWatermark[wm_q_shared_lossy] and testQosSaiPgSharedWatermark[wm_pg_shared_lossy] as the following rule: When current margin is smaller share buffer * 0.001, set margin to share buffer * 0.001, otherwise keep the original one

#### How did you verify/test it?
Run qos sai tests on Mellanox spc 4 and above platform

#### Any platform specific information?
Mellanox spc 4 and above platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
