### PR TITLE
Add fixture to provide designed routes information of topology file

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -76,6 +76,9 @@ AGGREGATE_ROUTES_DEFAULT_VALUE = []
 IPV6_ADDRESS_PATTERN_DEFAULT_VALUE = '20%02X:%02X%02X:0:%02X::/64'
 ENABLE_IPV4_ROUTES_GENERATION_DEFAULT_VALUE = True
 ENABLE_IPV6_ROUTES_GENERATION_DEFAULT_VALUE = True
+GENERATE_WITHOUT_APPLY = 'generate'
+IPV4 = 'ipv4'
+IPV6 = 'ipv6'
 BGP_SCALE_T1S = [
     't1-isolated-d254u2', 't1-isolated-d254u2s1', 't1-isolated-d254u2s2',
     't1-isolated-d510u2', 't1-isolated-d510u2s2'
@@ -511,7 +514,7 @@ def generate_t1_to_t0_routes(family, offset, leaf_number, subnet_size, tor_asn, 
     return routes, suffix
 
 
-def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_neighbor_groups=0):
+def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_neighbor_groups=0, routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -549,6 +552,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
+        routes[vm_name] = {}
 
         if enable_ipv4_routes_generation:
             routes_v4, last_suffix = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
@@ -559,7 +563,9 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             if aggregate_routes_v4:
                 filterout_subnet_ipv4(aggregate_routes, routes_v4)
                 routes_v4.extend(aggregate_routes_v4)
-            change_routes(action, ptf_ip, port, routes_v4)
+            routes[vm_name][IPV4] = routes_v4
+            if action != GENERATE_WITHOUT_APPLY:
+                change_routes(action, ptf_ip, port, routes_v4)
         if enable_ipv6_routes_generation:
             routes_v6, last_suffix = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                                      spine_asn, leaf_asn_start, tor_asn_start,
@@ -571,7 +577,9 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             if aggregate_routes_v6:
                 filterout_subnet_ipv6(aggregate_routes, routes_v6)
                 routes_v6.extend(aggregate_routes_v6)
-            change_routes(action, ptf_ip, port6, routes_v6)
+            routes[vm_name][IPV6] = routes_v6
+            if action != GENERATE_WITHOUT_APPLY:
+                change_routes(action, ptf_ip, port6, routes_v6)
         group_index = index * upstream_neighbor_groups // vms_len
         next_group_index = (index + 1) * upstream_neighbor_groups // vms_len
         if group_index != next_group_index:
@@ -579,7 +587,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
 
 
 def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce", tor_default_route=False,
-               downstream_neighbor_groups=0):
+               downstream_neighbor_groups=0, routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -618,6 +626,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         downstream_tor_number = len(downstream_vm_config)
         lov6_address_pattern = ipv6_address_pattern.split("/")[0] + "/128"
         current_routes_offset = last_suffix
+        routes[k] = {}
         for index, k in enumerate(sorted(downstream_vm_config.keys())):
             v = downstream_vm_config[k]
             if dpus and k in dpus:
@@ -639,6 +648,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v4:
                     filterout_subnet_ipv4(aggregate_routes, routes_v4)
                     routes_v4.extend(aggregate_routes_v4)
