### PR TITLE
[FRR]Remove show thread commands as they are deprecated in FRR 10.x versions

### DIFF
--- a/tests/show_techsupport/tech_support_cmds.py
+++ b/tests/show_techsupport/tech_support_cmds.py
@@ -79,8 +79,6 @@ frr_cmds = [
     "vtysh{} -c 'show mpls table'",
     "vtysh{} -c 'show mpls fec'",
     "vtysh{} -c 'show nexthop-group rib'",
-    "vtysh{} -c 'show thread cpu'",
-    "vtysh{} -c 'show thread poll'",
     "vtysh{} -c 'show debugging hashtable'",
     "vtysh{} -c 'show work-queues'",
     "vtysh{} -c 'show memory'",


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Following the change https://github.com/sonic-net/sonic-utilities/pull/4073 the test needs to be aligned. Since we have a circular dependency, removing the "show thread" commands first.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
