### PR TITLE
Fix calculate instance number issue

### DIFF
--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -14,6 +14,17 @@ steps:
 - script: |
     set -x
 
+    echo "PR_CHECKERS=$(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'])"
+    echo "This job CHECKER=$(CHECKER)"
+    if [[ ! ",${PR_CHECKERS}," == *",${CHECKER},"* ]]; then
+      echo "Checker not in impacted list, skipping..."
+      exit 0
+    fi
+  displayName: "Check if checker should to be skipped"
+
+- script: |
+    set -x
+
     sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
     echo "$TEST_SCRIPTS" > /tmp/ts.json

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -14,17 +14,6 @@ steps:
 - script: |
     set -x
 
-    echo "PR_CHECKERS=$PR_CHECKERS"
-    echo "CHECKER=$CHECKER"
-    if [[ ! "$PR_CHECKERS" == *"$CHECKER"* ]]; then
-      echo "Checker not in impacted list, skipping..."
-      exit 0
-    fi
-  displayName: "Check if checker should to be skipped"
-
-- script: |
-    set -x
-
     sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
     echo "$TEST_SCRIPTS" > /tmp/ts.json

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -19,11 +19,12 @@ steps:
     echo "$TEST_SCRIPTS" > /tmp/ts.json
     echo "TEST_SCRIPTS value from file:"
     cat /tmp/ts.json
-    TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker"' /tmp/ts.json)
+    TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker" // []' /tmp/ts.json)
     rm /tmp/ts.json
-    if [[ -z "$TEST_SCRIPTS" ]]; then
-      echo "##vso[task.complete result=Failed;]Get test scripts of specfic topology fails."
-      exit 1
+    if [[ "$TEST_SCRIPTS" == "[]" ]]; then
+      echo "##vso[task.complete result=Failed;]No test scripts found for topology."
+      INSTANCE_NUMBER=0
+      exit 0
     fi
     SCRIPTS=$(echo "$TEST_SCRIPTS" | jq -r '. | join(",")')
     echo -n "##vso[task.setvariable variable=SCRIPTS]$SCRIPTS"

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -19,12 +19,11 @@ steps:
     echo "$TEST_SCRIPTS" > /tmp/ts.json
     echo "TEST_SCRIPTS value from file:"
     cat /tmp/ts.json
-    TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker" // []' /tmp/ts.json)
+    TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker"' /tmp/ts.json)
     rm /tmp/ts.json
-    if [[ "$TEST_SCRIPTS" == "[]" ]]; then
-      echo "##vso[task.complete result=Failed;]No test scripts found for topology."
-      INSTANCE_NUMBER=0
-      exit 0
+    if [[ -z "$TEST_SCRIPTS" ]]; then
+      echo "##vso[task.complete result=Failed;]Get test scripts of specfic topology fails."
+      exit 1
     fi
     SCRIPTS=$(echo "$TEST_SCRIPTS" | jq -r '. | join(",")')
     echo -n "##vso[task.setvariable variable=SCRIPTS]$SCRIPTS"

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -17,7 +17,6 @@ steps:
 
       sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
-      echo "$CHECKER"
       echo "$TEST_SCRIPTS" > /tmp/ts.json
       echo "TEST_SCRIPTS value from file:"
       cat /tmp/ts.json

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -12,12 +12,12 @@ parameters:
 
 steps:
 
-- ${{ if contains(variables['PR_CHECKERS'], variables['CHECKER']) }}:
   - script: |
       set -x
 
       sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
+      echo "$CHECKER"
       echo "$TEST_SCRIPTS" > /tmp/ts.json
       echo "TEST_SCRIPTS value from file:"
       cat /tmp/ts.json

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -11,71 +11,73 @@ parameters:
     default: 30
 
 steps:
-- script: |
-    set -x
 
-    sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
+- ${{ if contains(variables['PR_CHECKERS'], variables['CHECKER']) }}:
+  - script: |
+      set -x
 
