### PR TITLE
Add qos params for Arista-7060X6-64PE-B-O128

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -310,5 +310,114 @@ qos_params:
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [40, 50, 150, 50, 50, 350]
             400000_5m: *topo-t0-isolated-d96u32s2-400000_40m
-        topo-t1-isolated-d128:
-            400000_40m: *topo-t0-isolated-d96u32s2-400000_40m
+        topo-t1-isolated-d128: &topo-t1-isolated-d128
+            200000_5m: &topo-t1-isolated-d128_200000_5m
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 2
+                    pgs:
+                    - 3
+                    - 4
+                    pkts_num_hdrm_full: 1185
+                    pkts_num_hdrm_partial: 47
+                    pkts_num_trig_pfc: 132925
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 132859
+                pkts_num_egr_mem: 376
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 134681
+                    pkts_num_trig_pfc: 132925
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 74
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 132925
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 132859
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 8
+                    pkts_num_trig_ingr_drp: 134681
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 8
+                    pkts_num_trig_egr_drp: 132859
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 134681
+                    pkts_num_trig_pfc: 132925
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 134681
+                    pkts_num_trig_pfc: 132925
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 132925
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 132925
+            cell_size: 254
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+            wrr_chg:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [40, 50, 150, 50, 50, 350]
+            400000_40m: *topo-t1-isolated-d128_200000_5m
+        topo-t1-isolated-d32: *topo-t1-isolated-d128


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This add params for the qos sai tests for Arista-7060X6-64PE-B-O128

### Back port request
- [x] 202505

#### How did you verify/test it?
100% pass on the qos sai tests. Verified with margins set to zero, e.g.  `testQosSaiPfcXoffLimit`:

```
sending 133300
Compensate 0 packets to port 1, and retry 0 times
after send packets short of triggering PFC:
        recv_counters [0, 117, 0, 0, 0, 2551833, 0, 0, 0, 0, 163339379, 140, 117, 0, 1199873, 222, 14, 0]
        recv_counters_base [0, 117, 0, 0, 0, 2551833, 0, 0, 0, 0, 163339379, 140, 117, 0, 1066544, 220, 14, 0]
        xmit_counters [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2646, 221, 22, 132925]
        xmit_counters_base [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2620, 219, 22, 0]

sending 1
after send a few packets to trigger PFC:
        recv_counters [0, 117, 0, 0, 0, 2714707, 0, 0, 0, 0, 173763315, 140, 117, 0, 1199878, 222, 14, 0]                                                                                                                                                                         
        recv_counters_base [0, 117, 0, 0, 0, 2551833, 0, 0, 0, 0, 163339379, 140, 117, 0, 1199873, 222, 14, 0]                                                                                                                                                                    
        xmit_counters [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2650, 221, 22, 132926]                                                                                                                                                                              
        xmit_counters_base [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2620, 219, 22, 0]                                                                                                                                                                              
                                                                                                                                                                                                                                                                                  
sending 1755                                                                                                                                                                                                                                                                      
after send packets short of ingress drop:                                                                                                                                                                                                                                         
        recv_counters [0, 117, 0, 0, 0, 2889558, 0, 0, 0, 0, 184953779, 140, 117, 0, 1201639, 223, 14, 0]                                                                                                                                                                         
        recv_counters_base [0, 117, 0, 0, 0, 2714707, 0, 0, 0, 0, 173763315, 140, 117, 0, 1199878, 222, 14, 0]                                                                                                                                                                    
        xmit_counters [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2654, 222, 22, 134681]                                                                                                                                                                                      xmit_counters_base [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2620, 219, 22, 0]                                                                                                                                                                              
                                                                                                                                                                                                                                                                                  
sending 1                                                                                                                                                                                                                                                                         
after send a few packets to trigger drop:                                                                                                                                                                                                                                         
        recv_counters [0, 118, 0, 0, 0, 3048560, 0, 0, 0, 0, 195129907, 140, 118, 0, 1201642, 223, 14, 0]                                                                                                                                                                         
        recv_counters_base [0, 117, 0, 0, 0, 2889558, 0, 0, 0, 0, 184953779, 140, 117, 0, 1201639, 223, 14, 0]                                                                                                                                                                    
        xmit_counters [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2659, 222, 22, 134681]                                                                                                                                                                              
        xmit_counters_base [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 72362248, 1063956, 0, 0, 2620, 219, 22, 0]                                                                                                                                                                              
                                                                                                                                                                                                                                                                                  
ok
```