### PR TITLE
Fix test_vlan_ports_down failure on t0-isolated-d96u32s2 topo

### DIFF
--- a/tests/vlan/test_vlan_ports_down.py
+++ b/tests/vlan/test_vlan_ports_down.py
@@ -97,10 +97,18 @@ def test_vlan_ports_down(vlan_ports_setup, duthosts, rand_one_dut_hostname, nbrh
         return
     logger.info("Starting the IP-in-IP decapsulation test...")
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-    # Use the first Ethernet port associated with the first portchannel to send test packets to the DUT
-    portchannel_info = next(iter(mg_facts["minigraph_portchannels"].values()))
-    ptf_src_port = portchannel_info["members"][0]
-    ptf_src_port_index = mg_facts["minigraph_ptf_indices"][ptf_src_port]
+    if mg_facts["minigraph_portchannels"]:
+        # Use the first Ethernet port associated with the first portchannel to send test packets to the DUT
+        portchannel_info = next(iter(mg_facts["minigraph_portchannels"].values()))
+        ptf_src_port = portchannel_info["members"][0]
+        ptf_src_port_index = mg_facts["minigraph_ptf_indices"][ptf_src_port]
+    else:
+        # for topology which has no portchannel, use the first uplink port to send test packets to the DUT
+        upstream_intfs = mg_facts['minigraph_interfaces']
+        intfs_to_t1 = [_intf['attachto'] for _intf in upstream_intfs]
+        ptf_src_port = intfs_to_t1[0]
+        ptf_src_port_index = mg_facts["minigraph_ptf_indices"][ptf_src_port]
+
     ptf_dst_port_indices = list(mg_facts["minigraph_ptf_indices"].values())
     # Test IPv4 in IPv4 decapsulation.
     # Outer IP packet:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the following error on t0-isolated-d96u32s2 topo.

```
vlan/test_vlan_ports_down.py::test_vlan_ports_down FAILED                [100%]
```

```
>           pytest_assert(vlan_route["bgpRouteEntries"],
                          f"{vlan_name}'s IPv4 subnet is not advertised to the T1 neighbor {nbrname}.")
E           Failed: Vlan1000's IPv4 subnet is not advertised to the T1 neighbor ARISTA01PT0.
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
PT0 will only receive loopback subnets in t0-isolated topo.
The first VLAN ports in t0-isolated-d96u32s2 is on port 17. not the default port 0.

#### How did you do it?
- skip checking PT0 neighbor for Vlan1000's subnets.
- use the first port which is not connected to T1 for testing, instead of always using port 0.

#### How did you verify/test it?
on physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
