### PR TITLE
Stabilize null_route_helper test

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -206,11 +206,16 @@ def setup_ptf(rand_selected_dut, ptfhost, tbinfo):
 
     logger.info("Setting up ptf for testing")
     ptfhost.shell("ifconfig eth{} {}".format(dst_ports['port'], dst_ports[4]))
+    # Send ping packet to get neigh learnt
+    rand_selected_dut.shell("ping -c1 -W1 {}; true".format(dst_ports[4].split('/')[0]))
     ptfhost.shell("ifconfig eth{} inet6 add {}".format(dst_ports['port'], dst_ports[6]))
+    # Send ping packet to get neigh learnt
+    rand_selected_dut.shell("ping -c1 -W1 {}; true".format(dst_ports[6].split('/')[0]))
 
     yield dst_ports
     ptfhost.shell("ifconfig eth{} 0.0.0.0".format(dst_ports['port']))
     ptfhost.shell("ifconfig eth{} inet6 del {}".format(dst_ports['port'], dst_ports[6]))
+    rand_selected_dut.shell("sonic-clear arp")
 
 
 def generate_packet(src_ip, dst_ip, dst_mac):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to stabilize `test_null_route_helper` by triggering ARP learning by sending ping packet.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to stabilize `test_null_route_helper` by triggering ARP learning by sending ping packet.

#### How did you do it?
Send ping packet from DUT to PTF to trigger ARP learning.

#### How did you verify/test it?
The change is verified on a physical testbed. It's passing consistently.
```
collected 1 item                                                                                                                                                                                                              

acl/null_route/test_null_route_helper.py::test_null_route_helper PASSED                                                                                                                                                 [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
