### PR TITLE
Update calculation buffer in trimming case

### DIFF
--- a/tests/packet_trimming/constants.py
+++ b/tests/packet_trimming/constants.py
@@ -60,6 +60,7 @@ ECN = 2   # ECN Capable Transport(0), ECT(0)
 TRIM_QUEUE_PROFILE = "egress_lossy_profile"
 DYNAMIC_TH = "3"
 TRIMMING_CAPABILITY = "SAI_ADAPTIVE_ROUTING_CIRCULATION_PORT=257"
+STATIC_THRESHOLD_MULTIPLIER = 1.5   # Multiplier to ensure the buffer can be fully exhausted
 
 # Asymmetric DSCP constants
 ASYM_TC = TRIM_QUEUE


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update calculation buffer in packet trimming case
Fixes:
In the packet trimming cases, it needs to calculate the available buffer size of the egress queue and then block the queue to trigger the trimming packet.
There is a new feature "Update QoS to disable port alpha" (https://github.com/sonic-net/sonic-buildimage/pull/23381). After the change, the calculation method of available buffer size has changed. So need update the buffer calculation function in trimming case

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
