### PR TITLE
skip the zmq gnmi test for smartswitch

### DIFF
--- a/tests/zmq/test_gnmi_zmq.py
+++ b/tests/zmq/test_gnmi_zmq.py
@@ -121,6 +121,9 @@ def test_gnmi_zmq(duthosts,
                   enable_zmq):
     duthost = duthosts[rand_one_dut_hostname]
 
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+        pytest.skip("GNMI ZMQ test is not applicable to smartswitch")
+
     command = 'ps -auxww | grep "/usr/sbin/telemetry -logtostderr --noTLS --port 8080"'
     gnmi_process = duthost.shell(command, module_ignore_errors=True)["stdout"]
     logger.debug("gnmi_process: {}".format(gnmi_process))


### PR DESCRIPTION
### Description of PR
This test is not applicable to smartswitch becasue there is another smartswitch specific test that does similar things and also the telemetry on smartswitch is not started with -noTLS parameter so this test will always fail.
Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506

### Approach
#### What is the motivation for this PR?
Failure of this test when run on smartswitch

#### How did you do it?
Added a skip for the case of smartswitch

#### How did you verify/test it?
============================================================================================================ short test summary info =============================================================================================================
SKIPPED [1] zmq/test_gnmi_zmq.py:115: GNMI ZMQ test is not applicable to smartswitch
========================================================================================================= 1 skipped, 1 warning in 39.18s 

#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
