### PR TITLE
Allow time for ndppd to startup after arp/ndp proxy changes

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -280,7 +280,7 @@ def ip_and_intf_info(config_facts, intfs_for_test, ptfhost, ptfadapter):
 
 
 @pytest.fixture
-def proxy_arp_enabled(rand_selected_dut, config_facts):
+def proxy_arp_enabled(packets_for_test, rand_selected_dut, config_facts):
     """
     Tries to enable proxy ARP for each VLAN on the ToR
 
@@ -301,6 +301,7 @@ def proxy_arp_enabled(rand_selected_dut, config_facts):
     vlan_ids = [vlans[vlan]['vlanid'] for vlan in list(vlans.keys())]
     old_proxy_arp_vals = {}
     new_proxy_arp_vals = []
+    ip_version, _, _ = packets_for_test
 
     # Enable proxy ARP/NDP for the VLANs on the DUT
     for vid in vlan_ids:
@@ -312,6 +313,10 @@ def proxy_arp_enabled(rand_selected_dut, config_facts):
         logger.info("Enabled proxy ARP for Vlan{}".format(vid))
         new_proxy_arp_res = duthost.shell(proxy_arp_check_cmd.format(vid))
         new_proxy_arp_vals.append(new_proxy_arp_res['stdout'])
+
+    if ip_version == 'v6':
+        # Allow time for ndppd to reset and startup
+        time.sleep(30)
 
     yield all('enabled' in val for val in new_proxy_arp_vals)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Allow time for ndppd to fully start up after ndp proxy changes

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Test is running when ndppd is not fully ready yet. Happens only on topologies with many interfaces (even if those interfaces are down).

#### How did you do it?

#### How did you verify/test it?
`arp/test_arp_extended.py::test_proxy_arp[v6-*]` no longer fails.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Large topologies, i.e.  > 256 total intfs (up and down).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
