### PR TITLE
Parameterize gNMI CONFIG DB tests with different VRFs

### DIFF
--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -295,12 +295,12 @@ def create_revoked_cert_and_crl(localhost, ptfhost, duthost=None):
     localhost.shell(local_command)
 
 
-def create_gnmi_certs(duthost, localhost, ptfhost):
+def create_gnmi_certs(duthost, localhost, ptfhost, dut_ip=None):
     '''
     Create GNMI client certificates
     '''
     prepare_root_cert(localhost)
-    prepare_server_cert(duthost, localhost)
+    prepare_server_cert(duthost, localhost, dut_ip=dut_ip)
     prepare_client_cert(localhost)
     create_revoked_cert_and_crl(localhost, ptfhost)
     copy_certificate_to_dut(duthost)
@@ -351,10 +351,10 @@ def create_root_cert(localhost, days):
     _write_pem_certificate("gnmiCA.pem", cert)
 
 
-def prepare_server_cert(duthost, localhost, days="825"):
+def prepare_server_cert(duthost, localhost, days="825", dut_ip=None):
     create_server_key(localhost)
     create_server_csr(localhost)
-    sign_server_certificate(duthost, localhost, days)
+    sign_server_certificate(duthost, localhost, days, dut_ip=dut_ip)
 
 
 def create_server_key(localhost):
@@ -371,15 +371,20 @@ def create_server_csr(localhost):
     localhost.shell(local_command)
 
 
-def sign_server_certificate(duthost, localhost, days):
-    """Sign gnmiserver.csr with the CA, backdated, with SAN (hostname.com + DUT mgmt IP)."""
+def sign_server_certificate(duthost, localhost, days, dut_ip=None):
+    """Sign gnmiserver.csr with the CA, backdated, with SAN (hostname.com + DUT mgmt IP).
+
+    When dut_ip is provided, it is used as the SAN IP address instead of
+    duthost.mgmt_ip. This lets callers bind the cert to the address the
+    gnmi server is actually reachable at (e.g. when bound to a non-default VRF).
+    """
     ca_cert = _load_pem_certificate("gnmiCA.pem")
     ca_key = _load_pem_private_key("gnmiCA.key")
     csr = _load_pem_csr("gnmiserver.csr")
     not_before, not_after = _cert_validity_period(days)
     san_entries = [
         x509.DNSName("hostname.com"),
-        x509.IPAddress(ipaddress.ip_address(duthost.mgmt_ip)),
+        x509.IPAddress(ipaddress.ip_address(dut_ip or duthost.mgmt_ip)),
     ]
     cert = (
         x509.CertificateBuilder()

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -50,6 +50,8 @@ FORCED_MGMT_ROUTE_PRIORITY = 32764
 # Wait 300 seconds because sometime 'interfaces-config' service take 45 seconds to response
 # interfaces-config service issue track by: https://github.com/sonic-net/sonic-buildimage/issues/19045
 FILE_CHANGE_TIMEOUT = 300
+DEFAULT_VRF_NAME = "default"
+MGMT_VRF_NAME = "mgmt"
 
 NON_USER_CONFIG_TABLES = ["FLEX_COUNTER_TABLE", "ASIC_SENSORS", "LOGGER"]
 

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -3,7 +3,8 @@ import logging
 
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
-from tests.gnmi.helper import gnmi_container, apply_cert_config, recover_cert_config
+from tests.common.helpers.gnmi_utils import gnmi_container
+from tests.gnmi.helper import apply_cert_config, recover_cert_config
 from tests.gnmi.helper import GNMI_SERVER_START_WAIT_TIME, check_ntp_sync_status
 from tests.common.gu_utils import create_checkpoint, rollback
 from tests.common.helpers.gnmi_utils import create_revoked_cert_and_crl, create_gnmi_certs, \
@@ -14,6 +15,24 @@ from tests.common.helpers.ntp_helper import setup_ntp_context
 
 logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
+
+VRF_SCENARIOS = [
+    {"name": "default_1", "vrf": None, "description": "Default (no VRF)"},
+]
+
+
+@pytest.fixture(scope="module", params=VRF_SCENARIOS, ids=lambda scenario: f"vrf_{scenario['name']}")
+def vrf_config(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_vrf_configuration(vrf_config):
+    """
+    This fixture runs before setup_gnmi_server to ensure VRF config is in place.
+    It gets overridden in tests that parameterize the gNMI server VRF binding.
+    """
+    return vrf_config
 
 
 @pytest.fixture(scope="module")
@@ -42,7 +61,7 @@ def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
 
 
 @pytest.fixture(scope="module")
-def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
+def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost, vrf_config, setup_vrf_configuration):
     '''
     Setup GNMI server with client certificates
     '''
@@ -53,10 +72,10 @@ def setup_gnmi_server(duthosts, rand_one_dut_hostname, localhost, ptfhost):
         check_container_state(duthost, gnmi_container(duthost), should_be_running=True),
         "Test was not supported on devices which do not support GNMI!")
 
