### PR TITLE
Skip test_ro_disk.py due to github issue 20787

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3938,6 +3938,12 @@ tacacs/test_authorization.py::test_authorization_tacacs_and_local:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/11349
 
+tacacs/test_ro_disk.py:
+  skip:
+    reason: "Testcase skip due to Github issue: https://github.com/sonic-net/sonic-mgmt/issues/20787"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/20787
+
 #######################################
 #####           telemetry         #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Skip test_ro_disk.py due to github issue https://github.com/sonic-net/sonic-mgmt/issues/20787
Fixes # 
The case `test_ro_disk` set read-only mode. After case finish, execute reboot to restore to RW mode.

Sometimes after reboot the `/var/log/syslog` is not generated (the current case will not fail), which affects other cases and break loganalyzer.
Github issue https://github.com/sonic-net/sonic-mgmt/issues/20787 to track it. Skip this case to avoid affecting later cases
```
CMD: logrotate --force /etc/logrotate.d/rsyslog
STDERR:
error: stat of /var/log/syslog failed: Bad message
du: cannot access '/var/log/syslog': Bad message
du: cannot access '/var/log/swss/sairedis.rec.2.gz': Bad message
error: error renaming /var/log/swss/sairedis.rec.2.gz to /var/log/swss/sairedis.rec.3.gz: Bad message
logrotate_script: 10: [: -gt: unexpected operator
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
