### PR TITLE
Skipping test_dynamic_acl.py for x86_64-8102_28fh_dpu_o-r0 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2482,7 +2482,7 @@ generic_config_updater/test_dynamic_acl.py:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "hwsku in ['Cisco-8111-O64']"
       - "topo_name in ['m0-2vlan']"
-      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o_c01-r0']"
+      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-8101_32fh_o_c01-r0']"
 
 generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV4:
   skip:


### PR DESCRIPTION

### Description of PR
Skipping generic_config_updater/test_dynamic_acl.py for x86_64-8102_28fh_dpu_o-r0 platform, as it is not supported on this platform


### Type of change
-Test modification

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202505
- [x] 202506


#### How did you do it?
Added the platform in the existing skip condition for generic_config_updater/test_dynamic_acl.py

#### How did you verify/test it?
TCs is skipped for this platform

