### PR TITLE
[BGP] Fix Update Replication Test on Mellanox Devices

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -214,9 +214,9 @@ def test_bgp_update_replication(
     prev_num_rib = int(results[0]["num_rib"])
 
     # Inject and withdraw routes with a specified interval in between iterations
-    for interval in [4.0, 3.0, 2.5]:
+    for interval in [4.0, 3.5, 3.0]:
         # Repeat 20 times
-        for _ in range(20):
+        for _ in range(15):
             # Inject 10000 routes
             num_routes = 10_000
             route_injector.announce_routes_batch(generate_routes(num_routes=num_routes, nexthop=route_injector.ip))

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -21,7 +21,8 @@ PEER_COUNT = 16
 WAIT_TIMEOUT = 120
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2')
+    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2'),
+    pytest.mark.disable_loganalyzer
 ]
 
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -257,7 +257,9 @@ def test_bgp_update_replication(
                 f"All routes have not been received: current '{curr_num_rib}', expected: '{min_expected_rib}'"
             )
             if curr_num_rib < max_expected_rib:
-                logger.warning(f"All routes have not been announced: current '{curr_num_rib}', expected: '{max_expected_rib}'")
+                logger.warning(
+                    f"All routes have not been announced: current '{curr_num_rib}', expected: '{max_expected_rib}'"
+                )
 
             # Remove routes
             route_injector.withdraw_routes_batch(generate_routes(num_routes=num_routes, nexthop=route_injector.ip))

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -25,6 +25,10 @@ ASN_BASE = 61000
 PORT_BASE = 11000
 SUBNET_TMPL = "10.{first_iter}.{second_iter}.0/24"
 
+pytestmark = [
+    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2')
+]
+
 
 '''
     Helper functions

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -60,9 +60,6 @@ def measure_stats(dut):
     bgp_sum_template = "./bgp/templates/bgp_summary_extended.textfsm"
     # Time in seconds commands should execute within
     responsive_threshold = 2
-    # Percentage thresholds
-    cpu_threshold = 100.0
-    mem_threshold = 100.0
 
     time_before_cmd = time.process_time()
 
@@ -109,18 +106,6 @@ def measure_stats(dut):
     })
 
     logger.debug(stats)
-
-    # Check that CPU usage isn't excessive
-    pytest_assert(
-        cpu_threshold >= cpu_usage,
-        f"CPU utilisation has reached {cpu_usage}, which is above threshold of {cpu_threshold}"
-    )
-
-    # Check that memory usage isn't excessive
-    pytest_assert(
-        mem_threshold >= mem_usage,
-        f"Memory utilisation has reached {mem_usage}, which is above threshold of {mem_threshold}"
-    )
 
     return stats
 
@@ -229,7 +214,7 @@ def test_bgp_update_replication(
     prev_num_rib = int(results[0]["num_rib"])
 
     # Inject and withdraw routes with a specified interval in between iterations
-    for interval in [3.0, 1.0, 0.5]:
+    for interval in [4, 3, 2]:
         # Repeat 20 times
         for _ in range(20):
             # Inject 10000 routes

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -270,11 +270,14 @@ def test_bgp_update_replication(
 
             # Validate all routes have been withdrawn
             curr_num_rib = int(results[-1]["num_rib"])
-            expected = base_rib
             pytest_assert(
-                curr_num_rib == expected,
-                f"All routes have not been withdrawn: current '{curr_num_rib}', expected: '{expected}'"
+                curr_num_rib <= min_expected_rib,
+                f"All withdrawls have not been received: current '{curr_num_rib}', expected: '{min_expected_rib}'"
             )
+            if curr_num_rib > base_rib:
+                logger.warning(
+                    f"All routes have not been withdrawn: current '{curr_num_rib}', expected: '{base_rib}'"
+                )
 
     results.append(measure_stats(duthost))
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -24,6 +24,11 @@ WAIT_TIMEOUT = 120
 ASN_BASE = 61000
 PORT_BASE = 11000
 SUBNET_TMPL = "10.{first_iter}.{second_iter}.0/24"
+DEFAULT_INTERVALS = [4.0, 3.5, 3.0]
+PLATFORM_INTERVALS = {
+    'mellanox': [4.0, 3.5, 3.0],
+    'arista': [5.0, 4.5, 4.0]
+}
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2')
@@ -116,22 +121,16 @@ def setup_duthost_intervals(duthost):
     Fixture to allow for dynamic interval definitions for each interval, based on duthost facts.
     Returns a list of float values.
     '''
-    platform = duthost.facts["platform"]
+    dut_platform = duthost.facts["platform"]
 
