### PR TITLE
Adding fix to clear logs before reboot for disk out of space issue

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -367,6 +367,7 @@ def free_up_disk_space(module, disk_used_pcent):
         exec_command(module, "rm -f /var/core/*", ignore_error=True)
         exec_command(module, "rm -rf /var/dump/*", ignore_error=True)
         exec_command(module, "rm -rf /home/admin/*", ignore_error=True)
+        exec_command(module, "rm -rf /host/logs_before_reboot/*", ignore_error=True)
         latest_used_percent = get_disk_used_percent(module)
         log("Done free up, latest used percent: {}".format(latest_used_percent))
     else:


### PR DESCRIPTION
### Description of PR

Summary:
This PR adds a cleanup step to remove old log files from the `/host/logs_before_reboot` directory as part of the disk space freeing routine. This helps ensure sufficient disk space before performing upgrade operations and keeps the testbed environment tidy.

Fixes # (No specific issue number; general maintenance and disk space management improvement)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To proactively prevent disk space issues by cleaning up unnecessary log files in `/host/logs_before_reboot` during the disk space freeing step. This is especially useful before upgrades, where disk space can be a concern.

#### How did you do it?
Added the following line to the disk cleanup routine (typically found in the `free_up_disk_space` function):
```python
exec_command(module, "rm -rf /host/logs_before_reboot/*", ignore_error=True)
```
This line is placed with other similar cleanup commands for logs, cores, dumps, etc.

#### How did you verify/test it?
Tested the updated cleanup routine in a testbed and verified that files in `/host/logs_before_reboot` are deleted as expected. Confirmed that the upgrade process proceeds with sufficient disk space and no residual log files.

#### Any platform specific information?
No platform-specific changes. This cleanup is safe for all platforms supported by SONiC testbed.

#### Supported testbed topology if it's a new test case?
Not a new test case. This is a framework/testbed maintenance improvement.

### Documentation
No specific documentation updates are required for this change, as it is a maintenance step within the existing disk cleanup routine.
