### PR TITLE
feat: add sonic docker manager module

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -1,4 +1,5 @@
 import copy
+from functools import lru_cache
 import ipaddress
 import json
 import logging
@@ -6,6 +7,7 @@ import logging
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.devices.sonic import SonicHost
 from tests.common.devices.sonic_asic import SonicAsic
+from tests.common.devices.sonic_docker import SonicDockerManager
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE, ASICS_PRESENT
 from tests.common.platform.interface_utils import get_dut_interfaces_status
@@ -919,3 +921,7 @@ class MultiAsicSonicHost(object):
                     logger.info(line)
                     return False
         return True
+
+    @lru_cache
+    def containers(self):
+        return SonicDockerManager(self)

--- a/tests/common/devices/sonic_docker.py
+++ b/tests/common/devices/sonic_docker.py
@@ -1,0 +1,219 @@
+from collections import defaultdict
+from multiprocessing.pool import AsyncResult
+from pprint import pformat
+import random
+from typing import List
+from natsort import natsorted
+import re
+
+from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.helpers.dut_utils import is_container_running
+
+INVALID_ASIC_INDEX = -1
+
+
+class SonicDocker:
+    """
+    SonicDocker container wrapper. When execute function, it will calls SonicDockerManager functions
+    with pre-populated self.name (container_name) as the first argument.
+
+    See also:
+        SonicDockerManager: Manager class to manage all SonicDocker containers instances
+    """
+    __slots__ = ('name', 'docker_manager', 'asic_index')
+
+    def __init__(self, manager, container_name):
+        self.name = container_name
+        self.docker_manager = manager
+
+        parse_asic = re.search(r"(\d+)$", container_name)
+        self.asic_index = int(parse_asic.group()) if parse_asic is not None else None
+
+    def __str__(self):
+        return f"<DockerContainer({self.name})>"
+
+    def __getattr__(self, attr):
+        if attr.startswith("_") or attr in self.__slots__:
+            return object.__getattribute__(self, attr)
+
+        func = getattr(self.docker_manager, attr)
+
+        if callable(func):
+            def _handle(*args, **kwargs):
+                return func(self.name, *args, **kwargs)
+            return _handle
+
+        return object.__getattribute__(self, attr)
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        if isinstance(other, SonicDocker):
+            return self.name == other.name
+        return False
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class SonicDockerManager:
+    """
+    Manager docker containers instance for multi-asic and single asics.
+
+    Usage:
+        duthost.containers().<container_name>().<method>()
+
+    See: https://github.com/sonic-net/sonic-mgmt/pull/20513 for detail examples
+
+    Common usage:
+        1. Execute command on `syncd` for single-asic and `syncd0` for multi asic
+
+            duthost.containers().syncd()[0].exec("echo hello-world")
+
+            # Or randomly pick one syncd container for multi-asic
+
+            duthost.containers().syncd().random().exec("echo hello-world")
+
+        2. Execute command on `syncd` for single-asic and `syncd0`, `syncd1`, ...`syncdN` for multi asic
+        in PARALLEL
+
+            duthost.containers().syncd().exec("echo hello-world")
+
+        3. Execute command only on `syncd1`
+
+            duthost.containers().syncd(1).exec("echo hello-world")
+            # or
+            duthost.containers().syncd(namespace="asic1").exec("echo hello-world")
+            # or
+            duthost.containers().syncd(asic_index=1).exec("echo hello-world")
+
+        4. Get list of all container name for syncd
+
+            [docker.name for docker in duthost.containers().syncd()]
+
+
+    See also:
+        duthost: an instance of MultiAsicSonicHost
+        containers: Return the list of containers organise by group.
+
+    """
+
+    __slots__ = ('duthost', 'containers')
+
+    class ContainerList(list):
+        """
+        SonicDockerManager.ContainerList is internal class to store and execute command SonicDocker in parallel
+        """
+        def __init__(self, manager, *args):
+            super().__init__(*args)
+            self.manager = manager
+
+        def __str__(self):
+            return f"<SonicDockerManager.ContainerList({[docker.name for docker in self]})>"
+
+        def __getattr__(self, attr):
+            try:
+                value = object.__getattribute__(self, attr)
+                return value
+
+            except AttributeError as e:
+                func = object.__getattribute__(self.manager, attr)
+
+                if not callable(func):
+                    raise e
+
+                def _handle(*args, **kwargs):
+                    result: List[AsyncResult] = [None] * len(self)
+
+                    with SafeThreadPoolExecutor(max_workers=max(1, min(len(self), 8))) as executor:
+                        for i, docker in enumerate(self):
+                            result[i] = executor.submit(
+                                getattr(docker, attr), *args, **kwargs
+                            )
+
+                    for i, res in enumerate(result):
+                        result[i] = res.get()
+
+                    return result
+
+                return _handle
+
+        def get_by_asic_index(self, asic_index=None):
+            """
+            Return instance of filtered SonicDockerManager.ContainerList for index
+
+            :param asic_index: Asic index
+            """
+            if asic_index is None:
+                return self
+
+            return self.__class__(self.manager,
+                                  filter(lambda docker: docker.asic_index == asic_index, self))
+
+        def random(self):
+            if not self:
+                raise ValueError("Cannot select a random container from an empty ContainerList.")
+            return random.choice(self)
+
+    def __init__(self, duthost):
+        self.duthost = duthost
+        self.__init_containers()
+
+    def __init_containers(self):
+        """
+        Initialize the containers inventory to self.containers
+
+        :param self: SonicDockerManager instance
+        """
+        container_names = natsorted(self.duthost.get_all_containers())
+        self.containers = defaultdict(
+            lambda: SonicDockerManager.ContainerList(self)
+        )
+
+        for name in container_names:
+            container_group_name = name.rstrip("0123456789")
+            self.containers[container_group_name].append(SonicDocker(self, name))
+
+    def __getattr__(self, attr):
+        if attr.startswith("_") or attr in self.__slots__:
+            return object.__getattribute__(self, attr)
+
+        if attr in object.__getattribute__(self, "containers"):
+            def _handle(asic_index=None, namespace=None):
+                if asic_index is None and namespace is None:
+                    return self.containers[attr]
+                if namespace:
+                    match = re.search(r"(\d+)$", string=namespace)
+                    asic_index = int(match.group()) if match else INVALID_ASIC_INDEX
+                return self.containers[attr].get_by_asic_index(asic_index)
+            return _handle
+
+    def __str__(self):
+        container_infos = {
+            group: [docker.name for docker in self.containers[group]] for group in natsorted(self.containers)
+        }
+
+        return f"<SonicDockerManager [{pformat(container_infos, width=120)}]>"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def refresh(self):
+        """
+        Update to get the latest container info. By default it's cached first run for performance.
+        """
+        self.__init_containers()
+
+    """
+    Functions that will inherit from SonicDockerManager.ContainerList and SonicDocker.
+
+    NOTE: Call to this functions performed by SonicDockerManager.ContainerList or SonicDocker will pass container_name
+    as the first argument.
+    """
+    def exec(self, container_name, cmd, shell=False, **kwargs):
+        exec_cmd = self.duthost.shell if shell else self.duthost.command
+        return exec_cmd(f'sudo docker exec {container_name} {cmd}', **kwargs)
+
+    def is_running(self, container_name):
+        return is_container_running(self.duthost, container_name)

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -431,14 +431,14 @@ def get_debian_codename_from_syncd(duthost):
     # This applies to: master branch and internal branches >= 202405 (except 202411)
     try:
         # Try to get codename from syncd container
