### PR TITLE
Generalize OVS add-flows Improvement to All Topologies

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -889,7 +889,7 @@ class VMTopology(object):
         VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
                        (br_name, vlan2_iface_id, vlan1_iface_id))
 
-    def bind_fp_ports(self, disconnect_vm=False, batch_mode=False):
+    def bind_fp_ports(self, disconnect_vm=False):
         """
         bind dut front panel ports to VMs
 
@@ -921,12 +921,9 @@ class VMTopology(object):
                     (br_name, self.duts_fp_ports[self.duts_name[dut_index]][str(vlan_index)],
                      injected_iface, vm_iface, disconnect_vm)
                 )
-        if batch_mode:
-            with VMTopologyWorker.safe_subprocess_manager() as [processes, tmpdir]:
-                self.worker.map(lambda args: self.bind_ovs_ports(*args, processes=processes,
-                                                                 tmpdir=tmpdir), bind_ovs_ports_args)
-        else:
-            self.worker.map(lambda args: self.bind_ovs_ports(*args), bind_ovs_ports_args)
+        with VMTopologyWorker.safe_subprocess_manager() as [processes, tmpdir]:
+            self.worker.map(lambda args: self.bind_ovs_ports(*args, processes=processes,
+                                                             tmpdir=tmpdir), bind_ovs_ports_args)
 
         for k, attr in self.VM_LINKs.items():
             logging.info("Create VM links for {} : {}".format(k, attr))
@@ -960,7 +957,7 @@ class VMTopology(object):
                 injected_iface = adaptive_name(INJECTED_INTERFACES_TEMPLATE, self.vm_set_name, ptf_index)
                 self.bind_ovs_ports(br_name, port1, injected_iface, port2, disconnect_vm)
 
-    def unbind_fp_ports(self, batch_mode=False):
+    def unbind_fp_ports(self):
         logging.info("=== unbind front panel ports ===")
         unbind_ovs_ports_args = []
         for attr in self.VMs.values():
@@ -971,11 +968,8 @@ class VMTopology(object):
                     self.vm_names[self.vm_base_index + attr['vm_offset']], vlan_num)
                 unbind_ovs_ports_args.append((br_name, vm_iface))
 
-        if batch_mode:
-            with VMTopologyWorker.safe_subprocess_manager() as [processes, _]:
-                self.worker.map(lambda args: self.unbind_ovs_ports(*args, processes=processes), unbind_ovs_ports_args)
-        else:
-            self.worker.map(lambda args: self.unbind_ovs_ports(*args), unbind_ovs_ports_args)
+        with VMTopologyWorker.safe_subprocess_manager() as [processes, _]:
+            self.worker.map(lambda args: self.unbind_ovs_ports(*args, processes=processes), unbind_ovs_ports_args)
 
         for k, attr in self.VM_LINKs.items():
             logging.info("Remove VM links for {} : {}".format(k, attr))
@@ -1168,13 +1162,9 @@ class VMTopology(object):
             VMTopology.cmd("ovs-ofctl add-flow %s table=0,in_port=%s,action=output:%s" %
                            (br_name, dut_iface_id, injected_iface_id))
         else:
-            bind_helper = VMTopology.cmd
-            is_batch_mode = "processes" in kwargs
             all_cmds = []
-
-            if is_batch_mode:
-                bind_helper = lambda cmd: \
-                    all_cmds.append(cmd.split()[-1])  # noqa: E731
+            bind_helper = lambda cmd: \
+                all_cmds.append(cmd.split()[-1])  # noqa: E731
 
             # Add flow from external iface to a VM and a ptf container
             # Allow BGP, IPinIP, fragmented packets, ICMP, SNMP packets and layer2 packets from DUT to neighbors
@@ -1244,7 +1234,7 @@ class VMTopology(object):
             bind_helper("ovs-ofctl add-flow %s 'table=0,in_port=%s,action=output:%s'" %
                         (br_name, injected_iface_id, dut_iface_id))
 
-            if is_batch_mode and all_cmds:
+            if all_cmds:
                 processes = kwargs.get("processes")
                 tmpdir = kwargs.get("tmpdir")
                 with tempfile.NamedTemporaryFile("w", dir=tmpdir, delete=False) as f:
@@ -1257,21 +1247,15 @@ class VMTopology(object):
         """unbind all ports except the vm port from an ovs bridge"""
         if VMTopology.intf_exists(br_name):
             ports = VMTopology.get_ovs_br_ports(br_name)
-
-            bind_helper = VMTopology.cmd
-            is_batch_mode = "processes" in kwargs
-
             all_cmds = []
-
-            if is_batch_mode:
-                bind_helper = lambda cmd: \
-                    all_cmds.append(cmd[len("ovs-vsctl "):])  # noqa: E731
+            bind_helper = lambda cmd: \
+                all_cmds.append(cmd[len("ovs-vsctl "):])  # noqa: E731
 
             for port in ports:
                 if port != vm_port:
                     bind_helper('ovs-vsctl --if-exists del-port %s %s' % (br_name, port))
 
-            if is_batch_mode and all_cmds:
+            if all_cmds:
                 processes = kwargs.get("processes")
                 batch_cmd = 'ovs-vsctl -- %s' % (' -- '.join(all_cmds))
                 processes.append(VMTopology.fire_and_forget(batch_cmd))
@@ -2211,7 +2195,6 @@ def main():
             thread_worker_count=dict(required=False, type='int',
                                      default=max(MIN_THREAD_WORKER_COUNT,
                                                  multiprocessing.cpu_count() // 8)),
-            batch_mode=dict(required=False, type='bool', default=False)
         ),
         supports_check_mode=False)
 
@@ -2226,7 +2209,6 @@ def main():
     dut_interfaces = module.params['dut_interfaces']
     use_thread_worker = module.params['use_thread_worker']
     thread_worker_count = module.params['thread_worker_count']
-    batch_mode = module.params['batch_mode']
 
     config_module_logging(construct_log_filename(cmd, vm_set_name))
 
@@ -2303,7 +2285,7 @@ def main():
             if vms_exists:
                 net.add_injected_fp_ports_to_docker()
                 net.add_injected_VM_ports_to_docker()
-                net.bind_fp_ports(batch_mode=batch_mode)
+                net.bind_fp_ports()
                 net.bind_vm_backplane()
                 net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
                 if is_vs_chassis:
@@ -2383,7 +2365,7 @@ def main():
 
             if vms_exists:
                 net.unbind_vm_backplane()
-                net.unbind_fp_ports(batch_mode=batch_mode)
+                net.unbind_fp_ports()
                 net.remove_injected_fp_ports_from_docker()
                 if is_vs_chassis:
                     net.unbind_vs_chassis_ports(duts_midplane_ports, duts_inband_ports)
@@ -2455,12 +2437,12 @@ def main():
                 net.delete_network_namespace()
 
             if vms_exists:
-                net.unbind_fp_ports(batch_mode=batch_mode)
+                net.unbind_fp_ports()
                 if is_vs_chassis:
                     net.unbind_vs_chassis_ports(duts_midplane_ports, duts_inband_ports)
                 net.add_injected_fp_ports_to_docker()
                 net.add_injected_VM_ports_to_docker()
-                net.bind_fp_ports(batch_mode=batch_mode)
+                net.bind_fp_ports()
                 net.bind_vm_backplane()
                 net.add_bp_port_to_docker(ptf_bp_ip_addr, ptf_bp_ipv6_addr)
                 if is_vs_chassis:

--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -32,11 +32,6 @@
   become: yes
   when: docker_registry_username is defined and docker_registry_password is defined
 
-- name: set batch_mode for lt2 topo
-  set_fact:
-    batch_mode: True
-  when: "'lt2' in topo"
-
 - name: Deploy Keysight API Server container
   block:
     - name: Get Keysight API Server container status
@@ -156,7 +151,6 @@
         duts_name: "{{ duts_name.split(',') }}"
         fp_mtu: "{{ fp_mtu_size }}"
         max_fp_num: "{{ max_fp_num }}"
-        batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
       become: yes
 
   when: container_type == "IxANVL-CONF-TESTER"
@@ -247,7 +241,6 @@
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Bind topology {{ topo }} to DPUs.
@@ -273,7 +266,6 @@
       fp_mtu: "{{ fp_mtu_size }}"
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
       is_dpu: true
     become: yes
     when: dpu_targets is defined and dpu_targets | length > 0

--- a/ansible/roles/vm_set/tasks/remove_topo.yml
+++ b/ansible/roles/vm_set/tasks/remove_topo.yml
@@ -12,11 +12,6 @@
     container_type: "IxANVL-CONF-TESTER"
   when: ptf_imagename is defined and ptf_imagename == "docker-ptf-anvl"
 
-- name: set batch_mode for lt2 topo
-  set_fact:
-    batch_mode: True
-  when: "'lt2' in topo"
-
 - block:
 
   - name: Stop mux simulator
@@ -58,9 +53,7 @@
       max_fp_num: "{{ max_fp_num }}"
       dut_interfaces: "{{ dut_interfaces | default('') }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
-
 
   - name: Unbind topology {{ topo }} to DPU VMs. base vm = {{ VM_base }}
     vm_topology:
@@ -74,7 +67,6 @@
       duts_mgmt_port: "{{ duts_mgmt_port }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
       is_dpu: true
     become: yes
     when: dpu_targets is defined and dpu_targets | length > 0
@@ -146,7 +138,6 @@
       duts_mgmt_port: "{{ duts_mgmt_port }}"
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Remove duts ports

--- a/ansible/roles/vm_set/tasks/renumber_topo.yml
+++ b/ansible/roles/vm_set/tasks/renumber_topo.yml
@@ -64,11 +64,6 @@
     loop_control:
       loop_var: dut_name
 
-  - name: set batch_mode for lt2 topo
-    set_fact:
-      batch_mode: True
-    when: "'lt2' in topo"
-
   - name: Unbind topology {{ topo }} to VMs. base vm = {{ VM_base }}
     vm_topology:
       cmd: "unbind"
@@ -84,7 +79,6 @@
       duts_name: "{{ duts_name.split(',') }}"
       max_fp_num: "{{ max_fp_num }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Stop ptf container ptf_{{ vm_set_name }}
@@ -186,7 +180,6 @@
       max_fp_num: "{{ max_fp_num }}"
       netns_mgmt_ip_addr: "{{ netns_mgmt_ip if netns_mgmt_ip is defined else omit }}"
       is_vs_chassis: "{{ is_vs_chassis | default(false) }}"
-      batch_mode: "{{ batch_mode if batch_mode is defined else omit }}"
     become: yes
 
   - name: Change MAC address for PTF interfaces


### PR DESCRIPTION
### Description of PR
Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
To expand the setup speed improvement of the OVS add-flows command to all topologies, i.e. beyond just the lt2-based topologies.

Additionally, this improves maintainability/readability by simplifying the logic and reducing the number of lines of  code.

#### How did you do it?
Removed the batch_mode ansible variable and conditional statements to allow all topologies to leverage the OVS add-flows mechanism by default.

#### How did you verify/test it?
Ran the setup with this change across several non-lt2 topologies, followed by sonic-mgmt test runs to confirm no blatant regressions.