### PR TITLE
Revert "Fix get impact area parameter missing issue"

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -47,8 +47,6 @@ jobs:
       - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
           - checkout: ${{ parameters.SONIC_MGMT_NAME }}
       - template: impacted_area_testing/get-impacted-area.yml
-        parameters:
-          BUILD_BRANCH: $(BUILD_BRANCH)
 
   - job: impacted_area_kvmtest
     displayName: " "


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#20335
Although it fixed impact area not working issue, it exposed another issue that the job condition `contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], variables['CHECKER'])` is not working. For example, even if TEST_SCRIPTS do not contain t0 tests, t0 PR checker will not be skipped, but continue to run, then it will get issue in finding test scripts.