### PR TITLE
Adding namespace argument in get_interfaces_status function

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1929,7 +1929,7 @@ Totals               6450                 6449
                     vlan_brief[vlan_name]["interface_ipv6"].append(prefix)
         return vlan_brief
 
-    def get_interfaces_status(self):
+    def get_interfaces_status(self, namespace=None):
         '''
         Get intnerfaces status by running 'show interfaces status' on the DUT, and parse the result into a dict.
 
@@ -1963,7 +1963,11 @@ Totals               6450                 6449
                 }
             }
         '''
-        return {x.get('interface'): x for x in self.show_and_parse('show interfaces status')}
+        if namespace is None:
+            return {x.get('interface'): x for x in self.show_and_parse('show interfaces status')}
+        else:
+            return {x.get('interface'): x for x in self.show_and_parse('show interfaces status -n {}'
+                                                                       .format(namespace))}
 
     def show_ipv6_interfaces(self):
         '''


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

This is an enhancement in existing `get_interfaces_status()` function under file `tests/common/devices/sonic.py` so that we can get output for a specific asic namespace.

This is useful for multi-asic platforms and suites (e.g. gcu add cluster case https://github.com/sonic-net/sonic-mgmt/pull/14887).

The change as it is designed do not affect existing functionality as the new argument is added withd efault value None, simulating same behavior as before.

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Needed to get interfaces status for specific asic namespace.

#### How did you do it?
Added a new argument in existing `get_interfaces_status()` function under file `tests/common/devices/sonic.py` .
Default value is `None` so does not affect the current default functionality.

#### How did you verify/test it?
Used the function with the namespace argument. Tested that new argument works.
Used the function with the default namespace argument. Tested that everything goes fine and there is no change in the current execution.

#### Any platform specific information?
generic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
