### PR TITLE
Qos test case added for verifying ECN configuration based on WRED profile

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3068,7 +3068,7 @@ qos/test_ecn_config.py:
   skip:
     reason: "This test only support on cisco device"
     conditions:
-      - "asic_type not in ['cisco-8000']"
+      - "asic_type not in ['cisco-8000', 'broadcom']"
 
 qos/test_oq_watchdog.py:
   skip:

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -344,6 +344,13 @@ qos_params:
                 min_limit: 180000
                 cell_size: 4096
             ecn_4:
+                dscp: 3
+                ecn: 1
+                num_of_pkts: 8500
+                limit: 182320
+                min_limit: 0
+                cell_size: 4096
+            ecn_5:
                 dscp: 0
                 ecn: 1
                 num_of_pkts: 8500
@@ -718,6 +725,13 @@ qos_params:
                 min_limit: 180000
                 cell_size: 4096
             ecn_4:
+                dscp: 3
+                ecn: 1
+                num_of_pkts: 8500
+                limit: 182320
+                min_limit: 0
+                cell_size: 4096
+            ecn_5:
                 dscp: 0
                 ecn: 1
                 num_of_pkts: 8500
@@ -1411,6 +1425,13 @@ qos_params:
                 min_limit: 180000
                 cell_size: 4096
             ecn_4:
+                dscp: 3
+                ecn: 1
+                num_of_pkts: 8500
+                limit: 182320
+                min_limit: 0
+                cell_size: 4096
+            ecn_5:
                 dscp: 0
                 ecn: 1
                 num_of_pkts: 8500

--- a/tests/qos/files/qos_params.j2c.yaml
+++ b/tests/qos/files/qos_params.j2c.yaml
@@ -323,30 +323,30 @@ qos_params:
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
             ecn_1:
-                dscp: 8
+                dscp: 3
                 ecn: 0
-                num_of_pkts: 5000
+                num_of_pkts: 8500
                 limit: 182000
                 min_limit: 180000
                 cell_size: 4096
             ecn_2:
-                dscp: 8
+                dscp: 3
                 ecn: 1
-                num_of_pkts: 2047
+                num_of_pkts: 1800
                 limit: 182320
                 min_limit: 0
                 cell_size: 4096
             ecn_3:
-                dscp: 0
-                ecn: 0
-                num_of_pkts: 5000
+                dscp: 3
+                ecn: 2
+                num_of_pkts: 8500
                 limit: 182000
                 min_limit: 180000
                 cell_size: 4096
             ecn_4:
                 dscp: 0
                 ecn: 1
-                num_of_pkts: 2047
+                num_of_pkts: 8500
                 limit: 182320
                 min_limit: 0
                 cell_size: 4096
@@ -697,30 +697,30 @@ qos_params:
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
             ecn_1:
-                dscp: 8
+                dscp: 3
                 ecn: 0
-                num_of_pkts: 5000
+                num_of_pkts: 8500
                 limit: 182000
                 min_limit: 180000
                 cell_size: 4096
             ecn_2:
-                dscp: 8
+                dscp: 3
                 ecn: 1
-                num_of_pkts: 2047
+                num_of_pkts: 1800
                 limit: 182320
                 min_limit: 0
                 cell_size: 4096
             ecn_3:
-                dscp: 0
-                ecn: 0
-                num_of_pkts: 5000
+                dscp: 3
+                ecn: 2
+                num_of_pkts: 8500
                 limit: 182000
                 min_limit: 180000
                 cell_size: 4096
             ecn_4:
                 dscp: 0
                 ecn: 1
-                num_of_pkts: 2047
+                num_of_pkts: 8500
                 limit: 182320
                 min_limit: 0
                 cell_size: 4096
@@ -1390,30 +1390,30 @@ qos_params:
                     pkts_num_fill_egr_min: 0
                     cell_size: 4096
             ecn_1:
-                dscp: 8
+                dscp: 3
                 ecn: 0
-                num_of_pkts: 5000
+                num_of_pkts: 8500
                 limit: 182000
                 min_limit: 180000
                 cell_size: 4096
             ecn_2:
-                dscp: 8
+                dscp: 3
                 ecn: 1
-                num_of_pkts: 2047
+                num_of_pkts: 1800
                 limit: 182320
                 min_limit: 0
                 cell_size: 4096
             ecn_3:
-                dscp: 0
-                ecn: 0
-                num_of_pkts: 5000
+                dscp: 3
+                ecn: 2
+                num_of_pkts: 8500
                 limit: 182000
                 min_limit: 180000
                 cell_size: 4096
             ecn_4:
                 dscp: 0
                 ecn: 1
-                num_of_pkts: 2047
+                num_of_pkts: 8500
                 limit: 182320
                 min_limit: 0
                 cell_size: 4096

--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -60,3 +60,34 @@ def leaf_fanouts(conn_graph_facts):         # noqa: F811
                 leaf_fanouts.append(peer_device)
 
     return leaf_fanouts
+
+@pytest.fixture(scope="module")
+def lossless_prio_list(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_rand_one_frontend_asic_index):
+    """
+    This fixture returns the list of lossless priorities
+
+    Args:
+       duthosts (pytest fixture) : list of DUTs
+       enum_rand_one_per_hwsku_frontend_hostname (pytest fixture): DUT hostname
+
+    Returns:
+        Lossless priorities (list)
+    """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    config_facts = duthost.config_facts(host=duthost.hostname, asic_index=enum_rand_one_frontend_asic_index,
+                                        source="running")['ansible_facts']
+
+    if "PORT_QOS_MAP" not in list(config_facts.keys()):
+        return None
+
+    port_qos_map = config_facts["PORT_QOS_MAP"]
+    if len(list(port_qos_map.keys())) == 0:
+        return None
+
+    """ Here we assume all the ports have the same lossless priorities """
+    intf = list(port_qos_map.keys())[0]
+    if 'pfc_enable' not in port_qos_map[intf]:
+        return None
+
+    result = [int(x) for x in port_qos_map[intf]['pfc_enable'].split(',')]
+    return result

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3174,24 +3174,3 @@ def set_queue_pir(interface, queue, rate):
             "QUEUE",
             dstport
         )
-
-    @pytest.fixture(scope="function", autouse=False)
-    def enable_ecn(self, get_src_dst_asic_and_duts, dutConfig, dutTestParams):
-        duthost = dutConfig["dstDutInstance"]
-        if ('platform_asic' in dutTestParams["basicParams"] and
-                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
-            if duthost.sonichost.is_multi_asic:
-                for asic in duthost.asics:
-                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} on".format(
-                        asic.asic_index, self.TARGET_QUEUE_WRED), module_ignore_errors=True)
-                    if cmd_output['rc'] != 0:
-                        pytest.skip("Command failed for ecn on/off on queue")
-        yield
-        if ('platform_asic' in dutTestParams["basicParams"] and
-                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
-            if duthost.sonichost.is_multi_asic:
-                for asic in duthost.asics:
-                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} off".format(
-                        asic.asic_index, self.TARGET_QUEUE_WRED), module_ignore_errors=True)
-                    if cmd_output['rc'] != 0:
-                        pytest.skip("Command failed for ecn on/off on queue")

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -460,6 +460,11 @@ class QosSaiBase(QosBase):
             Returns:
                 wredProfile (dict): Map of ECN/WRED attributes
         """
+        if table == "QUEUE" and dut_asic.sonichost.facts['switch_type'] == 'voq':
+            # For VoQ chassis, the buffer queues config is based on system port
+            if dut_asic.sonichost.is_multi_asic:
+                port = "{}|{}|{}".format(
+                    dut_asic.sonichost.hostname, dut_asic.namespace, port)
         if check_qos_db_fv_reference_with_table(dut_asic):
             out = dut_asic.run_redis_cmd(
                 argv=[
@@ -1690,7 +1695,7 @@ class QosSaiBase(QosBase):
         self, duthosts, get_src_dst_asic_and_duts,
         dutConfig, ingressLosslessProfile, ingressLossyProfile,
         egressLosslessProfile, egressLossyProfile, sharedHeadroomPoolSize,
-        tbinfo, lower_tor_host  # noqa: F811
+        tbinfo, lower_tor_host, ecnLosslessProfile  # noqa: F811
     ):
         """
             Prepares DUT host QoS configuration