-    echo "$TEST_SCRIPTS" > /tmp/ts.json
-    echo "TEST_SCRIPTS value from file:"
-    cat /tmp/ts.json
-    TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker"' /tmp/ts.json)
-    rm /tmp/ts.json
-    if [[ -z "$TEST_SCRIPTS" ]]; then
-      echo "##vso[task.complete result=Failed;]Get test scripts of specfic topology fails."
-      exit 1
-    fi
-    SCRIPTS=$(echo "$TEST_SCRIPTS" | jq -r '. | join(",")')
-    echo -n "##vso[task.setvariable variable=SCRIPTS]$SCRIPTS"
-  displayName: "Get ${{ parameters.TOPOLOGY }} test scripts"
+      sudo apt-get -o DPkg::Lock::Timeout=600 update && sudo apt-get -o DPkg::Lock::Timeout=600 -y install jq
 
-- script: |
-    set -x
+      echo "$TEST_SCRIPTS" > /tmp/ts.json
+      echo "TEST_SCRIPTS value from file:"
+      cat /tmp/ts.json
+      TEST_SCRIPTS=$(jq -r -c '."${{ parameters.TOPOLOGY }}_checker"' /tmp/ts.json)
+      rm /tmp/ts.json
+      if [[ -z "$TEST_SCRIPTS" ]]; then
+        echo "##vso[task.complete result=Failed;]Get test scripts of specfic topology fails."
+        exit 1
+      fi
+      SCRIPTS=$(echo "$TEST_SCRIPTS" | jq -r '. | join(",")')
+      echo -n "##vso[task.setvariable variable=SCRIPTS]$SCRIPTS"
+    displayName: "Get ${{ parameters.TOPOLOGY }} test scripts"
 
-    # Check if azure cli is installed. If not, try to install it
-    if ! command -v az; then
-      echo "Azure CLI is not installed. Trying to install it..."
+  - script: |
+      set -x
 
-      echo "Get packages needed for the installation process"
-      sudo apt-get -o DPkg::Lock::Timeout=600 update
-      sudo apt-get -o DPkg::Lock::Timeout=600 -y install apt-transport-https ca-certificates curl gnupg lsb-release
+      # Check if azure cli is installed. If not, try to install it
+      if ! command -v az; then
+        echo "Azure CLI is not installed. Trying to install it..."
 
-      echo "Download and install the Microsoft signing key"
-      sudo mkdir -p /etc/apt/keyrings
-      curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-        gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
-      sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+        echo "Get packages needed for the installation process"
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 -y install apt-transport-https ca-certificates curl gnupg lsb-release
 
-      echo "Add the Azure CLI software repository"
-      AZ_DIST=$(lsb_release -cs)
-      echo "Types: deb
-    URIs: https://packages.microsoft.com/repos/azure-cli/
-    Suites: ${AZ_DIST}
-    Components: main
-    Architectures: $(dpkg --print-architecture)
-    Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+        echo "Download and install the Microsoft signing key"
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+          gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
 
-      echo "Update repository information and install the azure-cli package"
-      sudo apt-get -o DPkg::Lock::Timeout=600 update
-      sudo apt-get -o DPkg::Lock::Timeout=600 -y install azure-cli
-    else
-      echo "Azure CLI is already installed"
-    fi
-  displayName: "Install azure-cli"
+        echo "Add the Azure CLI software repository"
+        AZ_DIST=$(lsb_release -cs)
+        echo "Types: deb
+      URIs: https://packages.microsoft.com/repos/azure-cli/
+      Suites: ${AZ_DIST}
+      Components: main
+      Architectures: $(dpkg --print-architecture)
+      Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
 
-- script: |
-    set -x
+        echo "Update repository information and install the azure-cli package"
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 -y install azure-cli
+      else
+        echo "Azure CLI is already installed"
+      fi
+    displayName: "Install azure-cli"
 
-    pip install azure-kusto-data
-    pip install azure-kusto-data azure-identity
+  - script: |
+      set -x
 
-    INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
+      pip install azure-kusto-data
+      pip install azure-kusto-data azure-identity
 
