### PR TITLE
[Test Gap] enable test_forced_mgmt_route for lt2 and ft2

### DIFF
--- a/tests/route/test_forced_mgmt_route.py
+++ b/tests/route/test_forced_mgmt_route.py
@@ -11,7 +11,7 @@ from tests.common.utilities import wait_until, wait_for_file_changed, backup_con
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
-    pytest.mark.topology('t0', 't2'),
+    pytest.mark.topology('t0', 't2', 'lt2', 'ft2'),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable the test on ft2 and lt2 platform
Fixes # (issue) 3291771

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Enable the test on ft2 and lt2 platform

<img width="1885" height="57" alt="image" src="https://github.com/user-attachments/assets/f56ce465-e620-440e-aa0b-370d0f2044de" />

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
