### PR TITLE
Port test_fib.py test cases to sonic-vpp platform

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -614,19 +614,19 @@ class HashTest(BaseTest):
                 for member in ecmp_entry:
                     total_entry_hit_cnt += port_hit_cnt.get(member, 0)
                 (p, r) = self.check_within_expected_range(
-                    total_entry_hit_cnt, float(total_hit_cnt) / len(asic_member))
+                    total_entry_hit_cnt, float(total_hit_cnt) / len(asic_member), hash_key)
                 logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
                              % ("ECMP", str(ecmp_entry), total_hit_cnt // len(asic_member),
-                                total_entry_hit_cnt, str(round(p, 4) * 100) + '%'), hash_key)
+                                total_entry_hit_cnt, str(round(p, 4) * 100) + '%'))
                 result &= r
                 if len(ecmp_entry) == 1 or total_entry_hit_cnt == 0:
                     continue
                 for member in ecmp_entry:
                     (p, r) = self.check_within_expected_range(port_hit_cnt.get(
-                        member, 0), float(total_entry_hit_cnt) / len(ecmp_entry))
+                        member, 0), float(total_entry_hit_cnt) / len(ecmp_entry), hash_key)
                     logging.info("%-10s \t %-10s \t %10d \t %10d \t %10s"
                                  % ("LAG", str(member), total_entry_hit_cnt // len(ecmp_entry),
-                                    port_hit_cnt.get(member, 0), str(round(p, 4) * 100) + '%'), hash_key)
+                                    port_hit_cnt.get(member, 0), str(round(p, 4) * 100) + '%'))
                     result &= r
         assert result
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -449,18 +449,10 @@ fib/test_fib.py::test_ecmp_group_member_flap:
     conditions:
       - "asic_type in ['vpp']"
 
-fib/test_fib.py::test_hash:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 fib/test_fib.py::test_ipinip_hash:
   skip:
     reason: >
-            Failed/Errored: To be included
+            Unsupported
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"
@@ -468,7 +460,7 @@ fib/test_fib.py::test_ipinip_hash:
 fib/test_fib.py::test_nvgre_hash:
   skip:
     reason: >
-            Failed/Errored: To be included
+            Unsupported
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"
@@ -476,7 +468,7 @@ fib/test_fib.py::test_nvgre_hash:
 fib/test_fib.py::test_vxlan_hash:
   skip:
     reason: >
-            Failed/Errored: To be included
+            Unsupported
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['vpp']"

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -387,6 +387,11 @@ def hash_keys(duthost):
             hash_keys.remove('src-port')
         if 'dst-port' in hash_keys:
             hash_keys.remove('dst-port')
+    if duthost.facts['asic_type'] in ["vpp"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+        if 'ingress-port' in hash_keys:
+            hash_keys.remove('ingress-port')
     if duthost.facts['asic_type'] in ["mellanox"]:
         if 'ip-proto' in hash_keys:
             hash_keys.remove('ip-proto')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Port test_fib.py to sonic-vpp platform. sonic-vpp has limited support with hash calculation but it does support src-ip, dst-ip, src-port, dst-port. With these, it can support base hash test.
There is also a bug in hash_test.py where hash_key parameter is not provided in the call of check_within_expected_range. 
#### How did you do it?
Specify supported hash-key for vpp platform
Remove skip marker to enable fib/test_fib.py::test_hash
#### How did you verify/test it?
run the test in t1-lag topology
#### Any platform specific information?
This is specific for sonic-vpp
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
