### PR TITLE
Use upper case for buffer profiles in test

### DIFF
--- a/tests/packet_trimming/conftest.py
+++ b/tests/packet_trimming/conftest.py
@@ -128,8 +128,8 @@ def test_params(duthost, mg_facts, dut_qos_maps_module, downstream_links, upstre
     test_param = {
         'block_queue': block_queue,
         'trim_buffer_profiles': {
-            'uplink': f"queue{block_queue}_uplink_lossy_profile",
-            'downlink': f"queue{block_queue}_downlink_lossy_profile",
+            'uplink': f"QUEUE{block_queue}_UPLINK_LOSSY_PROFILE",
+            'downlink': f"QUEUE{block_queue}_DOWNLINK_LOSSY_PROFILE",
         },
         'ingress_port': {
             'name': ingress_port_name,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The packet_trimming/* tests are using lower case buffer profile names. This goes against the convention of upper case buffer profile names. The mismatch in expectation causes a new buffer profile to be created during the test, instead of using the existing buffer profile. This causes the test to use a haphazard buffer profile without all needed information, blocking the test.

Swap to use upper case profile naming to unblock test.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
Test is blocked by buffer profile case error.

#### How did you do it?
Swap from using lower case buffer profile naming to upper case.

#### How did you verify/test it?
Test no longer blocked on being unable to retrieve critical information from buffer profiles.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
