### PR TITLE
[202411] Add multi binding acl test into everflow test scope

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ from tests.common.helpers.inventory_utils import trim_inventory
 from tests.common.utilities import InterruptableThread
 from tests.common.plugins.ptfadapter.dummy_testutils import DummyTestUtils
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.mellanox_data import is_mellanox_device
 
 try:
     from tests.common.macsec import MacsecPluginT2, MacsecPluginT0
@@ -2890,3 +2891,42 @@ def setup_pfc_test(
 
     logger.info("setup_info : {}".format(setup_info))
     yield setup_info
+
+
+def is_sai_profile_multi_binding_enabled(duthost):
+    """
+    Check if SAI_ACL_MULTI_BINDING_ENABLED is enabled in syncd docker's sai.profile
+
+    Args:
+        duthost: DUT host object
+
+    Returns:
+        bool: True if SAI_ACL_MULTI_BINDING_ENABLED=1 exists in sai.profile, False otherwise
+    """
+    try:
+        # Check if sai.profile exists in syncd docker
+        result = duthost.shell(
+            "docker exec syncd ls /tmp/sai.profile", module_ignore_errors=True)
+        if result['rc'] != 0:
+            return False
+
+        # Check if SAI_ACL_MULTI_BINDING_ENABLED=1 exists in the file
+        result = duthost.shell(
+            "docker exec syncd grep 'SAI_ACL_MULTI_BINDING_ENABLED=1' /tmp/sai.profile", module_ignore_errors=True)
+        return result['rc'] == 0
+    except Exception as e:
+        logger.error("Failed to check sai.profile: %s", str(e))
+        return False
+
+
+@pytest.fixture(scope="module")
+def is_multi_binding_acl_enabled(duthosts, tbinfo):
+    """
+    Check if multi-binding ACL is enabled on the DUT
+    """
+    for duthost in duthosts:
+        if not is_sai_profile_multi_binding_enabled(duthost):
+            if is_mellanox_device(duthost) and 'dualtor' in tbinfo['topo']['name']:
+                pytest.fail(
+                    "No multi-binding ACL supported on this platform, please check the sai.profile")
+            pytest.skip("No multi-binding ACL supported on this platform")

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -18,6 +18,7 @@ from ptf.mask import Mask
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import find_duthost_on_role
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
 # TODO: Add suport for CONFIGLET mode
@@ -378,6 +379,28 @@ def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario):
     time.sleep(60)
 
 
+def validate_asic_route(duthost, prefix):
+    """
+    Check if a route exists in the routing table of the asic.
+    """
+    asicdb = AsicDbCli(duthost)
+    route_table = asicdb.dump("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+    if prefix in str(route_table):
+        return True
+    return False
+
+
+def validate_mirror_session_up(duthost, session_name):
+    """
+    Check if a mirror session is up.
+    """
+    cmd = f'sonic-db-cli STATE_DB HGET \"MIRROR_SESSION_TABLE|{session_name}\" status'
+    mirror_status = duthost.command(cmd)['stdout']
+    if 'active' in mirror_status:
+        return True
+    return False
+
+
 # TODO: This should be refactored to some common area of sonic-mgmt.
 def add_route(duthost, prefix, nexthop, namespace):
     """
@@ -452,7 +475,7 @@ def setup_arp_responder(duthost, ptfhost, setup_info):
 
 
 # TODO: This should be refactored to some common area of sonic-mgmt.
-def get_neighbor_info(duthost, dest_port, tbinfo, resolved=True):
+def get_neighbor_info(duthost, dest_port, tbinfo, resolved=True, ip_version=4):
     """
     Get the IP and MAC of the neighbor on the specified destination port.
 
@@ -462,13 +485,13 @@ def get_neighbor_info(duthost, dest_port, tbinfo, resolved=True):
         resolved: Whether to return a resolved route or not
     """
     if not resolved:
-        return "20.20.20.100"
+        return "20.20.20.100" if ip_version == 4 else "2020::20:20:20:100"
 
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     for bgp_peer in mg_facts["minigraph_bgp"]:
         if bgp_peer["name"] == mg_facts["minigraph_neighbors"][dest_port]["name"] \
-                and ipaddr.IPAddress(bgp_peer["addr"]).version == 4:
+                and ipaddr.IPAddress(bgp_peer["addr"]).version == ip_version:
             peer_ip = bgp_peer["addr"]
             break
 
@@ -745,6 +768,47 @@ class BaseEverflowTest(object):
         """
         pass
 
+    def remove_outer_ip(self, packet_data):
+        """
+        The mirror packet from IP in IP tunnel would take an external IP header.
+        Remove the outer IP header from the IPinIP packet and keeps the original Ethernet header.
+
+        Args:
+            packet_data: Original IPinIP packet
+
+        Returns:
+            scapy.Ether: Original Ethernet header + Inner IP header + payload
+        """
+        if isinstance(packet_data, bytes):
+            outer_pkt = Ether(packet_data)  # noqa: F821
+        else:
+            outer_pkt = packet_data
+
+        if not outer_pkt.haslayer(IP):      # noqa: F821
+            return None
+
+        outer_ip = outer_pkt[IP]            # noqa: F821
+
+        if outer_ip.proto != 4:
+            return None
+
+        # Extract the original Ethernet header
+        original_eth = outer_pkt[Ether]     # noqa: F821
+        eth_dst = original_eth.dst
+        eth_src = original_eth.src
+        eth_type = 0x0800
+
+        inner_payload = outer_ip.payload
+
+        # If the payload is Raw type, we need to re-parse it as IP
+        if isinstance(inner_payload, Raw):  # noqa: F821
+            inner_ip_packet = IP(bytes(inner_payload))   # noqa: F821
+        else:
+            inner_ip_packet = inner_payload
+        new_packet = Ether(dst=eth_dst, src=eth_src, type=eth_type) / inner_ip_packet  # noqa: F821
+
+        return new_packet
+
     def send_and_check_mirror_packets(self,
                                       setup,
                                       mirror_session,
@@ -755,8 +819,8 @@ class BaseEverflowTest(object):
                                       src_port=None,
                                       dest_ports=None,
                                       expect_recv=True,
-                                      valid_across_namespace=True):
-
+                                      valid_across_namespace=True,
+                                      multi_binding_acl=False):
         # In Below logic idea is to send traffic in such a way so that mirror traffic
         # will need to go across namespaces and within namespace. If source and mirror destination
         # namespace are different then traffic mirror will go across namespace via (backend asic)
