### PR TITLE
Changing trim size and trim queue index used in packet trimming GCU tests for Broadcom ASICs

### DIFF
--- a/tests/generic_config_updater/test_packet_trimming_config_asymmetric.py
+++ b/tests/generic_config_updater/test_packet_trimming_config_asymmetric.py
@@ -13,16 +13,16 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 # Default values
-TRIM_SIZE = 256
+TRIM_SIZE = 256  # For Mellanox
 TRIM_DSCP = 48
 TRIM_DSCP_ASYM = "from-tc"
-TRIM_QUEUE = 6
+TRIM_QUEUE = 6  # For Mellanox
 TRIM_TC = 5
 
 # Update values
-TRIM_SIZE_UPDATE = 4084
+TRIM_SIZE_UPDATE = 4084  # For Mellanox
 TRIM_DSCP_UPDATE = 63
-TRIM_QUEUE_UPDATE = 3
+TRIM_QUEUE_UPDATE = 3  # For Mellanox
 TRIM_TC_UPDATE = 4
 
 # Invalid values
@@ -41,6 +41,12 @@ def setup_env(duthost):
     Args:
         duthost: DUT.
     """
+    global TRIM_SIZE, TRIM_QUEUE, TRIM_SIZE_UPDATE, TRIM_QUEUE_UPDATE
+    if duthost.facts["asic_type"] == "broadcom":
+        TRIM_SIZE = 206
+        TRIM_QUEUE = 7
+        TRIM_SIZE_UPDATE = 206
+        TRIM_QUEUE_UPDATE = 7
     create_checkpoint(duthost)
 
     yield

--- a/tests/generic_config_updater/test_packet_trimming_config_symmetric.py
+++ b/tests/generic_config_updater/test_packet_trimming_config_symmetric.py
@@ -13,14 +13,14 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 # Default values
-TRIM_SIZE = 256
+TRIM_SIZE = 256  # For Mellanox
 TRIM_DSCP = 48
-TRIM_QUEUE = 6
+TRIM_QUEUE = 6  # For Mellanox
 
 # Update values
-TRIM_SIZE_UPDATE = 4084
+TRIM_SIZE_UPDATE = 4084  # For Mellanox
 TRIM_DSCP_UPDATE = 63
-TRIM_QUEUE_UPDATE = 3
+TRIM_QUEUE_UPDATE = 3  # For Mellanox
 TRIM_TC_UPDATE = 4
 
 # Invalid values
@@ -38,6 +38,12 @@ def setup_env(duthost):
     Args:
         duthost: DUT.
     """
+    global TRIM_SIZE, TRIM_QUEUE, TRIM_SIZE_UPDATE, TRIM_QUEUE_UPDATE
+    if duthost.facts["asic_type"] == "broadcom":
+        TRIM_SIZE = 206
+        TRIM_QUEUE = 7
+        TRIM_SIZE_UPDATE = 206
+        TRIM_QUEUE_UPDATE = 7
     create_checkpoint(duthost)
 
     yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Microsoft ADO ID: 34612856
This PR sets trim size to 206 and trim queue index to 7 in Generic Config Updater (GCU) tests for Broadcom ASICs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Broadcom ASICs currently only support trimmed packet size of 206 bytes and trim queue index of 7. It is possible to config other values from the SONiC CLI, but the Broadcom SAI will report the following errors:
```
ERR syncd#syncd: [none] SAI_API_SWITCH:brcm_sai_set_switch_attribute:7929 Packet trim size can not be changed from 206 to 256
ERR syncd#syncd: [none] SAI_API_SWITCH:brcm_sai_set_switch_attribute:7881 Packet trim queue index can not be changed from 7 to 6
```

#### How did you do it?
If the GCU tests are run on a device with Broadcom ASIC, we always set trim size to 206 and trim queue index to 7.

#### How did you verify/test it?
Tested on a switch with Broadcom ASIC on which the above SAI errors were reported without these changes.
```
generic_config_updater/test_packet_trimming_config_symmetric.py::test_packet_trimming_config_sym PASSED                                               [100%]
generic_config_updater/test_packet_trimming_config_asymmetric.py::test_packet_trimming_config_asym PASSED                                             [100%]
```

#### Any platform specific information?
The changes only apply to Broadcom ASICs.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A