### PR TITLE
update FRR bgp memory for high bgp sessions count hwskus

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -270,7 +270,7 @@
           ],
           "memory_high_threshold": {
             "type": "value",
-            "value": 256
+            "value": 384
           }
         }
       },

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -1,7 +1,9 @@
 {
   "HWSKU": {
     "Arista-7050QX": ["Arista-7050-QX-32S", "Arista-7050-QX32", "Arista-7050QX-32S-S4Q31", "Arista-7050QX32S-Q32"],
-    "Mellanox-SN4600C": ["Mellanox-SN4600C-C64"]
+    "Mellanox-SN4600C": ["Mellanox-SN4600C-C64"],
+    "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128"],
+    "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2"]
   },
   "COMMON": [
     {
@@ -253,6 +255,46 @@
         }
       },
       "memory_check": "parse_docker_stats_output"
+    }
+  ],
+  "Arista-7060X6": [
+    {
+      "name": "frr_bgp",
+      "cmd": "vtysh -c \"show memory bgp\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "percentage", "value": "50%"},
+            {"type": "value", "value": 64},
+            {"type": "comparison", "value": "max"}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 256
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
+    }
+  ],
+  "Mellanox-SN5640": [
+    {
+      "name": "frr_bgp",
+      "cmd": "vtysh -c \"show memory bgp\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "percentage", "value": "50%"},
+            {"type": "value", "value": 64},
+            {"type": "comparison", "value": "max"}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 384
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
     }
   ]
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fix following error in pretest:

```
>               pytest.fail(failure_message)
E               Failed: [ALARM]: frr_bgp:used, Previous memory usage 273.0 MB exceeds high threshold 256.0 MB (previous: 273.0 MB, current: 273.0 MB)
E               [ALARM]: frr_bgp:used, Current memory usage 273.0 MB exceeds high threshold 256.0 MB (previous: 273.0 MB, current: 273.0 MB)
This is a new memory checking feature in 202505. Therefore, the fix is not applicable to 202412 branch.

```

TH5 testbed may have 32 neighbors, and each has 6400 prefixes, the total memory after deploy-mg is around 260-300MB. increase to 384MB.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
