### PR TITLE
Qos_yaml_updated for j2C+_topo-t2_single_node_max and min_wrt_PR23709

### DIFF
--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -108,22 +108,22 @@ qos_params:
                     pkts_num_trig_egr_drp: 2396745
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
-            400000_50m:
+            400000_30m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_pfc: 764215
+                    pkts_num_trig_ingr_drp: 765860
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_pfc: 764215
+                    pkts_num_trig_ingr_drp: 765860
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
@@ -132,7 +132,7 @@ qos_params:
                     src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 764215
                     pkts_num_hdrm_full: 1317
                     pkts_num_hdrm_partial: 1300
                     margin: 300
@@ -140,22 +140,22 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_pfc: 764215
+                    pkts_num_trig_ingr_drp: 765860
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 764215
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 764215
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -169,7 +169,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 764336
+                    pkts_num_trig_pfc: 764215
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -187,7 +187,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_ingr_drp: 765860
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -196,7 +196,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 28160
-                    pkts_num_trig_ingr_drp: 765653
+                    pkts_num_trig_ingr_drp: 765860
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:
@@ -482,22 +482,22 @@ qos_params:
                     pkts_num_trig_egr_drp: 2179900
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
-            400000_50m:
+            400000_30m:
                 pkts_num_leak_out: 140
                 internal_hdr_size: 48
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_pfc: 764101
+                    pkts_num_trig_ingr_drp: 765746
                     pkts_num_margin: 100
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_pfc: 764101
+                    pkts_num_trig_ingr_drp: 765746
                     pkts_num_margin: 100
                 hdrm_pool_size:
                     dscps: [3, 4]
@@ -506,7 +506,7 @@ qos_params:
                     src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
                     dst_port_id: 18
                     pgs_num: 18
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 764101
                     pkts_num_hdrm_full: 1317
                     pkts_num_hdrm_partial: 1300
                     margin: 300
@@ -514,22 +514,22 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_pfc: 764101
+                    pkts_num_trig_ingr_drp: 765746
                     cell_size: 4096
                     pkts_num_margin: 30
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 764101
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 764101
                     pkts_num_dismiss_pfc: 12985
                     pkts_num_margin: 150
                 lossy_queue_1:
@@ -543,7 +543,7 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_pfc: 764223
+                    pkts_num_trig_pfc: 764101
                     packet_size: 64
                     cell_size: 4096
                     pkts_num_margin: 40
@@ -561,7 +561,7 @@ qos_params:
                     ecn: 1
                     queue: 3
                     pkts_num_fill_min: 0
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_ingr_drp: 765746
                     cell_size: 4096
                 wm_buf_pool_lossless:
                     dscp: 3
@@ -570,7 +570,7 @@ qos_params:
                     queue: 3
                     pkts_num_fill_ingr_min: 0
                     pkts_num_trig_pfc: 28160
-                    pkts_num_trig_ingr_drp: 765540
+                    pkts_num_trig_ingr_drp: 765746
                     pkts_num_fill_egr_min: 8
                     cell_size: 4096
                 wm_q_shared_lossy:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Qos_yaml_updated for j2C+_topo-t2_single_node_max and topo-t2_single_node_min with respect to PR #https://github.com/sonic-net/sonic-buildimage/pull/23709

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Change in cable length & headroom size for UT2 & LT2 PR #23709
#### How did you do it?

#### How did you verify/test it?
Executed sonic-mgmt qos tests with 30m cable length profile
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
This PR is dependent on PR -https://github.com/sonic-net/sonic-buildimage/pull/23709
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
