### PR TITLE
Fix flakiness in pfcwd/test_pfcwd_cli.py

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -323,8 +323,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         neigh_port_channel = None
         min_links = None
         if isinstance(vm_host, EosHost):
-            neigh_port_channels = vm_host.eos_command(commands=['show port-channel | json'])\
-                                    ['stdout'][0]["portChannels"]
+            neigh_port_channels = vm_host.eos_command(
+                commands=['show port-channel | json'])['stdout'][0]["portChannels"]
             for po_name, po_config in neigh_port_channels.items():
                 for member in po_config['activePorts']:
                     if member == peer_port:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes [#714](https://github.com/aristanetworks/sonic-qual.msft/issues/714), [#18496](https://github.com/sonic-net/sonic-mgmt/issues/18496)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Recent fix: https://github.com/sonic-net/sonic-mgmt/pull/17411

The test was flaky before this fix (and continues to be so). When the test picks up an egress interface which happens to be a member of a LAG consisting of multiple members, only this member is stormed and some of the traffic successfully egresses out of the other LAG members leading to lesser drops than expected when PFCWD is triggered with DROP action. The proposed fix was to shut down all but one LAG members by reducing the number of min_links. But the same config on cEOS was missing therefore LAG doesn't come up after shutting down other LAG members.

This is being rectified in this change for cEOS neighbors.

#### How did you do it?
The proposed fix is to change the min_link setting for the involved port channel on the cEOS side as well.

#### How did you verify/test it?
Stressed this test 10 times on dualtor-120 and t0-116 with Arista 7260CX3 platform.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
