### PR TITLE
Use DPU_APPL_DB to program DASH objects

### DIFF
--- a/tests/dash/gnmi_utils.py
+++ b/tests/dash/gnmi_utils.py
@@ -349,14 +349,14 @@ def apply_messages(
 
         if set_db:
             if proto_utils.ENABLE_PROTO:
-                path = f"/APPL_DB/dpu{dpu_index}/{gnmi_key}:$/root/{filename}"
+                path = f"/DPU_APPL_DB/dpu{dpu_index}/{gnmi_key}:$/root/{filename}"
             else:
-                path = f"/APPL_DB/dpu{dpu_index}/{gnmi_key}:@/root/{filename}"
+                path = f"/DPU_APPL_DB/dpu{dpu_index}/{gnmi_key}:@/root/{filename}"
             with open(env.work_dir + filename, "wb") as file:
                 file.write(message.SerializeToString())
             update_list.append(path)
         else:
-            path = f"/APPL_DB/dpu{dpu_index}/{gnmi_key}"
+            path = f"/DPU_APPL_DB/dpu{dpu_index}/{gnmi_key}"
             delete_list.append(path)
 
     write_gnmi_files(localhost, duthost, ptfhost, env, delete_list, update_list, max_updates_in_single_cmd)
@@ -410,9 +410,9 @@ def apply_gnmi_file(localhost, duthost, ptfhost, dest_path=None, config_json=Non
                 keys = k.split(":", 1)
                 k = keys[0] + "[key=" + keys[1] + "]"
                 if proto_utils.ENABLE_PROTO:
-                    path = "/APPL_DB/%s/%s:$/root/%s" % (host, k, filename)
+                    path = "/DPU_APPL_DB/%s/%s:$/root/%s" % (host, k, filename)
                 else:
-                    path = "/APPL_DB/%s/%s:@/root/%s" % (host, k, filename)
+                    path = "/DPU_APPL_DB/%s/%s:@/root/%s" % (host, k, filename)
                 update_list.append(path)
         elif operation["OP"] == "DEL":
             for k, v in operation.items():
@@ -420,7 +420,7 @@ def apply_gnmi_file(localhost, duthost, ptfhost, dest_path=None, config_json=Non
                     continue
                 keys = k.split(":", 1)
                 k = keys[0] + "[key=" + keys[1] + "]"
-                path = "/APPL_DB/%s/%s" % (host, k)
+                path = "/DPU_APPL_DB/%s/%s" % (host, k)
                 delete_list.append(path)
         else:
             logger.info("Invalid operation %s" % operation["OP"])


### PR DESCRIPTION
 * DASH orchs are supposed to listen to DPU_APPL_DB instead of APPL_DB.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
