### PR TITLE
[Snappi] Add multiple tx port selection

### DIFF
--- a/tests/common/snappi_tests/port_selection.py
+++ b/tests/common/snappi_tests/port_selection.py
@@ -1,0 +1,130 @@
+import enum
+
+
+class SnappiPortType(enum.Enum):
+    """
+    Snappi port type
+    """
+    IPInterface = 1
+    PortChannelMember = 2
+    VlanMember = 3
+
+
+class SnappiPortConfig:
+    """
+    Snappi port configuration information
+    """
+    def __init__(self, id, ip, mac, gw, gw_mac, prefix_len, port_type, peer_port):
+        self.id = id
+        self.ip = ip
+        self.mac = mac
+        self.gateway = gw
+        self.gateway_mac = gw_mac
+        self.prefix_len = prefix_len
+        self.type = port_type
+        self.peer_port = peer_port
+
+    def __str__(self):
+        return "<SnappiPortConfig id: {}, ip: {}, mac: {}, gw: {}, gw_mac: {}, \
+                prefix_len: {}, type: {}, peer_port: {}>".format(
+                self.id, self.ip, self.mac, self.gateway, self.gateway_mac,
+                self.prefix_len, self.type, self.peer_port)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+def select_ports(port_config_list, pattern, rx_port_id):
+    """
+    Given a traffic pattern, select Snappi ports to send and receive traffic
+
+    Args:
+        port_config_list (list of SnappiPortConfig):
+        pattern (str): traffic pattern, "many to one" or "all to all"
+        rx_port_id (int): ID of the port that should receive traffic, e.g.,
+        recever in "many to one" traffic pattern
+
+    Returns:
+        tx_port_id_list (list): IDs of Snappi ports to send traffic
+        rx_port_id_list (list): IDs of Snappi ports to receive traffic
+    """
+    tx_port_id_list = []
+    rx_port_id_list = []
+
+    patterns = ['all to all', 'many to one']
+    if pattern not in patterns:
+        raise ValueError('invalid traffic pattern passed in "{}", must be {}'.format(
+            pattern, ' or '.join(['"{}"'.format(src) for src in patterns])))
+
+    rx_port_config = next((x for x in port_config_list if x.id == rx_port_id), None)
+    if rx_port_config is None:
+        raise ValueError('Fail to find configuration for RX port')
+
+    if pattern == "many to one":
+        rx_port_id_list = [rx_port_id]
+        """ Interfaces in the same portchannel cannot send traffic to each other """
+        if rx_port_config.type == SnappiPortType.PortChannelMember:
+            tx_port_id_list = [x.id for x in port_config_list
+                               if x.ip != rx_port_config.ip]
+        else:
+            tx_port_id_list = [x.id for x in port_config_list if x.id != rx_port_id]
+
+    elif pattern == "all to all":
+        """ Interfaces in the same portchannel cannot send traffic to each other """
+        if rx_port_config.type == SnappiPortType.PortChannelMember:
+            tx_port_id_list = [x.id for x in port_config_list
+                               if x.ip != rx_port_config.ip]
+            tx_port_id_list.append(rx_port_id)
+        else:
+            tx_port_id_list = [x.id for x in port_config_list]
+
+        rx_port_id_list = [x for x in tx_port_id_list]
+
+    return tx_port_id_list, rx_port_id_list
+
+
+def select_tx_port(tx_port_id_list, rx_port_id, num_tx_ports=1):
+    """
+    Select one or more Snappi ports to send traffic.
+
+    Args:
+        tx_port_id_list (list): IDs of ports that can send traffic
+        rx_port_id (int): ID of the port that should receive traffic
+        num_tx_ports (int): Number of TX ports to select (default: 1)
+
+    Returns:
+        int or list: ID of the port to send traffic (int) if num_tx_ports==1,
+                     or list of port IDs if num_tx_ports > 1.
+                     Returns None if no TX ports are available.
+
+    Raises:
+        ValueError: If num_tx_ports > number of available TX ports.
+    """
+    if not tx_port_id_list or len(tx_port_id_list) == 0:
+        return None
+
+    if num_tx_ports < 1:
+        raise ValueError("num_tx_ports must be at least 1")
+
+    if num_tx_ports > len(tx_port_id_list):
+        raise ValueError(
+            f"Requested {num_tx_ports} TX ports, but only {len(tx_port_id_list)} available"
+        )
+
+    sorted_tx_ports = sorted(tx_port_id_list)
+    # Find all TX ports with ID greater than RX port ID
+    tx_ports_gt_rx = [x for x in sorted_tx_ports if x > rx_port_id]
+    tx_ports_lt_rx = [x for x in sorted_tx_ports if x < rx_port_id]
+
+    selected_ports = []
+
+    # Prefer ports with ID greater than RX port ID, then wrap around if needed
+    if len(tx_ports_gt_rx) >= num_tx_ports:
+        selected_ports = tx_ports_gt_rx[:num_tx_ports]
+    else:
+        selected_ports = tx_ports_gt_rx + tx_ports_lt_rx[:num_tx_ports - len(tx_ports_gt_rx)]
+
+    if num_tx_ports == 1:
+        return selected_ports[0]
+    else:
+        return selected_ports

