### PR TITLE
[T2] modify helper function to use show ipv6 route for v6 addresses

### DIFF
--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -1,5 +1,6 @@
 from netaddr import IPNetwork
 import json
+from tests.common.utilities import is_ipv4_address
 
 ZERO_ADDR = r'0.0.0.0/0'
 ZERO_V6_ADDR = r'::/0'
@@ -31,7 +32,8 @@ def route_through_default_routes(host, ip_addr):
     @param ip_addr: The ip address to check
     @return: True if the given up goes to default route, False otherwise
     """
-    output = host.shell("show ip route {} json".format(ip_addr))['stdout']
+    ip_ver = "ip" if is_ipv4_address(ip_addr) else "ipv6"
+    output = host.shell("show {} route {} json".format(ip_ver, ip_addr))['stdout']
     routes_info = json.loads(output)
     ret = True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Due to recent changes in FRR, the helper function needs to be modified to use `show ipv6 route` for v6 addresses.
Fixes #20228 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

- identify `ip_ver`  from input `ip_address`

#### How did you verify/test it?
Ran `bgp/test_bgpmon_v6.py::test_bgpmon_v6` on Chassis with master image
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="588" height="59" alt="image" src="https://github.com/user-attachments/assets/2e3fea55-4ec7-45f9-8b8f-5bf2f1078d28" />
