### PR TITLE
[Snappi]: Fixed the Queue counter stats key issue for certain ingress-egress port combination.

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -1363,15 +1363,13 @@ def run_traffic_and_collect_stats(rx_duthost,
         f.write('Total DUT Loss Pkts:{} \n'.format(test_stats['dut_loss_pkts']))
         test_stats['dut_lossless_pkts'] = 0
         test_stats['dut_lossy_pkts'] = 0
-        prio_key = ['_prio_']
         for dut, port in dutport_list:
-            new_key = (dut.hostname + '_' + port).lower()
+            new_key = (dut.hostname + '_' + port).lower() + '_prio_'
             prio_dict = {}
             for item in results:
-                for key in prio_key:
-                    if (new_key in item and key in item.split(new_key)[1]):
-                        prio_dict[item.split(new_key)[1]] = df_t[item].max()
-            f.write('Egress Queue Count for {} : \n'.format(new_key))
+                if (new_key in item):
+                    prio_dict[item] = df_t[item].max()
+            f.write('Egress Queue Count for {} : \n'.format((dut.hostname + '_' + port).lower()))
             for key, val in prio_dict.items():
                 if val != 0:
                     # Checking for lossless priorities in the key.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20897 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Certain port combinations, for example - Ethernet16 as ingress port and Ethernet160 as egress port on the same DUT will cause the queue stats counters to be incorrectly reported in the generated summary file.
This will also be true if the ingress port is Ethernet24 and egress is Ethernet240 on the same DUT. The queue counter stats use 'dut-name+port counter' as key combination, and hence dut-name + Ethernet16 would also pass as key-name for dut-name + Ethernet160. 


#### How did you do it?
Added a small key factor - dut-name + port + '_prio_' as the key, and hence checks for the exact keyword instead of dut-name + port.

#### How did you verify/test it?
Captured the output of the file with and without the fix.

Before the fix:
```
cat Single_Ingress_Egress_1Prio_linerate_100Gbps_experiment-11_512B-2025-09-24-18-18.txt    
Captured data for 4 iterations at 60 seconds interval 
For test_flow_prio_3_stream_0 - Avg_Latency:nan, rx_pkts:7142857142, tx_pkts:7142857142, rx_thrput:98.55, tx_thrput:98.55 and loss prcnt:0.0 
Total Lossless Rx pkts:7142857142 and Tx pkts:7142857142 
Total Lossy Rx pkts:0 and Tx pkts:0 
Total TGEN Loss Pkts:0 
For ixre-egl-board71_ethernet160 - rx_pkts:0, tx_pkts:7142857154, rx_thrput:0, tx_thrput:0 and rx_loss:0, tx_loss:0 
For ixre-egl-board71_ethernet16 - rx_pkts:7142857142, tx_pkts:13, rx_thrput:0, tx_thrput:0 and rx_loss:0, tx_loss:0 
Total DUT Loss Pkts:0 
```

After the fix:
```
cat /tmp/Single_Ingress_Egress_1Prio_linerate_100Gbps_experiment-11_512B-2025-10-02-23-12.txt
Captured data for 4 iterations at 60 seconds interval 
For test_flow_prio_4_stream_0 - Avg_Latency:nan, rx_pkts:7142857142, tx_pkts:7142857142, rx_thrput:98.55, tx_thrput:98.55 and loss prcnt:0.0 
Total Lossless Rx pkts:7142857142 and Tx pkts:7142857142 
Total Lossy Rx pkts:0 and Tx pkts:0 
Total TGEN Loss Pkts:0 
For ixre-egl-board71_ethernet160 - rx_pkts:0, tx_pkts:7142857154, rx_thrput:0, tx_thrput:0 and rx_loss:0, tx_loss:0 
For ixre-egl-board71_ethernet16 - rx_pkts:7142857142, tx_pkts:13, rx_thrput:0, tx_thrput:0 and rx_loss:0, tx_loss:0 
Total DUT Loss Pkts:0 
Egress Queue Count for ixre-egl-board71_ethernet160 : 
ixre-egl-board71_ethernet160_prio_4:7142857142 
Egress Queue Count for ixre-egl-board71_ethernet16 : 
Received or Transmitted PFC counts: 
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
