### PR TITLE
Ensure pre-test is the first item in conditional mark check

### DIFF
--- a/.hooks/pre_commit_hooks/check_conditional_mark_sort.py
+++ b/.hooks/pre_commit_hooks/check_conditional_mark_sort.py
@@ -14,6 +14,14 @@ def main():
                 for line in file_contents:
                     if re.match('^[a-zA-Z]', line):
                         conditions.append(line.strip().rstrip(":"))
+                if conditions[0] == 'test_pretest.py':
+                    del conditions[0]  # This is at front where it should be
+                if 'test_pretest.py' in conditions:
+                    print("===========================================================================")
+                    print("test_pretest.py should be the first item in ")
+                    print("tests/common/plugins/conditional_mark/tests_mark_conditions*.yaml")
+                    print("===========================================================================")
+                    return 1
                 sorted_conditions = conditions[:]
                 sorted_conditions.sort()
                 for i in range(len(conditions)):


### PR DESCRIPTION
Summary:
Ensure pre-test is first item in conditional mark check, because pre-test runs before everything else, and it makes the most sense at the top of the file.

Also this change goes with https://github.com/sonic-net/sonic-mgmt/pull/20326
This change will allow that PR to pass its PR checks.

### Type of change
- [X] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
To allow https://github.com/sonic-net/sonic-mgmt/pull/20326 to pass the PR checks

#### How did you verify/test it?
Running it manually on PR 20326

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A
