### PR TITLE
Update test_duplicate_route to fix PR test failures

### DIFF
--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -92,9 +92,25 @@ def verify_expected_loganalyzer_logs(
         loganalyzer: Loganalyzer utility fixture
     """
     expectRegex = [
+        # TODO: uncomment when sairedis submodule is updated in sonic-buildimage PR #23334
+        #   sairedis submodule is not able to be merged due to test failure because of change in expected logs.
+        #   However, changing the expected logs fails current tests due to differences in log output.
+        #   Temporarily move log matches to ignoreRegex to pass both versions.
+
+        # ".*ERR.* object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* already exists.*",
+        ".*ERR.* addRoutePost: Failed to create route.*",
+        ]
+    ignoreRegex = [
+        # Ignored logs
+        ".*ERR.* create failed, object already exists.*",
+        ".*ERR.* bulkCreate: Failed to create object.*",
+        ".*ERR.* api SAI_COMMON_API_BULK_CREATE failed in syncd mode.*",
+        ".*ERR.* flush_creating_entries: EntityBulker.flush create entries failed.*",
+
+        # Expected logs. TODO: remove after PR #23334 merges
+        ".*ERR.* object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* already exists.*",
         ".*ERR.* meta_sai_validate_route_entry:.* already exists.*",
         ".*ERR.* status: SAI_STATUS_ITEM_ALREADY_EXISTS.*",
-        ".*ERR.* addRoutePost: Failed to create route.*",
         ".*ERR.* handleSaiFailure: Encountered failure in create operation, SAI API: SAI_API_ROUTE.*",
         ]
     if loganalyzer:
@@ -102,6 +118,10 @@ def verify_expected_loganalyzer_logs(
         loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].expect_regex.extend(
             expectRegex
         )
+        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend(
+            ignoreRegex
+        )
+
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
### Description of PR

test_duplicate_route is failing PR tests in sairedis submodule update for sonic-buildimge. This is due to a sairedis change which updates bulk operation functionality to match the expected behavior when SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR flag is set.

sonic-buildimage PR: sonic-net/sonic-buildimage#23334
sonic-sairedis PR: sonic-net/sonic-sairedis#1613

This sairedis change causes swss to process failures in a different way, which leads to a change in expected log output. test_duplicate_route will look for logs output before the change sairedis#1613 causing failure, and changing test_duplicate_route to expect logs after sairedis#1613 fails other PR.

This change looks to temporarily loosen the expected log output so that both versions of sairedis can pass this test. Once buildimage#23334 is merged, the expected logs can be updated to match only the new behavior.

Summary:
Fixes #20231

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Unblock sairedis module update in sonic-buildimage https://github.com/sonic-net/sonic-buildimage/pull/23334

#### How did you do it?
- Reduce expected logs to those that will be output in both cases
- add ignore logs to prevent failure

#### How did you verify/test it?
Run on testbed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
