### PR TITLE
[BGP] use `loopback3` address for dynamic bgp sessions

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -213,8 +213,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
                 return vlan_intf
         raise ValueError("No Vlan interface defined in current topo")
 
-    def _find_loopback_interface(mg_facts):
-        loopback_intf_name = "Loopback0"
+    def _find_loopback_interface(mg_facts, loopback_intf_name="Loopback0"):
         for loopback in mg_facts["minigraph_lo_interfaces"]:
             if loopback["name"] == loopback_intf_name:
                 return loopback
@@ -225,7 +224,7 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
         try:
             connections = []
             vlan_intf = _find_vlan_intferface(mg_facts)
-            loopback_intf = _find_loopback_interface(mg_facts)
+            loopback_intf = _find_loopback_interface(mg_facts, "Loopback3")
             vlan_intf_addr = vlan_intf["addr"]
             vlan_intf_prefixlen = vlan_intf["prefixlen"]
             loopback_intf_addr = loopback_intf["addr"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The dynamic BGP sessions on dualtor connect to DUT's `Loopback3` address by design.
Let's enforce this behavior.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
As the motivation

#### How did you verify/test it?
```
bgp/test_bgp_peer_shutdown.py::test_bgp_peer_shutdown[bjw-can-7260-16-default] PASSED [100%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[bjw-can-7260-16-default] PASSED [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down[bjw-can-7260-16-default] PASSED [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
