### PR TITLE
fix the issue #20935

### DIFF
--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -1,9 +1,13 @@
 import pytest
 import json
 import re
+import logging
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
+from tests.common.platform.interface_utils import get_dpu_npu_ports_from_hwsku
+
+logger = logging.getLogger(__name__)
 
 CFG_DB_PATH = "/etc/sonic/config_db.json"
 ORIG_CFG_DB = "/etc/sonic/orig_config_db.json"
@@ -57,17 +61,36 @@ def get_queue_cntrs_oid(interface):
     queue_cntrs_oid = '1.3.6.1.4.1.9.9.580.1.5.5.1.4.{}'.format(int(intf_num) + 1)
     return queue_cntrs_oid
 
+def get_dpu_npu_port_list(duthost):
+    dpu_npu_port_list = []
+    cmd_get_config_db_port_key_list = 'redis-cli --raw -n 4 keys "PORT|Ethernet*"'
+    cmd_dump_config_db = "sonic-db-dump -n CONFIG_DB -y"
+    dpu_npu_role = 'Dpc'
 
-def get_asic_interface(inter_facts):
+    port_key_list = duthost.command(cmd_get_config_db_port_key_list)['stdout'].split('\n')
+    config_db_res = json.loads(duthost.command(cmd_dump_config_db)["stdout"])
+
+    for port_key in port_key_list:
+        if port_key in config_db_res:
+            if dpu_npu_role == config_db_res[port_key].get('value').get('role'):
+                dpu_npu_port_list.append(port_key.split("|")[-1])
+    logger.info(f"dpu npu port list: {dpu_npu_port_list}")
+    return dpu_npu_port_list
+
+
+def get_asic_interface(inter_facts, duthost):
     """
     @summary: Returns interface dynamically based on the asic chosen
               for single/multi-asic sonic host.
     """
     ansible_inter_facts = inter_facts['ansible_interface_facts']
     interface = None
+    internal_port_list = get_dpu_npu_port_list(duthost)
     for key, v in ansible_inter_facts.items():
         # Exclude internal interfaces
         if 'IB' in key or 'Rec' in key or 'BP' in key:
+            continue
+        if key in internal_port_list:
             continue
         if 'Ether' in key and v['active']:
             interface = key
@@ -106,7 +129,7 @@ def test_snmp_queue_counters(duthosts,
         duthost.hostname).vars['ansible_host']
     asic = duthost.asic_instance(enum_frontend_asic_index)
     int_facts = asic.interface_facts()['ansible_facts']
-    interface = get_asic_interface(int_facts)
+    interface = get_asic_interface(int_facts, duthost)
     if interface is None:
         pytest.skip("No active interface present on the asic {}".format(asic))
     queue_cntrs_oid = get_queue_cntrs_oid(interface)


### PR DESCRIPTION
### Description of PR
The snmp queue test should skip the NPU to DPU interfaces on a smartswitch otherwise the test will fail because snmp is not enabled on those interfaces.

Summary:
Fixes # 20935

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
test_snmp_queue failure for smartswitch device

#### How did you do it?
Added code to skip the NPU to DPU interfaces used for testing
#### How did you verify/test it?
Successfully run the  test:
------------------------------------------------------------------------------------ generated xml file: /run_logs/aronovic/snmp/test_snmp_queue_counters.xml ------------------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------
19:06:44 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
=================================================================================================== 1 passed, 2 warnings in 471.36s (0:07:51) 


#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
