### PR TITLE
Add Xid in DHCP stress test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -58,7 +58,11 @@ class DHCPStressDiscoverTest(DHCPTest):
         # Form and send DHCPDISCOVER packet
         dhcp_discover = self.create_dhcp_discover_packet(dst_mac, src_port)
         end_time = time.time() + self.packets_send_duration
+        xid = 0
         while time.time() < end_time:
+            # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
+            dhcp_discover[scapy.BOOTP].xid = xid
+            xid += 1
             testutils.send_packet(self, self.client_port_index, dhcp_discover)
             time.sleep(1/self.client_packets_per_sec)
 
@@ -89,6 +93,7 @@ class DHCPStressDiscoverTest(DHCPTest):
 
         masked_discover.set_do_not_care_scapy(scapy.BOOTP, "sname")
         masked_discover.set_do_not_care_scapy(scapy.BOOTP, "file")
+        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "xid")
 
         discover_count = testutils.count_matched_packets_all_ports(
             self, masked_discover, self.server_port_indices)
@@ -119,7 +124,11 @@ class DHCPStressOfferTest(DHCPTest):
     def client_send_offer_stress(self):
         dhcp_offer = self.create_dhcp_offer_packet()
         end_time = time.time() + self.packets_send_duration
+        xid = 0
         while time.time() < end_time:
+            # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
+            dhcp_offer[scapy.BOOTP].xid = xid
+            xid += 1
             testutils.send_packet(self, self.server_port_indices[0], dhcp_offer)
             time.sleep(1/self.client_packets_per_sec)
 
@@ -149,6 +158,7 @@ class DHCPStressOfferTest(DHCPTest):
 
         masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
         masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
+        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "xid")
 
         offer_count = testutils.count_matched_packets(self, masked_offer, self.client_port_index)
         return offer_count
@@ -179,7 +189,11 @@ class DHCPStressRequestTest(DHCPTest):
         # Form and send DHCPREQUEST packet
         dhcp_request = self.create_dhcp_request_packet(dst_mac, src_port)
         end_time = time.time() + self.packets_send_duration
+        xid = 0
         while time.time() < end_time:
+            # Set a unique transaction ID for each DHCPACK packet for making sure no packet miss
+            dhcp_request[scapy.BOOTP].xid = xid
+            xid += 1
             testutils.send_packet(self, self.client_port_index, dhcp_request)
             time.sleep(1/self.client_packets_per_sec)
 
@@ -210,6 +224,7 @@ class DHCPStressRequestTest(DHCPTest):
 
         masked_request.set_do_not_care_scapy(scapy.BOOTP, "sname")
         masked_request.set_do_not_care_scapy(scapy.BOOTP, "file")
+        masked_request.set_do_not_care_scapy(scapy.BOOTP, "xid")
 
         request_count = testutils.count_matched_packets_all_ports(
             self, masked_request, self.server_port_indices)
@@ -240,7 +255,11 @@ class DHCPStressAckTest(DHCPTest):
     def client_send_ack_stress(self):
         dhcp_ack = self.create_dhcp_ack_packet()
         end_time = time.time() + self.packets_send_duration
+        xid = 0
         while time.time() < end_time:
+            # Set a unique transaction ID for each DHCPACK packet for making sure no packet miss
+            dhcp_ack[scapy.BOOTP].xid = xid
+            xid += 1
             testutils.send_packet(self, self.server_port_indices[0], dhcp_ack)
             time.sleep(1/self.client_packets_per_sec)
 
@@ -270,6 +289,7 @@ class DHCPStressAckTest(DHCPTest):
 
         masked_ack.set_do_not_care_scapy(scapy.BOOTP, "sname")
         masked_ack.set_do_not_care_scapy(scapy.BOOTP, "file")
+        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "xid")
 
         ack_count = testutils.count_matched_packets(self, masked_ack, self.client_port_index)
         return ack_count

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -163,7 +163,7 @@ def calculate_counters_per_pkts(pkts):
     """
     all_counters = {}
     for pkt in pkts:
-        if hasattr(pkt, 'ifindex') and pkt.haslayer(scapy.DHCP) and pkt[scapy.BOOTP].xid == 0:
+        if hasattr(pkt, 'ifindex') and pkt.haslayer(scapy.DHCP):
             counter = all_counters.setdefault(pkt.ifindex, {
                 "RX": {},
                 "TX": {}

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -148,14 +148,17 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             return not output['rc'] and output['stdout'].strip() == "exists"
 
         def _verify_server_packets(pkts):
-            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0]) * num_dhcp_servers
+            actual_count = len([pkt for pkt in pkts
+                               if pkt[scapy.BOOTP].xid <= packets_send_duration * client_packets_per_sec]
+                               ) * num_dhcp_servers
             lower_bound = int(exp_count * 0.9)
             upper_bound = int(exp_count * 1.1)
             pytest_assert(lower_bound <= actual_count <= upper_bound,
                           "Mismatch: DUT count = {}, PTF count = {}.".format(actual_count, exp_count))
 
         def _verify_client_packets(pkts):
-            actual_count = len([pkt for pkt in pkts if pkt[scapy.BOOTP].xid == 0])
+            actual_count = len([pkt for pkt in pkts
+                                if pkt[scapy.BOOTP].xid <= packets_send_duration * client_packets_per_sec])
             lower_bound = int(exp_count * 0.9)
             upper_bound = int(exp_count * 1.1)
             pytest_assert(lower_bound <= actual_count <= upper_bound,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
current stress test only counts the packets total number, we can't trace each packet in dhcp relay. Some packets are lost and some packets are duplicated. Even the total numbers are equal, we still need to verify if all of packets are relayed
#### How did you do it?
Add Xid in each packet
#### How did you verify/test it?
Run stress test: dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
