### PR TITLE
Skip ipv4 tests for IPv6-only topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -226,6 +226,12 @@ bgp/test_bgp_bbr.py:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20217 and '-v6-' in topo_name"
 
+bgp/test_bgp_bbr.py::test_bbr_status_consistent_after_reload[enabled]:
+  xfail:
+    reason: "Testcase ignored due to issue https://github.com/sonic-net/sonic-buildimage/issues/23642"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/23642 and hwsku in ['Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5600-C256S1','Mellanox-SN5600-C224O8']"
+
 bgp/test_bgp_bbr_default_state.py::test_bbr_disabled_constants_yml_default:
   skip:
     reason: "Skip for IPv6-only topologies"
@@ -237,12 +243,6 @@ bgp/test_bgp_dual_asn.py::test_bgp_dual_asn_v4:
     reason: "Skip for IPv6-only topologies"
     conditions:
       - "'-v6-' in topo_name"
-
-bgp/test_bgp_bbr.py::test_bbr_status_consistent_after_reload[enabled]:
-  xfail:
-    reason: "Testcase ignored due to issue https://github.com/sonic-net/sonic-buildimage/issues/23642"
-    conditions:
-      - "https://github.com/sonic-net/sonic-buildimage/issues/23642 and hwsku in ['Mellanox-SN5640-C512S2', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5600-C256S1','Mellanox-SN5600-C224O8']"
 
 bgp/test_bgp_gr_helper.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To skip ipv4 test on ipv6 only topo testbed

#### How did you do it?
Added skip condition in tests/common/plugins/conditional_mark/tests_mark_conditions.yaml

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
