### PR TITLE
Fix k8s node joining failure for Arista-7060X6-16PE-384C-B-O128S2 SKU

### DIFF
--- a/tests/kubesonic/test_k8s_join_disjoin.py
+++ b/tests/kubesonic/test_k8s_join_disjoin.py
@@ -204,7 +204,7 @@ def remove_node_ip_param(duthost):
         return
     logger.info("Detected SKU which requires removal of '--node-ip=::' from kubelet config")
     duthost.shell(f"sudo cp {KUBELET_DEFAULT_CONFIG} {KUBELET_DEFAULT_CONFIG_BAK}", module_ignore_errors=True)
-    duthost.shell(f"sudo sed -i 's/ --node-ip=:://g' {KUBELET_DEFAULT_CONFIG}")
+    duthost.shell(f"sudo sed -i 's/--node-ip=::/--node-ip={duthost.mgmt_ip}/g' {KUBELET_DEFAULT_CONFIG}")
     duthost.shell("sudo systemctl daemon-reload")
     logger.info("Kubelet config '--node-ip=::' parameter removed")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix k8s node joining failure for Arista-7060X6-16PE-384C-B-O128S2 SKU
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
For SKU Arista-7060X6-16PE-384C-B-O128S2, k8s test case fails due to joining failure, need to fix.
#### How did you do it?
The reason why the case fails is that there's a parameter for kubelet which will prefer IPv6 address, but in testbed, we are using IPv4, so just need to specify the --node-ip=mgmt_ip.
#### How did you verify/test it?
Run the modified code on Arista-7060X6-16PE-384C-B-O128S2 DUT, the case runs successfully.

#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
