### PR TITLE
Fixing an issue in outer IPv6 VxLAN hash tests

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -1175,10 +1175,16 @@ class VxlanHashTest(HashTest):
         # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
         # We don't care the actually value as long as the outer_dst_ip is routed by default routed
         # The outer_src_ip and outer_dst_ip are fixed
-        outer_src_ip = '80.1.0.31'
-        outer_dst_ip = '80.1.0.32'
+        outer_src_ipv4 = '80.1.0.31'
+        outer_dst_ipv4 = '80.1.0.32'
         outer_src_ipv6 = '80::31'
         outer_dst_ipv6 = '80::32'
+        if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
+            outer_src_ip = outer_src_ipv4
+            outer_dst_ip = outer_dst_ipv4
+        else:
+            outer_src_ip = outer_src_ipv6
+            outer_dst_ip = outer_dst_ipv6
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             outer_dst_ip)
         if self.switch_type == "chassis-packet":
@@ -1197,7 +1203,7 @@ class VxlanHashTest(HashTest):
             logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'
                          .format(hash_key, src_port, exp_port_lists, outer_src_ip, outer_dst_ip))
             (matched_index, _) = self.check_ip_route(hash_key,
-                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip,
+                                                     src_port, exp_port_lists, outer_src_ipv4, outer_dst_ipv4,
                                                      outer_src_ipv6, outer_dst_ipv6)
             hit_count_map[matched_index] = hit_count_map.get(
                 matched_index, 0) + 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Microsoft ADO ID: 34015622
This PR fixes an issue in VxLAN hash tests that causes outer IPv6 tests to fail in some situations.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
It is possible that the set of nexthop interfaces defined for `0.0.0.0/0` and `::/0` in `APP DB` is not the same. For example:
```
$ sonic-db-cli APPL_DB hgetall "ROUTE_TABLE:0.0.0.0/0"
{'protocol': 'bgp', 'nexthop': '10.0.0.59,10.0.0.61,10.0.0.63', 'ifname': 'PortChannel102,PortChannel103,PortChannel104'}

$ sonic-db-cli APPL_DB hgetall "ROUTE_TABLE:::/0"
{'protocol': 'bgp', 'nexthop': 'fc00::72,fc00::76,fc00::7a,fc00::7e', 'ifname': 'PortChannel101,PortChannel102,PortChannel103,PortChannel104'}
```
The VxLAN hash tests always get the list of expected interfaces using the outer IPv4 address set in `VxlanHashTest::check_hash`. So if the expected packet is sent out from an interface that is a member of nexthop interfaces for `::/0` but not `0.0.0.0/0` (`PortChannel101` in the above example), then the test will fail:
```
FAILED fib/test_fib.py::test_vxlan_hash[ipv6-ipv6]
FAILED fib/test_fib.py::test_vxlan_hash[ipv6-ipv4]

AssertionError: Received expected packet on port 28 for device 0, but it should have arrived on one of these ports: [29, 30, 31].
```

#### How did you do it?
Ensured that for outer IPv6 VxLAN hash tests, the outer IPv6 address is passed to `VxlanHashTest::get_src_and_exp_ports`.

#### How did you verify/test it?
Ran VxLAN hash tests:
```
fib/test_fib.py::test_vxlan_hash[ipv4-ipv4] PASSED                                                                                                                                                                                                                        [ 25%]
fib/test_fib.py::test_vxlan_hash[ipv4-ipv6] PASSED                                                                                                                                                                                                                               [ 50%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv6] PASSED                                                                                                                                                                                                                               [ 75%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv4] PASSED                                                                                                                                                                                                                               [100%]
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
