### PR TITLE
Apply loganalyzer on all duts for T2 support

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -238,14 +238,16 @@ def test_lldp_neighbor_post_swss_reboot(duthosts, enum_rand_one_per_hwsku_fronte
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
     if loganalyzer:
-        # Ignore all ERR messages, as it is expected many error messages will be generated during swss restart
-        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].ignore_regex.extend([
-            ".*ERR.*",  # Ignore all ERROR messages
-        ])
-        # Test should fail if LLDP 'unable to send packet on' errors are found
-        loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].match_regex.extend([
-            ".*WARNING lldp#lldpd.*unable to send packet on real device for.*No such device or address"
-        ])
+        # Apply ignore pattern to ALL devices in the testbed
+        for dut in duthosts:
+            # Ignore all ERR messages, as it is expected many error messages will be generated during swss restart
+            loganalyzer[dut.hostname].ignore_regex.extend([
+                ".*ERR.*",  # Ignore all ERROR messages
+            ])
+            # Test should fail if LLDP 'unable to send packet on' errors are found
+            loganalyzer[dut.hostname].match_regex.extend([
+                ".*WARNING lldp#lldpd.*unable to send packet on real device for.*No such device or address"
+            ])
     check_lldp_neighbor(duthost, localhost, eos, sonic, collect_techsupport_all_duts,
                         enum_frontend_asic_index, tbinfo, request)
     duthost.shell("sudo config feature autorestart swss enabled")

--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -236,14 +236,17 @@ def test_lldp_neighbor_post_swss_reboot(duthosts, enum_rand_one_per_hwsku_fronte
                                         sonic, collect_techsupport_all_duts, enum_frontend_asic_index,
                                         tbinfo, request, restart_swss_container, loganalyzer):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    ignoreRegex = [
+        ".*ERR.*",
+        "crash",
+        "kernel.*",
+    ]
 
     if loganalyzer:
         # Apply ignore pattern to ALL devices in the testbed
         for dut in duthosts:
             # Ignore all ERR messages, as it is expected many error messages will be generated during swss restart
-            loganalyzer[dut.hostname].ignore_regex.extend([
-                ".*ERR.*",  # Ignore all ERROR messages
-            ])
+            loganalyzer[dut.hostname].ignore_regex.extend(ignoreRegex)
             # Test should fail if LLDP 'unable to send packet on' errors are found
             loganalyzer[dut.hostname].match_regex.extend([
                 ".*WARNING lldp#lldpd.*unable to send packet on real device for.*No such device or address"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to address new issue found on PR https://github.com/sonic-net/sonic-mgmt/pull/20838
Issue caused by loganalyzer not applied for all DUTs for T2, failing the test as we observe ERR logs (as expected during swss restart).

This PR is to ignore expected ERR messages on other DUTs.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
T2 test plan 68d53b2af0e80c65e670d63f
============= 2 passed, 1 skipped, 4 warnings in 994.55s (0:16:34) =============

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
