### PR TITLE
refactor: optimize test link down for T2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1145,15 +1145,6 @@ platform_tests/test_kdump.py:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
 #######################################
-########   test_link_down.py   ########
-#######################################
-platform_tests/test_link_down.py::test_link_down_on_sup_reboot:
-  skip:
-    reason: "Skip for non T2"
-    conditions:
-      - "topo_type not in ['t2']"
-
-#######################################
 ####  test_memory_exhaustion.py   #####
 #######################################
 platform_tests/test_memory_exhaustion.py:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -1161,6 +1161,14 @@ platform_tests/test_link_down.py:
     conditions:
       - "asic_type in ['vpp']"
 
+platform_tests/test_link_down_sup.py:
+  skip:
+    reason: >
+            Failed/Errored: To be included
+    conditions_logical_operator: or
+    conditions:
+      - "asic_type in ['vpp']"
+
 platform_tests/test_memory_exhaustion.py:
   skip:
     reason: >

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t2.yaml
@@ -618,6 +618,11 @@ platform_tests/test_link_down.py:
     conditions:
     - asic_type in ['vs'] and 't2' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+platform_tests/test_link_down_sup.py:
+  skip:
+    conditions:
+    - asic_type in ['vs'] and 't2' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 platform_tests/test_platform_info.py:
   skip:
     conditions:

--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -1,53 +1,46 @@
 """
 On SONiC device reboot, tests the link down on fanout switches
 This test supports different platforms including:
-    1. chassis
-    2. single-asic dut
-    3. multi-asic dut
-    Note that for now we only run this on t2(chassis)
+    1. T0
+    2. T1
+    3. T2 Chassis
 
 """
 import logging
+
 import pytest
 
-from tests.platform_tests.test_reboot import check_interfaces_and_services
-from tests.common.platform.device_utils import fanout_switch_port_lookup
+from tests.common import reboot
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-from tests.common.reboot import reboot, wait_for_startup
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.reboot import wait_for_startup
+from tests.conftest import get_hosts_per_hwsku
+from tests.platform_tests.test_reboot import check_interfaces_and_services
+from tests.platform_tests.utils import get_max_to_reboot, fanout_hosts_and_ports, link_status_on_host
 
-logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2'),
     pytest.mark.disable_loganalyzer,
 ]
 
-MAX_TIME_TO_REBOOT = 300
+
+logger = logging.getLogger(__name__)
+
+_cached_frontend_nodes = None
 
 
-def set_max_to_reboot(duthost):
-    """
-    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
-    to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
-    """
-    global MAX_TIME_TO_REBOOT
-    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, 'test_link_down.py', 'cold')
-    if plt_reboot_ctrl:
-        MAX_TIME_TO_REBOOT = plt_reboot_ctrl.get('timeout', 120)
+def get_frontend_nodes_per_hwsku(duthosts, request):
+    global _cached_frontend_nodes
+    if _cached_frontend_nodes is None:
+        _cached_frontend_nodes = [
+            duthosts[hostname] for hostname in get_hosts_per_hwsku(
+                request,
+                [host.hostname for host in duthosts.frontend_nodes],
+            )
+        ]
 
-
-def multi_duts_and_ports(duthosts):
-    """
-    For multi-host
-    Returns:
-            dict of {{duthost1, [ports]}, {duthost2, [ports]}, ...}
-    """
-    duts_and_ports = {}
-    for duthost in duthosts.frontend_nodes:
-        ports = duthost.ports_list()
-        duts_and_ports[duthost] = ports
-    return duts_and_ports
+    return _cached_frontend_nodes
 
 
 def single_dut_and_ports(duthost):
@@ -62,184 +55,48 @@ def single_dut_and_ports(duthost):
     return duts_and_ports
 
 
