### PR TITLE
Fix dropcounter error when set before fdb config

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -163,7 +163,6 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
         drop_reason (str): The drop reason being tested.
     """
     duthost = duthosts[rand_one_dut_hostname]
-    counter_type = setup_counters([drop_reason])
 
     rx_port = random.choice([port
                              for port in list(testbed_params["physical_port_map"].keys())
@@ -180,6 +179,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
                          "SET", "static")
         mock_server["fanout_neighbor"].shutdown(mock_server["fanout_intf"])
         time.sleep(3)
+        counter_type = setup_counters([drop_reason])
         verifyFdbArp(duthost, mock_server['server_dst_addr'],
                      mock_server['server_dst_mac'], mock_server['server_dst_intf'])
         send_dropped_traffic(counter_type, pkt, rx_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
On Moby, if a drop counter is added and configured, followed by adding a static FDB entry, then the drop counter would not be able to count packets properly. Creating the drop counter after the FDB entry is added will fix the issue.

Note: moving setup_counters() would mean that the check to make sure the device is capable of supporting the specific drop reasons will happen after the FDB entry is added - which is in a try block and only cleaned up in the finally block. However, it poses no issue as the finally block will be executed even if the pytest skip is triggered in the try block.

Test no longer fails on Moby, ERR syslogs no longer gets triggered.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
