### PR TITLE
Skip test_bgp_sentinel for topologies with no spine layer

### DIFF
--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -84,18 +84,6 @@ def is_bgp_monv6_supported(duthost):
     return False if re.search(bgp_sentinel_pattern, output['stdout']) is None else True
 
 
-# Returns True if the topology has a spine layer, else returns False
-def topo_has_spine_layer(tbinfo):
-    if not tbinfo:
-        return False
-
-    for k, v in tbinfo['topo']['properties']['configuration'].items():
-        if 'spine' in v['properties']:
-            return True
-
-    return False
-
-
 def get_dut_listen_range(tbinfo):
     # Find spine route and get the bp_interface's network
     ipv4_subnet, ipv6_subnet, = None, None
@@ -185,11 +173,6 @@ def dut_lo_addr(rand_selected_dut):
 
 @pytest.fixture(scope="module", params=['BGPSentinel', 'BGPMonV6'])
 def dut_setup_teardown(rand_selected_dut, tbinfo, dut_lo_addr, request):
-
-    # Skip test for topologies with no spine layer with BGP peers.
-    if not topo_has_spine_layer(tbinfo):
-        pytest.skip('This test is not applicable to topologies with no SPINE layer')
-
     duthost = rand_selected_dut
     lo_ipv4_addr, lo_ipv6_addr = dut_lo_addr
     ipv4_subnet, ipv6_subnet, spine_bp_addr = get_dut_listen_range(tbinfo)

--- a/tests/bgp/test_bgp_sentinel.py
+++ b/tests/bgp/test_bgp_sentinel.py
@@ -84,6 +84,18 @@ def is_bgp_monv6_supported(duthost):
     return False if re.search(bgp_sentinel_pattern, output['stdout']) is None else True
 
 
+# Returns True if the topology has a spine layer, else returns False
+def topo_has_spine_layer(tbinfo):
+    if not tbinfo:
+        return False
+
+    for k, v in tbinfo['topo']['properties']['configuration'].items():
+        if 'spine' in v['properties']:
+            return True
+
+    return False
+
+
 def get_dut_listen_range(tbinfo):
     # Find spine route and get the bp_interface's network
     ipv4_subnet, ipv6_subnet, = None, None
@@ -173,6 +185,11 @@ def dut_lo_addr(rand_selected_dut):
 
 @pytest.fixture(scope="module", params=['BGPSentinel', 'BGPMonV6'])
 def dut_setup_teardown(rand_selected_dut, tbinfo, dut_lo_addr, request):
+
+    # Skip test for topologies with no spine layer with BGP peers.
+    if not topo_has_spine_layer(tbinfo):
+        pytest.skip('This test is not applicable to topologies with no SPINE layer')
+
     duthost = rand_selected_dut
     lo_ipv4_addr, lo_ipv6_addr = dut_lo_addr
     ipv4_subnet, ipv6_subnet, spine_bp_addr = get_dut_listen_range(tbinfo)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -307,6 +307,10 @@ bgp/test_bgp_router_id.py::test_bgp_router_id_set_without_loopback:
       - "https://github.com/sonic-net/sonic-mgmt/issues/19916 and '-v6-' in topo_name"
 
 bgp/test_bgp_sentinel.py:
+  skip:
+    reason: "Skip for t1-isolated-d128/32 topologies"
+    conditions:
+      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
   xfail:
     reason: "xfail for IPv6-only topologies, with issue it try to parse with IPv4 style"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202412 

### Approach
#### What is the motivation for this PR?

Skip test_bgp_sentinel for topologies with no spine layer, as this test depends on spine layer BGP information to run.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
