### PR TITLE
[dualtor] Fix `test_stress_arp.py`

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -22,7 +22,8 @@ TEST_INCOMPLETE_NEIGHBOR_CNT = 10
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0')
+    pytest.mark.topology('t0'),
+    pytest.mark.dualtor_active_standby_toggle_to_enum_tor
 ]
 
 LOOP_TIMES_LEVEL_MAP = {
@@ -90,13 +91,15 @@ def genrate_ipv4_ip():
     return list(ptf_intf_ipv4_hosts)
 
 
-def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
+def test_ipv4_arp(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                  garp_enabled, ip_and_intf_info, intfs_for_test,
                   ptfadapter, get_function_completeness_level):
     """
     Send gratuitous ARP (GARP) packet sfrom the PTF to the DUT
 
     The DUT should learn the (previously unseen) ARP info from the packet
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     normalized_level = get_function_completeness_level
     if normalized_level is None:
         normalized_level = "debug"
@@ -187,8 +190,10 @@ def add_nd(ptfadapter, ip_and_intf_info, ptf_intf_index, nd_available):
     logger.info("Sending {} ipv6 neighbor entries".format(nd_available))
 
 
-def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
+def test_ipv6_nd(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                 ptfhost, config_facts, tbinfo, ip_and_intf_info,
                  ptfadapter, get_function_completeness_level, proxy_arp_enabled):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     _, _, ptf_intf_ipv6_addr, _, ptf_intf_index = ip_and_intf_info
     ptf_intf_ipv6_addr = increment_ipv6_addr(ptf_intf_ipv6_addr)
     pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs')
@@ -251,9 +256,10 @@ def send_ipv6_echo_request(ptfadapter, dut_mac, ip_and_intf_info, ptf_intf_index
         testutils.send_packet(ptfadapter, ptf_intf_index, er_pkt)
 
 
-def test_ipv6_nd_incomplete(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
+def test_ipv6_nd_incomplete(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                            ptfhost, config_facts, tbinfo, ip_and_intf_info,
                             ptfadapter, get_function_completeness_level, proxy_arp_enabled):
-
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     _, _, ptf_intf_ipv6_addr, _, ptf_intf_index = ip_and_intf_info
     ptf_intf_ipv6_addr = increment_ipv6_addr(ptf_intf_ipv6_addr)
     pytest_require(proxy_arp_enabled, 'Proxy ARP not enabled for all VLANs')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix `test_stress_arp` (https://github.com/aristanetworks/sonic-qual.msft/issues/652):
1. use `enum_rand_one_per_hwsku_frontend_hostname` on test functions 
`test_stress_arp` uses `duthost` as target DUT, but its fixture `config_facts` uses `enum_rand_one_per_hwsku_frontend_hostname` as the target DUT.
Let's enforce the same DUT selection behavior.

2. add the missing toggle on active-standby dualtor.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
Run on active-standby dualtor.
```
arp/test_stress_arp.py::test_ipv4_arp[str2-7050cx3-32c-f-acs-08-None] PASSED                                     [ 33%]
arp/test_stress_arp.py::test_ipv6_nd[str2-7050cx3-32c-f-acs-08-None] PASSED                                      [ 66%]
arp/test_stress_arp.py::test_ipv6_nd_incomplete[str2-7050cx3-32c-f-acs-08-None] PASSED                           [100%]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
