### PR TITLE
Add Telemetry cert authorization E2E test

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -4,6 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+GNMI_CERT_NAME = "test.client.gnmi.sonic"
 
 @lru_cache(maxsize=None)
 class GNMIEnvironment(object):
@@ -231,8 +232,8 @@ def create_gnmi_certs(duthost, localhost, ptfhost):
     local_command = "openssl req \
                         -new \
                         -key gnmiclient.key \
-                        -subj '/CN=test.client.gnmi.sonic' \
-                        -out gnmiclient.csr"
+                        -subj '/CN={}' \
+                        -out gnmiclient.csr".format(GNMI_CERT_NAME)
     localhost.shell(local_command)
 
     # Sign client certificate

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -4,7 +4,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 GNMI_CERT_NAME = "test.client.gnmi.sonic"
+TELEMETRY_CONTAINER = "telemetry"
+
 
 @lru_cache(maxsize=None)
 class GNMIEnvironment(object):
@@ -51,10 +54,10 @@ class GNMIEnvironment(object):
     def generate_telemetry_config(self, duthost):
         cmd = "docker images | grep -w sonic-telemetry"
         if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-            cmd = "docker ps | grep -w telemetry"
+            cmd = "docker ps | grep -w {}".format(TELEMETRY_CONTAINER)
             if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
                 self.gnmi_config_table = "TELEMETRY"
-                self.gnmi_container = "telemetry"
+                self.gnmi_container = TELEMETRY_CONTAINER
                 # GNMI program is telemetry or gnmi-native
                 res = duthost.shell("docker exec %s supervisorctl status" % self.gnmi_container,
                                     module_ignore_errors=True)

--- a/tests/gnmi_e2e/conftest.py
+++ b/tests/gnmi_e2e/conftest.py
@@ -52,7 +52,7 @@ def apply_cert_config(duthost):
     add_gnmi_client_common_name(duthost, GNMI_CERT_NAME, role)
 
     # Setup gnmi config
-    setup_service_config(duthost, "GNMI", gnmi_env.gnmi_port)
+    setup_service_config(duthost, gnmi_env.gnmi_config_table, gnmi_env.gnmi_port)
 
     # restart gnmi
     command = "docker exec {} supervisorctl stop {}".format(gnmi_env.gnmi_container, gnmi_env.gnmi_program)
@@ -65,7 +65,7 @@ def apply_cert_config(duthost):
     if telemetry_enabled(duthost):
         tele_env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
         # Setup telemetry config
-        setup_service_config(duthost, "TELEMETRY", tele_env.gnmi_port)
+        setup_service_config(duthost, tele_env.gnmi_config_table, tele_env.gnmi_port)
 
         # Restart telemetry service to apply the updated configuration changes
         command = "docker exec {} supervisorctl stop {}".format(tele_env.gnmi_container, tele_env.gnmi_program)

--- a/tests/gnmi_e2e/conftest.py
+++ b/tests/gnmi_e2e/conftest.py
@@ -5,9 +5,10 @@ from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
 from tests.common.helpers.gnmi_utils import gnmi_container, add_gnmi_client_common_name, \
-                                            create_gnmi_certs, delete_gnmi_certs, GNMIEnvironment
+                                            create_gnmi_certs, delete_gnmi_certs, GNMIEnvironment, \
+                                            GNMI_CERT_NAME
 from tests.common.gu_utils import create_checkpoint, rollback
-from tests.gnmi_e2e.helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER, TELEMETRY_PROGRAM
+from tests.gnmi_e2e.helper import telemetry_enabled
 
 
 logger = logging.getLogger(__name__)
@@ -44,33 +45,33 @@ def apply_cert_config(duthost):
     command = 'sudo config save -y'
     duthost.shell(command, module_ignore_errors=True)
 
-    env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
+    gnmi_env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
 
     # Setup gnmi & telemetry client cert common name
     role = "gnmi_readwrite,gnmi_config_db_readwrite,gnmi_appl_db_readwrite,gnmi_dpu_appl_db_readwrite,gnoi_readwrite"
-    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-    add_gnmi_client_common_name(duthost, "test.client.revoked.gnmi.sonic", role)
+    add_gnmi_client_common_name(duthost, GNMI_CERT_NAME, role)
 
     # Setup gnmi config
-    setup_service_config(duthost, "GNMI", env.gnmi_port)
+    setup_service_config(duthost, "GNMI", gnmi_env.gnmi_port)
 
     # restart gnmi
