### PR TITLE
[xfail][test_sfputil]: Interface Optics issue SFP error status

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1124,14 +1124,14 @@ platform_tests/sfp/test_sfputil.py:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-      
+
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status:
   xfail:
     reason: "Per lane interface status is not supported on SP4/SP5 platform."
     conditions_logical_operator: or
     conditions:
     - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2']
-    
+
 platform_tests/sfp/test_sfputil.py::test_check_sfputil_low_power_mode:
   skip:
     reason: "Get/Set low power mode is not supported in Cisco 8000 platform or in bluefield platform"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: xfail Interface496 Optics issue SFP error status, per lane interface status is not supported on SP4/SP5 platform.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
xfail Interface496 Optics issue SFP error status 
#### How did you do it?
xfail it until it gets resolved 
#### How did you verify/test it?
Verified it in the internal tests
```
==================================================================================== short test summary info ====================================================================================
XFAIL platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status[str4-sn5640-3-None-sudo sfputil show error-status --fetch-from-hardware] - Per lane interface status is not supported on SP4/SP5 platform.
```
#### Any platform specific information?
str4-sn5640-3
#### Supported testbed topology if it's a new test case?
t1-isolated-d56u1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
