### PR TITLE
[Smartswitch] need to avoid skipping the dash tests on smartswitch

### DIFF
--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -11,7 +11,6 @@ from tests.common.config_reload import config_reload
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t1'),
     pytest.mark.topology('smartswitch'),
     pytest.mark.skip_check_dut_health
 ]

--- a/tests/dash/test_dash_smartswitch_vnet.py
+++ b/tests/dash/test_dash_smartswitch_vnet.py
@@ -14,7 +14,7 @@ ENABLE_GNMI_API = True
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t1'),
+    pytest.mark.topology('smartswitch'),
     pytest.mark.disable_loganalyzer,
     pytest.mark.skip_check_dut_health
 ]

--- a/tests/dash/test_fnic.py
+++ b/tests/dash/test_fnic.py
@@ -14,7 +14,6 @@ from tests.dash.dash_utils import verify_tunnel_packets
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology("t1"),
     pytest.mark.topology("smartswitch"),
     pytest.mark.skip_check_dut_health
 ]


### PR DESCRIPTION
### Description of PR
Need to avoid skipping the dash tests on smartswitch

Summary:
Fixes # #20953

### Type of change

-  [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506

### Approach
#### What is the motivation for this PR?
Under smartswitch topology these dash tests were skipped

#### How did you do it?
Removed the t1 topology marker

#### How did you verify/test it?
Executed the tests

#### Any platform specific information?
Smartswitch

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
