### PR TITLE
Ignore error message "Failed to confirm VDM freeze" due to github issue 23426

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -392,6 +392,6 @@ r, ".* ERR dhcp_relay\#supervisor-proc-exit-listener: Exception:.*len.*trace: Tr
 # https://github.com/sonic-net/sonic-buildimage/issues/23426
 r, ".*ERR pmon.*Failed to confirm VDM freeze status for port.*"
 r, ".*ERR pmon.*Failed to freeze VDM stats in contextmanager for port.*"
-r, ".*ERR pmon.*DOM-INFO-UPDATE: Failed to freeze VDM stats for port.*"
+r, ".*ERR pmon.*Failed to freeze VDM stats for port.*"
 r, ".*ERR pmon.*Failed to confirm VDM unfreeze status for port.*"
 r, ".*ERR pmon.*Failed to unfreeze VDM stats in contextmanager for port.*"


### PR DESCRIPTION

Summary: Ignore error message "Failed to confirm VDM freeze" due to github issue 23426
Fixes # 
PR https://github.com/sonic-net/sonic-mgmt/pull/20338 had Ignore error message "Failed to confirm VDM freeze" due to github issue 23426, need update the regex to match the error log

```
2025 Sep  2 21:03:33.593159 xxxxx ERR pmon#DomInfoUpdateTask[36]: Failed to freeze VDM stats for port 18
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
