### PR TITLE
Fix test_bgp_establish_combo teardown scope

### DIFF
--- a/tests/bgp/test_bgp_establish_combo.py
+++ b/tests/bgp/test_bgp_establish_combo.py
@@ -10,7 +10,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def teardown(duthost):
     yield
     config_reload(duthost, safe_reload=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
tests/bgp/test_bgp_establish_combo.py always fails on IPv6 test cases
Root cause:
IPv4 and IPv6 BGP neighbors doesn't share the same bgp_facts, but share the same DEVICE_NEIGHBOR_METADATA.
IPv4 tests are run first, which modifies DEVICE_NEIGHBOR_METADATA, then IPv6 modify it again with the original neighbor name. 
IPv6 test runs
```sonic-db-cli CONFIG_DB RENAME 'DEVICE_NEIGHBOR_METADATA|ARISTA01MA' 'DEVICE_NEIGHBOR_METADATA|mock-*-v6'```
The command fails because the original name was modified to mock-*-v4 name already, and we can't get it from bgp_facts.
Fix:
Change teardown scope to function, so config_reload is called after every test.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
tests/bgp/test_bgp_establish_combo.py always fails on IPv6 test cases

#### How did you do it?
Renamed neighbor metadata from IPv4 tests are not reset after each test
IPv6 tests use original names and fail due to that, reload config after each test

#### How did you verify/test it?
Tested on m1-48