--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -91,7 +91,8 @@ def lossless_prio_list(duthosts, rand_one_dut_front_end_hostname):
 
     """ Here we assume all the ports have the same lossless priorities """
     intf = list(port_qos_map.keys())[0]
-    if 'pfc_enable' not in port_qos_map[intf]:
+    pfc_enable = port_qos_map[intf].get('pfc_enable')
+    if not pfc_enable:
         return None
 
     result = [int(x) for x in port_qos_map[intf]['pfc_enable'].split(',')]

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -365,9 +365,42 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
     return True
 
 
+@pytest.fixture(scope="module")
+def is_pfc_enabled(duthosts, rand_one_dut_front_end_hostname):
+    """
+    This fixture checks if Priority Flow Control (PFC) is enabled on the SONiC DUT.
+
+    Args:
+        duthosts (pytest fixture): List of DUT hosts.
+        rand_one_dut_front_end_hostname (pytest fixture): Hostname of a randomly selected front-end DUT.
+
+    Returns:
+        bool: True if PFC is enabled on at least one port, False otherwise.
+    """
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+    config_facts = duthost.config_facts(host=duthost.hostname, asic_index=0,
+                                        source="running")['ansible_facts']
+
+    if "PORT_QOS_MAP" not in list(config_facts.keys()):
+        return False
+
+    port_qos_map = config_facts["PORT_QOS_MAP"]
+    if len(list(port_qos_map.keys())) == 0:
+        return False
+
+    # Here we assume all the ports have the same lossless priorities
+    intf = list(port_qos_map.keys())[0]
+    pfc_enable = port_qos_map[intf].get('pfc_enable')
+    if pfc_enable:
+        return True
+
+    return False
+
+
 @pytest.fixture(scope="function")
 def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
-                          duthosts, rand_one_dut_hostname, snappi_api):
+                          duthosts, rand_one_dut_hostname, is_pfc_enabled,
+                          snappi_api):
     """
     Geenrate snappi API config and port config information for the testbed
     Args:
@@ -427,28 +460,29 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
     l1_config.auto_negotiation.link_training = True
     l1_config.auto_negotiation.rs_fec = True
 
-    pfc = l1_config.flow_control.ieee_802_1qbb
-    pfc.pfc_delay = 0
-    if pfcQueueGroupSize == 8:
-        pfc.pfc_class_0 = 0
-        pfc.pfc_class_1 = 1
-        pfc.pfc_class_2 = 2
-        pfc.pfc_class_3 = 3
-        pfc.pfc_class_4 = 4
-        pfc.pfc_class_5 = 5
-        pfc.pfc_class_6 = 6
-        pfc.pfc_class_7 = 7
-    elif pfcQueueGroupSize == 4:
-        pfc.pfc_class_0 = pfcQueueValueDict[0]
-        pfc.pfc_class_1 = pfcQueueValueDict[1]
-        pfc.pfc_class_2 = pfcQueueValueDict[2]
-        pfc.pfc_class_3 = pfcQueueValueDict[3]
-        pfc.pfc_class_4 = pfcQueueValueDict[4]
-        pfc.pfc_class_5 = pfcQueueValueDict[5]
-        pfc.pfc_class_6 = pfcQueueValueDict[6]
-        pfc.pfc_class_7 = pfcQueueValueDict[7]
-    else:
-        pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
+    if is_pfc_enabled:
+        pfc = l1_config.flow_control.ieee_802_1qbb
+        pfc.pfc_delay = 0
+        if pfcQueueGroupSize == 8:
+            pfc.pfc_class_0 = 0
+            pfc.pfc_class_1 = 1
+            pfc.pfc_class_2 = 2
+            pfc.pfc_class_3 = 3
+            pfc.pfc_class_4 = 4
+            pfc.pfc_class_5 = 5
+            pfc.pfc_class_6 = 6
+            pfc.pfc_class_7 = 7
+        elif pfcQueueGroupSize == 4:
+            pfc.pfc_class_0 = pfcQueueValueDict[0]
+            pfc.pfc_class_1 = pfcQueueValueDict[1]
+            pfc.pfc_class_2 = pfcQueueValueDict[2]
+            pfc.pfc_class_3 = pfcQueueValueDict[3]
+            pfc.pfc_class_4 = pfcQueueValueDict[4]
+            pfc.pfc_class_5 = pfcQueueValueDict[5]
+            pfc.pfc_class_6 = pfcQueueValueDict[6]
+            pfc.pfc_class_7 = pfcQueueValueDict[7]
+        else:
+            pytest_assert(False, 'pfcQueueGroupSize value is not 4 or 8')
 
     port_config_list = []
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add data classes and support for multiple tx port selections that are > 1. This is to support future scenarios with multiple incast streams.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
