### PR TITLE
[BGP Scale] Fix NHG Member Scale Announce Routes Convergence Timeout

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -515,7 +515,6 @@ def test_nexthop_group_member_scale(
     tbinfo,
     bgp_peers_info,
     setup_routes_before_test,
-    topo_bgp_routes,
     request
 ):
     '''
@@ -617,17 +616,6 @@ def test_nexthop_group_member_scale(
         duthost.facts['router_mac'],
         pdp.get_mac(pdp.port_to_device(injection_port), injection_port)
     )
-    for hostname, routes in peers_routes_to_change.items():
-        for route in routes:
-            prefix = route[0].upper()
-            found = False
-            for topo_route in topo_bgp_routes[hostname]['ipv6']:
-                if topo_route[0] == prefix:
-                    route[2] = topo_route[2]
-                    found = True
-                    break
-            if not found:
-                logger.warning('Fail to update AS path of route %s, because of prefix was not found in topo', route[0])
     terminated = Event()
     traffic_thread = Thread(
         target=send_packets, args=(terminated, pdp, pdp.port_to_device(injection_port), injection_port, pkts)
@@ -637,8 +625,7 @@ def test_nexthop_group_member_scale(
     traffic_thread.start()
     for ptfhost in ptfhosts:
         ptf_ip = ptfhost.mgmt_ip
-        change_routes_on_peers(localhost, ptf_ip, topo_name, peers_routes_to_change, ACTION_ANNOUNCE,
-                               servers_dut_interfaces.get(ptf_ip, ''))
+        announce_routes(localhost, tbinfo, ptf_ip, servers_dut_interfaces.get(ptf_ip, ''))
     compressed_startup_routes = compress_expected_routes(startup_routes)
     result = check_bgp_routes_converged(
         duthost,


### PR DESCRIPTION
### Description of PR
Revert the topo_bgp_routes change from PR20238 to enable the test_nexthop_group_member_scale test to progress past the announce routes portion of the test.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
To remedy the annouce routes convergence check, which otherwise fails due to a timeout waiting for routes to converge.

#### How did you do it?
Reverted the topo_bgp_routes portion of PR20238.

#### How did you verify/test it?
Ran the test against the t0-isolated-d2u510s2 topology, confirming that the test case now passes this step.

#### Any platform specific information?
Tested on Arista-7060X6-64PE-B-C512S2.