-        if duthost.is_multi_asic:
-            syncd_codename_cmd = (f"docker exec syncd{duthost.asics[0].asic_index} "
-                                  f"grep VERSION_CODENAME /etc/os-release | "
-                                  f"cut -d= -f2 | tr -d '\"'")
-        else:
-            syncd_codename_cmd = ("docker exec syncd grep VERSION_CODENAME /etc/os-release | "
-                                  "cut -d= -f2 | tr -d '\"'")
-        syncd_codename_result = duthost.shell(syncd_codename_cmd, module_ignore_errors=True)
+        codename_cmd = (
+            "grep VERSION_CODENAME /etc/os-release | "
+            "cut -d= -f2 | tr -d '\"'"
+        )
+
+        syncd_codename_result = duthost.containers().syncd().random().exec(codename_cmd,
+                                                                           shell=True,
+                                                                           module_ignore_errors=True)
         if syncd_codename_result['rc'] == 0 and syncd_codename_result['stdout'].strip():
             return syncd_codename_result['stdout'].strip()
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This PR abstract the container handling method for sonic-mgmt. Provide a consistent way to handle and run command on docker containers in multi-asic and single-asic platform.

Fixes # (issue) 
- https://github.com/sonic-net/sonic-mgmt/issues/20348 
- 34520139

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Add abstraction for containers handling in sonic-mgmt
```python
Usage: 
      duthost.containers().<container_name>().<method>()
```

## How our API will change for multi-asic and single-asic

Previously 

1. Execute on `syncd` for single-asic, `syncd0` for multi asic

```python
if duthost.is_multi_asic:
      duthost.shell("docker exec syncd0 echo hello-world")
else:
      duthost.shell("docker exec syncd echo hello-world")
```

