### PR TITLE
Fix config-vm sub command in testbed-cli.sh

### DIFF
--- a/ansible/roles/eos/tasks/main.yml
+++ b/ansible/roles/eos/tasks/main.yml
@@ -37,6 +37,9 @@
   with_items: "{{ properties_list }}"
   when: hostname in configuration and configuration_properties[item] is defined
 
+- set_fact:
+    base_topo: "{{ topo.split('_') | first }}"
+
 - include_tasks: veos.yml
   when: vm_type == "veos"
 

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -710,10 +710,11 @@ function set_l2_mode
 function config_vm
 {
   echo "Configure VM $2"
+  testbed_name=$1
 
-  read_file $1
+  read_file ${testned_name}
 
-  ansible-playbook -i $vmfile eos.yml --vault-password-file="$3" -l "$2" -e topo="$topo" -e VM_base="$vm_base"
+  ansible-playbook -i $vmfile eos.yml --vault-password-file="$3" -l "$2" -e vm_type="$vm_type" -e vm_set_name="$vm_set_name" -e topo="$topo" -e VM_base="$vm_base"
 
   echo Done
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The `config-vm` command was broken because some parameters are not given, including `testned_name` and `vm_type`.
This PR addressed this issue by adding the missing parameters.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to fix `config-vm` subcommand in `testbed-cli.sh`.

#### How did you do it?
This PR addressed this issue by adding the missing parameters.

#### How did you verify/test it?
The change is verified by running it to config a VM. It can complete successfully after this change.
<img width="3798" height="768" alt="image" src="https://github.com/user-attachments/assets/17dc12ce-28bb-47fc-8fc8-55d293275917" />

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