-def fanout_hosts_and_ports(fanouthosts, duts_and_ports):
-    """
-    Use cases:
-        1 duthost -> 1 fanout host
-        1 duthost -> no fanout host
-        1 duthost -> multiple fanout hosts
-        multiple duthosts -> 1 fanout hosts
+def test_link_status_on_host_reboot(request, duthosts, localhost, conn_graph_facts, fanouthosts, xcvr_skip_list):
+    frontend_nodes_per_hwsku = get_frontend_nodes_per_hwsku(duthosts, request)
+    max_time_to_reboot = dict()
+    fanouts_and_ports = dict()
+    for duthost in frontend_nodes_per_hwsku:
+        max_time_to_reboot[duthost] = get_max_to_reboot(duthost, 'test_link_down.py')
+        dut_ports = single_dut_and_ports(duthost)
+        fanouts_and_ports[duthost] = fanout_hosts_and_ports(fanouthosts, dut_ports)
 
-    Returns:
-            dict of [fanout, {set of its ports}]
-    """
-    fanout_and_ports = {}
-    for duthost in list(duts_and_ports.keys()):
-        for port in duts_and_ports[duthost]:
-            fanout, fanout_port = fanout_switch_port_lookup(
-                fanouthosts, duthost.hostname, port)
-            # some ports on dut may not have link to fanout
-            if fanout is None and fanout_port is None:
-                logger.info("Interface {} on duthost {} doesn't link to any fanout switch"
-                            .format(port, duthost.hostname))
-                continue
-            logger.info("Interface {} on fanout {} (os type {}) map to interface {} on duthost {}"
-                        .format(fanout_port, fanout.hostname, fanout.get_fanout_os(), port, duthost.hostname))
-            if fanout in list(fanout_and_ports.keys()):
-                fanout_and_ports[fanout].add(fanout_port)
-            else:
-                fanout_and_ports[fanout] = {fanout_port}
-    return fanout_and_ports
-
-
-def links_down(fanout, ports):
-    """
-    Input:
-        ports: set of ports on this fanout
-    Returns:
-        True: if all ports are down
-        False: if any port is up
-    """
-    return fanout.links_status_down(ports)
-
-
-def links_up(fanout, ports):
-    """
-    Returns:
-        True: if all ports are up
-        False: if any port is down
-    """
-    return fanout.links_status_up(ports)
-
-
-def link_status_on_host(fanouts_and_ports, up=True):
-    for fanout, ports in list(fanouts_and_ports.items()):
-        hostname = fanout.hostname
-        # Assumption here is all fanouts are healthy.
-        # If fanout is not healthy, or links not in expected state, following errors will be thrown
-        if up:
-            # Make sure interfaces are up on fanout hosts
-            pytest_assert(wait_until(MAX_TIME_TO_REBOOT, 5, 0, links_up, fanout, ports),
-                          "Interface(s) on {} is still down after {}sec".format(hostname, MAX_TIME_TO_REBOOT))
-        else:
-            # Check every interfaces are down on this host every 5 sec until device boots up
-            pytest_assert(wait_until(MAX_TIME_TO_REBOOT, 5, 0, links_down, fanout, ports),
-                          "Interface(s) on {} is still up after {}sec".format(hostname, MAX_TIME_TO_REBOOT))
-    return True
-
-
-def link_status_on_all_fanouts(fanouts_and_ports, up=True):
-    """
-    Return:
-        True: if up=True, and all links on all fanout hosts are up
-              or
-              if up=False, and all link on all fanout hosts are down
-    """
-    link_status_on_host(fanouts_and_ports, up)
-    logger.info("All interfaces on all fanouts are {}!".format('up' if up else 'down'))
-    return True
-
-
-def check_interfaces_and_services_all_LCs(duthosts, conn_graph_facts, xcvr_skip_list):
-    for LC in duthosts.frontend_nodes:
+    def check_interfaces_and_links(dut):
+        # Before and after test, check all interfaces and services are up
         check_interfaces_and_services(
-            LC, conn_graph_facts["device_conn"][LC.hostname], xcvr_skip_list)
+            dut, conn_graph_facts.get("device_conn", {}).get(dut.hostname, {}), xcvr_skip_list)
+        # Also make sure fanout hosts' links are up
+        link_status_on_host(fanouts_and_ports[dut], max_time_to_reboot[dut])
 
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in frontend_nodes_per_hwsku:
+            executor.submit(check_interfaces_and_links, duthost)
 
-def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
-                                 conn_graph_facts,
-                                 fanouthosts, xcvr_skip_list):
-    if len(duthosts.nodes) == 1:
-        pytest.skip("Skip single-host dut for this test")
+    def reboot_and_check(dut):
+        # Get a dut uptime before reboot
+        dut_uptime_before = dut.get_up_time()
 
-    duthost = duthosts[enum_supervisor_dut_hostname]
-    set_max_to_reboot(duthost)
+        # Reboot dut, we should detect this host's fanout switches have all links down
+        reboot(dut, localhost, wait_for_ssh=False)
 
-    # There are some errors due to reboot happened before this test file for some reason,
-    # and SUP may not have enough time to recover all dockers and the wait for process wait for 300 secs in
-    # pytest_assert(wait_until(300, 20, 0, _all_critical_processes_healthy, dut),
-    # would not be enough. _all_critical_processes_healthy only validates processes are started
-    # Wait for ssh port to open up on the DUT
-    wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
+        # After reboot, immediately check if all links on all fanouts are down
+        link_status_on_host(fanouts_and_ports[dut], max_time_to_reboot[dut], up=False)
 
