### PR TITLE
Fix the log rotation error handling

### DIFF
--- a/tests/tacacs/test_ro_disk.py
+++ b/tests/tacacs/test_ro_disk.py
@@ -166,8 +166,8 @@ def log_rotate(duthost):
         state_failed_pattern = r"error: stat of \S* failed: Bad message"
         can_not_access_pattern = r"du: cannot access \S*: Bad message"
         if ("logrotate does not support parallel execution on the same set of logfiles" in message) or \
-                re.match(state_failed_pattern, message) or \
-                re.match(can_not_access_pattern, message) or \
+                re.search(state_failed_pattern, message) or \
+                re.search(can_not_access_pattern, message) or \
                 ("failed to compress log" in message):
             logger.warning("logrotate command failed: {}".format(e))
         else:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: use re.search instead of re.match in order to find out the first occurrence anywhere in string
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The original re.match will only match at the beginning of the string and this will not catch the error string in the middle
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
