### PR TITLE
[dualtor] Stablize `test_static_route`

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -120,7 +120,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, expected_po
     upstream_name = UPSTREAM_NEIGHBOR_MAP[topo_type]
     ptf_upstream_intf = random.choice(get_neighbor_ptf_port_list(duthost, upstream_name, tbinfo))
     ptfadapter.dataplane.flush()
-    testutils.send(ptfadapter, ptf_upstream_intf, pkt)
+    testutils.send(ptfadapter, ptf_upstream_intf, pkt, count=10)
     testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=expected_ports)
 
 
@@ -241,6 +241,12 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
         # try to refresh arp entry before traffic testing to improve stability
         for nexthop_addr in nexthop_addrs:
             duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)
+
+        # show neighbor and check neighbor consistency on dualtor
+        duthost.shell("show arp" if not ipv6 else "show ndp")
+        if is_dual_tor:
+            duthost.shell("dualtor_neighbor_check.py")
+
         with RouteFlowCounterTestContext(is_route_flow_counter_supported,
                                          duthost, [prefix], {prefix: {'packets': '1'}}):
             generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
@@ -293,6 +299,8 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
         if config_reload_test:
             duthost.shell('config save -y')
             if is_dual_tor:
+                duthost.shell('config mux mode auto all')
+                unselected_duthost.shell('config mux mode auto all')
                 unselected_duthost.shell('config save -y')
 
         # Clean up arp or ndp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Stablize `test_static_route` on dualtor:
1. check neighbor status after populating the arp entry.
2. send more packets in packet verification.
3. recover mux config to `auto` to allow faster recovery.

Signed-off-by: Longxiang <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
```
route/test_static_route.py::test_static_route[bjw3-can-7260-15] PASSED                                                                                                                                                                                                                                                                       [ 25%]
route/test_static_route.py::test_static_route_ecmp[bjw3-can-7260-15] PASSED                                                                                                                                                                                                                                                                  [ 50%]
route/test_static_route.py::test_static_route_ipv6[bjw3-can-7260-15] PASSED                                                                                                                                                                                                                                                                  [ 75%]
route/test_static_route.py::test_static_route_ecmp_ipv6[bjw3-can-7260-15] SKIPPED (Test case may fail due to a known issue / Test not supported for 201911 images or older. Does not apply to standalone topos.)                                                                                                                             [100%]
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
