### PR TITLE
remove dangerous fixture disable_ipv6 for ptf container

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -690,4 +690,3 @@ def iptables_drop_ipv6_tx(ptfhost):
     ptfhost.shell("ip6tables -P OUTPUT DROP")
     yield
     ptfhost.shell("ip6tables -P OUTPUT ACCEPT")
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

https://github.com/sonic-net/sonic-mgmt/pull/16153 break the nightly, because of it disable ipv6 for ptf container.
bug had already been fixed in https://github.com/sonic-net/sonic-mgmt/pull/19709

since the fixture "disable_ipv6" is dangerous, remove it to avoid abuse, just in case.

#### How did you do it?

remove fixture "disable_ipv6"

#### How did you verify/test it?

local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
