### PR TITLE
[dualtor] Recover mux config to `auto` in sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -759,6 +759,10 @@ def check_mux_simulator(tbinfo, duthosts, duts_minigraph_facts, get_mux_status, 
                 check_passed, err_msg, duts_mux_status = _check_dut_mux_status(duthosts, duts_minigraph_facts, **kwargs)
                 return check_passed
 
+            # try to recover the mux config back to auto mode
+            if "'show mux config' output differs between two ToRs" in err_msg:
+                duthosts.shell("config mux mode auto all")
+
             logger.warning('Mux state check failed, trying to recover via linkmgrd restart')
             duthosts.shell("docker exec mux supervisorctl restart linkmgrd")
             wait_until(30, 5, 0, _verify_mux_simulator_status_passed)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Some tests might left the DUT with mux config as `active`/`standby`, and sanity check will complain.
Let's recover the DUT mux config back to `auto` in the very first place.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
* set mux config as standby on DUT, and run testcase to validate the sanity check can recover and testcase can pass.
```
bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[str3-7260cx3-acs-2-default] PASSED                                                                                                                                                                                                                                          [100%]

================================================================================================================================================================= warnings summary =================================================================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
