### PR TITLE
Refactor get_upstream_neigh_type to also use topo_name

### DIFF
--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -124,7 +124,7 @@ def create_acl_table(rand_selected_dut, tbinfo):
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
     if topo == "mx" or len(mg_facts["minigraph_portchannels"]) == 0:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
+        upstream_neigh_type = get_upstream_neigh_type(tbinfo)
         neighbor_ports = get_neighbor_port_list(rand_selected_dut, upstream_neigh_type)
         ports = ",".join(neighbor_ports)
     else:
@@ -259,7 +259,7 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter,
     mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
     if topo == "mx" or len(mg_facts["minigraph_portchannels"]) == 0:
-        upstream_neigh_type = get_upstream_neigh_type(topo)
+        upstream_neigh_type = get_upstream_neigh_type(tbinfo)
         ptf_interfaces = get_neighbor_ptf_port_list(rand_selected_dut, upstream_neigh_type, tbinfo)
     else:
         portchannel_members = []

--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -20,7 +20,9 @@ UPSTREAM_NEIGHBOR_MAP = {
     "m0_vlan": "m1",
     "m0_l3": "m1",
     "ft2": "lt2",
-    "lt2": "ut2"
+    "lt2": "ut2",
+    "t1-isolated-d128": "t0",
+    "t1-isolated-d32": "t0",
 }
 
 # Describe ALL upstream neighbor of dut in different topos

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -931,16 +931,21 @@ def get_neighbor_ptf_port_list(duthost, neighbor_name, tbinfo):
     return ptf_port_list
 
 
-def get_upstream_neigh_type(topo_type, is_upper=True):
+def get_upstream_neigh_type(tbinfo, is_upper=True):
     """
     @summary: Get neighbor type by topo type
-    @param topo_type: topo type
+    @param tbinfo: testbed info
     @param is_upper: if is_upper is True, return uppercase str, else return lowercase str
     @return a str
         Sample output: "mx"
     """
-    if topo_type in UPSTREAM_NEIGHBOR_MAP:
-        return UPSTREAM_NEIGHBOR_MAP[topo_type].upper() if is_upper else UPSTREAM_NEIGHBOR_MAP[topo_type]
+    topo_name = tbinfo["topo"]["name"]
+    topo_type = tbinfo["topo"]["type"]
+    topo_attrs = [topo_name, topo_type]
+
+    for topo_attr in topo_attrs:
+        if topo_attr in UPSTREAM_NEIGHBOR_MAP:
+            return UPSTREAM_NEIGHBOR_MAP[topo_attr].upper() if is_upper else UPSTREAM_NEIGHBOR_MAP[topo_attr]
 
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2274,7 +2274,7 @@ def enum_rand_one_frontend_asic_index(request):
 
 @pytest.fixture(scope='module')
 def enum_upstream_dut_hostname(duthosts, tbinfo):
-    upstream_nbr_type = get_upstream_neigh_type(tbinfo["topo"]["type"], is_upper=True)
+    upstream_nbr_type = get_upstream_neigh_type(tbinfo, is_upper=True)
     if upstream_nbr_type is None:
         upstream_nbr_type = "T3"
 

--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -362,7 +362,7 @@ def copp_testbed(
         # There is no upstream neighbor in T1 backend topology. Test is skipped on T0 backend.
         # For Non T2 topologies, setting upStreamDuthost as duthost to cover dualTOR and MLAG scenarios.
         if 't2' in tbinfo["topo"]["name"]:
-            upStreamDuthost = find_duthost_on_role(duthosts, get_upstream_neigh_type(tbinfo['topo']['type']), tbinfo)
+            upStreamDuthost = find_duthost_on_role(duthosts, get_upstream_neigh_type(tbinfo), tbinfo)
         else:
             upStreamDuthost = duthost
 

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -51,7 +51,7 @@ def is_in_neighbor(neigh_types, neigh_name):
 def get_default_route_upstream_neigh_type(tb):
     if tb["topo"]["name"] in ["t1-isolated-d128", "t1-isolated-d32"]:
         return "T0"
-    return get_upstream_neigh_type(tb["topo"]["type"])
+    return get_upstream_neigh_type(tb)
 
 
 def get_default_route_all_upstream_neigh_type(tb):

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -61,8 +61,7 @@ def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, config_sflow_feature
 
     upstream_ports = []
     if len(mg_facts["minigraph_portchannels"]) == 0:
-        topo = tbinfo["topo"]["type"]
-        upstream_neigh_type = get_upstream_neigh_type(topo)
+        upstream_neigh_type = get_upstream_neigh_type(tbinfo)
         upstream_ports = get_neighbor_port_list(duthost, upstream_neigh_type)
     else:
         for port_channel, interfaces in list(mg_facts['minigraph_portchannels'].items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Refactor the `get_upstream_neigh_type` fixture to use a combination of topo_name and  topo_type to determine the correct upstream neighbour.

Additionally, fix `route/test_route_flap` for t1-isolated-d128/d32 topos by providing the correct t0 neighbour type

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
