### PR TITLE
set the protocol field to 'kernel' in generate_route_file

### DIFF
--- a/tests/route/utils.py
+++ b/tests/route/utils.py
@@ -83,6 +83,7 @@ def generate_route_file(duthost, prefixes, str_intf_nexthop, dir, op):
         route = {}
         route["ifname"] = str_intf_nexthop["ifname"]
         route["nexthop"] = str_intf_nexthop["nexthop"]
+        route["protocol"] = "kernel"
         route_command = {}
         route_command[key] = route
         route_command["OP"] = op


### PR DESCRIPTION
Analysis provided by @dgsudharsan:
> With fib suppression enabled sonic is expected to ack with protocol field to zebra
> However the protocol field is set as empty in the swssconfig loaded for every route. This when converted to int crashes. The protocl field is mandatory. Request to set protocol field in the test to avoid the log

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Avoid the fpmsyncd crash

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
