### PR TITLE
Avoid using soc ip as server ip in everflow/test_everflow_testbed.py

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,7 +24,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.macsec.macsec_helper import MACSEC_INFO
-from tests.common.dualtor.dual_tor_common import mux_config
+from tests.common.dualtor.dual_tor_common import mux_config # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
@@ -61,7 +61,7 @@ UP_STREAM = "upstream"
 DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
 
 
-def get_default_server_ip(mux_config, avoidList):
+def get_default_server_ip(mux_config, avoidList): # noqa F811
     """
     Get default server IP
     """
@@ -516,7 +516,7 @@ def remove_route(duthost, prefix, nexthop, namespace):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def setup_arp_responder(duthost, ptfhost, setup_info, mux_config):
+def setup_arp_responder(duthost, ptfhost, setup_info, mux_config): # noqa F811
     if setup_info['topo'] not in ['t0', 'm0_vlan']:
         yield
         return

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,6 +24,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.macsec.macsec_helper import MACSEC_INFO
+from tests.common.dualtor.dual_tor_common import mux_config    # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
@@ -58,6 +59,16 @@ DOWN_STREAM = "downstream"
 UP_STREAM = "upstream"
 # Topo that downstream neighbor of DUT are servers
 DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
+
+def get_default_server_ip(mux_config, avoidList):
+    """
+    Get default server IP
+    """
+    for _, port_config in list(mux_config.items()):
+        if (server_ip := port_config["SERVER"]["IPv4"].split('/')[0]) not in avoidList:
+            return server_ip
+    return DEFAULT_SERVER_IP
+
 
 
 def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
@@ -506,11 +517,11 @@ def remove_route(duthost, prefix, nexthop, namespace):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def setup_arp_responder(duthost, ptfhost, setup_info):
+def setup_arp_responder(duthost, ptfhost, setup_info, mux_config):
     if setup_info['topo'] not in ['t0', 'm0_vlan']:
         yield
         return
-    ip_list = [TARGET_SERVER_IP, DEFAULT_SERVER_IP]
+    ip_list = [TARGET_SERVER_IP, get_default_server_ip(mux_config, [TARGET_SERVER_IP])]
     port_list = setup_info["server_dest_ports_ptf_id"][0:2]
     arp_responder_cfg = {}
     for i, ip in enumerate(ip_list):

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,7 +24,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.macsec.macsec_helper import MACSEC_INFO
-from tests.common.dualtor.dual_tor_common import mux_config    # noqa: F401
+from tests.common.dualtor.dual_tor_common import mux_config
 from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
@@ -60,6 +60,7 @@ UP_STREAM = "upstream"
 # Topo that downstream neighbor of DUT are servers
 DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
 
+
 def get_default_server_ip(mux_config, avoidList):
     """
     Get default server IP
@@ -68,8 +69,6 @@ def get_default_server_ip(mux_config, avoidList):
         if (server_ip := port_config["SERVER"]["IPv4"].split('/')[0]) not in avoidList:
             return server_ip
     return DEFAULT_SERVER_IP
-
-
 
 def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
     """

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -24,7 +24,7 @@ from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyze
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
 from tests.common.macsec.macsec_helper import MACSEC_INFO
-from tests.common.dualtor.dual_tor_common import mux_config # noqa: F401
+from tests.common.dualtor.dual_tor_common import mux_config              # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
@@ -61,7 +61,7 @@ UP_STREAM = "upstream"
 DOWNSTREAM_SERVER_TOPO = ["t0", "m0_vlan"]
 
 
-def get_default_server_ip(mux_config, avoidList): # noqa F811
+def get_default_server_ip(mux_config, avoidList):      # noqa F811
     """
     Get default server IP
     """
@@ -69,6 +69,7 @@ def get_default_server_ip(mux_config, avoidList): # noqa F811
         if (server_ip := port_config["SERVER"]["IPv4"].split('/')[0]) not in avoidList:
             return server_ip
     return DEFAULT_SERVER_IP
