### PR TITLE
Remove application dependent fields from get_transceiver_info tests.

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -156,3 +156,6 @@ def get_all_thermals(conn, index):
 
 def get_thermal(conn, index, thermal_index):
     return sfp_api(conn, index, 'get_thermal', [thermal_index])
+
+def is_coherent_module(conn, index):
+    return sfp_api(conn, index, 'is_coherent_module')

--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -157,5 +157,6 @@ def get_all_thermals(conn, index):
 def get_thermal(conn, index, thermal_index):
     return sfp_api(conn, index, 'get_thermal', [thermal_index])
 
+
 def is_coherent_module(conn, index):
     return sfp_api(conn, index, 'is_coherent_module')

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -118,11 +118,7 @@ class TestSfpApi(PlatformApiTestBase):
     EXPECTED_XCVR_NEW_CMIS_INFO_KEYS = ['host_lane_count',
                                         'media_lane_count',
                                         'cmis_rev',
-                                        'host_lane_assignment_option',
                                         'media_interface_technology',
-                                        'media_interface_code',
-                                        'host_electrical_interface',
-                                        'media_lane_assignment_option',
                                         'vdm_supported']
 
     EXPECTED_XCVR_NEW_CMIS_FIRMWARE_INFO_KEYS = ['active_firmware',
@@ -477,7 +473,7 @@ class TestSfpApi(PlatformApiTestBase):
                                 if self.expect(isinstance(firmware_info_dict, dict),
                                                "Transceiver {} firmware info appears incorrect".format(i)):
                                     actual_keys.extend(list(firmware_info_dict.keys()))
-                            if 'ZR' in info_dict['media_interface_code']:
+                            if sfp.is_coherent_module(platform_api_conn, i):
                                 UPDATED_EXPECTED_XCVR_INFO_KEYS = UPDATED_EXPECTED_XCVR_INFO_KEYS + \
                                                                   self.QSFPZR_EXPECTED_XCVR_INFO_KEYS
                         else:
@@ -553,7 +549,7 @@ class TestSfpApi(PlatformApiTestBase):
                     expected_keys = list(self.EXPECTED_XCVR_COMMON_THRESHOLD_INFO_KEYS)
                     if info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X"]:
                         expected_keys += self.QSFPDD_EXPECTED_XCVR_THRESHOLD_INFO_KEYS
-                        if 'ZR' in info_dict["media_interface_code"]:
+                        if sfp.is_coherent_module(platform_api_conn, i):
                             if 'INPHI CORP' in info_dict['manufacturer'] and 'IN-Q3JZ1-TC' in info_dict['model']:
                                 logger.info("INPHI CORP Transceiver is not populating the associated threshold fields \
                                              in redis TRANSCEIVER_DOM_THRESHOLD table. Skipping this transceiver")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: As a result of https://github.com/sonic-net/sonic-platform-common/pull/590 , the application dependent fields are not returned by get_transceiver_info api. `platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info` and 
`platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info` were failing as a result. Removed application dependent fields from the tests to get them to pass again.
Fixes # (issue)
Fixes failure of `platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info` and 
`platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info` tests after https://github.com/sonic-net/sonic-platform-common/pull/590 is merged.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
As a result of https://github.com/sonic-net/sonic-platform-common/pull/590 , the application dependent fields are not returned by get_transceiver_info api. `platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_info` and 
`platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_threshold_info` were failing as a result. 

#### How did you do it?
Removed application dependent fields from the tests to get the tests to pass again. And updated the logic to check if the optic is a ZR module.
 
#### How did you verify/test it?
Ran the sonic-mgmt tests with various optics. The tests are passing after this change.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
ADO: 34547252