### PR TITLE
Added Testcases for gNOI OS Service

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -419,7 +419,7 @@ def gnoi_reboot(duthost, method, delay, message):
         return 0, output['stdout']
 
 
-def gnoi_request(duthost, localhost, module, rpc, request_json_data):
+def gnoi_request(duthost, localhost, module, rpc, request_json_data, input_data=None):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     ip = duthost.mgmt_ip
     port = env.gnmi_port
@@ -429,6 +429,10 @@ def gnoi_request(duthost, localhost, module, rpc, request_json_data):
     cmd += "-ca /etc/sonic/telemetry/gnmiCA.pem "
     cmd += "-logtostderr -module {} -rpc {} ".format(module, rpc)
     cmd += f'-jsonin \'{request_json_data}\''
+
+    if input_data:
+        cmd += input_data
+
     output = duthost.shell(cmd, module_ignore_errors=True)
     if output['stderr']:
         logger.error(output['stderr'])


### PR DESCRIPTION
### [UMF] gNOI OS - Install Test Results

**Test Summary :-**
```
gnmi/test_gnoi_os.py::test_gnoi_os_verify PASSED                         [ 20%]
gnmi/test_gnoi_os.py::test_gnoi_os_activate_invalid_image PASSED         [ 40%]
gnmi/test_gnoi_os.py::test_gnoi_os_activate_valid_image PASSED           [ 60%]
gnmi/test_gnoi_os.py::test_gnoi_os_install_valid_image

-------------------------------- live log call ---------------------------------
09:51:52 helper.gnoi_request                      L0409 ERROR  | Error receiving stream: rpc error: code = Unimplemented desc = OS Install not supported
PASSED                                                                   [ 80%]
gnmi/test_gnoi_os.py::test_gnoi_os_install_without_valid_image

-------------------------------- live log call ---------------------------------
09:52:08 helper.gnoi_request                      L0409 ERROR  | --input_file is required for Install RPC
PASSED                                                                   [100%]

=============================== warnings summary ===============================
../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------ generated xml file: /data/sonic-mgmt/tests/logs/tr.xml ------------
=================== 5 passed, 1 warning in 784.40s (0:13:04) ===================

```

**For Entire Test result please refer to the below file :-**
[OS Service Install RPC.log](https://github.com/user-attachments/files/22745841/OS.Service.Install.RPC.log)


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
