### PR TITLE
Revert PR19910 as the original issue was fixed

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3683,12 +3683,6 @@ snmp/test_snmp_phy_entity.py:
     conditions:
       - "asic_type in ['vs']"
 
-snmp/test_snmp_phy_entity.py::test_transceiver_info:
-  xfail:
-    reason: "Testcase ignored due to github issue: https://github.com/sonic-net/sonic-buildimage/issues/22213"
-    conditions:
-    - "https://github.com/sonic-net/sonic-buildimage/issues/22213"
-
 snmp/test_snmp_queue.py:
   skip:
     reason: "Interfaces not present on supervisor node or M* topo does not support test_snmp_queue or unsupported platform"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Revert PR19910 as the original issue was fixed
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

The original issue https://github.com/sonic-net/sonic-buildimage/issues/22213 was fixed by https://github.com/sonic-net/sonic-platform-daemons/pull/604.

Hence, this change reverts https://github.com/sonic-net/sonic-mgmt/pull/19910 to re-enable the test.

#### How did you do it?

#### How did you verify/test it?

Verified `test_transceiver_info` now can pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
