### PR TITLE
[ansible] check for dir before download ceos

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -60,6 +60,9 @@
                 ]
               when: working_image_urls | length == 0
 
+            - name: Ensure {{ root_path }}/images exists
+              file: path={{ root_path }}/images state=directory
+
             - name: Download cEOS image file from working ceos_image_urls using the first working URL
               get_url:
                 url: "{{ working_image_urls[0] }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Check for veos-vm/images directory before download image into it. Create if need to.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Sometimes images dir is not there and there will be error

#### How did you do it?
Check for missing dir

#### How did you verify/test it?
Add topo with no veos-vm dir in server

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