+
 
 def gen_setup_information(dutHost, downStreamDutHost, upStreamDutHost, tbinfo, topo_scenario):
     """
@@ -516,7 +517,7 @@ def remove_route(duthost, prefix, nexthop, namespace):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def setup_arp_responder(duthost, ptfhost, setup_info, mux_config): # noqa F811
+def setup_arp_responder(duthost, ptfhost, setup_info, mux_config):      # noqa F811
     if setup_info['topo'] not in ['t0', 'm0_vlan']:
         yield
         return

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -672,6 +672,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -14,7 +14,7 @@ from common.helpers.assertions import pytest_assert
 from . import everflow_test_utilities as everflow_utils
 import ptf.packet as scapy
 from tests.ptf_runner import ptf_runner
-from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, DEFAULT_SERVER_IP
+from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, get_default_server_ip
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                   # noqa: F401
@@ -22,6 +22,7 @@ from .everflow_test_utilities import setup_info, setup_arp_responder, erspan_ip_
 from .everflow_test_utilities import skip_ipv6_everflow_tests                                             # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                     # noqa: F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
+from tests.common.dualtor.dual_tor_common import mux_config                                               # noqa: F401
 from tests.common.helpers.ptf_tests_helper import find_links
 from ipaddress import ip_address, IPv4Address
 from tests.common.fixtures.duthost_utils import is_multi_binding_acl_enabled  # noqa: F401
@@ -257,6 +258,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -267,7 +269,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         )
 
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
-                                       dest_port_type, ptfadapter, tbinfo,
+                                       dest_port_type, ptfadapter, tbinfo, mux_config,
                                        toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                                        setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
                                        erspan_ip_ver):                                              # noqa F811
@@ -302,6 +304,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -320,6 +323,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -344,6 +348,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -362,6 +367,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -375,7 +381,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             setup_info[dest_port_type]["remote_namespace"]))
 
     def test_everflow_neighbor_mac_change(self, setup_info, setup_mirror_session,               # noqa F811
-                                          dest_port_type, ptfadapter, tbinfo,
+                                          dest_port_type, ptfadapter, tbinfo, mux_config,
                                           toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
                                           setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
                                           erspan_ip_ver):                                              # noqa F811
@@ -399,6 +405,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -420,6 +427,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             self._run_everflow_test_scenarios(
                 ptfadapter,
                 setup_info,
+                mux_config,
                 setup_mirror_session,
                 everflow_dut,
                 rx_port_ptf_id,
@@ -442,6 +450,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -451,7 +460,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         )
 
     def test_everflow_remove_unused_ecmp_next_hop(self, setup_info, setup_mirror_session,               # noqa F811
-                                                  dest_port_type, ptfadapter, tbinfo,
+                                                  dest_port_type, ptfadapter, tbinfo, mux_config,
                                                   toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
                                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
                                                   erspan_ip_ver):                                              # noqa F811
@@ -484,6 +493,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -508,6 +518,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -527,6 +538,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -541,6 +553,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -550,7 +563,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         )
 
     def test_everflow_remove_used_ecmp_next_hop(self, setup_info, setup_mirror_session,                 # noqa F811
-                                                dest_port_type, ptfadapter, tbinfo,
+                                                dest_port_type, ptfadapter, tbinfo, mux_config,
                                                 toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
                                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
                                                 erspan_ip_ver):                                              # noqa F811
@@ -582,6 +595,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -606,6 +620,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -623,6 +638,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -642,6 +658,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         self._run_everflow_test_scenarios(
             ptfadapter,
             setup_info,
+            mux_config,
             setup_mirror_session,
             everflow_dut,
             rx_port_ptf_id,
@@ -793,7 +810,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
     def test_everflow_frwd_with_bkg_trf(self,
                                         setup_info,  # noqa F811
                                         setup_mirror_session,
-                                        dest_port_type, ptfadapter, tbinfo,
+                                        dest_port_type, ptfadapter, tbinfo, mux_config,
                                         erspan_ip_ver, toggle_all_simulator_ports_to_rand_selected_tor,  # noqa F811
                                         setup_standby_ports_on_rand_unselected_tor_unconditionally):  # noqa F811
         """
@@ -883,6 +900,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             self._run_everflow_test_scenarios(
                 ptfadapter,
                 setup_info,
+                mux_config,
                 setup_mirror_session,
                 everflow_dut,
                 rx_port_ptf_id,
@@ -903,6 +921,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             self._run_everflow_test_scenarios(
                 ptfadapter,
                 setup_info,
+                mux_config,
                 setup_mirror_session,
                 everflow_dut,
                 rx_port_ptf_id,
@@ -927,6 +946,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             self._run_everflow_test_scenarios(
                 ptfadapter,
                 setup_info,
+                mux_config,
                 setup_mirror_session,
                 everflow_dut,
                 rx_port_ptf_id,
@@ -945,6 +965,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
             self._run_everflow_test_scenarios(
                 ptfadapter,
                 setup_info,
+                mux_config,
                 setup_mirror_session,
                 everflow_dut,
                 rx_port_ptf_id,
@@ -1080,7 +1101,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 "vtysh -c \"configure terminal\" -c \"ip nht resolve-via-default\"",
                 setup_info[dest_port_type]["remote_namespace"]))
 
-    def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port,
+    def _run_everflow_test_scenarios(self, ptfadapter, setup, mux_config, mirror_session, duthost, rx_port,
                                      tx_ports, direction, expect_recv=True, valid_across_namespace=True,
                                      erspan_ip_ver=4, multi_binding_acl=False):  # noqa F811
         # FIXME: In the ptf_runner version of these tests, LAGs were passed down to the tests
@@ -1092,7 +1113,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
         default_ip = self.DEFAULT_DST_IP
         if setup['topo'] in ['t0', 'm0_vlan'] and direction == DOWN_STREAM:
             target_ip = TARGET_SERVER_IP
-            default_ip = DEFAULT_SERVER_IP
+            default_ip = get_default_server_ip(mux_config, [TARGET_SERVER_IP])
 
         router_mac = setup[direction]["ingress_router_mac"]
 


### PR DESCRIPTION
We should not use soc ip as server ip, It can interfere with grpc connection between tor and nic_simulator.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.

-->
We should not use soc ip as server ip, It can interfere with grpc connection between tor and nic_simulator.


Summary:
Fixes # (https://github.com/aristanetworks/sonic-qual.msft/issues/804)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
In case of dualtor, we have notion of soc IPs, which are critical for tor-nic-simulator communication via grpc. For everflow/test_everflow_testbed.py we were using one of these IPs as `DEFAULT_SERVER_IP` that can interfere with grpc connection.

#### How did you do it?
defined `get_default_server_ip()` which gives correct server IP in case of dualtor topo

#### How did you verify/test it?
ran everflow/test_everflow_testbed.py

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
