### PR TITLE
Enable gnmi test for non x86 platform

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import shutil
 import logging
 import os
 import glob

--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -21,28 +21,6 @@ logger = logging.getLogger(__name__)
 SETUP_ENV_CP = "test_setup_checkpoint"
 
 
-@pytest.fixture(scope="function", autouse=True)
-def skip_non_x86_platform(duthosts, rand_one_dut_hostname):
-    """
-    Skip the current test if DUT is not x86_64 platform.
-    """
-    duthost = duthosts[rand_one_dut_hostname]
-    platform = duthost.facts["platform"]
-    if 'x86_64' not in platform:
-        pytest.skip("Test not supported for current platform. Skipping the test")
-
-
-@pytest.fixture(scope="module", autouse=True)
-def download_gnmi_client(duthosts, rand_one_dut_hostname, localhost):
-    duthost = duthosts[rand_one_dut_hostname]
-    for file in ["gnmi_cli", "gnmi_set", "gnmi_get", "gnoi_client"]:
-        duthost.shell("docker cp %s:/usr/sbin/%s /tmp" % (gnmi_container(duthost), file))
-        ret = duthost.fetch(src="/tmp/%s" % file, dest=".")
-        gnmi_bin = ret.get("dest", None)
-        shutil.copyfile(gnmi_bin, "gnmi/%s" % file)
-        localhost.shell("sudo chmod +x gnmi/%s" % file)
-
-
 @pytest.fixture(scope="module", autouse=True)
 def setup_gnmi_ntp_client_server(duthosts, rand_one_dut_hostname, ptfhost):
     """Auto-setup NTP for all gNMI tests using existing helper."""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
We disabled gnmi test for arm platform, and now we can remove this limitation.

#### How did you do it?
Remove related fixture, including disable test and download gnmi client.

#### How did you verify/test it?
Run gnmi end to end test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
