### PR TITLE
Fix for GNMI errors in DPU reboot recommended by MSFT

### DIFF
--- a/ansible/golden_config_db/smartswitch_t1.json
+++ b/ansible/golden_config_db/smartswitch_t1.json
@@ -11,6 +11,20 @@
             "port": "50052"
         }
     },
+    "DPU": {
+        "dpu0": {
+            "gnmi_port": "50052"
+        },
+        "dpu1": {
+            "gnmi_port": "50052"
+        },
+        "dpu2": {
+            "gnmi_port": "50052"
+        },
+        "dpu3": {
+            "gnmi_port": "50052"
+        }
+    },
     "STATIC_ROUTE": {
         "default|10.2.0.1/32": {
             "blackhole": "false",


### PR DESCRIPTION
Summary:
Fixes # (issue)
Smart switch reboot GNMI errors.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Open GNMI ports at DPU were needed for standalone DPU appliances.
When the DPU is integrated into the switch, with this config option, switch reboot shows errors:
```
2025-06-12 20:10:44 - ERROR: Failed to send gnoi command to halt services on dpu1
2025-06-12 20:10:44 - ERROR: proceeding without halting the services
```
Cleanup of the config and switch reboot ERRORs.

#### How did you do it?
Provided the correct gnmi port in the switch config

#### How did you verify/test it?
Deploy and manual reboot.
Regression run

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