+                routes[k][IPV4] = routes_v4
                 routes_to_change[port] += routes_v4
             if enable_ipv6_routes_generation:
                 routes_v6, last_suffix = generate_t1_to_t0_routes("v6", current_routes_offset, leaf_number, 1, tor_asn,
@@ -647,6 +657,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v6:
                     filterout_subnet_ipv6(aggregate_routes, routes_v6)
                     routes_v6.extend(aggregate_routes_v6)
+                routes[k][IPV6] = routes_v6
                 routes_to_change[port6] += routes_v6
             group_index = index * downstream_neighbor_groups // downstream_tor_number
             next_group_index = (index + 1) * downstream_neighbor_groups // downstream_tor_number
@@ -676,7 +687,8 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
-
+        if k not in routes:
+            routes[k] = {}
         router_type = None
         if 'spine' in v['properties']:
             router_type = 'spine'
@@ -695,6 +707,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v4:
                     filterout_subnet_ipv4(aggregate_routes, routes_v4)
                     routes_v4.extend(aggregate_routes_v4)
+                routes[k][IPV4] = routes_v4
                 routes_to_change[port] += routes_v4
             if enable_ipv6_routes_generation:
                 routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
@@ -707,6 +720,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v6:
                     filterout_subnet_ipv6(aggregate_routes, routes_v6)
                     routes_v6.extend(aggregate_routes_v6)
+                routes[k][IPV6] = routes_v6
                 routes_to_change[port6] += routes_v6
 
         if 'vips' in v:
@@ -715,10 +729,11 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 routes_vips.append((prefix, nhipv4, v["vips"]["ipv4"]["asn"]))
             routes_to_change[port] += routes_vips
 
-    for port, routes in routes_to_change.items():
-        if len(routes) <= 0:
-            continue
-        change_routes(action, ptf_ip, port, routes)
+    if action != GENERATE_WITHOUT_APPLY:
+        for port, routes in routes_to_change.items():
+            if len(routes) <= 0:
+                continue
+            change_routes(action, ptf_ip, port, routes)
 
 
 def get_new_ip(curr_ip, skip_count):
@@ -798,7 +813,7 @@ We would have the following distribution:
 """
 
 
-def fib_m0(topo, ptf_ip, action="announce"):
+def fib_m0(topo, ptf_ip, action="announce", routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     colo_number = common_config.get("colo_number", COLO_NUMBER)
     m0_number = common_config.get("m0_number", M0_NUMBER)
@@ -863,8 +878,12 @@ def fib_m0(topo, ptf_ip, action="announce"):
                 m1_routes_v4 = routes_v4
                 m1_routes_v6 = routes_v6
 
-        change_routes(action, ptf_ip, port, routes_v4)
-        change_routes(action, ptf_ip, port6, routes_v6)
+        routes[k] = {}
+        routes[k][IPV4] = routes_v4
+        routes[k][IPv6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 def generate_m0_subnet_routes(m0_subnet_number, m0_subnet_size, ip_base, nexthop, base_offset=0, m0_asn=None):
@@ -970,7 +989,7 @@ Routes announced by M0 can be broken down to 5 sets:
 """
 
 
-def fib_mx(topo, ptf_ip, action="announce"):
+def fib_mx(topo, ptf_ip, action="announce", routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     colo_number = common_config.get("colo_number", COLO_NUMBER)
     m0_number = common_config.get("m0_number", M0_NUMBER)
@@ -1024,8 +1043,12 @@ def fib_mx(topo, ptf_ip, action="announce"):
             m0_routes_v4 = routes_v4
             m0_routes_v6 = routes_v6
 
-        change_routes(action, ptf_ip, port, routes_v4)
-        change_routes(action, ptf_ip, port6, routes_v6)
+        routes[k] = {}
+        routes[k][IPV4] = routes_v4
+        routes[k][IPv6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 """
@@ -1093,7 +1116,7 @@ def generate_m1_m0_routes(nexthop, ip_base, m0_subnet_number, m0_subnet_size, m0
     return routes, ip_base, mx_lo_ip
 
 
-def fib_m1(topo, ptf_ip, action="announce"):
+def fib_m1(topo, ptf_ip, action="announce", routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
@@ -1148,9 +1171,13 @@ def fib_m1(topo, ptf_ip, action="announce"):
             # C0 announce nothing but it's loopback IP.
             pass
 
-        # routes_v4 = generate_m1_routes(nhipv4)
-        change_routes(action, ptf_ip, port, routes_v4)
-        change_routes(action, ptf_ip, port6, routes_v6)
+        routes[k] = {}
+        routes[k][IPV4] = routes_v4
+        routes[k][IPv6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            # routes_v4 = generate_m1_routes(nhipv4)
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 """
@@ -1186,7 +1213,7 @@ We would have the following distribution:
 """
 
 
-def fib_t2_lag(topo, ptf_ip, action="announce"):
+def fib_t2_lag(topo, ptf_ip, action="announce", routes={}):
     route_set = []
     vms = topo['topology']['VMs']
     # T1 VMs per linecard(asic) - key is the dut index, and value is a list of T1 VMs
@@ -1209,12 +1236,13 @@ def fib_t2_lag(topo, ptf_ip, action="announce"):
                 t3_vms[dut_index] = list()
             t3_vms[dut_index].append(key)
 
-    route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action)
-    route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action)
-    send_routes_in_parallel(route_set)
+    route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action, routes={})
+    route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action, routes={})
+    if action != GENERATE_WITHOUT_APPLY:
+        send_routes_in_parallel(route_set)
 
 
-def fib_ft2_routes(topo, ptf_ip, action="announce"):
+def fib_ft2_routes(topo, ptf_ip, action="announce", routes={}):
     """
     Generate routes from LT2 to FT2 in the FT2 topology.
     """
@@ -1266,12 +1294,16 @@ def fib_ft2_routes(topo, ptf_ip, action="announce"):
             # Generate default routes for both IPv4 and IPv6
             ipv4_routes.append(("0.0.0.0/0", nhipv4, default_route_as_path))
             ipv6_routes.append(("::/0", nhipv6, default_route_as_path))
-            # Send the routes to the PTF
-            change_routes(action, ptf_ip, port, ipv4_routes)
-            change_routes(action, ptf_ip, port6, ipv6_routes)
+            routes[vm_name] = {}
+            routes[vm_name][IPV4] = ipv4_routes
+            routes[vm_name][IPv6] = ipv6_routes
+            if action != GENERATE_WITHOUT_APPLY:
+                # Send the routes to the PTF
+                change_routes(action, ptf_ip, port, ipv4_routes)
+                change_routes(action, ptf_ip, port6, ipv6_routes)
 
 
-def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
+def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     vms = topo['topology']['VMs']
     vms_config = topo['configuration']
@@ -1317,6 +1349,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
             aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
             aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
             aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
+            routes[a_vm] = {}
 
             router_type = None
             if 'leaf' in vms_config[a_vm]['properties']:
@@ -1337,6 +1370,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
                         filterout_subnet_ipv4(aggregate_routes, routes_v4)
                         routes_v4.extend(aggregate_routes_v4)
                     random.shuffle(routes_v4)
+                    routes[a_vm][IPV4] = routes_v4
                     r_set.append((routes_v4, port, action, ptf_ip))
                 if enable_ipv6_routes_generation:
                     routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
@@ -1348,9 +1382,10 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
                         filterout_subnet_ipv6(aggregate_routes, routes_v6)
                         routes_v6.extend(aggregate_routes_v6)
                     random.shuffle(routes_v6)
+                    routes[a_vm][IPv6] = routes_v6
                     r_set.append((routes_v6, port6, action, ptf_ip))
 
-                if 'vips' in vms_config[a_vm]:
+                if 'vips' in vms_config[a_vm] and action != GENERATE_WITHOUT_APPLY:
                     routes_vips = []
                     for prefix in vms_config[a_vm]["vips"]["ipv4"]["prefixes"]:
                         routes_vips.append(
@@ -1359,7 +1394,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce"):
     return r_set
 
 
-def fib_t0_mclag(topo, ptf_ip, action="announce"):
+def fib_t0_mclag(topo, ptf_ip, action="announce", routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -1395,6 +1430,7 @@ def fib_t0_mclag(topo, ptf_ip, action="announce"):
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
+        routes[vm] = {}
 
         if enable_ipv4_routes_generation:
             routes_v4, _ = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
@@ -1404,7 +1440,9 @@ def fib_t0_mclag(topo, ptf_ip, action="announce"):
             if aggregate_routes_v4:
                 filterout_subnet_ipv4(aggregate_routes, routes_v4)
                 routes_v4.extend(aggregate_routes_v4)
-            change_routes(action, ptf_ip, port, routes_v4)
+            routes[vm][IPV4] = routes_v4
+            if action != GENERATE_WITHOUT_APPLY:
+                change_routes(action, ptf_ip, port, routes_v4)
         if enable_ipv6_routes_generation:
             routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
                                            spine_asn, leaf_asn_start, tor_asn_start,
@@ -1414,10 +1452,12 @@ def fib_t0_mclag(topo, ptf_ip, action="announce"):
             if aggregate_routes_v6:
                 filterout_subnet_ipv6(aggregate_routes, routes_v6)
                 routes_v6.extend(aggregate_routes_v6)
-            change_routes(action, ptf_ip, port6, routes_v6)
+            routes[vm][IPv6] = routes_v6
+            if action != GENERATE_WITHOUT_APPLY:
+                change_routes(action, ptf_ip, port6, routes_v6)
 
 
-def fib_lt2_routes(topo, ptf_ip, action="annouce"):
+def fib_lt2_routes(topo, ptf_ip, action="annouce", routes={}):
     T1_GROUP_SIZE = 2
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
@@ -1471,8 +1511,12 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce"):
 
             ipv4_routes.append((str(next(extra_ipv4_t1)), nhipv4, as_path))
 
-            change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
-            change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
+            routes[vm_name] = {}
+            routes[vm_name][IPV4] = ipv4_routes
+            routes[vm_name][IPv6] = ipv6_routes
+            if action != GENERATE_WITHOUT_APPLY:
+                change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
+                change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
 
     for device in range(len(ut2_vms)):
         ipv4_routes = [
@@ -1492,11 +1536,16 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce"):
         ipv4_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv4'], nhipv4, as_path))
         ipv6_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv6'], nhipv6, as_path))
 
-        change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
-        change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
+        if vm_name not in routes:
+            routes[vm_name] = {}
+        routes[vm_name][IPV4] = ipv4_routes
+        routes[vm_name][IPv6] = ipv6_routes
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
+            change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
 
 
-def fib_dpu(topo, ptf_ip, action="announce"):
+def fib_dpu(topo, ptf_ip, action="announce", routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
@@ -1513,8 +1562,12 @@ def fib_dpu(topo, ptf_ip, action="announce"):
         port = IPV4_BASE_PORT + vm_offset
         port6 = IPV6_BASE_PORT + vm_offset
 
-        change_routes(action, ptf_ip, port, routes_v4)
-        change_routes(action, ptf_ip, port6, routes_v6)
+        routes[vm] = {}
+        routes[vm][IPV4] = routes_v4
+        routes[vm][IPv6] = routes_v6
+        if action != GENERATE_WITHOUT_APPLY:
+            change_routes(action, ptf_ip, port, routes_v4)
+            change_routes(action, ptf_ip, port6, routes_v6)
 
 
 def adhoc_routes(topo, ptf_ip, peers_routes_to_change, action):
@@ -1527,12 +1580,15 @@ def adhoc_routes(topo, ptf_ip, peers_routes_to_change, action):
         port = IPV4_BASE_PORT + vm_offset
         port6 = IPV6_BASE_PORT + vm_offset
 
+        routes[hostname] = {}
+        routes[hostname][IPV4] = ipv4_routes
+        routes[hostname][IPv6] = ipv6_routes
         ipv4_routes = [r for r in routes if '.' in r[0]]
-        if ipv4_routes:
+        if ipv4_routes and action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, ipv4_routes)
 
         ipv6_routes = [r for r in routes if ':' in r[0]]
-        if ipv6_routes:
+        if ipv6_routes and action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port6, ipv6_routes)
 
 
@@ -1570,7 +1626,7 @@ def main():
             topo_name=dict(required=True, type='str'),
             ptf_ip=dict(required=True, type='str'),
             action=dict(required=False, type='str',
-                        default='announce', choices=["announce", "withdraw"]),
+                        default='announce', choices=["announce", "withdraw", GENERATE_WITHOUT_APPLY]),
             path=dict(required=False, type='str', default=''),
             dut_interfaces=dict(required=False, type='str', default=''),
             adhoc=dict(required=False, type='bool', default=False),
@@ -1607,44 +1663,45 @@ def main():
     tor_default_route = topo_name in ["t1-isolated-d128", "t1-isolated-d32"]
 
     topo_type = get_topo_type(topo_name)
-
+    routes = {}
     try:
         if adhoc:
             adhoc_routes(topo, ptf_ip, peers_routes_to_change, action)
             module.exit_json(change=True)
         elif topo_type == "t0":
             fib_t0(topo, ptf_ip, no_default_route=is_storage_backend, action=action,
-                   upstream_neighbor_groups=upstream_neighbor_groups)
-            module.exit_json(changed=True)
+                   upstream_neighbor_groups=upstream_neighbor_groups, routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "t1" or topo_type == "smartswitch-t1":
             fib_t1_lag(
                 topo, ptf_ip, topo_name, no_default_route=is_storage_backend, action=action,
-                tor_default_route=tor_default_route, downstream_neighbor_groups=downstream_neighbor_groups)
-            module.exit_json(changed=True)
+                tor_default_route=tor_default_route, downstream_neighbor_groups=downstream_neighbor_groups,
+                routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "t2":
-            fib_t2_lag(topo, ptf_ip, action=action)
-            module.exit_json(changed=True)
+            fib_t2_lag(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "t0-mclag":
-            fib_t0_mclag(topo, ptf_ip, action=action)
-            module.exit_json(changed=True)
+            fib_t0_mclag(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "m1":
-            fib_m1(topo, ptf_ip, action=action)
-            module.exit_json(changed=True)
+            fib_m1(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "m0":
-            fib_m0(topo, ptf_ip, action=action)
-            module.exit_json(changed=True)
+            fib_m0(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "mx":
-            fib_mx(topo, ptf_ip, action=action)
-            module.exit_json(changed=True)
+            fib_mx(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(changed=True, routes=routes)
         elif topo_type == "dpu":
-            fib_dpu(topo, ptf_ip, action=action)
-            module.exit_json(change=True)
+            fib_dpu(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(change=True, routes=routes)
         elif topo_type == "lt2":
-            fib_lt2_routes(topo, ptf_ip, action=action)
-            module.exit_json(change=True)
+            fib_lt2_routes(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(change=True, routes=routes)
         elif topo_type == "ft2":
-            fib_ft2_routes(topo, ptf_ip, action=action)
-            module.exit_json(change=True)
+            fib_ft2_routes(topo, ptf_ip, action=action, routes=routes)
+            module.exit_json(change=True, routes=routes)
         else:
             module.exit_json(
                 msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -514,7 +514,7 @@ def generate_t1_to_t0_routes(family, offset, leaf_number, subnet_size, tor_asn, 
     return routes, suffix
 
 
-def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_neighbor_groups=0, routes={}):
+def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_neighbor_groups=0, topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -552,7 +552,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
-        routes[vm_name] = {}
+        topo_routes[vm_name] = {}
 
         if enable_ipv4_routes_generation:
             routes_v4, last_suffix = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
@@ -563,7 +563,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             if aggregate_routes_v4:
                 filterout_subnet_ipv4(aggregate_routes, routes_v4)
                 routes_v4.extend(aggregate_routes_v4)
-            routes[vm_name][IPV4] = routes_v4
+            topo_routes[vm_name][IPV4] = routes_v4
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, port, routes_v4)
         if enable_ipv6_routes_generation:
@@ -577,7 +577,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
             if aggregate_routes_v6:
                 filterout_subnet_ipv6(aggregate_routes, routes_v6)
                 routes_v6.extend(aggregate_routes_v6)
-            routes[vm_name][IPV6] = routes_v6
+            topo_routes[vm_name][IPV6] = routes_v6
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, port6, routes_v6)
         group_index = index * upstream_neighbor_groups // vms_len
@@ -587,7 +587,7 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
 
 
 def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce", tor_default_route=False,
-               downstream_neighbor_groups=0, routes={}):
+               downstream_neighbor_groups=0, topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -626,7 +626,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         downstream_tor_number = len(downstream_vm_config)
         lov6_address_pattern = ipv6_address_pattern.split("/")[0] + "/128"
         current_routes_offset = last_suffix
-        routes[k] = {}
+        topo_routes[k] = {}
         for index, k in enumerate(sorted(downstream_vm_config.keys())):
             v = downstream_vm_config[k]
             if dpus and k in dpus:
@@ -648,7 +648,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v4:
                     filterout_subnet_ipv4(aggregate_routes, routes_v4)
                     routes_v4.extend(aggregate_routes_v4)
-                routes[k][IPV4] = routes_v4
+                topo_routes[k][IPV4] = routes_v4
                 routes_to_change[port] += routes_v4
             if enable_ipv6_routes_generation:
                 routes_v6, last_suffix = generate_t1_to_t0_routes("v6", current_routes_offset, leaf_number, 1, tor_asn,
@@ -657,7 +657,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v6:
                     filterout_subnet_ipv6(aggregate_routes, routes_v6)
                     routes_v6.extend(aggregate_routes_v6)
-                routes[k][IPV6] = routes_v6
+                topo_routes[k][IPV6] = routes_v6
                 routes_to_change[port6] += routes_v6
             group_index = index * downstream_neighbor_groups // downstream_tor_number
             next_group_index = (index + 1) * downstream_neighbor_groups // downstream_tor_number
@@ -687,8 +687,8 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
-        if k not in routes:
-            routes[k] = {}
+        if k not in topo_routes:
+            topo_routes[k] = {}
         router_type = None
         if 'spine' in v['properties']:
             router_type = 'spine'
@@ -707,7 +707,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v4:
                     filterout_subnet_ipv4(aggregate_routes, routes_v4)
                     routes_v4.extend(aggregate_routes_v4)
-                routes[k][IPV4] = routes_v4
+                topo_routes[k][IPV4] = routes_v4
                 routes_to_change[port] += routes_v4
             if enable_ipv6_routes_generation:
                 routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
@@ -720,7 +720,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v6:
                     filterout_subnet_ipv6(aggregate_routes, routes_v6)
                     routes_v6.extend(aggregate_routes_v6)
-                routes[k][IPV6] = routes_v6
+                topo_routes[k][IPV6] = routes_v6
                 routes_to_change[port6] += routes_v6
 
         if 'vips' in v:
@@ -813,7 +813,7 @@ We would have the following distribution:
 """
 
 
-def fib_m0(topo, ptf_ip, action="announce", routes={}):
+def fib_m0(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     colo_number = common_config.get("colo_number", COLO_NUMBER)
     m0_number = common_config.get("m0_number", M0_NUMBER)
@@ -878,9 +878,9 @@ def fib_m0(topo, ptf_ip, action="announce", routes={}):
                 m1_routes_v4 = routes_v4
                 m1_routes_v6 = routes_v6
 
-        routes[k] = {}
-        routes[k][IPV4] = routes_v4
-        routes[k][IPv6] = routes_v6
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPv6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, routes_v4)
             change_routes(action, ptf_ip, port6, routes_v6)
@@ -989,7 +989,7 @@ Routes announced by M0 can be broken down to 5 sets:
 """
 
 
-def fib_mx(topo, ptf_ip, action="announce", routes={}):
+def fib_mx(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     colo_number = common_config.get("colo_number", COLO_NUMBER)
     m0_number = common_config.get("m0_number", M0_NUMBER)
@@ -1043,9 +1043,9 @@ def fib_mx(topo, ptf_ip, action="announce", routes={}):
             m0_routes_v4 = routes_v4
             m0_routes_v6 = routes_v6
 
-        routes[k] = {}
-        routes[k][IPV4] = routes_v4
-        routes[k][IPv6] = routes_v6
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPv6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, routes_v4)
             change_routes(action, ptf_ip, port6, routes_v6)
@@ -1116,7 +1116,7 @@ def generate_m1_m0_routes(nexthop, ip_base, m0_subnet_number, m0_subnet_size, m0
     return routes, ip_base, mx_lo_ip
 
 
-def fib_m1(topo, ptf_ip, action="announce", routes={}):
+def fib_m1(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
@@ -1171,9 +1171,9 @@ def fib_m1(topo, ptf_ip, action="announce", routes={}):
             # C0 announce nothing but it's loopback IP.
             pass
 
-        routes[k] = {}
-        routes[k][IPV4] = routes_v4
-        routes[k][IPv6] = routes_v6
+        topo_routes[k] = {}
+        topo_routes[k][IPV4] = routes_v4
+        topo_routes[k][IPv6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             # routes_v4 = generate_m1_routes(nhipv4)
             change_routes(action, ptf_ip, port, routes_v4)
@@ -1213,7 +1213,7 @@ We would have the following distribution:
 """
 
 
-def fib_t2_lag(topo, ptf_ip, action="announce", routes={}):
+def fib_t2_lag(topo, ptf_ip, action="announce", topo_routes={}):
     route_set = []
     vms = topo['topology']['VMs']
     # T1 VMs per linecard(asic) - key is the dut index, and value is a list of T1 VMs
@@ -1236,13 +1236,13 @@ def fib_t2_lag(topo, ptf_ip, action="announce", routes={}):
                 t3_vms[dut_index] = list()
             t3_vms[dut_index].append(key)
 
-    route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action, routes={})
-    route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action, routes={})
+    route_set += generate_t2_routes(t1_vms, topo, ptf_ip, action, topo_routes)
+    route_set += generate_t2_routes(t3_vms, topo, ptf_ip, action, topo_routes)
     if action != GENERATE_WITHOUT_APPLY:
         send_routes_in_parallel(route_set)
 
 
-def fib_ft2_routes(topo, ptf_ip, action="announce", routes={}):
+def fib_ft2_routes(topo, ptf_ip, action="announce", topo_routes={}):
     """
     Generate routes from LT2 to FT2 in the FT2 topology.
     """
@@ -1294,16 +1294,16 @@ def fib_ft2_routes(topo, ptf_ip, action="announce", routes={}):
             # Generate default routes for both IPv4 and IPv6
             ipv4_routes.append(("0.0.0.0/0", nhipv4, default_route_as_path))
             ipv6_routes.append(("::/0", nhipv6, default_route_as_path))
-            routes[vm_name] = {}
-            routes[vm_name][IPV4] = ipv4_routes
-            routes[vm_name][IPv6] = ipv6_routes
+            topo_routes[vm_name] = {}
+            topo_routes[vm_name][IPV4] = ipv4_routes
+            topo_routes[vm_name][IPv6] = ipv6_routes
             if action != GENERATE_WITHOUT_APPLY:
                 # Send the routes to the PTF
                 change_routes(action, ptf_ip, port, ipv4_routes)
                 change_routes(action, ptf_ip, port6, ipv6_routes)
 
 
-def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", routes={}):
+def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     vms = topo['topology']['VMs']
     vms_config = topo['configuration']
@@ -1349,7 +1349,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", routes={}):
             aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
             aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
             aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
-            routes[a_vm] = {}
+            topo_routes[a_vm] = {}
 
             router_type = None
             if 'leaf' in vms_config[a_vm]['properties']:
@@ -1370,7 +1370,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", routes={}):
                         filterout_subnet_ipv4(aggregate_routes, routes_v4)
                         routes_v4.extend(aggregate_routes_v4)
                     random.shuffle(routes_v4)
-                    routes[a_vm][IPV4] = routes_v4
+                    topo_routes[a_vm][IPV4] = routes_v4
                     r_set.append((routes_v4, port, action, ptf_ip))
                 if enable_ipv6_routes_generation:
                     routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
@@ -1382,7 +1382,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", routes={}):
                         filterout_subnet_ipv6(aggregate_routes, routes_v6)
                         routes_v6.extend(aggregate_routes_v6)
                     random.shuffle(routes_v6)
-                    routes[a_vm][IPv6] = routes_v6
+                    topo_routes[a_vm][IPv6] = routes_v6
                     r_set.append((routes_v6, port6, action, ptf_ip))
 
                 if 'vips' in vms_config[a_vm] and action != GENERATE_WITHOUT_APPLY:
@@ -1394,7 +1394,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", routes={}):
     return r_set
 
 
-def fib_t0_mclag(topo, ptf_ip, action="announce", routes={}):
+def fib_t0_mclag(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     podset_number = common_config.get("podset_number", PODSET_NUMBER)
     tor_number = common_config.get("tor_number", TOR_NUMBER)
@@ -1430,7 +1430,7 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", routes={}):
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
         aggregate_routes_v4 = get_ipv4_routes(aggregate_routes)
         aggregate_routes_v6 = get_ipv6_routes(aggregate_routes)
-        routes[vm] = {}
+        topo_routes[vm] = {}
 
         if enable_ipv4_routes_generation:
             routes_v4, _ = generate_routes("v4", podset_number, tor_number, tor_subnet_number,
@@ -1440,7 +1440,7 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", routes={}):
             if aggregate_routes_v4:
                 filterout_subnet_ipv4(aggregate_routes, routes_v4)
                 routes_v4.extend(aggregate_routes_v4)
-            routes[vm][IPV4] = routes_v4
+            topo_routes[vm][IPV4] = routes_v4
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, port, routes_v4)
         if enable_ipv6_routes_generation:
@@ -1452,12 +1452,12 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", routes={}):
             if aggregate_routes_v6:
                 filterout_subnet_ipv6(aggregate_routes, routes_v6)
                 routes_v6.extend(aggregate_routes_v6)
-            routes[vm][IPv6] = routes_v6
+            topo_routes[vm][IPv6] = routes_v6
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, port6, routes_v6)
 
 
-def fib_lt2_routes(topo, ptf_ip, action="annouce", routes={}):
+def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
     T1_GROUP_SIZE = 2
     BASE_ADDR_V4 = "192.128.0.0/9"
     BASE_ADDR_V6 = "20c0:a800::0:0/108"
@@ -1511,9 +1511,9 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", routes={}):
 
             ipv4_routes.append((str(next(extra_ipv4_t1)), nhipv4, as_path))
 
-            routes[vm_name] = {}
-            routes[vm_name][IPV4] = ipv4_routes
-            routes[vm_name][IPv6] = ipv6_routes
+            topo_routes[vm_name] = {}
+            topo_routes[vm_name][IPV4] = ipv4_routes
+            topo_routes[vm_name][IPv6] = ipv6_routes
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
                 change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
@@ -1536,16 +1536,16 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", routes={}):
         ipv4_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv4'], nhipv4, as_path))
         ipv6_routes.append((topo['configuration'][vm_name]['interfaces']['Loopback0']['ipv6'], nhipv6, as_path))
 
-        if vm_name not in routes:
-            routes[vm_name] = {}
-        routes[vm_name][IPV4] = ipv4_routes
-        routes[vm_name][IPv6] = ipv6_routes
+        if vm_name not in topo_routes:
+            topo_routes[vm_name] = {}
+        topo_routes[vm_name][IPV4] = ipv4_routes
+        topo_routes[vm_name][IPv6] = ipv6_routes
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
             change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
 
 
-def fib_dpu(topo, ptf_ip, action="announce", routes={}):
+def fib_dpu(topo, ptf_ip, action="announce", topo_routes={}):
     common_config = topo['configuration_properties'].get('common', {})
     nhipv4 = common_config.get("nhipv4", NHIPV4)
     nhipv6 = common_config.get("nhipv6", NHIPV6)
@@ -1562,9 +1562,9 @@ def fib_dpu(topo, ptf_ip, action="announce", routes={}):
         port = IPV4_BASE_PORT + vm_offset
         port6 = IPV6_BASE_PORT + vm_offset
 
-        routes[vm] = {}
-        routes[vm][IPV4] = routes_v4
-        routes[vm][IPv6] = routes_v6
+        topo_routes[vm] = {}
+        topo_routes[vm][IPV4] = routes_v4
+        topo_routes[vm][IPv6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, routes_v4)
             change_routes(action, ptf_ip, port6, routes_v6)
@@ -1580,9 +1580,6 @@ def adhoc_routes(topo, ptf_ip, peers_routes_to_change, action):
         port = IPV4_BASE_PORT + vm_offset
         port6 = IPV6_BASE_PORT + vm_offset
 
-        routes[hostname] = {}
-        routes[hostname][IPV4] = ipv4_routes
-        routes[hostname][IPv6] = ipv6_routes
         ipv4_routes = [r for r in routes if '.' in r[0]]
         if ipv4_routes and action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, ipv4_routes)