-    if [[ $? -ne 0 ]]; then
-      echo "##vso[task.complete result=Failed;]Get instances number fails."
-      exit 1
-    fi
+      INSTANCE_NUMBER=$(python ./.azure-pipelines/impacted_area_testing/calculate_instance_number.py --scripts $(SCRIPTS) --topology ${{ parameters.TOPOLOGY }} --branch ${{ parameters.BUILD_BRANCH }} --prepare_time ${{ parameters.PREPARE_TIME }} --target_pr_test_time $(TARGET_PR_TEST_TIME))
 
-    INSTANCE_NUMBER=$(echo $INSTANCE_NUMBER | tr -d '\r' | tr -d ' ')
-    echo -n "##vso[task.setvariable variable=INSTANCE_NUMBER; isOutput=true]$INSTANCE_NUMBER"
-  displayName: "Calculate instance number"
+      if [[ $? -ne 0 ]]; then
+        echo "##vso[task.complete result=Failed;]Get instances number fails."
+        exit 1
+      fi
+
+      INSTANCE_NUMBER=$(echo $INSTANCE_NUMBER | tr -d '\r' | tr -d ' ')
+      echo -n "##vso[task.setvariable variable=INSTANCE_NUMBER; isOutput=true]$INSTANCE_NUMBER"
+    displayName: "Calculate instance number"

--- a/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
+++ b/.azure-pipelines/impacted_area_testing/calculate-instance-numbers.yml
@@ -14,9 +14,9 @@ steps:
 - script: |
     set -x
 
-    echo "PR_CHECKERS=$(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'])"
-    echo "This job CHECKER=$(CHECKER)"
-    if [[ ! ",${PR_CHECKERS}," == *",${CHECKER},"* ]]; then
+    echo "PR_CHECKERS=$PR_CHECKERS"
+    echo "CHECKER=$CHECKER"
+    if [[ ! "$PR_CHECKERS" == *"$CHECKER"* ]]; then
       echo "Checker not in impacted list, skipping..."
       exit 0
     fi

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -68,7 +68,8 @@ steps:
       exit 1
     fi
 
-    PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
+    #PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
+    PR_CHECKERS='["t0_checker","t1_checker"]'
 
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Get valid PR checkers fails."

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -68,7 +68,6 @@ steps:
       exit 1
     fi
 
-    TEST_SCRIPTS='{"t0_checker": ["acl/custom_acl_table/test_custom_acl_table.py"]}'
     PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
 
     if [[ $? -ne 0 ]]; then

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -68,6 +68,7 @@ steps:
       exit 1
     fi
 
+    TEST_SCRIPTS='{"t0_checker": ["acl/custom_acl_table/test_custom_acl_table.py"]}'
     PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
 
     if [[ $? -ne 0 ]]; then

--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -68,8 +68,8 @@ steps:
       exit 1
     fi
 
-    #PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
-    PR_CHECKERS='["t0_checker","t1_checker"]'
+    TEST_SCRIPTS='{"t0_checker": ["acl/custom_acl_table/test_custom_acl_table.py"]}'
+    PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
 
     if [[ $? -ne 0 ]]; then
       echo "##vso[task.complete result=Failed;]Get valid PR checkers fails."

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
@@ -121,10 +121,6 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
-      - script: |
-          echo "CHECKER=$(CHECKER)"
-          echo "PR_CHECKERS=$[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]"
-        displayName: "Debug condition variables"
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: containsValue(split(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], ','), variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains('t0_checker', variables['CHECKER'])
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't3')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -121,7 +121,6 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
-    - ${{ if contains(variables['PR_CHECKERS'], variables['CHECKER']) }}:
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(fromJson(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS']), variables['CHECKER'])
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
@@ -121,6 +121,10 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - script: |
+          echo "CHECKER=$(CHECKER)"
+          echo "PR_CHECKERS=$(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'])"
+        displayName: "Debug condition variables"
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't3')
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['matrix.CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,8 +108,8 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
+    condition: containsValue(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], '$(CHECKER)')
     variables:
-      PR_CHECKERS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
@@ -117,7 +117,6 @@ jobs:
       COMMON_EXTRA_PARAMS: "--disable_sai_validation "
       DEPLOY_MG_EXTRA_PARAMS: ""
       SPECIFIC_PARAM: "[]"
-    condition: contains(variables['PR_CHECKERS'], variables['CHECKER'])
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(t0_checker, variables['CHECKER'])
+    condition: contains('t0_checker', variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], $(CHECKER))
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], strategy.matrix.CHECKER)
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -110,6 +110,7 @@ jobs:
 
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      PR_CHECKERS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
       STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
