### PR TITLE
Add a regex option to support multiple  DPU reboot reasons

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -239,8 +239,8 @@ def check_dpu_reboot_cause(duthost, dpu_name, reason):
     output_reboot_cause = duthost.shell(
             'show reboot-cause all | grep %s' % (dpu_name))
 
-    output_str = output_reboot_cause["stdout"]
-    if reason in output_str.strip():
+    output_str = output_reboot_cause["stdout"].strip()
+    if (isinstance(reason, re.Pattern) and reason.search(output_str)) or reason in output_str:
         logging.info("'{}' - reboot cause is {} as expected".format(dpu_name,
                                                                     reason))
         return True

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -272,4 +272,5 @@ def test_cold_reboot_switch(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname
     perform_reboot(duthost, REBOOT_TYPE_COLD, None)
 
     logging.info("Executing post switch reboot dpu check")
-    post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules, "reboot")
+    post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list, num_dpu_modules,
+                         re.compile(r"reboot|Non-Hardware", re.IGNORECASE))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Mellanox DPUs report a different reason for the DPU reboot when the switch is rebooted.

Summary:
Fixes # (issue) N/A

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?

Support the Mellanox and other platforms that may report the reboot reason differently

#### How did you do it?

Passing a complied regex in the case of multiple possible reboot reasons. Checking the type before comparing with the reported reboot reason.

#### How did you verify/test it?

ran dpu_reload_test.py

#### Any platform specific information?
Mellanox DPU reports "Non-hardware" as the reboot reason when the switch is rebooted.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A