### PR TITLE
[pfcwd] Skip pfcwd tests on m0/mx/m1

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3012,11 +3012,21 @@ pfcwd/test_pfcwd_all_port_storm.py:
       - "topo_type in ['m0', 'mx', 'm1']"
       - *lossyTopos
 
+pfcwd/test_pfcwd_function.py::
+  skip:
+    reason: "Pfcwd tests skipped on M* topo."
+    conditions:
+      - "topo_type in ['m0', 'mx', 'm1']"
+
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions:
   xfail:
     reason: "On Dualtor AA setup, test_pfcwd_actions is not stable due to github issue https://github.com/sonic-net/sonic-mgmt/issues/15387"
     conditions:
       - "'dualtor-aa' in topo_name and https://github.com/sonic-net/sonic-mgmt/issues/15387"
+  skip:
+    reason: "Pfcwd tests skipped on M* topo."
+    conditions:
+      - "topo_type in ['m0', 'mx', 'm1']"
 
 pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic:
    skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Skip pfcwd related test on m0/mx/m1

#### How did you do it?
Skip pfcwd related test on m0/mx/m1

#### How did you verify/test it?
Run test on m0 testbed
```
collected 10 items                                                                                                                                                                           

pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[IPv6-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                        [ 10%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[IPv6-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                     [ 20%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv6-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                     [ 30%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[IPv6-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                    [ 40%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[IPv6-sonic] SKIPPED (This test is applicable only for cisco-8000 / Pfcwd tests skipped on M* testbed.)    [ 50%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[IPv4-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                        [ 60%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[IPv4-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                     [ 70%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv4-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                     [ 80%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[IPv4-sonic] SKIPPED (Pfcwd tests skipped on M* topo.)                                                    [ 90%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[IPv4-sonic] SKIPPED (This test is applicable only for cisco-8000 / Pfcwd tests skipped on M* testbed.)    [100%]

====================================================================================== warnings summary ======================================================================================
../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/pfcwd/test_pfcwd_function.xml ----------------------------------------------------
================================================================================== short test summary info ===================================================================================
SKIPPED [8] pfcwd/test_pfcwd_function.py: Pfcwd tests skipped on M* topo.
SKIPPED [2] pfcwd/test_pfcwd_function.py: This test is applicable only for cisco-8000 / Pfcwd tests skipped on M* testbed.
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
