### PR TITLE
Add OCS support in testbed session generator.

### DIFF
--- a/ansible/devutil/ssh_session_repo.py
+++ b/ansible/devutil/ssh_session_repo.py
@@ -77,6 +77,8 @@ class SshSessionRepoGenerator(object):
             device_type = "ptf"
         elif "Root" in device.device_type:
             device_type = "root"
+        elif "FanoutL1" in device.device_type:
+            device_type = "ocs"
         elif "Fanout" in device.device_type:
             device_type = "fan"
         elif "Console" in device.device_type:

--- a/ansible/devutil/testbed.py
+++ b/ansible/devutil/testbed.py
@@ -96,7 +96,7 @@ class TestBed(object):
         self.duts = raw_dict.get("duts", raw_dict.get("dut", []))
 
         # Create a PTF node object
-        if "ptf" in raw_dict:
+        if "ptf" in raw_dict and raw_dict["ptf"]:
             self.ptf_node = DeviceInfo(
                 hostname=self.ptf,
                 management_ip=self.ptf_ip.split("/")[0],
@@ -123,6 +123,13 @@ class TestBed(object):
                     break
             else:
                 print(f"Error: Failed to find device info for DUT {dut}")
+
+        self.ocs_nodes = {}
+        for ocs in raw_dict.get("l1s", []):
+            for inv in device_inventories:
+                ocs_device = inv.get_device(ocs)
+                if ocs_device is not None:
+                    self.ocs_nodes[ocs] = ocs_device
 
         # Some testbeds are dummy ones and doesn't have inv_name specified,
         # so we need to use "unknown" as inv_name instead.

--- a/ansible/ssh_session_gen.py
+++ b/ansible/ssh_session_gen.py
@@ -204,6 +204,7 @@ class TestBedSshSessionRepoGenerator(DeviceSshSessionRepoGenerator):
             testbed.dut_nodes.values(),
             [testbed.ptf_node] if testbed.ptf_node else [],
             testbed.fanout_nodes.values(),
+            testbed.ocs_nodes.values(),
             testbed.root_fanout_nodes.values(),
             testbed.console_nodes.values(),
             testbed.server_nodes.values()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

With OCS being supported in the NUT testbeds, it will be better to also add the OCS into the testbed session.

#### How did you do it?

Updated the testbed session generator to handle this.

#### How did you verify/test it?

Run locally.

<img width="1212" height="363" alt="image" src="https://github.com/user-attachments/assets/9e95a8f6-d4e9-45d8-a5e5-be30d41522ce" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
