### PR TITLE
Update qos params for Arista-7060X6-16PE-384C-B-O128S2

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -401,22 +401,6 @@ qos_params:
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 2
                     pkts_num_trig_pfc: 134690
-            cell_size: 254
-            hdrm_pool_wm_multiplier: 1
-            wrr:
-                dscp_list: [0, 47, 3, 4, 46, 44]
-                ecn: 1
-                limit: 80
-                q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
-            wrr_chg:
-                dscp_list: [0, 47, 3, 4, 46, 44]
-                ecn: 1
-                limit: 80
-                lossless_weight: 30
-                lossy_weight: 8
-                q_list: [0, 1, 3, 4, 5, 6]
-                q_pkt_cnt: [40, 50, 150, 50, 50, 350]
         topo-t1-isolated-d128: &topo-t1-isolated-d128
             200000_5m: &topo-t1-isolated-d128_200000_5m
                 hdrm_pool_size:

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -214,13 +214,13 @@ qos_params:
                     - 4
                     pkts_num_hdrm_full: 1549
                     pkts_num_hdrm_partial: 1118
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_pfc: 134690
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134550
+                    pkts_num_trig_egr_drp: 134624
                 pkts_num_egr_mem: 376
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
@@ -229,8 +229,8 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136165
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_ingr_drp: 136239
+                    pkts_num_trig_pfc: 134690
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -239,7 +239,7 @@ qos_params:
                     pg: 3
                     pkts_num_fill_min: 74
                     pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_pfc: 134690
                 wm_pg_shared_lossy:
                     cell_size: 254
                     dscp: 8
@@ -248,14 +248,14 @@ qos_params:
                     pg: 0
                     pkts_num_fill_min: 7
                     pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134550
+                    pkts_num_trig_egr_drp: 134624
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
                     pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136165
+                    pkts_num_trig_ingr_drp: 136239
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
@@ -263,36 +263,36 @@ qos_params:
                     ecn: 1
                     pkts_num_fill_min: 7
                     pkts_num_margin: 2
-                    pkts_num_trig_egr_drp: 134550
+                    pkts_num_trig_egr_drp: 134624
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136165
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_ingr_drp: 136239
+                    pkts_num_trig_pfc: 134690
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_margin: 2
-                    pkts_num_trig_ingr_drp: 136165
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_ingr_drp: 136239
+                    pkts_num_trig_pfc: 134690
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_pfc: 134690
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 2
-                    pkts_num_trig_pfc: 134616
+                    pkts_num_trig_pfc: 134690
             cell_size: 254
             hdrm_pool_wm_multiplier: 1
             wrr:

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -229,6 +229,114 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136446
+                    pkts_num_trig_pfc: 134690
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 74
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 134690
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 2
+                    pkts_num_trig_egr_drp: 134624
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136446
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 2
+                    pkts_num_trig_egr_drp: 134624
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136446
+                    pkts_num_trig_pfc: 134690
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 2
+                    pkts_num_trig_ingr_drp: 136446
+                    pkts_num_trig_pfc: 134690
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 134690
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 2
+                    pkts_num_trig_pfc: 134690
+            cell_size: 254
+            hdrm_pool_wm_multiplier: 1
+            wrr:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+            wrr_chg:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [40, 50, 150, 50, 50, 350]
+            400000_5m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 2
+                    pgs:
+                    - 3
+                    - 4
+                    pkts_num_hdrm_full: 1549
+                    pkts_num_hdrm_partial: 1118
+                    pkts_num_trig_pfc: 134690
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 2
+                    pkts_num_trig_egr_drp: 134624
+                pkts_num_egr_mem: 376
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 2
                     pkts_num_trig_ingr_drp: 136239
                     pkts_num_trig_pfc: 134690
                 wm_pg_shared_lossless:
@@ -309,7 +417,6 @@ qos_params:
                 lossy_weight: 8
                 q_list: [0, 1, 3, 4, 5, 6]
                 q_pkt_cnt: [40, 50, 150, 50, 50, 350]
-            400000_5m: *topo-t0-isolated-d96u32s2-400000_40m
         topo-t1-isolated-d128: &topo-t1-isolated-d128
             200000_5m: &topo-t1-isolated-d128_200000_5m
                 hdrm_pool_size:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For Moby hwsku, uplink and downlink has different speed and cable length, hence creating the params for each profile seperately.
one params for 400000_5m.
```
pkts_num_trig_ingr_drp: 136239
pkts_num_trig_pfc: 134690
pkts_num_trig_egr_drp: 134624
```

one params for 400000_40m.
```
pkts_num_trig_ingr_drp: 136446
pkts_num_trig_pfc: 134690
pkts_num_trig_egr_drp: 134624
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Update QoS params values.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
