### PR TITLE
[Dash] Fix the wrong port number range in dash vxlan source port test

### DIFF
--- a/docs/testplan/dash/VXLAN_source_port_range.md
+++ b/docs/testplan/dash/VXLAN_source_port_range.md
@@ -12,7 +12,7 @@
 ## Overview
   The feature "VXLAN source port range" is to support entropy in the VxLAN UDP source port field on the smartsiwtch.
   A smartswitch DPU should use connection 5-tuple to calculate entropy, and fill it in the VxLAN UDP source port field.
-  The entropy should be within the range of [5128, 5255].
+  The entropy should be within the range of [5120, 5247](5120 with 7 bit mask).
   The configuration should be applied on the DPU via swssconfig in the swss container, and it takes effect immediatly after the configuration is applied.
   The purpose of this test is to verify the functionality of VXLAN source port range on smartswitch.
 
@@ -37,7 +37,7 @@ Configuration example to config the VxLAN UDP source port range:
 [
     {
         "SWITCH_TABLE:switch": {
-            "vxlan_sport": 5128,
+            "vxlan_sport": 5120,
             "vxlan_mask": 7
         },
         "OP": "SET"
@@ -52,9 +52,9 @@ Verify VXLAN UDP source port range can be configured as user defined range on th
 ### Test steps
 * The validation of the VxLAN port is integrated to the dash PL test tests/dash/test_dash_privatelink.py.
 * For now there is only one test case in the PL test: test_privatelink_basic_transform.
-* The UDP port range configuration(vxlan_sport=5128, vxlan_mask=7) is applied in the setup phase of the PL test module.
+* The UDP port range configuration(vxlan_sport=5120, vxlan_mask=7) is applied in the setup phase of the PL test module.
 * Send the outbound and inbound PL traffic.
-* Validate that the VxLAN UDP source port in the captured inbound packet is in the range of [5128, 5255]
+* Validate that the VxLAN UDP source port in the captured inbound packet is in the range of [5120, 5247]
 * Restore the source port range config to the default by config reload on the DPU.
 
 

--- a/tests/dash/constants.py
+++ b/tests/dash/constants.py
@@ -48,5 +48,5 @@ ACL_PROTOCOL = "protocol"
 ACL_TAG = "acl_tag"
 ACL_PREFIX_LIST = "prefix_list"
 # For VxLAN source UDP port range
-VXLAN_UDP_BASE_SRC_PORT = 5128
+VXLAN_UDP_BASE_SRC_PORT = 5120
 VXLAN_UDP_SRC_PORT_MASK = 7  # number of least significant bits


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The port number should be [5120, 5247] when the start port is 5120 and the mask is 7 bits.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the dash pl test on SN4280, passed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
