### PR TITLE
[VRF]: Fix intermittent test errors because of DHCPv6 server configuration

### DIFF
--- a/tests/vrf/vrf_config_db.j2
+++ b/tests/vrf/vrf_config_db.j2
@@ -119,6 +119,7 @@
 
 {%         endfor %}
     },
+{%     elif k == 'DHCP_RELAY' %}
 {%     else %}
     "{{ k }}": {{ cfg_t0[k] | to_nice_json | indent}},
 {%     endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The dhcp6relay daemon is not VRF-aware. When Vlan1000 in T0 is moved to Vrf1, the dhcp6relay fails to start. This intermittently causes log analyzer to capture teardown errors such as:

```bash
ERR dhcp_relay#supervisor-proc-exit-listener: Process 'dhcp6relay' is not running in namespace 'host' (2.0 minutes).
```

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

```bash
# docker exec -it dhcp_relay supervisorctl status
dependent-startup                EXITED    Sep 09 02:02 PM
dhcp-relay:dhcp6relay            FATAL     Exited too quickly (process log may have details)
dhcp-relay:dhcprelayd            RUNNING   pid 74, uptime 0:19:47
dhcpmon:dhcpmon-Vlan1000         RUNNING   pid 81, uptime 0:19:45
isc-dhcpv4-relay-Vlan1000        RUNNING   pid 75, uptime 0:19:47
rsyslogd                         RUNNING   pid 20, uptime 0:20:09
start                            EXITED    Sep 09 02:02 PM
supervisor-proc-exit-listener    RUNNING   pid 17, uptime 0:20:10
```

When DHCP_RELAY is not configured:

```bash
# docker exec -it dhcp_relay supervisorctl status
dependent-startup                EXITED    Sep 09 01:22 PM
dhcp-relay:dhcprelayd            RUNNING   pid 86, uptime 0:06:57
dhcpmon:dhcpmon-Vlan1000         RUNNING   pid 88, uptime 0:06:55
isc-dhcpv4-relay-Vlan1000        RUNNING   pid 87, uptime 0:06:57
rsyslogd                         RUNNING   pid 20, uptime 0:07:25
start                            EXITED    Sep 09 01:22 PM
supervisor-proc-exit-listener    RUNNING   pid 17, uptime 0:07:26
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
Currently, the DHCPv6 server configuration (["VLAN"]["Vlan1000"]["dhcpv6_servers"]) is already excluded by vrf_config_db.j2.

This change excludes DHCP_RELAY table configuration which is consumed by dhcp6relay, preventing dhcp6relay from staring during test run.
#### What is the motivation for this PR?
To fix intermittent VRF tests errors.

#### How did you do it?

#### How did you verify/test it?
By running below test on T0 and T1:

```bash
./run_tests.sh -n ptf2-m -d str-marvell-01 -c "vrf/test_vrf.py" -f ../ansible/testbed.yaml -i ../ansible/lab,../ansible/veos -t t0,any -u
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
