### PR TITLE
Enable Fairwater FT0 IPv6 data acl test

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -535,7 +535,9 @@ def setup(duthosts, ptfhost, rand_selected_dut, rand_selected_front_end_dut, ran
 
 @pytest.fixture(scope="module", params=["ipv4", "ipv6"])
 def ip_version(request, tbinfo, duthosts, rand_one_dut_hostname):
-    if tbinfo["topo"]["type"] in ["t0"] and request.param == "ipv6":
+    if tbinfo['topo']['name'] in ["t0-d18u8s4"] and request.param == "ipv6":
+        return request.param
+    elif tbinfo["topo"]["type"] in ["t0"] and request.param == "ipv6":
         pytest.skip("IPV6 ACL test not currently supported on t0 testbeds")
 
     return request.param

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1036,9 +1036,9 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
                 logger.info("No byte counters for this hwsku\n")
 
     @pytest.fixture(params=["downlink->uplink", "uplink->downlink"])
-    def direction(self, request, tbinfo):
+    def direction(self, request, tbinfo, ip_version):
         """Parametrize test based on direction of traffic."""
-        if tbinfo['topo']['name'] in ["t0-d18u8s4"] and request.param == "uplink->downlink":
+        if tbinfo['topo']['name'] in ["t0-d18u8s4"] and request.param == "uplink->downlink" and ip_version == "ipv6":
             pytest.skip("Not applicable for t0-d18u8s4 topology")
         if is_multi_binding_acl() and request.param == "downlink->uplink":
             pytest.skip("Not applicable for multi binding ACL")

--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1038,6 +1038,8 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
     @pytest.fixture(params=["downlink->uplink", "uplink->downlink"])
     def direction(self, request, tbinfo):
         """Parametrize test based on direction of traffic."""
+        if tbinfo['topo']['name'] in ["t0-d18u8s4"] and request.param == "uplink->downlink":
+            pytest.skip("Not applicable for t0-d18u8s4 topology")
         if is_multi_binding_acl() and request.param == "downlink->uplink":
             pytest.skip("Not applicable for multi binding ACL")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
IPV6 ACL test not currently supported on t0 testbeds.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
IPV6 ACL test not currently supported on t0 testbeds

#### How did you do it?
Enable IPv6 ACL test on Fairwater topo.

#### How did you verify/test it?
On physical testbed

#### Any platform specific information?
Only on t0-d18u8s4 topo name

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