@@ -3144,3 +3149,49 @@ def set_queue_pir(interface, queue, rate):
         sai_profile_content = duthost.shell(get_sai_profile_cmd)['stdout']
         logging.info(f"sai_profile_content: {sai_profile_content}")
         return "SAI_KEY_DISABLE_PORT_ALPHA=1" not in sai_profile_content
+
+    def ecnLosslessProfile(
+            self, request, duthosts, get_src_dst_asic_and_duts, dutConfig, tbinfo, lower_tor_host  # noqa F811
+    ):
+        """
+                   Retreives ecn lossless profile
+
+                   Args:
+                       request (Fixture): pytest request object
+                       duthost (AnsibleHost): Device Under Test (DUT)
+                       dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                           and test ports
+
+                   Returns:
+                       ecnLosslessProfile (dict): Map of ecn marking for lossless queue
+               """
+
+        dut_asic = get_src_dst_asic_and_duts['dst_asic']
+        dstport = dutConfig["dutInterfaces"][dutConfig["testPorts"]["dst_port_id"]]
+
+        yield self.__getEcnWredParam(
+            dut_asic,
+            "QUEUE",
+            dstport
+        )
+
+    @pytest.fixture(scope="function", autouse=False)
+    def enable_ecn(self, get_src_dst_asic_and_duts, dutConfig, dutTestParams):
+        duthost = dutConfig["dstDutInstance"]
+        if ('platform_asic' in dutTestParams["basicParams"] and
+                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+            if duthost.sonichost.is_multi_asic:
+                for asic in duthost.asics:
+                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} on".format(
+                        asic.asic_index, self.TARGET_QUEUE_WRED), module_ignore_errors=True)
+                    if cmd_output['rc'] != 0:
+                        pytest.skip("Command failed for ecn on/off on queue")
+        yield
+        if ('platform_asic' in dutTestParams["basicParams"] and
+                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+            if duthost.sonichost.is_multi_asic:
+                for asic in duthost.asics:
+                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} off".format(
+                        asic.asic_index, self.TARGET_QUEUE_WRED), module_ignore_errors=True)
+                    if cmd_output['rc'] != 0:
+                        pytest.skip("Command failed for ecn on/off on queue")

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -378,6 +378,20 @@ class TestQosSai(QosSaiBase):
                     startPos += 1
         logger.debug('updateTestPortIdIp dutConfig["testPorts"]: {}'.format(dutConfig["testPorts"]))
 
+    def check_ecn_status(self, duthost, qosConfig):
+        ecn_queue_status = []
+        if duthost.sonichost.is_multi_asic:
+            ecn_status = ""
+            for asic in duthost.asics:
+                cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {}".format(
+                    asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
+                if cmd_output['rc'] != 0:
+                    pytest.skip("ecnconfig on/off not supported")
+                else:
+                    ecn_queue_status.append(cmd_output['stdout_lines'][1].split(':')[1].strip())
+            ecn_status = 'on' if all("on" in status for status in ecn_queue_status) else 'off'
+        return ecn_status
+
     def testParameter(
         self, duthosts, get_src_dst_asic_and_duts, dutConfig, dutQosConfig, ingressLosslessProfile,
         ingressLossyProfile, egressLosslessProfile, dualtor_ports_for_duts
@@ -2579,3 +2593,86 @@ class TestQosSai(QosSaiBase):
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.XonHysteresisTest",
             testParams=test_params)
