### PR TITLE
[TH5] Skip VxLAN Tests for Non-Applicable Topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -26,6 +26,16 @@ test_pretest.py:
             't1-isolated-d448u16', 't1-isolated-v6-d448u16',
             't1-isolated-d56u1-lag', 't1-isolated-v6-d56u1-lag',
             't1-isolated-d56u2', 't1-isolated-v6-d56u2' ]
+      - &noVxlanTopos |
+          topo_name in [
+            't0-isolated-d32u32s2', 't0-isolated-d256u256s2',
+            't0-isolated-d96u32s2', 't0-isolated-v6-d32u32s2',
+            't0-isolated-v6-d256u256s2', 't0-isolated-v6-d96u32s2',
+            't1-isolated-d56u2', 't1-isolated-d56u1-lag',
+            't1-isolated-d448u15-lag', 't1-isolated-d128',
+            't1-isolated-d32', 't1-isolated-v6-d56u2',
+            't1-isolated-v6-d56u1-lag', 't1-isolated-v6-d448u15-lag',
+            't1-isolated-v6-d128' ]
 
 #######################################
 #####          cutsom_acl         #####
@@ -489,12 +499,12 @@ decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=disable]:
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]:
   skip:
-    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release, marvell-teralynx, x86_64-8111_32eh_o-r0 platform. Skip on mellanox all releases. Skip on 7260CX3 T1 topo in 202305 release. Skip on t1-isolated-d32/128 topos"
+    reason: "Not supported on backend, T2 topologies , broadcom platforms before 202012 release, marvell-teralynx, x86_64-8111_32eh_o-r0 platform. Skip on mellanox all releases. Skip on 7260CX3 T1 topo in 202305 release. Not required on isolated topologies d256u256s2, d96u32s2, d448u15-lag, and d128, as well as their minimzed and -v6 variants."
     conditions_logical_operator: or
     conditions:
       - "('t2' in topo_name) or (topo_name in ['t1-backend', 't0-backend']) or (asic_type in ['broadcom'] and release in ['201811', '201911']) or asic_type in ['marvell-teralynx'] or platform in ['x86_64-8111_32eh_o-r0'] or asic_type in ['mellanox']"
       - "'7260CX3' in hwsku and release in ['202305'] and 't1' in topo_type"
-      - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
+      - *noVxlanTopos
 
 decap/test_decap.py::test_decap[ttl=uniform, dscp=pipe, vxlan=disable]:
   skip:
@@ -3545,9 +3555,11 @@ vxlan/test_vxlan_crm.py::Test_VxLAN_Crm::test_crm_512_nexthop_groups[v6_in_v6]:
 
 vxlan/test_vxlan_decap.py:
   skip:
-    reason: "vxlan support not available for cisco-8122 platforms"
+    reason: "vxlan support not available for cisco-8122 platforms. Not required on isolated topologies d256u256s2, d96u32s2, d448u15-lag, and d128, as well as their minimzed and -v6 variants."
+    conditions_logical_operator: OR
     conditions:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
+      - *noVxlanTopos
   xfail:
     reason: "Skipped due to bug https://github.com/sonic-net/sonic-buildimage/issues/22056"
     conditions:


### PR DESCRIPTION
Note: this is a manual cherry-pick to 202505 of https://github.com/sonic-net/sonic-mgmt/pull/20552
Note: depends on https://github.com/sonic-net/sonic-mgmt/pull/20382 to pass static analysis.

### Description of PR
Skip the following tests:
decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]
vxlan/test_vxlan_decap.py

for the following topologes:
- t0-isolated-d32u32s2
- t0-isolated-d256u256s2
- t0-isolated-v6-d32u32s2
- t0-isolated-v6-d256u256s2
- t1-isolated-d56u2
- t1-isolated-d56u1-lag
- t1-isolated-d448u15-lag
- t1-isolated-v6-d56u2
- t1-isolated-v6-d56u1-lag
- t1-isolated-v6-d448u15-lag
- t1-isolated-d32
- t1-isolated-d128
- t1-isolated-v6-d128
- t0-isolated-d96u32s2
- t0-isolated-v6-d96u32s2

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202505

### Approach
#### What is the motivation for this PR?
Skip tests that are not required for the following topologies: t0-isolated-d32u32s2, t0-isolated-d256u256s2, t0-isolated-v6-d32u32s2, t0-isolated-v6-d256u256s2, t1-isolated-d56u2, t1-isolated-d56u1-lag, t1-isolated-d448u15-lag, t1-isolated-v6-d56u2, t1-isolated-v6-d56u1-lag, t1-isolated-v6-d448u15-lag, t1-isolated-d32, t1-isolated-d128, t1-isolated-v6-d128, t0-isolated-d96u32s2, t0-isolated-v6-d96u32s2.

#### How did you do it?
Added a skip conditional mark to the following tests:
decap/test_decap.py::test_decap[ttl=pipe, dscp=uniform, vxlan=set_unset]
vxlan/test_vxlan_decap.py

#### How did you verify/test it?
Tried to run the test and confirmed it is skipped.