### PR TITLE
Enhance the nhop test to override packet loss on weak server

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -20,6 +20,7 @@ from tests.common.utilities import wait_until
 from tests.common.platform.device_utils import fanout_switch_port_lookup, toggle_one_link
 
 CISCO_NHOP_GROUP_FILL_PERCENTAGE = 0.92
+PTF_QUEUE_LEN = 100000
 
 pytestmark = [
     pytest.mark.topology('t1', 't2', 'm1')
@@ -520,7 +521,7 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
             pkt, exp_pkt = build_pkt(rtr_mac, ip_route, ip_ttl, flow_count)
             testutils.send(ptfadapter, gather_facts['dst_port_ids'][0], pkt, 10)
             verify_result = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
-                                                             ports=gather_facts['src_port_ids'])
+                                                             ports=gather_facts['src_port_ids'], timeout=30)
             if isinstance(verify_result, bool):
                 logger.info("Using dummy testutils to skip traffic test.")
                 return
@@ -558,6 +559,7 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
                           f"Static route: {ip_prefix} is failed to be programmed!")
 
             ptfadapter.dataplane.flush()
+            ptfadapter.dataplane.set_qlen(PTF_QUEUE_LEN)
 
             built_and_send_tcp_ip_packet()
 
@@ -950,9 +952,10 @@ def test_nhop_group_interface_flap(duthosts, enum_rand_one_per_hwsku_frontend_ho
         time.sleep(sleep_seconds)
         duthost.shell("portstat -c")
         ptfadapter.dataplane.flush()
+        ptfadapter.dataplane.set_qlen(PTF_QUEUE_LEN)
         testutils.send(ptfadapter, gather_facts['dst_port_ids'][0], pkt, pkt_count)
         verify_result = testutils.verify_packet_any_port(test=ptfadapter, pkt=exp_pkt,
-                                                         ports=gather_facts['src_port_ids'])
+                                                         ports=gather_facts['src_port_ids'], timeout=30)
         if isinstance(verify_result, bool):
             logger.info("Using dummy testutils to skip traffic test.")
             return


### PR DESCRIPTION
When there is BGP update packets affected the packet would loss on weak server
Enhance the script to override it


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When there is BGP update packets affection, the dataplane packet would be lost on the weak performance server
Enhance the script to override it

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Nhop test dataplane packet loss sometimes.
#### How did you do it?
Enhance the test:
1. Set a big ptf queue size
2. Set a big ptf timeout value to wait for ptf process if there are BGP updates packets.
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
