### PR TITLE
[202505]Removed hostname,platform and hwsku from assert failed summary

### DIFF
--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -42,11 +42,10 @@ def verify_bfd_only(dut, nexthops, asic, expected_bfd_state):
         0,
         lambda: verify_bfd_state(dut, nexthops.values(), asic, expected_bfd_state),
     ), (
-        "Timed out waiting to verify BFD state is expected for nexthops {} on ASIC {} of DUT '{}' to reach state '{}'."
+        "Timed out waiting to verify BFD state is expected for nexthops {} on ASIC {}  to reach state '{}'."
     ).format(
         nexthops.values(),
         asic,
-        dut.hostname,
         expected_bfd_state
     )
 
@@ -198,11 +197,10 @@ def toggle_interfaces_in_parallel(cmds, dut, asic, interfaces, target_state):
             0,
             lambda: check_interfaces_oper_state(dut, asic, interfaces, target_state),
         ), (
-            "Timed out waiting for interfaces {} on ASIC {} of DUT '{}' to reach state '{}'."
+            "Timed out waiting for interfaces {} on ASIC {} of  to reach state '{}'."
         ).format(
             interfaces,
             asic,
-            dut.hostname,
             target_state
         )
 
@@ -774,11 +772,10 @@ def wait_until_given_bfd_down(next_hops, port_channel, asic_index, dut):
         0,
         lambda: verify_given_bfd_state(next_hops, port_channel, asic_index, dut, "Down"),
     ), (
-        "Timed out waiting for BFD session on port channel '{}' (ASIC {} of DUT '{}') to reach state 'Down'."
+        "Timed out waiting for BFD session on port channel '{}' (ASIC {} ) to reach state 'Down'."
     ).format(
         port_channel,
-        asic_index,
-        dut.hostname
+        asic_index
     )
 
 

--- a/tests/bgp/test_bgp_azng_migration.py
+++ b/tests/bgp/test_bgp_azng_migration.py
@@ -151,13 +151,10 @@ def test_bgp_azng_migration(duthosts, enum_upstream_dut_hostname):
             not rc['failed'],
             (
                 "AZNG Migration Rollback failed. "
-                "Return code: {}, Output: {}, Hostname: {}, Platform: {}, HWSKU: {}"
+                "Return code: {}, Output: {}"
             ).format(
                 rc.get('rc', 'N/A'),
-                rc.get('stdout', 'N/A'),
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
+                rc.get('stdout', 'N/A')
             )
         )
 
@@ -211,13 +208,10 @@ def test_bgp_azng_migration(duthosts, enum_upstream_dut_hostname):
             not rc['failed'],
             (
                 "AZNG Migration Deny Route-map apply failed. "
-                "Return code: {}, Output: {}, Hostname: {}, Platform: {}, HWSKU: {}"
+                "Return code: {}, Output: {}"
             ).format(
                 rc.get('rc', 'N/A'),
-                rc.get('stdout', 'N/A'),
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
+                rc.get('stdout', 'N/A')
             )
         )
 
@@ -271,13 +265,10 @@ def test_bgp_azng_migration(duthosts, enum_upstream_dut_hostname):
             not rc['failed'],
             (
                 "AZNG Migration Outbound Route-map permit apply failed. "
-                "Return code: {}, Output: {}, Hostname: {}, Platform: {}, HWSKU: {}"
+                "Return code: {}, Output: {}"
             ).format(
                 rc.get('rc', 'N/A'),
-                rc.get('stdout', 'N/A'),
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
+                rc.get('stdout', 'N/A')
             )
         )
 
@@ -367,13 +358,10 @@ def test_bgp_azng_migration(duthosts, enum_upstream_dut_hostname):
             not rc['failed'],
             (
                 "AZNG Migration Inbound Route-map permit apply failed. "
-                "Return code: {}, Output: {}, Hostname: {}, Platform: {}, HWSKU: {}"
+                "Return code: {}, Output: {}"
             ).format(
                 rc.get('rc', 'N/A'),
-                rc.get('stdout', 'N/A'),
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
+                rc.get('stdout', 'N/A')
             )
         )
 
@@ -454,11 +442,7 @@ def test_bgp_azng_migration(duthosts, enum_upstream_dut_hostname):
         pytest_assert(
             not recover_via_minigraph,
             (
-                "AZNG Migration Production set failed. Hostname: {}, Platform: {}, HWSKU: {}"
-            ).format(
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
+                "AZNG Migration Production set failed"
             )
         )
 

