### PR TITLE
Post routes to ptf exabgp in batch to avoid failure in silence

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1625,12 +1625,11 @@ def filterout_subnet(aggregate_routes, candidate_routes):
 
 
 def convert_routes_to_str(topo_routes):
-    for vm in topo_routes.keys():
-        for ip_version in topo_routes[vm].keys():
+    for vm in topo_routes:
+        for ip_version in topo_routes[vm]:
             topo_routes[vm][ip_version] = \
                 [(str(r[0]) if r[0] else None, str(r[1]) if r[1] else None, str(r[2]) if r[2] else None)
                  for r in topo_routes[vm][ip_version]]
-    return topo_routes
 
 
 def main():

--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -162,7 +162,8 @@ def read_topo(topo_name, path):
 
 
 def change_routes(action, ptf_ip, port, routes, routes_batch_size=ROUTES_BATCH_SIZE):
-    logging.debug("action = {}, ptf_ip = {}, port = {}, routes_batch_size = {}, routes = {}".format(action, ptf_ip, port, routes_batch_size, routes))
+    logging.debug("action = {}, ptf_ip = {}, port = {}, routes_batch_size = {}, routes = {}"
+                  .format(action, ptf_ip, port, routes_batch_size, routes))
     messages = []
     for prefix, nexthop, aspath in routes:
         if aspath:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
When announce routes more than 1000, previous code will post those routes in single http post, and the exceed routes may be dropped in silence, when show routes on DUT, DUT only print 1000 routes.

To avoid this issue, post routes in batch.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
When announce routes more than 1000, previous code will post those routes in single http post, and the exceed routes may be dropped in silence, when show routes on DUT, DUT only print 1000 routes.

#### How did you do it?
To avoid this issue, post routes in batch.
#### How did you verify/test it?
Run on testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
