### PR TITLE
Mark two test cases as xfail for virtual T2 because the retries take a very long time

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -138,6 +138,12 @@ container_upgrade/test_container_upgrade.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+crm/test_crm.py:
+  xfail:
+    conditions:
+    - asic_type in ['vs'] and 't2' in topo_name
+    - https://github.com/sonic-net/sonic-mgmt/issues/20256
+    reason: This test case is flaky on virtual chassis
 decap/test_decap.py:
   skip:
     conditions:
@@ -193,6 +199,12 @@ everflow/test_everflow_per_interface.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+everflow/test_everflow_testbed.py:
+  xfail:
+    conditions:
+    - asic_type in ['vs'] and 't2' in topo_name
+    - https://github.com/sonic-net/sonic-mgmt/issues/20257
+    reason: This test case is flaky on virtual chassis
 generic_config_updater/test_bgp_prefix.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: These two test cases are flaky on virtual T2 and their retries took very long time.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
