### PR TITLE
Use VLAN member interfaces for some arp and gcu tests

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -73,6 +73,8 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     is_storage_backend = 'backend' in tbinfo['topo']['name']
 
     if tbinfo['topo']['type'] == 't0':
+        # Use ports only in VLAN
+        ports = list(list(config_facts['VLAN_MEMBER'].values())[0].keys())
         if is_storage_backend:
             vlan_sub_intfs = mg_facts['minigraph_vlan_sub_interfaces']
             intfs_to_t1 = [_['attachto'].split(constants.VLAN_SUB_INTERFACE_SEPARATOR)[0] for _ in vlan_sub_intfs]

--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -338,6 +338,8 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     is_storage_backend = 'backend' in tbinfo['topo']['name']
 
     if tbinfo['topo']['type'] == 't0':
+        # Use ports only in VLAN
+        ports = list(list(config_facts['VLAN_MEMBER'].values())[0].keys())
         if is_storage_backend:
             vlan_sub_intfs = mg_facts['minigraph_vlan_sub_interfaces']
             intfs_to_t1 = [_['attachto'].split(constants.VLAN_SUB_INTERFACE_SEPARATOR)[0] for _ in vlan_sub_intfs]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The tests use the first couple interfaces right now. However, the tests needs VLAN member interfaces to work and the first couple interfaces are not VLAN members in all topos, i.e. `t0-isolated-d96u32s2`.

Ensure use of VLAN member interfaces by retrieving the proper interfaces from config_facts.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Incorrect ports are used for tests on the `t0-isolated-d96u32s2` topology.

#### How did you do it?
Retrieve VLAN member ports from `config_facts`.

#### How did you verify/test it?
Test no longer fails on the `t0-isolated-d96u32s2` topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