-    create_gnmi_certs(duthost, localhost, ptfhost)
+    create_gnmi_certs(duthost, localhost, ptfhost, dut_ip=vrf_config.get("dut_ip"))
 
     create_checkpoint(duthost, SETUP_ENV_CP)
-    stopped_programs = apply_cert_config(duthost)
+    stopped_programs = apply_cert_config(duthost, vrf_config.get("vrf"))
 
     yield
 

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -6,7 +6,6 @@ from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import get_dpu_ip, get_dpu_port
 from tests.common.helpers.gnmi_utils import GNMIEnvironment, add_gnmi_client_common_name, del_gnmi_client_common_name, \
                                             dump_gnmi_log, dump_system_status
-from tests.common.helpers.gnmi_utils import gnmi_container   # noqa: F401
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
 from tests.common.helpers.dut_utils import check_container_state
 
@@ -19,7 +18,12 @@ GNMI_PORT = 0
 GNMI_SERVER_START_WAIT_TIME = 15
 
 
-def apply_cert_config(duthost):
+def is_mgmt_vrf_enabled(duthost):
+    res = duthost.shell('sudo sonic-db-cli CONFIG_DB HGET "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled"')["stdout"]
+    return res == "true"
+
+
+def apply_cert_config(duthost, vrf_name=None):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     # Get subtype
     cfg_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -50,6 +54,8 @@ def apply_cert_config(duthost):
     dut_command += "--enable_crl=true "
     if subtype == 'SmartSwitch':
         dut_command += "--zmq_address=tcp://127.0.0.1:8100 "
+    if vrf_name:
+        dut_command += "--gnmi_vrf %s " % vrf_name
     dut_command += "--ca_crt /etc/sonic/telemetry/gnmiCA.pem -gnmi_native_write=true -v=10 >/root/gnmi.log 2>&1 &\""
     duthost.shell(dut_command)
 
@@ -193,7 +199,7 @@ def check_system_time_sync(duthost):
         return False
 
 
-def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None):
+def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None, ip=None):
     """
     Send GNMI set request with GNMI client
 
@@ -207,7 +213,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
     Returns:
     """
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    ip = duthost.mgmt_ip
+    ip = ip or duthost.mgmt_ip
     port = env.gnmi_port
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
     cmd += '--timeout 30 '
@@ -276,7 +282,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
         raise Exception(f"py_gnmicli failed rc={rc}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")
 
 
-def gnmi_get(duthost, ptfhost, path_list):
+def gnmi_get(duthost, ptfhost, path_list, ip=None):
     """
     Send GNMI get request with GNMI client
 
@@ -289,7 +295,7 @@ def gnmi_get(duthost, ptfhost, path_list):
         msg_list: list for get result
     """
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    ip = duthost.mgmt_ip
+    ip = ip or duthost.mgmt_ip
     port = env.gnmi_port
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
     cmd += '--timeout 30 '
@@ -325,7 +331,7 @@ def gnmi_get(duthost, ptfhost, path_list):
 
 # py_gnmicli does not fully support POLLING mode
 # Use gnmi_cli instead
