### PR TITLE
sonic-mgmt: BGP TSA testcases failure in t2 non-chassis

### DIFF
--- a/tests/common/devices/duthosts.py
+++ b/tests/common/devices/duthosts.py
@@ -100,13 +100,7 @@ class DutHosts(object):
             self._nodes_for_parallel_initial_checks if self.is_parallel_leader else self._nodes_for_parallel_tests
         )
 
-        self._supervisor_nodes = self._Nodes([
-            node for node in self._nodes_for_parallel if node.is_supervisor_node()
-        ])
-
-        self._frontend_nodes = self._Nodes([
-            node for node in self._nodes_for_parallel if node.is_frontend_node()
-        ])
+        self.__assign_groups(self._nodes_for_parallel)
 
     def __initialize_nodes(self):
         self._nodes = self._Nodes([
@@ -118,8 +112,7 @@ class DutHosts(object):
             ) for hostname in self.tbinfo["duts"] if hostname in self.duts
         ])
 
-        self._supervisor_nodes = self._Nodes([node for node in self._nodes if node.is_supervisor_node()])
-        self._frontend_nodes = self._Nodes([node for node in self._nodes if node.is_frontend_node()])
+        self.__assign_groups(self._nodes)
 
     def __should_reinit_when_parallel(self):
         return (
@@ -137,8 +130,17 @@ class DutHosts(object):
             self.parallel_run_stage = NON_INITIAL_CHECKS_STAGE
             self._nodes_for_parallel = self._nodes_for_parallel_tests
 
-        self._supervisor_nodes = self._Nodes([node for node in self._nodes_for_parallel if node.is_supervisor_node()])
-        self._frontend_nodes = self._Nodes([node for node in self._nodes_for_parallel if node.is_frontend_node()])
+        self.__assign_groups(self._nodes_for_parallel)
+
+    def __assign_groups(self, nodes):
+        """Assign supervisor_nodes and frontend_nodes based on provided nodes list.
+        For non-chassis (no supervisors), frontend_nodes is an empty list.
+        """
+        self._supervisor_nodes = self._Nodes([node for node in nodes if node.is_supervisor_node()])
+        if any(node.is_supervisor_node() for node in nodes):
+            self._frontend_nodes = self._Nodes([node for node in nodes if node.is_frontend_node()])
+        else:
+            self._frontend_nodes = self._Nodes([])
 
     @property
     def nodes(self):


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-mgmt/issues/20468

Description:
Following 4 testcases are failing in Q3D and t2 topology/

bgp/reliable_tsa/test_reliable_tsa_flaky.py
bgp/reliable_tsa/test_reliable_tsa_stable.py
bgp/test_traffic_shift_sup.py
bgp/test_traffic_shift.py
Rootcause:

Test helpers and CLI scripts could touch CHASSIS_APP_DB based on “chassis-like” config signals without verifying that redis-chassis is running and the chassis DB socket is present. Resolution:

get_tsa_chassisdb_config(), verify_dut_configdb_tsa_value(): use CHASSIS_APP_DB only on a true chassis supervisor; otherwise use CONFIG_DB. This prevents CHASSIS_APP_DB queries on non‑chassis/linecards and eliminates spurious syslog errors. is_chassis_system: rely only on sonic_py_common.device_info.is_chassis(); removed is_supervisor_node fallback to prevent false positives. 

Signed-off-by: Selvamani Ramasamy <selva@nexthop.ai>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
