### PR TITLE
Add support for marvell-teralynx Sonic device as fanout

### DIFF
--- a/ansible/roles/fanout/tasks/sonic/copp_cfg_mrvl_teralynx.j2
+++ b/ansible/roles/fanout/tasks/sonic/copp_cfg_mrvl_teralynx.j2
@@ -1,0 +1,86 @@
+{
+    "COPP_GROUP": {
+            "default": {
+                    "trap_action":"forward",
+                    "queue": "0"
+            },
+            "queue4_group1": {
+                    "trap_action":"forward",
+                    "trap_priority":"4",
+                    "queue": "4"
+            },
+            "queue4_group2": {
+                    "trap_action":"forward",
+                    "trap_priority":"4"
+            },
+            "queue4_group3": {
+                    "trap_action":"forward",
+                    "trap_priority":"4",
+                    "queue": "4"
+            },
+            "queue1_group1": {
+                    "trap_action":"forward",
+                    "trap_priority":"1",
+                    "queue": "1"
+            },
+            "queue1_group2": {
+                    "trap_action":"forward",
+                    "trap_priority":"1",
+                    "queue": "1"
+            },
+            "queue2_group1": {
+                    "genetlink_mcgrp_name": "packets",
+                    "genetlink_name": "psample",
+                    "queue": "2",
+                    "trap_action": "forward",
+                    "trap_priority": "1"
+
+            }
+    },
+    "COPP_TRAP": {
+            "bgp": {
+                    "trap_ids": "bgp,bgpv6",
+                    "trap_group": "queue4_group1"
+            },
+            "lacp": {
+                    "trap_ids": "lacp",
+                    "trap_group": "queue4_group1",
+                    "always_enabled": "true"
+            },
+            "arp": {
+                    "trap_ids": "arp_req,arp_resp,neigh_discovery",
+                    "trap_group": "queue4_group2",
+                    "always_enabled": "true"
+            },
+            "lldp": {
+                    "trap_ids": "lldp",
+                    "trap_group": "queue4_group3"
+            },
+            "dhcp_relay": {
+                    "trap_ids": "dhcp,dhcpv6",
+                    "trap_group": "queue4_group3"
+            },
+            "udld": {
+                    "trap_ids": "udld",
+                    "trap_group": "queue4_group3",
+                    "always_enabled": "true"
+            },
+            "ip2me": {
+                    "trap_ids": "ip2me",
+                    "trap_group": "queue1_group1",
+                    "always_enabled": "true"
+            },
+            "macsec": {
+                    "trap_ids": "eapol",
+                    "trap_group": "queue4_group1"
+            },
+            "nat": {
+                    "trap_ids": "src_nat_miss,dest_nat_miss",
+                    "trap_group": "queue1_group2"
+            },
+            "sflow": {
+                    "trap_group": "queue2_group1",
+                    "trap_ids": "sample_packet"
+            }
+    }
+}

--- a/ansible/roles/fanout/tasks/sonic/fanout_sonic_202505.yml
+++ b/ansible/roles/fanout/tasks/sonic/fanout_sonic_202505.yml
@@ -36,6 +36,21 @@
   become: yes
   when: "'mellanox' in fanout_sonic_version.asic_type"
 
+- name: Ensure TPID enabled in SAI
+  lineinfile:
+    path: /usr/share/sonic/device/{{ fanout_platform }}/{{ fanout_hwsku }}/ivm.sai.config.yaml
+    line: 'IVM_SAI_PARAM_A0057: "TRUE"'
+    state: present
+  become: yes
+  when: "'marvell-teralynx' in fanout_sonic_version.asic_type"
+
+- name: Override topo.conf file with def_lossy content
+  copy:
+    content: "def_lossy\n"
+    dest: "/usr/share/sonic/device/{{ fanout_platform }}/topo.conf"
+  become: yes
+  when: "'marvell-teralynx' in fanout_sonic_version.asic_type"
+
 - name: Disable software control module function
   block:
     - name: Disable software control module function in SAI
@@ -82,7 +97,7 @@
     content: "{}"
     dest: "/usr/share/sonic/templates/copp_cfg.j2"
   become: yes
-  when: "'mellanox' not in fanout_sonic_version.asic_type"
+  when: "fanout_sonic_version.asic_type not in ['marvell-teralynx', 'mellanox']"
 
 - name: Overwrite copp rules for Mellanox FanoutLeaf
   copy:
@@ -90,6 +105,13 @@
     dest: "/usr/share/sonic/templates/copp_cfg.j2"
   become: yes
   when: "'mellanox' in fanout_sonic_version.asic_type"
+
+- name: Overwrite copp rules for Marvell-Teralynx FanoutLeaf
+  copy:
+    src: "copp_cfg_mrvl_teralynx.j2"
+    dest: "/usr/share/sonic/templates/copp_cfg.j2"
+  become: yes
+  when: "'marvell-teralynx' in fanout_sonic_version.asic_type"
 
 - name: Disable feature teamd and remove teamd container (avoid swss crash after config reload)
   block:
