### PR TITLE
Align test_load_minigraph_with_traffic_shift_away for smartswitch

### DIFF
--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -305,8 +305,11 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
         orig_v4_routes = parse_routes_on_neighbors(duthost, nbrhosts, 4)
         orig_v6_routes = parse_routes_on_neighbors(duthost, nbrhosts, 6)
 
+        is_override_config = True if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get(
+            "is_smartswitch") else False
+
         config_reload(duthost, config_source='minigraph', safe_reload=True, check_intf_up_ports=True,
-                      traffic_shift_away=True)
+                      traffic_shift_away=True, override_config=is_override_config)
 
         # Verify DUT is in maintenance state.
         pytest_assert(TS_MAINTENANCE == get_traffic_shift_state(duthost),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Align test_load_minigraph_with_traffic_shift_away for smartswitch.
When loading minigraph with the smartswitch, it is essential to load the gold_config to prevent the loss of configuration related to the DPU. The gold_config will only be loaded when the override_config is set to True.

Summary:
Fixes # (issue)
 https://github.com/sonic-net/sonic-mgmt/issues/20703

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Align test_load_minigraph_with_traffic_shift_away for smartswitch

#### How did you do it?
override_config is set to True.

#### How did you verify/test it?
Run test_load_minigraph_with_traffic_shift_away on smartswitch

#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
