### PR TITLE
Fix test_vnet_bgp_route_precedence TC failure on Cisco platform

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -61,11 +61,14 @@ def fixture_route_type(request):
     name="monitor_type",
     scope="module",
     params=SUPPORTED_MONITOR_TYPES)
-def fixture_monitor_type(request):
+def fixture_monitor_type(duthosts, request, rand_one_dut_hostname):
     '''
         This fixture forces the script to perform one monitor_type at a time.
         So this script doesn't support multiple monitor types at the same time.
     '''
+    asic_type = duthosts[rand_one_dut_hostname].facts["asic_type"]
+    if request.param in ["custom"] and asic_type in ["cisco-8000"]:
+        pytest.skip(f"{asic_type} is not a supported platform for this monitor type: {request.param}.")
     return request.param
 
 

--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -61,14 +61,15 @@ def fixture_route_type(request):
     name="monitor_type",
     scope="module",
     params=SUPPORTED_MONITOR_TYPES)
-def fixture_monitor_type(duthosts, request, rand_one_dut_hostname):
+def fixture_monitor_type(duthosts, request, rand_one_dut_hostname, tbinfo):
     '''
         This fixture forces the script to perform one monitor_type at a time.
         So this script doesn't support multiple monitor types at the same time.
     '''
     asic_type = duthosts[rand_one_dut_hostname].facts["asic_type"]
-    if request.param in ["custom"] and asic_type in ["cisco-8000"]:
-        pytest.skip(f"{asic_type} is not a supported platform for this monitor type: {request.param}.")
+    topo = tbinfo["topo"]["type"]
+    if request.param in ["custom"] and asic_type in ["cisco-8000"] and topo == "t1":
+        pytest.skip(f"{asic_type} {topo} is not a supported platform for this monitor type: {request.param}.")
     return request.param
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test failure test_vnet_bgp_route_precedence on Cisco platform

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Test failed on Cisco platform. Cisco supports BFD as the monitor type, not "custom" monitor type.

#### How did you do it?
Skip the test case for Cisco platform.

#### How did you verify/test it?
On physical testbed.

#### Any platform specific information?
Cisco

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