+
+    @pytest.mark.parametrize("ecn", ["ecn_1", "ecn_2", "ecn_3", "ecn_4"])
+    def testQosSaiDscpEcn(
+        self, ecn, duthosts, get_src_dst_asic_and_duts,
+        ptfhost, dutTestParams, dutConfig, dutQosConfig,ecnLosslessProfile, enable_ecn,
+        change_lag_lacp_timer
+    ):
+        """
+            Test QoS SAI ECN CONFIG
+
+            Args:
+                ptfhost (AnsibleHost): Packet Test Framework (PTF)
+                dutTestParams (Fixture, dict): DUT host test params
+                dutConfig (Fixture, dict): Map of DUT config containing dut interfaces, test port IDs, test port IPs,
+                    and test ports
+                dutQosConfig (Fixture, dict): Map containing DUT host QoS configuration
+                ecnLosslessProfile (Fxiture): Map of ecn marking for lossless queue
+                enable_ecn (Fixture): enables the ecnconfig on each asic
+
+            Returns:
+                None
+
+            Raises:
+                RunAnsibleModuleFail if ptf test fails
+        """
+        duthost = dutConfig["dstDutInstance"]
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        skip_test_on_no_lossless_pg(portSpeedCableLength)
+        if dutTestParams['hwsku'] in self.BREAKOUT_SKUS and 'backend' not in dutTestParams['topo']:
+            qosConfig = dutQosConfig["param"][portSpeedCableLength]["breakout"]
+        else:
+            qosConfig = dutQosConfig["param"][ecn]
+
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update({"test_port_ids": dutConfig["testPortIds"]})
+        testParams.update({
+            "dscp": qosConfig["dscp"],
+            "ecn": qosConfig["ecn"],
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "num_of_pkts": qosConfig["num_of_pkts"],
+            "limit": qosConfig["limit"],
+            "min_limit": qosConfig["min_limit"],
+            "cell_size": qosConfig["cell_size"],
+            "hwsku": dutTestParams['hwsku']
+        })
+
+        if "platform_asic" in dutTestParams["basicParams"]:
+            testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
+        else:
+            testParams["platform_asic"] = None
+
+
+        testParams.update({"ecn_queue_status": self.check_ecn_status(duthost, qosConfig)})
+        #enable ecnconfig for queue 0
+        if ecn == "ecn_4":
+            if duthost.sonichost.is_multi_asic:
+                for asic in duthost.asics:
+                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} on".format(
+                        asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
+                    if cmd_output['rc'] != 0:
+                        pytest.skip("ecnconfig on/off not supported")
+        self.runPtfTest(
+            ptfhost, testCase="sai_qos_tests.DscpEcnSend", testParams=testParams
+        )
+
+        if ecn == "ecn_3":
+            if duthost.sonichost.is_multi_asic:
+                for asic in duthost.asics:
+                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} off".format(
+                        asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
+                    if cmd_output['rc'] != 0:
+                        pytest.skip("ecnconfig on/off not supported")
+            testParams["ecn_queue_status"] = self.check_ecn_status(duthost, qosConfig)
+            self.runPtfTest(
+                ptfhost, testCase="sai_qos_tests.DscpEcnSend", testParams=testParams
+            )

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -378,19 +378,39 @@ class TestQosSai(QosSaiBase):
                     startPos += 1
         logger.debug('updateTestPortIdIp dutConfig["testPorts"]: {}'.format(dutConfig["testPorts"]))
 
-    def check_ecn_status(self, duthost, qosConfig):
-        ecn_queue_status = []
+    def check_and_set_ecn_status(self, duthost, qosConfig, expected_status='on'):
+        ecn_status = ''
         if duthost.sonichost.is_multi_asic:
-            ecn_status = ""
+            status = []
             for asic in duthost.asics:
                 cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {}".format(
                     asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
                 if cmd_output['rc'] != 0:
-                    pytest.skip("ecnconfig on/off not supported")
+                    pytest.skip("command failed for ecnconfig on/off status")
                 else:
-                    ecn_queue_status.append(cmd_output['stdout_lines'][1].split(':')[1].strip())
-            ecn_status = 'on' if all("on" in status for status in ecn_queue_status) else 'off'
+                    ecn_status = cmd_output['stdout_lines'][1].split(':')[1].strip()
+                    if ecn_status != expected_status:
+                        duthost.shell("sudo ecnconfig -n asic{} -q {} {}".format(
+                            asic.asic_index, qosConfig["dscp"], expected_status), module_ignore_errors=True)
+                cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {}".format(
+                    asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
+                status.append(cmd_output['stdout_lines'][1].split(':')[1].strip())
+            ecn_status = 'on' if all("on" in status for status in status) else 'off'
+
+        else:
+            cmd_output = duthost.shell("sudo ecnconfig -q {}".format(qosConfig["dscp"]), module_ignore_errors=True)
+            if cmd_output['rc'] != 0:
+                pytest.skip("command failed for ecnconfig on/off status")
+            else:
+                ecn_status = cmd_output['stdout_lines'][1].split(':')[1].strip()
+                if ecn_status != expected_status:
+                    duthost.shell("sudo ecnconfig -q {} {}".format(qosConfig["dscp"], expected_status),
+                                  module_ignore_errors=True)
+                cmd_output = duthost.shell("sudo ecnconfig -q {}".format(qosConfig["dscp"]), module_ignore_errors=True)
+            ecn_status = 'on' if "on" in cmd_output['stdout_lines'][1].split(':')[1].strip() else 'off'
+
         return ecn_status
+
 
     def testParameter(
         self, duthosts, get_src_dst_asic_and_duts, dutConfig, dutQosConfig, ingressLosslessProfile,
@@ -2594,10 +2614,10 @@ class TestQosSai(QosSaiBase):
             ptfhost, testCase="sai_qos_tests.XonHysteresisTest",
             testParams=test_params)
 
