### PR TITLE
Fix test_static_route issue import by PR 20793

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -28,6 +28,9 @@ from tests.common.flow_counter.flow_counter_utils import RouteFlowCounterTestCon
 from tests.common.helpers.dut_ports import get_vlan_interface_list, get_vlan_interface_info
 
 
+# packet count for traffic test
+COUNT = 10
+
 pytestmark = [
     pytest.mark.topology('t0', 'm0', 'mx'),
     pytest.mark.device_type('vs')
@@ -122,7 +125,7 @@ def generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, expected_po
     upstream_name = UPSTREAM_NEIGHBOR_MAP[topo_type]
     ptf_upstream_intf = random.choice(get_neighbor_ptf_port_list(duthost, upstream_name, tbinfo))
     ptfadapter.dataplane.flush()
-    testutils.send(ptfadapter, ptf_upstream_intf, pkt, count=10)
+    testutils.send(ptfadapter, ptf_upstream_intf, pkt, count=COUNT)
     testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=expected_ports)
 
 
@@ -256,7 +259,7 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
             duthost.shell("dualtor_neighbor_check.py")
 
         with RouteFlowCounterTestContext(is_route_flow_counter_supported,
-                                         duthost, [prefix], {prefix: {'packets': '1'}}):
+                                         duthost, [prefix], {prefix: {'packets': COUNT}}):
             generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
 
         # Check the route is advertised to the neighbors
@@ -285,7 +288,7 @@ def run_static_route_test(duthost, unselected_duthost, ptfadapter, ptfhost, tbin
             for nexthop_addr in nexthop_addrs:
                 duthost.shell("timeout 1 ping -c 1 -w 1 {}".format(nexthop_addr), module_ignore_errors=True)
             with RouteFlowCounterTestContext(is_route_flow_counter_supported, duthost,
-                                             [prefix], {prefix: {'packets': '1'}}):
+                                             [prefix], {prefix: {'packets': COUNT}}):
                 generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
             check_route_redistribution(duthost, prefix, ipv6)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix test_static_route issue import by PR #20793
Fixes # 
PR #20793 updated send packet count to 10, but did not update the received packet count, so case fail. Now fix the issue
```
Failed: Expected packets value of 1.1.1.0/24 is 1, but got 10
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
