### PR TITLE
Fix test_arp_extended.py::test_proxy_arp failure for IPv6

### DIFF
--- a/tests/arp/test_arp_extended.py
+++ b/tests/arp/test_arp_extended.py
@@ -87,6 +87,12 @@ def test_proxy_arp(rand_selected_dut, proxy_arp_enabled, ip_and_intf_info, ptfad
         ndppd_conf = rand_selected_dut.shell('docker exec swss cat /etc/ndppd.conf',
                                              module_ignore_errors=True)['stdout']
         logger.debug(ndppd_conf)
+        # when there are a large number of routes, ndppd will take long time to read /proc/net/ipv6_route.
+        # instead of sleep for a specific time, we just log the time taken to read the file to match the delay time.
+        # once ndppd performance is improved, this can be removed.
+        ipv6_routes_read_time = rand_selected_dut.shell("docker exec swss bash -c 'time wc -l /proc/net/ipv6_route'")
+        logger.debug("Total ipv6 route entries: {} \n Read time:{}".format(ipv6_routes_read_time['stdout'],
+                                                                           ipv6_routes_read_time['stderr']))
 
         neigh_table = rand_selected_dut.shell('ip -6 neigh')['stdout']
         logger.debug(neigh_table)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the following error on t0-isolated-d96u32s2 topo. 
```
arp/test_arp_extended.py::test_proxy_arp[v6-str5-7060x6-moby-512-1-None] 
-------------------------------- live log call ---------------------------------
03/10/2025 02:10:49 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt_vms91-t0-7060x6-moby-512-1/tests/arp/test_arp_extended.py", line 98, in test_proxy_arp
    testutils.verify_packet(ptfadapter, expected_packet, ptf_intf_index, timeout=10)
  File "/usr/local/lib/python3.8/dist-packages/ptf/testutils.py", line 3250, in verify_packet
    test.fail(
  File "/usr/lib/python3.8/unittest/case.py", line 753, in fail
    raise self.failureException(msg)
AssertionError: Expected packet was not received on device 0, port 32.
```

When ndppd is starting up, it will read the whole ipv6 routes via `/proc/net/ipv6_route`. For  topology with large ipv6 routes and next hops, this reading may take long time to finish.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix test_arp_extended.py::test_proxy_arp failure for large topo.

#### How did you do it?
Add an extra delay in test case by reading `/proc/net/ipv6_route` to match up with the behavior in ndppd.

#### How did you verify/test it?
physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
