### PR TITLE
Add DUT check after pfcwd warm-reboot tests

### DIFF
--- a/tests/pfcwd/test_pfcwd_warm_reboot.py
+++ b/tests/pfcwd/test_pfcwd_warm_reboot.py
@@ -631,6 +631,8 @@ class TestPfcwdWb(SetupPfcwdFunc):
                     except Exception as e:
                         pfcwd_show_status(self.dut, "pfcwd wr: run_test exception")
                         pytest.fail(str(e))
+            wait_until(300, 20, 20, self.dut.critical_services_fully_started), \
+                "All critical services should fully started!"
 
     @pytest.fixture(params=['no_storm', 'storm', 'async_storm'])
     def testcase_action(self, request):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, the individual pfcwd warm reboot test cases (from `pfcwd/test_pfcwd_warm_reboot.py`) are ending prematurely, causing subsequent pfcwd warm reboot test cases to fail.

Adding a check to ensure the DUT is ready before proceeding to the next test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
`pfcwd/test_pfcwd_warm_reboot.py` is failing due to bad DUT state after the first test case.

#### How did you do it?
Add a check to ensure the DUT is ready before proceeding to the next test case.

#### How did you verify/test it?
Test no longer fails.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
