### PR TITLE
Add show command to gnmi path conversion library

### DIFF
--- a/tests/telemetry/show_cli_to_gnmi_path.py
+++ b/tests/telemetry/show_cli_to_gnmi_path.py
@@ -29,7 +29,6 @@ class ShowCliToGnmiPathConverter:
     def __init__(self, tokens):
         self.tokens = tokens
 
-
     def parseLongOption(self, token: str):
         # --flag         -> ('flag', 'True')
         # --key=value    -> ('key',  'value')
@@ -49,7 +48,6 @@ class ShowCliToGnmiPathConverter:
             return name, escape_gnmi(value)
 
         return body, "True"
-
 
     def convert(self) -> str:
         tokens = self.tokens

--- a/tests/telemetry/show_cli_to_gnmi_path.py
+++ b/tests/telemetry/show_cli_to_gnmi_path.py
@@ -11,19 +11,24 @@ SHORT_OPTION_ERROR = "Short options are not supported"
 INVALID_OPTION_TOKEN_ERROR = "Invalid option token: --"
 INVALID_LONG_OPTION_ERROR = "Invalid long option '--'"
 
+
 class OptionException(Exception):
     pass
 
+
 def has_special_char(text: str) -> bool:
     return "=" in text or "]" in text or "[" in text
+
 
 def escape_gnmi(text: str) -> str:
     # Escape only '/' → '\/'
     return text.replace("/", r"\/")
 
+
 class ShowCliToGnmiPathConverter:
     def __init__(self, tokens):
         self.tokens = tokens
+
 
     def parseLongOption(self, token: str):
         # --flag         -> ('flag', 'True')
@@ -44,6 +49,7 @@ class ShowCliToGnmiPathConverter:
             return name, escape_gnmi(value)
 
         return body, "True"
+
 
     def convert(self) -> str:
         tokens = self.tokens
@@ -76,6 +82,7 @@ class ShowCliToGnmiPathConverter:
         if not out:
             raise OptionException(NO_PATH_ERROR)
         return "".join(out)
+
 
 def main():
     parser = argparse.ArgumentParser(add_help=True)
@@ -111,6 +118,7 @@ def main():
         sys.exit(2)
 
     sys.exit(1 if had_error else 0)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/telemetry/show_cli_to_gnmi_path.py
+++ b/tests/telemetry/show_cli_to_gnmi_path.py
@@ -57,14 +57,14 @@ class ShowCliToGnmiPathConverter:
             raise OptionException(INVALID_COMMAND_ERROR)
 
         tokens = tokens[1:]  # drop 'show'
-        out = []
+        out = ["SHOW"]
 
         for tok in tokens:
             if tok.startswith("-") and not tok.startswith("--"):
                 raise OptionException(f"{SHORT_OPTION_ERROR}: '{tok}'")
 
             if tok.startswith("--"):
-                if not out:
+                if len(out) == 1:
                     raise ValueError("Option before first path segment")
                 key, val = self.parseLongOption(tok)
                 out.append(f"[{key}={val}]")

