### PR TITLE
Skip test_bgp_operation_in_ro due to feature reverted

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -165,6 +165,12 @@ bgp/test_bgp_multipath_relax.py:
       - "'backend' in topo_name"
       - "'t1-isolated' in topo_name"
 
+bgp/test_bgp_operation_in_ro.py:
+  skip:
+    reason: "Feature is reverted and pending enhancement"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/23462"
+
 bgp/test_bgp_port_disable.py:
   skip:
     reason: "Not supperted on master."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip test_bgp_operation_in_ro due to feature reverted
Issue: https://github.com/sonic-net/sonic-buildimage/issues/23462
PR: https://github.com/sonic-net/sonic-buildimage/pull/23460

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip test_bgp_operation_in_ro due to feature reverted

#### How did you do it?
Skip test via conditional mark.

#### How did you verify/test it?
Verified on 7050CX3 T0 testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
