### PR TITLE
[dhcpmon] Update pps for dhcpmon stress test

### DIFF
--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -22,6 +22,10 @@ DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 DUAL_TOR_MODE = 'dual'
 logger = logging.getLogger(__name__)
+PACKET_RATE_PER_SEC_MAP = {
+    "Mellanox-SN2700": 20
+}
+DEFAULT_PACKET_RATE_PER_SEC = 25
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
@@ -31,12 +35,13 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
                                        dhcp_type, clean_processes_after_stress_test,
                                        rand_unselected_dut, request):
     '''
-    Test DHCP relay counters functionality can handle the maximum load within 5% miss.
+    Test DHCP relay counters functionality can handle the maximum load within 0.01% miss.
     '''
     testing_mode, duthost = testing_config
     packets_send_duration = 120
     error_margin = 0.01
-    client_packets_per_sec = 25\
+    dut_hwsku = duthost.facts["hwsku"]
+    client_packets_per_sec = PACKET_RATE_PER_SEC_MAP.get(dut_hwsku, DEFAULT_PACKET_RATE_PER_SEC) \
         if request.config.option.max_packets_per_sec is None else request.config.option.max_packets_per_sec
     logger.info("Testing mode: {}, client packets per second: {}, error margin: {}".format(
         testing_mode, client_packets_per_sec, error_margin))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
25 PPS is too high for 2700 hwsku

#### How did you do it?
Use 20 pps for 2700

#### How did you verify/test it?
Run test in 2700 t0 and non-2700 t0

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
