### PR TITLE
[7215] Ignore ERR logs generated during test_lag_member_forwarding

### DIFF
--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -24,9 +24,24 @@ def ignore_expected_loganalyzer_exception(loganalyzer, duthosts):
         r".* ERR memory_checker: \[memory_checker\] Failed to get container ID of.*",
         r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file.*"
         ]
+    ignore_errors_nokia7215 = [
+        r".* ERR swss#orchagent: :- on_switch_shutdown_request: Syncd stopped",
+        r".* ERR syncd#syncd: xpsIdAllocator.cpp:\d+ Could not allocate id.*",
+        r".* ERR syncd#syncd: :- setEndTime: event 'create:SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000'"
+        r" took -\d+ ms to execute",
+        r".* ERR syncd#syncd: :- logEventData: op: create, key: SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000",
+        r".* ERR syncd#syncd: :- logEventData: fv:.*",
+        r".* ERR swss#orchagent: :- queryTrim.*: Failed to get attribute.*capabilities",
+        r".* ERR swss#orchagent: :- offload_supported: Unable to query BFD offload capability",
+        r".* ERR swss#orchagent: :- readTextFile: failed to read file: "
+        r"'/usr/share/swss/pfc_detect_marvell-prestera.lua': No such file or directory",
+    ]
     if loganalyzer:
         for duthost in duthosts:
             loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors)
+        if duthost.facts['hwsku'] == 'nokia-M0-7215':
+            for duthost in duthosts:
+                loganalyzer[duthost.hostname].ignore_regex.extend(ignore_errors_nokia7215)
 
     return None
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Due to Marvel SAI issue, many ERR syslog are generated in `test_lag_member_forwarding`.
Update testcase to ignore them until SAI fix release.

```
E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost str2-7215-acs-1>" exit code:"1"
E               match: 21
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2025 Aug 12 00:20:58.558254 str2-7215-acs-1 ERR swss#orchagent: :- on_switch_shutdown_request: Syncd stopped
E               
E               2025 Aug 12 00:24:02.468779 str2-7215-acs-1 ERR syncd#syncd: xpsIdAllocator.cpp:216 Could not allocate id[0] , as this value is already used 
E               
E               2025 Aug 12 00:24:02.469571 str2-7215-acs-1 ERR syncd#syncd: xpsAllocatorMgr.cpp:186 Could not allocate id[4096] for allocatorId[2] 
E               
E               2025 Aug 12 00:24:06.331725 str2-7215-acs-1 ERR syncd#syncd: :- setEndTime: event 'create:SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000' took -2028016384 ms to execute
E               
E               2025 Aug 12 00:24:06.332137 str2-7215-acs-1 ERR syncd#syncd: :- logEventData: op: create, key: SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000
E               
E               2025 Aug 12 00:24:06.332511 str2-7215-acs-1 ERR syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_INIT_SWITCH: true
E               
E               2025 Aug 12 00:24:06.332795 str2-7215-acs-1 ERR syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY: 0x52b3a1
E               
E               2025 Aug 12 00:24:06.333062 str2-7215-acs-1 ERR syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_SWITCH_SHUTDOWN_REQUEST_NOTIFY: 0x52b669
E               
E               2025 Aug 12 00:24:06.333317 str2-7215-acs-1 ERR syncd#syncd: :- logEventData: fv: SAI_SWITCH_ATTR_SRC_MAC_ADDRESS: 50:E0:EF:7A:F1:D1
E               
E               2025 Aug 12 00:24:06.377755 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimSizeAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_SIZE) capabilities
E               
E               2025 Aug 12 00:24:06.379648 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimDscpModeEnumCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE) enum value capabilities
E               
E               2025 Aug 12 00:24:06.381483 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimDscpModeAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE) capabilities
E               
E               2025 Aug 12 00:24:06.383322 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimDscpAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_VALUE) capabilities
E               
E               2025 Aug 12 00:24:06.385151 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimTcAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_TC_VALUE) capabilities
E               
E               2025 Aug 12 00:24:06.386977 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimQueueModeEnumCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE) enum value capabilities
E               
E               2025 Aug 12 00:24:06.388871 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimQueueModeAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE) capabilities
E               
E               2025 Aug 12 00:24:06.390732 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimQueueIndexAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_INDEX) capabilities
E               
E               2025 Aug 12 00:24:06.392874 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimTrafficClassNumberAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_TRAFFIC_CLASSES) capabilities
E               
E               2025 Aug 12 00:24:06.394679 str2-7215-acs-1 ERR swss#orchagent: :- queryTrimUnicastQueueNumberAttrCapabilities: Failed to get attribute(SAI_SWITCH_ATTR_NUMBER_OF_UNICAST_QUEUES) capabilities
E               
E               2025 Aug 12 00:24:06.906080 str2-7215-acs-1 ERR swss#orchagent: :- offload_supported: Unable to query BFD offload capability
E               
E               2025 Aug 12 00:24:07.282121 str2-7215-acs-1 ERR swss#orchagent: :- readTextFile: failed to read file: '/usr/share/swss/pfc_detect_marvell-prestera.lua': No such file or directory
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Ignore the known ERR syslog generated during `test_lag_member_forwarding`.

#### How did you do it?
Update loganalyzer ignore list for `test_lag_member_forwarding` on Nokia-7215

#### How did you verify/test it?
Verified on Nokia-7215 M0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
