### PR TITLE
Enable traffic test on sonic-vpp

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -195,6 +195,13 @@
       - hostvars[duts_name.split(',')[0]].type is defined
     become: yes
 
+  - name: Create file to store asic type in PTF
+    command: docker exec -i ptf_{{ vm_set_name }} sh -c 'echo {{ hostvars[duts_name.split(',')[0]]['asic_type'] }} > /sonic/asic_type.txt'
+    when:
+      - hostvars[duts_name.split(',')[0]] is defined
+      - hostvars[duts_name.split(',')[0]].asic_type is defined
+    become: yes
+
   - name: Get dut ports
     include_tasks: get_dut_port.yml
     loop: "{{ duts_name.split(',') }}"

--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -53,6 +53,18 @@ def get_dut_type(host):
         logger.info("DUT type file doesn't exist.")
     return "Unknown"
 
+def get_asic_type(host):
+    asic_type_stat = host.stat(path="/sonic/asic_type.txt")
+    if asic_type_stat["stat"]["exists"]:
+        asic_type = host.shell("cat /sonic/asic_type.txt")["stdout"]
+        if asic_type:
+            logger.info("ASIC type is {}".format(asic_type))
+            return asic_type.lower()
+        else:
+            logger.warning("ASIC type file is empty.")
+    else:
+        logger.info("ASIC type file doesn't exist.")
+    return "Unknown"
 
 def get_ptf_image_type(host):
     """
@@ -110,8 +122,9 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
                device_sockets=[], timeout=0, custom_options="",
                module_ignore_errors=False, is_python3=None, async_mode=False, pdb=False):
     dut_type = get_dut_type(host)
+    asic_type = get_asic_type(host)
     kvm_support = params.get("kvm_support", False)
-    if dut_type == "kvm" and kvm_support is False:
+    if dut_type == "kvm" and asic_type != "vpp" and kvm_support is False:
         logger.info("Skip test case {} for not support on KVM DUT".format(testname))
         return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
sonic-vpp dataplane supports traffic although it is also a kvm testbed.

#### How did you do it?
In ptf-runner, check asic-type in addition to dut-type.

#### How did you verify/test it?
Run sonic-mgmt test like test_vxlan_ecmp and verify traffic is sent 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
