### PR TITLE
[dhcp_relay] Fix ACL drop count validation for expanded DHCP packet types

### DIFF
--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -111,3 +111,20 @@ def loganalyzer(duthosts, request, log_rotate_modular_chassis):
     )
     consolidated_bughandler = get_bughandler_instance({"type": "consolidated"})
     consolidated_bughandler.bug_handler_wrapper(analyzers, duthosts, la_results)
+
+
+@pytest.fixture(autouse=True)
+def ignore_pkt_trim_errors(duthosts, loganalyzer):
+    ASIC_LIST = ["th5"]
+    if loganalyzer:
+        for duthost in duthosts:
+            if duthost.facts["platform_asic"].lower() == "broadcom" and duthost.get_asic_name().lower() not in ASIC_LIST:
+                # We should cleanup this code once CSP12420291 is fixed.
+                loganalyzer[duthost.hostname].ignore_regex.extend(
+                    [
+                        r".*ERR syncd#syncd: .* SAI_API_SWITCH:_brcm_sai_xgs_pkt_trim_get_mapped_counter:[\d]+ Packet trim feature is not supported.*",
+                        r".*ERR syncd#syncd: .* SAI_API_QUEUE:_brcm_sai_xgs_queue_pkt_trim_get_clear_ctr:[\d]+ Get Trim mapped counter failed with error -2.*",
+                        r".*ERR syncd#syncd: .* SAI_API_QUEUE:_brcm_sai_cosq_stat_get:[\d]+ Get Trim stats packets failed with error -2.*",
+                        r".*ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_switch_attribute_enum_values_capability:[\d]+ packet trim Enum Capability values get for [\d]+ failed with error -2.*"
+                    ]
+                )

--- a/tests/common/plugins/loganalyzer/__init__.py
+++ b/tests/common/plugins/loganalyzer/__init__.py
@@ -118,13 +118,21 @@ def ignore_pkt_trim_errors(duthosts, loganalyzer):
     ASIC_LIST = ["th5"]
     if loganalyzer:
         for duthost in duthosts:
-            if duthost.facts["platform_asic"].lower() == "broadcom" and duthost.get_asic_name().lower() not in ASIC_LIST:
+            platform_asic = duthost.facts["platform_asic"].lower()
+            asic_name = duthost.get_asic_name().lower()
+            if platform_asic == "broadcom" and asic_name not in ASIC_LIST:
                 # We should cleanup this code once CSP12420291 is fixed.
                 loganalyzer[duthost.hostname].ignore_regex.extend(
                     [
-                        r".*ERR syncd#syncd: .* SAI_API_SWITCH:_brcm_sai_xgs_pkt_trim_get_mapped_counter:[\d]+ Packet trim feature is not supported.*",
-                        r".*ERR syncd#syncd: .* SAI_API_QUEUE:_brcm_sai_xgs_queue_pkt_trim_get_clear_ctr:[\d]+ Get Trim mapped counter failed with error -2.*",
-                        r".*ERR syncd#syncd: .* SAI_API_QUEUE:_brcm_sai_cosq_stat_get:[\d]+ Get Trim stats packets failed with error -2.*",
-                        r".*ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_switch_attribute_enum_values_capability:[\d]+ packet trim Enum Capability values get for [\d]+ failed with error -2.*"
+                        r".*ERR syncd#syncd: .* SAI_API_SWITCH:"
+                        r"_brcm_sai_xgs_pkt_trim_get_mapped_counter:[\d]+ Packet trim feature is not supported.*",
+                        r".*ERR syncd#syncd: .* SAI_API_QUEUE:"
+                        r"_brcm_sai_xgs_queue_pkt_trim_get_clear_ctr:[\d]+ "
+                        r"Get Trim mapped counter failed with error -2.*",
+                        r".*ERR syncd#syncd: .* SAI_API_QUEUE:"
+                        r"_brcm_sai_cosq_stat_get:[\d]+ Get Trim stats packets failed with error -2.*",
+                        r".*ERR syncd#syncd: .* SAI_API_SWITCH:"
+                        r"sai_query_switch_attribute_enum_values_capability:[\d]+ "
+                        r"packet trim Enum Capability values get for [\d]+ failed with error -2.*"
                     ]
                 )

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -187,7 +187,7 @@ def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, tes
     if testing_mode == DUAL_TOR_MODE and "dualtor-aa" not in tbinfo["topo"]["name"]:
         for client_interface_name, item in pre_client_dhcp_acl_counts.items():
             after_count = get_acl_count_by_mark(rand_unselected_dut, item["mark"])
-            pytest_assert(after_count == item["count"] + 3, "Drop count of {} {} is unexpected, pre: {}, after: {}"
+            pytest_assert(after_count == item["count"] + 7, "Drop count of {} {} is unexpected, pre: {}, after: {}"
                           .format(client_interface_name, item["mark"], item["count"], after_count))
 
 


### PR DESCRIPTION
## What is the motivation for this PR?

Fix DHCP relay test failures in dual-ToR testbeds caused by ACL drop count validation mismatch after PR #20059.

## Issue Description
- Tests pass functionally but fail during teardown validation
- Error: Expected 3 ACL drops, but getting 7 drops consistently
- Affects: test_dhcp_relay_default, test_dhcp_relay_with_source_port_ip_in_relay_enabled, test_dhcp_relay_random_sport

## Root Cause
PR #20059 (Aug 2025) expanded DHCP packet types from 3 to 7:
- **Before**: Discover, Request, Bootp (3 packets)
- **After**: Unknown, Discover, Request, Bootp, Decline, Release, Inform (7 packets)

The `verify_acl_drop_on_standby_tor` fixture still expected 3 drops, causing validation failures.

## How did you do it?
Update expected ACL drop count from 3 to 7 in the fixture validation logic.

## How did you verify/test it?
- Analyzed consistent failure patterns across multiple testbeds
- Confirmed 7 drops per test matches the new packet type count
- Change aligns fixture validation with actual test behavior

## Related Issues
- Related to PR #20059

## Test Results
This fix will resolve teardown failures while maintaining functional test coverage.