### PR TITLE
Fix bad "condition" to xfail snmp/test_snmp_link_local.py

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3660,7 +3660,7 @@ snmp/test_snmp_link_local.py:
       - "release in ['202205', '202211', '202305', '202311']"
   xfail:
     reason: "Test script has issues on kvm testbed."
-    condition:
+    conditions:
       - "asic_type in ['vs']"
       - "https://github.com/sonic-net/sonic-mgmt/issues/15081"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix bad "condition" to xfail snmp/test_snmp_link_local.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] msft-202412
- [x] msft-202503

### Approach
#### What is the motivation for this PR?
Currently the wrong token,`condition` instead of `conditions`, is used to xfail snmp/test_snmp_link_local.py, and this causes this test to unconditionally xfail on all the platforms

#### How did you do it?

#### How did you verify/test it?

Confirmed now snmp/test_snmp_link_local.py can correctly run and pass on our switches

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
