### PR TITLE
Restrict TH5 pfcwd fixes to strictly TH5 HwSKUs

### DIFF
--- a/tests/pfcwd/test_pfcwd_function.py
+++ b/tests/pfcwd/test_pfcwd_function.py
@@ -744,7 +744,8 @@ class TestPfcwdFunc(SetupPfcwdFunc):
         test_ports_info = {self.pfc_wd['rx_port'][0]: self.pfc_wd}
         queues = [self.storm_hndle.pfc_queue_idx]
 
-        extra_pfc_storm_timeout_needed = dut.facts['asic_type'] in ["mellanox", "cisco-8000", "broadcom"]
+        extra_pfc_storm_timeout_needed = dut.facts['asic_type'] in ["mellanox", "cisco-8000"] or \
+            "7060X6" in dut.facts['hwsku'].upper()
         if extra_pfc_storm_timeout_needed:
             PFC_STORM_TIMEOUT = 30
             pfcwd_stats_before_test = check_pfc_storm_state(dut, port, self.storm_hndle.pfc_queue_idx)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Restrict the TH5 pfcwd test fixes to TH5 HwSKUs only strictly.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix a regression on Arista non-TH5 HwSKUs caused by a fix for Arista TH5 HwSKUs.

#### How did you do it?
Use a stricter condition for toggling extra timeout for pfc storm - check the HwSKU instead of checking Broadcom platform in general.

#### How did you verify/test it?
`pfcwd/test_pfcwd_function.py` no longer fails on non-TH5 Arista HwSKUs after this commit is applied to 202505: https://github.com/sonic-net/sonic-mgmt/pull/20781

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
