### PR TITLE
correct qos param of topo dualtor-aa-56 on th2 platform

### DIFF
--- a/tests/qos/files/qos_params.th2.yaml
+++ b/tests/qos/files/qos_params.th2.yaml
@@ -213,6 +213,21 @@ qos_params:
                     pkts_num_trig_pfc: 19939
                     pkts_num_margin: 4
             100000_300m:
+                pkts_num_leak_out: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 19939
+                    pkts_num_trig_ingr_drp: 20425
+                    pkts_num_margin: 4
                 pcbb_xoff_1:
                     dscp: 3
                     ecn: 1
@@ -243,6 +258,40 @@ qos_params:
                     pkts_num_margin: 4
                     pkts_num_trig_ingr_drp: 19939
                     pkts_num_trig_pfc: 19939
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [1, 2, 3, 4, 5, 6, 7]
+                    dst_port_id: 0
+                    pgs_num: 14
+                    pkts_num_trig_pfc: 1826
+                    pkts_num_hdrm_full: 682
+                    pkts_num_hdrm_partial: 542
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 4457
+                    pkts_num_trig_ingr_drp: 5140
+                    cell_size: 208
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 5140
+                    cell_size: 208
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 6
+                    pkts_num_trig_pfc: 4457
+                    pkts_num_trig_ingr_drp: 5140
+                    pkts_num_fill_egr_min: 16
+                    cell_size: 208
             xon_1:
                 dscp: 3
                 ecn: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

nightly failure, as below:
```
KeyError('wm_q_shared_lossless')
Traceback (most recent call last):
  File "/var/src/sonic-mgmt_vms64-dual-t0-7260-1/tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File "/var/src/sonic-mgmt_vms64-dual-t0-7260-1/tests/qos/qos_sai_base.py", line 1767, in dutQosConfig
    qosParams = qpm.run()
  File "/var/src/sonic-mgmt_vms64-dual-t0-7260-1/tests/qos/files/brcm/qos_param_generator.py", line 521, in run
    self.prepare_default_parameters()
  File "/var/src/sonic-mgmt_vms64-dual-t0-7260-1/tests/qos/files/brcm/qos_param_generator.py", line 640, in prepare_default_parameters
    self.create_default_queue_shared_watermark_parameter(que_profile)
  File "/var/src/sonic-mgmt_vms64-dual-t0-7260-1/tests/qos/files/brcm/qos_param_generator.py", line 580, in create_default_queue_shared_watermark_parameter
    self.qos_params[self.speed_cable_len][que_profile] = self.qos_params[que_profile]
KeyError: 'wm_q_shared_lossless'
ERROR   
```

#### How did you do it?

add missing qos parameters of topo dualtor-aa-56 for th2 platform.

#### How did you verify/test it?

pass local test:
<img width="2126" height="511" alt="image" src="https://github.com/user-attachments/assets/e6ce5429-a6e3-4973-9b81-3f6eeeb66d4c" />



#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
