### PR TITLE
[IXIA] fix flakiness for BGP tests

### DIFF
--- a/tests/snappi_tests/bgp/files/bgp_outbound_helper.py
+++ b/tests/snappi_tests/bgp/files/bgp_outbound_helper.py
@@ -752,6 +752,10 @@ def get_convergence_for_link_flap(duthosts,
         logger.info('Verifying protocol sessions state')
         protocolsSummary = StatViewAssistant(ixnetwork, 'Protocols Summary')
         protocolsSummary.CheckCondition('Sessions Down', StatViewAssistant.EQUAL, 0)
+
+        # NOTE: we sleep 60 seconds to make sure DUT is ready before receiving traffic, avoiding traffic lost
+        time.sleep(60)
+
         logger.info('Starting Traffic')
 
         cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
@@ -1034,6 +1038,9 @@ def get_convergence_for_process_flap(duthosts,
                         logger.info('Verifying protocol sessions state')
                         protocolsSummary = StatViewAssistant(ixnetwork, 'Protocols Summary')
                         protocolsSummary.CheckCondition('Sessions Down', StatViewAssistant.EQUAL, 0)
+
+                        # NOTE: we sleep 60 seconds to make sure DUT is ready before receiving traffic
+                        time.sleep(60)
 
                         logger.info('Starting Traffic')
                         cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
@@ -1593,6 +1600,9 @@ def get_convergence_for_ungraceful_restart(duthosts,
             'Sessions Down', StatViewAssistant.EQUAL, 0)
         logger.info('Starting Traffic')
 
+        # NOTE: we sleep 60 seconds to make sure DUT is ready before receiving traffic, avoiding traffic lost
+        time.sleep(60)
+
         cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
         api.set_control_state(cs)
         wait(SNAPPI_TRIGGER, "For Traffic To start")
@@ -1645,7 +1655,7 @@ def get_convergence_for_ungraceful_restart(duthosts,
         logger.info('Clearing Stats')
         ixnetwork.ClearStats()
         for duthost in duthosts:
-            ping_device(duthost, timeout=180)
+            ping_device(duthost, timeout=300)
         wait(DUT_TRIGGER, "Contaniers on the DUT to stabalize after restart")
 
         flow_stats = get_flow_stats(api)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix BGP nightly flakiness test
Fixes # (issue) 34806354, 34806351, 34806343

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR address a few problems that happen during our nightly, namely

- E                                   Failed: Snappi_Uplink_PO_2_Link_1 is not receiving                                               any packet

- E               Failed: Loss Observed in IPv4_Traffic/IPv6_Traffic

- E                   Failed: Snappi_Uplink_PO_8_Link_1 is not receiving any packet

The reason it after protocol starts. We started the traffic too early that caused some rx drops / missing packets

#### How did you do it?
Simply add some delays after the protocol start to ensure that our testbeds has successfully established bgp neighbor before sending the traffic 
#### How did you verify/test it?

test_bgp_outbound_ungraceful_restart


<img width="2561" height="931" alt="image" src="https://github.com/user-attachments/assets/1a1e1060-2bda-4c2c-9a48-cc92cf9759b0" />


test_bgp_outbound_downlink_port_flap

<img width="2540" height="1020" alt="image" src="https://github.com/user-attachments/assets/d24d63f7-960f-4b0a-ba31-9121a34c329b" />


test_bgp_outbound_ungraceful_restart

<img width="2561" height="931" alt="image" src="https://github.com/user-attachments/assets/2f66c1cc-8910-4c3b-874d-f36e36ef989d" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
