### PR TITLE
chore: fix StopIteration on bgp test

### DIFF
--- a/tests/snappi_tests/bgp/conftest.py
+++ b/tests/snappi_tests/bgp/conftest.py
@@ -280,6 +280,7 @@ def record_property(request):
 @pytest.fixture(scope="session", autouse=True)
 def initial_setup(duthosts, creds, tbinfo):
     if 'route_conv' not in tbinfo['topo']['name']:
+        yield
         return
 
     """Perform initial DUT configurations (T1, Fanout) for convergence tests (runs once per test session)."""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix stop iteration for bgp t0/t1 device 

```
    @decorator.decorator
    def _fixture_generator_decorator(fixture_generator, *args, **kargs):
        # setup, to the first yield in fixture
        logging.info("-" * 20 + (" fixture %s setup starts " % fixture_generator.__name__) + "-" * 20)
        it = fixture_generator(*args, **kargs)
        try:
>           res = next(it)
E           StopIteration
```

Fixes # (issue) 3498901

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
