### PR TITLE
Enhance get_dut_version.py

### DIFF
--- a/.azure-pipelines/get_dut_version.py
+++ b/.azure-pipelines/get_dut_version.py
@@ -81,7 +81,7 @@ def get_duts_version(sonichosts, output=None):
                             dut_info["HwSKU"] = value
                             dut_info["ASIC"] = read_asic_name(value)
                         elif key == "ASIC":
-                            ret[dut]["ASIC TYPE"] = value
+                            dut_info["ASIC TYPE"] = value
                         else:
                             dut_info[key] = value
                     continue
@@ -113,7 +113,7 @@ def get_duts_version(sonichosts, output=None):
 
         return ret
     except Exception as e:
-        logger.error("Failed to get DUT version: {}".format(e))
+        logger.error(f"Failed to get DUT version: {repr(e)}", exc_info=True)
         sys.exit(RC_GET_DUT_VERSION_FAILED)
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Enhance get_dut_version.py, make it More stable when parsing `show version` output.
`../.azure-pipelines/get_dut_version.py -i ../ansible/veos_vtb -t vms-kvm-t1-lag --tbfile vtestbed.yaml -o vms-kvm-t1-lag_version --log-level info`
<img width="900" height="779" alt="image" src="https://github.com/user-attachments/assets/f70f2289-2824-4c1c-ae57-c0e4b040381e" />

And PR tests shows the DUT version can get successfully.
<img width="697" height="52" alt="image" src="https://github.com/user-attachments/assets/0c4832d7-f38e-4a93-96a4-f571de8d461f" />


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
