### PR TITLE
Validate server-status for active-active mux ports.

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -1404,6 +1404,7 @@ def show_muxcable_status(duthost):
     for port, muxcable in list(output['MUX_CABLE'].items()):
         ret[port] = {
             'status': muxcable['STATUS'],
+            'serverstatus': muxcable['SERVER_STATUS'],
             'health': muxcable['HEALTH'],
             'hwstatus': muxcable['HWSTATUS']
         }
@@ -1700,7 +1701,7 @@ def check_active_active_port_status(duthost, ports, status):
     for port in ports:
         if port not in show_mux_status_ret:
             return False
-        elif show_mux_status_ret[port]['status'] != status:
+        elif show_mux_status_ret[port]['status'] != status or show_mux_status_ret[port]['serverstatus'] != status:
             return False
     return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Validates server-status for active-active mux ports

Summary:
Fixes # (https://github.com/aristanetworks/sonic-qual.msft/issues/804)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
In some tests, we configure active active dualtor to active standby via `config mux mode <state> <port>`. State of the configured port should be validated from server's perspective as well to meet test's expectations.

#### How did you do it?
Added extra check for `SERVER_STATUS`

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
