### PR TITLE
Fixing HashTest Bugs #20840 and #21071

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -617,7 +617,7 @@ class HashTest(BaseTest):
                     total_entry_hit_cnt, float(total_hit_cnt) / len(asic_member), hash_key)
                 logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
                              % ("ECMP", str(ecmp_entry), total_hit_cnt // len(asic_member),
-                                total_entry_hit_cnt, str(round(p, 4) * 100) + '%'), hash_key)
+                                total_entry_hit_cnt, str(round(p, 4) * 100) + '%'))
                 result &= r
                 if len(ecmp_entry) == 1 or total_entry_hit_cnt == 0:
                     continue
@@ -626,7 +626,7 @@ class HashTest(BaseTest):
                         member, 0), float(total_entry_hit_cnt) / len(ecmp_entry), hash_key)
                     logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
                                  % ("LAG", str(member), total_entry_hit_cnt // len(ecmp_entry),
-                                    port_hit_cnt.get(member, 0), str(round(p, 4) * 100) + '%'), hash_key)
+                                    port_hit_cnt.get(member, 0), str(round(p, 4) * 100) + '%'))
                     result &= r
         assert result
 

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -614,7 +614,7 @@ class HashTest(BaseTest):
                 for member in ecmp_entry:
                     total_entry_hit_cnt += port_hit_cnt.get(member, 0)
                 (p, r) = self.check_within_expected_range(
-                    total_entry_hit_cnt, float(total_hit_cnt) / len(asic_member))
+                    total_entry_hit_cnt, float(total_hit_cnt) / len(asic_member), hash_key)
                 logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
                              % ("ECMP", str(ecmp_entry), total_hit_cnt // len(asic_member),
                                 total_entry_hit_cnt, str(round(p, 4) * 100) + '%'), hash_key)
@@ -623,7 +623,7 @@ class HashTest(BaseTest):
                     continue
                 for member in ecmp_entry:
                     (p, r) = self.check_within_expected_range(port_hit_cnt.get(
-                        member, 0), float(total_entry_hit_cnt) / len(ecmp_entry))
+                        member, 0), float(total_entry_hit_cnt) / len(ecmp_entry), hash_key)
                     logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
                                  % ("LAG", str(member), total_entry_hit_cnt // len(ecmp_entry),
                                     port_hit_cnt.get(member, 0), str(round(p, 4) * 100) + '%'), hash_key)

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -657,7 +657,7 @@ class IPinIPHashTest(HashTest):
 
     def create_packets_logs(
             self, src_port, sport, dport, version='IP', pkt=None, ipinip_pkt=None,
-            vxlan_pkt=None,nvgre_pkt=None, inner_pkt=None, outer_sport=None,
+            vxlan_pkt=None, nvgre_pkt=None, inner_pkt=None, outer_sport=None,
             ip_src=None, ip_dst=None, ip_proto=None
     ):
         """

--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -648,9 +648,16 @@ class IPinIPHashTest(HashTest):
     for IPinIP packet.
     '''
 
+    def send_and_verify_packets(self, src_port, pkt, masked_exp_pkt, dst_port_lists, is_timeout=False, logs=[]):
+        """
+        @summary: Send an IPinIP encapsulated packet and verify it is received on expected ports.
+        """
+        return super().send_and_verify_packets(src_port, pkt, masked_exp_pkt, dst_port_lists, is_timeout=False,
+                                               logs=logs)
+
     def create_packets_logs(
             self, src_port, sport, dport, version='IP', pkt=None, ipinip_pkt=None,
-            vxlan_pkt=None, nvgre_pkt=None, inner_pkt=None, outer_sport=None,
+            vxlan_pkt=None,nvgre_pkt=None, inner_pkt=None, outer_sport=None,
             ip_src=None, ip_dst=None, ip_proto=None
     ):
         """
@@ -665,9 +672,9 @@ class IPinIPHashTest(HashTest):
                             ipinip_pkt['IP'].dst,
                             ipinip_pkt['IP'].proto,
                             version,
-                            pkt[version].src,
-                            pkt[version].dst,
-                            pkt[version].proto if version == 'IP' else pkt['IPv6'].nh,
+                            inner_pkt[version].src,
+                            inner_pkt[version].dst,
+                            inner_pkt[version].proto if version == 'IP' else inner_pkt['IPv6'].nh,
                             sport,
                             dport,
                             src_port))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixing Bugs https://github.com/sonic-net/sonic-mgmt/issues/20840#issuecomment-3353468394 and https://github.com/sonic-net/sonic-mgmt/issues/21071 (HashTest)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fixing Bug https://github.com/sonic-net/sonic-mgmt/issues/20840#issuecomment-3353468394  and https://github.com/sonic-net/sonic-mgmt/issues/21071(HashTest)

by override send_and_verify_packets on class IPinIPHashTest to make sure that the verification of the packet arrival will succeed

How did you do it?
fixed HashTest.check_within_expected_range usage 
Fixed IPinIP Hash Test  by override send_and_verify_packets on class IPinIPHashTest and use no timeout for the packets arrival verification.

How did you verify/test it?
Ran fib_test::test_hash locally.
Conducted a full overnight regression test.

Any platform specific information?
No

Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
