### PR TITLE
Remove optional multi-asic t1-lag PR test

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -247,34 +247,34 @@ jobs:
           BUILD_REASON: ${{ parameters.BUILD_REASON }}
 
   # This PR checker aims to run all t1 test scripts on multi-asic topology.
-  - job: impacted_area_multi_asic_t1_elastictest
-    displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest - optional"
-    dependsOn:
-    - get_impacted_area
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: impacted_area_testing/calculate-instance-numbers.yml
-        parameters:
-          TOPOLOGY: t1
-          BUILD_BRANCH: $(BUILD_BRANCH)
+  # - job: impacted_area_multi_asic_t1_elastictest
+  #   displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest - optional"
+  #   dependsOn:
+  #   - get_impacted_area
+  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
+  #   variables:
+  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: true
+  #   pool: sonic-ubuntu-1c
+  #   steps:
+  #     - template: impacted_area_testing/calculate-instance-numbers.yml
+  #       parameters:
+  #         TOPOLOGY: t1
+  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          TOPOLOGY: t1-8-lag
-          STOP_ON_FAILURE: "False"
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          NUM_ASIC: 4
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         TOPOLOGY: t1-8-lag
+  #         STOP_ON_FAILURE: "False"
+  #         SCRIPTS: $(SCRIPTS)
+  #         MIN_WORKER: $(INSTANCE_NUMBER)
+  #         MAX_WORKER: $(INSTANCE_NUMBER)
+  #         NUM_ASIC: 4
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
 
   - job: impacted_area_t2_elastictest
     displayName: "impacted-area-kvmtest-t2 by Elastictest"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Since we already have t2 PR test, we can remove multi-asic t1-lag PR test to save more Azure cpu quota.
#### How did you do it?
Remove multi-asic t1-lag PR test.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
