### PR TITLE
[snmp] use snmpv3 in pdu controller

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -150,23 +150,80 @@ class snmpPduController(PduControllerBase):
         if not self.pduType:
             logger.error('PDU type is unknown: pdu_ip {}'.format(self.controller))
             return
+        if not hasattr(self, 'ro_snmp_auth'):
+            logger.error('Does not have readonly snmp_auth')
+            return
 
         cmdGen = cmdgen.CommandGenerator()
-        snmp_auth = cmdgen.CommunityData(self.snmp_rocommunity)
-
         for lane_id in range(1, self.max_lanes + 1):
-            self._probe_lane(lane_id, cmdGen, snmp_auth)
+            self._probe_lane(lane_id, cmdGen, self.ro_snmp_auth)
+
+    def _render_value(self, value, context):
+        if '{{' in value and '}}' in value:
+            return jinja2.Template(value).render(context)
+        return value
+
+    def _get_pdu_snmp_creds(self, pdu, perm):
+        context = {'secret_group_vars': pdu['secret_group_vars']}
+        if 'pdu_{}_snmp_version'.format(perm) in pdu:
+            version = pdu['pdu_{}_snmp_version'.format(perm)]
+            if version == 'v2c':
+                if 'pdu_snmp_{}community'.format(perm) not in pdu:
+                    logger.error("If pdu_{}_snmp_version is v2c, pdu_snmp_{}community should be provided"
+                                 .format(perm, perm))
+                    return False
+                snmp_auth = cmdgen.CommunityData(self._render_value(pdu['pdu_snmp_{}community'.format(perm)], context))
+            elif version == 'v3':
+                if 'pdu_{}_snmp_user'.format(perm) not in pdu:
+                    logger.error("If pdu_{}_snmp_version is v3, pdu_{}_snmp_user should be provided".format(perm, perm))
+                    return False
+                if 'pdu_{}_snmp_auth_type'.format(perm) not in pdu or 'pdu_{}_snmp_auth_pass'.format(perm) not in pdu:
+                    logger.error("If pdu_{}_snmp_version is v3, pdu_{}_snmp_auth_type/pass should be provided"
+                                 .format(perm, perm))
+                    return False
+                if pdu['pdu_{}_snmp_auth_type'.format(perm)] == "sha":
+                    auth_type = cmdgen.usmHMACSHAAuthProtocol
+                elif pdu['pdu_{}_snmp_auth_type'.format(perm)] == "md5":
+                    auth_type = cmdgen.usmHMACMD5AuthProtocol
+                else:
+                    logger.error("Unknown auth_type {}, only accepts sha, md5"
+                                 .format(pdu['pdu_{}_snmp_auth_type'.format(perm)]))
+                    return False
+                if 'pdu_{}_snmp_priv_type'.format(perm) in pdu and 'pdu_{}_snmp_priv_pass'.format(perm) in pdu:
+                    if pdu['pdu_{}_snmp_priv_type'.format(perm)] == "aes":
+                        priv_type = cmdgen.usmAesCfb128Protocol
+                    elif pdu['pdu_{}_snmp_priv_type'.format(perm)] == "des":
+                        priv_type = cmdgen.usmDESPrivProtocol
+                    else:
+                        logger.error("Unknown priv_type {}, only accepts aes, des"
+                                     .format(pdu['pdu_{}_snmp_priv_type'.format(perm)]))
+                        return False
+                    snmp_auth = cmdgen.UsmUserData(self._render_value(pdu['pdu_{}_snmp_user'.format(perm)], context),
+                                                   authProtocol=auth_type,
+                                                   authKey=self._render_value(pdu['pdu_{}_snmp_auth_pass'.format(perm)],
+                                                                              context),
+                                                   privProtocol=priv_type,
+                                                   privKey=self._render_value(pdu['pdu_{}_snmp_priv_pass'.format(perm)],
+                                                                              context))
+                else:
+                    snmp_auth = cmdgen.UsmUserData(pdu['pdu_{}_snmp_user'.format(perm)],
+                                                   authProtocol=auth_type,
+                                                   authKey=self._render_value(pdu['pdu_{}_snmp_auth_pass'.format(perm)],
+                                                                              context))
+
+        else:
+            snmp_community = pdu['snmp_{}community'.format(perm)]
+            snmp_auth = cmdgen.CommunityData(self._render_value(snmp_community, context))
+        setattr(self, "{}_snmp_auth".format(perm), snmp_auth)
+        return True
 
     def __init__(self, controller, pdu, hwsku, psu_peer_type):
         logger.info("Initializing " + self.__class__.__name__)
         PduControllerBase.__init__(self)
         self.controller = controller
-        self.snmp_rocommunity = pdu['snmp_rocommunity']
-        if 'secret_group_vars' in pdu['snmp_rwcommunity']:
-            context = {'secret_group_vars': pdu['secret_group_vars']}
-            self.snmp_rwcommunity = jinja2.Template(pdu['snmp_rwcommunity']).render(context)
-        else:
-            self.snmp_rwcommunity = pdu['snmp_rwcommunity']
+        if self._get_pdu_snmp_creds(pdu, "ro") is False and self._get_pdu_snmp_creds(pdu, "rw") is False:
+            logger.error("No available snmp creds for pdu")
+            return False
         self.pduType = 'Sentry4' if hwsku == 'Sentry' and psu_peer_type == 'Pdu' else hwsku
         self.port_oid_dict = {}
         self.port_label_dict = {}
