### PR TITLE
[TH4/TH5]: Skip test_everflow_dscp_with_policer

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -91,7 +91,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
 
     DEFAULT_SRC_IP = "20.0.0.1"
     DEFAULT_DST_IP = "30.0.0.1"
-    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th3", "j2c+", "jr2"]
+    MIRROR_POLICER_UNSUPPORTED_ASIC_LIST = ["th5", "th4", "th3", "j2c+", "jr2"]
 
     @pytest.fixture(params=[DOWN_STREAM, UP_STREAM])
     def dest_port_type(self, setup_info, setup_mirror_session, tbinfo, request, erspan_ip_ver):        # noqa F811


### PR DESCRIPTION
### Description of PR
Summary: Skip the everflow_dscp_with_policer test for the TH4 and TH5 Broadcom ASICs, as Policer is not supported for MIRROR_SESSION on those ASICs.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
Mirror policing is not supported on Broadcom TH4/TH5 ASICs, so test_everflow_dscp_with_policer should be skipped accordingly.

#### How did you do it?
Added th4 and th5 to the list of unsupported ASICs for mirror policing.

#### How did you verify/test it?
Attempted to run the test and confirmed it is skipped.
Note: test log shows: "Skipping test since mirror policing is not supported on broadcom th5 platforms"

#### Any platform specific information?
TH4/TH5-based platforms.