### PR TITLE
[dualtor] Fix `test_server_reboot`

### DIFF
--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -3,8 +3,7 @@ import pytest
 import random
 
 from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, \
-                                                       simulator_flap_counter, simulator_server_down, \
-                                                       toggle_all_simulator_ports                       # noqa: F401
+                                                       simulator_flap_counter, simulator_server_down    # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status                                    # noqa: F401
 from tests.common.dualtor.dual_tor_common import active_active_ports                                    # noqa: F401
@@ -101,11 +100,11 @@ def test_server_down(cable_type, duthosts, tbinfo, active_active_ports, active_s
 
 
 @pytest.mark.enable_active_active
+@pytest.mark.dualtor_active_standby_toggle_to_upper_tor
 def test_server_reboot(request, cable_type, tbinfo,                                # noqa: F811
                        start_icmp_responder, shutdown_icmp_responder,              # noqa: F811
                        active_standby_ports, active_active_ports,                  # noqa: F811
                        upper_tor_host, lower_tor_host,                             # noqa: F811
-                       toggle_all_simulator_ports,                                 # noqa: F811
                        fanout_upper_tor_port_control,                              # noqa: F811
                        fanout_lower_tor_port_control):                             # noqa: F811
 
@@ -119,8 +118,6 @@ def test_server_reboot(request, cable_type, tbinfo,                             
 
     if cable_type == CableType.active_standby:
         interface_name = random.choice(active_standby_ports)
-        # Set upper_tor as active
-        toggle_all_simulator_ports(UPPER_TOR)
         verify_tor_states(expected_active_host=upper_tor_host,
                           expected_standby_host=lower_tor_host, cable_type=cable_type)
 

--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -24,7 +24,7 @@ from tests.common.dualtor.icmp_responder_control import shutdown_icmp_responder 
 from tests.common.dualtor.icmp_responder_control import start_icmp_responder                            # noqa: F401
 from tests.common.dualtor.control_plane_utils import verify_tor_states
 from tests.common.platform.interface_utils import expect_interface_status
-from tests.common.dualtor.constants import UPPER_TOR
+
 
 pytestmark = [
     pytest.mark.topology('dualtor'),


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The test requires the upper tor to be active, but it uses
`toggle_all_simulator_ports`, which is deprecated.
Let's use the correct toggle fixture to allow better toggle success.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
```
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-standby] PASSED                                   [ 50%]
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-active] SKIPPED (Skip as no mux ports of 'active-
active' cable type)                                                                                              [100%]

=================================================== warnings summary ===================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
