### PR TITLE
Add new HWSKU for marvell-teralynx

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -36,7 +36,8 @@ cavium_hwskus: [ "AS7512", "XP-SIM" ]
 barefoot_hwskus: [ "montara", "mavericks", "Arista-7170-64C", "newport", "Arista-7170-32CD-C32" ]
 
 marvell_hwskus: [ "et6448m", "Nokia-7215" ]
-innovium_tl7_hwskus: ["Wistron_sw_to3200k_32x100" , "Wistron_sw_to3200k"]
+marvell-teralynx_tl7_hwskus: ["Wistron_sw_to3200k_32x100" , "Wistron_sw_to3200k"]
+marvell-teralynx_tl10_hwskus: ["dbmvtx9180_64osfp_128x400G_lab"]
 
 cisco_hwskus: ["Cisco-8102-C64", "Cisco-8101-T32", "Cisco-8111-O32", "Cisco-8101-C64", "Cisco-8101-V64", "Cisco-8101-C48T8", "Cisco-8101-O8V48", "Cisco-8101-O8C48", "Cisco-8101C01-C32", "Cisco-8101C01-C28S4", "Cisco-8111-C32", "Cisco-8111-O32", "Cisco-8111-O64", "Cisco-8122-O64", "Cisco-8122-O64S2", "Cisco-8122-O128", "Cisco-8800-LC-48H-C48", "Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36", "cisco-8101-p4-32x100-vs", "Cisco-8102-28FH-DPU-O"]
 cisco-8000_gb_hwskus: ["Cisco-8102-C64", "Cisco-8101-T32", "Cisco-8101-O32", "Cisco-8101-C64", "Cisco-8101-V64", "Cisco-8101-C48T8", "Cisco-8101-O8V48", "Cisco-8101-O8C48", "Cisco-8101C01-C32", "Cisco-8101C01-C28S4", "Cisco-8111-C32", "Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36", "Cisco-8102-28FH-DPU-O", "Cisco-8102-28FH-DPU-O8C40", "Cisco-8102-28FH-DPU-C28", "Cisco-8102-28FH-DPU-O8V40", "Cisco-8102-28FH-DPU-O8C20", "Cisco-8102-28FH-DPU-O12C16"]

--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -504,11 +504,17 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
         elif hwsku == "RA-B6920-4S":
             for i in range(1, 129):
                 port_alias_to_name_map["hundredGigE%d" % i] = "Ethernet%d" % i
-        elif hwsku in ["Wistron_sw_to3200k_32x100", "Wistron_sw_to3200k"]:
+        elif hwsku in ["Wistron_sw_to3200k"]:
             for i in range(0, 256, 8):
+                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+        elif hwsku in ["Wistron_sw_to3200k_32x100"]:
+            for i in range(0, 252, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku in ["dbmvtx9180_64x100G"]:
             for i in range(0, 505, 8):
+                port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
+        elif hwsku in ["dbmvtx9180_64osfp_128x400G_lab"]:
+            for i in range(0, 509, 4):
                 port_alias_to_name_map["Ethernet%d" % i] = "Ethernet%d" % i
         elif hwsku == "Arista-720DT-48S" or hwsku == "Arista-720DT-G48S4":
             for i in range(1, 53):

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -198,7 +198,8 @@ class TestQosSai(QosSaiBase):
         'Arista-7260CX3-Q64',
         'Arista-7050CX3-32S-C32',
         'Arista-7050CX3-32S-C28S4',
-        'Arista-7050CX3-32S-D48C8'
+        'Arista-7050CX3-32S-D48C8',
+        'dbmvtx9180_64osfp_128x400G_lab'
     ]
 
     @pytest.fixture(scope="class", autouse=True)


### PR DESCRIPTION
### Description of PR
This PR introduces the new HWSKU dbmvtx9180_64osfp_128x400G_lab for the Marvell Teralynx ASIC.


### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The purpose of this PR is to extend sonic-mgmt support for the HWSKU dbmvtx9180_64osfp_128x400G_lab, introduced through [sonic-net/sonic-buildimage#23989](https://github.com/sonic-net/sonic-buildimage/pull/23989).

#### How did you do it?

#### How did you verify/test it?
Ran the SONIC PTF test suite for the new hwsku

#### Any platform specific information?
Applicable only for marvell-teralynx platform.

#### Supported testbed topology if it's a new test case?
T0 and T1


