### PR TITLE
Add qos params for Arista-7060X6-16PE-384C-B-O128S2

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -200,3 +200,113 @@ qos_params:
         topo-t0-standalone-256: *topo-t0-standalone
         topo-t0-standalone-32:  *topo-t0-standalone
         topo-lt2-p32o64:  *topo-t0-standalone
+        topo-t0-isolated-d96u32s2:
+            400000_40m: &topo-t0-isolated-d96u32s2-400000_40m
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 2
+                    pgs:
+                    - 3
+                    - 4
+                    pkts_num_hdrm_full: 1549
+                    pkts_num_hdrm_partial: 1118
+                    pkts_num_trig_pfc: 134616
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 2
+                    pkts_num_trig_egr_drp: 134550
+                pkts_num_egr_mem: 376
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136165
+                    pkts_num_trig_pfc: 134616
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 74
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 134616
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 2
+                    pkts_num_trig_egr_drp: 134550
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136165
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 2
+                    pkts_num_trig_egr_drp: 134550
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136165
+                    pkts_num_trig_pfc: 134616
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136165
+                    pkts_num_trig_pfc: 134616
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 134616
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 134616
+            cell_size: 254
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+            wrr_chg:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [40, 50, 150, 50, 50, 350]
+            400000_5m: *topo-t0-isolated-d96u32s2-400000_40m

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -3048,7 +3048,8 @@ def set_queue_pir(interface, queue, rate):
     @pytest.fixture(scope='class', autouse=True)
     def is_supported_per_dir(self, get_src_dst_asic_and_duts, tbinfo):  # noqa F811
         supported_per_dir_platform = ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2",
-                                      "Mellanox-SN5600-C224O8", "Mellanox-SN5600-C256S1"]
+                                      "Mellanox-SN5600-C224O8", "Mellanox-SN5600-C256S1",
+                                      "Arista-7060X6-16PE-384C-B-O128S2"]
         is_supported_per_dir = \
             get_src_dst_asic_and_duts["src_asic"].sonichost.facts["hwsku"] in supported_per_dir_platform
         logging.info(f"is_supported_per_dir: {is_supported_per_dir}")

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4147,8 +4147,6 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         limit = int(self.test_params['limit'])
         pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
         pkts_num_egr_mem = int(self.test_params.get('pkts_num_egr_mem', 0))
-        lossless_weight = int(self.test_params.get('lossless_weight', 1))
-        lossy_weight = int(self.test_params.get('lossy_weight', 1))
         topo = self.test_params['topo']
         platform_asic = self.test_params['platform_asic']
         prio_list = self.test_params.get('dscp_list', [])
@@ -4243,15 +4241,15 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                     n_prio[i] += 1
                 for n, prio in zip(n_prio, prio_list):
                     pkt = construct_ip_pkt(64,
-                        pkt_dst_mac,
-                        src_port_mac,
-                        src_port_ip,
-                        dst_port_ip,
-                        prio,
-                        src_port_vlan,
-                        ip_id=exp_ip_id + 1,
-                        ecn=ecn,
-                        ttl=64)
+                                           pkt_dst_mac,
+                                           src_port_mac,
+                                           src_port_ip,
+                                           dst_port_ip,
+                                           prio,
+                                           src_port_vlan,
+                                           ip_id=exp_ip_id + 1,
+                                           ecn=ecn,
+                                           ttl=64)
                     send_packet(self, src_port_id, pkt, n)
 
             # Get a snapshot of counter values


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

This adds QoS parameters and the necessary test case changes to use them. This generalizes the handling of `pkts_num_egr_mem` to be applied to all `Arista-7060X6*` SKUs and updates its value for TH5-512.

Changes were manually tested and verified for 100% pass rate of the `qos/test_qos_sai.py` tests.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
