### PR TITLE
Exclude SmartSwitch-related tests on non-SmartSwitch testbeds

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1349,8 +1349,14 @@ platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db:
 #######################################
 #####   test_platform_dpu.py   #####
 #######################################
-smartswitch/platform_tests/test_platform_dpu.py::test_data_control_mid_plane_sync:
+smartswitch/platform_tests/test_platform_dpu.py:
   skip:
-    reason: "Test case is skipped on Nvidia smartswitch due to sonic-mgmt issue: https://github.com/sonic-net/sonic-mgmt/issues/19675"
+    reason: "Skip for non-smartswitch topology"
     conditions:
-    - "https://github.com/sonic-net/sonic-mgmt/issues/19675 and 'sn4280' in platform"
+      - "is_smartswitch==False"
+
+smartswitch/platform_tests/test_reload_dpu.py:
+  skip:
+    reason: "Skip for non-smartswitch topology"
+    conditions:
+      - "is_smartswitch==False"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
https://github.com/sonic-net/sonic-mgmt/issues/19675 issue is closed now. Also skip smartswich based testcases on a non-smartswitch platform.

#### How did you do it?
1. Remove the condition to skip test_data_control_mid_plane_sync()
2. Add conditions to skip smartswitch exclusive tests for non-smartswitch platforms.

#### How did you verify/test it?
Tests are skipped on Arista-7060x6 platform.
-----------------------------------------------------------------
smartswitch/platform_tests/test_platform_dpu.py::test_midplane_ip[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                       [  9%]
smartswitch/platform_tests/test_platform_dpu.py::test_reboot_cause[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                      [ 18%]
smartswitch/platform_tests/test_platform_dpu.py::test_pcie_link[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                         [ 27%]
smartswitch/platform_tests/test_platform_dpu.py::test_restart_pmon[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                      [ 36%]
smartswitch/platform_tests/test_platform_dpu.py::test_system_health_state[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                               [ 45%]
smartswitch/platform_tests/test_platform_dpu.py::test_dpu_console[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                       [ 54%]
smartswitch/platform_tests/test_platform_dpu.py::test_npu_dpu_date[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                      [ 63%]
smartswitch/platform_tests/test_platform_dpu.py::test_dpu_memory[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                                        [ 72%]
smartswitch/platform_tests/test_platform_dpu.py::test_system_health_summary[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                             [ 81%]
smartswitch/platform_tests/test_platform_dpu.py::test_data_control_mid_plane_sync[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                       [ 90%]
smartswitch/platform_tests/test_platform_dpu.py::test_watchdog_status_check[str5-7060x6-512-6] SKIPPED (Skip for non-smartswitch topology)                                                             [100%]
--------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------
04/10/2025 02:48:56 conftest.log_custom_msg                  L1163 DEBUG  | [log_custom_msg] item: <Function test_watchdog_status_check[str5-7060x6-512-6]>


============================================================================================== warnings summary ==============================================================================================
../../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------------------------------------- generated xml file: /var/src/src/logs-skip/smartswitch/platform_tests/test_platform_dpu.xml ---------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
04/10/2025 02:48:56 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================================================================== short test summary info ===========================================================================================
SKIPPED [11] smartswitch/platform_tests/test_platform_dpu.py: Skip for non-smartswitch topology
====================================================================================== 11 skipped, 1 warning in 41.91s =======================================================================================
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
