### PR TITLE
Xfail test_acl_egress_drop for ipv6 only topologies.

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -848,6 +848,12 @@ drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/19920 and '-v6-' in topo_name"
 
+drop_packets/test_drop_counters.py::test_acl_egress_drop:
+  xfail:
+    reason: "xfail for IPv6-only topologies, issue with valid_ipv4"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/19921 and '-v6-' in topo_name"
+
 drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link:
   xfail:
     reason: "xfail for IPv6-only topologies, issue with valid_ipv4"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Xfail test_acl_egress_drop for ipv6 only topologies.

Fixes # (issue)
*https://github.com/sonic-net/sonic-mgmt/issues/19921

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [] New Test case
    - [] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
*The test is set for IPv4 and fail when run on IPv6 only topo testbed



#### How did you do it?
Add xfail in tests_mark_conditions.yaml as this test run only for ipv4.

#### How did you verify/test it?
rerun and make sure test is skip if fail for ipv6 only.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