-def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count):
+def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count, ip=None, vrf_name=None):
     """
     Send GNMI subscribe request with GNMI client
 
@@ -335,6 +341,9 @@ def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count):
         path_list: list for get path
         interval_ms: interval, unit is ms
         count: update count
+        ip: server IP to connect to (defaults to duthost.mgmt_ip)
+        vrf_name: when set, run gnmi_cli on the DUT inside the given VRF
+            (using `ip vrf exec`) instead of inside the gnmi container.
 
     Returns:
         msg: gnmi client output
@@ -343,12 +352,18 @@ def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count):
         logger.error("path_list is None")
         return "", ""
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    dut_facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
-    ip = f"[{duthost.mgmt_ip}]" if dut_facts.get('is_mgmt_ipv6_only', False) else duthost.mgmt_ip
+    if ip is None:
+        dut_facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
+        ip = f"[{duthost.mgmt_ip}]" if dut_facts.get('is_mgmt_ipv6_only', False) else duthost.mgmt_ip
     port = env.gnmi_port
     interval = interval_ms / 1000.0
-    # Run gnmi_cli in gnmi container as workaround
-    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, ip, port)
+    # For a non-default VRF the gnmi container does not have `ip vrf exec`
+    # privileges, so run gnmi_cli on the DUT host in the target VRF instead.
+    if vrf_name and vrf_name != "default":
+        cmd = "sudo ip vrf exec %s /tmp/gnmi_cli -client_types=gnmi -a %s:%s " % (vrf_name, ip, port)
+    else:
+        # Run gnmi_cli in gnmi container as workaround
+        cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, ip, port)
     cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "
@@ -364,7 +379,8 @@ def gnmi_subscribe_polling(duthost, ptfhost, path_list, interval_ms, count):
     return output['stdout'], output['stderr']
 
 
-def gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, interval_ms, count, origin=None, target=None):
+def gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, interval_ms, count, origin=None, target=None,
+                                    ip=None):
     """
     Send GNMI subscribe request with GNMI client
 
@@ -382,7 +398,7 @@ def gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, interval_ms, co
         logger.error("path_list is None")
         return "", ""
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    ip = duthost.mgmt_ip
+    ip = ip or duthost.mgmt_ip
     port = env.gnmi_port
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
     cmd += '--timeout 30 '
@@ -407,7 +423,7 @@ def gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, interval_ms, co
     return msg, output['stderr']
 
 
