### PR TITLE
Fix pdu issue 

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -164,7 +164,9 @@ class snmpPduController(PduControllerBase):
         return value
 
     def _get_pdu_snmp_creds(self, pdu, perm):
-        context = {'secret_group_vars': pdu['secret_group_vars']}
+        context = {}
+        if 'secret_group_vars' in pdu:
+            context = {'secret_group_vars': pdu['secret_group_vars']}
         if 'pdu_{}_snmp_version'.format(perm) in pdu:
             version = pdu['pdu_{}_snmp_version'.format(perm)]
             if version == 'v2c':


### PR DESCRIPTION
The secret_group_vars is not always exist for all users, need to allow the secret_group_vars not defined as previously, the logic was broke by the PR: https://github.com/sonic-net/sonic-mgmt/pull/20269

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
