### PR TITLE
[Smartswitch] Fix test_neighbor_mac_noptf.py for SN4280

### DIFF
--- a/tests/arp/test_neighbor_mac_noptf.py
+++ b/tests/arp/test_neighbor_mac_noptf.py
@@ -98,7 +98,7 @@ class TestNeighborMacNoPtf:
         bgp_routes = 0
 
         filter_ip_list = []
-        if duthost.facts["asic_type"] == "cisco-8000":
+        if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
             filter_ip_list = self._get_back_plane_port_ips(duthost)
 
         # Checks that there are no routes installed by BGP in ASIC_DB


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([issue](https://github.com/sonic-net/sonic-mgmt/issues/20656))
Cisco has already implemented the logic for Smartswitch in PR(https://github.com/sonic-net/sonic-mgmt/pull/17857), we need make it work on all the smartswitch platforms.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fixes # ([issue](https://github.com/sonic-net/sonic-mgmt/issues/20656)) for SN4280
#### How did you do it?
get the filter_ip_list for all smartswitch platforms
#### How did you verify/test it?
Run the test on SN4280 light mode, passed.
<img width="309" height="177" alt="image" src="https://github.com/user-attachments/assets/938d2489-e7ee-4f67-a20c-7b6107894f69" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
