### PR TITLE
Ignore kernel linkdown routes in test_cont_link_flap.py

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1470,7 +1470,7 @@ Totals               6450                 6449
                     ret[key] = val
         return ret
 
-    def get_ip_route_summary(self, skip_kernel_tunnel=False):
+    def get_ip_route_summary(self, skip_kernel_tunnel=False, skip_kernel_linkdown=False):
         """
         @summary: issue "show ip[v6] route summary" and parse output into dicitionary.
                   Going forward, this show command should use tabular output so that
@@ -1493,6 +1493,20 @@ Totals               6450                 6449
                 ipv4_summary['Totals']['routes'] -= ipv4_route_kernel_count
                 ipv4_summary['Totals']['FIB'] -= ipv4_route_kernel_count
 
+        if skip_kernel_linkdown is True:
+            output = self.shell("show ip route kernel")["stdout_lines"]
+            ipv4_route_kernel_skip_count = 0
+            pattern = re.compile(r'^K\s+.*directly connected.*linkdown')
+
+            for line in output:
+                if pattern.search(line):
+                    ipv4_route_kernel_skip_count += 1
+                    logging.debug("skip IPv4 route kernel for linkdown: {}".format(line))
+
+            if ipv4_route_kernel_skip_count > 0:
+                ipv4_summary['kernel']['routes'] -= ipv4_route_kernel_skip_count
+                ipv4_summary['Totals']['routes'] -= ipv4_route_kernel_skip_count
+
         ipv6_output = self.shell("show ipv6 route sum")["stdout_lines"]
         ipv6_summary = self._parse_route_summary(ipv6_output)
 
@@ -1509,6 +1523,20 @@ Totals               6450                 6449
                 ipv6_summary['kernel']['FIB'] -= ipv6_route_kernel_count
                 ipv6_summary['Totals']['routes'] -= ipv6_route_kernel_count
                 ipv6_summary['Totals']['FIB'] -= ipv6_route_kernel_count
+
+        if skip_kernel_linkdown is True:
+            output = self.shell("show ipv6 route kernel")["stdout_lines"]
+            ipv6_route_kernel_skip_count = 0
+            pattern = re.compile(r'^K\s+.*directly connected.*linkdown')
+
+            for line in output:
+                if pattern.search(line):
+                    ipv6_route_kernel_skip_count += 1
+                    logging.debug("skip IPv6 route kernel for linkdown: {}".format(line))
+
+            if ipv6_route_kernel_skip_count > 0:
+                ipv6_summary['kernel']['routes'] -= ipv6_route_kernel_skip_count
+                ipv6_summary['Totals']['routes'] -= ipv6_route_kernel_skip_count
 
         return ipv4_summary, ipv6_summary
 

--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -119,7 +119,7 @@ def check_bgp_routes(dut, start_time_ipv4_route_counts, start_time_ipv6_route_co
     """
     MAX_DIFF = 5
 
-    sumv4, sumv6 = dut.get_ip_route_summary(skip_kernel_tunnel=True)
+    sumv4, sumv6 = dut.get_ip_route_summary(skip_kernel_tunnel=True, skip_kernel_linkdown=True)
     totalsv4 = sumv4.get('Totals', {})
     totalsv6 = sumv6.get('Totals', {})
     routesv4 = totalsv4.get('routes', 0)

--- a/tests/platform_tests/link_flap/test_cont_link_flap.py
+++ b/tests/platform_tests/link_flap/test_cont_link_flap.py
@@ -107,7 +107,7 @@ class TestContLinkFlap(object):
         logging.info("Redis Memory: %f M", start_time_redis_memory)
 
         # Record ipv4 route counts at start
-        sumv4, sumv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True)
+        sumv4, sumv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True, skip_kernel_linkdown=True)
         logging.debug("sumv4  {} ".format(sumv4))
         logging.debug("sumv6  {} ".format(sumv6))
 
@@ -156,7 +156,7 @@ class TestContLinkFlap(object):
         # Make Sure all ipv4/ipv6 routes are relearned with jitter of ~5
         if not wait_until(120, 2, 0, check_bgp_routes, duthost,
                           start_time_ipv4_route_counts, start_time_ipv6_route_counts):
-            endv4, endv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True)
+            endv4, endv6 = duthost.get_ip_route_summary(skip_kernel_tunnel=True, skip_kernel_linkdown=True)
             failmsg = []
             failmsg.append("IP routes are not equal after link flap: before ipv4 {} ipv6 {}, after ipv4 {} ipv6 {}"
                            .format(sumv4, sumv6, endv4, endv6))


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: fix test_cont_link_flap.py by ignoring linkdown routes
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
From FRR 10.3 upgrade, some kernel routes were added when the interfaces
were down in booting but failed to be updated when the interfaces come up later.

When looking into the pattern of those routes (K route below), they are
always showing as linkdown, directly connected, and not selected.
Meanwhile, there always exist some other routes (C route below) in "show
ip route" on the protocol of Connected and state of selected that
override the K routes in questions and diminish their importance. So our
solution now is to fix the testcase by ignoring those K routes matching
'^K\s+.*directly connected.*linkdown'.

show ip route
C>*10.0.0.36/31 is directly connected, Ethernet72, 00:01:54
K 10.0.0.36/31 [0/0] is directly connected, Ethernet72, 00:02:07

show ip route kernel
K   10.0.0.36/31 [0/0] is directly connected, Ethernet72 linkdown,
weight 1, 00:02:36

#### How did you do it?
Ignore routes matching regex '^K\s+.*directly connected.*linkdown' 

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
