### PR TITLE
Remove test_vxlan_bfd_tsa from t1-lag-vpp test list

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -710,7 +710,6 @@ t1-lag-vpp:
   - route/test_route_flap.py
   - route/test_route_perf.py
   - route/test_route_bgp_ecmp.py
-  - vxlan/test_vxlan_bfd_tsa.py
   - vxlan/test_vxlan_ecmp.py
   - vxlan/test_vxlan_decap.py
   - vxlan/test_vnet_decap.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
test_vxlan_bfd_tsa is not supported on sonic-vpp platform yet. 

#### How did you do it?
remove the test suite from .azure-pipelines/pr_test_scripts.yaml
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
