### PR TITLE
Fix testbed_vm_info.py for ansible >= 2.14

### DIFF
--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.multi_servers_utils import MultiServersUtils
 import re
@@ -37,11 +37,13 @@ options:
         type: str
         default: veos
     servers_info:
-        description: Optional mapping describing multi-server VM allocation. If provided, used to derive VM name mapping.
+        description: Optional mapping describing multi-server VM allocation. If provided, used to derive VM name
+                     mapping.
         required: false
         type: dict
 notes:
-    - This module no longer imports ansible.parsing.dataloader or ansible.inventory.manager; inventory data is parsed directly via YAML.
+    - This module no longer imports ansible.parsing.dataloader or ansible.inventory.manager; inventory data is parsed
+      directly via YAML.
     - The inventory file must be accessible from the target host where this module runs.
 author:
     - SONiC Community

--- a/ansible/library/testbed_vm_info.py
+++ b/ansible/library/testbed_vm_info.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.multi_servers_utils import MultiServersUtils
@@ -6,35 +5,66 @@ import re
 import yaml
 import traceback
 import ipaddress
+import os
 
-try:
-    from ansible.parsing.dataloader import DataLoader
-    from ansible.inventory.manager import InventoryManager
-    has_dataloader = True
-except ImportError:
-    has_dataloader = False
+# NOTE:
+# Direct usage of Ansible internal controller APIs (DataLoader, InventoryManager, etc.)
+# from within custom modules is no longer supported/recommended starting Ansible 2.14.
+# This module previously attempted to import and use InventoryManager to resolve
+# host variables. We now always parse the provided inventory YAML file directly
+# using standard YAML loading which keeps the module self‑contained and future proof.
 
 DOCUMENTATION = '''
-module: testbed_vm_info.py
-Ansible_version_added:  2.0.0.2
-short_description: Gather all related VMs info
-Description:
-       When deploy testbed topology with VM connected to SONiC,
-       gather neighbor VMs info for generating SONiC minigraph file
- options:
-    base_vm:  base vm name defined in testbed.csv for the deployed topology; required: True
-    topo:     topology name defined in testbed.csv for the deployed topology; required: True
-    vm_file:  the virtual machine file path; default: 'veos'
-
-Ansible_facts:
-    'neighbor_eosvm_mgmt':  all VM hosts management IPs
-    'topoall':              topology information
-
+module: testbed_vm_info
+version_added: 2.0.0.2
+short_description: Gather related VM management information for a testbed topology
+description:
+    - When deploying a testbed topology with VMs connected to SONiC, gather neighbor VM management IPs
+        and full topology information used for generating SONiC minigraph files.
+    - Updated for Ansible >= 2.14 compatibility by removing direct usage of internal Ansible controller APIs.
+options:
+    base_vm:
+        description: Base VM name defined in testbed.csv for the deployed topology.
+        required: true
+        type: str
+    topo:
+        description: Topology name defined in testbed.csv for the deployed topology.
+        required: true
+        type: str
+    vm_file:
+        description: Path to the VM inventory YAML file.
+        required: false
+        type: str
+        default: veos
+    servers_info:
+        description: Optional mapping describing multi-server VM allocation. If provided, used to derive VM name mapping.
+        required: false
+        type: dict
+notes:
+    - This module no longer imports ansible.parsing.dataloader or ansible.inventory.manager; inventory data is parsed directly via YAML.
+    - The inventory file must be accessible from the target host where this module runs.
+author:
+    - SONiC Community
+returns:
+    ansible_facts:
+        description: Collected facts.
+        returned: always
+        type: dict
+        contains:
+            neighbor_eosvm_mgmt:
+                description: Mapping of neighbor device logical names to VM management IPs.
+                type: dict
+            topoall:
+                description: Raw topology YAML content loaded from topology definition file.
+                type: dict
 '''
 
 EXAMPLES = '''
-    - name: gather vm information
-      testbed_vm_info: base_vm='VM0100' topo='t1' vm_file='veos'
+- name: Gather VM information
+    testbed_vm_info:
+        base_vm: "VM0100"
+        topo: "t1"
+        vm_file: "veos"  # path accessible to the target host
 '''
 
 # Here are the assumption/expectation of files to gather VM information,
@@ -44,7 +74,7 @@ VM_INV_FILE = 'veos'
 TGEN_MGMT_NETWORK = '10.65.32.0/24'
 
 