2. Execute on `syncd` for single-asic. `syncd0`, `syncd1`, ...`syncdN` for multi asic

```python
if duthost.is_multi_asic:
      for asic in duthost.asics:
            duthost.shell(f"docker exec syncd{asic.asic_index} echo hello-world")
else:
      duthost.shell("docker exec syncd echo hello-world")
```

After this PR:

1. Execute on `syncd` for single-asic and `syncd0` for multi asic

```python
duthost.containers().syncd()[0].exec("echo hello-world")
```

or randomly choose one for multi-asic

```python
duthost.containers().syncd().random().exec("echo hello-world")
```

2. Execute on `syncd` for single-asic and `syncd0`, `syncd1`, ...`syncdN` for multi asic in PARALLEL
```python
duthost.containers().syncd().exec("echo hello-world")
```

3. Execute command only on `syncd1`
```python
duthost.containers().syncd(1).exec("echo hello-world")
# or
duthost.containers().syncd(namespace="asic1").exec("echo hello-world")
# or 
duthost.containers().syncd(asic_index=1).exec("echo hello-world")
```

4. Get list of all container name for `syncd`
```python
[docker.name for docker in duthost.containers().syncd()]
```

# Some example:
    
```python
> duthost.containers()
<SonicDockerManager [{'acms': ['acms'],
    'bgp': ['bgp0', 'bgp1', 'bgp2'],
    'database': ['database', 'database0', 'database1', 'database2'],
    'eventd': ['eventd'],
    'gnmi': ['gnmi'],
    'lldp': ['lldp0', 'lldp1', 'lldp2'],
    'macsec': ['macsec0', 'macsec1', 'macsec2'],
    'pmon': ['pmon'],
    'radv': ['radv'],
    'restapi': ['restapi'],
    'snmp': ['snmp'],
    'swss': ['swss0', 'swss1', 'swss2'],
    'syncd': ['syncd0', 'syncd1', 'syncd2'],
    'teamd': ['teamd0', 'teamd1', 'teamd2'],
    'telemetry': ['telemetry']}]>

```

Select all bgp instances
-----

```python
> duthost.containers().bgp()
[<DockerContainer(bgp0)>, <DockerContainer(bgp1)>, <DockerContainer(bgp2)>]

```

Select bgp instances for namespace asic0
-----


We have 3 ways to do
- `duthost.containers().bgp(0)`
- `duthost.containers().bgp(asic_index=0)`
- `duthost.containers().bgp(namespace="asic0")`

They all result to the same output
```python
> duthost.containers().bgp(namespace="asic0")
[<DockerContainer(bgp0)>]
```

Select database instance based on array index
-----

For example, our `database` containers runs 4 instance: 1 for global container, 3 for the asics -- assume that it's 3 asics.

```python
> duthost.containers().database()
[<DockerContainer(database)>, <DockerContainer(database0)>, <DockerContainer(database1)>, <DockerContainer(database2)>]
```

To select the first one `database` (not the asic0 `database0` one). We can do regular list index since if do `duthost.containers().database(0)` it will return for asic0 which it `database0` not `database`

```python
> duthost.containers().database()[0]   # select global database
<DockerContainer(database)>

> duthost.containers().database(0)   # select asic0 database
<DockerContainer(database0)>

```


Execute function on ALL containers in PARALLEL
-----

For example, our duthost has 3 bgp containers
```python
> duthost.containers().bgp()
[<DockerContainer(bgp0)>, <DockerContainer(bgp1)>, <DockerContainer(bgp2)>]
```


Let's run the following command on all 3 bgp containers in the same time
-  `docker exec bgp0 exec uname -a`
-  `docker exec bgp1 exec uname -a`
-  `docker exec bgp2 exec uname -a`

```python
> duthost.containers().bgp().exec("uname -a") # See the exec() method implentation below
[<result for bgp0>, <result for bgp1>, <result for bgp2>]
```

**NOTE**: The order of result is the same order as duthost.containers().bgp()

```python
> duthost.containers().bgp().is_running()
[True, True, True]
```

Execute function on ALL containers in SEQUENTIALLY
---

We can use normal python iteration

```python
> [docker.is_running() for docker in duthost.containers().bgp()]
[True, True, True]
```


Get all container name for syncd container
---

```python
> [docker.name for docker in duthost.containers().syncd()]
['syncd0', 'syncd1', 'syncd2']
```

#### How did you do it?

#### How did you verify/test it?
<img width="1156" height="83" alt="image" src="https://github.com/user-attachments/assets/616a8186-9f0e-49f3-ac00-3119b08ce7c9" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
