### PR TITLE
[test_voq_chassis_app_db_consistency.py] Increase delay after adding tmp portchannel

### DIFF
--- a/tests/voq/test_voq_chassis_app_db_consistency.py
+++ b/tests/voq/test_voq_chassis_app_db_consistency.py
@@ -145,7 +145,7 @@ def test_voq_chassis_app_db_consistency(duthosts, enum_rand_one_per_hwsku_fronte
         pytest_assert(int_facts['ansible_interface_facts'][tmp_portchannel]['ipv6'][0]['address'] == pc_ipv6)
         add_tmp_pc_ipv6 = True
 
-        time.sleep(30)
+        time.sleep(60)
         int_facts = asichost.interface_facts()['ansible_facts']
         pytest_assert(int_facts['ansible_interface_facts'][tmp_portchannel]['link'])
         post_change_db_dump = get_db_dump(duthosts, duthost)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20403

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Delay was too short, causing flakiness for this test on dT2 devices.
#### How did you do it?
Increase the delay from 30 -> 60
#### How did you verify/test it?
Ran it 10x, passed 10x
https://elastictest.org/scheduler/testplan/68ac5741ce84bdc893d28c69?testcase=voq%2ftest_voq_chassis_app_db_consistency.py%7c%7c%7c0&type=console
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A