### PR TITLE
Disable log analyzer for k8s GCU test case to avoid flaky failure

### DIFF
--- a/tests/generic_config_updater/test_kubernetes_config.py
+++ b/tests/generic_config_updater/test_kubernetes_config.py
@@ -11,6 +11,7 @@ from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback
 
 pytestmark = [
     pytest.mark.topology('any'),
+    pytest.mark.disable_loganalyzer,
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: For this GCU test case, it doesn't need to enable log analyzer. And the log analyzer reports some error logs which are not relevant to this case itself, so need to disable the log analyzer to avoid flaky failure.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
For this GCU test case, it doesn't need to enable log analyzer. And the log analyzer reports some error logs which are not relevant to this case itself, so need to disable the log analyzer to avoid flaky failure.
#### How did you do it?
Disable the log analyzer for this case.
#### How did you verify/test it?
Run it in a testbed, it passed.
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
