### PR TITLE
skip loganalyzer for test_bgp_bbr_default_state

### DIFF
--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -132,11 +132,6 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
 @pytest.mark.disable_loganalyzer
 def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, setup, config_bbr_disabled, loganalyzer):
     duthost = duthosts[rand_one_dut_hostname]
-    if duthost.sonichost.facts['platform_asic'] == 'broadcom':
-        ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
-            r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"
-        loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
-
     duthost.shell("sudo config save -y")
     config_reload(duthost, safe_reload=True)
     is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
loganalyzer be skipped by PR https://github.com/sonic-net/sonic-mgmt/pull/20515
```
bgp/test_bgp_bbr_default_state.py::test_bbr_disabled_constants_yml_default 
-------------------------------- live log call ---------------------------------
11/09/2025 17:48:10 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt_vms6-t1-7060/tests/bgp/test_bgp_bbr_default_state.py", line 138, in test_bbr_disabled_constants_yml_default
    loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
TypeError: 'NoneType' object is not subscriptable
```
#### How did you do it?
remove the code related to loganalyzer

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/68c3c191288a03159090ac43

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
