### PR TITLE
Exclude the DPU ports from the probed active ports in ipfwd/test_nhop_group.py tests

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2415,11 +2415,12 @@ Totals               6450                 6449
         """
         active_ip_intf_cnt = 0
         mg_facts = self.get_extended_minigraph_facts(tbinfo, ns_arg)
+        config_facts_ports = self.config_facts(host=self.hostname, source="running")["ansible_facts"].get("PORT", {})
         ip_ifaces = {}
         for k, v in list(ip_ifs.items()):
-            if ((k.startswith("Ethernet") and (not k.startswith("Ethernet-BP")) and not is_inband_port(k)) or
-               (k.startswith("PortChannel") and not
-               self.is_backend_portchannel(k, mg_facts))):
+            if ((k.startswith("Ethernet") and config_facts_ports.get(k, {}).get("role", "") != "Dpc" and
+                 (not k.startswith("Ethernet-BP")) and not is_inband_port(k)) or
+               (k.startswith("PortChannel") and not self.is_backend_portchannel(k, mg_facts))):
                 # Ping for some time to get ARP Re-learnt.
                 # We might have to tune it further if needed.
                 if (v["admin"] == "up" and v["oper_state"] == "up" and


### PR DESCRIPTION
### Description of PR
Smart switch with the DPUs in the light mode has extra ports that have N/A peer IPs.
Setting the test to ignore those ports when looking for the active switch port.
Port and IP output, DPU ports have N/A as peer IP
```
root@host:/home/admin# show ip interface
Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ------------  --------------  -------------
Ethernet64                 10.0.0.32/31         up/up         ARISTA01T0      10.0.0.33
Ethernet72                 10.0.0.34/31         up/up         ARISTA02T0      10.0.0.35
Ethernet80                 10.0.0.36/31         up/up         ARISTA03T0      10.0.0.37
Ethernet88                 10.0.0.38/31         up/up         ARISTA04T0      10.0.0.39
Ethernet96                 10.0.0.40/31         up/up         ARISTA05T0      10.0.0.41
Ethernet104                10.0.0.42/31         up/up         ARISTA06T0      10.0.0.43
Ethernet112                10.0.0.44/31         up/up         ARISTA07T0      10.0.0.45
Ethernet120                10.0.0.46/31         up/up         ARISTA08T0      10.0.0.47
Ethernet128                10.0.0.48/31         up/up         ARISTA09T0      10.0.0.49
Ethernet136                10.0.0.50/31         up/up         ARISTA10T0      10.0.0.51
Ethernet144                10.0.0.52/31         up/up         ARISTA11T0      10.0.0.53
Ethernet152                10.0.0.54/31         up/up         ARISTA12T0      10.0.0.55
Ethernet160                10.0.0.56/31         up/up         ARISTA13T0      10.0.0.57
Ethernet168                10.0.0.58/31         up/up         ARISTA14T0      10.0.0.59
Ethernet176                10.0.0.60/31         up/up         ARISTA15T0      10.0.0.61
Ethernet184                10.0.0.62/31         up/up         ARISTA16T0      10.0.0.63
Ethernet192                10.0.0.64/31         up/up         ARISTA17T0      10.0.0.65
Ethernet200                10.0.0.66/31         up/up         ARISTA18T0      10.0.0.67
Ethernet208                10.0.0.68/31         up/up         ARISTA19T0      10.0.0.69
Ethernet216                10.0.0.70/31         up/up         ARISTA20T0      10.0.0.71
Ethernet224                18.0.202.0/31        up/up         N/A             N/A
Ethernet232                18.1.202.0/31        up/up         N/A             N/A
Ethernet240                18.2.202.0/31        up/up         N/A             N/A
Ethernet248                18.3.202.0/31        up/up         N/A             N/A
Loopback0                  10.1.0.32/32         up/up         N/A             N/A
PortChannel102             10.0.0.0/31          up/up         ARISTA01T2      10.0.0.1
PortChannel105             10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
PortChannel108             10.0.0.8/31          up/up         ARISTA05T2      10.0.0.9
PortChannel111             10.0.0.12/31         up/up         ARISTA07T2      10.0.0.13
bridge-midplane            169.254.200.254/24   up/up         N/A             N/A
docker0                    240.127.1.1/24       up/up         N/A             N/A
eth0                       10.210.25.4/22       up/up         N/A             N/A
lo                         127.0.0.1/16         up/up         N/A             N/A
root@host:/home/admin# show chassis module status
  Name             Description    Physical-Slot    Oper-Status    Admin-Status        Serial
------  ----------------------  ---------------  -------------  --------------  ------------
  DPU0  NVIDIA BlueField-3 DPU              N/A         Online              up  MT2428XZ0JVU
  DPU1  NVIDIA BlueField-3 DPU              N/A         Online              up  MT2428XZ0JQT
  DPU2  NVIDIA BlueField-3 DPU              N/A         Online              up  MT2428XZ0JRA
  DPU3  NVIDIA BlueField-3 DPU              N/A         Online              up  MT2428XZ0JTK

 
```

Summary:
Fixes # (issue): N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Failing switch tests for the smart switch in the light mode

#### How did you do it?
Introduced the check to skip ports without a peer IP.

#### How did you verify/test it?
Re-ran the tests with the updated code. Tests passed

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
