### PR TITLE
Enable IPv6 for check_tacacs fixture

### DIFF
--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -9,6 +9,7 @@ from tests.common.utilities import wait_until, check_skip_release, delete_runnin
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.errors import RunAnsibleModuleFail
 from contextlib import contextmanager
+from tests.common.fixtures.duthost_utils import duthost_mgmt_ip     # noqa: F401
 
 # per-command accounting feature not available in following versions
 per_command_accounting_skip_versions = ["201811", "201911", "202106"]
@@ -368,9 +369,9 @@ def check_nss_config(duthost):
 
 
 @pytest.fixture(scope="module")
-def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):    # noqa: F811
+def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds, duthost_mgmt_ip):    # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    tacacs_server_ip = ptfhost.mgmt_ipv6 if ptfhost.mgmt_ipv6 else ptfhost.mgmt_ip
+    tacacs_server_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_ip["version"] == "v6" else ptfhost.mgmt_ip
     tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
 
     # Accounting test case randomly failed, need debug info to confirm NSS config file missing issue.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes various tacacs tests for mgmt IPv6 only setups

Blocked by: https://github.com/sonic-net/sonic-mgmt/pull/20942

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Enable check_tacacs feature to use PTF IPv6 address for a mgmt IPv6 only setup.

Fixes various tests under `tacacs/`

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
