### PR TITLE
fix test_lag_member_traffic flaky failure

### DIFF
--- a/tests/pc/test_lag_member.py
+++ b/tests/pc/test_lag_member.py
@@ -27,6 +27,7 @@ else:
     UNICODE_TYPE = unicode      # noqa: F821
 
 PTF_LAG_NAME = "bond1"
+PTF_LAG_MAC = "00:11:22:33:44:66"
 DUT_LAG_NAME = "PortChannel1"
 # Definition of behind or not behind:
 # Port behind lag means ports that in a lag, port not behind lag means ports that not in a lag.
@@ -200,6 +201,10 @@ def setup_ptf_lag(ptfhost, ptf_ports):
     for _, port_name in list(ptf_ports[ATTR_PORT_BEHIND_LAG].items()):
         ptfhost.add_intf_to_lag(PTF_LAG_NAME, port_name)
 
+    # Setup MAC manually for bond interface to avoid packets being dropped on leaf fanout or root fanout.
+    # The original MAC of bond interface can be seen in /proc/net/bonding/bond1.
+    # and will be restored when ptf lag is deleted.
+    ptfhost.shell("ip link set {} address {}".format(PTF_LAG_NAME, PTF_LAG_MAC))
     ptfhost.startup_lag(PTF_LAG_NAME)
     ptfhost.add_ip_to_dev(ptf_ports[ATTR_PORT_NOT_BEHIND_LAG]["port_name"], port_not_behind_lag_ip)
     ptfhost.ptf_nn_agent()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the following error in `pc/test_lag_member.py::test_lag_member_traffic`

```
pc/test_lag_member.py::test_lag_member_traffic                                                                                  
-------------------------------- live log call ---------------------------------
15/10/2025 02:37:59 ptf_runner.ptf_runner                    L0221 ERROR  | Exception caught while executing case: lag_test.LagMemberTrafficTest. Error message: Traceback (most recent call last):
  File "/data/sonic-mgmt-int-th5/tests/ptf_runner.py", line 206, in ptf_runner
    result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors, module_async=async_mode)
  File "/data/sonic-mgmt-int-th5/tests/common/devices/base.py", line 131, in _run
    raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), res)
tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
failed = True                                                                                                                   
changed = True                                                                                                                  
rc = 1                                                                                                                          
cmd = /root/env-python3/bin/ptf --test-dir acstests/py3 lag_test.LagMemberTrafficTest --platform-dir /root/ptftests --platform remote -t 'dut_mac='"'"'b4:92:fe:21:b5:44'"'"';dut_vlan={'"'"'id'"'"': 109, '"'"'ip'"'"': '"'"'192.168.9.1/24'"'"'};ptf_lag={'"'"
'port_list'"'"': ['"'"'eth1'"'"', '"'"'eth3'"'"', '"'"'eth4'"'"', '"'"'eth5'"'"', '"'"'eth6'"'"', '"'"'eth7'"'"', '"'"'eth8'"'"', '"'"'eth9'"'"'], '"'"'ip'"'"': '"'"'192.168.9.2/24'"'"'};port_not_behind_lag={'"'"'port_id'"'"': 10, '"'"'port_name'"'"': '"'"
'eth10'"'"', '"'"'ip'"'"': '"'"'192.168.9.3/24'"'"'};kvm_support=True' --relax --debug info
start = 2025-10-15 02:36:34.114688                                                                                              
end = 2025-10-15 02:36:37.522235                                                                                                
delta = 0:00:03.407547        
msg = non-zero return code                                                                                                      
invocation = {'module_args': {'chdir': '/root', '_raw_params': '/root/env-python3/bin/ptf --test-dir acstests/py3 lag_test.LagMemberTrafficTest --platform-dir /root/ptftests --platform remote -t \'dut_mac=\'"\'"\'b4:92:fe:21:b5:44\'"\'"\';dut_vlan={\'"\'"\
'id\'"\'"\': 109, \'"\'"\'ip\'"\'"\': \'"\'"\'192.168.9.1/24\'"\'"\'};ptf_lag={\'"\'"\'port_list\'"\'"\': [\'"\'"\'eth1\'"\'"\', \'"\'"\'eth3\'"\'"\', \'"\'"\'eth4\'"\'"\', \'"\'"\'eth5\'"\'"\', \'"\'"\'eth6\'"\'"\', \'"\'"\'eth7\'"\'"\', \'"\'"\'eth8\'"\'
"\', \'"\'"\'eth9\'"\'"\'], \'"\'"\'ip\'"\'"\': \'"\'"\'192.168.9.2/24\'"\'"\'};port_not_behind_lag={\'"\'"\'port_id\'"\'"\': 10, \'"\'"\'port_name\'"\'"\': \'"\'"\'eth10\'"\'"\', \'"\'"\'ip\'"\'"\': \'"\'"\'192.168.9.3/24\'"\'"\'};kvm_support=True\' --rel
ax --debug info', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = None                                                                                                          
stdout =                                                                                                                        
Using packet manipulation module: ptf.packet_scapy                                                                              
                                                                
******************************************
ATTENTION: SOME TESTS DID NOT PASS!!!
                                                                                                                                
The following tests failed:
LagMemberTrafficTest

******************************************stderr =
lag_test.LagMemberTrafficTest ... FAIL

======================================================================
FAIL: lag_test.LagMemberTrafficTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/acstests/py3/lag_test.py", line 257, in runTest
    self.run_ptf_to_dut_traffic_test()
  File "/root/acstests/py3/lag_test.py", line 223, in run_ptf_to_dut_traffic_test
    self.send_and_verify_packets(send_pkt, masked_exp_pkt, port_behind_lag, self.lag_ports)
  File "/root/acstests/py3/lag_test.py", line 205, in send_and_verify_packets
    verify_packet_any_port(self, exp_pkt, dst_ports)
  File "/root/env-python3/lib/python3.11/site-packages/ptf/testutils.py", line 3442, in verify_packet_any_port
    test.fail(
AssertionError: Did not receive expected packet on any of ports [1, 3, 4, 5, 6, 7, 8, 9] for device 0.
========== EXPECTED ==========
Mask:

packet status: OK
packet:
0000  98 03 9B 03 20 01 B4 92 FE 21 B5 44 08 00 45 00  .... ....!.D..E.
0010  00 56 00 01 00 00 40 01 E7 52 C0 A8 09 01 C0 A8  .V....@..R......
0020  09 02 00 00 8A 8A 00 00 00 00 30 30 30 30 30 30  ..........000000
0030  30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30  0000000000000000
0040  30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30  0000000000000000
0050  30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30  0000000000000000
0060  30 30 30 30                                      0000
.......
```