@@ -190,11 +247,14 @@ class snmpPduController(PduControllerBase):
         if not self.pduType:
             logger.error('Unable to turn on: PDU type is unknown: pdu_ip {}'.format(self.controller))
             return False
+        if not hasattr(self, 'rw_snmp_auth'):
+            logger.error("Does not have readwrite snmp_auth")
+            return False
 
         port_oid = '.' + self.PORT_CONTROL_BASE_OID + outlet
         errorIndication, errorStatus, _, _ = \
             cmdgen.CommandGenerator().setCmd(
-                cmdgen.CommunityData(self.snmp_rwcommunity),
+                self.rw_snmp_auth,
                 cmdgen.UdpTransportTarget((self.controller, 161)),
                 (port_oid, rfc1902.Integer(self.CONTROL_ON))
             )
@@ -219,11 +279,14 @@ class snmpPduController(PduControllerBase):
         if not self.pduType:
             logger.error('Unable to turn off: PDU type is unknown: pdu_ip {}'.format(self.controller))
             return False
+        if not hasattr(self, 'rw_snmp_auth'):
+            logger.error("Does not have readwritew snmp_auth")
+            return False
 
         port_oid = '.' + self.PORT_CONTROL_BASE_OID + outlet
         errorIndication, errorStatus, _, _ = \
             cmdgen.CommandGenerator().setCmd(
-                cmdgen.CommunityData(self.snmp_rwcommunity),
+                self.rw_snmp_auth,
                 cmdgen.UdpTransportTarget((self.controller, 161)),
                 (port_oid, rfc1902.Integer(self.CONTROL_OFF))
             )
@@ -303,8 +366,12 @@ class snmpPduController(PduControllerBase):
                  The outlet in returned result is integer starts from 0.
         """
         results = []
+
         if not self.pduType:
             logger.error('Unable to retrieve status: PDU type is unknown: pdu_ip {}'.format(self.controller))
+            return results
+        if not hasattr(self, 'ro_snmp_auth'):
+            logger.error('Does not have readonly snmp_auth')
             return results
 
         if not outlet and not hostname:
@@ -322,10 +389,8 @@ class snmpPduController(PduControllerBase):
                 logger.error("{} device is not attached to any outlet of PDU {}".format(hn, self.controller))
 
         cmdGen = cmdgen.CommandGenerator()
-        snmp_auth = cmdgen.CommunityData(self.snmp_rocommunity)
-
         for port in ports:
-            status = self._get_one_outlet_status(cmdGen, snmp_auth, port)
+            status = self._get_one_outlet_status(cmdGen, self.ro_snmp_auth, port)
             if status:
                 results.append(status)
 

--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -221,9 +221,8 @@ class snmpPduController(PduControllerBase):
         logger.info("Initializing " + self.__class__.__name__)
         PduControllerBase.__init__(self)
         self.controller = controller
-        if self._get_pdu_snmp_creds(pdu, "ro") is False and self._get_pdu_snmp_creds(pdu, "rw") is False:
-            logger.error("No available snmp creds for pdu")
-            return False
+        self._get_pdu_snmp_creds(pdu, "ro")
+        self._get_pdu_snmp_creds(pdu, "rw")
         self.pduType = 'Sentry4' if hwsku == 'Sentry' and psu_peer_type == 'Pdu' else hwsku
         self.port_oid_dict = {}
         self.port_label_dict = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Currently, the snmp pdu controller, which is both used by tests and devutils, only supports snmp v2c. Snmp v2c supports only community string as credential, and is currently shared by dut and pdu. This change supports a series of credentials that starts with pdu_, to separate dut snmp credentials from pdu snmp credentials. The pdu snmp variables can be provided either in inventory, group_vars or host_vars, depending on how lab ansible is setup. To accommodate old settings, if these pdu_* variables are not provided, we will fall back to the previous credential, which is the one shared with dut, snmp_rocommunity and snmp_rwcommunity.

New variables:

pdu_ro_snmp_version: # v2c or v3
pdu_snmp_rocommunity: # credential for v2c
pdu_ro_snmp_user: # credential for v3, user name
pdu_ro_snmp_auth_type: # credential for v3, authentication protocol, can be md5, sha
pdu_ro_snmp_auth_pass: # credential for v3, authentication password
pdu_ro_snmp_priv_type: # credential for v3, privacy protocol, can be des, aes (optional depending on pdu config)
pdu_ro_snmp_priv_pass: # credential for v3, privacy password (optional depending on pdu config)

pdu_rw_snmp_version: # v2c or v3
pdu_snmp_rwcommunity: # credential for v2c
pdu_rw_snmp_user: # credential for v3, user name
pdu_rw_snmp_auth_type: # credential for v3, authentication protocol, can be md5, sha
pdu_rw_snmp_auth_pass: # credential for v3, authentication password
pdu_rw_snmp_priv_type: # credential for v3, privacy protocol, can be des, aes (optional depending on pdu config)
pdu_rw_snmp_priv_pass: # credential for v3, privacy password (optional depending on pdu config)

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To support snmpv3 in pdu control

#### How did you do it?
Add snmpv3 credentials for pdu controller

#### How did you verify/test it?
Run pdu test on devices and use devutils manually.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
