### PR TITLE
Added DPU control plane and default config wait for DPU minigraph

### DIFF
--- a/ansible/module_utils/misc_utils.py
+++ b/ansible/module_utils/misc_utils.py
@@ -1,0 +1,19 @@
+import time
+
+
+def wait_for_path(ssh, host_ip, path_to_check, empty_ok=False, tries=1, delay=5):
+    with ssh.open_sftp() as sftp:
+        for _ in range(tries):
+            try:
+                stat_result = sftp.stat(path_to_check)
+                if empty_ok or stat_result.st_size > 0:
+                    return
+            except FileNotFoundError:
+                pass
+            time.sleep(delay)
+    raise FileNotFoundError(
+         "Failed to find {}path {} on host {} after {} retries.".
+         format("" if empty_ok else "not empty ",
+                path_to_check,
+                host_ip,
+                tries))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
DPU control plane up wait for DPU minigraph

Summary:
Before the DPU config is deployed, DPU needs to start with the DPU control plane up and default config available.

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?

Random smartswitch minigraph deployment failures

#### How did you do it?
Added the wait for the DPU control plane up and the default config file.

#### How did you verify/test it?
Smartswitch light mode deployment

#### Any platform specific information?
Smartswitch light mode 

#### Supported testbed topology if it's a new test case?

### Documentation
