### PR TITLE
Generate new golden config db for cisco smartswitch platforms.

### DIFF
--- a/ansible/module_utils/smartswitch_utils.py
+++ b/ansible/module_utils/smartswitch_utils.py
@@ -28,7 +28,7 @@ smartswitch_hwsku_config = {
     ]
 }
 
-# Mellanox SKUs 
+# Mellanox SKUs
 smartswitch_hwsku_config.update({
     "Mellanox-SN4280-O28": common_mellanox_hwsku_config.copy(),
     "Mellanox-SN4280-O8C40": common_mellanox_hwsku_config.copy()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Generate new golden config for cisco smartswitch platforms.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X ] 202505

### Approach
used existing file generate_golden_config_db.py to generate the smartswicth golden config
#### What is the motivation for this PR?
The fix is to generate npu-dpu ports for the cisco smarts with platform

#### How did you do it?

#### How did you verify/test it?
Deployed the minigraph tool, cross-verified the config_db.json file, and ensured that ports Ethernet224 to Ethernet280 appear in the configuration.
#### Any platform specific information?
'Cisco-8102-28FH-DPU-O'
'Cisco-8102-28FH-DPU-C28'
'Cisco-8102-28FH-DPU-O8C20' 
'Cisco-8102-28FH-DPU-O12C16, 
'Cisco-8102-28FH-DPU-O8C40' 
'Cisco-8102-28FH-DPU-O8V40'
#### Supported testbed topology if it's a new test case?
t1-28-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