--- a/tests/telemetry/show_cli_to_gnmi_path.py
+++ b/tests/telemetry/show_cli_to_gnmi_path.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import shlex
+import sys
+import argparse
+
+NO_COMMAND_ERROR = "No command provided for conversion"
+EMPTY_COMMAND_ERROR = "Empty command"
+INVALID_COMMAND_ERROR = "Command must start with 'show'"
+NO_PATH_ERROR = "No path segments after 'show'"
+SHORT_OPTION_ERROR = "Short options are not supported"
+INVALID_OPTION_TOKEN_ERROR = "Invalid option token: --"
+INVALID_LONG_OPTION_ERROR = "Invalid long option '--'"
+
+class OptionException(Exception):
+    pass
+
+def has_special_char(text: str) -> bool:
+    return "=" in text or "]" in text or "[" in text
+
+def escape_gnmi(text: str) -> str:
+    # Escape only '/' → '\/'
+    return text.replace("/", r"\/")
+
+class ShowCliToGnmiPathConverter:
+    def __init__(self, tokens):
+        self.tokens = tokens
+
+    def parseLongOption(self, token: str):
+        # --flag         -> ('flag', 'True')
+        # --key=value    -> ('key',  'value')
+        if token == "--":
+            raise OptionException(INVALID_OPTION_TOKEN_ERROR)
+
+        body = token[2:]
+        if not body:
+            raise OptionException(INVALID_LONG_OPTION_ERROR)
+
+        if "=" in body:
+            name, value = body.split("=", 1)
+            if not name:
+                raise OptionException("Invalid long option: missing name before '='")
+            if has_special_char(name) or has_special_char(value):
+                raise OptionException("Invalid long option: key/value cannot contain =,[,]")
+            return name, escape_gnmi(value)
+
+        return body, "True"
+
+    def convert(self) -> str:
+        tokens = self.tokens
+        if not tokens:
+            raise OptionException(EMPTY_COMMAND_ERROR)
+        if tokens[0].lower() != "show":
+            raise OptionException(INVALID_COMMAND_ERROR)
+
+        tokens = tokens[1:]  # drop 'show'
+        out = []
+
+        for tok in tokens:
+            if tok.startswith("-") and not tok.startswith("--"):
+                raise OptionException(f"{SHORT_OPTION_ERROR}: '{tok}'")
+
+            if tok.startswith("--"):
+                if not out:
+                    raise ValueError("Option before first path segment")
+                key, val = self.parseLongOption(tok)
+                out.append(f"[{key}={val}]")
+                continue
+
+            if has_special_char(tok):
+                raise ValueError("Invalid characters inside of non option")
+
+            if out:
+                out.append("/")
+            out.append(escape_gnmi(tok))
+
+        if not out:
+            raise OptionException(NO_PATH_ERROR)
+        return "".join(out)
+
+def main():
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument(
+        "-f", "--file", required=True,
+        help="Path to a file containing one 'show ...' command per line"
+    )
+    args = parser.parse_args()
+
+    had_error = False
+    try:
+        with open(args.file, "r", encoding="utf-8") as showfile:
+            for lineno, raw in enumerate(showfile, 1):
+                line = raw.rstrip("\n")
+                if not line.strip():
+                    continue
+                try:
+                    # shlex will unescape '\' by default
+                    tokens = shlex.split(line)
+                    result = ShowCliToGnmiPathConverter(tokens).convert()
+                    print(result)
+                except OptionException as e:
+                    print(f"{args.file}:{lineno}: {e}", file=sys.stderr)
+                    had_error = True
+                except ValueError as e:
+                    print(f"{args.file}:{lineno}: failed to parse command: {e}", file=sys.stderr)
+                    had_error = True
+    except FileNotFoundError:
+        print(f"File not found: {args.file}", file=sys.stderr)
+        sys.exit(2)
+    except OSError as e:
+        print(f"Failed to read file '{args.file}': {e}", file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(1 if had_error else 0)
+
+if __name__ == "__main__":
+    main()

--- a/tests/telemetry/show_cli_to_gnmi_path.py
+++ b/tests/telemetry/show_cli_to_gnmi_path.py
@@ -73,8 +73,7 @@ class ShowCliToGnmiPathConverter:
             if has_special_char(tok):
                 raise ValueError("Invalid characters inside of non option")
 
-            if out:
-                out.append("/")
+            out.append("/")
             out.append(escape_gnmi(tok))
 
         if not out:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Add python library for converting show command into SHOW gnmi xpath.

#### How did you do it?

Rules:

- Cannot use short form of options (-v, -i, -a)
- For options that take in a value such as --period or --interface they must be supplied with "=" and the value such as --period=5 or --interface=Ethernet0,Ethernet40
- All other long form option without values will be treated as bools like --verbose = [verbose=True]
- Escape forward slash, use shlex to unescape . Special characters like =,[,] will be errored out if they appear in path or option key/value
- Convert show cli command to SHOW gnmi path in place, keep option order and tokens


show interfaces counters --period=5 detailed --verbose = "interfaces/counters[period=5]/detailed[verbose=True]


#### How did you verify/test it?

```
$ python3 show_cli_to_gnmi_path.py -c "show interfaces counters --period=5 detailed --verbose"
interfaces/counters[period=5]/detailed[verbose=True]
```

```
$ python3 show_cli_to_gnmi_path.py -c "show interfaces errors Ethernet0"
interfaces/errors/Ethernet0
```

```
$ python3 show_cli_to_gnmi_path.py -c "show interfaces errors Ethernet0 -h"
Short options are not supported: '-h'
```

```
$ python3 show_cli_to_gnmi_path.py -c "show interfaces --help errors Ethernet0 --json"
interfaces[help=True]/errors/Ethernet0[json=True]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
