### PR TITLE
Fix test_stress_acl for m1 topologies

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -207,7 +207,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
 
     dst_ip_addr = None
     if tbinfo["topo"]['name'] in ["t1-isolated-d28u1", "t1-isolated-d56u2", "t1-isolated-d448u15-lag",
-                                  "t1-isolated-d56u1-lag"]:
+                                  "t1-isolated-d56u1-lag"] or topo == "m1":
         dst_ip_addr = random.choices(list(upstream_port_neighbor_ips.values()))
     return ptf_src_port, upstream_port_ids, dut_port, dst_ip_addr
 


### PR DESCRIPTION
Summary:
Default dst IP 10.0.0.1 conflicts with downstream VM IP in M1-44,108,128.
Test packets for the upstream are forwarded to the downstream port.
Use a random upstream interface IP as dst IP for M1.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
M1-44,108,128 fails acl/test_stress_acl.py acl.test_stress_acl test_acl_add_del_stress
M1-48 doesn't have this problem because default dst IP 10.0.0.1 is one of upstream VM's IP.

#### How did you do it?
Use a random upstream interface IP as dst IP for M1 like those t1-isolated* topos

#### How did you verify/test it?
Tested on m1-48 and m1-108
