### PR TITLE
[test_ro_cleanup.py] Add multi-asic support for stop rsyslogd command

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -104,7 +104,10 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         #
         # Since we don't care about logs from swss for this test case, stop rsyslogd in
         # the swss container completely.
-        duthost.command("docker exec swss supervisorctl stop rsyslogd")
+        for asic_id in duthost.get_asic_ids():
+            if asic_id is None:
+                asic_id = ""
+            duthost.command("docker exec swss{} supervisorctl stop rsyslogd".format(asic_id))
 
         with loganalyzer:
             logging.info("Reloading config..")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20968

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Stop failures of pc/test_ro_cleanup.py on multi-asic platforms due to stop rsyslogd command added in #20327 not working for multi-asic devices
#### How did you do it?
Append asic id to stop rsyslogd command and loop for each asic id
#### How did you verify/test it?
Test on single-asic platform (T1): https://elastictest.org/scheduler/testplan/68e77bdbf92481107107cf05
Test on multi-asic platform (T2): https://elastictest.org/scheduler/testplan/68e786461361e49840cf5bd7
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A