### PR TITLE
[single-dut] [masic] Fix for false positive CHASSIS_APP_DB checks for test_po_voq.py

### DIFF
--- a/tests/common/helpers/voq_lag.py
+++ b/tests/common/helpers/voq_lag.py
@@ -154,8 +154,13 @@ def verify_lag_member_in_app_db(asic, pc_member, pc=TMP_PC, expected=True):
 
 def verify_lag_member_in_chassis_db(duthosts, pc_member, pc=TMP_PC, expected=True):
     """Verifies if LAG member exists or not in CHASSIS DB"""
-    for sup in duthosts.supervisor_nodes:
-        voqdb = VoqDbCli(sup)
+    if len(duthosts) == 1:
+        nodes = duthosts.frontend_nodes
+    else:
+        nodes = duthosts.supervisor_nodes
+
+    for dut in nodes:
+        voqdb = VoqDbCli(dut)
         lag_member_list = voqdb.get_lag_member_list()
         exists = False
         pattern = "{}.*{}".format(pc, pc_member)
@@ -164,8 +169,8 @@ def verify_lag_member_in_chassis_db(duthosts, pc_member, pc=TMP_PC, expected=Tru
                 exists = True
                 break
 
-        lag_member_exists_msg = "LAG {} member {} exists in {} CHASSIS_APP_DB".format(pc, pc_member, sup)
-        lag_member_missing_msg = "LAG {} member {} doesn't exist in {} CHASSIS_APP_DB".format(pc, pc_member, sup)
+        lag_member_exists_msg = "LAG {} member {} exists in {} CHASSIS_APP_DB".format(pc, pc_member, dut)
+        lag_member_missing_msg = "LAG {} member {} doesn't exist in {} CHASSIS_APP_DB".format(pc, pc_member, dut)
         lag_member_msg = lag_member_exists_msg if exists else lag_member_missing_msg
         if exists == expected:
             logging.info(lag_member_msg)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes ''_verify_lag_member_in_chassis_db_' method for single-dut multi-asic.
- CHASSIS_APP_DB KEYS *SYSTEM_LAG_MEMBER_TABLE* checks/verifications are not happening if its single-dut node.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

- CHASSIS_APP_DB KEYS *SYSTEM_LAG_MEMBER_TABLE* verifications are not happening if the Dut is single-dut.
- ''_verify_lag_member_in_chassis_db_' checks only if its supervisor node.

#### How did you do it?

- If the number of nodes is 1, select the front_end_nodes and continue with CHASSIS_APP_DB checks and verifications.

#### How did you verify/test it?

- Ran test_po_voq.py tests on single-dut multi-asic node and made sure tests are passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="632" height="527" alt="image" src="https://github.com/user-attachments/assets/95b01a5d-fe9e-4d6c-bc0c-1db1688ca2c3" />