### PR TITLE
Fix loganalyzer error in test_bbr_disabled_constants_yml_default

### DIFF
--- a/tests/bgp/test_bgp_bbr_default_state.py
+++ b/tests/bgp/test_bgp_bbr_default_state.py
@@ -132,11 +132,6 @@ def setup(duthosts, rand_one_dut_hostname, tbinfo, nbrhosts):
 @pytest.mark.disable_loganalyzer
 def test_bbr_disabled_constants_yml_default(duthosts, rand_one_dut_hostname, setup, config_bbr_disabled, loganalyzer):
     duthost = duthosts[rand_one_dut_hostname]
-    if duthost.sonichost.facts['platform_asic'] == 'broadcom':
-        ignore_regex = r".* ERR swss#orchagent:\s*.*\s*queryAattributeEnumValuesCapability:\s*returned value " \
-            r"\d+ is not allowed on SAI_SWITCH_ATTR_(?:ECMP|LAG)_DEFAULT_HASH_ALGORITHM.*"
-        loganalyzer[duthost.hostname].ignore_regex.extend([ignore_regex])
-
     duthost.shell("sudo config save -y")
     config_reload(duthost, safe_reload=True)
     is_bbr_enabled = duthost.shell("show runningconfiguration bgp | grep allowas", module_ignore_errors=True)['stdout']


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix loganalyzer error in test_bbr_disabled_constants_yml_default
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/pull/20515 disabled loganalyzer for test_bbr_disabled_constants_yml_default, but   introduced a regression to existing code of the if branch for broadcom platforms

#### How did you do it?
The broadcom-specific lines are not needed now after disabling loganalyzer

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
