### PR TITLE
Enhance test_pktgen for T2 chassis

### DIFF
--- a/tests/test_pktgen.py
+++ b/tests/test_pktgen.py
@@ -86,6 +86,11 @@ def test_pktgen(duthosts, enum_dut_hostname, enum_frontend_asic_index, tbinfo, l
 
     # Select a random port to run traffic
     port_list = get_port_list(duthost, tbinfo)
+
+    # Skip test if no data ports are available (e.g., on supervisor cards)
+    if not port_list:
+        pytest.skip("No data ports available for packet generation test")
+
     port = random.choice(port_list)
     asichost = duthost.get_port_asic_instance(port)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This test would fail in T2 devices, like Cisco 8800, as supervisor node will have empty `port_list`. 
To avoid failure in T2 supervisor and also to skip invalid scenario, add pytest.skip logic with port_list empty check
Summary:
Fixes # (issue)
This pull request adds a safeguard to the packet generation test in `tests/test_pktgen.py`. The change ensures that the test is skipped if no data ports are available, preventing unnecessary failures on devices such as supervisor cards.

Test robustness improvement:

* Added a check to skip the packet generation test when `get_port_list` returns an empty list, avoiding test failures on hardware without data ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
We noticed packets discard issue with leaba error recently, and found this test coverage was not tested properly.
We need to add this change to 202405 and onwards to make sure we cover this test gap.
#### How did you do it?
tested locally with Cisco 8800 device
#### How did you verify/test it?
testplan id: 68da3e0f94c3b56043447aad
=========================== short test summary info ============================
SKIPPED [1] test_pktgen.py:92: No data ports available for packet generation test
============= 9 passed, 1 skipped, 4 warnings in 981.04s (0:16:21) =============
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
