### PR TITLE
Fix upgrade/downgrade flow

### DIFF
--- a/ansible/library/reduce_and_add_sonic_images.py
+++ b/ansible/library/reduce_and_add_sonic_images.py
@@ -331,6 +331,12 @@ def install_new_sonic_image(module, new_image_url, save_as=None, required_space=
             cmd="rm -f /host/old_config/config_db.json",
             msg="Remove config_db.json in preference of minigraph.xml"
         )
+        log("Remove /host/old_config/golden_config_db.json when /etc/old_config/minigraph.xml exists")
+        exec_command(
+            module,
+            cmd="rm -f /host/old_config/golden_config_db.json",
+            msg="Remove golden_config_db.json in preference of minigraph.xml"
+        )
 
     try:
         get_sonic_image_size(module)

--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -368,6 +368,8 @@ class AdvancedReboot:
 
         logger.info('Remove config_db.json so the new image will reload minigraph')
         self.duthost.shell('rm -f /host/old_config/config_db.json')
+        logger.info('Remove golden_config_db.json so the new image will reload minigraph')
+        self.duthost.shell('rm -f /host/old_config/golden_config_db.json')
         logger.info('Remove downloaded tempfile')
         self.duthost.shell('rm -f {}'.format(tempfile))
 

--- a/tests/upgrade_path/utilities.py
+++ b/tests/upgrade_path/utilities.py
@@ -25,11 +25,12 @@ def boot_into_base_image(duthost, localhost, base_image, tbinfo):
     logger.info("Remove old config_db file if exists, to load minigraph from scratch")
     if duthost.shell("ls /host/old_config/minigraph.xml", module_ignore_errors=True)['rc'] == 0:
         duthost.shell("rm -f /host/old_config/config_db.json")
+        duthost.shell("rm -f /host/old_config/golden_config_db.json")
     # Perform a cold reboot
     logger.info("Cold reboot the DUT to make the base image as current")
     # for 6100 devices, sometimes cold downgrade will not work, use soft-reboot here
     reboot_type = 'soft' if "s6100" in duthost.facts["platform"] else 'cold'
-    reboot(duthost, localhost, reboot_type=reboot_type)
+    reboot(duthost, localhost, reboot_type=reboot_type, safe_reboot=True)
     check_sonic_version(duthost, target_version)
 
 


### PR DESCRIPTION
* remove golden_config_db.json to regenerate config_db in case of upgrade/downgrade
* use safe_reboot=True in boot_into_base_image

After recent changes, if the golden_config_db.json is present, it will be used instead of generating a config from minigraph.
If we want to use minigraph as a source of config, we need to remove the golden config first.

`safe_reboot=True` is needed to ensure all the critical services are started before performing further configurations/checks

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
