### PR TITLE
Fix test_cpu_memory_usage for Arista-7060CX-32S

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -41,7 +41,8 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
                                      'x86_64-cel_e1031-r0', 'x86_64-arista_7800r3a_36dm2_lc') or is_asan:
         memory_threshold = 90
     if duthost.facts['platform'] in ('x86_64-mlnx_msn3800-r0',
-                                     'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-mlnx_msn3420-r0'):
+                                     'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-mlnx_msn3420-r0',
+                                     'x86_64-arista_7060_cx32s'):
         memory_threshold = 70
     if duthost.facts['platform'] in ('x86_64-8800_rp_o-r0', 'x86_64-8800_rp-r0'):
         memory_threshold = 65


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
A proper memory threshold for this test has not been set for this platform. This change updates platform_tests/test_cpu_memory_usage.py to special case the threshold for Arista-7060CX-32S.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
100% failure rate on platform_tests/test_cpu_memory_usage.py on this platform only

#### How did you do it?
Observed the memory usage when running the test and adjusted the logic on the test to use an appropriate threshold.

#### How did you verify/test it?
The test is now passing with the change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