-class TestbedVMFacts():
+class TestbedVMFacts:
     """
     Retrieve testbed VMs management information that for a specified toplogy defined in testbed.yaml
 
@@ -53,13 +83,11 @@ class TestbedVMFacts():
     def __init__(self, toponame, base_vm, vm_file, servers_info):
         CLET_SUFFIX = "-clet"
         self.toponame = re.sub(CLET_SUFFIX + "$", "", toponame)
-        self.topofile = TOPO_PATH + 'topo_' + self.toponame + '.yml'
+        self.topofile = os.path.join(TOPO_PATH, f'topo_{self.toponame}.yml')
         self.base_vm = base_vm
         self.vm_file = vm_file
         self.servers_info = servers_info
-        if has_dataloader:
-            self.inv_mgr = InventoryManager(
-                loader=DataLoader(), sources=self.vm_file)
+        self._inventory_cache = None  # lazy‑loaded parsed inventory content
 
     def get_neighbor_eos(self):
         eos = {}
@@ -107,15 +135,33 @@ class TestbedVMFacts():
 
         return dpu
 
+    def _load_inventory(self):
+        if self._inventory_cache is not None:
+            return self._inventory_cache
+        if not os.path.exists(self.vm_file):
+            raise IOError(f"Inventory file not found: {self.vm_file}")
+        with open(self.vm_file, 'r') as f:
+            try:
+                data = yaml.safe_load(f) or {}
+            except yaml.YAMLError as e:
+                raise ValueError(f"Failed to parse inventory yaml {self.vm_file}: {e}")
+        self._inventory_cache = data
+        return data
+
     def gather_veos_vms(self):
-        yaml_data = {}
-        with open(self.vm_file, 'r') as default_f:
-            yaml_data = yaml.safe_load(default_f)
+        """Parse inventory YAML and return a mapping host-> {ansible_host: ip} for groups named vms_*"""
+        yaml_data = self._load_inventory()
         result_dict = {}
+        # inventory may have 'all' root with children pointing to group names
+        # We flatten by directly scanning top-level keys for vms_* groups.
         for group_name, group_content in yaml_data.items():
+            if not isinstance(group_content, dict):
+                continue
             if group_name.startswith('vms_'):
-                for host_name, host_info in group_content.get('hosts', {}).items():
-                    result_dict[host_name] = {'ansible_host': host_info.get('ansible_host', '')}
+                hosts_section = group_content.get('hosts', {}) or {}
+                for host_name, host_info in hosts_section.items():
+                    if isinstance(host_info, dict):
+                        result_dict[host_name] = {'ansible_host': host_info.get('ansible_host', '')}
         return result_dict
 
 
@@ -140,21 +186,14 @@ def main():
             m_args['topo'], m_args['base_vm'], m_args['vm_file'], m_args['servers_info'])
         neighbor_eos = vm_facts.get_neighbor_eos()
         neighbor_eos.update(vm_facts.get_neighbor_dpu())
-        if has_dataloader:
-            hosts = vm_facts.inv_mgr.hosts
-        else:
-            hosts = vm_facts.gather_veos_vms()
+        hosts = vm_facts.gather_veos_vms()
         tgen_mgmt_ips = list(ipaddress.ip_network(TGEN_MGMT_NETWORK.encode().decode()))
         for index, eos in enumerate(neighbor_eos):
             vm_name = neighbor_eos[eos]
             if 'tgen' in topo_type:
                 vm_mgmt_ip[eos] = str(tgen_mgmt_ips[index])
             elif vm_name in hosts:
-                if has_dataloader:
-                    vm_mgmt_ip[eos] = vm_facts.inv_mgr.get_host(
-                        vm_name).get_vars()['ansible_host']
-                else:
-                    vm_mgmt_ip[eos] = hosts[vm_name]['ansible_host']
+                vm_mgmt_ip[eos] = hosts[vm_name]['ansible_host']
             else:
                 err_msg = "Cannot find the vm {} in VM inventory file {}, please make sure you have enough VMs" \
                           "for the topology you are using."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
After ansible >= 2.14, custom modules are executed on the managed node (or in an execution environment container) that only contains the runtime bits Ansible intentionally ships there (mainly ansible.module_utils plus Python stdlib). Controller‑only internals like ansible.inventory.manager and ansible.parsing.dataloader are not present. So importing them on the remote side is fundamentally unsupported now.

#### How did you do it?
This change removed the code of importing ansible API in the testbed_vm_info.py customized module. Then this module can be executed in sonic-mgmt docker using ansible >= 2.14.

#### How did you verify/test it?
Tested on ansible 2.13.13 and 2.19.2

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
