### PR TITLE
DON'T MERGE JUST FOR DEMO FAILURE Add demo test to reproduce pipeline issue with topology('any') mapping

### DIFF
--- a/.azure-pipelines/impacted_area_testing/get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/get_test_scripts.py
@@ -45,7 +45,7 @@ def distribute_scripts_to_PR_checkers(match, script_name, test_scripts_per_topol
     for topology in match.group(1).split(","):
         topology_mark = topology.strip().strip('"').strip("'")
         if topology_mark == "any":
-            for key in ["t0_checker", "t1_checker", "t2_checker"]:
+            for key in test_scripts_per_topology_checker.keys():
                 if script_name not in test_scripts_per_topology_checker[key]:
                     test_scripts_per_topology_checker[key].append(script_name)
         else:

--- a/.azure-pipelines/impacted_area_testing/get_test_scripts.py
+++ b/.azure-pipelines/impacted_area_testing/get_test_scripts.py
@@ -45,7 +45,7 @@ def distribute_scripts_to_PR_checkers(match, script_name, test_scripts_per_topol
     for topology in match.group(1).split(","):
         topology_mark = topology.strip().strip('"').strip("'")
         if topology_mark == "any":
-            for key in test_scripts_per_topology_checker.keys():
+            for key in ["t0_checker", "t1_checker", "t2_checker"]:
                 if script_name not in test_scripts_per_topology_checker[key]:
                     test_scripts_per_topology_checker[key].append(script_name)
         else:

--- a/tests/pipeline_issue_demo/test_topology_any_mapping.py
+++ b/tests/pipeline_issue_demo/test_topology_any_mapping.py
@@ -1,0 +1,36 @@
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+"""
+This test demonstrates a pipeline issue where tests marked with topology('any')
+are not mapped to specialized topology checkers like:
+- dpu_checker
+- dualtor_checker  
+- t1-multi-asic_checker (shown as multi-asic-t1 in pipeline)
+- t0-2vlans_checker
+- t0-sonic_checker
+
+The issue occurs in .azure-pipelines/impacted_area_testing/get_test_scripts.py
+where topology('any') only maps to t0_checker, t1_checker, and t2_checker.
+
+This causes the pipeline to fail with:
+"calculate_instance_number.py: error: argument --scripts: expected one argument"
+
+Because SCRIPTS variable is empty for these specialized topologies.
+"""
+
+
+def test_dummy_for_any_topology():
+    """
+    Dummy test to demonstrate the pipeline issue.
+    This test should run on ANY topology, but the pipeline
+    fails to recognize it for specialized topologies.
+    """
+    logger.info("This test should run on any topology")
+    assert True, "This is a dummy test"

--- a/tests/pipeline_issue_demo/test_topology_any_mapping.py
+++ b/tests/pipeline_issue_demo/test_topology_any_mapping.py
@@ -11,7 +11,7 @@ pytestmark = [
 This test demonstrates a pipeline issue where tests marked with topology('any')
 are not mapped to specialized topology checkers like:
 - dpu_checker
-- dualtor_checker  
+- dualtor_checker
 - t1-multi-asic_checker (shown as multi-asic-t1 in pipeline)
 - t0-2vlans_checker
 - t0-sonic_checker


### PR DESCRIPTION
Tests marked with topology('any') are not mapped to specialized topology checkers:
- dpu_checker
- dualtor_checker
- t1-multi-asic_checker
- t0-2vlans_checker
- t0-sonic_checker

This causes pipeline failures with empty SCRIPTS parameter.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
