### PR TITLE
fix testPortIps update issue in test_qos_sai

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1093,7 +1093,7 @@ class QosSaiBase(QosBase):
 
             # restore currently assigned IPs
             if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
-                testPortIps.update(dutPortIps)
+                testPortIps[src_dut_index][src_asic_index].update(dutPortIps[src_dut_index][src_asic_index])
 
             if is_supported_per_dir:
                 for portIndex, _ in testPortIps[src_dut_index][src_asic_index].items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
fix dict update issue in test_qos_sai.

In t0-isolated topology, testPortIds has both upstream and downstream ports.

For the following value:
```
dutPortIps = {0: {0: {0: {'peer_addr': '10.0.0.1'}, 1: {'peer_addr': '10.0.0.3'}, .... 
testPortIps = {0: {0: {32: {'peer_addr': '192.168.0.34'}, 33: {'peer_addr': '192.168.0.35'}, ...
```

After the following code:
```
            # restore currently assigned IPs
            if len(dutPortIps[src_dut_index][src_asic_index]) != 0:
                testPortIps.update(dutPortIps)
```

testPortIps is overwritten to have only. 10.x.x.x IPs, instead of having both 192.168.x.x and 10.x.x.x ranges.
```
testPortIps =  {0: {0: {0: {'peer_addr': '10.0.0.1'}, 25: {'peer_addr': '10.0.0.51'}, 26: {'peer_addr': '10.0.0.53'}, 27: {'peer_addr': '10.0.0.55'}, 28: {'peer_addr': '10.0.0.57'}, 29: {'peer_addr': '10.0.0.59'}, 3: {'peer_addr': '10.0.0.7'}, 30: {'peer_addr': '10.0.0.61'}, 31: {'peer_addr': '10.0.0.63'}, 4: {'peer_addr': '10.0.0.9'}, 5: {'peer_addr': '10.0.0.11'}, 6: {'peer_addr': '10.0.0.13'}, 7: {'peer_addr': '10.0.0.15'}, 8: {'peer_addr': '10.0.0.17'}, 9: {'peer_addr': '10.0.0.19'}, 1: {'peer_addr': '10.0.0.3'}, 10: {'peer_addr': '10.0.0.21'}, 11: {'peer_addr': '10.0.0.23'}, 12: {'peer_addr': '10.0.0.25'}, 128: {'peer_addr': '10.0.1.1'}, 129: {'peer_addr': '10.0.1.3'}, 13: {'peer_addr': '10.0.0.27'}, 14: {'peer_addr': '10.0.0.29'}, 15: {'peer_addr': '10.0.0.31'}, 16: {'peer_addr': '10.0.0.33'}, 17: {'peer_addr': '10.0.0.35'}, 18: {'peer_addr': '10.0.0.37'}, 19: {'peer_addr': '10.0.0.39'}, 2: {'peer_addr': '10.0.0.5'}, 20: {'peer_addr': '10.0.0.41'}, 21: {'peer_addr': '10.0.0.43'}, 22: {'peer_addr': '10.0.0.45'}, 23: {'peer_addr': '10.0.0.47'}, 24: {'peer_addr': '10.0.0.49'}}}}

```

And causing the following error:

```
======================================================================
ERROR: sai_qos_tests.ARPpopulate
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/saitests/py3/sai_qos_tests.py", line 883, in runTest
    dst_port_ip = self.test_port_ips[dut_i][asic_i][dst_port_id]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 32

```

This error doesn't affecting normal T0 topo, as upstream are all port-channel interfaces, and port-channel interfaces are not part of the testPortIds. So only isolated topologies are being affected so far.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix testPortIps issue in test_qos_sai 

#### How did you do it?
combine two IP dict.

#### How did you verify/test it?
Local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
