### PR TITLE
skip BUFFER config for Moby fanout

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -203,7 +203,7 @@
     {% endfor %}
     },
 {% endif %}
-{% if fanout_hwsku not in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") and "Arista-7060X6-64PE" not in fanout_hwsku %}
+{% if fanout_hwsku not in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") and "Arista-7060X6" not in fanout_hwsku %}
     "BUFFER_QUEUE": {
     {% for port_name in fanout_port_config %}
          "{{ port_name }}|0-7": {

--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -195,7 +195,7 @@
     "Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4",
     "Arista-7050CX3-32S-S128", "Arista-7050CX3-32S-C6S104", "Arista-7050CX3-32S-C28S16"
 ) %}
-{% if not (fanout_hwsku in no_buffer_hwsku or "Arista-7060X6-64PE" in fanout_hwsku) %}
+{% if not (fanout_hwsku in no_buffer_hwsku or "Arista-7060X6" in fanout_hwsku) %}
     "BUFFER_QUEUE": {
     {% for port_name in fanout_port_config %}
          "{{ port_name }}|0-7": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When deploying fanout, BUFFER related config needs to be skipped for 7060X6-64PE and Moby (7060X6-16PE).
Currently, the code only checks for 7060X6-64PE, extend the check to cover Moby too.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
support Moby in fanout.yml

#### How did you do it?
check for 7060X6 which covers both  7060X6-64PE and 7060X6-16PE.

#### How did you verify/test it?
on local physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
