### PR TITLE
changed port alias index for cisco platforms as per sonic standard

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -652,8 +652,8 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                        "Cisco-8102-28FH-DPU-C28",
                        "Cisco-8102-28FH-DPU-O8C20",
                        "Cisco-8102-28FH-DPU-O12C16"]:
-            for i in range(0, 28):
-                port_alias_to_name_map["etp%d" % (i * 8)] = "Ethernet%d" % (i * 8)
+            for i in range(0, 36):
+                port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % (i * 8)
         elif hwsku in ["Cisco-8102-28FH-DPU-O8C40", "Cisco-8102-28FH-DPU-O8V40"]:
             idx = 0
             # Range 1: etp0a, etp0b ... etp11a, etp11b


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:changed port alias index for cisco platforms as per sonic standard
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X ] 202411
- [X ] 202505

### Approach
updated port_alias_to_name_map variable for all cisco smartswicth platforms.
#### What is the motivation for this PR?

#### How did you do it?


#### How did you verify/test it?
verified port_alias_to_name_map has all ports with alias index as port port_config.ini file.

#### Any platform specific information?
Cisco-8102-28FH-DPU-0 and other cisco smartswicth platforms

#### Supported testbed topology if it's a new test case?
t1-128-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
