### PR TITLE
add xfail for TestDhcpv6RelayWithMultipleVlan due to GH issue 20760

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -808,6 +808,10 @@ dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan:
     reason: "skip the multiple vlan test on aa dualtor as interface state is not aa after vlan split"
     conditions:
       - "'dualtor-aa' in topo_name"
+  xfail:
+    reason: "The test is expected to fail due to GH issue: https://github.com/sonic-net/sonic-mgmt/issues/20760"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20760"
 
 dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add xfail for the TestDhcpv6RelayWithMultipleVlan due to the #20760

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
- [x] Xfail condition


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Avoid failing dhcp6 relay test caused by a problematic commit affected the deployment process

#### How did you do it?
added xfail based on a GH issue

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
