### PR TITLE
[vxlan.test_vnet_bgp_route_precedence]: Remove xfail as test has been fixed

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3449,10 +3449,6 @@ vxlan/test_vnet_bgp_route_precedence.py:
     conditions:
       - "asic_type not in ['cisco-8000', 'mellanox']"
       - "release in ['202411']"
-  xfail:
-    reason: "Skip due to the test issue: https://github.com/sonic-net/sonic-mgmt/issues/18594"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/18594"
 
 vxlan/test_vnet_route_leak.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Remove xfail as #18594 has been fixed in #19242, test could pass.
Fixes # (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Remove xfail as #18594 has been fixed in #19242, test could pass.

#### How did you do it?

#### How did you verify/test it?
Verified it on internal mgmt test
```
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v4_in_v4-custom-initially_up] SKIPPED [  2%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v4_in_v4-custom-initially_up] SKIPPED [  5%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v4_in_v4-custom-initially_up] SKIPPED [  8%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v4_in_v4-custom-initially_up] SKIPPED [ 11%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v4_in_v4-BFD-initially_up] PASSED [ 13%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v4_in_v4-BFD-initially_up] PASSED [ 16%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v4_in_v4-BFD-initially_up] PASSED [ 19%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v4_in_v4-BFD-initially_up] PASSED [ 22%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v4_in_v4-BFD-initially_down] PASSED [ 25%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v4_in_v4-BFD-initially_down] PASSED [ 27%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v4_in_v4-BFD-initially_down] PASSED [ 30%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v4_in_v4-BFD-initially_down] PASSED [ 33%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v6_in_v4-BFD-initially_down] PASSED [ 36%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v6_in_v4-BFD-initially_down] PASSED [ 38%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v6_in_v4-BFD-initially_down] PASSED [ 41%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v6_in_v4-BFD-initially_down] PASSED [ 44%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v6_in_v4-custom-initially_down] PASSED [ 47%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v6_in_v4-custom-initially_down] PASSED [ 50%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v6_in_v4-custom-initially_down] PASSED [ 52%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v6_in_v4-custom-initially_down] PASSED [ 55%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v6_in_v4-BFD-initially_up] PASSED [ 58%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v6_in_v4-BFD-initially_up] PASSED [ 61%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v6_in_v4-BFD-initially_up] PASSED [ 63%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v6_in_v4-BFD-initially_up] PASSED [ 66%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_with_early_bgp_removal[v6_in_v4-BFD] PASSED [ 69%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v6_in_v4-custom-initially_up] SKIPPED [ 72%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v6_in_v4-custom-initially_up] SKIPPED [ 75%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v6_in_v4-custom-initially_up] SKIPPED [ 77%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v6_in_v4-custom-initially_up] SKIPPED [ 80%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_with_early_bgp_removal[v6_in_v4-custom] PASSED [ 83%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp[v4_in_v4-custom-initially_down] PASSED [ 86%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_before_bgp_after_ep_up[v4_in_v4-custom-initially_down] PASSED [ 88%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_bgp_removal_before_ep[v4_in_v4-custom-initially_down] PASSED [ 91%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_multi_flap[v4_in_v4-custom-initially_down] PASSED [ 94%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_with_early_bgp_removal[v4_in_v4-BFD] PASSED [ 97%]
vxlan/test_vnet_bgp_route_precedence.py::Test_VNET_BGP_route_Precedence::test_vnet_route_after_bgp_with_early_bgp_removal[v4_in_v4-custom] PASSED [100%]DEBUG:tests.conftest:
```
#### Any platform specific information?
str4-sn5640-3

#### Supported testbed topology if it's a new test case?
t1-isolated-d56u1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
