### PR TITLE
Update the host list during vsonic start up

### DIFF
--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -92,8 +92,9 @@ def session(new_params):
     seq.extend([
         ('pkill dhclient', [r'#']),
         ('hostname %s' % str(new_params['hostname']), [r'#']),
-        ('sed -i s:sonic:%s: /etc/hosts' %
-         str(new_params['hostname']), [r'#']),
+        ('if grep -q "sonic" /etc/hosts; then sed -i s:sonic:%s: /etc/hosts; \
+            else echo "127.0.0.1 %s" >> /etc/hosts; fi' %
+            (str(new_params['hostname']), str(new_params['hostname'])), [r'#']),
         ('ifconfig eth0 %s' % str(new_params['mgmt_ip']), [r'#']),
         ('ifconfig eth0', [r'#']),
         ('ip route add 0.0.0.0/0 via %s table default' %


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
If there is no placeholder 'sonic' in file /etc/hosts at the vsonic VM, the sudo command would be failed due to execution timeout. 
In this case, the vsonic start up script should also add an entry for the current hostname, in order to avoid sudo action timeout due to lacking of trusted entry in /etc/host file.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
If there is no placeholder 'sonic' in file /etc/hosts at the vsonic VM, the sudo command during topology deployment would be failed due to command execution timeout. 
#### How did you do it?
In this case, the vsonic start up script should also add an entry for the current hostname, in order to avoid sudo action timeout due to lacking of trusted entry in /etc/host file.
#### How did you verify/test it?
Deploy the vsonic topology locally.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
