### PR TITLE
Fix flakyness in test_copp for large topos

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -533,6 +533,15 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost, is_bac
     logging.info("Update the rate limit for the COPP policer")
     copp_utils.limit_policer(dut, rate_limit, test_params.nn_target_namespace, test_params.neighbor_miss_trap_supported)
 
+    if not is_backend_topology:
+        # make sure traffic goes over management port by shutdown bgp toward upstream neigh that gives default route
+        upStreamDuthost.command("sudo config bgp shutdown all")
+        time.sleep(30)
+        # save BGP shutdown into config, so backup_restore_config_db won't bring it back up
+        # without shutting down, background BGP traffic can consume significant COPP bandwidth on large topos
+        if dut == upStreamDuthost:
+            dut.command("sudo config save -y")
+
     # Multi-asic will not support this mode as of now.
     if test_params.swap_syncd:
         logging.info("Swap out syncd to use RPC image...")
@@ -548,11 +557,6 @@ def _setup_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost, is_bac
         # SWSS for the COPP changes to take effect.
         logging.info("Reloading config and restarting swss...")
         config_reload(dut, safe_reload=True, check_intf_up_ports=True)
-
-    if not is_backend_topology:
-        # make sure traffic goes over management port by shutdown bgp toward upstream neigh that gives default route
-        upStreamDuthost.command("sudo config bgp shutdown all")
-        time.sleep(30)
 
     logging.info("Configure syncd RPC for testing")
     copp_utils.configure_syncd(dut, test_params.nn_target_port, test_params.nn_target_interface,
@@ -570,6 +574,12 @@ def _teardown_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost, is_
     logging.info("Restore COPP policer to default settings")
     copp_utils.restore_policer(dut, test_params.nn_target_namespace)
 
+    if not is_backend_topology:
+        # Testbed is not a T1 backend device, so bring up bgp session to upstream device
+        upStreamDuthost.command("sudo config bgp startup all")
+        if dut == upStreamDuthost:
+            dut.command("sudo config save -y")
+
     if test_params.swap_syncd:
         logging.info("Restore default syncd docker...")
         docker.restore_default_syncd(dut, creds, test_params.nn_target_namespace)
@@ -577,11 +587,6 @@ def _teardown_testbed(dut, creds, ptf, test_params, tbinfo, upStreamDuthost, is_
         copp_utils.restore_syncd(dut, test_params.nn_target_namespace)
         logging.info("Reloading config and restarting swss...")
         config_reload(dut, safe_reload=True, check_intf_up_ports=True)
-
-    if not is_backend_topology:
-        # Testbed is not a T1 backend device, so bring up bgp session to upstream device
-        upStreamDuthost.command("sudo config bgp startup all")
-
 
 def _setup_multi_asic_proxy(dut, creds, test_params, tbinfo):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_remove_trap and test_trap_config_save_after_reboot are flaky on large topos like m1-108/128
Root cause:
Class fixture  _setup_testbed shuts down BGP at the beginning of tests but doesn't save the configuration
Function fixture  backup_restore_config_db (used after  test_add_new_trap) brings BGP back up
This causes background BGP traffic to resume, consuming significant COPP bandwidth on large topologies
The increased traffic causes test packet rx_pps to drop below the expected range, leading to test flakiness
Fix:
Save BGP shutdown state in  _setup_testbed and restore it in  _teardown_testbed to maintain consistent BGP state throughout all tests.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix flakyness in test_copp for large topos

#### How did you do it?

Save BGP shutdown into config in _setup_testbed and restore it in _teardown_testbed

#### How did you verify/test it?
Tested on m1-108/128