-    command = "docker exec {} supervisorctl stop {}".format(env.gnmi_container, env.gnmi_program)
+    command = "docker exec {} supervisorctl stop {}".format(gnmi_env.gnmi_container, gnmi_env.gnmi_program)
     duthost.shell(command, module_ignore_errors=True)
 
-    command = "docker exec {} supervisorctl start {}".format(env.gnmi_container, env.gnmi_program)
+    command = "docker exec {} supervisorctl start {}".format(gnmi_env.gnmi_container, gnmi_env.gnmi_program)
     duthost.shell(command, module_ignore_errors=True)
 
     # tememetry container not avaliable on all image
     if telemetry_enabled(duthost):
+        tele_env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
         # Setup telemetry config
-        setup_service_config(duthost, "TELEMETRY", TELEMETRY_PORT)
+        setup_service_config(duthost, "TELEMETRY", tele_env.gnmi_port)
 
         # Restart telemetry service to apply the updated configuration changes
-        command = "docker exec {} supervisorctl stop {}".format(TELEMETRY_CONTAINER, TELEMETRY_PROGRAM)
+        command = "docker exec {} supervisorctl stop {}".format(tele_env.gnmi_container, tele_env.gnmi_program)
         duthost.shell(command, module_ignore_errors=True)
 
-        command = "docker exec {} supervisorctl start {}".format(TELEMETRY_CONTAINER, TELEMETRY_PROGRAM)
+        command = "docker exec {} supervisorctl start {}".format(tele_env.gnmi_container, tele_env.gnmi_program)
         duthost.shell(command, module_ignore_errors=True)
 
 

--- a/tests/gnmi_e2e/conftest.py
+++ b/tests/gnmi_e2e/conftest.py
@@ -5,14 +5,14 @@ from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
 from tests.common.helpers.gnmi_utils import gnmi_container, add_gnmi_client_common_name, \
-                                            create_gnmi_certs, delete_gnmi_certs, GNMIEnvironment, \
-                                            del_gnmi_client_common_name
+                                            create_gnmi_certs, delete_gnmi_certs, GNMIEnvironment
 from tests.common.gu_utils import create_checkpoint, rollback
-from .helper import telemetry_enabled
+from .helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER, TELEMETRY_PROGRAM
 
 
 logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
+
 
 
 def setup_service_config(duthost, table, port):
@@ -65,13 +65,13 @@ def apply_cert_config(duthost):
     # tememetry container not avaliable on all image
     if telemetry_enabled(duthost):
         # Setup telemetry config
-        setup_service_config(duthost, "TELEMETRY", "50052")
+        setup_service_config(duthost, "TELEMETRY", TELEMETRY_PORT)
 
         # Restart telemetry service to apply the updated configuration changes
-        command = "docker exec {} supervisorctl stop {}".format("telemetry", "telemetry")
+        command = "docker exec {} supervisorctl stop {}".format(TELEMETRY_CONTAINER, TELEMETRY_PROGRAM)
         duthost.shell(command, module_ignore_errors=True)
 
-        command = "docker exec {} supervisorctl start {}".format("telemetry", "telemetry")
+        command = "docker exec {} supervisorctl start {}".format(TELEMETRY_CONTAINER, TELEMETRY_PROGRAM)
         duthost.shell(command, module_ignore_errors=True)
 
 

--- a/tests/gnmi_e2e/conftest.py
+++ b/tests/gnmi_e2e/conftest.py
@@ -7,7 +7,7 @@ from tests.common.helpers.dut_utils import check_container_state
 from tests.common.helpers.gnmi_utils import gnmi_container, add_gnmi_client_common_name, \
                                             create_gnmi_certs, delete_gnmi_certs, GNMIEnvironment
 from tests.common.gu_utils import create_checkpoint, rollback
-from .helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER, TELEMETRY_PROGRAM
+from test.gnmi_e2e.helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER, TELEMETRY_PROGRAM
 
 
 logger = logging.getLogger(__name__)

--- a/tests/gnmi_e2e/conftest.py
+++ b/tests/gnmi_e2e/conftest.py
@@ -7,7 +7,7 @@ from tests.common.helpers.dut_utils import check_container_state
 from tests.common.helpers.gnmi_utils import gnmi_container, add_gnmi_client_common_name, \
                                             create_gnmi_certs, delete_gnmi_certs, GNMIEnvironment
 from tests.common.gu_utils import create_checkpoint, rollback
