### PR TITLE
[Smartswitch] Xfail fib and decap test on smartswitch light mode

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -603,6 +603,10 @@ decap/test_decap.py:
     reason: 'Skip on t1-isolated-d32/128 topos'
     conditions:
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+  xfail:
+    reason: "Xfail due to test is not aligned with Smartswitch light mode: https://github.com/sonic-net/sonic-mgmt/issues/20599"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20599 and is_smartswitch==True and 't1' in topo_name" 
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
   skip:
@@ -1920,6 +1924,16 @@ fib/test_fib.py::test_basic_fib[True-True-1514]:
     reason: "Skip for IPv6-only topologies"
     conditions:
       - "'-v6-' in topo_name"
+  xfail:
+    reason: "Xfail due to test is not aligned with Smartswitch light mode: https://github.com/sonic-net/sonic-mgmt/issues/20599"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20599 and is_smartswitch==True and 't1' in topo_name"
+
+fib/test_fib.py::test_hash:
+  xfail:
+    reason: "Xfail due to test is not aligned with Smartswitch light mode: https://github.com/sonic-net/sonic-mgmt/issues/20599"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20599 and is_smartswitch==True and 't1' in topo_name"
 
 fib/test_fib.py::test_hash[ipv4]:
   skip:
@@ -1934,6 +1948,10 @@ fib/test_fib.py::test_ipinip_hash:
     conditions:
       - "asic_type in ['mellanox']"
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+  xfail:
+    reason: "Xfail due to test is not aligned with Smartswitch light mode: https://github.com/sonic-net/sonic-mgmt/issues/20599"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20599 and is_smartswitch==True and 't1' in topo_name"
 
 fib/test_fib.py::test_nvgre_hash:
   skip:
@@ -1943,9 +1961,11 @@ fib/test_fib.py::test_nvgre_hash:
       - "asic_type in ['vs', 'broadcom'] or topo_type in ['m0', 'mx', 'm1']"
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
   xfail:
-    reason: 'Nvgre hash test is not fully supported on SPC1 platform due to known limitation'
+    reason: 'Nvgre hash test is not fully supported on SPC1 platform due to known limitation. Xfail due to test is not aligned with Smartswitch light mode: https://github.com/sonic-net/sonic-mgmt/issues/20599'
+    conditions_logical_operator: or
     conditions:
       - "asic_gen == 'spc1' and 't1-lag' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/17526"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20599 and is_smartswitch==True and 't1' in topo_name"
 
 fib/test_fib.py::test_nvgre_hash[ipv4-ipv4]:
   skip:
@@ -1990,6 +2010,10 @@ fib/test_fib.py::test_vxlan_hash:
     conditions:
       - "asic_type in ['vs'] or topo_type in ['m0', 'mx', 'm1']"
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+  xfail:
+    reason: "Xfail due to test is not aligned with Smartswitch light mode: https://github.com/sonic-net/sonic-mgmt/issues/20599"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20599 and is_smartswitch==True and 't1' in topo_name"
 
 fib/test_fib.py::test_vxlan_hash[ipv4-ipv4]:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The fib related tests are not fully aligned with smartswitch light mode, test issue is opened: https://github.com/sonic-net/sonic-mgmt/issues/20599.
Cfail the failing test cases on is_smartswitch and t1 topo conditions for we don't have a specific condition for the light mode.
This is required for master and 202506(but not 202505) until the test issue is fixed.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