-    # Example (same as default interval)
-    if 'mellanox' in platform:
-        intervals = [4.0, 3.5, 3.0]
-        logger.info(f"'mellanox' found in platform {platform}, intervals {intervals} selected")
+    for platform, intervals in PLATFORM_INTERVALS.values():
+        if dut_platform not in platform:
+            continue
+        logger.info(f"'{platform}' found in platform {dut_platform}, intervals {intervals} selected")
         return intervals
 
-    if 'arista' in platform:
-        intervals = [5.0, 4.5, 4.0]
-        logger.info(f"'arista' found in platform {platform}, intervals {intervals} selected")
-        return intervals
-
-    intervals = [4.0, 3.5, 3.0]
-    logger.info(f"No matching conditions for platform {platform}, selecting default intervals {intervals}")
-    return intervals
+    logger.info(f"No matching conditions for platform {dut_platform}, selecting default intervals {DEFAULT_INTERVALS}")
+    return DEFAULT_INTERVALS
 
 
 @pytest.fixture

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -24,7 +24,7 @@ WAIT_TIMEOUT = 120
 ASN_BASE = 61000
 PORT_BASE = 11000
 SUBNET_TMPL = "10.{first_iter}.{second_iter}.0/24"
-DEFAULT_INTERVALS = [4.0, 3.5, 3.0]
+DEFAULT_INTERVALS = [6.0, 5.5, 5.0]
 PLATFORM_INTERVALS = {
     'mellanox': [4.0, 3.5, 3.0],
     'arista': [5.0, 4.5, 4.0]

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -214,7 +214,7 @@ def test_bgp_update_replication(
     prev_num_rib = int(results[0]["num_rib"])
 
     # Inject and withdraw routes with a specified interval in between iterations
-    for interval in [4, 3, 2]:
+    for interval in [4.0, 3.0, 2.5]:
         # Repeat 20 times
         for _ in range(20):
             # Inject 10000 routes

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -61,8 +61,8 @@ def measure_stats(dut):
     # Time in seconds commands should execute within
     responsive_threshold = 2
     # Percentage thresholds
-    cpu_threshold = 90.0
-    mem_threshold = 90.0
+    cpu_threshold = 100.0
+    mem_threshold = 100.0
 
     time_before_cmd = time.process_time()
 
@@ -112,13 +112,13 @@ def measure_stats(dut):
 
     # Check that CPU usage isn't excessive
     pytest_assert(
-        cpu_threshold > cpu_usage,
+        cpu_threshold >= cpu_usage,
         f"CPU utilisation has reached {cpu_usage}, which is above threshold of {cpu_threshold}"
     )
 
     # Check that memory usage isn't excessive
     pytest_assert(
-        mem_threshold > mem_usage,
+        mem_threshold >= mem_usage,
         f"Memory utilisation has reached {mem_usage}, which is above threshold of {mem_threshold}"
     )
 

--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -123,7 +123,7 @@ def setup_duthost_intervals(duthost):
     '''
     dut_platform = duthost.facts["platform"]
 
-    for platform, intervals in PLATFORM_INTERVALS.values():
+    for platform, intervals in PLATFORM_INTERVALS.items():
         if dut_platform not in platform:
             continue
         logger.info(f"'{platform}' found in platform {dut_platform}, intervals {intervals} selected")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes https://github.com/sonic-net/sonic-mgmt/issues/20583

Additionally, adds missing topology markers.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

As mentioned in the issue, Mellanox devices would consistently fail upon starting the lower intervals. Additionally, CPU and memory thresholds were arbitrary and unnecessary, and could not be guaranteed to be satisfied.

Topology markers were also missing, so added them to ensure tests run on all expected platforms.

#### How did you do it?

* Replaced intervals with platform-specific intervals, with the default ensuring passing on all platforms, and more specific intervals allowing platform owners to speed up the test after performing tests on devices:
  * Defaults to [10, 9, 8] 
  * Mellanox: [4.0, 3.5, 3.0]
  * Arista: [5.0, 4.5, 4.0]
* Removed CPU and memory thresholds (kept the calculated values in the final tabulated info dump)
* Add missing topology markers

#### How did you verify/test it?

Tested at a number of different intervals on Mellanox device where failures were observed - below 3 seconds, the test would consistently fail. Therefore, the interval values have been increased to values at which the test consistently passes on the previously failing devices. 

##### Test Evidence
Now passes on previously failing device:
<img width="1199" height="186" alt="image" src="https://github.com/user-attachments/assets/f1e5f767-d00e-4e22-920c-50fd24b6fefe" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
