### PR TITLE
Test_VRF : Reboot_Fix to add check for interface after reboot

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -274,9 +274,11 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
     duthost.shell("cp /tmp/config_db_vrf.json /etc/sonic/config_db.json")
 
     reboot(duthost, localhost)
-    pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),("Not all critical services started within the allotted time after reboot.\n"))
-    pytest_assert(wait_until(180, 20, 0, check_interface_status_of_up_ports, duthost),("Not all admin-up ports are operationally up after reboot.\n"))
- 
+    pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),
+                  ("Not all critical services started within the allotted time after reboot.\n"))
+    pytest_assert(wait_until(180, 20, 0, check_interface_status_of_up_ports, duthost),
+                  ("Not all admin-up ports are operationally up after reboot.\n"))
+
 
 def setup_vlan_peer(duthost, ptfhost, cfg_facts):
     """

--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -16,6 +16,7 @@ from six.moves import queue
 
 import pytest
 
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses  # noqa: F401
 from tests.ptf_runner import ptf_runner
@@ -273,7 +274,9 @@ def setup_vrf_cfg(duthost, localhost, cfg_facts):
     duthost.shell("cp /tmp/config_db_vrf.json /etc/sonic/config_db.json")
 
     reboot(duthost, localhost)
-
+    pytest_assert(wait_until(180, 20, 0, duthost.critical_services_fully_started),("Not all critical services started within the allotted time after reboot.\n"))
+    pytest_assert(wait_until(180, 20, 0, check_interface_status_of_up_ports, duthost),("Not all admin-up ports are operationally up after reboot.\n"))
+ 
 
 def setup_vlan_peer(duthost, ptfhost, cfg_facts):
     """


### PR DESCRIPTION

### Description of PR
Test vrf/test_vrf.py::test_vrf2_neigh failing due to interface not up
This PR add interface check to make sure interfaces are up after reboot before test execution. 

Summary:
This PR adds check to make sure all critical services started within the allotted time after reboot and all admin-up ports are operationally up after reboot.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach

#### How did you do it?
Added a check after reboot

#### How did you verify/test it?
[test_vrf_log.txt](https://github.com/user-attachments/files/22804105/test_vrf_log.txt)

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
