### PR TITLE
add missing qos test parameter for topology dualtor-aa-56 on th2

### DIFF
--- a/tests/qos/files/qos_params.th2.yaml
+++ b/tests/qos/files/qos_params.th2.yaml
@@ -255,6 +255,97 @@ qos_params:
                 pg: 4
                 pkts_num_trig_pfc: 4457
                 pkts_num_dismiss_pfc: 12
+            ecn_1:
+                dscp: 8
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 208
+            ecn_2:
+                dscp: 8
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 208
+            ecn_3:
+                dscp: 0
+                ecn: 0
+                num_of_pkts: 5000
+                limit: 182000
+                min_limit: 180000
+                cell_size: 208
+            ecn_4:
+                dscp: 0
+                ecn: 1
+                num_of_pkts: 2047
+                limit: 182320
+                min_limit: 0
+                cell_size: 208
+            lossy_queue_1:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_trig_egr_drp: 10692
+            wrr:
+                ecn: 1
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+                limit: 80
+            wrr_chg:
+                ecn: 1
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80
+                limit: 80
+                lossy_weight: 8
+                lossless_weight: 30
+            wm_pg_shared_lossless:
+                dscp: 3
+                ecn: 1
+                pg: 3
+                pkts_num_fill_min: 6
+                pkts_num_trig_pfc: 4457
+                packet_size: 64
+                cell_size: 208
+            wm_pg_shared_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                pkts_num_fill_min: 0
+                pkts_num_trig_egr_drp: 10692
+                packet_size: 64
+                cell_size: 208
+            wm_q_shared_lossy:
+                dscp: 8
+                ecn: 1
+                queue: 0
+                pkts_num_fill_min: 8
+                pkts_num_trig_egr_drp: 10692
+                cell_size: 208
+            wm_buf_pool_lossy:
+                dscp: 8
+                ecn: 1
+                pg: 0
+                queue: 0
+                pkts_num_fill_ingr_min: 0
+                pkts_num_trig_egr_drp: 10692
+                pkts_num_fill_egr_min: 16
+                cell_size: 208
+            hdrm_pool_wm_multiplier: 4
+            cell_size: 208
         topo-any:
             40000_300m:
                 pkts_num_leak_out: 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

encountered keyerror issue for topology topology dualtor-aa-56 on th2. as below:
```
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] 
-------------------------------- live log setup --------------------------------
02/09/2025 10:56:46 __init__._fixture_generator_decorator    L0088 ERROR  | 
KeyError('wm_pg_shared_lossless')
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/qos_sai_base.py", line 1767, in dutQosConfig
    qosParams = qpm.run()
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/files/brcm/qos_param_generator.py", line 521, in run
    self.prepare_default_parameters()
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/files/brcm/qos_param_generator.py", line 636, in prepare_default_parameters
    self.create_default_pg_shared_watermark_parameter(pg_profile)
  File "/var/src/sonic-mgmt_testbed-bjw3-can-dual-t0-7260-2/tests/qos/files/brcm/qos_param_generator.py", line 575, in create_default_pg_shared_watermark_parameter
    self.qos_params[self.speed_cable_len][pg_profile] = self.qos_params[pg_profile]
KeyError: 'wm_pg_shared_lossless'
```

#### How did you do it?

add missing qos parameter which value come from topo-any.

#### How did you verify/test it?

local test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
