### PR TITLE
Adding missing support for multi-asic in re-enabled test eth update speed

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -357,17 +357,18 @@ def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_
 
 
 def test_update_valid_index(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readiness,
-                            enum_rand_one_frontend_asic_index):
+                            enum_rand_one_frontend_asic_index, cli_namespace_prefix):
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    output = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|"\\*')["stdout"]
+    output = duthost.shell('sonic-db-cli {} CONFIG_DB keys "PORT|"\\*'.format(cli_namespace_prefix))["stdout"]
     interfaces = {}  # to be filled with two interfaces mapped to their indeces
 
     for line in output.split('\n'):
         if line.startswith('PORT|Ethernet'):
             interface = line[line.index('Ethernet'):].strip()
-            index = duthost.shell('sonic-db-cli CONFIG_DB hget "PORT|{}" index'.format(interface))["stdout"]
+            index = duthost.shell('sonic-db-cli {} CONFIG_DB hget "PORT|{}" index'.format(
+                cli_namespace_prefix, interface))["stdout"]
             interfaces[interface] = index
             if len(interfaces) == 2:
                 break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20586 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Passing namespace as argument in sonic-db-cli in case platform is multi-asic.

#### How did you verify/test it?
Ran test case in multi-asic platfrom and passed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
