### PR TITLE
Add watchdog test config values for nexthop devices

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -205,3 +205,10 @@ x86_64-8102_28fh_dpu_o-r0:
     valid_timeout: 10
     greater_timeout: 6553
     too_big_timeout: 6554
+
+# Nexthop watchdog
+x86_64-nexthop_40(1|2)0-r.*:
+  default:
+    valid_timeout: 10
+    greater_timeout: 16777
+    too_big_timeout: 16778


### PR DESCRIPTION
### Description of PR

Add watchdog test config values for nexthop devices

Fixes #20526

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

The default values are not compatible with the watchdog on nexthop devices (`x86_64-nexthop_4010-r.*`) 

#### How did you do it?

Add test values compatible for testing nexthop devices.

#### How did you verify/test it?

Run sonic-mgmt `test_watchdog.py` on nexthop devices (`x86_64-nexthop_4010-r.*`). Make sure all tests in `test_watchdog.py` pass without causing additional test failures.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
