### PR TITLE
Fix conditional marks for marvell-teralynx

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4078,7 +4078,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark:
     reason: "Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['marvell-teralynx'] and platform in ['x86_64-wistron_6512_32r-r0', 'x86_64-wistron_6512_32r-r0']"
+      - "asic_type in ['marvell-teralynx'] and platform in ['x86_64-wistron_6512_32r-r0', 'x86_64-wistron_sw_to3200k-r0']"
       - "asic_type in ['cisco-8000'] and not platform.startswith('x86_64-8122_')"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox']"


### PR DESCRIPTION
### Description of PR
Fixed the conditional mark for the following test cases for marvell-teralynx asic
qos/test_pfc_counters.py::test_pfc_unpause
qos/test_qos_dscp_mapping.py::TestQoSSaiDSCPQueueMapping_IPIP_Base::test_dscp_to_queue_mapping_uniform_mode
qos/test_qos_sai.py::TestQosSai
qos/test_qos_sai.py::TestQosSai::testQosSaiBufferPoolWatermark
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pPgMapping
qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize
qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The conditional markers needed to be handled for various qos cases for marvell-teralynx TL7 and TL10 asic family.

#### How did you do it?
Depending on the ASIC and Topology, fixed the conditions to either skip or run the test case for marvell-teralynx

#### How did you verify/test it?
Ran the PTF cases listed above in T0 and T1 topology both in TL7 and TL10 platform

#### Any platform specific information?
Changes Applicable only for marvell-teralynx ASIC