@@ -146,5 +147,3 @@ jobs:
           SPECIFIC_PARAM: $(SPECIFIC_PARAM)
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           ASIC_TYPE: ${{ parameters.ASIC_TYPE }}
-
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: containsValue(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], matrix.CHECKER)
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,6 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
@@ -121,6 +120,7 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      - condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,8 +108,9 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], format(',{0},', variables['CHECKER']))
     variables:
+      PR_CHECKERS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
@@ -123,7 +124,7 @@ jobs:
     steps:
       - script: |
           echo "CHECKER=$(CHECKER)"
-          echo "PR_CHECKERS=$(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'])"
+          echo "PR_CHECKERS=$(PR_CHECKERS)"
         displayName: "Debug condition variables"
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: contains(fromJson(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS']), variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,8 +108,8 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], matrix.CHECKER)
     variables:
+      CHECKER: $[ matrix.CHECKER ]
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
@@ -120,6 +120,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     steps:
       - script: |
           echo "CHECKER=$(CHECKER)"

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains('t0_checker', variables['matrix.CHECKER'])
+    condition: contains('t0_checker', '${{ matrix.CHECKER }}')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,9 +108,8 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], format(',{0},', variables['CHECKER']))
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     variables:
-      PR_CHECKERS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
@@ -124,7 +123,7 @@ jobs:
     steps:
       - script: |
           echo "CHECKER=$(CHECKER)"
-          echo "PR_CHECKERS=$(PR_CHECKERS)"
+          echo "PR_CHECKERS=$(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'])"
         displayName: "Debug condition variables"
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -125,7 +125,6 @@ jobs:
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml
-        condition: contains(variables['PR_CHECKERS'], variables['CHECKER'])
         parameters:
           TOPOLOGY: $(TESTBED_PREP_TOPOLOGY)
           BUILD_BRANCH: $(BUILD_BRANCH)

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -128,22 +128,22 @@ jobs:
           TOPOLOGY: $(TESTBED_PREP_TOPOLOGY)
           BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: $(TOPOLOGY)
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          DEPLOY_MG_EXTRA_PARAMS: $(DEPLOY_MG_EXTRA_PARAMS)
-          COMMON_EXTRA_PARAMS: $(COMMON_EXTRA_PARAMS)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          STOP_ON_FAILURE: $(STOP_ON_FAILURE)
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          NUM_ASIC: $(NUM_ASIC)
-          VM_TYPE: $(VM_TYPE)
-          SPECIFIC_PARAM: $(SPECIFIC_PARAM)
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          ASIC_TYPE: ${{ parameters.ASIC_TYPE }}
+      # - template: run-test-elastictest-template.yml
+      #   parameters:
+      #     TOPOLOGY: $(TOPOLOGY)
+      #     SCRIPTS: $(SCRIPTS)
+      #     MIN_WORKER: $(INSTANCE_NUMBER)
+      #     MAX_WORKER: $(INSTANCE_NUMBER)
+      #     DEPLOY_MG_EXTRA_PARAMS: $(DEPLOY_MG_EXTRA_PARAMS)
+      #     COMMON_EXTRA_PARAMS: $(COMMON_EXTRA_PARAMS)
+      #     KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+      #     MGMT_BRANCH: $(BUILD_BRANCH)
+      #     BUILD_REASON: ${{ parameters.BUILD_REASON }}
+      #     RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+      #     STOP_ON_FAILURE: $(STOP_ON_FAILURE)
+      #     TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+      #     NUM_ASIC: $(NUM_ASIC)
+      #     VM_TYPE: $(VM_TYPE)
+      #     SPECIFIC_PARAM: $(SPECIFIC_PARAM)
+      #     MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+      #     ASIC_TYPE: ${{ parameters.ASIC_TYPE }}

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -121,17 +121,7 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
-      # - script: |
-      #     set -x
-
-      #     echo "PR_CHECKERS=$PR_CHECKERS"
-      #     echo "CHECKER=$CHECKER"
-      #     if [[ ! "$PR_CHECKERS" == *"$CHECKER"* ]]; then
-      #       echo "Checker not in impacted list, skipping..."
-      #       echo -n "##vso[task.setvariable variable=SKIP_FOLLOWING_TESTS]true"
-      #       exit 0
-      #     fi
-      #   name: CheckChecker
+    - ${{ if contains(variables['PR_CHECKERS'], variables['CHECKER']) }}:
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml
@@ -141,7 +131,6 @@ jobs:
           BUILD_BRANCH: $(BUILD_BRANCH)
 
       - template: run-test-elastictest-template.yml
