### PR TITLE
Remove topo 'vs' in vxlan/test_vxlan_route_advertisement.py

### DIFF
--- a/tests/vxlan/test_vxlan_route_advertisement.py
+++ b/tests/vxlan/test_vxlan_route_advertisement.py
@@ -21,7 +21,7 @@ DESTINATION_PREFIX = 150
 NEXTHOP_PREFIX = 100
 pytestmark = [
     # This script supports any T1 topology: t1, t1-64-lag, t1-56-lag, t1-lag.
-    pytest.mark.topology("t1", "vs")
+    pytest.mark.topology("t1")
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
"vs" is not really a valid topology. Remove it from the topology mark in `vxlan/test_vxlan_route_advertisement.py`.

#### How did you do it?
Remove the "vs" topology from the topology mark in `vxlan/test_vxlan_route_advertisement.py`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
