### PR TITLE
Preserve original saithrift URL for vendor URLs and private images

### DIFF
--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -384,7 +384,7 @@ def get_asic_and_branch_name(duthost):
 
     Supported image version patterns:
     1. Master: SONiC Software Version: SONiC.master.921927-18199d73f
-    2. Internal: SONiC Software Version: SONiC.internal.135691748-dbb8d29985  
+    2. Internal: SONiC Software Version: SONiC.internal.135691748-dbb8d29985
     3. Official feature branch: SONiC Software Version: SONiC.20250510.14
     4. Private image: SONiC Software Version: SONiC.20250902_202505_counters.135706687-5bc1f6cba6
 
@@ -404,7 +404,7 @@ def get_asic_and_branch_name(duthost):
     master_pattern = re.compile(r'^SONiC\.master\.\d+-[a-f0-9]+$', re.IGNORECASE)
     if master_pattern.match(version):
         branch_name = "master"
-    # Pattern 2: Internal - SONiC.internal.XXXXXXXXX-XXXXXXXXXX  
+    # Pattern 2: Internal - SONiC.internal.XXXXXXXXX-XXXXXXXXXX
     elif re.match(r'^SONiC\.internal\.\d+-[a-f0-9]+$', version, re.IGNORECASE):
         branch_name = "internal"
     # Pattern 3: Official feature branch - SONiC.YYYYMMDD.XX


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

1. fix issue: https://github.com/sonic-net/sonic-mgmt/issues/20072
2. URL remains unchanged when private image

#### How did you do it?

do not modify non-msft url

#### How did you verify/test it?

ut and local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
