### PR TITLE
[dhcp_relay] Remove skip dhcp_relay related tests on vs asic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -719,19 +719,6 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
     conditions:
       - "release in ['201811', '201911', '202012']"
 
-dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default:
-  skip:
-    reason: "Skip test_dhcp_relay_monitor_checksum_validation for bypassing the build image failure"
-    conditions:
-      - "asic_type in ['vs']"
-
-
-dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
-  skip:
-    reason: "Skip test_dhcp_relay_monitor_checksum_validation for bypassing the build image failure"
-    conditions:
-      - "asic_type in ['vs']"
-
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby:
   skip:
     reason: "The test case only tests DHCP relay on the dualtor standby dut"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
dhcp_relay related tests were skip in vs by this PR https://github.com/sonic-net/sonic-mgmt/pull/20655
It was to unblock submodule update PR: https://github.com/sonic-net/sonic-buildimage/pull/24046. Now the submodule update pr has been merged, hence remove the skip condition

#### How did you do it?
Remove skip for dhcp_relay test on vs

#### How did you verify/test it?
PR check

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
