### PR TITLE
Skip test_snmp_interfaces_error_discard since RIF stats are not suppo…

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3008,6 +3008,12 @@ snmp/test_snmp_default_route.py::test_snmp_default_route:
     conditions:
       - "'standalone' in topo_name"
 
+snmp/test_snmp_interfaces.py::test_snmp_interfaces_error_discard:
+  skip:
+    reason: "Skipping test since the flag is set to false for BCM DNX platforms and the RIF stats are not supported."
+    conditions:
+      - "asic_subtype in ['broadcom-dnx']"
+
 snmp/test_snmp_link_local.py:
   skip:
     reason: "SNMP over IPv6 support not present in release branches."


### PR DESCRIPTION
### Description of PR
Skip test_snmp_interfaces_error_discard since RIF stats are not supported for BCM DNX

This is a fix for issue https://github.com/sonic-net/sonic-mgmt/issues/20324
counters RIF are not pupilated since RIF stats are not supported for BCM DNX.
test_snmp_interfaces_error_discard need to be skipped

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To Fix issue https://github.com/sonic-net/sonic-mgmt/issues/20324
#### How did you do it?

#### How did you verify/test it?
Verified on a DNX platform

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