-    @pytest.mark.parametrize("ecn", ["ecn_1", "ecn_2", "ecn_3", "ecn_4"])
+    @pytest.mark.parametrize("ecn", ["ecn_1", "ecn_2", "ecn_3", "ecn_4", "ecn_5"])
     def testQosSaiDscpEcn(
         self, ecn, duthosts, get_src_dst_asic_and_duts,
-        ptfhost, dutTestParams, dutConfig, dutQosConfig,ecnLosslessProfile, enable_ecn,
+        ptfhost, dutTestParams, dutConfig, dutQosConfig, ecnLosslessProfile,
         change_lag_lacp_timer
     ):
         """
@@ -2648,31 +2668,18 @@ class TestQosSai(QosSaiBase):
 
         if "platform_asic" in dutTestParams["basicParams"]:
             testParams["platform_asic"] = dutTestParams["basicParams"]["platform_asic"]
+            testParams["ecn_queue_status"] = self.check_and_set_ecn_status(duthost, qosConfig)
         else:
             testParams["platform_asic"] = None
-
-
-        testParams.update({"ecn_queue_status": self.check_ecn_status(duthost, qosConfig)})
-        #enable ecnconfig for queue 0
-        if ecn == "ecn_4":
-            if duthost.sonichost.is_multi_asic:
-                for asic in duthost.asics:
-                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} on".format(
-                        asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
-                    if cmd_output['rc'] != 0:
-                        pytest.skip("ecnconfig on/off not supported")
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.DscpEcnSend", testParams=testParams
         )
-
+        # Run ecn_3 scenario with ecn_status off
         if ecn == "ecn_3":
-            if duthost.sonichost.is_multi_asic:
-                for asic in duthost.asics:
-                    cmd_output = duthost.shell("sudo ecnconfig -n asic{} -q {} off".format(
-                        asic.asic_index, qosConfig["dscp"]), module_ignore_errors=True)
-                    if cmd_output['rc'] != 0:
-                        pytest.skip("ecnconfig on/off not supported")
-            testParams["ecn_queue_status"] = self.check_ecn_status(duthost, qosConfig)
+            testParams["ecn_queue_status"] = self.check_and_set_ecn_status(duthost, qosConfig, 'off')
             self.runPtfTest(
                 ptfhost, testCase="sai_qos_tests.DscpEcnSend", testParams=testParams
             )
+            self.check_and_set_ecn_status(duthost, qosConfig, 'on')
+        elif ecn == "ecn_5":
+            self.check_and_set_ecn_status(duthost, qosConfig, 'off')

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4030,12 +4030,6 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
                                    ecn=ecn,
                                    ttl=64)
             send_packet(self, src_port_id, pkt, num_of_pkts)
-            '''
-            leaking_pkt_number = 0
-            for (rcv_port_number, pkt_str, pkt_time) in self.dataplane.packets(0, 1):
-                leaking_pkt_number += 1
-            print("leaking packet %d" % leaking_pkt_number)
-            '''
 
             # Set receiving socket buffers to some big value
             for p in list(self.dataplane.ports.values()):
@@ -4112,16 +4106,11 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
                 assert (marked_cnt == 0)
             else:
                 assert (marked_cnt >= (num_of_pkts - not_marked_cnt))
-                '''
-                for cntr in egress_counters:
-                    assert (port_counters[cntr] == 0)
-                '''
+
                 for cntr in ingress_counters:
                     assert (port_counters[cntr] == port_counters_base[cntr])
-
         finally:
             # RELEASE PORT
-
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             print("END OF TEST")
 

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -3971,51 +3971,79 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
         router_mac = self.test_params['router_mac']
         sonic_version = self.test_params['sonic_version']
         asic_type = self.test_params['sonic_asic_type']
-        default_packet_length = 64
+        default_packet_length = 1000
         dst_port_id = int(self.test_params['dst_port_id'])
         dst_port_ip = self.test_params['dst_port_ip']
+        dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
         src_port_id = int(self.test_params['src_port_id'])
         src_port_ip = self.test_params['src_port_ip']
         src_port_mac = self.dataplane.get_mac(0, src_port_id)
         num_of_pkts = self.test_params['num_of_pkts']
+        cell_size = self.test_params['cell_size']
+        pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
+        src_port_vlan = self.test_params['src_port_vlan']
         limit = self.test_params['limit']
         min_limit = self.test_params['min_limit']
-        cell_size = self.test_params['cell_size']
-        asic_type = self.test_params['sonic_asic_type']
+        exp_ip_id = 100
+        platform_asic = self.test_params['platform_asic']
+        ecn_queue_status = self.test_params['ecn_queue_status']
         # get counter names to query
         ingress_counters, egress_counters = get_counter_names(sonic_version)
 
         # STOP PORT FUNCTION
-        sched_prof_id = sai_thrift_create_scheduler_profile(
-            self.src_client, STOP_PORT_MAX_RATE)
-        attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
-        attr = sai_thrift_attribute_t(
-            id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-        self.dst_client.sai_thrift_set_port_attribute(port_list['dst'][dst_port_id], attr)
 
-        # Clear Counters
-        sai_thrift_clear_all_counters(self.src_client, 'src')
-        sai_thrift_clear_all_counters(self.dst_client, 'dst')
+        dst_port_id = get_rx_port(
+            self, 0, src_port_id, pkt_dst_mac, dst_port_ip, src_port_ip, src_port_vlan
+        )
+        log_message("actual dst_port_id: {}".format(dst_port_id), to_stderr=True)
+
+        # Get a snapshot of counter values
+        port_counters_base, queue_counters_base = sai_thrift_read_port_counters(
+            self.dst_client, asic_type, port_list['dst'][dst_port_id])
+        print(port_counters_base)
+        print(queue_counters_base)
+        self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id])
+        # Clear wred counters
+        if platform_asic and platform_asic == "broadcom-dnx":
+            stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
+                                                            self.test_params['dut_password'],
+                                                            'sonic-clear queue wredcounters')
+            if stdErr and retValue != 0:
+                raise RuntimeError("Command might have failed in the DUT.Error:{}".format(stdErr))
+            else:
+                print("---------Wredcounter queue counters reset------------")
 
         # send packets
         try:
             tos = dscp << 2
             tos |= ecn
             ttl = 64
-            for i in range(0, num_of_pkts):
-                pkt = simple_tcp_packet(pktlen=default_packet_length,
-                                        eth_dst=router_mac,
-                                        eth_src=src_port_mac,
-                                        ip_src=src_port_ip,
-                                        ip_dst=dst_port_ip,
-                                        ip_tos=tos,
-                                        ip_ttl=ttl)
-                send_packet(self, 0, pkt)
 
+            pkt = construct_ip_pkt(default_packet_length,
+                                   pkt_dst_mac,
+                                   src_port_mac,
+                                   src_port_ip,
+                                   dst_port_ip,
+                                   dscp,
+                                   src_port_vlan,
+                                   ip_id=exp_ip_id,
+                                   ecn=ecn,
+                                   ttl=64)
+            send_packet(self, src_port_id, pkt, num_of_pkts)
+            '''
             leaking_pkt_number = 0
             for (rcv_port_number, pkt_str, pkt_time) in self.dataplane.packets(0, 1):
                 leaking_pkt_number += 1
             print("leaking packet %d" % leaking_pkt_number)
+            '''
+
+            # Set receiving socket buffers to some big value
+            for p in list(self.dataplane.ports.values()):
+                p.socket.setsockopt(socket.SOL_SOCKET,
+                                    socket.SO_RCVBUF, 41943040)
+            # RELEASE PORT
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
+            time.sleep(2)
 
             # Read Counters
             print("DST port counters: ")
@@ -4024,91 +4052,77 @@ class DscpEcnSend(sai_base_test.ThriftInterfaceDataPlane):
             print(port_counters)
             print(queue_counters)
 
-            # Clear Counters
-            sai_thrift_clear_all_counters(self.src_client, 'src')
-            sai_thrift_clear_all_counters(self.dst_client, 'dst')
-
-            # Set receiving socket buffers to some big value
-            for p in list(self.dataplane.ports.values()):
-                p.socket.setsockopt(socket.SOL_SOCKET,
-                                    socket.SO_RCVBUF, 41943040)
-
-            # RELEASE PORT
-            sched_prof_id = sai_thrift_create_scheduler_profile(
-                self.src_client, RELEASE_PORT_MAX_RATE)
-            attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
-            attr = sai_thrift_attribute_t(
-                id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-            self.dst_client.sai_thrift_set_port_attribute(
-                port_list['dst'][dst_port_id], attr)
-
             # if (ecn == 1) - capture and parse all incoming packets
             marked_cnt = 0
             not_marked_cnt = 0
-            if (ecn == 1):
+            if (ecn != 0):
                 print("")
                 print(
                     "ECN capable packets generated, releasing dst_port and analyzing traffic -")
-
-                cnt = 0
+                total_recv_cnt = 0
                 pkts = []
-                for i in range(num_of_pkts):
-                    (rcv_device, rcv_port, rcv_pkt, pkt_time) = dp_poll(
-                        self, device_number=0, port_number=dst_port_id, timeout=0.2)
-                    if rcv_pkt is not None:
-                        cnt += 1
-                        pkts.append(rcv_pkt)
-                    else:  # Received less packets then expected
-                        assert (cnt == num_of_pkts)
-                print("    Received packets:    " + str(cnt))
-
+                while total_recv_cnt < num_of_pkts:
+                    result = self.dataplane.poll(
+                        device_number=0, port_number=dst_port_id, timeout=3)
+                    if isinstance(result, self.dataplane.PollFailure):
+                        self.fail("Expected packet was not received on port %d. Total received: %d.\n%s" % (
+                            dst_port_id, total_recv_cnt, result.format()))
+                    recv_pkt = scapy.Ether(result.packet)
+                    try:
+                        if(recv_pkt.payload.src == src_port_ip) and (recv_pkt.payload.dst == dst_port_ip):
+                            total_recv_cnt += 1
+                            pkts.append(recv_pkt)
+                    except AttributeError:
+                        continue
+                    except IndexError:
+                        # Ignore captured non-IP packet
+                        continue
+                print("Total packet recieved: " + str(total_recv_cnt))
                 for pkt_to_inspect in pkts:
-                    pkt_str = hex_dump_buffer(pkt_to_inspect)
-
                     # Count marked and not marked amount of packets
-                    if ((int(pkt_str[ECN_INDEX_IN_HEADER]) & 0x03) == 1):
+                    if((pkt_to_inspect.payload.tos & 0x03) == 1) or ((pkt_to_inspect.payload.tos & 0x03) == 2):
                         not_marked_cnt += 1
-                    elif ((int(pkt_str[ECN_INDEX_IN_HEADER]) & 0x03) == 3):
-                        assert (not_marked_cnt == 0)
+                    elif((pkt_to_inspect.payload.tos & 0x03) == 3):
                         marked_cnt += 1
 
                 print("    ECN non-marked pkts: " + str(not_marked_cnt))
                 print("    ECN marked pkts:     " + str(marked_cnt))
                 print("")
 
-            time.sleep(5)
-            # Read Counters
-            print("DST port counters: ")
-            port_counters, queue_counters = sai_thrift_read_port_counters(
-                self.dst_client, asic_type, port_list['dst'][dst_port_id])
-            print(port_counters)
-            print(queue_counters)
-            if (ecn == 0):
-                # num_of_pkts*pkt_size_in_cells*cell_size
-                transmitted_data = port_counters[TRANSMITTED_PKTS] * \
-                    2 * cell_size
-                assert (port_counters[TRANSMITTED_OCTETS] <= limit * 1.05)
-                assert (transmitted_data >= min_limit)
+            dut_port = self.get_dut_port(dst_port_id)
+            if platform_asic and platform_asic == "broadcom-dnx":
+                time.sleep(8)
+                stdOut, stdErr, retValue = self.exec_cmd_on_dut(self.dst_server_ip, self.test_params['dut_username'],
+                                                                self.test_params['dut_password'],
+                                                                'show queue wredcounters -n asic{}| grep {}| grep UC{}'
+                                                                .format(self.dst_asic_index, dut_port, dscp))
+                if stdErr and retValue !=0:
+                    raise RuntimeError("Command might have failed in the DUT.Error:{}".format(stdErr))
+                else:
+                    print("----Queue WredCounters on DUT----")
+                    print("ECNMarked pkts: {}  ECNMarked bytes: {}".format(stdOut[0].split()[4],
+                                                                           stdOut[0].split()[5]))
+                # the output number format is comma seperated value,remove comma if expected marked_pkts > 999
+                if ecn_queue_status == 'off':
+                    assert (marked_cnt == 0)
+                assert (int(stdOut[0].split()[4]) == marked_cnt)
+
+            assert (port_counters[TRANSMITTED_PKTS] - port_counters_base[TRANSMITTED_PKTS] >= num_of_pkts)
+            if(ecn == 0):
                 assert (marked_cnt == 0)
-            elif (ecn == 1):
-                non_marked_data = not_marked_cnt * 2 * cell_size
-                assert (non_marked_data <= limit*1.05)
-                assert (non_marked_data >= limit*0.95)
-                assert (marked_cnt == (num_of_pkts - not_marked_cnt))
+            else:
+                assert (marked_cnt >= (num_of_pkts - not_marked_cnt))
+                '''
                 for cntr in egress_counters:
                     assert (port_counters[cntr] == 0)
+                '''
                 for cntr in ingress_counters:
-                    assert (port_counters[cntr] == 0)
+                    assert (port_counters[cntr] == port_counters_base[cntr])
 
         finally:
             # RELEASE PORT
-            sched_prof_id = sai_thrift_create_scheduler_profile(
-                self.src_client, RELEASE_PORT_MAX_RATE)
-            attr_value = sai_thrift_attribute_value_t(oid=sched_prof_id)
-            attr = sai_thrift_attribute_t(
-                id=SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID, value=attr_value)
-            self.dst_client.sai_thrift_set_port_attribute(
-                port_list['dst'][dst_port_id], attr)
+
+            self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id])
             print("END OF TEST")
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Test Gap related issue -https://github.com/sonic-net/sonic-buildimage/issues/22856
Summary:
New test cases are added to qos tests to verify the ECN marked packets according to the ECN WRED parameters.
The test cases are only enabled for 'broadcom' platform

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Failures in ecnconfig CLI . Issue#22856
#### How did you do it?
The test cases are added to qos folder to verify
-The supported CLI commands for ecnconfig 
-The Ecn marked traffic and the wredcounter updates
#### How did you verify/test it?
Enabled ecnconfig on dut .Execute & verify the new test cases  results
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
