### PR TITLE
skip generic_config_updater.test_packet_trimming_config_asymmetric for 202505

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2179,6 +2179,12 @@ generic_config_updater/test_multiasic_linkcrc.py:
     conditions:
       - "(is_multi_asic is False)"
 
+generic_config_updater/test_packet_trimming_config_asymmetric.py:
+    skip:
+        reason: "Packet trim is not supported in 202505 image"
+        conditions:
+        - "release in ['202505']"
+
 generic_config_updater/test_packet_trimming_config_symmetric:
   skip:
     reason: "Packet trim is not supported in 202505 image"


### PR DESCRIPTION
…r 202505 release

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
skip generic_config_updater.test_packet_trimming_config_asymmetric  for 202505 release as there is no packet trim feature in 202505 release

Previous PR skipped test_packet_trimming_config_symmetric, this PR adds test_packet_trimming_config_asymmetric, 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
skip generic_config_updater.test_packet_trimming_config_asymmetric  for 202505 release as there is no packet trim feature in 202505 release

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