--- a/tests/bgp/test_bgp_queue.py
+++ b/tests/bgp/test_bgp_queue.py
@@ -78,7 +78,12 @@ def test_bgp_queues(duthosts, enum_frontend_dut_hostname, enum_asic_index, tbinf
                 for port in mg_facts['minigraph_portchannels'][ifname]['members']:
                     logger.info("PortChannel '{}' : port {}".format(ifname, port))
                     for q in range(0, 7):
-                        assert (get_queue_counters(asichost, port, q) == 0)
+                        assert (get_queue_counters(asichost, port, q) == 0), (
+                            (
+                                "Queue counter for port '{}' queue {} is not zero after clearing queue counters. "
+                                "Counter value: {}"
+                            ).format(port, q, get_queue_counters(asichost, port, q))
+                        )
             else:
                 logger.info(ifname)
                 for q in range(0, 7):

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -690,13 +690,6 @@ def do_and_wait_reboot(duthost, localhost, reboot_type):
             wait_until(300, 20, 0, duthost.critical_services_fully_started),
             (
                 "Not all critical services started within the allotted time after reboot or config reload. "
-                "Hostname: {}\n"
-                "Platform: {}\n"
-                "HWSKU: {}\n"
-            ).format(
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
             )
         )
 
@@ -704,13 +697,6 @@ def do_and_wait_reboot(duthost, localhost, reboot_type):
             wait_until(300, 20, 0, check_interface_status_of_up_ports, duthost),
             (
                 "Not all admin-up ports are operationally up after reboot or config reload.\n"
-                "Hostname: {}\n"
-                "Platform: {}\n"
-                "HWSKU: {}"
-            ).format(
-                duthost.hostname,
-                duthost.facts.get("platform"),
-                duthost.facts.get("hwsku")
             )
         )
 
@@ -1080,8 +1066,8 @@ def test_credit_loop(duthost, tbinfo, nbrhosts, ptfadapter, prepare_param, gener
 
             with allure.step("Restore orchagent process"):
                 assert is_orchagent_stopped(duthost), (
-                    "Orchagent process is not in the expected 'stop' state on DUT '{}'."
-                ).format(duthost.hostname)
+                    "Orchagent process is not in the expected 'stop' state on DUT "
+                )
 
                 operate_orchagent(duthost, action=ACTION_CONTINUE)
 
@@ -1143,8 +1129,8 @@ def test_suppress_fib_stress(duthost, tbinfo, nbrhosts, ptfadapter, prepare_para
 
             with allure.step("Restore orchagent process"):
                 assert is_orchagent_stopped(duthost), (
-                    "Orchagent process is not in the expected 'stop' state on DUT '{}'."
-                ).format(duthost.hostname)
+                    "Orchagent process is not in the expected 'stop' state on DUT ."
+                )
 
                 operate_orchagent(duthost, action=ACTION_CONTINUE)
 

