### PR TITLE
Fix: mac address change during oq watchdog test with soft_reset

### DIFF
--- a/tests/saitests/py3/switch.py
+++ b/tests/saitests/py3/switch.py
@@ -25,6 +25,7 @@ from sai_base_test import interface_to_front_mapping
 from ptf.thriftutils import *       # noqa F403
 from switch_sai_thrift.ttypes import *          # noqa F403
 from switch_sai_thrift.sai_headers import*      # noqa F403
+import ptf.testutils as testutils
 from switch_sai_thrift.ttypes import sai_thrift_fdb_entry_t, sai_thrift_ip_t, sai_thrift_ip_address_t,\
     sai_thrift_ip_prefix_t, sai_thrift_object_list_t, sai_thrift_vlan_list_t, sai_thrift_acl_mask_t,\
     sai_thrift_acl_data_t, sai_thrift_acl_field_data_t, sai_thrift_attribute_value_t, sai_thrift_attribute_t,\
@@ -114,9 +115,13 @@ def switch_init(clients):
 
         # TOFIX in brcm sai: This causes the following error on td2 (a7050-qx-32s)
         # ERR syncd: brcm_sai_set_switch_attribute:842 updating switch mac addr failed with error -2.
-        attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
-        attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
-        client.sai_thrift_set_switch_attribute(attr)
+        test_params = testutils.test_params_get()
+        asic_type = test_params['sonic_asic_type']
+        print("switch_init asic_type= {}".format(asic_type))
+        if asic_type not in ['cisco-8000']:
+            attr_value = sai_thrift_attribute_value_t(mac='00:77:66:55:44:33')
+            attr = sai_thrift_attribute_t(id=SAI_SWITCH_ATTR_SRC_MAC_ADDRESS, value=attr_value)
+            client.sai_thrift_set_switch_attribute(attr)
 
         # wait till the port are up
         time.sleep(10)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Recently, a new QoS test case was added, which triggered an issue:
https://migsonic.atlassian.net/browse/MIGSMSFT-1203

The root cause is that during the test case, the system MAC address is changed after a soft reset. The script that

changes the MAC address was introduced in the following upstream PR: https://github.com/sonic-net/sonic-mgmt/pull/8149

After debugging and discussion, it is confirmed that the script was added to fix a TD2-specific issue and is not applicable to Cisco devices.

Following the discussions, we implemented a fix to skip the MAC address setting for Cisco platforms.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
