### PR TITLE
Addition of prober_typer knob of MUX_CABLE as part of golden config

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -154,6 +154,10 @@
         is_bmc_topo: "{{ 'bmc' in topo }}"
       tags: always
 
+    - name: set prober_type
+      set_fact:
+        prober_type: "{{ testbed_facts['prober_type'] | default(None) }}"
+
     - name: set lit mode
       set_fact:
         is_lit_mode: "{{ testbed_facts.get('is_lit_mode', topo in ['t1-smartswitch-ha', 't1-28-lag', 'smartswitch-t1', 't1-48-lag']) }}"
@@ -916,6 +920,7 @@
           port_override_from_links: "{{ port_override_from_links | default(false) | bool }}"
           hwsku: "{{ (lab_csv_result.stdout | from_json).hwsku if (port_override_from_links | default(false) | bool) and lab_csv_result is defined and lab_csv_result.rc == 0 and (lab_csv_result.stdout | from_json).hwsku else hwsku }}"
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
+          prober_type: "{{ prober_type | default(omit) }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
           npu_index: "{{ dut_index | default(0) | int }}"
           bgp_confd_asn: "{{ bgp_confd_asn }}"

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -182,7 +182,7 @@ class GenerateGoldenConfigDBModule(object):
                                     num_asics=dict(required=False, type='int', default=1),
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
-                                    prober_type=dict(require=False, type='str', default=None),
+                                    prober_type=dict(required=False, type='str', default=None),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
@@ -1133,6 +1133,7 @@ class GenerateGoldenConfigDBModule(object):
         # Preserve DEVICE_METADATA
         if "DEVICE_METADATA" in ori_config_db:
             golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
+        golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
 
         # Add prober_type to MUX_CABLE if it exists and prober_type is specified
         if ("MUX_CABLE" in ori_config_db and "PORT" in ori_config_db

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -182,6 +182,7 @@ class GenerateGoldenConfigDBModule(object):
                                     num_asics=dict(required=False, type='int', default=1),
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
+                                    prober_type=dict(require=False, type='str', default=None),
                                     is_lit_mode=dict(required=False, type='bool', default=True),
                                     npu_index=dict(required=False, type='int', default=0),
                                     duts_list=dict(required=False, type='list', default=[]),
@@ -205,6 +206,7 @@ class GenerateGoldenConfigDBModule(object):
             self.hwsku = dut_hwsku
 
         self.vm_configuration = self.module.params['vm_configuration']
+        self.prober_type = self.module.params['prober_type']
         self.is_lit_mode = self.module.params['is_lit_mode']
         self.bgp_confd_asn = self.module.params['bgp_confd_asn']
         self.bgp_confd_peers = self.module.params['bgp_confd_peers']
@@ -1116,6 +1118,35 @@ class GenerateGoldenConfigDBModule(object):
 
         return json.dumps(golden_config, indent=4)
 
+    def generate_dualtor_golden_config_db(self):
+        """
+        Generate golden config for dualtor topology with prober_type support.
+        This adds prober_type to existing MUX_CABLE entries from minigraph.
+        """
+        rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
+        if rc != 0:
+            self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
+        # Get existing config from minigraph
+        ori_config_db = json.loads(out)
+        golden_config_db = {}
+
+        # Preserve DEVICE_METADATA
+        if "DEVICE_METADATA" in ori_config_db:
+            golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
+
+        # Add prober_type to MUX_CABLE if it exists and prober_type is specified
+        if ("MUX_CABLE" in ori_config_db and "PORT" in ori_config_db
+           and self.prober_type != "" and self.prober_type is not None):
+            mux_cable_config = copy.deepcopy(ori_config_db["MUX_CABLE"])
+            port_config = copy.deepcopy(ori_config_db["PORT"])
+            # Add prober_type to each interface
+            for intf_name, intf_config in mux_cable_config.items():
+                intf_config["prober_type"] = self.prober_type
+            golden_config_db["MUX_CABLE"] = mux_cable_config
+            golden_config_db["PORT"] = port_config
+
+        return json.dumps(golden_config_db, indent=4)
+
     def override_port_table_from_platform(self, config):
         """
         Rebuild the PORT table from port_speeds + platform.json.
@@ -1225,6 +1256,9 @@ class GenerateGoldenConfigDBModule(object):
             config = self.generate_full_lossy_golden_config_db()
         elif self.topo_name in ["t1-filterleaf-lag"]:
             config = self.generate_filterleaf_golden_config_db()
+        elif "dualtor" in self.topo_name:
+            config = self.generate_dualtor_golden_config_db()
+            module_msg = module_msg + " for dualtor"
         elif "c0" in self.topo_name:
             config = self.generate_c0_golden_config_db()
             module_msg = module_msg + " for c0"

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -283,3 +283,21 @@
   inv_name: lab
   auto_recover: 'False'
   comment: BMC dual-mgmt testbed
+
+- conf-name: tor-dualtor3
+  group-name: tor-dualtor
+  topo: dualtor-aa
+  ptf_image_name: docker-ptf
+  ptf: ptf_dtor3
+  ptf_ip: 10.255.0.210/24
+  ptf_ipv6: 2001:db8:1::20/64
+  prober_type: hardware
+  server: server_1
+  vm_base: VM0100
+  dut:
+    - dtor3-dut0
+    - dtor3-dut1
+  inv_name: lab
+  auto_recover: 'True'
+  netns_mgmt_ip: 10.255.0.211/16
+  comment: dualtor setup example


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Prober_type knob was added in MUX_CABLE,now we needed an option to run mgmt runs with software prober or hardware prober for any run on dualtor.

How to enable it :
- conf-name: docker-ptf
  group-name: sonic_cisco
  topo: t0
  ptf_image_name: docker-ptf-titan
  **prober_type: hardware**
  ptf: docker-ptf
  ptf_ip: 192.168.122.78/24
  ptf_ipv6: fc0b::1/64
  server: server_1
  vm_base: VM0100
  dut:
  - titan-01
  inv_name: lab
  auto_recover: 'True'
  comment: Test ptf titan

Fixes # (issue)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
This PR is to add support for prober_type knob enable or disable in golden_config 

#### How did you do it?
added prober_type: <hardware/software> to testbed.yaml
specific config will be added to golden_config_db.json
which will eventaully go to config_db.json using minigraph_override

#### How did you verify/test it?
Ran sanities with this option enabled and then disabled. It was generating the right golden_config

#### Any platform specific information?
Default value of this prober_type will be software .if nothing is added in testbed.yaml then no need to add this as default is already software.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
