### PR TITLE
fix xon key error for th2 asic's qos test

### DIFF
--- a/tests/qos/files/qos_params.th2.yaml
+++ b/tests/qos/files/qos_params.th2.yaml
@@ -243,6 +243,18 @@ qos_params:
                     pkts_num_margin: 4
                     pkts_num_trig_ingr_drp: 19939
                     pkts_num_trig_pfc: 19939
+            xon_1:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_trig_pfc: 4457
+                pkts_num_dismiss_pfc: 12
+            xon_2:
+                dscp: 4
+                ecn: 1
+                pg: 4
+                pkts_num_trig_pfc: 4457
+                pkts_num_dismiss_pfc: 12
         topo-any:
             40000_300m:
                 pkts_num_leak_out: 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

QoS tests are failing with KeyError: 'xon_1' when running on TH2 ASIC with topo-dualtor-aa-56 topology and 100000_300m speed/cable length configuration. as below:
```
13/08/2025 08:31:56 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError('xon_1')
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/qos_sai_base.py", line 1744, in dutQosConfig
    qosParams = qpm.run()
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/files/brcm/qos_param_generator.py", line 521, in run
    self.prepare_default_parameters()
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/files/brcm/qos_param_generator.py", line 628, in prepare_default_parameters
    self.create_default_xon_parameter(xon_profile)
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/files/brcm/qos_param_generator.py", line 562, in create_default_xon_parameter
    self.qos_params[self.speed_cable_len][xon_profile] = self.qos_params[xon_profile]
KeyError: 'xon_1'
```

**Test Environment:**

ASIC Type: th2 (Broadcom)
Topology: topo-dualtor-aa-56
Speed/Cable Length: 100000_300m
Profile: pg_lossless_100000_300m_profil

**Root Cause Analysis**
The issue occurs in the Broadcom QoS parameter generator (qos_param_generator.py) during the prepare_default_parameters() function execution.
The code expects to find global xon_1 and xon_2 definitions at the topology level (qos_params[th2][topo-dualtor-aa-56][xon_1]) to copy them into speed-specific sections (qos_params[th2][topo-dualtor-aa-56][100000_300m][xon_1]).
But the topology level (qos_params[th2][topo-dualtor-aa-56]) miss xon_1 and xon_2 parameter.
<img width="562" height="868" alt="image" src="https://github.com/user-attachments/assets/be771485-59b6-4bed-80dd-f4ac3c5278bb" />

so cause the keyerror.

#### How did you do it?
Add the missing global xon_1 and xon_2 parameter definitions to the topo-dualtor-aa-56 section by copying the proven configurations from topo-any.
#### How did you verify/test it?
local test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
