### PR TITLE
Fix is_xcvr_optical check failure for Moby backplane port SFP type

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -287,8 +287,7 @@ class TestSfpApi(PlatformApiTestBase):
     def is_xcvr_optical(self, xcvr_info_dict):
         """Returns True if transceiver is optical, False if copper (DAC)"""
         # For QSFP-DD specification compliance will return type as passive or active
-        if xcvr_info_dict["type_abbrv_name"] == "QSFP-DD" or xcvr_info_dict["type_abbrv_name"] == "OSFP-8X" \
-                or xcvr_info_dict["type_abbrv_name"] == "QSFP+C":
+        if xcvr_info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C", "BP"]:
             if xcvr_info_dict["specification_compliance"] == "Passive Copper Cable" or \
                     xcvr_info_dict["specification_compliance"] == "passive_copper_media_interface":
                 return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the following issue:
```
platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_los[xxxx]   FAILED     43%

01/09/2025 09:42:17 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_rx_los", index: 16, arguments: "[]", result: "[False, False, False, False, False, False, False, False]"
01/09/2025 09:42:17 sfp.sfp_api                              L0018 INFO   | Executing sfp API: "get_transceiver_info", index: 17, arguments: "[]", result: "{'type': 'Backplane Cartridge', 'type_abbrv_name': 'BP', 'hardware_rev': '0.0', 'serial': 'APH1725600050   ', 'cable_length': 1.0, 'manufacturer': 'Amphenol        ', 'model': 'HS33006-001     ', 'vendor_date': '2025-04-30   ', 'vendor_oui': '41-50-48', 'vendor_rev': '03', 'application_advertisement': "{1: {'host_electrical_interface_id': '800G-ETC-CR8', 'module_media_interface_id': 'Undefined', 'media_lane_count': 8, 'host_lane_count': 8, 'host_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '400GBASE-CR4 (Clause 162)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}}", 'host_electrical_interface': 'N/A', 'host_lane_count': 8, 'cable_type': 'Length Cable Assembly(m)', 'cmis_rev': '5.1', 'specification_compliance': 'passive_copper_media_interface', 'slot_id': '1', 'host_lane_assignment_option': 1, 'vdm_supported': False}"
01/09/2025 09:42:17 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt_vms92-t0-7060x6-moby-512-2/tests/platform_tests/api/test_sfp.py", line 595, in test_get_rx_los
    if not self.is_xcvr_optical(info_dict):
  File "/var/src/sonic-mgmt_vms92-t0-7060x6-moby-512-2/tests/platform_tests/api/test_sfp.py", line 296, in is_xcvr_optical
    spec_compliance_dict = ast.literal_eval(xcvr_info_dict["specification_compliance"])
  File "/usr/lib/python3.8/ast.py", line 99, in literal_eval
    return _convert(node_or_string)
  File "/usr/lib/python3.8/ast.py", line 98, in _convert
    return _convert_signed_num(node)
  File "/usr/lib/python3.8/ast.py", line 75, in _convert_signed_num
    return _convert_num(node)
  File "/usr/lib/python3.8/ast.py", line 66, in _convert_num
    _raise_malformed_node(node)
  File "/usr/lib/python3.8/ast.py", line 63, in _raise_malformed_node
    raise ValueError(f'malformed node or string: {node!r}')
ValueError: malformed node or string: <_ast.Name object at 0x7fdab9497ee0>

```

Moby's backplane port has the following attribute:
'type': 'Backplane Cartridge', 
'type_abbrv_name': 'BP',

However, 'BP' is not in the non-optical check list, this PR adds it into the list.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix optical checking API to include the new backplane port used in Moby.

#### How did you do it?
Add Moby BP port type into the list.

#### How did you verify/test it?
Local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
