### PR TITLE
[route/test_route_perf] Get l3_alpm_template from config.bcm for all TH5 platform

### DIFF
--- a/tests/route/test_route_perf.py
+++ b/tests/route/test_route_perf.py
@@ -107,7 +107,7 @@ def check_config(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_
     asic_id = enum_rand_one_frontend_asic_index
 
     if (asic == "broadcom"):
-        if "7060x6_64pe" in platform:
+        if "x86_64-arista_7060x6" in platform:
             # For all TH5 family devices, l3_alpm_template is set in config.bcm
             # * 1 - Combined (By default)
             # * 2 - Parallel


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Change the condition to include Moby platform so we can get l3_alpm_template from config.bcm.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix the route.test_route_perf case on Moby.

#### How did you do it?
Change the condition to include Moby platform so we can get l3_alpm_template from config.bcm.

#### How did you verify/test it?
Manually run route.test_route_perf case on a Moby platform and case can pass.
```
route/test_route_perf.py::test_perf_add_remove_routes[4-str5-7060x6-moby-512-1-None] PASSED     [ 50%]
route/test_route_perf.py::test_perf_add_remove_routes[6-str5-7060x6-moby-512-1-None] PASSED     [100%]
```

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