@@ -123,6 +145,12 @@
   pause:
     seconds: 180
 
+- name: Save configurations back to config db
+  shell: config save -y
+  become: true
+  when: "'marvell-teralynx' in fanout_sonic_version.asic_type"
+
+
 - name: Shutdown arp_update process in swss (avoid fanout broadcasting it's MAC address)
   shell: docker exec -i swss supervisorctl stop arp_update
   become: yes
@@ -153,4 +181,24 @@
     shell: "sysctl -p"
     become: yes
 
-  when: "'mellanox' in fanout_sonic_version.asic_type"
+  when: "fanout_sonic_version.asic_type in ['marvell-teralynx', 'mellanox']"
+
+- name: Stop lldp container
+  block:
+    - name: Check if lldp container exists
+      shell: "docker ps -a -q -f name=lldp"
+      register: lldp_container
+
+    - name: Stop lldp and remove container
+      block:
+        - name: ensure lldp container is stopped
+          docker_container:
+            name: lldp
+            state: stopped
+          become: true
+        - name: remove lldp container
+          docker_container:
+            name: lldp
+            state: absent
+          become: true
+      when: lldp_container.stdout != "" and "marvell-teralynx" in fanout_sonic_version.asic_type

--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -3,7 +3,10 @@
         "localhost": {
             "default_pfcwd_status": "disable",
             "hwsku": "{{ fanout_hwsku }}",
-            "hostname": "{{ inventory_hostname }}"
+            "hostname": "{{ inventory_hostname }}",
+{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] %}
+            "type": "LeafRouter"
+{% endif %}
         }
     },
 
@@ -22,7 +25,19 @@
     {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
             "fec" : "rs",
     {% endif %}
-    {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] or 'mellanox' in fanout_sonic_version["asic_type"] %}
+    {% if port_name in device_conn[inventory_hostname] %}
+        {% if 'autoneg' in device_conn[inventory_hostname][port_name] %}
+                {% if 'on' in device_conn[inventory_hostname][port_name]['autoneg'] %}
+                    "autoneg": "on",
+                    {% if msft_an_enabled is defined %}
+                        "fec": "none",
+                    {% endif %}
+                {% elif 'off' in device_conn[inventory_hostname][port_name]['autoneg'] %}
+                    "autoneg": "off",
+                {% endif %}
+        {% endif %}
+    {% endif %}
+    {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] or 'marvell-teralynx' in fanout_sonic_version["asic_type"] or 'mellanox' in fanout_sonic_version["asic_type"] %}
         {% if port_name in device_port_vlans[inventory_hostname] and device_port_vlans[inventory_hostname][port_name]["mode"].lower() == "access" %}
             "tpid": "0x9100",
         {% endif %}
@@ -195,7 +210,7 @@
     "Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4",
     "Arista-7050CX3-32S-S128", "Arista-7050CX3-32S-C6S104", "Arista-7050CX3-32S-C28S16"
 ) %}
-{% if not (fanout_hwsku in no_buffer_hwsku or "Arista-7060X6" in fanout_hwsku) %}
+{% if 'marvell-teralynx' not in fanout_sonic_version["asic_type"] and not (fanout_hwsku in no_buffer_hwsku or "Arista-7060X6" in fanout_hwsku) %}
     "BUFFER_QUEUE": {
     {% for port_name in fanout_port_config %}
          "{{ port_name }}|0-7": {
@@ -211,7 +226,7 @@
     {% endfor %}
     },
 {% endif %}
-{% if fanout_hwsku in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") %}
+{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] or fanout_hwsku in ("Nokia-7215", "Nokia-7215-A1", "Arista-720DT-G48S4") %}
 
     "FLEX_COUNTER_TABLE": {
         "ACL": {
@@ -367,6 +382,16 @@
             "auto_restart": "disabled",
             "high_mem_alert": "disabled"
         },
+    {% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] %}
+            "lldp": {
+            "state": "enabled",
+            "has_timer": false,
+            "has_global_scope": true,
+            "has_per_asic_scope": true,
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        },
+    {% else %}
         "lldp": {
             "state": "disabled",
             "has_timer": false,
@@ -375,6 +400,7 @@
             "auto_restart": "disabled",
             "high_mem_alert": "disabled"
         },
+    {% endif %}
         "pmon": {
             "state": "enabled",
             "has_timer": false,


### PR DESCRIPTION
Add support for marvell-teralynx Sonic device as fanout

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
To enable marvell-teralynx Sonic device as fanout.

#### How did you do it?
Added required config changes to deploy marvell-teralynx sonic device as fanout

#### How did you verify/test it?
Ran fanout ansible-playbook and verified T0 and T1 topology comes up.
```bash
cd ansible
ansible-playbook -i lab fanout.yml --vault-password-file password.txt -vvv
```

#### Any platform specific information?
Applicable for marvell-teralynx sonic device only

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