--- a/tests/fdb/test_fdb.py
+++ b/tests/fdb/test_fdb.py
@@ -222,9 +222,7 @@ def send_recv_eth(duthost, ptfadapter, source_ports, source_mac,                
         logger.info("Dest MAC is {}, show mac results {}".format(dest_mac, result['stdout']))
         pytest_assert(
             False,
-            (
-                "Expected packet was not received on ports {}."
-            ).format(dest_ports)
+            "Expected packet was not received on ports {}.".format(dest_ports)
         )
 
 

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -44,13 +44,6 @@ def restart_orchagent(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         # make sure all critical services are up
         assert wait_until(600, 5, 30, duthost.critical_services_fully_started), (
             "Not all critical services are fully started after restarting orchagent. "
-            "Hostname: {}\n"
-            "Platform: {}\n"
-            "HWSKU: {}\n"
-        ).format(
-            duthost.hostname,
-            duthost.facts.get("platform"),
-            duthost.facts.get("hwsku")
         )
 
         # wait for ports to be up and lldp neighbor information has been received by dut

--- a/tests/platform_tests/link_flap/test_link_flap.py
+++ b/tests/platform_tests/link_flap/test_link_flap.py
@@ -88,6 +88,8 @@ def test_link_flap(request, duthosts, rand_one_dut_hostname, tbinfo, fanouthosts
     logger.info("watch orchagent CPU utilization when it goes below %d", orch_cpu_threshold)
     pytest_assert(
         wait_until(900, 20, 0, check_orch_cpu_utilization, duthost, orch_cpu_threshold),
-        "Orch CPU utilization {} > orch cpu threshold {} before link flap. ".format(duthost.shell(
-            "show processes cpu | grep orchagent | awk '{print $9}'")["stdout"], orch_cpu_threshold)
+        "Orch CPU utilization {} > orch cpu threshold {} before link flap. ".format(
+            duthost.shell("show processes cpu | grep orchagent | awk '{print $9}'")["stdout"],
+            orch_cpu_threshold
+        )
     )

--- a/tests/platform_tests/test_reload_config.py
+++ b/tests/platform_tests/test_reload_config.py
@@ -62,13 +62,6 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
     if config_force_option_supported(duthost):
         assert wait_until(360, 20, 0, config_system_checks_passed, duthost), (
             "System checks did not pass within the allotted time after config reload. "
-            "Hostname: {}\n"
-            "Platform: {}\n"
-            "HWSKU: {}\n"
-        ).format(
-            duthost.hostname,
-            duthost.facts.get("platform"),
-            duthost.facts.get("hwsku")
         )
 
     logging.info("Reload configuration")
@@ -84,16 +77,10 @@ def test_reload_configuration(duthosts, enum_rand_one_per_hwsku_hostname,
     assert wait_until(max_wait_time_for_transceivers, 20, 0, check_all_interface_information,
                       duthost, interfaces, xcvr_skip_list), (
         "Not all transceivers detected in {timeout} seconds. "
-        "- Hostname: {hostname}\n"
-        "- Platform: {platform}\n"
-        "- HWSKU: {hwsku}\n"
         "- Interfaces checked: {interfaces}\n"
         "- Max wait time (seconds): {timeout}"
     ).format(
         timeout=max_wait_time_for_transceivers,
-        hostname=duthost.hostname,
-        platform=duthost.facts.get('platform'),
-        hwsku=duthost.facts.get('hwsku'),
         interfaces=list(interfaces.keys())
     )
 
@@ -226,26 +213,19 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     assert result and "Retry later" in out['stdout'], (
         "The config reload command did not return the expected 'Retry later' message. "
         "Output: '{}'\n"
-        "Hostname: {}\n"
-        "Platform: {}\n"
-        "HWSKU: {}\n"
     ).format(
-        out['stdout'],
-        duthost.hostname,
-        duthost.facts.get("platform"),
-        duthost.facts.get("hwsku")
+        out['stdout']
     )
 
     assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services), (
-        "System checks did not pass within the allotted time after config reload on '{}'. Delayed services: {}"
-    ).format(duthost.hostname, delayed_services)
+        "System checks did not pass within the allotted time after config reload on  Delayed services: {}"
+    ).format(delayed_services)
 
     if not duthost.get_facts().get("modular_chassis"):
         # Check if all containers have started
         assert wait_until(300, 10, 0, check_docker_status, duthost), (
             "Not all Docker containers reached the 'fully started' state within 300 seconds "
-            "after config reload on '{}'."
-        ).format(duthost.hostname)
+        )
 
         # To ensure the system is stable enough, wait for another 30s
         time.sleep(30)
@@ -255,14 +235,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     assert result and "Retry later" not in out['stdout'], (
         "The config reload command returned an unexpected 'Retry later' message or failed to execute successfully. "
         "Output: '{}'\n"
-        "Hostname: {}\n"
-        "Platform: {}\n"
-        "HWSKU: {}\n"
     ).format(
-        out['stdout'],
-        duthost.hostname,
-        duthost.facts.get("platform"),
-        duthost.facts.get("hwsku")
+        out['stdout']
     )
 
     # Immediately after one config reload command, another shouldn't execute and wait for system checks
@@ -273,19 +247,13 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     assert result and "Retry later" in out['stdout'], (
         "The config reload command did not return the expected 'Retry later' message. "
         "Output: '{}'\n"
-        "Hostname: {}\n"
-        "Platform: {}\n"
-        "HWSKU: {}\n"
     ).format(
-        out['stdout'],
-        duthost.hostname,
-        duthost.facts.get("platform"),
-        duthost.facts.get("hwsku")
+        out['stdout']
     )
 
     assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services), (
-        "System checks did not pass within the allotted time after config reload on '{}'. Delayed services: {}"
-    ).format(duthost.hostname, delayed_services)
+        "System checks did not pass within the allotted time after config reload on Delayed services: {}"
+    ).format(delayed_services)
 
     # Wait untill all critical processes come up so that it doesnt interfere with swss stop job
     wait_critical_processes(duthost)