@@ -797,7 +861,8 @@ class BaseEverflowTest(object):
                                                                                  duthost,
                                                                                  direction,
                                                                                  mirror_packet,
-                                                                                 src_port_metadata_map[src_port][1])
+                                                                                 src_port_metadata_map[src_port][1],
+                                                                                 multi_binding_acl=multi_binding_acl)
             # Avoid changing the original packet
             mirror_packet_sent = mirror_packet.copy()
             if src_port_metadata_map[src_port][0]:
@@ -819,7 +884,9 @@ class BaseEverflowTest(object):
                 _, received_packet = result
                 logging.info("Received packet: %s", packet.Ether(received_packet).summary())
 
-                inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet_sent))
+                inner_packet = self._extract_mirror_payload(received_packet, len(mirror_packet_sent),
+                                                            multi_binding_acl=multi_binding_acl)
+
                 logging.info("Received inner packet: %s", inner_packet.summary())
 
                 inner_packet = Mask(inner_packet)
@@ -847,6 +914,12 @@ class BaseEverflowTest(object):
                     inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
                     inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
 
+                if multi_binding_acl:
+                    inner_packet.set_do_not_care_scapy(packet.Ether, "dst")
+                    inner_packet.set_do_not_care_scapy(packet.Ether, "src")
+                    inner_packet.set_do_not_care_scapy(packet.IP, "chksum")
+                    inner_packet.set_do_not_care_scapy(packet.IP, "ttl")
+
                 logging.info("Expected inner packet: %s", mirror_packet_sent.summary())
                 pytest_assert(inner_packet.pkt_match(mirror_packet_sent),
                               "Mirror payload does not match received packet")
@@ -854,15 +927,24 @@ class BaseEverflowTest(object):
                 testutils.verify_no_packet_any(ptfadapter, expected_mirror_packet, dest_ports)
 
     @staticmethod
-    def get_expected_mirror_packet(mirror_session, setup, duthost, direction, mirror_packet, ttl_dec):
+    def get_expected_mirror_packet(mirror_session, setup, duthost, direction, mirror_packet, ttl_dec,
+                                   multi_binding_acl=False):
         payload = mirror_packet.copy()
 
         # Add vendor specific padding to the packet
         if duthost.facts["asic_type"] in ["mellanox"]:
             if six.PY2:
-                payload = binascii.unhexlify("0" * 44) + str(payload)
+                if multi_binding_acl:
+                    payload = binascii.unhexlify("0" * 44) + str(payload)[:24] + binascii.unhexlify("0" * 40) + \
+                        str(payload)[24:]
+                else:
+                    payload = binascii.unhexlify("0" * 44) + str(payload)
             else:
-                payload = binascii.unhexlify("0" * 44) + bytes(payload)
+                if multi_binding_acl:
+                    payload = binascii.unhexlify("0" * 44) + bytes(payload)[:24] + binascii.unhexlify("0" * 40) + \
+                        bytes(payload)[24:]
+                else:
+                    payload = binascii.unhexlify("0" * 44) + bytes(payload)
         if (
             duthost.facts["asic_type"] in ["barefoot", "cisco-8000", "marvell-teralynx"]
             or duthost.facts.get("platform_asic") in ["broadcom-dnx"]
@@ -908,11 +990,18 @@ class BaseEverflowTest(object):
 
         return expected_packet
 
-    def _extract_mirror_payload(self, encapsulated_packet, payload_size):
-        pytest_assert(len(encapsulated_packet) >= OUTER_HEADER_SIZE,
-                      "Incomplete packet, expected at least {} header bytes".format(OUTER_HEADER_SIZE))
+    def _extract_mirror_payload(self, encapsulated_packet, payload_size, multi_binding_acl=False):
+        outer_header_size = OUTER_HEADER_SIZE
+        if multi_binding_acl:
+            outer_header_size += 20
+        pytest_assert(len(encapsulated_packet) >= outer_header_size,
+                      "Incomplete packet, expected at least {} header bytes".format(outer_header_size))
 
         inner_frame = encapsulated_packet[-payload_size:]
+        if multi_binding_acl:
+            inner_frame = encapsulated_packet[-(payload_size + 20):]
+            inner_frame = self.remove_outer_ip(inner_frame)
+            return inner_frame
         return packet.Ether(inner_frame)
 
     @staticmethod

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -7,16 +7,21 @@ import threading
 import ptf.testutils as testutils
 from ptf.mask import Mask
 import ptf.packet as packet
+
+from tests.common.utilities import wait_until
+from common.helpers.assertions import pytest_assert
 from . import everflow_test_utilities as everflow_utils
 import ptf.packet as scapy
 from tests.ptf_runner import ptf_runner
 from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, DEFAULT_SERVER_IP
 # Module-level fixtures
-from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                 # noqa: F401
-from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                 # noqa: F401
-from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES               # noqa: F401
-from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                   # noqa: F401
-from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                   # noqa: F401
+from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                   # noqa: F401
+from .everflow_test_utilities import setup_info, setup_arp_responder, EVERFLOW_DSCP_RULES  # noqa: F401
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py                                     # noqa: F401
+from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor    # noqa: F401
+from tests.common.helpers.ptf_tests_helper import find_links
+from ipaddress import ip_address, IPv4Address
 
 pytestmark = [
     pytest.mark.topology("t0", "t1", "t2", "m0")
@@ -129,6 +134,121 @@ class EverflowIPv4Tests(BaseEverflowTest):
         yield
 
         everflow_utils.remove_route(duthost, dst_mask, nexthop_ip, ns)
+
+    @pytest.fixture()
+    def restore_bgp(self, rand_selected_dut):
+        """
+        Restore the BGP configuration to the original state.
+        """
+        rand_selected_dut.command("sudo config bgp startup all")
+
+        yield
+
+        rand_selected_dut.command("sudo config bgp shutdown all")
+
+    @pytest.fixture()
+    def restore_setup_info(self, setup_info, rand_unselected_dut):  # noqa F811
+        """
+        In everflow test cases, the bgp session would be shutdown at active tor
+        It would affects the basic function of dualtor muxcable
+        In multi binding acl case, it should startup the bgp sessions in order to make
+        Dual tor function works fine.
+        """
+        original_router_mac = setup_info[DOWN_STREAM]["ingress_router_mac"]
+        # router mac address of unselected DUT is needed in multi-binding acl test
+        setup_info[DOWN_STREAM]["ingress_router_mac"] = rand_unselected_dut.facts['router_mac']
+
+        yield
+
+        setup_info[DOWN_STREAM]["ingress_router_mac"] = original_router_mac
+
+    @pytest.fixture(scope="module")
+    def upstream_links_for_unselected_dut(self, rand_unselected_dut, tbinfo, nbrhosts):
+        """
+        Returns a dictionary of all the links that are upstream from the unselected DUT.
+
+        Args:
+            rand_unselected_dut: DUT fixture
+            tbinfo: testbed information fixture
+            nbrhosts: neighbor host fixture
+        Returns:
+            links: Dictionary of links upstream from the unselected DUT
+        """
+        links = dict()
+        duthost = rand_unselected_dut
+
+        if "dualtor" not in tbinfo["topo"]["name"]:
+            pytest.skip("Multi-binding ACL is not supported for non-dualtor testbed")
+
+        def filter(interface, neighbor, mg_facts, tbinfo):
+            if ((tbinfo["topo"]["type"] == "t0" and ("T1" in neighbor["name"] or "PT0" in neighbor["name"]))
+                    or (tbinfo["topo"]["type"] == "t1" and "T2" in neighbor["name"])):
+                local_ipv4_addr = None
+                peer_ipv4_addr = None
+                for item in mg_facts["minigraph_bgp"]:
+                    if item["name"] == neighbor["name"]:
+                        if isinstance(ip_address(item["addr"]), IPv4Address):
+                            # The address of neighbor device
+                            local_ipv4_addr = item["addr"]
+                            # The address of DUT
+                            peer_ipv4_addr = item["peer_addr"]
+                            break
+                port = mg_facts["minigraph_neighbors"][interface]["port"]
+                links[interface] = {
+                    "name": neighbor["name"],
+                    "ptf_port_id": mg_facts["minigraph_ptf_indices"][interface],
+                    "local_ipv4_addr": local_ipv4_addr,
+                    "peer_ipv4_addr": peer_ipv4_addr,
+                    "upstream_port": port,
+                    "host": nbrhosts[neighbor["name"]]["host"]
+                }
+
+        find_links(duthost, tbinfo, filter)
+        return links
+
+    def test_everflow_multi_binding_acl(self, setup_info, setup_mirror_session,              # noqa F811
+                                        dest_port_type, ptfadapter, tbinfo,
+                                        toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
+                                        setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
+                                        upstream_links_for_unselected_dut,            # noqa F811
+                                        is_multi_binding_acl_enabled, restore_setup_info, restore_bgp, duthosts):
+        """
+        Verify multi-binding ACL scenarios for the Everflow feature.
+        """
+        if self.acl_stage() == "egress":
+            pytest.skip("Multi-binding ACL is not supported for egress ACL")
+
+        if dest_port_type == UP_STREAM:
+            pytest.skip("Multi-binding ACL is not supported for up stream direction")
+
+        everflow_dut = setup_info[dest_port_type]['everflow_dut']
+        remote_dut = setup_info[dest_port_type]['remote_dut']
+
+        # Add a route to the mirror session destination IP
+        tx_port = setup_info[dest_port_type]["dest_port"][0]
+        peer_ip = everflow_utils.get_neighbor_info(remote_dut, tx_port, tbinfo)
+        session_prefixes = setup_mirror_session["session_prefixes"]
+        everflow_utils.add_route(remote_dut, session_prefixes[0], peer_ip,
+                                 setup_info[dest_port_type]["remote_namespace"])
+
+        pytest_assert(wait_until(30, 10, 0, everflow_utils.validate_asic_route, remote_dut, session_prefixes[0]))
+        pytest_assert(wait_until(30, 10, 0, everflow_utils.validate_mirror_session_up,
+                                 remote_dut, setup_mirror_session["session_name"]))
+
+        # Verify that mirrored traffic is sent along the route we installed
+        random_upstream_intf = random.choice(list(upstream_links_for_unselected_dut.keys()))
+        rx_port_ptf_id = upstream_links_for_unselected_dut[random_upstream_intf]["ptf_port_id"]
+        tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+        self._run_everflow_test_scenarios(
+            ptfadapter,
+            setup_info,
+            setup_mirror_session,
+            everflow_dut,
+            rx_port_ptf_id,
+            [tx_port_ptf_id],
+            dest_port_type,
+            multi_binding_acl=True
+        )
 
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811
                                        dest_port_type, ptfadapter, tbinfo,
@@ -790,7 +910,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
             background_traffic(run_count=1)
 
     def _run_everflow_test_scenarios(self, ptfadapter, setup, mirror_session, duthost, rx_port,
-                                     tx_ports, direction, expect_recv=True, valid_across_namespace=True):
+                                     tx_ports, direction, expect_recv=True, valid_across_namespace=True,
+                                     multi_binding_acl=False):  # noqa F811
         # FIXME: In the ptf_runner version of these tests, LAGs were passed down to the tests
         # as comma-separated strings of LAG member port IDs (e.g. portchannel0001 -> "2,3").
         # Because the DSCP test is still using ptf_runner we will preserve this for now,
@@ -828,7 +949,8 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 src_port=rx_port,
                 dest_ports=tx_port_ids,
                 expect_recv=expect_recv,
-                valid_across_namespace=valid_across_namespace
+                valid_across_namespace=valid_across_namespace,
+                multi_binding_acl=multi_binding_acl
             )
 
     def _base_tcp_packet(


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add multi binding acl test into everflow test scope
1. Toggle dualtor setup to AS mode
2. Only send packet from upstream to standby downstream side
3. Match the bounce back ipinip tunnel packet my multi binding acl at active downstream side
4. Mirror the match result
5. Validate the inner packet

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Add everflow multi binding acl test cases
#### How did you do it?
Add multi binding acl test into everflow test scope
#### How did you verify/test it?
Run it locally:
<img width="530" height="891" alt="image" src="https://github.com/user-attachments/assets/1bf1d879-a961-4556-aa17-f69cdd9d1284" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
