### PR TITLE
Add VLAN and VRF support for building snake testbed.

### DIFF
--- a/ansible/roles/testbed/nut/tasks/dut_create_config_patch.yml
+++ b/ansible/roles/testbed/nut/tasks/dut_create_config_patch.yml
@@ -1,6 +1,10 @@
 ---
 - name: allocate ip for device
-  nut_allocate_ip: testbed_facts="{{ testbed_facts }}" device_info="{{ device_info }}" device_port_links="{{ device_conn }}"
+  nut_allocate_ip:
+    testbed_facts: "{{ testbed_facts }}"
+    device_info: "{{ device_info }}"
+    device_port_links: "{{ device_conn }}"
+    device_port_vrfs: "{{ device_port_vrfs }}"
   delegate_to: localhost
 
 - name: output device info
@@ -14,6 +18,10 @@
 - name: output device conn
   debug:
     var: device_conn[inventory_hostname]
+
+- name: output device port vlan
+  debug:
+    var: device_vlan_map_list[inventory_hostname]
 
 - name: output device bgp neighbor devices
   debug:
@@ -42,6 +50,10 @@
     info: "{{ device_info[inventory_hostname] }}"
     meta: "{{ device_meta[inventory_hostname] }}"
     conn: "{{ device_conn[inventory_hostname] }}"
+    vlans: "{{ device_vlan_list[inventory_hostname] }}"
+    vrfs: "{{ device_vrfs[inventory_hostname] }}"
+    intfs: "{{ device_interfaces[inventory_hostname] }}"
+    port_vlans: "{{ device_port_vlans[inventory_hostname] }}"
     bgp_neighbor_devices: "{{ device_bgp_neighbor_devices[inventory_hostname] }}"
     bgp_neighbor_ports: "{{ device_bgp_neighbor_ports[inventory_hostname] }}"
     features: "{{ device_feature_settings }}"

--- a/ansible/roles/testbed/nut/templates/config_patch/dut/all.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/dut/all.json.j2
@@ -3,7 +3,10 @@
   {%- include 'templates/config_patch/dut/features.json.j2' %}
   {%- include 'templates/config_patch/dut/ports.json.j2' %}
   {%- include 'templates/config_patch/dut/loopback_interfaces.json.j2' %}
+  {%- include 'templates/config_patch/dut/vrfs.json.j2' %}
   {%- include 'templates/config_patch/dut/interfaces.json.j2' %}
+  {%- include 'templates/config_patch/dut/vlans.json.j2' %}
+  {%- include 'templates/config_patch/dut/vlan_members.json.j2' %}
   {%- include 'templates/config_patch/dut/bgp_neighbor_ports.json.j2' %}
   {%- include 'templates/config_patch/dut/bgp_neighbor_devices.json.j2' %}
   {%- include 'templates/config_patch/dut/device_metadata.json.j2' %}

--- a/ansible/roles/testbed/nut/templates/config_patch/dut/interfaces.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/dut/interfaces.json.j2
@@ -1,10 +1,13 @@
 { "op": "add", "path": "/INTERFACE", "value": {} },
-{% for port, peer in bgp_neighbor_ports.items() %}
+{% for port, intf in intfs.items() %}
 { "op": "add", "path": "/INTERFACE/{{ port }}", "value": {} },
-{% if peer.local_ip_v4 %}
-{ "op": "add", "path": "/INTERFACE/{{ port }}|{{ peer.local_ip_v4 }}~1{{ peer.p2p_v4_subnet_size }}", "value": {} },
+{% if intf.vrf_name %}
+{ "op": "add", "path": "/INTERFACE/{{ port }}/vrf_name", "value": "{{ intf.vrf_name }}" },
 {% endif %}
-{% if peer.local_ip_v6 %}
-{ "op": "add", "path": "/INTERFACE/{{ port }}|{{ peer.local_ip_v6 }}~1{{ peer.p2p_v6_subnet_size }}", "value": {} },
+{% if intf.ip_v4 %}
+{ "op": "add", "path": "/INTERFACE/{{ port }}|{{ intf.ip_v4 }}~1{{ intf.ip_v4_subnet_size}}", "value": {} },
+{% endif %}
+{% if intf.ip_v6 %}
+{ "op": "add", "path": "/INTERFACE/{{ port }}|{{ intf.ip_v6 }}~1{{ intf.ip_v6_subnet_size }}", "value": {} },
 {% endif %}
 {% endfor %}

--- a/ansible/roles/testbed/nut/templates/config_patch/dut/vlan_members.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/dut/vlan_members.json.j2
@@ -1,0 +1,11 @@
+{ "op": "add", "path": "/VLAN_MEMBER", "value": {} },
+{% for port, port_vlan in port_vlans.items() %}
+{% for vlan_id in port_vlan.vlanlist %}
+{ "op": "add", "path": "/VLAN_MEMBER/Vlan{{ vlan_id }}|{{ port }}", "value": {} },
+{% if port_vlan.mode == "Access" %}
+{ "op": "add", "path": "/VLAN_MEMBER/Vlan{{ vlan_id }}|{{ port }}/tagging_mode", "value": "untagged" },
+{% else %}
+{ "op": "add", "path": "/VLAN_MEMBER/Vlan{{ vlan_id }}|{{ port }}/tagging_mode", "value": "tagged" },
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/ansible/roles/testbed/nut/templates/config_patch/dut/vlans.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/dut/vlans.json.j2
@@ -1,0 +1,4 @@
+{ "op": "add", "path": "/VLAN", "value": {} },
+{% for vlan in vlans %}
+{ "op": "add", "path": "/VLAN/Vlan{{ vlan }}", "value": { "vlanid": "{{ vlan }}" } },
+{% endfor %}

--- a/ansible/roles/testbed/nut/templates/config_patch/dut/vrfs.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/dut/vrfs.json.j2
@@ -1,0 +1,4 @@
+{ "op": "add", "path": "/VRF", "value": {} },
+{% for vrf in vrfs %}
+{ "op": "add", "path": "/VRF/{{ vrf }}", "value": {} },
+{% endfor %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

sonic-mgmt doesn't have support to create L2 and L3 snake testbed for IXIA tests.

#### How did you do it?

This PR extends the NUT testbed with snake testbed setup support, by adding explicit VLAN and VRF support.

#### How did you verify/test it?

Run locally and successfully deployed.

<img width="1101" height="597" alt="image" src="https://github.com/user-attachments/assets/7fe68949-c570-4dfe-84cf-13495ac20985" />

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
