### PR TITLE
Update function get_lldp_entry_content_with_retry

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -246,12 +246,10 @@ def verify_lldp_table(duthost):
 def verify_each_interface_lldp_content(db_instance, interface, lldpctl_interfaces):
     def get_lldp_entry_content_with_retry():
         nonlocal entry_content
+        entry_content = get_lldp_entry_content(db_instance, interface)
+        return len(entry_content) > 0
 
-        if not entry_content:
-            entry_content = get_lldp_entry_content(db_instance, interface)
-        return entry_content
-
-    entry_content = get_lldp_entry_content(db_instance, interface)
+    entry_content = ''
 
     wait_until(20, 1, 0, get_lldp_entry_content_with_retry)
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update function get_lldp_entry_content_with_retry in tests/lldp/test_lldp_syncd.py
The return value of function get_lldp_entry_content_with_retry is not bool value, it's not proper for wait_until function

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The return value of function get_lldp_entry_content_with_retry is not bool value, it's not proper for wait_until function
#### How did you do it?
Update function get_lldp_entry_content_with_retry in tests/lldp/test_lldp_syncd.py
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
