### PR TITLE
[Dualtor] Stabilize the test_tunnel_decap_dscp_to_pg_mapping test case

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1511,6 +1511,11 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
         }
 
         try:
+            # Any watermark value before disabling the tx should be ignored
+            pg_shared_wm_res_before_tx_disable = sai_thrift_read_pg_shared_watermark(
+                    self.src_client, asic_type, port_list['src'][src_port_id])
+            logging.info(f"pg_shared_wm_res_before_tx_disable: {pg_shared_wm_res_before_tx_disable}")
+
             # Disable tx on EGRESS port so that headroom buffer cannot be free
             self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
 
@@ -1569,14 +1574,26 @@ class TunnelDscpToPgMapping(sai_base_test.ThriftInterfaceDataPlane):
                 )
                 pg_shared_wm_res_base = sai_thrift_read_pg_shared_watermark(
                     self.src_client, asic_type, port_list['src'][src_port_id])
-                logging.info(pg_shared_wm_res_base)
+                logging.info(f"pg_shared_wm_res_base: {pg_shared_wm_res_base}")
+
+                # Ignore the watermark values before disabling the tx, do this for all the PGs only for the
+                # first iteration.
+                if pg_shared_wm_res_before_tx_disable:
+                    pg_shared_wm_res_base = \
+                        [pg_shared_wm_res_base[pg] - pg_shared_wm_res_before_tx_disable[pg] for pg in range(PG_NUM)]
+                    logging.info(
+                        f"pg_shared_wm_res_base - pg_shared_wm_res_before_tx_disable: {pg_shared_wm_res_base}")
+                    pg_shared_wm_res_before_tx_disable = None
+
                 send_packet(self, src_port_id, pkt, PKT_NUM)
                 # validate pg counters increment by the correct pkt num
                 time.sleep(8)
 
                 pg_shared_wm_res = sai_thrift_read_pg_shared_watermark(self.src_client, asic_type,
                                                                        port_list['src'][src_port_id])
+                logging.info(f"pg_shared_wm_res: {pg_shared_wm_res}")
                 pg_wm_inc = pg_shared_wm_res[pg] - pg_shared_wm_res_base[pg]
+                logging.info(f"pg_wm_inc: {pg_wm_inc}")
                 lower_bounds = (PKT_NUM - ERROR_TOLERANCE[pg]) * cell_size * cell_occupancy
                 upper_bounds = (PKT_NUM + ERROR_TOLERANCE[pg]) * cell_size * cell_occupancy
                 print("DSCP {}, PG {}, expectation: {} <= {} <= {}".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is to fix a test issue only observed on MSFT testbed due to noisy packets received by dut during the test. The size of the packet is very big, so the base watermark of PG0 has an unexpected big initial value which casues test failure. 
When the test fails, the pg 0 watermark is already 9216 before disabling the egress port, so we have the counter but not the packet in buffer:
```
08:48:08.060  root      : INFO    : [9216, 0, 0, 0, 0, 0, 0, 0]
```
The test then sends 100 small packets which should take 100 cells and the size should be 14400 on SN4700 platform.
And then it calculates the difference between the watermark after 100 packets and the base one. This is correct logic if the big packet was received after the tx disable, while it will fail the test if the packet is before tx disable, because the packet that increased the watermark is not in the buffer.
This is the failure pytest log: 
```
sai_qos_tests.TunnelDscpToPgMapping ... DSCP 0, PG 0, expectation: 11520 <= 5472 <= 17280
```
5472 + 9216 = 14688 = 14400 + 288(expected margin due to background small packets, there is logic to tolerant this in the test)

In the passed runs, the base wartermark are all 0:
10:46:24.694  root      : INFO    : [0, 0, 0, 0, 0, 0, 0, 0]

So, the initial wartermark values before disabling tx should be ignored.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Take the watermark values before disabling tx and subtract them from the base watermark values in the first iteration.
#### How did you verify/test it?
Run the test on SN4700 dualtor testbed and it passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
