### PR TITLE
fix: fix peer_snappi_chassis issue for t0/t1 community

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -259,7 +259,10 @@ def get_peer_snappi_chassis(conn_data, dut_hostname):
     peer_devices = list(set(peer_devices))
     # in case there are other fanout devices (Arista, SONiC, etc) defined in the inventory file,
     # try to filter out the other device based on the name for now.
-    peer_snappi_devices = list(filter(lambda dut_name: ('ixia' in dut_name), peer_devices))
+    peer_snappi_devices = list(filter(
+        lambda dut_name: ('ixia' in dut_name or 'snappi' in dut_name), peer_devices)
+    )
+
     if len(peer_snappi_devices) == 1:
         return peer_snappi_devices[0]
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: community is using different naming convention for ixia devices. This will add some extra naming convention as required 

Fixes # (issue) 34957124

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