-from test.gnmi_e2e.helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER, TELEMETRY_PROGRAM
+from tests.gnmi_e2e.helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER, TELEMETRY_PROGRAM
 
 
 logger = logging.getLogger(__name__)

--- a/tests/gnmi_e2e/conftest.py
+++ b/tests/gnmi_e2e/conftest.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
 
 
-
 def setup_service_config(duthost, table, port):
     command = 'sudo sonic-db-cli CONFIG_DB hset "{}|certs" "server_crt" "/etc/sonic/telemetry/gnmiserver.crt"' \
               .format(table)

--- a/tests/gnmi_e2e/helper.py
+++ b/tests/gnmi_e2e/helper.py
@@ -4,12 +4,13 @@ import logging
 
 from tests.common.helpers.gnmi_utils import add_gnmi_client_common_name, \
                                             del_gnmi_client_common_name, \
-                                            GNMI_CERT_NAME
+                                            GNMI_CERT_NAME, TELEMETRY_CONTAINER
 
 
 logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
 INVALID_CERT_NAME = "invalid.cname"
+
 
 def telemetry_enabled(duthost):
     containers = duthost.get_all_containers()

--- a/tests/gnmi_e2e/helper.py
+++ b/tests/gnmi_e2e/helper.py
@@ -3,17 +3,13 @@ import pytest
 import logging
 
 from tests.common.helpers.gnmi_utils import add_gnmi_client_common_name, \
-                                            del_gnmi_client_common_name
+                                            del_gnmi_client_common_name, \
+                                            GNMI_CERT_NAME
 
 
 logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
-
-
-TELEMETRY_PORT = "50052"
-TELEMETRY_CONTAINER = "telemetry"
-TELEMETRY_PROGRAM = "telemetry"
-
+INVALID_CERT_NAME = "invalid.cname"
 
 def telemetry_enabled(duthost):
     containers = duthost.get_all_containers()
@@ -24,13 +20,13 @@ def telemetry_enabled(duthost):
 @pytest.fixture(scope="function")
 def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
-    del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
-    add_gnmi_client_common_name(duthost, "invalid.cname")
+    del_gnmi_client_common_name(duthost, GNMI_CERT_NAME)
+    add_gnmi_client_common_name(duthost, INVALID_CERT_NAME)
 
     keys = duthost.shell('sudo sonic-db-cli CONFIG_DB keys GNMI*')["stdout_lines"]
     logger.debug("GNMI client cert keys: {}".format(keys))
 
     yield
 
-    del_gnmi_client_common_name(duthost, "invalid.cname")
-    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
+    del_gnmi_client_common_name(duthost, INVALID_CERT_NAME)
+    add_gnmi_client_common_name(duthost, GNMI_CERT_NAME)

--- a/tests/gnmi_e2e/helper.py
+++ b/tests/gnmi_e2e/helper.py
@@ -10,10 +10,15 @@ logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
 
 
+TELEMETRY_PORT = "50052"
+TELEMETRY_CONTAINER = "telemetry"
+TELEMETRY_PROGRAM = "telemetry"
+
+
 def telemetry_enabled(duthost):
     containers = duthost.get_all_containers()
     logger.warning("running containers: {}".format(containers))
-    return "telemetry" in containers
+    return TELEMETRY_CONTAINER in containers
 
 
 @pytest.fixture(scope="function")

--- a/tests/gnmi_e2e/helper.py
+++ b/tests/gnmi_e2e/helper.py
@@ -1,0 +1,31 @@
+
+import pytest
+import logging
+
+from tests.common.helpers.gnmi_utils import add_gnmi_client_common_name, \
+                                            del_gnmi_client_common_name
+
+
+logger = logging.getLogger(__name__)
+SETUP_ENV_CP = "test_setup_checkpoint"
+
+
+def telemetry_enabled(duthost):
+    containers = duthost.get_all_containers()
+    logger.warning("running containers: {}".format(containers))
+    return "telemetry" in containers
+
+
+@pytest.fixture(scope="function")
+def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
+    add_gnmi_client_common_name(duthost, "invalid.cname")
+
+    keys = duthost.shell('sudo sonic-db-cli CONFIG_DB keys GNMI*')["stdout_lines"]
+    logger.debug("GNMI client cert keys: {}".format(keys))
+
+    yield
+
+    del_gnmi_client_common_name(duthost, "invalid.cname")
+    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")

