### PR TITLE
Added logs around cpu up/down signals

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -1719,7 +1719,7 @@ class ReloadTest(BaseTest):
         return stdout, stderr, return_code
 
     def peer_state_check(self, ip, queue):
-        self.log('SSH thread for VM {} started'.format(ip))
+        self.log('SSH thread for VM {} started with queue {}'.format(ip, queue))
         self.test_params['port_channel_intf_idx'] = [x['ptf_ports'][0] for x in self.vm_dut_map.values()
                                                      if x['mgmt_addr'] == ip]
         ssh = HostDevice.getHostDeviceInstance(self.test_params['neighbor_type'], ip, queue,
@@ -1796,7 +1796,9 @@ class ReloadTest(BaseTest):
                 self.put_nowait(q, 'cpu_going_down')
             if self.cpu_state.get() == 'down':
                 for _, q in self.ssh_jobs:
+                    self.log('CPU port is down, sending cpu_down signal to SSH thread queue {}'.format(q))
                     q.put('cpu_down')
+                    self.log('Sent cpu_down signal to SSH thread queue {}'.format(q))
                 break
             time.sleep(self.TIMEOUT)
 
@@ -1806,7 +1808,9 @@ class ReloadTest(BaseTest):
                 self.put_nowait(q, 'cpu_going_up')
             if self.cpu_state.get() == 'up':
                 for _, q in self.ssh_jobs:
+                    self.log('CPU port is up, sending cpu_up signal to SSH thread queue {}'.format(q))
                     q.put('cpu_up')
+                    self.log('Sent cpu_up signal to SSH thread queue {}'.format(q))
                 break
             time.sleep(self.TIMEOUT)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

During an advanced-upgrade test it failed with:

```
2025-09-05 17:58:31 : DUT hasn't shutdown in 600 seconds: Traceback (most recent call last):
  File "/root/ptftests/py3/advanced-reboot.py", line 411, in timeout
    res = async_res.get(timeout=seconds)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/multiprocessing/pool.py", line 770, in get
    raise TimeoutError
multiprocessing.context.TimeoutError
```
but in the warm-reboot.log it had:
```
2025-09-05 17:47:45 : Control plane state transition from init to up
2025-09-05 17:48:31 : Wait until Control plane is down
2025-09-05 17:50:23 : Control plane state transition from up to down
2025-09-05 17:52:49 : Control plane state transition from down to partial
2025-09-05 17:52:53 : Control plane state transition from partial to up
```
so the CPU did in fact go down and up.

I'm suspecting the "wait_until_cpu_port_down" thread got stuck putting an item in the queue and hit the timeout. I have added logs in this area to improve the debuggability of this if we experience it again.

MSFT ADO: 34807995

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To enhance the debuggability of advanced-reboot tests.

#### How did you do it?
Added logs around either side of blocking calls to signal if it gets blocked there

#### How did you verify/test it?
Ran the test_upgrade_path test which uses advanced-reboot and confirmed the logs were seen. Now we see these logs:
```
2025-09-09 04:29:01 : SSH thread for VM 172.16.0.10 started with queue <queue.Queue object at 0x7f0bdb863e10>
2025-09-09 04:29:01 : SSH thread for VM 172.16.0.11 started with queue <queue.Queue object at 0x7f0bdb8a5490>
2025-09-09 04:29:01 : SSH thread for VM 172.16.0.12 started with queue <queue.Queue object at 0x7f0bdb8a5110>
2025-09-09 04:29:01 : SSH thread for VM 172.16.0.13 started with queue <queue.Queue object at 0x7f0bdb8a45d0>
...
2025-09-09 04:31:53 : CPU port is down, sending cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb863e10>
2025-09-09 04:31:54 : Send     1 Received     0 arp ping
2025-09-09 04:31:54 : Reachability watcher - checking VLAN GW IP
2025-09-09 04:31:55 : Sent cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb863e10>
2025-09-09 04:31:55 : CPU port is down, sending cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5490>
2025-09-09 04:31:55 : Sent cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5490>
2025-09-09 04:31:55 : CPU port is down, sending cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5110>
2025-09-09 04:31:55 : Sent cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5110>
2025-09-09 04:31:55 : CPU port is down, sending cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a45d0>
2025-09-09 04:31:55 : Sent cpu_down signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a45d0>
...
2025-09-09 04:33:09 : CPU port is up, sending cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb863e10>
2025-09-09 04:33:10 : Send     1 Received     0 arp ping
2025-09-09 04:33:10 : Reachability watcher - checking VLAN GW IP
2025-09-09 04:33:11 : Sent cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb863e10>
2025-09-09 04:33:11 : CPU port is up, sending cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5490>
2025-09-09 04:33:11 : Sent cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5490>
2025-09-09 04:33:11 : CPU port is up, sending cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5110>
2025-09-09 04:33:11 : Sent cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a5110>
2025-09-09 04:33:11 : CPU port is up, sending cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a45d0>
2025-09-09 04:33:11 : Sent cpu_up signal to SSH thread queue <queue.Queue object at 0x7f0bdb8a45d0>
```
The timestamps between each log can tell us how long we spend waiting on putting the item in the queue.

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