-        condition: contains(variables['PR_CHECKERS'], variables['CHECKER'])
         parameters:
           TOPOLOGY: $(TOPOLOGY)
           SCRIPTS: $(SCRIPTS)

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], strategy.matrix.CHECKER)
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: containsValue(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], '$(CHECKER)')
+    condition: containsValue(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['matrix.CHECKER'])
+    condition: contains('t0_checker', variables['matrix.CHECKER'])
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains('t0_checker', '${{ matrix.CHECKER }}')
+    condition: containsValue('["t0_checker"]', '${{ matrix.CHECKER }}')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: containsValue('["t0_checker"]', '${{ matrix.CHECKER }}')
+    condition: containsValue('dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS']', 't0_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -120,15 +120,17 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
-      - condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml
+        name: CalculateInstanceNumbers
+        condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
         parameters:
           TOPOLOGY: $(TESTBED_PREP_TOPOLOGY)
           BUILD_BRANCH: $(BUILD_BRANCH)
 
       - template: run-test-elastictest-template.yml
+        condition: eq(steps.CalculateInstanceNumbers.result, 'Succeeded')
         parameters:
           TOPOLOGY: $(TOPOLOGY)
           SCRIPTS: $(SCRIPTS)

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -123,14 +123,11 @@ jobs:
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml
-        name: CalculateInstanceNumbers
-        condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
         parameters:
           TOPOLOGY: $(TESTBED_PREP_TOPOLOGY)
           BUILD_BRANCH: $(BUILD_BRANCH)
 
       - template: run-test-elastictest-template.yml
-        condition: eq(steps.CalculateInstanceNumbers.result, 'Succeeded')
         parameters:
           TOPOLOGY: $(TOPOLOGY)
           SCRIPTS: $(SCRIPTS)
@@ -149,3 +146,5 @@ jobs:
           SPECIFIC_PARAM: $(SPECIFIC_PARAM)
           MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
           ASIC_TYPE: ${{ parameters.ASIC_TYPE }}
+
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,8 +108,8 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], $(CHECKER))
     variables:
-      CHECKER: $[ matrix.CHECKER ]
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
@@ -120,11 +120,10 @@ jobs:
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     steps:
       - script: |
           echo "CHECKER=$(CHECKER)"
-          echo "PR_CHECKERS=$(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'])"
+          echo "PR_CHECKERS=$[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]"
         displayName: "Debug condition variables"
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -60,68 +60,31 @@ jobs:
           TESTBED_PREP_TOPOLOGY: t0
           CHECKER: t0_checker
           TOPOLOGY: t0
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          VM_TYPE: ceos
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          DEPLOY_MG_EXTRA_PARAMS: ""
-          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-t0-2vlans_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t0-2vlans
           CHECKER: t0-2vlans_checker
           DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a "
           TOPOLOGY: t0
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          VM_TYPE: ceos
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-t1-lag_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t1
           CHECKER: t1_checker
           TOPOLOGY: t1-lag
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          VM_TYPE: ceos
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          DEPLOY_MG_EXTRA_PARAMS: ""
-          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-dualtor_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: dualtor
           CHECKER: dualtor_checker
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
           TOPOLOGY: dualtor
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          VM_TYPE: ceos
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          DEPLOY_MG_EXTRA_PARAMS: ""
-          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-multi-asic-t1_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t1-multi-asic
           CHECKER: t1-multi-asic_checker
           TOPOLOGY: t1-8-lag
           NUM_ASIC: 4
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          VM_TYPE: ceos
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          DEPLOY_MG_EXTRA_PARAMS: ""
-          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-multi-asic-t1_by_Elastictest_optional:
           TESTBED_PREP_TOPOLOGY: t1
           CHECKER: t1_checker
           TOPOLOGY: t1-8-lag
           NUM_ASIC: 4
           STOP_ON_FAILURE: "False"
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          VM_TYPE: ceos
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          DEPLOY_MG_EXTRA_PARAMS: ""
-          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-t0-sonic_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t0-sonic
           CHECKER: t0-sonic_checker
