### PR TITLE
[dhcp_relay] Fix ACL drop count validation for expanded DHCP packet types

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -187,7 +187,7 @@ def verify_acl_drop_on_standby_tor(rand_unselected_dut, dut_dhcp_relay_data, tes
     if testing_mode == DUAL_TOR_MODE and "dualtor-aa" not in tbinfo["topo"]["name"]:
         for client_interface_name, item in pre_client_dhcp_acl_counts.items():
             after_count = get_acl_count_by_mark(rand_unselected_dut, item["mark"])
-            pytest_assert(after_count == item["count"] + 3, "Drop count of {} {} is unexpected, pre: {}, after: {}"
+            pytest_assert(after_count == item["count"] + 7, "Drop count of {} {} is unexpected, pre: {}, after: {}"
                           .format(client_interface_name, item["mark"], item["count"], after_count))
 
 


### PR DESCRIPTION
### Description of PR
Fix DHCP relay test failures in dual-ToR testbeds.

Summary:
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/775

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

## What is the motivation for this PR?

Fix DHCP relay test failures in dual-ToR testbeds caused by ACL drop count validation mismatch after PR #20059.

## Issue Description
- Tests pass functionally but fail during teardown validation
- Error: Expected 3 ACL drops, but getting 7 drops consistently
- Affects: test_dhcp_relay_default, test_dhcp_relay_with_source_port_ip_in_relay_enabled, test_dhcp_relay_random_sport

## Root Cause
PR #20059 (Aug 2025) expanded DHCP packet types from 3 to 7:
- **Before**: Discover, Request, Bootp (3 packets)
- **After**: Unknown, Discover, Request, Bootp, Decline, Release, Inform (7 packets)

The `verify_acl_drop_on_standby_tor` fixture still expected 3 drops, causing validation failures.

## How did you do it?
Update expected ACL drop count from 3 to 7 in the fixture validation logic.

## How did you verify/test it?
- Analyzed consistent failure patterns across multiple testbeds
- Confirmed 7 drops per test matches the new packet type count
- Change aligns fixture validation with actual test behavior

## Related Issues
- Related to PR #20059

## Test Results
This fix will resolve teardown failures while maintaining functional test coverage.