### PR TITLE
Update arp leftover clean step for dualtor topology

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -35,7 +35,8 @@ LOOP_TIMES_LEVEL_MAP = {
 
 
 @pytest.fixture(autouse=True)
-def arp_cache_fdb_cleanup(duthost):
+def arp_cache_fdb_cleanup(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
     try:
         clear_dut_arp_cache(duthost)
         fdb_cleanup(duthost)
@@ -51,8 +52,10 @@ def arp_cache_fdb_cleanup(duthost):
 
     # Ensure clean test environment even after failing
     try:
-        clear_dut_arp_cache(duthost)
-        fdb_cleanup(duthost)
+        dut_list = duthosts if "dualtor-aa" in tbinfo["topo"]["name"] else [duthost]
+        for dut in dut_list:
+            clear_dut_arp_cache(dut)
+            fdb_cleanup(dut)
     except RunAnsibleModuleFail as e:
         if 'Failed to send flush request: No such file or directory' in str(e):
             logger.warning("Failed to clear arp cache or cleanup fdb table, file may not exist yet")


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
In dualtor setup, although arp stress test would be run at the selected tor, there would be arp table leftovers at the non selected tor indeed.
It should also be cleaned for the non selected tor


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Enhance test to remove arp table leftovers at the non selected tor in dualtor setup
#### How did you do it?
Clean the arp table leftovers at the non selected tor in dualtor setup
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
