### PR TITLE
Fixed the dpu status output parsing error.

### DIFF
--- a/tests/gnmi/test_gnmi_smartswitch.py
+++ b/tests/gnmi/test_gnmi_smartswitch.py
@@ -38,21 +38,10 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     # ------  -------------  ---------------  -------------  --------------  --------
     # DPU0            N/A              N/A         Online              up       N/A
     target = None
-    result = duthost.shell("show chassis module status")
-    headers = result['stdout_lines'][0].split()
-    name_idx = None
-    oper_status_idx = None
-    for i, header in enumerate(headers):
-        if header == "Name":
-            name_idx = i
-        if header == "Oper-Status":
-            oper_status_idx = i
-    assert name_idx is not None, "Can't locate Name in the headers"
-    assert oper_status_idx is not None, "Can't locate Oper-Status in the headers"
-    for line in result['stdout_lines']:
-        module_status = line.split()
-        if module_status[oper_status_idx] == "Online":
-            target = module_status[name_idx].lower()
+    result = duthost.show_and_parse("show chassis module status")
+    for dpu_status_line in result:
+        if dpu_status_line["oper-status"] == "Online":
+            target = dpu_status_line["name"].lower()
             logger.info("target is {}".format(target))
             break
     assert target is not None, "Can't locate online DPU"


### PR DESCRIPTION
Using duthost.show_and_parse function

Summary:
Fixes # [18453](https://github.com/sonic-net/sonic-mgmt/issues/18453)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Bug fix, incorrect parsing of the command output with values containing spaces.
Eliminate code duplication.

#### How did you do it?

Utilized the existing correct functionality to parse.

#### How did you verify/test it?

Ran the test on the on sn4280.

#### Any platform specific information?

Applies to sn4280 platform.

#### Supported testbed topology if it's a new test case?

N/A

