### PR TITLE
Sort in each physical port the subports by indexes in interface_utils.py

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -307,6 +307,8 @@ def get_lport_to_first_subport_mapping(duthost, logical_intfs=None):
     """
     physical_port_indices = get_physical_port_indices(duthost, logical_intfs)
     pport_to_lport_mapping = get_physical_to_logical_port_mapping(physical_port_indices)
+    for sub_ports_list in pport_to_lport_mapping.values():
+        sub_ports_list.sort(key=lambda x: int(x.replace("Ethernet", "")))
     first_subport_dict = {k: pport_to_lport_mapping[v][0] for k, v in physical_port_indices.items()}
     logging.debug("First subports mapping: {}".format(first_subport_dict))
     return first_subport_dict


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Modify the  function get_lport_to_first_subport_mapping  so the interfaces will be sort by index and not by lexicographical sorting because using regular sorting , sort all the subport by lexicographical sorting and not by index sorting, which is the sort that required for the test for getting the first index subport for each port.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The function get_lport_to_first_subport_mapping  assumes that the first value in the list has the lowest index.
However, in cases like ['Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13', 'Ethernet14', 'Ethernet15', 'Ethernet8', 'Ethernet9'],
lexicographical sorting does not preserve the actual numerical order — for example, 'Ethernet10' comes before 'Ethernet8', even though 8 is a lower index.

#### How did you do it?
Sort the subports  in get_lport_to_first_subport_mapping  funtion by the index.
#### How did you verify/test it?
Test it on Nvidia platforms

#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
No.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