The reason for the failure is the MAC of the port-channel is same as port 32.  because of port32-39 are all in vlan 1000, so on the leaf or root fanout, you will see the MAC address being learnt as following:
```
leaf-fanout#show mac address-table | grep 2001
 250    9803.9b03.2001    DYNAMIC     Et64/1     1       8:40:57 ago       >>>> towards PTF
 251    9803.9b03.2001    DYNAMIC     Et3/1      1       0:03:36 ago        >>>> towards DUT
 252    9803.9b03.2001    DYNAMIC     Et4/1      2       0:03:36 ago
 253    9803.9b03.2001    DYNAMIC     Et5/1      2       0:03:36 ago
 254    9803.9b03.2001    DYNAMIC     Et6/1      2       0:03:36 ago
 255    9803.9b03.2001    DYNAMIC     Et7/1      2       0:03:36 ago
 256    9803.9b03.2001    DYNAMIC     Et8/1      2       0:03:36 ago
 257    9803.9b03.2001    DYNAMIC     Et9/1      3       0:03:36 ago
 258    9803.9b03.2001    DYNAMIC     Et10/1     2       0:03:36 ago
 259    9803.9b03.2001    DYNAMIC     Et11/1     1       0:03:36 ago
 260    9803.9b03.2001    DYNAMIC     Et12/1     1       0:03:36 ago
 261    9803.9b03.2001    DYNAMIC     Et13/1     1       0:03:36 ago
 262    9803.9b03.2001    DYNAMIC     Et14/1     1       0:03:36 ago
 263    9803.9b03.2001    DYNAMIC     Et15/1     1       0:03:36 ago
 264    9803.9b03.2001    DYNAMIC     Et16/1     1       0:03:36 ago
 265    9803.9b03.2001    DYNAMIC     Et17/1     1       0:03:36 ago
 266    9803.9b03.2001    DYNAMIC     Et18/1     1       0:03:36 ago
 267    9803.9b03.2001    DYNAMIC     Et19/1     1       0:03:36 ago
 268    9803.9b03.2001    DYNAMIC     Et20/1     1       0:03:36 ago
 269    9803.9b03.2001    DYNAMIC     Et21/1     1       0:03:36 ago
 270    9803.9b03.2001    DYNAMIC     Et22/1     1       0:03:36 ago
 271    9803.9b03.2001    DYNAMIC     Et23/1     1       0:03:36 ago
 272    9803.9b03.2001    DYNAMIC     Et24/1     1       0:03:36 ago
 273    9803.9b03.2001    DYNAMIC     Et25/1     1       0:03:36 ago
2686    9803.9b03.2001    DYNAMIC     Et64/1     1       7:45:52 ago
......
```

In the above output, port-channel is for Et1/1, Et3/1---Et9/1. 

When DUT responds to PTF, dst MAC is ptf bond1's MAC: 9803.9b03.2001. However, if the link used in the port-channel is Et3/1, the packet will be dropped on leaf-fanout as incoming interface is same as outgoing interface. Hence, ARP reply or ICMP reply won't reach PTF, causing packet being dropped.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Fix intermittent failure in test_lag_member_traffic.

#### How did you do it?
Use a new MAC instead to avoid being impacted by pre-existing traffic.

#### How did you verify/test it?
on local testbed.  Ran 10 times, all passed.  Previously, the failure rate is around 4 out of 10.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
