### PR TITLE
MIGSMSFT-1155 separate handling for Q200 and G200 in testQosSaiPfcXonLimit

### DIFF
--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -736,7 +736,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "hwsku": dutTestParams['hwsku'],
             "pkts_num_egr_mem": qosConfig[xonProfile].get('pkts_num_egr_mem', None),
-            "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic'])
+            "src_dst_asic_diff": (dutConfig['dutAsic'] != dutConfig['dstDutAsic']),
+            "dut_asic": dutConfig["dutAsic"]
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2504,6 +2504,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
             hysteresis = 0
         hwsku = self.test_params['hwsku']
         src_dst_asic_diff = self.test_params['src_dst_asic_diff']
+        dut_asic = self.test_params['dut_asic']
+
         self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
         # get a snapshot of counter values at recv and transmit ports
@@ -2751,11 +2753,13 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     fill_leakout_plus_one(
                         self, src_port_id, dst_port_2_id,
                         pkt2, int(self.test_params['pg']), asic_type)
-                    send_packet(
-                        self, src_port_id, pkt2,
-                        (pkts_num_leak_out + pkts_num_dismiss_pfc +
-                         hysteresis) // cell_occupancy - margin - 2
-                    )
+                    if dut_asic == 'gr2':
+                        pkt_count = (pkts_num_leak_out + pkts_num_dismiss_pfc +
+                                     hysteresis) // cell_occupancy - margin - 2
+                    else:
+                        pkt_count = (pkts_num_leak_out + pkts_num_dismiss_pfc +
+                                     hysteresis) // cell_occupancy + margin - 2
+                    send_packet(self, src_port_id, pkt2, pkt_count)
                 else:
                     fill_egress_plus_one(
                         self, src_port_id,
@@ -2797,7 +2801,11 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
                     fill_leakout_plus_one(
                         self, src_port_id, dst_port_3_id,
                         pkt3, int(self.test_params['pg']), asic_type)
-                    send_packet(self, src_port_id, pkt3, pkts_num_leak_out + margin * 2)
+                    if dut_asic == 'gr2':
+                        pkt_count = pkts_num_leak_out + margin * 2
+                    else:
+                        pkt_count = pkts_num_leak_out
+                    send_packet(self, src_port_id, pkt3, pkt_count)
                 else:
                     fill_egress_plus_one(
                         self, src_port_id,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Q200 testQosSaiPfcXonLimit failed at sonic-mgmt 202505 branch script.
The test was broken since a change added for G200.
Fix: Separate handling for Q200 and G200, keep G200 change for G200 only.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Q200 XonTest failed on 202505 script.

#### How did you do it?
Separate handling on Q200 and G200.

#### How did you verify/test it?
Q200:
```
------------ generated xml file: /run_logs/qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit_2025-08-21-17-55-12.xml -------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------- live log sessionfinish --------------------------------------------------------
18:06:29 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
======================================================= short test summary info =======================================================
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1]
PASSED qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2]
SKIPPED [2] qos/test_qos_sai.py:692: Additional DSCPs are not supported on non-dual ToR ports
SKIPPED [4] qos/test_qos_sai.py:666: Did not find any frontend node that is multi-asic - so can't run single_dut_multi_asic tests
SKIPPED [12] qos/test_qos_sai.py:666: multi-dut is not supported on T1 topologies
======================================== 2 passed, 18 skipped, 2 warnings in 675.03s (0:11:15) ========================================
sonic@sonic-ucs-m6-27:/data/tests$ 
```

G200: pending

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
