### PR TITLE
[202411][Dualtor-AA] Add xfail on dualtor-aa topo for all generic hash tests

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1125,6 +1125,10 @@ hash/test_generic_hash.py::test_lag_member_flap[CRC-IP_PROTOCOL-ipv4:
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
+  xfail:
+    reason: "xfail test due to it's still not fully stabilized on dualtor aa setup"
+    conditions:
+      - "'dualtor-aa' in topo_name"
 
 hash/test_generic_hash.py::test_lag_member_flap[CRC_CCITT-INNER_IP_PROTOCOL:
   skip:
@@ -1152,7 +1156,10 @@ hash/test_generic_hash.py::test_lag_member_flap[CRC_CCITT-IP_PROTOCOL-ipv4:
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
-
+  xfail:
+    reason: "xfail test due to it's still not fully stabilized on dualtor aa setup"
+    conditions:
+      - "'dualtor-aa' in topo_name"
 
 hash/test_generic_hash.py::test_lag_member_remove_add:
   skip:
@@ -1182,6 +1189,10 @@ hash/test_generic_hash.py::test_lag_member_remove_add[CRC-IP_PROTOCOL-ipv4:
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
+  xfail:
+    reason: "xfail test due to it's still not fully stabilized on dualtor aa setup"
+    conditions:
+      - "'dualtor-aa' in topo_name"
 
 hash/test_generic_hash.py::test_lag_member_remove_add[CRC_CCITT-INNER_IP_PROTOCOL:
   skip:
@@ -1209,6 +1220,10 @@ hash/test_generic_hash.py::test_lag_member_remove_add[CRC_CCITT-IP_PROTOCOL-ipv4
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
+  xfail:
+    reason: "xfail test due to it's still not fully stabilized on dualtor aa setup"
+    conditions:
+      - "'dualtor-aa' in topo_name"
 
 hash/test_generic_hash.py::test_nexthop_flap:
   skip:
@@ -1283,6 +1298,10 @@ hash/test_generic_hash.py::test_reboot[CRC-IP_PROTOCOL-ipv4:
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
+  xfail:
+    reason: "xfail test due to it's still not fully stabilized on dualtor aa setup"
+    conditions:
+      - "'dualtor-aa' in topo_name"
 
 hash/test_generic_hash.py::test_reboot[CRC_CCITT-INNER_IP_PROTOCOL:
   skip:
@@ -1310,6 +1329,10 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IP_PROTOCOL-ipv4:
     reason: "With IP Protocol alone, we don't have enough entropy to distribute the packets evenly"
     conditions:
       - "asic_type in ['cisco-8000']"
+  xfail:
+    reason: "xfail test due to it's still not fully stabilized on dualtor aa setup"
+    conditions:
+      - "'dualtor-aa' in topo_name"
 
 #######################################
 #####           http              #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
xfail the whole generic hash test due to it's still not fully stabilized on dualtor aa setup.
This is an amendment for PR https://github.com/sonic-net/sonic-mgmt/pull/19383, we need add the xfail in all the generic hash test items for dualtor-aa.
This is only for 202411 branch.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
