### PR TITLE
Add qos params for topos ft2-64, lt2-p32o64, lt2-o128

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -334,14 +334,14 @@ qos_params:
                     pgs_num: 24
                     pkts_num_hdrm_full: 2853
                     pkts_num_hdrm_partial: 701
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_pfc: 108469
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108442
-                pkts_num_egr_mem: 376
+                    pkts_num_trig_egr_drp: 108443
+                pkts_num_egr_mem: 714
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
                     cell_size: 254
@@ -349,8 +349,8 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111661
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_ingr_drp: 111323
+                    pkts_num_trig_pfc: 108469
                 wm_pg_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -359,7 +359,7 @@ qos_params:
                     pg: 3
                     pkts_num_fill_min: 34
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_pfc: 108469
                 wm_pg_shared_lossy:
                     cell_size: 254
                     dscp: 8
@@ -368,14 +368,14 @@ qos_params:
                     pg: 0
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108442
+                    pkts_num_trig_egr_drp: 108443
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111661
+                    pkts_num_trig_ingr_drp: 111323
                     queue: 3
                 wm_q_shared_lossy:
                     cell_size: 254
@@ -383,36 +383,36 @@ qos_params:
                     ecn: 1
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108442
+                    pkts_num_trig_egr_drp: 108443
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111661
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_ingr_drp: 111323
+                    pkts_num_trig_pfc: 108469
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_margin: 4
-                    pkts_num_trig_ingr_drp: 111661
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_ingr_drp: 111323
+                    pkts_num_trig_pfc: 108469
                 xon_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_pfc: 108469
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 4
-                    pkts_num_trig_pfc: 108807
+                    pkts_num_trig_pfc: 108469
             cell_size: 254
             hdrm_pool_wm_multiplier: 1
             wrr:
@@ -447,7 +447,7 @@ qos_params:
                     - 4
                     dst_port_id: 0
                     ecn: 1
-                    margin: 2
+                    margin: 4
                     pgs:
                     - 3
                     - 4
@@ -460,8 +460,8 @@ qos_params:
                     ecn: 1
                     pg: 0
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108442
-                pkts_num_egr_mem: 376
+                    pkts_num_trig_egr_drp: 108443
+                pkts_num_egr_mem: 714
                 pkts_num_leak_out: 0
                 wm_pg_headroom:
                     cell_size: 254
@@ -488,7 +488,7 @@ qos_params:
                     pg: 0
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108442
+                    pkts_num_trig_egr_drp: 108443
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
@@ -503,7 +503,7 @@ qos_params:
                     ecn: 1
                     pkts_num_fill_min: 7
                     pkts_num_margin: 4
-                    pkts_num_trig_egr_drp: 108442
+                    pkts_num_trig_egr_drp: 108443
                     queue: 0
                 xoff_1:
                     dscp: 3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adds qos test params for:
 - ft2-64
 - lt2-p32o64
 - lt2-o128

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
Manually ran `qos/test_qos_sai.py` tests, output:

```
topo-ft2-64:
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] PASSED                                                                                                                                                                                                                
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic] PASSED
======== 14 passed, 266 skipped, 1 warning in 2989.80s (0:49:49) =====================================

topo-lt2-p32o64:
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic] PASSED
======== 14 passed, 266 skipped, 1 warning in 3483.55s (0:58:03) =====================================

topo-lt2-o128:
qos/test_qos_sai.py::TestQosSai::testParameter[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_1] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXoffLimit[single_asic-xoff_2] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_1] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPfcXonLimit[single_asic-xon_2] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiLossyQueue[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrr[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossless] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgSharedWatermark[single_asic-wm_pg_shared_lossy] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiPgHeadroomWatermark[single_asic] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossless] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiQSharedWatermark[single_asic-wm_q_shared_lossy] PASSED
qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange[single_asic] PASSED
======== 14 passed, 266 skipped, 1 warning in 3559.45s (0:59:19) =====================================
```