### PR TITLE
Added timestamps to dropped packets for syslog correlation in advanced-reboot

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -2111,8 +2111,14 @@ class ReloadTest(BaseTest):
                         received_but_not_sent_packets.add(received_payload)
                         continue
                     # Packets in a row are missing, a potential disruption.
-                    self.log("received_payload: {}, prev_payload: {}, sent_counter: {}, received_counter: {}".format(
-                        received_payload, prev_payload, sent_counter, received_counter))
+                    self.log(
+                        "received_payload: {} (at {}), prev_payload: {} (at {}), "
+                        "sent_counter: {}, received_counter: {}".format(
+                            received_payload, datetime.datetime.fromtimestamp(received_time),
+                            prev_payload, datetime.datetime.fromtimestamp(prev_time),
+                            sent_counter, received_counter
+                        )
+                    )
                     # How many packets lost in a row.
                     lost_id = (received_payload - 1) - prev_payload
 
@@ -2184,8 +2190,16 @@ class ReloadTest(BaseTest):
                 [item[0] for item in self.lost_packets.values()])
             self.total_disrupt_time = sum(
                 [item[1] for item in self.lost_packets.values()])
-            self.log("Disruptions happen between %s and %s after the reboot." %
-                     (str(self.disruption_start - self.reboot_start), str(self.disruption_stop - self.reboot_start)))
+            time_from_reboot_disrupt_start = self.disruption_start - self.reboot_start
+            time_from_reboot_disrupt_stop = self.disruption_stop - self.reboot_start
+            self.log(
+                "Disruptions happen between {} and {} ({} and {} after the reboot).".format(
+                    self.disruption_start,
+                    self.disruption_stop,
+                    time_from_reboot_disrupt_start,
+                    time_from_reboot_disrupt_stop
+                )
+            )
         else:
             self.max_lost_id = 0
             self.max_disrupt_time = 0


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
MSFT ADO: 34923727

This an enhancement to make debugging faster as the timestamp printed with the received packets can be lined up with the timestamps in syslog to determine the reason for disruption as opposed to opening the pcap in wireshark and reading from there.

Logs in the case of disruption:

**Previously**
```
...

2025-09-07 02:35:35 : received_payload: 23331, prev_payload: 23329, sent_counter: 23332, received_counter: 23270
2025-09-07 02:35:35 : Disruption between packet ID 23329 and 23331. For 0.0040 
2025-09-07 02:35:35 : 
2025-09-07 02:35:35 : **************** Packet received summary: ********************
2025-09-07 02:35:35 : *********** Sent packets captured - 42793
2025-09-07 02:35:35 : *********** received packets captured - t1-to-vlan - 34234
2025-09-07 02:35:35 : *********** received packets captured - vlan-to-t1 - 8497
2025-09-07 02:35:35 : *********** Missed received packets - t1-to-vlan - 0
2025-09-07 02:35:35 : *********** Missed received packets - vlan-to-t1 - 62
2025-09-07 02:35:35 : *********** Flooded pkts - []
2025-09-07 02:35:35 : **************************************************************
2025-09-07 02:35:35 : Disruptions happen between 0:01:29.732231 and 0:01:41.956896 after the reboot.
...
```
**Now**
```
...
2025-09-16 05:55:36 : received_payload: 19235 (at 2025-09-16 05:52:37.564706), prev_payload: 19233 (at 2025-09-16 05:52:37.553268), sent_counter: 19236, received_counter: 14860
2025-09-16 05:55:36 : Disruption between packet ID 19233 and 19235. For 0.0073 
2025-09-16 05:55:36 : 
2025-09-16 05:55:37 : **************** Packet received summary: ********************
2025-09-16 05:55:37 : *********** Sent packets captured - 44313
2025-09-16 05:55:37 : *********** received packets captured - t1-to-vlan - 31880
2025-09-16 05:55:37 : *********** received packets captured - vlan-to-t1 - 8057
2025-09-16 05:55:37 : *********** Missed received packets - t1-to-vlan - 3570
2025-09-16 05:55:37 : *********** Missed received packets - vlan-to-t1 - 806
2025-09-16 05:55:37 : *********** Flooded pkts - []
2025-09-16 05:55:37 : **************************************************************
2025-09-16 05:55:37 : Disruptions happen between 2025-09-16 05:52:17.824487 and 2025-09-16 05:52:37.564706 (0:01:07.251729 and 0:01:26.991948 after the reboot).
...
```

The "received_payload" logs now have the timestamp when the packet was received and the "Disruptions happen between" log has the datetime range bounding the drops.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Improve debuggability of dataplane drop issues.

#### How did you do it?
Added logging of packet timestamps to use for correlation with syslog timestamps

#### How did you verify/test it?
Ran test_upgrade_path fast and warm reboot and looked at advanced reboot log

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
