### PR TITLE
Set PPS_LIMIT to 300 on LLDP/UDLD/DHCP COPP test for m1 topology

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -362,7 +362,7 @@ class DHCPTest(PolicyTest):
         elif self.asic_type == "cisco-8000":
             self.PPS_LIMIT = 400
         # M0 devices have CIR of 300 for DHCP
-        elif self.topo_type in {"m0", "mx"}:
+        elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
@@ -411,7 +411,7 @@ class DHCP6Test(PolicyTest):
         elif self.asic_type == "cisco-8000":
             self.PPS_LIMIT = 400
         # M0 devices have CIR of 300 for DHCP
-        elif self.topo_type in {"m0", "mx"}:
+        elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
@@ -479,7 +479,7 @@ class LLDPTest(PolicyTest):
         elif self.asic_type == "cisco-8000":
             self.PPS_LIMIT = 400
         # M0 devices have CIR of 300 for DHCP
-        elif self.topo_type in {"m0", "mx"}:
+        elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100
@@ -515,7 +515,7 @@ class UDLDTest(PolicyTest):
         elif self.asic_type == "cisco-8000":
             self.PPS_LIMIT = 400
         # M0 devices have CIR of 300 for DHCP
-        elif self.topo_type in {"m0", "mx"}:
+        elif self.topo_type in {"m0", "mx", "m1"}:
             self.PPS_LIMIT = 300
         else:
             self.PPS_LIMIT = 100


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the issue that m1 topos fail COPP test on LLDP and UDLD.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### How did you do it?
COPP rate limit of queue4_group3 for Mgmt devices is set to 300. But in copp_test default value of 100 is used.
m0 and mx were fixed in https://github.com/sonic-net/sonic-mgmt/pull/14627, now add m1.

#### How did you verify/test it?
test_copp.py passed for m1 topos 
