### PR TITLE
Fix vtysh 'received-routes' command for multi-asic duts - bgp_update_timer

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -438,6 +438,16 @@ def check_results(results):
                   'Unexpected routes on neighbors, failed_results={}'.format(json.dumps(failed_results, indent=2)))
 
 
+def check_routes_presence(result, prefix):
+    # Filter the route output
+    matched_lines = [line for line in result["stdout"].splitlines() if prefix in line]
+
+    if matched_lines:
+        logging.info("Found prefix {} in BGP received-routes: {}".format(prefix, matched_lines))
+    else:
+        logging.warning("Prefix {} not found in BGP received-routes".format(prefix))
+
+
 def check_routes_on_neighbors_empty_allow_list(nbrhosts, setup, permit=True):
     """
     Check routes result for neighbors in parallel without applying allow list

--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -14,7 +14,8 @@ from scapy.contrib import bgp
 from tests.bgp.bgp_helpers import (
         capture_bgp_packages_to_file,
         fetch_and_delete_pcap_file,
-        is_neighbor_sessions_established
+        is_neighbor_sessions_established,
+        check_routes_presence
 )
 from tests.common.helpers.bgp import BGPNeighbor
 from tests.common.utilities import wait_until, delete_running_config
@@ -337,33 +338,22 @@ def test_bgp_update_timer_single_route(
         for i, route in enumerate(constants.routes):
             bgp_pcap = BGP_LOG_TMPL % i
             with capture_bgp_packages_to_file(duthost, "any", bgp_pcap, n0.namespace):
+                asichost = duthost.asic_instance_from_namespace(n0.namespace)
                 n0.announce_route(route)
                 time.sleep(constants.sleep_interval)
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} received-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n0.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} advertised-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n1.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n0.ip))
+                check_routes_presence(res, route["prefix"])
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n1.ip))
+                check_routes_presence(res, route["prefix"])
                 n0.withdraw_route(route)
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} received-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n0.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
-                duthost.shell(
-                    "vtysh -c 'show {} neighbors {} advertised-routes' | grep '{}'".format(
-                        "bgp ipv6" if is_v6_topo else "ip bgp", n1.ip, route["prefix"]
-                    ),
-                    module_ignore_errors=True,
-                )
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n0.ip))
+                check_routes_presence(res, route["prefix"])
+                res = asichost.run_vtysh(
+                    " -c \'show ip bgp neighbors {} received-routes\'".format(n1.ip))
+                check_routes_presence(res, route["prefix"])
                 time.sleep(constants.sleep_interval)
 
             local_pcap_filename = fetch_and_delete_pcap_file(bgp_pcap, constants.log_dir, duthost, request)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes the following "_vtysh_" command execution on multi-asic duts, which throws the following error for '_test_bgp_update_timer_' tests.

_`AnsibleModule::shell Result => {"failed": true, "changed": true, "stdout": "", "stderr": "Usage: /usr/bin/vtysh -n [0 to 1] [OPTION]... ", "rc": 1, "cmd": "vtysh -c 'show ip bgp neighbors 20.0.0.1 received-routes' | grep '10.10.100.0/27'",`_ 

```shell
L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#144: [ixr-x3b-16] AnsibleModule::shell, args=["vtysh -c 'show ip bgp neighbors 20.0.0.1 received-routes' | grep '10.10.100.0/27'"], kwargs={"module_ignore_errors": true}

L0108 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#144: [ixr-x3b-16] AnsibleModule::shell Result => {"failed": true, "changed": true, "stdout": "", "stderr": "Usage: /usr/bin/vtysh -n [0 to 1] [OPTION]... ", "rc": 1, "cmd": "vtysh -c 'show ip bgp neighbors 20.0.0.1 received-routes' | grep '10.10.100.0/27'", "start": "2025-09-12 23:30:58.043409", "end": "2025-09-12 23:30:58.055180", "delta": "0:00:00.011771", "msg": "non-zero return code", "invocation": {"module_args": {"_raw_params": "vtysh -c 'show ip bgp neighbors 20.0.0.1 received-routes' | grep '10.10.100.0/27'", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": ["Usage: /usr/bin/vtysh -n [0 to 1] [OPTION]... "], "_ansible_no_log": null}
``` 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

- On multi-asic duts, '_vtysh_' commands for debugging are not executed and throws the following error,
`AnsibleModule::shell Result => {"failed": true, "changed": true, "stdout": "", "stderr": "Usage: /usr/bin/vtysh -n [0 to 1] [OPTION]... ", "rc": 1, "cmd": "vtysh -c 'show ip bgp neighbors 20.0.0.1 received-routes' | grep '10.10.100.0/27'", `

#### How did you do it?

- Fetch asichost and call '_run_vtysh_' commands to get the received-routes detail for both single-asic and multi-asic duts.

#### How did you verify/test it?

- Ran 'test_bgp_update_timer' tests on T2 duts and made sure tests are passing.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
<img width="1789" height="230" alt="image" src="https://github.com/user-attachments/assets/398cf047-c7f4-4b6c-a414-99569cb5c100" />
