### PR TITLE
Q3D ASIC allows IP packets with 0xffff checksum, tests needs be skipped/allowed accordingly

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2669,7 +2669,7 @@ ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_dr
       - "asic_type in ['broadcom', 'cisco-8000', 'marvell', 'barefoot', 'marvell-teralynx', 'marvell-prestera'] and asic_subtype not in ['broadcom-dnx']"
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
       - "topo_name in ['t2_2lc_36p-masic', 't2_2lc_min_ports-masic', 't2_5lc-mixed-96']"
-      - "hwsku in group_vars['broadcom_q3d_hwskus']"
+      - "hwsku in ['NH-5010-F-O64', 'NH-5010-F-O32-C32']"
 
 ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant:
   skip:
@@ -2677,7 +2677,7 @@ ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_to
             / Skipping ip packet test since can't provide enough interfaces"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox'] or ((asic_subtype in ['broadcom-dnx']) and (hwsku not in group_vars['broadcom_q3d_hwskus']))"
+      - "asic_type in ['mellanox'] or ((asic_subtype in ['broadcom-dnx']) and (hwsku not in ['NH-5010-F-O64', 'NH-5010-F-O32-C32']))"
       - "len(minigraph_interfaces) < 2 and len(minigraph_portchannels) < 2"
 
 ip/test_mgmt_ipv6_only.py:


### PR DESCRIPTION
### Description of PR
Since Q3D ASIC allows IP packets with 0xffff checksum, ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop need to be skipped and ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant need to be allowed. Currently test_forward_ip_packet_with_0xffff_chksum_drop is being skipped and test_forward_ip_packet_with_0xffff_chksum_drop is being allowed.

Summary:
Fixes # (issue)
#20885

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To skip ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_drop  and allow ip/test_ip_packet.py::TestIPPacket::test_forward_ip_packet_with_0xffff_chksum_tolerant
#### How did you do it?
Changed the conditions to allow/skip accordingly

#### How did you verify/test it?
Tests allowed skipped as expected with this fix.
#### Any platform specific information?
Platforms with Broadcom Q3D ASIC

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
