### PR TITLE
chore: enable dt2 on test_link_down

### DIFF
--- a/tests/platform_tests/test_link_down.py
+++ b/tests/platform_tests/test_link_down.py
@@ -20,7 +20,7 @@ from tests.platform_tests.utils import get_max_to_reboot, fanout_hosts_and_ports
 
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2'),
+    pytest.mark.topology('t0', 't1', 't2', 'lt2', 'ft2'),
     pytest.mark.disable_loganalyzer,
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable DT2 on test link down
Fixes # (issue) 32921769

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

this test is passing and can be enabled for dt2 topo

ft2: 
<img width="2189" height="72" alt="image" src="https://github.com/user-attachments/assets/896148f2-062f-477a-ad3b-aada1f5a74ef" />


lt2:
<img width="2353" height="100" alt="image" src="https://github.com/user-attachments/assets/77219690-5c06-402c-989f-db5fb596238e" />

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
