### PR TITLE
Fix BPF filter specification in arp_responder

### DIFF
--- a/tests/scripts/arp_responder.py
+++ b/tests/scripts/arp_responder.py
@@ -147,8 +147,14 @@ def main():
                 #
                 # icmp_filter_entries.append(f'icmp6[20:4] = 0x{ipv6_address_integer & 0xffffffff:0x}')  # noqa: E231
                 icmp_filter_entries.append(f'ip6[60:4] = 0x{ipv6_address_integer & 0xffffffff:0x}')  # noqa: E231
-        pcap_filter = f"(arp and ({' or '.join(arp_filter_entries)})) or " + \
-            f"(icmp6 and ({' or '.join(icmp_filter_entries)}))"
+        if len(arp_filter_entries) > 0 and len(icmp_filter_entries) > 0:
+            pcap_filter = f"(arp and ({' or '.join(arp_filter_entries)})) or " + \
+                f"(icmp6 and ({' or '.join(icmp_filter_entries)}))"
+        elif len(arp_filter_entries) > 0:
+            pcap_filter = f"arp and ({' or '.join(arp_filter_entries)})"
+        elif len(icmp_filter_entries) > 0:
+            pcap_filter = f"icmp6 and ({' or '.join(icmp_filter_entries)})"
+
         sockets[iface] = scapy.conf.L2socket(iface=iface, filter=pcap_filter)
         inverse_sockets[sockets[iface]] = iface
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

If only IPv4 or only IPv6 addresses are passed in into arp_responder, then the constructed BPF filter is syntactically invalid. Fix this.

#### How did you do it?

Check to see if both IPv4 and IPv6 addresses are being passed in, or only IPv4, or only IPv6.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
