### PR TITLE
Remove test_neighbour_mac from vpp test list

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -643,7 +643,6 @@ t1-lag-vpp:
   - arp/test_unknown_mac.py
   - arp/test_arp_extended.py
   - arp/test_tagged_arp.py
-  - arp/test_neighbor_mac.py
   - arp/test_wr_arp.py
   - arp/test_arp_dualtor.py
   - arp/test_stress_arp.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
test_neighbor_mac.py failed due to a race condition in setting IP on Ethernet0. This is because in response to removing Ethernet0 from PortChannel, sonic-vpp needs to update all the affected routes which takes a long time. In the end, setting IP on Ethernet0 happens before the interface is removed from the PortChannel. At the end, the IP on Ethernet0 was not set successfully so ping failed. 
To fix this issue, sonic-vpp has to be more efficient in handling nexthop-group replacement. Until then, this test has to be disabled.
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
