### PR TITLE
[ansible] fix deploy-mg issue

### DIFF
--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -114,8 +114,9 @@ class TestbedVMFacts():
         result_dict = {}
         for group_name, group_content in yaml_data.items():
             if group_name.startswith('vms_'):
-                for host_name, host_info in group_content.get('hosts', {}).items():
-                    result_dict[host_name] = {'ansible_host': host_info.get('ansible_host', '')}
+                if 'hosts' in group_content and group_content['hosts']:
+                    for host_name, host_info in group_content['hosts'].items():
+                        result_dict[host_name] = {'ansible_host': host_info.get('ansible_host', '')}
         return result_dict
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Current code does not deal with the case where there is server entry in veos, but no vm under it. Currently we typically put a place holder vm entry under a new server to hint on the ip network for this server. This is a nice convention but code should not throw error if it doesnt have this place holder.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Deploy mg will fail if there is server entry in veos but no vm entry under this server.

#### How did you do it?
Fix the bug.

#### How did you verify/test it?
Run deploy-mg, add-topo and remove-topo on testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