--- a/tests/gnmi_e2e/test_gnmi_auth.py
+++ b/tests/gnmi_e2e/test_gnmi_auth.py
@@ -3,7 +3,7 @@ import logging
 
 from tests.common.helpers.gnmi_utils import gnmi_capabilities
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from .helper import setup_invalid_client_cert_cname       # noqa: F401
+from tests.gnmi_e2e.helper import setup_invalid_client_cert_cname       # noqa: F401
 
 logger = logging.getLogger(__name__)
 allure.logger = logger

--- a/tests/gnmi_e2e/test_gnmi_auth.py
+++ b/tests/gnmi_e2e/test_gnmi_auth.py
@@ -3,7 +3,7 @@ import logging
 
 from tests.common.helpers.gnmi_utils import gnmi_capabilities
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from .helper import setup_invalid_client_cert_cname # noqa: F401
+from .helper import setup_invalid_client_cert_cname       # noqa: F401
 
 logger = logging.getLogger(__name__)
 allure.logger = logger
@@ -34,7 +34,7 @@ def test_gnmi_authorize_passed_with_valid_cname(duthosts,
 def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
                                                   rand_one_dut_hostname,
                                                   localhost,
-                                                  setup_invalid_client_cert_cname):
+                                                  setup_invalid_client_cert_cname):    # noqa: F401
     '''
     Verify GNMI native write, incremental config for configDB
     GNMI set request with invalid path

--- a/tests/gnmi_e2e/test_gnmi_auth.py
+++ b/tests/gnmi_e2e/test_gnmi_auth.py
@@ -1,9 +1,9 @@
 import pytest
 import logging
 
-from tests.common.helpers.gnmi_utils import gnmi_capabilities, add_gnmi_client_common_name, \
-                                            del_gnmi_client_common_name
+from tests.common.helpers.gnmi_utils import gnmi_capabilities
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from conftest import setup_invalid_client_cert_cname
 
 logger = logging.getLogger(__name__)
 allure.logger = logger
@@ -12,21 +12,6 @@ pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer
 ]
-
-
-@pytest.fixture(scope="function")
-def setup_invalid_client_cert_cname(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
-    del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
-    add_gnmi_client_common_name(duthost, "invalid.cname")
-
-    keys = duthost.shell('sudo sonic-db-cli CONFIG_DB keys GNMI*')["stdout_lines"]
-    logger.debug("GNMI client cert keys: {}".format(keys))
-
-    yield
-
-    del_gnmi_client_common_name(duthost, "invalid.cname")
-    add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
 def test_gnmi_authorize_passed_with_valid_cname(duthosts,

--- a/tests/gnmi_e2e/test_gnmi_auth.py
+++ b/tests/gnmi_e2e/test_gnmi_auth.py
@@ -3,7 +3,7 @@ import logging
 
 from tests.common.helpers.gnmi_utils import gnmi_capabilities
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from conftest import setup_invalid_client_cert_cname
+from .helper import setup_invalid_client_cert_cname
 
 logger = logging.getLogger(__name__)
 allure.logger = logger

--- a/tests/gnmi_e2e/test_gnmi_auth.py
+++ b/tests/gnmi_e2e/test_gnmi_auth.py
@@ -3,7 +3,7 @@ import logging
 
 from tests.common.helpers.gnmi_utils import gnmi_capabilities
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from .helper import setup_invalid_client_cert_cname
+from .helper import setup_invalid_client_cert_cname # noqa: F401
 
 logger = logging.getLogger(__name__)
 allure.logger = logger

--- a/tests/gnmi_e2e/test_gnmi_auth.py
+++ b/tests/gnmi_e2e/test_gnmi_auth.py
@@ -34,7 +34,7 @@ def test_gnmi_authorize_passed_with_valid_cname(duthosts,
 def test_gnmi_authorize_failed_with_invalid_cname(duthosts,
                                                   rand_one_dut_hostname,
                                                   localhost,
-                                                  setup_invalid_client_cert_cname):    # noqa: F401
+                                                  setup_invalid_client_cert_cname):    # noqa: F811
     '''
     Verify GNMI native write, incremental config for configDB
     GNMI set request with invalid path

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -32,7 +32,7 @@ def ptf_telemetry_get(duthost, ptfhost):
     cmd += '-m get -x DEVICE_METADATA/localhost -xt CONFIG_DB'
     output = ptfhost.shell(cmd, module_ignore_errors=True)
     logger.debug("ptf_telemetry_capabilities: {} output: {}".format(cmd, output))
