### PR TITLE
Removing seaborn and matplotlib from imports.py

### DIFF
--- a/tests/snappi_tests/dataplane/imports.py
+++ b/tests/snappi_tests/dataplane/imports.py
@@ -17,11 +17,7 @@ import numpy as np
 # ==============================
 import pytest
 import pandas as pd
-import matplotlib.pyplot as plt
-import matplotlib.colors as mcolors
-import seaborn as sns
 from copy import deepcopy
-from rich import print as pr
 from tabulate import tabulate
 from natsort import natsorted
 from dataclasses import dataclass, field


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Removing seaborn and matplotlib from imports.py
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The modules are not needed as of now
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
