### PR TITLE
Generate new golden config db for cisco smartswitch platforms

### DIFF
--- a/ansible/module_utils/smartswitch_utils.py
+++ b/ansible/module_utils/smartswitch_utils.py
@@ -1,23 +1,35 @@
-smartswitch_hwsku_config = {
-    "Cisco-8102-28FH-DPU-O-T1": {
-        "dpu_num": 8,
-        "port_key": "Ethernet-BP{}",
-        "interface_key": "Ethernet-BP{}|18.{}.202.0/31",
-        "dpu_key": "dpu{}"
-    },
-    "Mellanox-SN4280-O28": {
-        "dpu_num": 4,
-        "port_key": "Ethernet{}",
-        "base": 224,
-        "step": 8,
-        "dpu_key": "dpu{}"
-    },
-    "Mellanox-SN4280-O8C40": {
-        "dpu_num": 4,
-        "port_key": "Ethernet{}",
-        "interface_key": "Ethernet{}|18.{}.202.0/31",
-        "base": 224,
-        "step": 8,
-        "dpu_key": "dpu{}"
-    }
+common_cisco_hwsku_config = {
+    "dpu_num": 8,
+    "port_key": "Ethernet{}",
+    "interface_key": "Ethernet{}|18.{}.202.0/31",
+    "base": 224,
+    "step": 8,
+    "dpu_key": "dpu{}"
 }
+
+common_mellanox_hwsku_config = {
+    "dpu_num": 4,
+    "port_key": "Ethernet{}",
+    "interface_key": "Ethernet{}|18.{}.202.0/31",
+    "base": 224,
+    "step": 8,
+    "dpu_key": "dpu{}"
+}
+
+smartswitch_hwsku_config = {
+    # Cisco SKUs
+    hwsku: common_cisco_hwsku_config.copy() for hwsku in [
+        "Cisco-8102-28FH-DPU-O",
+        "Cisco-8102-28FH-DPU-C28",
+        "Cisco-8102-28FH-DPU-O8C20",
+        "Cisco-8102-28FH-DPU-O12C16",
+        "Cisco-8102-28FH-DPU-O8C40",
+        "Cisco-8102-28FH-DPU-O8V40"
+    ]
+}
+
+# Mellanox SKUs
+smartswitch_hwsku_config.update({
+    "Mellanox-SN4280-O28": common_mellanox_hwsku_config.copy(),
+    "Mellanox-SN4280-O8C40": common_mellanox_hwsku_config.copy()
+})


### PR DESCRIPTION
pr_20314 missing in 202505 branch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR_20314 missing in 202505 branch, which generates new golden config db for cisco smartswitch platforms
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202506
 
### Approach
#### What is the motivation for this PR?
Add the missing changes from PR_20314 in 202505 branch

#### How did you do it?
Picked changes from the PR

#### How did you verify/test it?
Run the tests on the given hw_sku

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
