### PR TITLE
Adding retry mechanisms for mux config commands

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1662,6 +1662,7 @@ def config_dualtor_arp_responder(tbinfo, duthost, mux_config, ptfhost):     # no
 
     ptfhost.shell("supervisorctl stop arp_responder", module_ignore_errors=True)
 
+
 def check_active_active_port_status(duthost, ports, status):
     """Validate the active-active mux ports status."""
     logging.debug("Check mux status for ports {} is {}".format(ports, status))
@@ -1686,16 +1687,17 @@ def run_mux_config_command(tor, cmd, expected_output=None, forbidden_output=None
         forbidden_output = []
 
     for output in forbidden_output:
-       if output in result['results'][0]['stdout']:
-           logging.error("Unexpected output {} in when running command {}".format(output, cmd))
-           return False
+        if output in result['results'][0]['stdout']:
+            logging.error("Unexpected output {} in when running command {}".format(output, cmd))
+            return False
 
     for output in expected_output:
-       if output not in result['results'][0]['stdout']:
-           logging.error("Unexpected output {} in when running command {}".format(output, cmd))
-           return False
+        if output not in result['results'][0]['stdout']:
+            logging.error("Unexpected output {} in when running command {}".format(output, cmd))
+            return False
 
     return True
+
 
 def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally=False):
     """Toggle the active-active mux ports via CLI."""
@@ -2017,4 +2019,3 @@ def disable_timed_oscillation_active_standby(duthosts, tbinfo):
     for duthost in duthosts:
         duthost.shell('sonic-db-cli CONFIG_DB HSET "MUX_LINKMGR|TIMED_OSCILLATION" "oscillation_enabled" "false"')
         duthost.shell("config save -y")
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411

### Approach
What is the motivation for this PR?

This fixes the failures we were seeing in the dualtor/test_ipinip.py test case, where in order to configure an Active-Active dualtor system to Active-Standby, we are changing the mux states of one switch to Standby while the other remains active. This configuration was not happening smoothly, since we were not waiting for the mux cable to be ready, before changing its configuration, and we also were not waiting long enough after the change of configuration before starting the traffic test.

How did you do it?

Added a retry mechanism to run mux config commands, which will check for the output we expect to see and don't expect to see, on each run of the command. Also added docker status checks, before the mux commands are run.

#### How did you verify/test it?
By running the dualtor/test_ipinip.py testcase in sonic-mgmt.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