-    hostname = duthost.hostname
-    # Before test, check all interfaces and services are up on all linecards
-    check_interfaces_and_services_all_LCs(
-        duthosts, conn_graph_facts, xcvr_skip_list)
+        # Wait for ssh port to open up on the DUT
+        wait_for_startup(dut, localhost, 0, max_time_to_reboot[dut])
 
-    duts_and_ports = multi_duts_and_ports(duthosts)
-    fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, duts_and_ports)
+        dut_uptime = dut.get_up_time()
+        logger.info('DUT {} up since {}'.format(dut.hostname, dut_uptime))
+        rebooted = float(dut_uptime_before.strftime("%s")) != float(dut_uptime.strftime("%s"))
+        pytest_assert(rebooted, "Device {} did not reboot".format(dut.hostname))
 
-    # Also make sure fanout hosts' links are up
-    link_status_on_all_fanouts(fanouts_and_ports)
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in frontend_nodes_per_hwsku:
+            executor.submit(reboot_and_check, duthost)
 
-    # Get a dut uptime before reboot
-    dut_uptime_before = duthost.get_up_time()
-
-    # Reboot RP should reboot both RP&LC, should detect all links on all linecards go down
-    reboot(duthost, localhost, wait_for_ssh=False)
-
-    # Also make sure fanout hosts' links are down
-    link_status_on_all_fanouts(fanouts_and_ports, up=False)
-
-    # Wait for ssh port to open up on the SUP
-    wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
-    # Wait for ssh port to open up on the linecards
-    for linecard in duthosts.frontend_nodes:
-        wait_for_startup(linecard, localhost, 0, MAX_TIME_TO_REBOOT)
-
-    dut_uptime = duthost.get_up_time()
-    logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
-    rebooted = float(dut_uptime_before.strftime(
-        "%s")) != float(dut_uptime.strftime("%s"))
-    assert rebooted, "Device {} did not reboot".format(hostname)
-
-    # Verify that the links are all LCs are up
-    check_interfaces_and_services_all_LCs(
-        duthosts, conn_graph_facts, xcvr_skip_list)
-
-    # Also make sure fanout hosts' links are up
-    link_status_on_all_fanouts(fanouts_and_ports)
-
-
-def test_link_status_on_host_reboot(duthosts, localhost, enum_rand_one_per_hwsku_frontend_hostname,
-                                    conn_graph_facts,
-                                    fanouthosts, xcvr_skip_list):
-    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    set_max_to_reboot(duthost)
-    hostname = duthost.hostname
-
-    # Before test, check all interfaces and services are up
-    check_interfaces_and_services(
-        duthost, conn_graph_facts.get("device_conn", {}).get("hostname", {}), xcvr_skip_list)
-
-    dut_ports = single_dut_and_ports(duthost)
-    fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, dut_ports)
-
-    # Also make sure fanout hosts' links are up
-    link_status_on_host(fanouts_and_ports)
-
-    # Get a dut uptime before reboot
-    dut_uptime_before = duthost.get_up_time()
-
-    # Reboot dut, we should detect this host's fanout switches have all links down
-    reboot(duthost, localhost, wait_for_ssh=False)
-
-    # After reboot, immediately check if all links on all fanouts are down
-    link_status_on_host(fanouts_and_ports, up=False)
-
-    # Wait for ssh port to open up on the DUT
-    wait_for_startup(duthost, localhost, 0, MAX_TIME_TO_REBOOT)
-
-    dut_uptime = duthost.get_up_time()
-    logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
-    rebooted = float(dut_uptime_before.strftime(
-        "%s")) != float(dut_uptime.strftime("%s"))
-    assert rebooted, "Device {} did not reboot".format(hostname)
-
-    # After test, check all interfaces and services are up
-    check_interfaces_and_services(
-        duthost, conn_graph_facts.get("device_conn", {}).get("hostname", {}), xcvr_skip_list)
-
-    # Also make sure fanout hosts' links are up
-    link_status_on_host(fanouts_and_ports)
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for duthost in frontend_nodes_per_hwsku:
+            executor.submit(check_interfaces_and_links, duthost)

