### PR TITLE
Add stress test for GNMI API latency

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -90,18 +90,9 @@ def recover_cert_config(duthost):
     dut_command = "docker exec %s pkill %s" % (env.gnmi_container, env.gnmi_process)
     duthost.shell(dut_command, module_ignore_errors=True)
     wait_until(60, 1, 0, check_gnmi_process, duthost)
-    # Recover all stopped program
-    dut_command = "docker exec %s supervisorctl status" % (env.gnmi_container)
-    output = duthost.shell(dut_command, module_ignore_errors=True)
-    for line in output['stdout_lines']:
-        res = line.split()
-        if len(res) < 3:
-            continue
-        program = res[0]
-        status = res[1]
-        if status == "STOPPED":
-            dut_command = "docker exec %s supervisorctl start %s" % (env.gnmi_container, program)
-            duthost.shell(dut_command, module_ignore_errors=True)
+    # Recover stopped program
+    dut_command = "docker exec %s supervisorctl start %s" % (env.gnmi_container, "gnmi-native")
+    duthost.shell(dut_command, module_ignore_errors=True)
 
     # Remove gnmi client cert common name
     del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -90,9 +90,17 @@ def recover_cert_config(duthost):
     dut_command = "docker exec %s pkill %s" % (env.gnmi_container, env.gnmi_process)
     duthost.shell(dut_command, module_ignore_errors=True)
     wait_until(60, 1, 0, check_gnmi_process, duthost)
-    # Recover stopped program
-    dut_command = "docker exec %s supervisorctl start %s" % (env.gnmi_container, "gnmi-native")
-    duthost.shell(dut_command, module_ignore_errors=True)
+    # Recover all stopped program
+    dut_command = "docker exec %s supervisorctl status" % (env.gnmi_container)
+    output = duthost.shell(dut_command, module_ignore_errors=True)
+    for line in output['stdout_lines']:
+        res = line.split()
+        if len(res) < 3:
+            continue
+        program = res[0]
+        if program in ["gnmi-native", "telemetry"]:
+            dut_command = "docker exec %s supervisorctl start %s" % (env.gnmi_container, program)
+            duthost.shell(dut_command, module_ignore_errors=True)
 
     # Remove gnmi client cert common name
     del_gnmi_client_common_name(duthost, "test.client.gnmi.sonic")

--- a/tests/gnmi/test_gnmi_stress.py
+++ b/tests/gnmi/test_gnmi_stress.py
@@ -1,8 +1,5 @@
-import json
 import logging
-import multiprocessing
 import pytest
-import re
 import time
 
 from .helper import gnmi_set

--- a/tests/gnmi/test_gnmi_stress.py
+++ b/tests/gnmi/test_gnmi_stress.py
@@ -59,30 +59,30 @@ def test_gnmi_latency_01(duthosts, rand_one_dut_hostname, ptfhost):
         file.write(text)
     ptfhost.copy(src=down_file, dest='/root')
     ptfhost.copy(src=up_file, dest='/root')
-    
+
     # Initialize latency tracking
     total_latencies = []
-    
+
     for i in range(test_loop):
         logger.info(f"Starting iteration {i+1}/{test_loop}")
-        
+
         # Measure total latency for both operations
         start_time = time.time()
-        
+
         # Update description
         gnmi_set(duthost, ptfhost, [], down_list, [])
         # Update description
         gnmi_set(duthost, ptfhost, [], up_list, [])
-        
+
         total_latency = (time.time() - start_time) / 2 * 1000  # Convert to milliseconds
         total_latencies.append(total_latency)
         logger.info(f"Total iteration latency: {total_latency:.2f} ms")
-    
+
     # Calculate and log statistics
     avg_total = sum(total_latencies) / len(total_latencies)
     min_total = min(total_latencies)
     max_total = max(total_latencies)
-    
+
     logger.info("=== GNMI SET LATENCY STATISTICS ===")
     logger.info(f"Total per iteration - Avg: {avg_total:.2f}ms, Min: {min_total:.2f}ms, Max: {max_total:.2f}ms")
     logger.info(f"Test completed: {test_loop} iterations on interface {interface}")

