### PR TITLE
Cleanup DPU reboot errors. Removing the GNMI from the DPU golden config/

### DIFF
--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -6,11 +6,5 @@
             "switch_type": "dpu",
             "type": "SmartSwitchDPU"
         }
-    },
-    "GNMI": {
-        "gnmi": {
-            "log_level": "2",
-            "port": "50052"
-        }
     }
 }


### PR DESCRIPTION
Summary:
Fixes # (issue)
Smart switch reboot GNMI errors.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Open GNMI ports at DPU were needed for standalone DPU appliances.
When the DPU is integrated into the switch, with this config option, switch reboot shows errors:
```
2025-06-12 20:10:44 - ERROR: Failed to send gnoi command to halt services on dpu1
2025-06-12 20:10:44 - ERROR: proceeding without halting the services
```
Cleanup of the config and switch reboot ERRORs.

#### How did you do it?
Removed the unnecessary config information.

#### How did you verify/test it?
Regression on the smart switch in the light mode.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

