### PR TITLE
Revert "Enable orch_northbond_route_zmq_enabled feature in sonic-mgmt test."

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -533,34 +533,6 @@ class GenerateGoldenConfigDBModule(object):
         else:
             return config
 
-    def generate_default_init_config_db(self):
-        rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
-        if rc != 0:
-            self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
-
-        # Generate config table from init_cfg.ini
-        ori_config_db = json.loads(out)
-
-        golden_config_db = {}
-        if "DEVICE_METADATA" in ori_config_db:
-            golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
-
-        return json.dumps(golden_config_db, indent=4)
-
-    def update_zmq_config(self, config):
-        ori_config_db = json.loads(config)
-        if "DEVICE_METADATA" not in ori_config_db:
-            ori_config_db["DEVICE_METADATA"] = {}
-        if "localhost" not in ori_config_db["DEVICE_METADATA"]:
-            ori_config_db["DEVICE_METADATA"]["localhost"] = {}
-
-        # Older version image may not support ZMQ feature flag
-        rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
-        if "orch_northbond_route_zmq_enabled" in out:
-            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
-
-        return json.dumps(ori_config_db, indent=4)
-
     def generate_lt2_ft2_golden_config_db(self):
         """
         Generate golden_config for FT2 to enable FEC.
@@ -603,10 +575,7 @@ class GenerateGoldenConfigDBModule(object):
         elif self.topo_name in ["t1-filterleaf-lag"]:
             config = self.generate_filterleaf_golden_config_db()
         else:
-            config = self.generate_default_init_config_db()
-
-        # update ZMQ config
-        config = self.update_zmq_config(config)
+            config = "{}"
 
         # update dns config
         config = self.update_dns_config(config)


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#19446

Revert this PR as it caused regression. `buffer_model` is set to `dynamic`, which is incorrect.
```
 "DEVICE_METADATA": {
        "localhost": {
            "buffer_model": "dynamic",
            ......
        }
    },
```

It should be `traditional`. https://github.com/sonic-net/sonic-utilities/blob/19594b99129f3c881d500ff65d4955d077accb25/config/main.py#L2216