--- a/tests/gnmi/test_gnmi_stress.py
+++ b/tests/gnmi/test_gnmi_stress.py
@@ -1,0 +1,94 @@
+import json
+import logging
+import multiprocessing
+import pytest
+import re
+import time
+
+from .helper import gnmi_set
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer
+]
+
+
+def get_first_interface(duthost):
+    cmds = "show interface status"
+    output = duthost.shell(cmds)
+    assert (not output['rc']), "No output"
+    status_data = output["stdout_lines"]
+    if 'Admin' not in status_data[0]:
+        return None
+    if 'Lanes' not in status_data[0]:
+        return None
+    admin_index = status_data[0].split().index('Admin')
+    lanes_index = status_data[0].split().index('Lanes')
+    for line in status_data:
+        interface_status = line.strip()
+        assert len(interface_status) > 0, "Failed to read interface properties"
+        sl = interface_status.split()
+        # Skip portchannel
+        if sl[lanes_index] == 'N/A':
+            continue
+        if sl[admin_index] == 'up':
+            return sl[0]
+    return None
+
+
+def test_gnmi_latency_01(duthosts, rand_one_dut_hostname, ptfhost):
+    '''
+    Verify GNMI native write latency
+    Update interface description repeatedly and check latency
+    '''
+    duthost = duthosts[rand_one_dut_hostname]
+    if duthost.is_supervisor_node():
+        pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
+    interface = get_first_interface(duthost)
+    assert interface is not None, "Invalid interface"
+
+    test_loop = 10
+    text = "\"down\""
+    down_file = "down.txt"
+    down_list = ["/sonic-db:CONFIG_DB/localhost/PORT/%s/description:@/root/%s" % (interface, down_file)]
+    with open(down_file, 'w') as file:
+        file.write(text)
+    text = "\"up\""
+    up_file = "up.txt"
+    up_list = ["/sonic-db:CONFIG_DB/localhost/PORT/%s/description:@/root/%s" % (interface, up_file)]
+    with open(up_file, 'w') as file:
+        file.write(text)
+    ptfhost.copy(src=down_file, dest='/root')
+    ptfhost.copy(src=up_file, dest='/root')
+    
+    # Initialize latency tracking
+    total_latencies = []
+    
+    for i in range(test_loop):
+        logger.info(f"Starting iteration {i+1}/{test_loop}")
+        
+        # Measure total latency for both operations
+        start_time = time.time()
+        
+        # Update description
+        gnmi_set(duthost, ptfhost, [], down_list, [])
+        # Update description
+        gnmi_set(duthost, ptfhost, [], up_list, [])
+        
+        total_latency = (time.time() - start_time) / 2 * 1000  # Convert to milliseconds
+        total_latencies.append(total_latency)
+        logger.info(f"Total iteration latency: {total_latency:.2f} ms")
+    
+    # Calculate and log statistics
+    avg_total = sum(total_latencies) / len(total_latencies)
+    min_total = min(total_latencies)
+    max_total = max(total_latencies)
+    
+    logger.info("=== GNMI SET LATENCY STATISTICS ===")
+    logger.info(f"Total per iteration - Avg: {avg_total:.2f}ms, Min: {min_total:.2f}ms, Max: {max_total:.2f}ms")
+    logger.info(f"Test completed: {test_loop} iterations on interface {interface}")
+    cmd = "lscpu"
+    output = duthost.shell(cmd)
+    logger.info("CPU Info:\n%s" % output['stdout'])

--- a/tests/gnmi/test_gnmi_stress.py
+++ b/tests/gnmi/test_gnmi_stress.py
@@ -40,7 +40,8 @@ def test_gnmi_latency_01(duthosts, rand_one_dut_hostname, ptfhost):
     if duthost.is_supervisor_node():
         pytest.skip("gnmi test relies on port data not present on supervisor card '%s'" % rand_one_dut_hostname)
     interface = get_first_interface(duthost)
-    assert interface is not None, "Invalid interface"
+    if interface is None:
+        pytest.skip("No valid interface found on DUT '%s'" % rand_one_dut_hostname)
 
     test_loop = 10
     text = "\"down\""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We need to assess GNMI API latency across multiple platforms.

#### How did you do it?
The new test will invoke the GNMI API 10 times and measure the total execution time. Currently, there is no defined latency threshold. The next step will be to collect performance data across multiple platforms, which will inform the establishment of an appropriate latency threshold.

#### How did you verify/test it?
Run gnmi end to end test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
