### PR TITLE
Ignoring expected err log from invalid prefix added for static route …

### DIFF
--- a/tests/generic_config_updater/test_static_route.py
+++ b/tests/generic_config_updater/test_static_route.py
@@ -157,11 +157,19 @@ def test_static_route_remove(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_static_route_add_invalid(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
+def test_static_route_add_invalid(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
+                                  loganalyzer):
     """
     Test adding an invalid static route configuration.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+    if loganalyzer and loganalyzer[duthost.hostname]:
+        ignore_regex_list = [
+            ".*ERR.*Data Loading Failed:Invalid value \"fcbb:bbbb:1::\" in \"prefix\" element."
+        ]
+        loganalyzer[duthost.hostname].ignore_regex.extend(ignore_regex_list)
+
     asic_namespace = duthost.get_namespace_from_asic_id(enum_frontend_asic_index)
     json_patch = [
         {


### PR DESCRIPTION
…case

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20537 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Ignoring expected error log from test case `test_static_route_add_invalid`

#### How did you do it?
Ignored the err log printed in syslog by test case.

#### How did you verify/test it?
Ran test case `test_static_route_add_invalid` in single-asic/multi-asic platforms.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
