### PR TITLE
sonic-mgmt test changes needed for FS voq

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -44,16 +44,18 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts, testname=None):
     dut_inband_intfs = {}
     dut_port_channels = {}
     switch_type = ''
+    is_chassis = False
     for duthost in duthosts.frontend_nodes:
         cfg_facts = duts_cfg_facts[duthost.hostname]
         for asic_cfg_facts in cfg_facts:
             if duthost.facts['switch_type'] == "voq":
+                is_chassis = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_chassis")
                 switch_type = "voq"
                 if 'VOQ_INBAND_INTERFACE' in asic_cfg_facts[1]:
                     dut_inband_intfs.setdefault(duthost.hostname, []).extend(asic_cfg_facts[1]['VOQ_INBAND_INTERFACE'])
             dut_port_channels.setdefault(duthost.hostname, {}).update(asic_cfg_facts[1].get('PORTCHANNEL_MEMBER', {}))
     sys_neigh = {}
-    if switch_type == "voq":
+    if switch_type == "voq" and is_chassis:
         if len(duthosts) == 1:
             voq_db = VoqDbCli(duthosts.frontend_nodes[0])
         else:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_voq.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_voq.yaml
@@ -1,0 +1,8 @@
+#######################################
+#####test_po_voq.py #####
+#######################################
+pc/test_po_voq.py:
+  skip:
+    reason: "Skipped as the test applies to chassis only"
+    conditions:
+      - "is_chassis==False"


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
- sonic-mgmt tests need to be improved for FS voq

#### How did you do it?
- access to Chassis DB is done only if the voq is a chassis

#### How did you verify/test it?
- ran the test on FS voq

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