@@ -132,10 +95,6 @@ jobs:
             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
             ]'
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          DEPLOY_MG_EXTRA_PARAMS: ""
         impacted-area-kvmtest-dpu_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: dpu
           CHECKER: dpu_checker
@@ -143,25 +102,21 @@ jobs:
           SPECIFIC_PARAM: '[
             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
             ]'
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          VM_TYPE: ceos
-          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          DEPLOY_MG_EXTRA_PARAMS: ""
         impacted-area-kvmtest-t2_by_Elastictest_optional:
           TESTBED_PREP_TOPOLOGY: t2
           CHECKER: t2_checker
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
-          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-          NUM_ASIC: 1
-          VM_TYPE: ceos
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          DEPLOY_MG_EXTRA_PARAMS: ""
-          SPECIFIC_PARAM: "[]"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
+    condition: contains(t0_checker, variables['CHECKER'])
+    variables:
+      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      NUM_ASIC: 1
+      VM_TYPE: ceos
+      STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+      COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+      DEPLOY_MG_EXTRA_PARAMS: ""
+      SPECIFIC_PARAM: "[]"
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -60,31 +60,68 @@ jobs:
           TESTBED_PREP_TOPOLOGY: t0
           CHECKER: t0_checker
           TOPOLOGY: t0
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          VM_TYPE: ceos
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          DEPLOY_MG_EXTRA_PARAMS: ""
+          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-t0-2vlans_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t0-2vlans
           CHECKER: t0-2vlans_checker
           DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a "
           TOPOLOGY: t0
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          VM_TYPE: ceos
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-t1-lag_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t1
           CHECKER: t1_checker
           TOPOLOGY: t1-lag
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          VM_TYPE: ceos
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          DEPLOY_MG_EXTRA_PARAMS: ""
+          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-dualtor_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: dualtor
           CHECKER: dualtor_checker
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
           TOPOLOGY: dualtor
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          VM_TYPE: ceos
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          DEPLOY_MG_EXTRA_PARAMS: ""
+          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-multi-asic-t1_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t1-multi-asic
           CHECKER: t1-multi-asic_checker
           TOPOLOGY: t1-8-lag
           NUM_ASIC: 4
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          VM_TYPE: ceos
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          DEPLOY_MG_EXTRA_PARAMS: ""
+          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-multi-asic-t1_by_Elastictest_optional:
           TESTBED_PREP_TOPOLOGY: t1
           CHECKER: t1_checker
           TOPOLOGY: t1-8-lag
           NUM_ASIC: 4
           STOP_ON_FAILURE: "False"
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          VM_TYPE: ceos
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          DEPLOY_MG_EXTRA_PARAMS: ""
+          SPECIFIC_PARAM: "[]"
         impacted-area-kvmtest-t0-sonic_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: t0-sonic
           CHECKER: t0-sonic_checker
@@ -95,6 +132,10 @@ jobs:
             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
             ]'
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          DEPLOY_MG_EXTRA_PARAMS: ""
         impacted-area-kvmtest-dpu_by_Elastictest:
           TESTBED_PREP_TOPOLOGY: dpu
           CHECKER: dpu_checker