--- a/tests/platform_tests/test_link_down_sup.py
+++ b/tests/platform_tests/test_link_down_sup.py
@@ -1,0 +1,95 @@
+"""
+On SONiC device reboot, tests the link down on fanout switches for T2 chassis Supervisor
+"""
+import logging
+import pytest
+
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.reboot import reboot, wait_for_startup
+from tests.platform_tests.utils import get_max_to_reboot, check_interfaces_and_services_all_lcs, \
+    fanout_hosts_and_ports, link_status_on_host
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2'),
+    pytest.mark.disable_loganalyzer,
+]
+
+
+def multi_duts_and_ports(duthosts):
+    """
+    For multi-host
+    Returns:
+            dict of {{duthost1, [ports]}, {duthost2, [ports]}, ...}
+    """
+    duts_and_ports = {}
+    for duthost in duthosts.frontend_nodes:
+        ports = duthost.ports_list()
+        duts_and_ports[duthost] = ports
+    return duts_and_ports
+
+
+def link_status_on_all_fanouts(fanouts_and_ports, max_time_to_reboot, up=True):
+    """
+    Return:
+        True: if up=True, and all links on all fanout hosts are up
+              or
+              if up=False, and all link on all fanout hosts are down
+    """
+    link_status_on_host(fanouts_and_ports, max_time_to_reboot, up=up)
+    logger.info("All interfaces on all fanouts are {}!".format('up' if up else 'down'))
+    return True
+
+
+def test_link_down_on_sup_reboot(duthosts, localhost, enum_supervisor_dut_hostname,
+                                 conn_graph_facts, fanouthosts, xcvr_skip_list):
+    if len(duthosts.nodes) == 1:
+        pytest.skip("Skip single-host dut for this test")
+
+    duthost = duthosts[enum_supervisor_dut_hostname]
+    max_time_to_reboot = get_max_to_reboot(duthost, 'test_link_down_sup.py')
+
+    # There are some errors due to reboot happened before this test file for some reason,
+    # and SUP may not have enough time to recover all dockers and the wait for process wait for 300 secs in
+    # pytest_assert(wait_until(300, 20, 0, _all_critical_processes_healthy, dut),
+    # would not be enough. _all_critical_processes_healthy only validates processes are started
+    # Wait for ssh port to open up on the DUT
+    wait_for_startup(duthost, localhost, 0, max_time_to_reboot)
+
+    hostname = duthost.hostname
+    # Before test, check all interfaces and services are up on all linecards
+    check_interfaces_and_services_all_lcs(duthosts, conn_graph_facts, xcvr_skip_list)
+
+    duts_and_ports = multi_duts_and_ports(duthosts)
+    fanouts_and_ports = fanout_hosts_and_ports(fanouthosts, duts_and_ports)
+
+    # Also make sure fanout hosts' links are up
+    link_status_on_all_fanouts(fanouts_and_ports, max_time_to_reboot)
+
+    # Get a dut uptime before reboot
+    dut_uptime_before = duthost.get_up_time()
+
+    # Reboot RP should reboot both RP&LC, should detect all links on all linecards go down
+    reboot(duthost, localhost, wait_for_ssh=False)
+
+    # Also make sure fanout hosts' links are down
+    link_status_on_all_fanouts(fanouts_and_ports, max_time_to_reboot, up=False)
+
+    # Wait for ssh port to open up on the SUP
+    wait_for_startup(duthost, localhost, 0, max_time_to_reboot)
+    # Wait for ssh port to open up on the linecards
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for linecard in duthosts.frontend_nodes:
+            executor.submit(wait_for_startup, linecard, localhost, 0, max_time_to_reboot)
+
+    dut_uptime = duthost.get_up_time()
+    logger.info('DUT {} up since {}'.format(hostname, dut_uptime))
+    rebooted = float(dut_uptime_before.strftime("%s")) != float(dut_uptime.strftime("%s"))
+    assert rebooted, "Device {} did not reboot".format(hostname)
+
+    # Verify that the links are all LCs are up
+    check_interfaces_and_services_all_lcs(duthosts, conn_graph_facts, xcvr_skip_list)
+
+    # Also make sure fanout hosts' links are up
+    link_status_on_all_fanouts(fanouts_and_ports, max_time_to_reboot)

