### PR TITLE
Ignore iptable command nss_tacplus error in loganalyzer_common_ignore.txt

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -321,6 +321,9 @@ r, ".* ERR sshd\[\d*\]: auth fail.*"
 r, ".* ERR ntpd\[\d*\]: nss_tacplus: .*"
 r, ".* ERR chronyd\[\d*\]: nss_tacplus: .*"
 
+# ignore iptable nss_tacplus error, some change iptable operations may temporarily disrupt the DUT-to-PTF network connection, which triggers the error. It is safe to ignore this message during such transitions.
+r, ".* ERR iptables: nss_tacplus: failed to connect TACACS+ server .*"
+
 # ignore leap second file NTP daemon (ntpd) is using has passed its expiration date
 r, ".* ERR ntpd\[\d*\]:.*leapsecond file \('/usr/share/zoneinfo/leap-seconds\.list'\): expired.*"
 


### PR DESCRIPTION
Ignore iptable command nss_tacplus error in loganalyzer_common_ignore.txt

#### Why I did it
test_everflow_dscp_with_policer failed because following error:

2025 Sep 13 00:18:15.829923 str2-msn2700-spy-2 ERR iptables: nss_tacplus: failed to connect TACACS+ server 10.64.246.146:49, ret=-8: Operation now in progress

These test case enable everflow which may cause DUT device lost network to PTF device.

##### Work item tracking
- Microsoft ADO **(number only)**: 34922073

#### How I did it
Ignore iptable command nss_tacplus error in loganalyzer_common_ignore.txt

#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Ignore iptable command nss_tacplus error in loganalyzer_common_ignore.txt

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


