### PR TITLE
minigraph template changes needed for FS voq

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -332,6 +332,15 @@
 
     when: switch_type is defined and switch_type == 'voq' and slot_num is defined and asic_topo_config|length > 0
 
+  - name: set default voq_chassis
+    set_fact:
+      voq_chassis: false
+
+  - name: set voq_chassis
+    set_fact:
+      voq_chassis: true
+    when: switch_type is defined and switch_type == 'voq' and slot_num is defined
+
   - name: create minigraph file in ansible minigraph folder
     template: src=templates/minigraph_template.j2
               dest=minigraph/{{ inventory_hostname}}.{{ topo }}.xml

--- a/ansible/templates/minigraph_cpg.j2
+++ b/ansible/templates/minigraph_cpg.j2
@@ -92,7 +92,7 @@
 {% endfor %}
 {% endfor %}
 {% endif %}
-{% if switch_type is defined and (switch_type == 'voq' or switch_type == 'chassis-packet') %}
+{% if (switch_type is defined and switch_type == 'chassis-packet') or voq_chassis %}
 {% set chassis_ibgp_peers = dict() %}
 {% for asic_id in range(num_asics) %}
 {% if num_asics == 1 %}
@@ -112,7 +112,7 @@
 {% set end_rtr = a_linecard + "-ASIC" + idx|string %}
 {% endif %}
 {% endif %}
-{% if switch_type == 'voq' %}
+{% if voq_chassis %}
 {% set _ = chassis_ibgp_peers.update({ all_inbands[a_linecard][idx].split('/')[0] : end_rtr }) %}
 {% else %}
 {% set _ = chassis_ibgp_peers.update({ all_loopback4096[a_linecard][idx].split('/')[0] : end_rtr }) %}
@@ -120,7 +120,7 @@
       <BGPSession>
         <StartRouter>{{ start_rtr }}</StartRouter>
         <EndRouter>{{ end_rtr }}</EndRouter>
-{% if switch_type == 'voq' %}
+{% if voq_chassis %}
         <StartPeer>{{ voq_inband_ip[asic_id].split('/')[0] }}</StartPeer>
         <EndPeer>{{ all_inbands[a_linecard][idx].split('/')[0] }}</EndPeer>
 {% else %}
@@ -135,7 +135,7 @@
       <BGPSession>
         <StartRouter>{{ start_rtr }}</StartRouter>
         <EndRouter>{{ end_rtr }}</EndRouter>
-{% if switch_type == 'voq' %}
+{% if voq_chassis %}
         <StartPeer>{{ voq_inband_ipv6[asic_id].split('/')[0] }}</StartPeer>
         <EndPeer>{{ all_inbands_ipv6[a_linecard][idx].split('/')[0] }}</EndPeer>
 {% else %}
@@ -171,7 +171,7 @@
 {% endfor %}
 {% endif %}
 {% endfor %}
-{% if num_asics == 1 and switch_type is defined and (switch_type == 'voq' or switch_type == 'chassis-packet') %}
+{% if num_asics == 1 and ((switch_type is defined and switch_type == 'chassis-packet') or voq_chassis) %}
 {% for a_chassis_ibgp_peer in chassis_ibgp_peers %}
           <BGPPeer>
             <Address>{{ a_chassis_ibgp_peer }}</Address>
@@ -230,7 +230,7 @@
           </BGPPeer>
 {% endif %}
 {% endfor %}
-{% if switch_type is defined and switch_type == 'voq' %}
+{% if voq_chassis %}
 {% set asic_id = asic.split('ASIC')[1]|int %}
 {% for a_linecard in all_loopback4096 %}
 {% for idx in range(all_loopback4096[a_linecard]|length) %}
@@ -263,13 +263,13 @@
       </a:BGPRouterDeclaration>
 {% endfor %}
 {% endif %}
-{% if switch_type is defined and (switch_type == 'voq' or switch_type == 'chassis-packet') %}
+{% if (switch_type is defined and switch_type == 'chassis-packet') or voq_chassis %}
 {% for a_linecard in all_loopback4096 %}
 {% if a_linecard != inventory_hostname %}
 {% for idx in range(all_loopback4096[a_linecard]|length) %}
       <a:BGPRouterDeclaration>
         <a:ASN>{{ vm_topo_config['dut_asn'] }}</a:ASN>
-{% if switch_type == 'voq' %}
+{% if voq_chassis %}
         <a:Hostname>{{ chassis_ibgp_peers[all_inbands[a_linecard][idx].split('/')[0]] }}</a:Hostname>
 {% else %}
         <a:Hostname>{{ chassis_ibgp_peers[all_loopback4096[a_linecard][idx].split('/')[0]] }}</a:Hostname>


### PR DESCRIPTION

### Description of PR
For VOQ fixed systems, bgp configuration needed for chassis should not be generated.

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
- ibgp peering configuration should not be generated for FS voq

#### How did you do it?
- added task to set if the system is a chassis or FS
- update minigraph templates to not generate chassis configs for FS

#### How did you verify/test it?
- VOQ mode is up and BGP tests pass (few sonic-mgmt BGP tests failures are under triage)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
