### PR TITLE
Skip test_bgp_suppress_fib for T1 with no spine layer

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -66,6 +66,18 @@ BGP_ROUTE_FLAP_TIMES = 5
 UPDATE_WITHDRAW_THRESHOLD = 5  # consider the switch with low power cpu and a lot of bgp neighbors
 
 
+# Returns True if the topology has a spine layer, else returns False
+def topo_has_spine_layer(tbinfo):
+    if not tbinfo:
+        return False
+
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        if 'spine' in v['properties']:
+            return True
+
+    return False
+
+
 @pytest.fixture(scope="module")
 def generate_route_and_traffic_data():
     """
@@ -177,6 +189,11 @@ def prepare_param(duthost, tbinfo, get_exabgp_ptf_ports):
     """
     Prepare parameters
     """
+
+    # Skip test if t1 topo does not have a spine layer
+    if not topo_has_spine_layer(tbinfo):
+        pytest.skip('This test is not applicable to topologies with no SPINE layer')
+
     router_mac = duthost.facts["router_mac"]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     ptf_ip = tbinfo['ptf_ip']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Skip test_bgp_suppress_fib if T1 topology does not have spine layer (ex: t1-isolated-d128)

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
