### PR TITLE
Fix lldp test on all platform (#20782)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2153,11 +2153,6 @@ lldp/test_lldp.py::test_lldp_neighbor:
     conditions:
       - "'standalone' in topo_name"
 
-lldp/test_lldp.py::test_lldp_neighbor_post_orchagent_reboot:
-  xfail:
-    reason: "Xfail the test due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/19658"
-    conditions:
-    - "https://github.com/sonic-net/sonic-mgmt/issues/19658 and asic_type in ['mellanox', 'nvidia']"
 
 #######################################
 #####           macsec            #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR is a cherry-pick PR of PR20782, where conflict is manually resolved.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/19658
This pull request updates the LLDP test suite to improve reliability and clarity when testing LLDP neighbor functionality after restarting the `swss` container, instead of just the `orchagent` process. The changes also improve log analysis and clean up code to remove unnecessary complexity.

**Test behavior and reliability improvements:**

* The test previously named `test_lldp_neighbor_post_orchagent_reboot` has been renamed to `test_lldp_neighbor_post_swss_reboot` and now restarts the entire `swss` container, not just the `orchagent` process. This makes the test more robust and consistent with how services are typically managed. [[1]](diffhunk://#diff-9dc8b2b410c2fb399f9fd25115bb8b5c13e2d1f1a393e9fa0942957171e0530fL26-L31) [[2]](diffhunk://#diff-9dc8b2b410c2fb399f9fd25115bb8b5c13e2d1f1a393e9fa0942957171e0530fL261-R251)
* The test now uses a new fixture, `restart_swss_container`, which simplifies and standardizes the restart logic by always restarting the `swss` container via `systemctl`, removing the previous logic that handled `orchagent` restarts differently for different switch types. [[1]](diffhunk://#diff-9dc8b2b410c2fb399f9fd25115bb8b5c13e2d1f1a393e9fa0942957171e0530fL26-L31) [[2]](diffhunk://#diff-9dc8b2b410c2fb399f9fd25115bb8b5c13e2d1f1a393e9fa0942957171e0530fL40-R39) [[3]](diffhunk://#diff-9dc8b2b410c2fb399f9fd25115bb8b5c13e2d1f1a393e9fa0942957171e0530fL60-L78)

**Log analysis improvements:**

* The test now integrates with `loganalyzer` to ignore expected error messages during `swss` restarts and to explicitly check for LLDP packet send errors, improving the accuracy of test failure detection.

**Test mark and maintenance:**

* The `xfail` marker for the test (previously present in `tests_mark_conditions.yaml` due to a known issue) has been removed, indicating that the test is now expected to pass under the affected conditions.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To address the test issue we found
#### How did you do it?
Change the test design
#### How did you verify/test it?
testplan 68d11830ffe8a57db4ba4158
lldp/test_lldp.py executed 10 consecutive times to pass on affected device (mellanox)
lldp/test_lldp.py::test_lldp PASSED                [ 33%]
lldp/test_lldp.py::test_lldp_neighbor PASSED       [ 66%]
lldp/test_lldp.py::test_lldp_neighbor_post_orchagent_reboot PASSED [100%]
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