@@ -102,21 +143,25 @@ jobs:
           SPECIFIC_PARAM: '[
             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
             ]'
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          VM_TYPE: ceos
+          STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          DEPLOY_MG_EXTRA_PARAMS: ""
         impacted-area-kvmtest-t2_by_Elastictest_optional:
           TESTBED_PREP_TOPOLOGY: t2
           CHECKER: t2_checker
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
+          TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+          NUM_ASIC: 1
+          VM_TYPE: ceos
+          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+          DEPLOY_MG_EXTRA_PARAMS: ""
+          SPECIFIC_PARAM: "[]"
 
-    condition: containsValue(split(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], ','), variables['CHECKER'])
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-      NUM_ASIC: 1
-      VM_TYPE: ceos
-      STOP_ON_FAILURE: ${{ parameters.TEST_PLAN_STOP_ON_FAILURE }}
-      COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-      DEPLOY_MG_EXTRA_PARAMS: ""
-      SPECIFIC_PARAM: "[]"
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,8 +108,8 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
     variables:
+      PR_CHECKERS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1
       VM_TYPE: ceos
@@ -117,6 +117,7 @@ jobs:
       COMMON_EXTRA_PARAMS: "--disable_sai_validation "
       DEPLOY_MG_EXTRA_PARAMS: ""
       SPECIFIC_PARAM: "[]"
+    condition: contains(variables['PR_CHECKERS'], variables['CHECKER'])
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: sonic-ubuntu-1c

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -121,14 +121,27 @@ jobs:
     continueOnError: false
     pool: sonic-ubuntu-1c
     steps:
+      # - script: |
+      #     set -x
+
+      #     echo "PR_CHECKERS=$PR_CHECKERS"
+      #     echo "CHECKER=$CHECKER"
+      #     if [[ ! "$PR_CHECKERS" == *"$CHECKER"* ]]; then
+      #       echo "Checker not in impacted list, skipping..."
+      #       echo -n "##vso[task.setvariable variable=SKIP_FOLLOWING_TESTS]true"
+      #       exit 0
+      #     fi
+      #   name: CheckChecker
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
         - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/calculate-instance-numbers.yml
+        condition: contains(variables['PR_CHECKERS'], variables['CHECKER'])
         parameters:
           TOPOLOGY: $(TESTBED_PREP_TOPOLOGY)
           BUILD_BRANCH: $(BUILD_BRANCH)
 
       - template: run-test-elastictest-template.yml
+        condition: contains(variables['PR_CHECKERS'], variables['CHECKER'])
         parameters:
           TOPOLOGY: $(TOPOLOGY)
           SCRIPTS: $(SCRIPTS)

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,7 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
-    condition: containsValue('dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS']', 't0_checker')
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker')
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       NUM_ASIC: 1

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -108,6 +108,7 @@ jobs:
           TOPOLOGY: t2
           STOP_ON_FAILURE: "False"
 
+    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], "$(CHECKER)")
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       PR_CHECKERS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'] ]

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -197,7 +197,6 @@ parameters:
     default: ""
 
 steps:
-- ${{ if contains(variables['PR_CHECKERS'], variables['CHECKER']) }}:
   - ${{ if not(contains(variables['BUILD.REPOSITORY.NAME'], 'sonic-mgmt')) }}:
       - script: |
           # If not sonic-mgmt/sonic-mgmt-int repo, need to download test_plan.py and pr_test_scripts.yaml

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -197,6 +197,7 @@ parameters:
     default: ""
 
 steps:
+- ${{ if contains(variables['PR_CHECKERS'], variables['CHECKER']) }}:
   - ${{ if not(contains(variables['BUILD.REPOSITORY.NAME'], 'sonic-mgmt')) }}:
       - script: |
           # If not sonic-mgmt/sonic-mgmt-int repo, need to download test_plan.py and pr_test_scripts.yaml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Calculate instance number yaml got issue when some topology do not have scripts to be executed, TEST_SCRIPTS will get numm with jq command, and pass to SCRIPTS with error, then python command executing calculate_instance_number.py would miss a parameter, causing pipeline fail.
#### How did you do it?
Use $(jq -r -c '."${{ parameters.TOPOLOGY }}_checker" // []' /tmp/ts.json) to get a empty [] if no script to be executed, and immediately return 0 instance.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
