### PR TITLE
Fix fast-reboot advanced-reboot test TypeError: conversion from datetime.datetime to Decimal is not supported

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -2053,7 +2053,7 @@ class ReloadTest(BaseTest):
 
         # Re-arrange packets, if delayed, by Payload ID and Timestamp:
         packets = sorted(filtered_packets, key=lambda packet: (
-            int(bytes(packet[scapyall.TCP].payload)), packet.time))
+            int(bytes(packet[scapyall.TCP].payload)), float(packet.time)))
         self.lost_packets = dict()
         self.max_disrupt, self.total_disruption = 0, 0
         sent_packets = dict()
@@ -2092,7 +2092,7 @@ class ReloadTest(BaseTest):
                     # for dualtor both MACs are needed:
                     #   t1->server rcvd pkt will have src MAC as vlan_mac,
                     #   and server->t1 rcvd pkt will have src MAC as dut_mac
-                    received_time = packet.time
+                    received_time = float(packet.time)
                     received_payload = int(bytes(packet[scapyall.TCP].payload))
                     if (received_payload % 5) == 0:   # From vlan to T1.
                         received_vlan_to_t1 += 1


### PR DESCRIPTION
This allows timestamp comparisons to work

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
MSFT ADO: 34628299

Fix the following error when advanced-reboot calculates dataplane disruption duration
```
******************************************stderr =
advanced-reboot.ReloadTest ... 02:55:33.486  device_connection: ERROR   : Caught exception socket.timeout: TimeoutError(), , <class 'TimeoutError'>
ERROR

======================================================================
ERROR: advanced-reboot.ReloadTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/ptftests/py3/advanced-reboot.py", line 1470, in runTest
    self.handle_post_reboot_test_reports()
  File "/root/ptftests/py3/advanced-reboot.py", line 1344, in handle_post_reboot_test_reports
    self.no_routing_stop - self.reboot_start)
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
  File "/usr/lib/python3/dist-packages/scapy/utils.py", line 115, in __sub__
    return EDecimal(Decimal.__sub__(self, Decimal(other)))
                                          ^^^^^^^^^^^^^^
TypeError: conversion from datetime.datetime to Decimal is not supported

----------------------------------------------------------------------
Ran 1 test in 439.920s

FAILED (errors=1)
```

As part of the migration to python3 for docker-ptf in https://github.com/sonic-net/sonic-buildimage/pull/22409, the `PTF_ENV_PY_VER` is now `"py3"` so when the container builds it uses debian:bookworm (on master) or debian:bullseye (on 202505) as opposed to debian:buster that it was using before the move.

python3-scapy has versions:
- 2.4.0-2 on buster
- 2.4.4-4 on bullseye
- 2.5.0+dfsg-2 on bookworm

In Scapy [2.4.0](https://github.com/secdev/scapy/blob/v2.4.0/scapy/utils.py#L908), the type of time on a packet is float, but on [2.4.4](https://github.com/secdev/scapy/blob/v2.4.4/scapy/utils.py#L1154) it is now an EDecimal.

This change converts it to a float as all the logic and handling was based around this being a float before the ptf upgrade.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix a broken test

#### How did you do it?
Convert packet.time to a float before it is used anywhere in advanced-reboot

#### How did you verify/test it?
Ran test_upgrade_path with both warm and fast reboot types and both pass with disruption time calculated correctly

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
