### PR TITLE
Fix incorrectly selected OCS links when traffic generator are shared by multiple testbed

### DIFF
--- a/ansible/module_utils/graph_utils.py
+++ b/ansible/module_utils/graph_utils.py
@@ -531,4 +531,4 @@ class LabGraph(object):
                 l1_port_pair = sorted([l1_start_port, l1_end_port])
                 l1_cross_connects[l1_start_device][l1_port_pair[0]] = l1_port_pair[1]
 
-            return l1_cross_connects
+        return l1_cross_connects


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

When an test port in the traffic generator is shared by multiple testbeds, the current lab graph doesn't support this case and will only keep 1 port in the end. This causes OCS link could not be correctly setup.

#### How did you do it?

This change fixes the lab graph and keep all the links in the graph for link selection.

#### How did you verify/test it?

Run locally and works.

<img width="1067" height="267" alt="image" src="https://github.com/user-attachments/assets/3a40faa1-02d3-43e6-9871-2c994555d327" />

<img width="541" height="405" alt="image" src="https://github.com/user-attachments/assets/2f7696a0-ced3-42e5-80f4-6258432f6940" />


#### Any platform specific information?

No.


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
