### PR TITLE
[t1-isolated-d128][test_route_flap] Skip test_route_flap.py on t1-isolated-d128 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3530,7 +3530,7 @@ route/test_duplicate_route.py::test_duplicate_routes[4:
 
 route/test_route_flap.py:
   skip:
-    reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo. Does not apply to standalone topos."
+    reason: "Test case has issue on the t0-56-povlan and dualtor-64 topo. Does not apply to standalone or t1-isolated-d128 topos."
     conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/11323 and 't0-56-po2vlan' in topo_name"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3536,6 +3536,7 @@ route/test_route_flap.py:
       - "https://github.com/sonic-net/sonic-mgmt/issues/11323 and 't0-56-po2vlan' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/11324 and 'dualtor-64' in topo_name"
       - "'standalone' in topo_name"
+      - "topo_name in ['t1-isolated-d128']"
 
 route/test_route_flow_counter.py:
   skip:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2285,6 +2285,10 @@ def enum_upstream_dut_hostname(duthosts, tbinfo):
             if upstream_nbr_type in value['name']:
                 return a_dut.hostname
 
+    # In case of t1-isolated-d128, there is no upstream nbr, return the first dut
+    if tbinfo["topo"]["name"] == "t1-isolated-d128":
+        return duthosts[0].hostname
+
     pytest.fail("Did not find a dut in duthosts that for topo type {} that has upstream nbr type {}".
                 format(tbinfo["topo"]["type"], upstream_nbr_type))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2285,10 +2285,6 @@ def enum_upstream_dut_hostname(duthosts, tbinfo):
             if upstream_nbr_type in value['name']:
                 return a_dut.hostname
 
-    # In case of t1-isolated-d128, there is no upstream nbr, return the first dut
-    if tbinfo["topo"]["name"] == "t1-isolated-d128":
-        return duthosts[0].hostname
-
     pytest.fail("Did not find a dut in duthosts that for topo type {} that has upstream nbr type {}".
                 format(tbinfo["topo"]["type"], upstream_nbr_type))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes test_route_flap.py case failure on t1-isolated-d128 topo by skipping the case.
```
>       pytest.fail("Did not find a dut in duthosts that for topo type {} that has upstream nbr type {}".
                    format(tbinfo["topo"]["type"], upstream_nbr_type))
E       Failed: Did not find a dut in duthosts that for topo type t1 that has upstream nbr type T2
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix the test_route_flap.py on t1-isolated-d128 topo.

#### How did you do it?
`enum_upstream_dut_hostname` is supposed to find a dut that has upstream nbr for its topo. But since t1-isolated-d128 didn't have upstream, case would be failed at setup. And `enum_upstream_dut_hostname` is only used for T2 topo, so return a first DUT name for t1-isolated-d128 topo to get the case running. Case is skipped after the fix, so skip it in conditional mark.
```
duthost_upstream = duthosts[enum_upstream_dut_hostname]
...
if 't2' in tbinfo["topo"]["type"] and duthost == duthost_upstream:
```

#### How did you verify/test it?
Run test_route_flap.py locally with the fix, case is skipped.
```
route/test_route_flap.py::test_route_flap[str5-7060x6-512-4-None] SKIPPED (Test case has issue on the t0-56-povlan and dualtor-64 topo. Does not apply to standalone or t1-isolated-d128 topos.)                    [100%]
```

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
