### PR TITLE
Fix bgp_update_timer test for t2 single node min-topo

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -447,8 +447,12 @@ def setup_interfaces(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfhos
             interfaces = []
             used_subnets = set()
             asic_idx = 0
-            if mg_facts["minigraph_interfaces"]:
-                for intf in mg_facts["minigraph_interfaces"]:
+            mg_interfaces = mg_facts["minigraph_interfaces"]
+            if mg_interfaces:
+                if tbinfo["topo"]["name"] == "t2_single_node_min":
+                    mg_interfaces = sorted(mg_facts["minigraph_interfaces"],
+                                           key=lambda x: int(x['attachto'].replace("Ethernet", "")))
+                for intf in mg_interfaces:
                     if (is_matching_ip_version(intf["addr"])):
                         intf_asic_idx = duthost.get_port_asic_instance(intf["attachto"]).asic_index
                         if not interfaces:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR fixes the following issue, where _test_bgp_update_timer_ tests fail with for t2_single_node_min topo multi-asic duts.

```shell
>       pytest_assert(
            conn0_ns == conn1_ns,
            "Test fail for conn0 on {} and conn1 on {} \
                      started on different asics!".format(
                conn0_ns, conn1_ns
            ),
        )
E       Failed: Test fail for conn0 on asic0 and conn1 on asic1                   started on different asics!
``` 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To fix the following issue w.r.t T2 single node min topo duts.

```shell
>       pytest_assert(
            conn0_ns == conn1_ns,
            "Test fail for conn0 on {} and conn1 on {} \
                      started on different asics!".format(
                conn0_ns, conn1_ns
            ),
        )
E       Failed: Test fail for conn0 on asic0 and conn1 on asic1                   started on different asics!
``` 

#### How did you do it?

- Sort the minigraph_interfaces before selecting the interfaces to test so that even in the case of min-topo, interfaces could be selected from the same asic instance.
- Test requires interfaces to be selected on same asic.

#### How did you verify/test it?

- Ran tests on t2 single node min-topo as well as on max-topo duts and made sure _test_bgp_update_timer_ are passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="479" height="80" alt="image" src="https://github.com/user-attachments/assets/312fa9f8-85b7-4d49-ac5f-5fb015702538" />