@@ -301,14 +269,8 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     assert result and "Retry later" in out['stdout'], (
         "The config reload command did not return the expected 'Retry later' message. "
         "Output: '{}'\n"
-        "Hostname: {}\n"
-        "Platform: {}\n"
-        "HWSKU: {}\n"
     ).format(
-        out['stdout'],
-        duthost.hostname,
-        duthost.facts.get("platform"),
-        duthost.facts.get("hwsku")
+        out['stdout']
     )
 
     # However with force option config reload should proceed
@@ -317,16 +279,10 @@ def test_reload_configuration_checks(duthosts, enum_rand_one_per_hwsku_hostname,
     assert "Retry later" not in out['stdout'], (
         "The config reload command returned an unexpected 'Retry later' message or failed to execute successfully. "
         "Output: '{}'\n"
-        "Hostname: {}\n"
-        "Platform: {}\n"
-        "HWSKU: {}\n"
     ).format(
-        out['stdout'],
-        duthost.hostname,
-        duthost.facts.get("platform"),
-        duthost.facts.get("hwsku")
+        out['stdout']
     )
 
     assert wait_until(360, 20, 0, config_system_checks_passed, duthost, delayed_services), (
-        "System checks did not pass within the allotted time after config reload on '{}'. Delayed services: {}"
-    ).format(duthost.hostname, delayed_services)
+        "System checks did not pass within the allotted time after config reload on  Delayed services: {}"
+    ).format(delayed_services)

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -269,9 +269,9 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
                 duthost.shell("config mux mode active all")
                 unselected_duthost.shell("config mux mode standby all")
                 pytest_assert(wait_until(60, 5, 0, check_mux_status, duthost, 'active'),
-                              "Could not config ports to active on {}".format(duthost.hostname))
+                              "Could not config ports to active ")
                 pytest_assert(wait_until(60, 5, 0, check_mux_status, unselected_duthost, 'standby'),
-                              "Could not config ports to standby on {}".format(unselected_duthost.hostname))
+                              "Could not config ports to standby ")
             # FIXME: We saw re-establishing BGP sessions can takes around 7 minutes
             # on some devices (like 4600) after config reload, so we need below patch
             wait_all_bgp_up(duthost)

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -453,10 +453,9 @@ def test_fan_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_enti
             tachometers_oid = expect_oid + SENSOR_TYPE_FAN
             assert tachometers_oid in snmp_physical_entity_info, (
                 "Cannot find fan tachometers info in physical entity MIB. "
-                "Expected OID '{}'. SNMP physical entity info: {}"
+                "Expected OID '{}'. "
             ).format(
-                tachometers_oid,
-                snmp_physical_entity_info
+                tachometers_oid
             )
 
             tachometers_fact = snmp_physical_entity_info[tachometers_oid]
