### PR TITLE
Update expected iptable rule on smart switch

### DIFF
--- a/tests/cacl/test_cacl_application.py
+++ b/tests/cacl/test_cacl_application.py
@@ -511,6 +511,10 @@ def generate_expected_rules(duthost, tbinfo, docker_network, asic_index, expecte
     iptables_rules.append("-A INPUT -s 127.0.0.1/32 -i lo -j ACCEPT")
     ip6tables_rules.append("-A INPUT -s ::1/128 -i lo -j ACCEPT")
 
+    # Allow smart switch chassis midplane IP (from https://github.com/sonic-net/sonic-host-services/pull/301)
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+        iptables_rules.append("-A INPUT -d 169.254.200.254/32 -j ACCEPT")
+
     if asic_index is None:
         # Allow Communication among docker containers
         for k, v in list(docker_network['container'].items()):

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -480,6 +480,10 @@ cacl/test_cacl_application.py:
     reason: "skip test_cacl_application in PR test temporarily"
     conditions:
       - "asic_type in ['vs']"
+  xfail:
+    reason: "Wait PR https://github.com/sonic-net/sonic-host-services/pull/301 include in sonic-buildimage"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/21175"
 
 cacl/test_cacl_application.py::test_cacl_acl_loader_commands_internal:
   skip:


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update expected iptable rule on smart switch
Fixes # 
An new iptable was added on smart switch by PR https://github.com/sonic-net/sonic-host-services/pull/301. After the change, a new rule `-A INPUT -d 169.254.200.254/32 -j ACCEPT` was generate after deploy minigraph.
Need update function `generate_expected_rules` in `tests/cacl/test_cacl_application.py` to include this rule

```
admin@router:~$ sudo iptables -S
-P INPUT ACCEPT
-P FORWARD ACCEPT
-P OUTPUT ACCEPT
-A INPUT -s 127.0.0.1/32 -i lo -j ACCEPT
-A INPUT -d 169.254.200.254/32 -j ACCEPT             <<<
-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
```

**Note**: The current PR needs to be merged after https://github.com/sonic-net/sonic-host-services/pull/301 merge

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Update function `generate_expected_rules

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
