### PR TITLE
Fix saithrift VERSION_CODENAME on multi-asic issue

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -421,8 +421,12 @@ def test_update_saithrift_ptf(request, ptfhost, duthosts, enum_dut_hostname):
         # This applies to: master branch and internal branches >= 202405 (except 202411)
         try:
             # Try to get codename from syncd container
-            syncd_codename_cmd = ("docker exec syncd grep VERSION_CODENAME /etc/os-release | "
-                                  "cut -d= -f2 | tr -d '\"'")
+            if duthost.is_multi_asic:
+                syncd_codename_cmd = (f"docker exec syncd{duthost.asics[0].asic_index} grep VERSION_CODENAME /etc/os-release | "
+                                      f"cut -d= -f2 | tr -d '\"'")
+            else:
+                syncd_codename_cmd = ("docker exec syncd grep VERSION_CODENAME /etc/os-release | "
+                                      "cut -d= -f2 | tr -d '\"'")
             syncd_codename_result = duthost.shell(syncd_codename_cmd, module_ignore_errors=True)
             if syncd_codename_result['rc'] == 0 and syncd_codename_result['stdout'].strip():
                 debian_codename = syncd_codename_result['stdout'].strip()

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -422,7 +422,8 @@ def test_update_saithrift_ptf(request, ptfhost, duthosts, enum_dut_hostname):
         try:
             # Try to get codename from syncd container
             if duthost.is_multi_asic:
-                syncd_codename_cmd = (f"docker exec syncd{duthost.asics[0].asic_index} grep VERSION_CODENAME /etc/os-release | "
+                syncd_codename_cmd = (f"docker exec syncd{duthost.asics[0].asic_index} "
+                                      f"grep VERSION_CODENAME /etc/os-release | "
                                       f"cut -d= -f2 | tr -d '\"'")
             else:
                 syncd_codename_cmd = ("docker exec syncd grep VERSION_CODENAME /etc/os-release | "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/20339

MSFT ADO: 34478399
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix saithrift VERSION_CODENAME on multi-asic issue
#### How did you do it?
If device is multi-asic, use 'syncd{index}' instead of 'syncd'
#### How did you verify/test it?
Tested on physical multi-asic devices, it works well
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