-    return output
+    return "\n".join(output['stdout_lines'])
 
 
 def test_telemetry_authorize_passed_with_valid_cname(duthosts,

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -48,7 +48,7 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
     failed, msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_passed_with_valid_cname: {}".format(msg))
 
-    assert not failed, ("Telemetry 'get' command failed to execute: ").format(msg)
+    assert not failed, ("Telemetry 'get' command failed to execute: {}").format(msg)
 
     assert "Unauthenticated" not in msg, (
         "'Unauthenticated' error message found in Telemetry response. "
@@ -70,7 +70,7 @@ def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
     failed, msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_failed_with_invalid_cname: {}".format(msg))
 
-    assert failed, ("Telemetry 'get' command executed successfully: ").format(msg)
+    assert failed, ("Telemetry 'get' command executed successfully: {}").format(msg)
 
     assert "Unauthenticated" in msg, (
         "'Unauthenticated' error message not found in Telemetry response. "

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -32,7 +32,7 @@ def ptf_telemetry_get(duthost, ptfhost):
     cmd += '-m get -x DEVICE_METADATA/localhost -xt CONFIG_DB'
     output = ptfhost.shell(cmd, module_ignore_errors=True)
     logger.debug("ptf_telemetry_capabilities: {} output: {}".format(cmd, output))
-    return "\n".join(output['stdout_lines'])
+    return output['failed'], "\n".join(output['stdout_lines'])
 
 
 def test_telemetry_authorize_passed_with_valid_cname(duthosts,
@@ -45,8 +45,10 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
     if not telemetry_enabled(duthost):
         pytest.skip("Skipping because telemetry not enabled")
 
-    msg = ptf_telemetry_get(duthost, ptfhost)
+    failed, msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_passed_with_valid_cname: {}".format(msg))
+
+    assert not failed, ("Telemetry 'get' command failed to execute: ").format(msg)
 
     assert "Unauthenticated" not in msg, (
         "'Unauthenticated' error message found in Telemetry response. "
@@ -65,8 +67,10 @@ def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
     if not telemetry_enabled(duthost):
         pytest.skip("Skipping because telemetry not enabled")
 
-    msg = ptf_telemetry_get(duthost, ptfhost)
+    failed, msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_failed_with_invalid_cname: {}".format(msg))
+
+    assert failed, ("Telemetry 'get' command executed successfully: ").format(msg)
 
     assert "Unauthenticated" in msg, (
         "'Unauthenticated' error message not found in Telemetry response. "

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -2,8 +2,9 @@ import pytest
 import logging
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.gnmi_e2e.helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER
+from tests.gnmi_e2e.helper import telemetry_enabled
 from tests.gnmi_e2e.helper import setup_invalid_client_cert_cname     # noqa: F401
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
 logger = logging.getLogger(__name__)
 allure.logger = logger
@@ -14,26 +15,29 @@ pytestmark = [
 ]
 
 
-def telemetry_capabilities(duthost, localhost):
+def ptf_telemetry_get(duthost, ptfhost):
+    output = ptfhost.shell("whoami", module_ignore_errors=True)
+    logger.error("whoami: {}".format(output))
+
+    env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
     ip = duthost.mgmt_ip
-    # Connect to Telemetry service port 50052
-    cmd = "docker exec %s gnmi_cli -client_types=gnmi " % (TELEMETRY_CONTAINER)
-    cmd += "-a %s:%s " % (ip, TELEMETRY_PORT)
-    cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
-    cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
-    cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
-    cmd += "-logtostderr -capabilities"
-    output = duthost.shell(cmd, module_ignore_errors=True)
-    logger.debug("telemetry_capabilities: {} output: {}".format(cmd, output))
-    if output['stderr']:
-        return -1, output['stderr']
-    else:
-        return 0, output['stdout']
+    port = env.gnmi_port
+    cmd = 'python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
+    cmd += '--timeout 30 '
+    cmd += '-t %s -p %u ' % (ip, port)
+    cmd += '-xo sonic-db '
+    cmd += '-rcert /root/gnmiCA.pem '
+    cmd += '-pkey /root/gnmiclient.key '
+    cmd += '-cchain /root/gnmiclient.crt '
+    cmd += '-m get -x DEVICE_METADATA/localhost -xt CONFIG_DB'
+    output = ptfhost.shell(cmd, module_ignore_errors=True)
+    logger.debug("ptf_telemetry_capabilities: {} output: {}".format(cmd, output))
+    return output
 
 
 def test_telemetry_authorize_passed_with_valid_cname(duthosts,
                                                      rand_one_dut_hostname,
-                                                     localhost):
+                                                     ptfhost):
     '''
     Verify telemetry authorization using a valid certificate to ensure secure access
     '''
@@ -41,7 +45,7 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
     if not telemetry_enabled(duthost):
         pytest.skip("Skipping because telemetry not enabled")
 
-    ret, msg = telemetry_capabilities(duthost, localhost)
+    ret, msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_passed_with_valid_cname: {}".format(msg))
 
     assert "Unauthenticated" not in msg, (
@@ -52,7 +56,7 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
 
 def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
                                                        rand_one_dut_hostname,
-                                                       localhost,
+                                                       ptfhost,
                                                        setup_invalid_client_cert_cname):    # noqa: F811
     '''
     Verify telemetry authorization using an invalid certificate to confirm rejection behavior
@@ -61,7 +65,7 @@ def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
     if not telemetry_enabled(duthost):
         pytest.skip("Skipping because telemetry not enabled")
 
-    ret, msg = telemetry_capabilities(duthost, localhost)
+    ret, msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_failed_with_invalid_cname: {}".format(msg))
 
     assert "Unauthenticated" in msg, (

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -45,7 +45,7 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
     if not telemetry_enabled(duthost):
         pytest.skip("Skipping because telemetry not enabled")
 
-    ret, msg = ptf_telemetry_get(duthost, ptfhost)
+    msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_passed_with_valid_cname: {}".format(msg))
 
     assert "Unauthenticated" not in msg, (
@@ -65,7 +65,7 @@ def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
     if not telemetry_enabled(duthost):
         pytest.skip("Skipping because telemetry not enabled")
 
-    ret, msg = ptf_telemetry_get(duthost, ptfhost)
+    msg = ptf_telemetry_get(duthost, ptfhost)
     logger.debug("test_telemetry_authorize_failed_with_invalid_cname: {}".format(msg))
 
     assert "Unauthenticated" in msg, (

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -3,7 +3,7 @@ import logging
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from .helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER
-from .helper import setup_invalid_client_cert_cname # noqa: F401
+from .helper import setup_invalid_client_cert_cname     # noqa: F401
 
 logger = logging.getLogger(__name__)
 allure.logger = logger
@@ -17,8 +17,8 @@ pytestmark = [
 def telemetry_capabilities(duthost, localhost):
     ip = duthost.mgmt_ip
     # Connect to Telemetry service port 50052
-    cmd = "docker exec %s gnmi_cli -client_types=gnmi "
-    cmd += "-a %s:%s " % (TELEMETRY_CONTAINER, ip, TELEMETRY_PORT)
+    cmd = "docker exec %s gnmi_cli -client_types=gnmi " % (TELEMETRY_CONTAINER)
+    cmd += "-a %s:%s " % (ip, TELEMETRY_PORT)
     cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
@@ -53,7 +53,7 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
 def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
                                                        rand_one_dut_hostname,
                                                        localhost,
-                                                       setup_invalid_client_cert_cname):
+                                                       setup_invalid_client_cert_cname):    # noqa: F401
     '''
     Verify telemetry authorization using an invalid certificate to confirm rejection behavior
     '''

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from conftest import setup_invalid_client_cert_cname, telemetry_enabled
+from .helper import setup_invalid_client_cert_cname, telemetry_enabled
 
 logger = logging.getLogger(__name__)
 allure.logger = logger

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -2,8 +2,8 @@ import pytest
 import logging
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from .helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER
-from .helper import setup_invalid_client_cert_cname     # noqa: F401
+from tests.gnmi_e2e.helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER
+from tests.gnmi_e2e.helper import setup_invalid_client_cert_cname     # noqa: F401
 
 logger = logging.getLogger(__name__)
 allure.logger = logger

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -2,7 +2,8 @@ import pytest
 import logging
 
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from .helper import setup_invalid_client_cert_cname, telemetry_enabled
+from .helper import telemetry_enabled, TELEMETRY_PORT, TELEMETRY_CONTAINER
+from .helper import setup_invalid_client_cert_cname # noqa: F401
 
 logger = logging.getLogger(__name__)
 allure.logger = logger
@@ -12,10 +13,12 @@ pytestmark = [
     pytest.mark.disable_loganalyzer
 ]
 
+
 def telemetry_capabilities(duthost, localhost):
     ip = duthost.mgmt_ip
     # Connect to Telemetry service port 50052
-    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % ("telemetry", ip, "50052")
+    cmd = "docker exec %s gnmi_cli -client_types=gnmi "
+    cmd += "-a %s:%s " % (TELEMETRY_CONTAINER, ip, TELEMETRY_PORT)
     cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
@@ -29,8 +32,8 @@ def telemetry_capabilities(duthost, localhost):
 
 
 def test_telemetry_authorize_passed_with_valid_cname(duthosts,
-                                                rand_one_dut_hostname,
-                                                localhost):
+                                                     rand_one_dut_hostname,
+                                                     localhost):
     '''
     Verify telemetry authorization using a valid certificate to ensure secure access
     '''
@@ -48,9 +51,9 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
 
 
 def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
-                                                  rand_one_dut_hostname,
-                                                  localhost,
-                                                  setup_invalid_client_cert_cname):
+                                                       rand_one_dut_hostname,
+                                                       localhost,
+                                                       setup_invalid_client_cert_cname):
     '''
     Verify telemetry authorization using an invalid certificate to confirm rejection behavior
     '''

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -1,0 +1,67 @@
+import pytest
+import logging
+
+from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
+from conftest import setup_invalid_client_cert_cname, telemetry_enabled
+
+logger = logging.getLogger(__name__)
+allure.logger = logger
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+def telemetry_capabilities(duthost, localhost):
+    ip = duthost.mgmt_ip
+    # Connect to Telemetry service port 50052
+    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % ("telemetry", ip, "50052")
+    cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
+    cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
+    cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
+    cmd += "-logtostderr -capabilities"
+    output = duthost.shell(cmd, module_ignore_errors=True)
+    logger.debug("telemetry_capabilities: {} output: {}".format(cmd, output))
+    if output['stderr']:
+        return -1, output['stderr']
+    else:
+        return 0, output['stdout']
+
+
+def test_telemetry_authorize_passed_with_valid_cname(duthosts,
+                                                rand_one_dut_hostname,
+                                                localhost):
+    '''
+    Verify telemetry authorization using a valid certificate to ensure secure access
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    if not telemetry_enabled(duthost):
+        pytest.skip("Skipping because telemetry not enabled")
+
+    ret, msg = telemetry_capabilities(duthost, localhost)
+    logger.debug("test_telemetry_authorize_passed_with_valid_cname: {}".format(msg))
+
+    assert "Unauthenticated" not in msg, (
+        "'Unauthenticated' error message found in Telemetry response. "
+        "- Actual message: '{}'"
+    ).format(msg)
+
+
+def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
+                                                  rand_one_dut_hostname,
+                                                  localhost,
+                                                  setup_invalid_client_cert_cname):
+    '''
+    Verify telemetry authorization using an invalid certificate to confirm rejection behavior
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    if not telemetry_enabled(duthost):
+        pytest.skip("Skipping because telemetry not enabled")
+
+    ret, msg = telemetry_capabilities(duthost, localhost)
+    logger.debug("test_telemetry_authorize_failed_with_invalid_cname: {}".format(msg))
+
+    assert "Unauthenticated" in msg, (
+        "'Unauthenticated' error message not found in Telemetry response. "
+        "- Actual message: '{}'"
+    ).format(msg)

--- a/tests/gnmi_e2e/test_telemetry_auth.py
+++ b/tests/gnmi_e2e/test_telemetry_auth.py
@@ -53,7 +53,7 @@ def test_telemetry_authorize_passed_with_valid_cname(duthosts,
 def test_telemetry_authorize_failed_with_invalid_cname(duthosts,
                                                        rand_one_dut_hostname,
                                                        localhost,
-                                                       setup_invalid_client_cert_cname):    # noqa: F401
+                                                       setup_invalid_client_cert_cname):    # noqa: F811
     '''
     Verify telemetry authorization using an invalid certificate to confirm rejection behavior
     '''


### PR DESCRIPTION
Add Telemetry cert authorization E2E test

#### Why I did it
Telemetry cert authorization does not have end to end test.

##### Work item tracking
- Microsoft ADO **(number only)**: 

#### How I did it
Add Telemetry cert authorization E2E test

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Add Telemetry cert authorization E2E test

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


