### PR TITLE
Everflow IPv6 tests failing since mirror type is not set correctly (test_everflow_ipv6.py) #20874

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -732,7 +732,7 @@ class BaseEverflowTest(object):
                 command = f"sonic-db-cli CONFIG_DB HSET 'MIRROR_SESSION|{session_info['session_name']}' \
                             'dscp' '{session_info['session_dscp']}' 'dst_ip' '{session_info['session_dst_ipv6']}' \
                             'gre_type' '{session_info['session_gre']}' 'src_ip' '{session_info['session_src_ipv6']}' \
-                            'ttl' '{session_info['session_ttl']}'"
+                            'ttl' '{session_info['session_ttl']}' 'type' 'ERSPAN'"
                 if policer:
                     command += f" 'policer' {policer}"
 


### PR DESCRIPTION
### Description of PR
Test cases in test_everflow_ipv6.py are failing since apply_mirror_config function is not passing in the mirror type. When the mirror type is not passed in by default type is being set as empty string. That is causing mirror session to be not setup correctly by mirrororch. Probably earlier default was different and this test was working but not working any more. Either way, it is better to pass in the type explicitly instead of depending on the default value.

Summary:
Fixes # (issue)
#20874

### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
test_everflow_ipv6.py fails without this fix

#### How did you do it?
Passing in the mirror type while configuring v6 mirror.

#### How did you verify/test it?
test_everflow_ipv6.py is passing with this fix

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

