### PR TITLE
[DHCPmon] Add a test case for testing the case of big length dhcp packet

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_test.py
@@ -1041,10 +1041,10 @@ class DHCPlargePacketSizeTest(DHCPTest):
         pkt = super().create_dhcp_discover_packet(dst_mac, src_port)
         dhcp_options = [
             ("message-type", "discover"),
-            ("param_req_list", list(range(1, 255)))
+            ("param_req_list", list(range(1, 255))),
+            ("vendor_specific", os.urandom(250)),
+            ("end")
         ]
-        dhcp_options.append(("vendor_specific", os.urandom(250)))
-        dhcp_options.append("end")
         dhcp = scapy.DHCP(options=dhcp_options)
         pkt[scapy.DHCP].options = dhcp.options
         return pkt
@@ -1057,10 +1057,44 @@ class DHCPlargePacketSizeTest(DHCPTest):
             ("server_id", self.server_ip[0]),
             ("lease_time", 86400),
             ("vendor_class_id", "http://0.0.0.0/this_is_a_very_very_long_path/test.bin".encode('utf-8')),
-            ("param_req_list", list(range(1, 255)))
+            ("param_req_list", list(range(1, 255))),
+            ("vendor_specific", os.urandom(250)),
+            ("end")
         ]
-        dhcp_options.append(("vendor_specific", os.urandom(250)))
-        dhcp_options.append("end")
+        dhcp = scapy.DHCP(options=dhcp_options)
+        pkt[scapy.DHCP].options = dhcp.options
+        return pkt
+
+    def create_dhcp_offer_packet(self):
+        pkt = super().create_dhcp_offer_packet()
+        dhcp_options = [
+            ("message-type", "offer"),
+            ("server_id", self.server_ip[0]),
+            ("lease_time", 86400),
+            ("subnet_mask", self.client_subnet),
+            (82, self.option82),
+            ("vendor_class_id", "http://0.0.0.0/this_is_a_very_very_long_path/test.bin".encode('utf-8')),
+            ("param_req_list", list(range(1, 255))),
+            ("vendor_specific", os.urandom(250)),
+            ("end")
+        ]
+        dhcp = scapy.DHCP(options=dhcp_options)
+        pkt[scapy.DHCP].options = dhcp.options
+        return pkt
+
+    def create_dhcp_ack_packet(self):
+        pkt = super().create_dhcp_ack_packet()
+        dhcp_options = [
+            ("message-type", "ack"),
+            ("subnet_mask", self.client_subnet),
+            ("server_id", self.server_ip[0]),
+            ("lease_time", 86400),
+            (82, self.option82),
+            ("vendor_class_id", "http://0.0.0.0/this_is_a_very_very_long_path/test.bin".encode('utf-8')),
+            ("param_req_list", list(range(1, 255))),
+            ("vendor_specific", os.urandom(250)),
+            ("end")
+        ]
         dhcp = scapy.DHCP(options=dhcp_options)
         pkt[scapy.DHCP].options = dhcp.options
         return pkt
@@ -1073,8 +1107,10 @@ class DHCPlargePacketSizeTest(DHCPTest):
 
         self.client_send_discover(
             self.dest_mac_address, self.client_udp_src_port)
+        self.server_send_offer()
         self.client_send_request(
             self.dest_mac_address, self.client_udp_src_port)
+        self.server_send_ack()
 
 
 class DHCPPacketsServerToClientTest(DHCPTest):

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -457,9 +457,11 @@ def test_dhcp_relay_monitor_packet_length_validation(ptfhost, dut_dhcp_relay_dat
                 # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpcom relay counters should all be 0
                 validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost, {}, {})
             expected_downlink_counter = {
-                "RX": {"Malformed": 2}
+                "RX": {"Malformed": 2},
+                "TX": {"Offer": 1, "Ack": 1}
             }
             expected_uplink_counter = {
+                "RX": {"Offer": 1, "Ack": 1}
             }
             validate_dhcpcom_relay_counters(dhcp_relay, duthost,
                                             expected_uplink_counter,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Currently, dhcp relay agent will drop the packets bigger than 618 bytes, but dhcp monitor will still count it. The  PR https://github.com/sonic-net/sonic-dhcpmon/pull/55 is for counting the invalid packets to malformed. This PR is for testing the feature.
#### How did you do it?
PTF send big size of DHCP discover and request packets. Then verify the dhcp monitor malformed counters.
#### How did you verify/test it?
Run the test case
 ./run_tests.sh -i ../ansible/bjw2,../ansible/veos -n testbed-bjw2-can-720dt-3  -u -m individual -e --disable_loganalyzer  -e --skip_sanity  -c dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_packet_length_validation
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
