### PR TITLE
feat: add support multi-lanes L1 NUT

### DIFF
--- a/ansible/module_utils/graph_utils.py
+++ b/ansible/module_utils/graph_utils.py
@@ -325,16 +325,27 @@ class LabGraph(object):
 
             if l1_name not in from_l1_links:
                 from_l1_links[l1_name] = {}
-            from_l1_links[l1_name][l1_port] = {
-                "peerdevice": device_name,
-                "peerport": device_port,
-            }
+
+            if "|" in l1_port:
+                lanes = l1_port.split("|")
+
+                for lane in lanes:
+                    from_l1_links[l1_name][lane] = {
+                        "peerdevice": device_name,
+                        "peerport": device_port
+                    }
+            else:
+                from_l1_links[l1_name][l1_port] = {
+                    "peerdevice": device_name,
+                    "peerport": device_port,
+                }
 
             if device_name not in to_l1_links:
                 to_l1_links[device_name] = {}
+
             to_l1_links[device_name][device_port] = {
                 "peerdevice": l1_name,
-                "peerport": l1_port,
+                "peerport": l1_port if "|" not in l1_port else l1_port.split("|"),
             }
 
         logging.debug("Found L1 links from L1 switches to devices: {}".format(from_l1_links))
@@ -548,6 +559,11 @@ class LabGraph(object):
                     l1_cross_connects[l1_start_device] = {}
 
                 l1_port_pair = sorted([l1_start_port, l1_end_port])
-                l1_cross_connects[l1_start_device][l1_port_pair[0]] = l1_port_pair[1]
+
+                if isinstance(l1_port_pair[0], list) and isinstance(l1_port_pair[1], list):
+                    for l1_port_start, l1_port_end in zip(l1_port_pair[0], l1_port_pair[1]):
+                        l1_cross_connects[l1_start_device][l1_port_start] = l1_port_end
+                else:
+                    l1_cross_connects[l1_start_device][l1_port_pair[0]] = l1_port_pair[1]
 
         return l1_cross_connects


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR allows option to group multiple L1 ports into 1 peer connection. Which is needed when we run with ixia topology requires 4 lanes per port connection.

Fixes # (issue) 35384297

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Due to the need of running L1 test on IXIA, we need to allow ocs to configure using `n` lane per port.

Now the user can use something like

```
tgen,Card2/Port1,l1-switch,13|14|15|16
tgen,Card2/Port2,l1-switch,17|18|19|20
tgen,Card2/Port3,l1-switch,21|22|23|24
...
dut,Ethernet184,l1-switch,41|42|43|44
dut,Ethernet188,l1-switch,45|46|47|48
dut,Ethernet192,l1-switch,49|50|51|52
```

This will in turn generates the follow mapping

```
"device_l1_cross_connects[inventory_hostname]": {
        "13": "41",
        "14": "42",
        "15": "43",
        "16": "44",
        "17": "45",
        "18": "46",
        "19": "47",
        "20": "48",
        "21": "49",
        "22": "50",
        "23": "51",
        "24": "52"
    }
```

And result into the following cross connects

```
id       a_side    b_side
-------  --------  --------
13A-41B  13A       41B
14A-42B  14A       42B
15A-43B  15A       43B
16A-44B  16A       44B
17A-45B  17A       45B
18A-46B  18A       46B
19A-47B  19A       47B
20A-48B  20A       48B
21A-49B  21A       49B
22A-50B  22A       50B
23A-51B  23A       51B
24A-52B  24A       52B
41A-13B  41A       13B
42A-14B  42A       14B
43A-15B  43A       15B
44A-16B  44A       16B
45A-17B  45A       17B
46A-18B  46A       18B
47A-19B  47A       19B
48A-20B  48A       20B
49A-21B  49A       21B
50A-22B  50A       22B
51A-23B  51A       23B
```


with labels

```

13A   Link to tgen Card2/Port1 RX        normal
13B   Link to tgen Card2/Port1 TX        normal
14A   Link to tgen Card2/Port1 RX        normal
14B   Link to tgen Card2/Port1 TX        normal
15A   Link to tgen Card2/Port1 RX        normal
15B   Link to tgen Card2/Port1 TX        normal
16A   Link to tgen Card2/Port1 RX        normal
16B   Link to tgen Card2/Port1 TX        normal
17A   Link to tgen Card2/Port2 RX        normal
17B   Link to tgen Card2/Port2 TX        normal
18A   Link to tgen Card2/Port2 RX        normal
18B   Link to tgen Card2/Port2 TX        normal
19A   Link to tgen Card2/Port2 RX        normal
19B   Link to tgen Card2/Port2 TX        normal
20A   Link to tgen Card2/Port2 RX        normal
20B   Link to tgen Card2/Port2 TX        normal
21A   Link to tgen Card2/Port3 RX        normal
21B   Link to tgen Card2/Port3 TX        normal
22A   Link to tgen Card2/Port3 RX        normal
22B   Link to tgen Card2/Port3 TX        normal
23A   Link to tgen Card2/Port3 RX        normal
23B   Link to tgen Card2/Port3 TX        normal
24A   Link to tgen Card2/Port3 RX        normal
24B   Link to tgen Card2/Port3 TX        normal

...

41A   Link to dut Ethernet184 RX  normal
41B   Link to dut Ethernet184 TX  normal
42A   Link to dut Ethernet184 RX  normal
42B   Link to dut Ethernet184 TX  normal
43A   Link to dut Ethernet184 RX  normal
43B   Link to dut Ethernet184 TX  normal
44A   Link to dut Ethernet184 RX  normal
44B   Link to dut Ethernet184 TX  normal
45A   Link to dut Ethernet188 RX  normal
45B   Link to dut Ethernet188 TX  normal
46A   Link to dut Ethernet188 RX  normal
46B   Link to dut Ethernet188 TX  normal
47A   Link to dut Ethernet188 RX  normal
47B   Link to dut Ethernet188 TX  normal
48A   Link to dut Ethernet188 RX  normal
48B   Link to dut Ethernet188 TX  normal
49A   Link to dut Ethernet192 RX  normal
49B   Link to dut Ethernet192 TX  normal
50A   Link to dut Ethernet192 RX  normal
50B   Link to dut Ethernet192 TX  normal
51A   Link to dut Ethernet192 RX  normal
51B   Link to dut Ethernet192 TX  normal
52A   Link to dut Ethernet192 RX  normal
52B   Link to dut Ethernet192 TX  normal
```
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