@@ -598,17 +597,14 @@ def test_psu_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_enti
             assert expect_oid not in snmp_physical_entity_info, (
                 "Unexpected OID found in SNMP physical entity MIB.\n"
                 "Expected OID '{}' to be absent, but it is present.\n"
-                "SNMP physical entity info: {}"
-            ).format(expect_oid, snmp_physical_entity_info)
+            ).format(expect_oid)
 
             continue
 
         assert expect_oid in snmp_physical_entity_info, (
             "Expected OID '{}' is missing in SNMP physical entity MIB.\n "
-            "SNMP physical entity info: {}"
         ).format(
-            expect_oid,
-            snmp_physical_entity_info
+            expect_oid
         )
         psu_snmp_fact = snmp_physical_entity_info[expect_oid]
         assert psu_snmp_fact['entPhysDescr'] == name, (
@@ -711,19 +707,15 @@ def _check_psu_sensor(duthost, psu_name, psu_info, psu_oid, snmp_physical_entity
         if is_null_str(psu_info[field]):
             assert expect_oid not in snmp_physical_entity_info, (
                 "Unexpectedly found PSU sensor OID '{}' in physical entity MIB. "
-                "SNMP physical entity info: {}"
             ).format(
-                expect_oid,
-                snmp_physical_entity_info
+                expect_oid
             )
             continue
 
         assert expect_oid in snmp_physical_entity_info, (
             "Cannot find PSU sensor OID '{}' in physical entity MIB. "
-            "SNMP physical entity info: {}"
         ).format(
-            expect_oid,
-            snmp_physical_entity_info
+            expect_oid
         )
         phy_entity_snmp_fact = snmp_physical_entity_info[expect_oid]
         sensor_name = '{sensor_name} for {psu_name}'.format(
@@ -885,9 +877,8 @@ def test_thermal_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_
     snmp_entity_sensor_info = snmp_physical_entity_and_sensor_info["sensor_mib"]
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     keys = redis_get_keys(duthost, STATE_DB, THERMAL_KEY_TEMPLATE.format('*'))
-    assert keys, (
-        "Thermal information does not exist in DB:{} "
-    ).format(keys)
+    assert keys, "Thermal information does not exist in DB: {}".format(keys)
+
     for key in keys:
         thermal_info = redis_hgetall(duthost, STATE_DB, key)
         if is_null_str(thermal_info['temperature']):
@@ -901,9 +892,8 @@ def test_thermal_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physical_
         expect_oid = CHASSIS_MGMT_SUB_ID + DEVICE_TYPE_CHASSIS_THERMAL + position * DEVICE_INDEX_MULTIPLE + \
             SENSOR_TYPE_TEMP
         assert expect_oid in snmp_physical_entity_info, (
-            "Expected OID '{}' is missing in SNMP physical entity MIB.\n"
-            "SNMP physical entity info: {}"
-        ).format(expect_oid, snmp_physical_entity_info)
+            "Expected OID '{}' is missing in SNMP physical entity MIB."
+        ).format(expect_oid)
 
         thermal_snmp_fact = snmp_physical_entity_info[expect_oid]
         assert thermal_snmp_fact['entPhysDescr'] == name, (
@@ -1157,10 +1147,8 @@ def _check_transceiver_dom_sensor_info(duthost, name, transceiver_oid, snmp_phys
         assert expect_oid in snmp_physical_entity_info, (
             "Cannot find port sensor OID '{}' in physical entity MIB. "
             "Expected to find the sensor OID in SNMP facts but it is missing. "
-            "SNMP physical entity info: {}"
         ).format(
-            expect_oid,
-            snmp_physical_entity_info
+            expect_oid
         )
         sensor_snmp_fact = snmp_physical_entity_info[expect_oid]
         assert sensor_snmp_fact['entPhysDescr'] is not None, (
@@ -1318,7 +1306,7 @@ def test_turn_off_psu_and_check_psu_info(duthosts, enum_supervisor_dut_hostname,
         # wait for psud update the database
         pytest_assert(
             wait_until(900, 20, 5, _check_psu_status_after_power_off, duthost, localhost, creds_all_duts),
-            "No PSUs turned off within the expected timeframe on DUT"
+            "No PSUs turned off within the expected timeframe."
         )
 
     finally:


### PR DESCRIPTION

 **Description of PR**

Removed hostname,platform and hwsku from assert failed summary

**This PR is the cherry pick PR to 202505**
https://github.com/sonic-net/sonic-mgmt/pull/19889


**Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

**Back port request**

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Summary:**

Removed hostname, platform, and hwsku from assertion failure summaries to make them more consistent across test cases. Including these details caused unique messages per DUT, making automated failure grouping harder. This change helps streamline log analysis and improves failure aggregation.

**What is the motivation for this PR?**
The Motivation is to improve the consistency of assertion failure messages across test cases. Including dynamic values like hostname, platform, and hwsku leads to unique failure summaries for each DUT, making it difficult to group and analyze failures automatically. By removing these, we enable better aggregation and more efficient debugging from test results.

**How did you do it?**
I updated the assertion statements in the following test files to include descriptive error messages:
tests/bfd/bfd_helpers.py
tests/bgp/test_bgp_azng_migration.py
tests/bgp/test_bgp_suppress_fib.py
tests/lldp/test_lldp.py
tests/platform_tests/test_reload_config.py
tests/route/test_static_route.py
tests/snmp/test_snmp_phy_entity.py
tests/fdb/test_fdb.py
tests/platform_tests/link_flap/test_link_flap.py
tests/bgp/test_bgp_queue.py

**How did you verify/test it?**
Verified that the updated assertion messages are correctly reflected in the test code by reviewing the changes locally.


