### PR TITLE
remove per_dir support for t1-isolated-d128 topo

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -2995,8 +2995,7 @@ def set_queue_pir(interface, queue, rate):
     def is_supported_per_dir(self, get_src_dst_asic_and_duts, tbinfo):  # noqa F811
         supported_per_dir_platform = ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2",
                                       "Mellanox-SN5600-C224O8", "Mellanox-SN5600-C256S1",
-                                      "Arista-7060X6-16PE-384C-B-O128S2",
-                                      "Arista-7060X6-64PE-B-O128", "Arista-7060X6-64PE-O128S2"]
+                                      "Arista-7060X6-16PE-384C-B-O128S2"]
         is_supported_per_dir = \
             get_src_dst_asic_and_duts["src_asic"].sonichost.facts["hwsku"] in supported_per_dir_platform
         logging.info(f"is_supported_per_dir: {is_supported_per_dir}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For hwsku using t1-isolated-d128 topo, there is no uplink neighbor, all neighbors are T0. Removing them from the per_dir list.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Removing TH5 400G t1 hwsku from the per_dir list.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
