### PR TITLE
Make route_through_default_platforms use correct ip ver command

### DIFF
--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -31,7 +31,11 @@ def route_through_default_routes(host, ip_addr):
     @param ip_addr: The ip address to check
     @return: True if the given up goes to default route, False otherwise
     """
-    output = host.shell("show ip route {} json".format(ip_addr))['stdout']
+    ip_cmd_suffix = ""
+    if ":" in ip_addr:
+        ip_cmd_suffix = "v6"
+
+    output = host.shell("show ip{} route {} json".format(ip_cmd_suffix, ip_addr))['stdout']
     routes_info = json.loads(output)
     ret = True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #20980

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Failures caused by ipv6 address being passed into `route_through_default_platforms`
#### How did you do it?
Change function to use `show ipv6` instead of `show ip` command when ipv6 address was provided
#### How did you verify/test it?
Test passing on platform previously showing failures: https://elastictest.org/scheduler/testplan/68e8ac7105b5e01c1b6aeb27
#### Any platform specific information?
N/A
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
