### PR TITLE
[DT2] get entry content with retry to ensure populated

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -244,8 +244,17 @@ def verify_lldp_table(duthost):
 
 
 def verify_each_interface_lldp_content(db_instance, interface, lldpctl_interfaces):
+    def get_lldp_entry_content_with_retry():
+        nonlocal entry_content
+
+        if not entry_content:
+            entry_content = get_lldp_entry_content(db_instance, interface)
+        return entry_content
 
     entry_content = get_lldp_entry_content(db_instance, interface)
+
+    wait_until(20, 1, 0, get_lldp_entry_content_with_retry)
+
     logger.debug("Interface {}, entry_content:{}".format(interface, entry_content))
     if isinstance(lldpctl_interfaces, dict):
         lldpctl_interface = lldpctl_interfaces.get(interface)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Sometimes the function `get_lldp_entry_content` will return an empty result since the content has not populated to database yet. When re-run the query we can see the content exists

This PR will add a simple retry mechanism to make sure that the content exists

This is to prevent false positive issue like

```
  File "/var/src/sonic-mgmt_vms13-lt2-7060x6-8/tests/lldp/test_lldp_syncd.py", line 246, in verify_each_interface_lldp_content
    assert_lldp_entry_content(interface, entry_content, lldpctl_interface)
  File "/var/src/sonic-mgmt_vms13-lt2-7060x6-8/tests/lldp/test_lldp_syncd.py", line 156, in assert_lldp_entry_content
    chassis_info = lldpctl_interface["chassis"][entry_content["lldp_rem_sys_name"]]
KeyError: 'lldp_rem_sys_name'
```
Fixes # (issue) 34939751

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Fix flakiness for lldp syncd test

#### How did you do it?

#### How did you verify/test it?

<img width="869" height="243" alt="image" src="https://github.com/user-attachments/assets/1c42e3f6-ece8-4fcb-8af1-3f5010d85a9a" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
