### PR TITLE
Skipping lo test case instead of failing when the LOOPBACK_INTERFACE …

### DIFF
--- a/tests/generic_config_updater/test_lo_interface.py
+++ b/tests/generic_config_updater/test_lo_interface.py
@@ -39,7 +39,7 @@ def lo_intf(cfg_facts):
     def _is_ipv4_address(ip_addr):
         return ipaddress.ip_address(ip_addr).version == 4
 
-    loopback = cfg_facts["LOOPBACK_INTERFACE"].get(DEFAULT_LOOPBACK, {})
+    loopback = cfg_facts.get("LOOPBACK_INTERFACE", {}).get(DEFAULT_LOOPBACK, {})
     if not loopback:
         pytest.skip("Skipping as Loopback0 does not existed...")
     lo_intf = {}


### PR DESCRIPTION
…is not configured.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20540 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran test case generic_config_updater/test_lo_interface.py::test_lo_interface_tc1_suite in a supervisor card that doesn't have LOOPBACK_INTERFACE configured.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
