### PR TITLE
[QoS] Fix buffer-deployment test bug

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -2661,6 +2661,44 @@ def _recovery_to_dynamic_buffer_model(duthost):
     config_reload(duthost, config_source='config_db')
 
 
+def _is_mgmt_port(port_config: dict) -> bool:
+    """
+    Determine whether a port is a management/management-like port.
+
+    Heuristics (keep existing semantics):
+      - Port config must exist and admin_status must not be 'down'
+      - If description contains 'pt0' => management
+      - If speed is one of known low speeds (1G / 10G) => management
+
+    Args:
+        port_config: Dict from CONFIG_DB for a port.
+
+    Returns:
+        True if considered a management port, else False.
+    """
+    if not port_config:
+        return False
+
+    if port_config.get('admin_status') == 'down':
+        return False
+
+    desc = port_config.get('description', '').lower()
+    if 'pt0:' in desc:
+        # PT0 ports are considered management ports
+        return True
+
+    speed_raw = port_config.get('speed')
+    if speed_raw:
+        try:
+            speed = int(speed_raw)
+        except ValueError:
+            speed = None
+        if speed in {1000, 10000}:  # 1G / 10G
+            return True
+
+    return False
+
+
 def test_buffer_model_test(duthosts, rand_one_dut_hostname, conn_graph_facts, skip_traditional_model):  # noqa: F811
     """Verify whether the buffer model is expected after configuration operations:
     The following items are verified
@@ -2973,6 +3011,10 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
             key_name = KEY_4_LOSSLESS_QUEUE
         else:
             key_name = KEY_2_LOSSLESS_QUEUE
+
+        if _is_mgmt_port(port_config):
+            logging.info("Skip management port {}".format(port))
+            continue
         # The last item in the check list various according to port's admin state.
         # We need to append it according to the port each time. Pop the last item first
         if port_config.get('admin_status') == 'up':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fixes the buffer-deployment test bug where buffer checks were being done on service ports which do not have key buffer attributes; skip lossless buffer config checks on those ports where lossless config is not present/expected. This makes the test case more robust.

With the changes in [#24085](https://github.com/sonic-net/sonic-buildimage/pull/24085), this test now passes.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Bug fix - causing successive test failures.
#### How did you do it?
If a port does not have any lossless config associated with it, skip the lossless buffer check
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
