### PR TITLE
Update tests custom_acl, null_route for V6 only topo

### DIFF
--- a/tests/acl/custom_acl_table/test_custom_acl_table.py
+++ b/tests/acl/custom_acl_table/test_custom_acl_table.py
@@ -11,8 +11,7 @@ import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa F401
-from tests.common.utilities import get_all_upstream_neigh_type
-from tests.common.utilities import get_neighbor_ptf_port_list
+from tests.common.utilities import get_all_upstream_neigh_type, get_neighbor_ptf_port_list, is_ipv6_only_topology
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +186,7 @@ def setup_acl_rules(rand_selected_dut, rand_unselected_dut, tbinfo, setup_custom
         rand_unselected_dut.shell(cmd_rm_rules)
 
 
-def build_testing_pkts(router_mac):
+def build_testing_pkts(router_mac, tbinfo):
     """
     Generate packet for IO test
     """
@@ -201,30 +200,33 @@ def build_testing_pkts(router_mac):
 
     test_packets = {}
 
-    # Verify matching destination IP and protocol
-    test_packets['RULE_2'] = testutils.simple_tcp_packet(eth_dst=router_mac,
-                                                         ip_src='192.168.0.3',
-                                                         ip_dst=DST_IP)
+    if not is_ipv6_only_topology(tbinfo):
+        # Verify matching destination IP and protocol
+        test_packets['RULE_2'] = testutils.simple_tcp_packet(eth_dst=router_mac,
+                                                             ip_src='192.168.0.3',
+                                                             ip_dst=DST_IP)
+        # Verify matching source port (IPV4)
+        test_packets['RULE_5'] = testutils.simple_tcp_packet(eth_dst=router_mac,
+                                                             ip_src='192.168.0.3',
+                                                             ip_dst='1.1.1.1',
+                                                             tcp_sport=SRC_PORT)
+        # Verify matching source port range (IPV4)
+        test_packets['RULE_7'] = testutils.simple_tcp_packet(eth_dst=router_mac,
+                                                             ip_src='192.168.0.3',
+                                                             ip_dst='1.1.1.1',
+                                                             tcp_sport=SRC_RANGE_PORT)
 
     # Verify matching IPV6 destination and next header
     test_packets['RULE_4'] = testutils.simple_tcpv6_packet(eth_dst=router_mac,
                                                            ipv6_src='fc02:1000::3',
                                                            ipv6_dst=DST_IPV6)
-    # Verify matching source port (IPV4)
-    test_packets['RULE_5'] = testutils.simple_tcp_packet(eth_dst=router_mac,
-                                                         ip_src='192.168.0.3',
-                                                         ip_dst='1.1.1.1',
-                                                         tcp_sport=SRC_PORT)
+
     # Verify matching destination port (IPV6)
     test_packets['RULE_6'] = testutils.simple_tcpv6_packet(eth_dst=router_mac,
                                                            ipv6_src='fc02:1000::3',
                                                            ipv6_dst='103:23:2:1::2',
                                                            tcp_dport=DST_PORT)
-    # Verify matching source port range (IPV4)
-    test_packets['RULE_7'] = testutils.simple_tcp_packet(eth_dst=router_mac,
-                                                         ip_src='192.168.0.3',
-                                                         ip_dst='1.1.1.1',
-                                                         tcp_sport=SRC_RANGE_PORT)
+
     # Verify matching destination port range (IPV6)
     test_packets['RULE_8'] = testutils.simple_tcpv6_packet(eth_dst=router_mac,
                                                            ipv6_src='fc02:1000::3',
@@ -290,7 +292,7 @@ def test_custom_acl(rand_selected_dut, rand_unselected_dut, tbinfo, ptfadapter,
         for upstream_neigh_type in upstream_neigh_types:
             dst_port_indices.extend(get_neighbor_ptf_port_list(rand_selected_dut, upstream_neigh_type, tbinfo))
 
-    test_pkts = build_testing_pkts(router_mac)
+    test_pkts = build_testing_pkts(router_mac, tbinfo)
     for rule, pkt in list(test_pkts.items()):
         logger.info("Testing ACL rule {}".format(rule))
         exp_pkt = build_exp_pkt(pkt)

--- a/tests/acl/null_route/test_null_route_helper.py
+++ b/tests/acl/null_route/test_null_route_helper.py
@@ -13,9 +13,8 @@ from tests.common.fixtures.ptfhost_utils import remove_ip_addresses  # noqa: F40
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_require
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
-from tests.common.utilities import get_upstream_neigh_type
-from tests.common.utilities import get_neighbor_ptf_port_list
-from tests.common.utilities import get_neighbor_port_list
+from tests.common.utilities import get_upstream_neigh_type, get_neighbor_ptf_port_list, \
+    get_neighbor_port_list, is_ipv6_only_topology
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +193,7 @@ def setup_ptf(rand_selected_dut, ptfhost, tbinfo):
             except Exception:
                 continue
     for key, value in vlans.items():
-        if len(value.keys()) == 2:
+        if len(value.keys()) in [1, 2]:
             vlan_name = key
             for ip_ver, value in value.items():
                 dst_ports[ip_ver] = value
@@ -205,11 +204,13 @@ def setup_ptf(rand_selected_dut, ptfhost, tbinfo):
     dst_ports['port'] = mg_facts['minigraph_ptf_indices'][vlan_port]
 
     logger.info("Setting up ptf for testing")
-    ptfhost.shell("ifconfig eth{} {}".format(dst_ports['port'], dst_ports[4]))
+    if not is_ipv6_only_topology(tbinfo):
+        ptfhost.shell("ifconfig eth{} {}".format(dst_ports['port'], dst_ports[4]))
     ptfhost.shell("ifconfig eth{} inet6 add {}".format(dst_ports['port'], dst_ports[6]))
 
     yield dst_ports
-    ptfhost.shell("ifconfig eth{} 0.0.0.0".format(dst_ports['port']))
+    if not is_ipv6_only_topology(tbinfo):
+        ptfhost.shell("ifconfig eth{} 0.0.0.0".format(dst_ports['port']))
     ptfhost.shell("ifconfig eth{} inet6 del {}".format(dst_ports['port'], dst_ports[6]))
 
 
@@ -276,6 +277,8 @@ def test_null_route_helper(rand_selected_dut, tbinfo, ptfadapter,
         action = test_item[1]
         expected_result = test_item[2]
         ip_ver = ipaddress.ip_network(src_ip.encode().decode(), False).version
+        if ip_ver == 4 and is_ipv6_only_topology(tbinfo):
+            continue
         logger.info("Testing with src_ip = {} action = {} expected_result = {}"
                     .format(src_ip, action, expected_result))
         pkt, exp_pkt = generate_packet(src_ip, ptf_port_info[ip_ver].split("/")[0], router_mac)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -73,6 +73,12 @@ acl/test_acl_outer_vlan.py:
     conditions:
       - "'dualtor' in topo_name"
 
+acl/test_stress_acl.py:
+  skip:
+    reason: "skip for IPv6-only topologies"
+    conditions:
+      - "'-v6-' in topo_name"
+
 #######################################
 #####            arp              #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Update tests for V6 only topo.

- _custom_acl_,  _null_route_ - do validation only for ipv6

- _stress_acl_ - the test is ipv4 only, added skip in conditions mark

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Tests running on new topologies

#### How did you do it?
Updated existing tests

#### How did you verify/test it?
Tests verified on t0-isolated-v6-d32u32s2 


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