-def gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, count):
+def gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, count, ip=None):
     """
     Send GNMI subscribe request with GNMI client
 
@@ -424,7 +440,7 @@ def gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, count):
         logger.error("path_list is None")
         return "", ""
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    ip = duthost.mgmt_ip
+    ip = ip or duthost.mgmt_ip
     port = env.gnmi_port
     cmd = '/root/env-python3/bin/python /root/gnxi/gnmi_cli_py/py_gnmicli.py '
     cmd += '--timeout 120 '

--- a/tests/gnmi/test_gnmi_configdb.py
+++ b/tests/gnmi/test_gnmi_configdb.py
@@ -5,12 +5,12 @@ import pytest
 import re
 import time
 
-from .helper import gnmi_set, gnmi_get
+from .helper import gnmi_set, gnmi_get, is_mgmt_vrf_enabled
 from .helper import gnmi_subscribe_polling
 from .helper import gnmi_subscribe_streaming_sample, gnmi_subscribe_streaming_onchange
-from tests.common.helpers.gnmi_utils import add_gnmi_client_common_name
+from tests.common.helpers.gnmi_utils import add_gnmi_client_common_name, gnmi_container
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.utilities import wait_until
+from tests.common.utilities import DEFAULT_VRF_NAME, MGMT_VRF_NAME, wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,71 @@ pytestmark = [
 ]
 
 
-def get_first_interface(duthost):
+VRF_SCENARIOS = [
+    {"name": "default_1", "vrf": None, "description": "Default (no VRF)"},
+    {"name": "default_2", "vrf": DEFAULT_VRF_NAME, "description": f"Default (explicit '{DEFAULT_VRF_NAME}')"},
+    {"name": "mgmt", "vrf": MGMT_VRF_NAME, "description": "Management VRF"},
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def download_gnmi_client(duthosts, rand_one_dut_hostname):
+    """Stage gnmi_cli on the DUT host filesystem.
+
+    When the gNMI server is bound to a non-default VRF, gnmi_subscribe_polling
+    must run gnmi_cli via `sudo ip vrf exec <vrf> /tmp/gnmi_cli ...` on the DUT
+    host (the gnmi container itself does not have `ip vrf exec` privileges).
+    The binary ships only inside the container, so copy it out once per module.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    container = gnmi_container(duthost)
+    duthost.shell("docker cp %s:/usr/sbin/gnmi_cli /tmp/gnmi_cli" % container)
+    duthost.shell("chmod +x /tmp/gnmi_cli")
+
+
+@pytest.fixture(scope="module", params=VRF_SCENARIOS, ids=lambda scenario: f"vrf_{scenario['name']}")
+def vrf_config(request, duthost, ptfhost):
+    vrf_cfg = request.param.copy()
+    vrf_cfg.update({
+        "dut_ip": duthost.mgmt_ip,
+        "ptf_ip": ptfhost.mgmt_ip,
+        "dut_intf": "eth0",
+        "ptf_intf": "mgmt",
+    })
+    return vrf_cfg
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_vrf_configuration(duthosts, rand_one_dut_hostname, vrf_config):
+    """
+    This fixture runs before setup_gnmi_server to ensure VRF config is in place.
+    Only default and mgmt VRFs are supported.
+
+    While these GNMI tests do not depend on SNMP, some tests fail while waiting
+    for all critical processes to be up and running. These are caused by SNMP
+    agent address misconfiguration during VRF transition. Hence SNMP services
+    are stopped before toggling mgmt VRF and restarted after.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    vrf_name = vrf_config["vrf"]
+    mgmt_vrf_enabled = is_mgmt_vrf_enabled(duthost)
+
+    try:
+        if vrf_name == MGMT_VRF_NAME and not mgmt_vrf_enabled:
+            duthost.shell('sudo systemctl stop snmpd snmp-subagent', module_ignore_errors=True)
+            duthost.shell('sonic-db-cli CONFIG_DB hset "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled" "true"')
+            duthost.shell('sudo systemctl start snmpd snmp-subagent', module_ignore_errors=True)
+        yield vrf_config
+
+    finally:
+        if vrf_name == MGMT_VRF_NAME and not mgmt_vrf_enabled:
+            duthost.shell('sudo systemctl stop snmpd snmp-subagent', module_ignore_errors=True)
+            duthost.shell('sonic-db-cli CONFIG_DB hset "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled" "false"')
+            duthost.shell('sonic-db-cli CONFIG_DB hdel "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled"')
+            duthost.shell('sudo systemctl start snmpd snmp-subagent', module_ignore_errors=True)
+
+
+def get_first_interface(duthost, excluded_interfaces=[]):
     if duthost.is_supervisor_node():
         return None
     cmds = "show interface status"
@@ -41,8 +105,9 @@ def get_first_interface(duthost):
         interface_status = line.strip()
         assert len(interface_status) > 0, "Failed to read interface properties"
         sl = interface_status.split()
+        intf_name = sl[0]
         # Skip portchannel
-        if sl[lanes_index] == 'N/A':
+        if sl[lanes_index] == 'N/A' or intf_name in excluded_interfaces:
             continue
         if sl[admin_index] == 'up':
             return sl[0]
@@ -78,7 +143,7 @@ def wait_bgp_neighbor(duthost):
                   "Not all BGP sessions are established on DUT")
 
 
-def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI native write, incremental config for configDB
     Toggle interface admin status
@@ -87,7 +152,7 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     if duthost.is_supervisor_node():
         pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
     file_name = "port.txt"
-    interface = get_first_interface(duthost)
+    interface = get_first_interface(duthost, [vrf_config['dut_intf']])
     assert interface is not None, "Invalid interface"
     update_list = ["/sonic-db:CONFIG_DB/localhost/PORT/%s/admin_status:@/root/%s" % (interface, file_name)]
     path_list = ["/sonic-db:CONFIG_DB/localhost/PORT/%s/admin_status" % (interface)]
@@ -97,11 +162,11 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     with open(file_name, 'w') as file:
         file.write(text)
     ptfhost.copy(src=file_name, dest='/root')
-    gnmi_set(duthost, ptfhost, [], update_list, [])
+    gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
     # Check interface status and gnmi_get result
     status = get_interface_status(duthost, "admin_status", interface)
     assert status == "down", "Incremental config failed to toggle interface %s status" % interface
-    msg_list = gnmi_get(duthost, ptfhost, path_list)
+    msg_list = gnmi_get(duthost, ptfhost, path_list, ip=vrf_config["dut_ip"])
     assert msg_list[0] == "\"down\"", msg_list[0]
 
     # Startup interface
@@ -109,17 +174,17 @@ def test_gnmi_configdb_incremental_01(duthosts, rand_one_dut_hostname, ptfhost):
     with open(file_name, 'w') as file:
         file.write(text)
     ptfhost.copy(src=file_name, dest='/root')
-    gnmi_set(duthost, ptfhost, [], update_list, [])
+    gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
     # Check interface status and gnmi_get result
     status = get_interface_status(duthost, "admin_status", interface)
     assert status == "up", "Incremental config failed to toggle interface %s status" % interface
-    msg_list = gnmi_get(duthost, ptfhost, path_list)
+    msg_list = gnmi_get(duthost, ptfhost, path_list, ip=vrf_config["dut_ip"])
     assert msg_list[0] == "\"up\"", msg_list[0]
     # Wait for BGP neighbor to be up
     wait_bgp_neighbor(duthost)
 
 
-def test_gnmi_configdb_incremental_02(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_incremental_02(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI native write, incremental config for configDB
     GNMI set request with invalid path
@@ -134,7 +199,7 @@ def test_gnmi_configdb_incremental_02(duthosts, rand_one_dut_hostname, ptfhost):
         file.write(text)
     ptfhost.copy(src=file_name, dest='/root')
     try:
-        gnmi_set(duthost, ptfhost, [], update_list, [])
+        gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
     except Exception as e:
         logger.info("Incremental config failed: " + str(e))
     else:
@@ -158,7 +223,7 @@ test_data_metadata = [
 
 
 @pytest.mark.parametrize('test_data', test_data_metadata)
-def test_gnmi_configdb_polling_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
+def test_gnmi_configdb_polling_01(duthosts, rand_one_dut_hostname, ptfhost, test_data, vrf_config):
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe polling mode
@@ -166,12 +231,14 @@ def test_gnmi_configdb_polling_01(duthosts, rand_one_dut_hostname, ptfhost, test
     duthost = duthosts[rand_one_dut_hostname]
     exp_cnt = 3
     path_list = [test_data["path"]]
-    msg, _ = gnmi_subscribe_polling(duthost, ptfhost, path_list, 1000, exp_cnt)
+    msg, _ = gnmi_subscribe_polling(
+        duthost, ptfhost, path_list, 1000, exp_cnt, ip=vrf_config["dut_ip"], vrf_name=vrf_config["vrf"]
+    )
     assert msg.count("bgp_asn") >= exp_cnt, test_data["name"] + ": " + msg
 
 
 @pytest.mark.parametrize('test_data', test_data_metadata)
-def test_gnmi_configdb_streaming_sample_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
+def test_gnmi_configdb_streaming_sample_01(duthosts, rand_one_dut_hostname, ptfhost, test_data, vrf_config):
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe streaming sample mode
@@ -180,12 +247,12 @@ def test_gnmi_configdb_streaming_sample_01(duthosts, rand_one_dut_hostname, ptfh
     exp_cnt = 5
     path_list = [test_data["path"]]
     msg, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, exp_cnt,
-                                             origin="sonic-db")
+                                             origin="sonic-db", ip=vrf_config["dut_ip"])
     assert msg.count("bgp_asn") >= exp_cnt, test_data["name"] + ": " + msg
 
 
 @pytest.mark.parametrize('test_data', test_data_metadata)
-def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, ptfhost, test_data):
+def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, ptfhost, test_data, vrf_config):
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe streaming onchange mode
@@ -209,13 +276,13 @@ def test_gnmi_configdb_streaming_onchange_01(duthosts, rand_one_dut_hostname, pt
     client_task.start()
     exp_cnt = 5
     path_list = [test_data["path"]]
-    msg, _ = gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, exp_cnt*2)
+    msg, _ = gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, exp_cnt*2, ip=vrf_config["dut_ip"])
     run_flag.value = False
     client_task.join()
     assert msg.count("bgp_asn") >= exp_cnt, test_data["name"] + ": " + msg
 
 
-def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI subscribe API, streaming onchange mode
     Subscribe table, and verify gnmi output has table key
@@ -236,7 +303,7 @@ def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, pt
     client_task.start()
     exp_cnt = 3
     path_list = ["/sonic-db:CONFIG_DB/localhost/DEVICE_METADATA"]
-    msg, _ = gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, exp_cnt)
+    msg, _ = gnmi_subscribe_streaming_onchange(duthost, ptfhost, path_list, exp_cnt, ip=vrf_config["dut_ip"])
     run_flag.value = False
     client_task.join()
 
@@ -250,7 +317,7 @@ def test_gnmi_configdb_streaming_onchange_02(duthosts, rand_one_dut_hostname, pt
         assert "bgp_asn" in result["localhost"], "Invalid result: " + match
 
 
-def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI native write, full config replace for configDB
     Toggle interface admin status
@@ -258,7 +325,7 @@ def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost)
     duthost = duthosts[rand_one_dut_hostname]
     if duthost.is_supervisor_node():
         pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
-    interface = get_first_interface(duthost)
+    interface = get_first_interface(duthost, [vrf_config['dut_intf']])
     assert interface is not None, "Invalid interface"
 
     # Get ASIC namespace and check interface
@@ -289,7 +356,7 @@ def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost)
     ptfhost.copy(src=filename, dest='/root')
 
     replace_list = ["/sonic-db:CONFIG_DB/localhost/:@/root/%s" % filename]
-    gnmi_set(duthost, ptfhost, [], [], replace_list)
+    gnmi_set(duthost, ptfhost, [], [], replace_list, ip=vrf_config["dut_ip"])
 
     # Check that interface is down after full config push
     pytest_assert(
@@ -303,7 +370,7 @@ def test_gnmi_configdb_full_replace_01(duthosts, rand_one_dut_hostname, ptfhost)
     wait_bgp_neighbor(duthost)
 
 
-def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI native write with authentication
     '''
@@ -319,7 +386,7 @@ def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = "gnmi_config_db_noaccess"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_set(duthost, ptfhost, [], update_list, [])
+            gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to set: " + str(e))
             assert role in str(e), str(e)
@@ -328,7 +395,7 @@ def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = "gnmi_config_db_readwrite"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_set(duthost, ptfhost, [], update_list, [])
+            gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to set: " + str(e))
             pytest.fail("Set request failed: " + str(e))
@@ -337,7 +404,7 @@ def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = "gnmi_config_db_readonly"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_set(duthost, ptfhost, [], update_list, [])
+            gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to set: " + str(e))
             assert role in str(e), str(e)
@@ -346,7 +413,7 @@ def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = ""
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_set(duthost, ptfhost, [], update_list, [])
+            gnmi_set(duthost, ptfhost, [], update_list, [], ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to set: " + str(e))
             assert "write access" in str(e), str(e)
@@ -355,7 +422,7 @@ def test_gnmi_configdb_set_authenticate(duthosts, rand_one_dut_hostname, ptfhost
     add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
-def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI native read with authentication
     '''
@@ -366,7 +433,7 @@ def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = "gnmi_config_db_noaccess"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_get(duthost, ptfhost, path_list)
+            gnmi_get(duthost, ptfhost, path_list, ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to get: " + str(e))
             assert role in str(e), str(e)
@@ -375,7 +442,7 @@ def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = "gnmi_config_db_readwrite"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_get(duthost, ptfhost, path_list)
+            gnmi_get(duthost, ptfhost, path_list, ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to get: " + str(e))
             pytest.fail("Get request failed: " + str(e))
@@ -384,7 +451,7 @@ def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = "gnmi_config_db_readonly"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_get(duthost, ptfhost, path_list)
+            gnmi_get(duthost, ptfhost, path_list, ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to get: " + str(e))
             pytest.fail("Get request failed: " + str(e))
@@ -393,7 +460,7 @@ def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost
         role = ""
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         try:
-            gnmi_get(duthost, ptfhost, path_list)
+            gnmi_get(duthost, ptfhost, path_list, ip=vrf_config["dut_ip"])
         except Exception as e:
             logger.info("Failed to get: " + str(e))
             pytest.fail("Get request failed: " + str(e))
@@ -402,7 +469,7 @@ def test_gnmi_configdb_get_authenticate(duthosts, rand_one_dut_hostname, ptfhost
     add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")
 
 
-def test_gnmi_configdb_subscribe_authenticate(duthosts, rand_one_dut_hostname, ptfhost):
+def test_gnmi_configdb_subscribe_authenticate(duthosts, rand_one_dut_hostname, ptfhost, vrf_config):
     '''
     Verify GNMI native read with authentication
     '''
@@ -413,7 +480,7 @@ def test_gnmi_configdb_subscribe_authenticate(duthosts, rand_one_dut_hostname, p
         role = "gnmi_config_db_noaccess"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         output, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, 1,
-                                                    origin="sonic-db")
+                                                    origin="sonic-db", ip=vrf_config["dut_ip"])
         logger.info("GNMI subscribe output: " + output)
         assert "GRPC error" in output, output
         assert role in output, output
@@ -422,7 +489,7 @@ def test_gnmi_configdb_subscribe_authenticate(duthosts, rand_one_dut_hostname, p
         role = "gnmi_config_db_readwrite"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         output, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, 1,
-                                                    origin="sonic-db")
+                                                    origin="sonic-db", ip=vrf_config["dut_ip"])
         assert "GRPC error" not in output, output
         assert "cloudtype" in output, output
 
@@ -430,7 +497,7 @@ def test_gnmi_configdb_subscribe_authenticate(duthosts, rand_one_dut_hostname, p
         role = "gnmi_config_db_readonly"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         output, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, 1,
-                                                    origin="sonic-db")
+                                                    origin="sonic-db", ip=vrf_config["dut_ip"])
         assert "GRPC error" not in output, output
         assert "cloudtype" in output, output
 
@@ -438,7 +505,7 @@ def test_gnmi_configdb_subscribe_authenticate(duthosts, rand_one_dut_hostname, p
         role = ""
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
         output, _ = gnmi_subscribe_streaming_sample(duthost, ptfhost, path_list, 0, 1,
-                                                    origin="sonic-db")
+                                                    origin="sonic-db", ip=vrf_config["dut_ip"])
         assert "GRPC error" not in output, output
         assert "cloudtype" in output, output
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Parameterize gNMI CONFIG DB tests with different VRFs to ensure correct VRF binding of gNMI listener

Summary:
Fixes https://github.com/sonic-net/sonic-gnmi/issues/504
Depends on:
- https://github.com/sonic-net/sonic-gnmi/pull/503
- https://github.com/sonic-net/sonic-buildimage/pull/23867
- https://github.com/sonic-net/sonic-utilities/pull/4395

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To test the changes in https://github.com/sonic-net/sonic-gnmi/pull/503 and https://github.com/sonic-net/sonic-buildimage/pull/23867

#### How did you do it?
Parameterized `test_gnmi_configdb.py` with `default`, `mgmt_vrf` and a custom VRF scenario.

#### How did you verify/test it?
Manual verification of relevant changes are already done with the `sonic-buildimage` changes.
The updated tests ran successfully in local setup.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
Any testbed works for the default and `mvrf` test cases.
Custom non-mgmt VRF testcase requires a `t0` topology for now, but it is not a realistic case anyway since the gNMI request is shoved through a dataplane VRF.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA

#### A picture of a cute animal (not mandatory but encouraged)
![samoyed](https://github.com/user-attachments/assets/fb646e32-3eca-4130-a530-7bc34b7f68d0)
