### PR TITLE
Avoiding fetching fib-info for DPU ports on SmartSwitch

### DIFF
--- a/tests/common/helpers/constants.py
+++ b/tests/common/helpers/constants.py
@@ -8,6 +8,7 @@ ASICS_PRESENT = 'asics_present'
 RANDOM_SEED = 'random_seed'
 CUSTOM_MSG_PREFIX = "sonic_custom_msg"
 DUT_CHECK_NAMESPACE = "dut_check_result"
+SMARTSWITCH_SUBTYPE = "SmartSwitch"
 
 # Describe upstream neighbor of dut in different topos
 UPSTREAM_NEIGHBOR_MAP = {

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2482,7 +2482,7 @@ generic_config_updater/test_dynamic_acl.py:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "hwsku in ['Cisco-8111-O64']"
       - "topo_name in ['m0-2vlan']"
-      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o_c01-r0']"
+      - "platform in ['x86_64-8101_32fh_o-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-8101_32fh_o_c01-r0']"
 
 generic_config_updater/test_dynamic_acl.py::test_gcu_acl_arp_rule_creation[IPV4:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- For SmartSwitch in lit-mode port Ethernet224 onword connects to DPU. 
- fib/test_fib.py cases was failing due to this
- This PR avoids fetching fib-info for those ports on SmartSwitch
-->

Summary:
- For SmartSwitch in lit-mode port Ethernet224 onword connects to DPU. 
- fib/test_fib.py cases was failing due to this
- This PR avoids fetching fib-info for those ports on SmartSwitch

Fixes # (fib/test_fib.py cases failure on SmartSwitch with DPUs)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202506

### Approach
#### What is the motivation for this PR?
Address fib/test_fib.py testcases failure for SmartSwitch with DPU
 
#### How did you do it?
This PR avoids fetching fib-info for DPU ports on SmartSwitch

#### How did you verify/test it?
 fib/test_fib.py testcases now passing

#### Any platform specific information?
Fix is for SmartSwitch with DPU

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
