### PR TITLE
Add Dpc role assignment for SmartSwitch interfaces

### DIFF
--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -14,7 +14,7 @@
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>
           <Priority>0</Priority>
-{% set intf = port_alias[index] %}
+{% set intf = port_name[index] %}
 {% if subtype is defined and subtype == 'SmartSwitch' and intf[8:]|int >= 224 %}
           <role>Dpc</role>
 {% endif %}

--- a/ansible/templates/minigraph_device.j2
+++ b/ansible/templates/minigraph_device.j2
@@ -14,7 +14,8 @@
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>
           <Priority>0</Priority>
-{% if subtype is defined and subtype == 'SmartSwitch' and index > 27 %}
+{% set intf = port_alias[index] %}
+{% if subtype is defined and subtype == 'SmartSwitch' and intf[8:]|int >= 224 %}
           <role>Dpc</role>
 {% endif %}
 {% if port_speed[port_alias[index]] is defined %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:This commit introduces logic to assign the 'Dpc' role based on specific conditions within the port alias and subtype.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ X] 202411
- [X ] 202505

### Approach
The 'Dpc' role is now assigned when:
The subtype is defined and equals 'SmartSwitch'.
The integer value extracted from the intf variable (starting from the 8th character) is greater than or equal to 224.
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Deployed the minigraph and confirmed that the DPU role configuration is present for all backplane interfaces.
#### Any platform specific information?
HwSKU: Cisco-8102-28FH-DPU-O
#### Supported testbed topology if it's a new test case?
t1-128-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
