### PR TITLE
Update the onyx docker check step

### DIFF
--- a/ansible/roles/fanout/tasks/mlnx/check_pfcwd_fanout.yml
+++ b/ansible/roles/fanout/tasks/mlnx/check_pfcwd_fanout.yml
@@ -10,6 +10,10 @@
   register: output
   args:
     login: "{{ switch_login['MLNX-OS'] }}"
+    enable: no
+  retries: 5
+  delay: 5
+  until: output.stdout is defined and 'pfc_storm' in output.stdout
 
 - set_fact:
     dockers_installed: "{{output.stdout|search(\"pfc_storm\")}}"

--- a/ansible/roles/fanout/templates/mlnx_check_pfcwd_fanout.j2
+++ b/ansible/roles/fanout/templates/mlnx_check_pfcwd_fanout.j2
@@ -1,4 +1,5 @@
+enable
+
 config t
 
 show docker ps
-show docker images


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The order of 'enable' command sent by apsswitch.py and 'config t' sent by mlnx_check_pfcwd_fanout.j2 was not correct due to time delay on some onyx switch
So improve this part to make sure the command 'enable' was always ahead of the command 'config t'


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Show docker failure during deploy pfcwd docker to onyx fanout switch
#### How did you do it?
Make sure the command 'enable' was always ahead of the command 'config t'
#### How did you verify/test it?
Run it locally
#### Any platform specific information?
Onyx fanout switch
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
