### PR TITLE
[test_ro_disk.py] Fix behaviour of TSA/TSB assert check on supervisor and multi-asic devices

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -12,6 +12,7 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import wait
 from tests.common.utilities import pdu_reboot
 from tests.common.reboot import reboot
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.tacacs.tacacs_helper import ssh_remote_run, check_tacacs  # noqa: F401
 from tests.common.helpers.tacacs.tacacs_helper import setup_tacacs_client
 from .utils import change_and_wait_aaa_config_update
@@ -258,13 +259,25 @@ def test_ro_disk(localhost, ptfhost, duthosts, enum_rand_one_per_hwsku_hostname,
 
         chk_ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo find /home -ls")
 
+        mode_str = "Chassis" if duthost.is_supervisor_node() else "System"
+        expected_match_count = 1 if duthost.is_supervisor_node() else duthost.num_asics()
+        expected_tsa_res = "{} Mode: Normal -> Maintenance".format(mode_str)
+        expected_tsb_res = "{} Mode: Maintenance -> Normal".format(mode_str)
         # Verify after monit fix login issue ,remote user can run TSA/TSB command.
         res = ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo TSA")
         logger.debug("TSA res={}".format(res))
-        assert "System Mode: Normal -> Maintenance" in res["stdout_lines"], "Failed to TSA"
+        match_count = 0
+        for stdout_line in res["stdout_lines"]:
+            if expected_tsa_res in stdout_line:
+                match_count += 1
+        pytest_assert(match_count == expected_match_count, "Failed to TSA")
         res = ssh_remote_run(localhost, dutip, rw_user, rw_pass, "sudo TSB")
         logger.debug("TSB res={}".format(res))
-        assert "System Mode: Maintenance -> Normal" in res["stdout_lines"], "Failed to TSB"
+        match_count = 0
+        for stdout_line in res["stdout_lines"]:
+            if expected_tsb_res in stdout_line:
+                match_count += 1
+        pytest_assert(match_count == expected_match_count, "Failed to TSB")
 
         if not os.path.exists(DATA_DIR):
             os.makedirs(DATA_DIR)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20577 and Fixes #20584 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Bugs were causing failures on T2/multi-asic devices.
#### How did you do it?
Correct the TSA/TSB assert behaviour
#### How did you verify/test it?
Tested on T2 multi-asic device - https://elastictest.org/scheduler/testplan/68c00dccdaa8f852625c8d1c
Tested on T1 single-asic device - https://elastictest.org/scheduler/testplan/68c0391b22b1312120142cd6
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A