@@ -1663,45 +1660,45 @@ def main():
     tor_default_route = topo_name in ["t1-isolated-d128", "t1-isolated-d32"]
 
     topo_type = get_topo_type(topo_name)
-    routes = {}
+    topo_routes = {}
     try:
         if adhoc:
             adhoc_routes(topo, ptf_ip, peers_routes_to_change, action)
             module.exit_json(change=True)
         elif topo_type == "t0":
             fib_t0(topo, ptf_ip, no_default_route=is_storage_backend, action=action,
-                   upstream_neighbor_groups=upstream_neighbor_groups, routes=routes)
-            module.exit_json(changed=True, routes=routes)
+                   upstream_neighbor_groups=upstream_neighbor_groups, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "t1" or topo_type == "smartswitch-t1":
             fib_t1_lag(
                 topo, ptf_ip, topo_name, no_default_route=is_storage_backend, action=action,
                 tor_default_route=tor_default_route, downstream_neighbor_groups=downstream_neighbor_groups,
-                routes=routes)
-            module.exit_json(changed=True, routes=routes)
+                topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "t2":
-            fib_t2_lag(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(changed=True, routes=routes)
+            fib_t2_lag(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "t0-mclag":
-            fib_t0_mclag(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(changed=True, routes=routes)
+            fib_t0_mclag(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "m1":
-            fib_m1(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(changed=True, routes=routes)
+            fib_m1(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "m0":
-            fib_m0(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(changed=True, routes=routes)
+            fib_m0(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "mx":
-            fib_mx(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(changed=True, routes=routes)
+            fib_mx(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(changed=True, topo_routes=topo_routes)
         elif topo_type == "dpu":
-            fib_dpu(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(change=True, routes=routes)
+            fib_dpu(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(change=True, topo_routes=topo_routes)
         elif topo_type == "lt2":
-            fib_lt2_routes(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(change=True, routes=routes)
+            fib_lt2_routes(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(change=True, topo_routes=topo_routes)
         elif topo_type == "ft2":
-            fib_ft2_routes(topo, ptf_ip, action=action, routes=routes)
-            module.exit_json(change=True, routes=routes)
+            fib_ft2_routes(topo, ptf_ip, action=action, topo_routes=topo_routes)
+            module.exit_json(change=True, topo_routes=topo_routes)
         else:
             module.exit_json(
                 msg='Unsupported topology "{}" - skipping announcing routes'.format(topo_name))

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -626,8 +626,8 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
         downstream_tor_number = len(downstream_vm_config)
         lov6_address_pattern = ipv6_address_pattern.split("/")[0] + "/128"
         current_routes_offset = last_suffix
-        topo_routes[k] = {}
         for index, k in enumerate(sorted(downstream_vm_config.keys())):
+            topo_routes[k] = {}
             v = downstream_vm_config[k]
             if dpus and k in dpus:
                 continue
@@ -880,7 +880,7 @@ def fib_m0(topo, ptf_ip, action="announce", topo_routes={}):
 
         topo_routes[k] = {}
         topo_routes[k][IPV4] = routes_v4
-        topo_routes[k][IPv6] = routes_v6
+        topo_routes[k][IPV6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, routes_v4)
             change_routes(action, ptf_ip, port6, routes_v6)
@@ -1045,7 +1045,7 @@ def fib_mx(topo, ptf_ip, action="announce", topo_routes={}):
 
         topo_routes[k] = {}
         topo_routes[k][IPV4] = routes_v4
-        topo_routes[k][IPv6] = routes_v6
+        topo_routes[k][IPV6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, routes_v4)
             change_routes(action, ptf_ip, port6, routes_v6)
@@ -1173,7 +1173,7 @@ def fib_m1(topo, ptf_ip, action="announce", topo_routes={}):
 
         topo_routes[k] = {}
         topo_routes[k][IPV4] = routes_v4
-        topo_routes[k][IPv6] = routes_v6
+        topo_routes[k][IPV6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             # routes_v4 = generate_m1_routes(nhipv4)
             change_routes(action, ptf_ip, port, routes_v4)
@@ -1296,7 +1296,7 @@ def fib_ft2_routes(topo, ptf_ip, action="announce", topo_routes={}):
             ipv6_routes.append(("::/0", nhipv6, default_route_as_path))
             topo_routes[vm_name] = {}
             topo_routes[vm_name][IPV4] = ipv4_routes
-            topo_routes[vm_name][IPv6] = ipv6_routes
+            topo_routes[vm_name][IPV6] = ipv6_routes
             if action != GENERATE_WITHOUT_APPLY:
                 # Send the routes to the PTF
                 change_routes(action, ptf_ip, port, ipv4_routes)
@@ -1382,7 +1382,7 @@ def generate_t2_routes(dut_vm_dict, topo, ptf_ip, action="announce", topo_routes
                         filterout_subnet_ipv6(aggregate_routes, routes_v6)
                         routes_v6.extend(aggregate_routes_v6)
                     random.shuffle(routes_v6)
-                    topo_routes[a_vm][IPv6] = routes_v6
+                    topo_routes[a_vm][IPV6] = routes_v6
                     r_set.append((routes_v6, port6, action, ptf_ip))
 
                 if 'vips' in vms_config[a_vm] and action != GENERATE_WITHOUT_APPLY:
@@ -1452,7 +1452,7 @@ def fib_t0_mclag(topo, ptf_ip, action="announce", topo_routes={}):
             if aggregate_routes_v6:
                 filterout_subnet_ipv6(aggregate_routes, routes_v6)
                 routes_v6.extend(aggregate_routes_v6)
-            topo_routes[vm][IPv6] = routes_v6
+            topo_routes[vm][IPV6] = routes_v6
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, port6, routes_v6)
 
@@ -1513,7 +1513,7 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
 
             topo_routes[vm_name] = {}
             topo_routes[vm_name][IPV4] = ipv4_routes
-            topo_routes[vm_name][IPv6] = ipv6_routes
+            topo_routes[vm_name][IPV6] = ipv6_routes
             if action != GENERATE_WITHOUT_APPLY:
                 change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
                 change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
@@ -1539,7 +1539,7 @@ def fib_lt2_routes(topo, ptf_ip, action="annouce", topo_routes={}):
         if vm_name not in topo_routes:
             topo_routes[vm_name] = {}
         topo_routes[vm_name][IPV4] = ipv4_routes
-        topo_routes[vm_name][IPv6] = ipv6_routes
+        topo_routes[vm_name][IPV6] = ipv6_routes
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, IPV4_BASE_PORT + vm_offset, ipv4_routes)
             change_routes(action, ptf_ip, IPV6_BASE_PORT + vm_offset, ipv6_routes)
@@ -1564,7 +1564,7 @@ def fib_dpu(topo, ptf_ip, action="announce", topo_routes={}):
 
         topo_routes[vm] = {}
         topo_routes[vm][IPV4] = routes_v4
-        topo_routes[vm][IPv6] = routes_v6
+        topo_routes[vm][IPV6] = routes_v6
         if action != GENERATE_WITHOUT_APPLY:
             change_routes(action, ptf_ip, port, routes_v4)
             change_routes(action, ptf_ip, port6, routes_v6)

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -568,7 +568,7 @@ def test_nexthop_group_member_scale(
     )
     for hostname, routes in peers_routes_to_change.items():
         for route in routes:
-            prefix = route[0]
+            prefix = route[0].upper()
             found = False
             for topo_route in topo_bgp_routes[hostname]['ipv6']:
                 if topo_route[0] == prefix:

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -576,7 +576,7 @@ def test_nexthop_group_member_scale(
                     found = True
                     break
             if not found:
-                logger.warning('Fail to update ASN of route %s, because of prefix was not found in topo', route[0])
+                logger.warning('Fail to update AS path of route %s, because of prefix was not found in topo', route[0])
     terminated = Event()
     traffic_thread = Thread(
         target=send_packets, args=(terminated, pdp, pdp.port_to_device(injection_port), injection_port, pkts)

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -576,7 +576,7 @@ def test_nexthop_group_member_scale(
                     found = True
                     break
             if not found:
-                logger.warning('Routes not found in topo')
+                logger.warning('Fail to update ASN of route %s, because of prefix was not found in topo', route[0])
     terminated = Event()
     traffic_thread = Thread(
         target=send_packets, args=(terminated, pdp, pdp.port_to_device(injection_port), injection_port, pkts)
@@ -586,7 +586,7 @@ def test_nexthop_group_member_scale(
     traffic_thread.start()
     for ptfhost in ptfhosts:
         ptf_ip = ptfhost.mgmt_ip
-        change_routes_on_peers(localhost, ptf_ip, topo_name, peers_routes_to_change, ACTION_WITHDRAW,
+        change_routes_on_peers(localhost, ptf_ip, topo_name, peers_routes_to_change, ACTION_ANNOUNCE,
                                servers_dut_interfaces.get(ptf_ip, ''))
     compressed_startup_routes = compress_expected_routes(startup_routes)
     result = check_bgp_routes_converged(

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -464,6 +464,7 @@ def test_nexthop_group_member_scale(
     tbinfo,
     bgp_peers_info,
     announce_bgp_routes_teardown,
+    topo_bgp_routes,
     request
 ):
     '''
@@ -565,6 +566,17 @@ def test_nexthop_group_member_scale(
         duthost.facts['router_mac'],
         pdp.get_mac(pdp.port_to_device(injection_port), injection_port)
     )
+    for hostname, routes in peers_routes_to_change.items():
+        for route in routes:
+            prefix = route[0]
+            found = False
+            for topo_route in topo_bgp_routes[hostname]['ipv6']:
+                if topo_route[0] == prefix:
+                    route[2] = topo_route[2]
+                    found = True
+                    break
+            if not found:
+                logger.warning('Routes not found in topo')
     terminated = Event()
     traffic_thread = Thread(
         target=send_packets, args=(terminated, pdp, pdp.port_to_device(injection_port), injection_port, pkts)
@@ -574,7 +586,8 @@ def test_nexthop_group_member_scale(
     traffic_thread.start()
     for ptfhost in ptfhosts:
         ptf_ip = ptfhost.mgmt_ip
-        announce_routes(localhost, tbinfo, ptf_ip, servers_dut_interfaces.get(ptf_ip, ''))
+        change_routes_on_peers(localhost, ptf_ip, topo_name, peers_routes_to_change, ACTION_WITHDRAW,
+                               servers_dut_interfaces.get(ptf_ip, ''))
     compressed_startup_routes = compress_expected_routes(startup_routes)
     result = check_bgp_routes_converged(
         duthost,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1109,10 +1109,10 @@ def topo_bgp_routes(localhost, ptfhosts, tbinfo):
             log_path="logs",
             dut_interfaces=servers_dut_interfaces.get(ptf_ip) if servers_dut_interfaces else None,
         )
-        if 'routes' not in res:
+        if 'topo_routes' not in res:
             logger.warning("No routes generated.")
         else:
-            bgp_routes.update(res['routes'])
+            bgp_routes.update(res['topo_routes'])
     return bgp_routes
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1091,6 +1091,31 @@ def creds(duthost):
     return creds_on_dut(duthost)
 
 
+@pytest.fixture(scope="session")
+def topo_bgp_routes(localhost, ptfhosts, tbinfo):
+    bgp_routes = {}
+    topo_name = tbinfo['topo']['name']
+    servers_dut_interfaces = None
+    if 'servers' in tbinfo:
+        servers_dut_interfaces = {value['ptf_ip'].split("/")[0]: value['dut_interfaces']
+                                  for value in tbinfo['servers'].values()}
+    for ptfhost in ptfhosts:
+        ptf_ip = ptfhost.mgmt_ip
+        res = localhost.announce_routes(
+            topo_name=topo_name,
+            ptf_ip=ptf_ip,
+            action='generate',
+            path="../ansible/",
+            log_path="logs",
+            dut_interfaces=servers_dut_interfaces.get(ptf_ip) if servers_dut_interfaces else None,
+        )
+        if 'routes' not in res:
+            logger.warning("No routes generated.")
+        else:
+            bgp_routes.update(res['routes'])
+    return bgp_routes
+
+
 @pytest.fixture(scope='module')
 def creds_all_duts(duthosts):
     creds_all_duts = dict()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In some user scenario, for example bgp scale test in this PR, we need designed routes information of topology file to announcee routes on exabgp, so this PR add a new fixture to provide designed routes information of topology file, and use the fixture in scale test to help annouce routes on exabgp.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In some user scenario, for example bgp scale test in this PR, we need designed routes information of topology file to announcee routes on exabgp
#### How did you do it?
add a new fixture to provide designed routes information of topology file, and use the fixture in scale test to help annouce routes on exabgp.
#### How did you verify/test it?
run on testbed
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