--- a/tests/platform_tests/utils.py
+++ b/tests/platform_tests/utils.py
@@ -1,0 +1,97 @@
+import logging
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.platform.device_utils import fanout_switch_port_lookup
+from tests.common.utilities import get_plt_reboot_ctrl, wait_until
+from tests.platform_tests.test_reboot import check_interfaces_and_services
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_max_to_reboot(duthost, test_name):
+    """
+    For chassis testbeds, we need to specify plt_reboot_ctrl in inventory file,
+    to let MAX_TIME_TO_REBOOT to be overwritten by specified timeout value
+    """
+    max_time_to_reboot = 300
+    plt_reboot_ctrl = get_plt_reboot_ctrl(duthost, test_name, 'cold')
+    if plt_reboot_ctrl:
+        max_time_to_reboot = plt_reboot_ctrl.get('timeout', 120)
+
+    return max_time_to_reboot
+
+
+def fanout_hosts_and_ports(fanouthosts, duts_and_ports):
+    """
+    Use cases:
+        1 duthost -> 1 fanout host
+        1 duthost -> no fanout host
+        1 duthost -> multiple fanout hosts
+        multiple duthosts -> 1 fanout hosts
+
+    Returns:
+            dict of [fanout, {set of its ports}]
+    """
+    fanout_and_ports = {}
+    for duthost in list(duts_and_ports.keys()):
+        for port in duts_and_ports[duthost]:
+            fanout, fanout_port = fanout_switch_port_lookup(fanouthosts, duthost.hostname, port)
+            # some ports on dut may not have link to fanout
+            if fanout is None and fanout_port is None:
+                logger.info("Interface {} on duthost {} doesn't link to any fanout switch"
+                            .format(port, duthost.hostname))
+                continue
+            logger.info("Interface {} on fanout {} (os type {}) map to interface {} on duthost {}"
+                        .format(fanout_port, fanout.hostname, fanout.get_fanout_os(), port, duthost.hostname))
+            if fanout in list(fanout_and_ports.keys()):
+                fanout_and_ports[fanout].add(fanout_port)
+            else:
+                fanout_and_ports[fanout] = {fanout_port}
+    return fanout_and_ports
+
+
+def links_down(fanout, ports):
+    """
+    Input:
+        ports: set of ports on this fanout
+    Returns:
+        True: if all ports are down
+        False: if any port is up
+    """
+    return fanout.links_status_down(ports)
+
+
+def links_up(fanout, ports):
+    """
+    Returns:
+        True: if all ports are up
+        False: if any port is down
+    """
+    return fanout.links_status_up(ports)
+
+
+def link_status_on_host(fanouts_and_ports, max_time_to_reboot, up=True):
+    for fanout, ports in list(fanouts_and_ports.items()):
+        hostname = fanout.hostname
+        # Assumption here is all fanouts are healthy.
+        # If fanout is not healthy, or links not in expected state, following errors will be thrown
+        if up:
+            # Make sure interfaces are up on fanout hosts
+            pytest_assert(wait_until(max_time_to_reboot, 5, 0, links_up, fanout, ports),
+                          "Interface(s) on {} is still down after {}sec".format(hostname, max_time_to_reboot))
+        else:
+            # Check every interface is down on this host every 5 sec until device boots up
+            pytest_assert(wait_until(max_time_to_reboot, 5, 0, links_down, fanout, ports),
+                          "Interface(s) on {} is still up after {}sec".format(hostname, max_time_to_reboot))
+    return True
+
+
+def check_interfaces_and_services_all_lcs(duthosts, conn_graph_facts, xcvr_skip_list):
+    with SafeThreadPoolExecutor(max_workers=8) as executor:
+        for linecard in duthosts.frontend_nodes:
+            executor.submit(
+                check_interfaces_and_services,
+                linecard, conn_graph_facts["device_conn"][linecard.hostname], xcvr_skip_list,
+            )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Optimize the `platform_tests/test_link_down.py` test for T2 splitting into two files: `platform_tests/test_link_down.py` for T2 front-end nodes (Line cards) with parallel optimization, and `platform_tests/test_link_down_sup.py` for the T2 Supervisor. T0 & T1 topologies are unchanged.

Summary:
Fixes # (issue) Microsoft ADO 34559041

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
On T2 topo, `platform_tests/test_link_down.py` currently takes too long (~85 minutes) to finish and we wanted to reduce the running time. 

#### How did you do it?
We split it into two files: `platform_tests/test_link_down.py` for Line cards and `platform_tests/test_link_down_sup.py` for the Supervisor. 

The `platform_tests/test_link_down.py` now parallelizes across LCs using Python multithreading, which can reduce the running time by ~40%. The `platform_tests/test_link_down_sup.py` test also has some slight improvements. Moreover, if multiple T2 testbeds are available, we can run these two files on separate testbeds to further shorten runtime. 

No changes for T0 & T1

#### How did you verify/test it?

T2: https://elastictest.org/scheduler/testplan/68af990fce84bdc893d28f4d

Regression verification:
- T0: https://elastictest.org/scheduler/testplan/68af98417a46e6c48bdfdac6
- T1: https://elastictest.org/scheduler/testplan/68af9882f195e8240b36bf20

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
