### PR TITLE
Fix: remove redundant 'latest' tag in docker image existence check

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -159,9 +159,9 @@ function pull_sonic_mgmt_docker_image() {
         DOCKER_IMAGES_CMD="docker images --format \"{{.Repository}}:{{.Tag}}\""
         DOCKER_PULL_CMD="docker pull \"${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}\""
 
-        if eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_SONIC_MGMT}:latest$"; then
+        if eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_SONIC_MGMT}$"; then
             IMAGE_ID="${DOCKER_SONIC_MGMT}"
-        elif eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}:latest$"; then
+        elif eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}$"; then
             IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
         elif log_info "pulling docker image from a registry ..." && eval "${DOCKER_PULL_CMD}"; then
             IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The current script appends ':latest' when checking for existing docker images. However, the `DOCKER_SONIC_MGMT` variable already includes the `latest` tag as shown here in this line [`sonic-mgmt/setup-container.sh`](https://github.com/sonic-net/sonic-mgmt/blob/master/setup-container.sh#L8), causing grep to look for `docker-sonic-mgmt:latest:latest` and thus failing to match existing images.

For example, if we already have the image pulled and `docker image ls` shows:
```
REPOSITORY                                            TAG       IMAGE ID       CREATED        SIZE
sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt   latest    0550f2d12fde   4 months ago   3.43GB
```
But the script was running a check like:
`grep "^sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest:latest$"` OR `grep "^docker-sonic-mgmt:latest:latest$"` which works only if the tag is not duplicated. The double `latest` tag causes the condition to fail, resulting in the script attempting to pull the image every time, which make these checks ineffective.

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR removes the hardcoded `:latest` suffix in the grep checks, relying on the tag already present in the `${DOCKER_SONIC_MGMT}` variable. This ensures proper matching of existing images. Avoids unnecessary pulls of images that already exist locally, thereby improving script reliability.

#### How did you do it?
Adjusting the image validation logic instead of removing the latest tag from the initial declaration, because that tag is intentionally used throughout the script, particularly in constructing IMAGE_ID and during the pull step. Modifying the declaration would have introduced inconsistencies or required broader changes. Fixing the check logic ensures the correct behavior without disrupting the existing script flow.

#### How did you verify/test it?
I tested the fix locally by ensuring the image was already pulled. Before the fix, attempting to create the container triggered an unnecessary pull every time. After applying the fix, the script no longer attempts to pull the image if it’s already available, confirming the validation logic now works as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
