### PR TITLE
Log the actual watchdog timeout in test error message

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -256,7 +256,7 @@ class TestWatchdogApi(PlatformApiTestBase):
             pytest.skip('"too_big_timeout" parameter is required for this test case')
         actual_timeout = watchdog.arm(platform_api_conn, watchdog_timeout)
         self.expect(actual_timeout == -1, "{}: Watchdog should be disarmed, but returned timeout of {} seconds"
-                    .format(self.test_arm_too_big_timeout.__name__, watchdog_timeout))
+                    .format(self.test_arm_too_big_timeout.__name__, actual_timeout))
         self.assert_expectations()
 
     @pytest.mark.dependency(depends=["test_arm_disarm_states"])
@@ -266,5 +266,5 @@ class TestWatchdogApi(PlatformApiTestBase):
         watchdog_timeout = -1
         actual_timeout = watchdog.arm(platform_api_conn, watchdog_timeout)
         self.expect(actual_timeout == -1, "{}: Watchdog should be disarmed, but returned timeout of {} seconds"
-                    .format(self.test_arm_negative_timeout.__name__, watchdog_timeout))
+                    .format(self.test_arm_negative_timeout.__name__, actual_timeout))
         self.assert_expectations()


### PR DESCRIPTION
### Description of PR

Improve test error message in test_watchdog.py 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

To improve test errror message and help with debugging test failure.

#### How did you do it?

Log the actual watchdog timeout returned by `arm()` in test error message , instead of the `watchdog_timeout` passed to `arm()`

#### How did you verify/test it?

Tested by running the test cases and checking the error message when the tests failed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

