### PR TITLE
Modifying tgen_ports() for multiple snappi_fanout

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -574,7 +574,7 @@ def snappi_testbed_config(conn_graph_facts, fanout_graph_facts,     # noqa: F811
 
 
 @pytest.fixture(scope="module")
-def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts):      # noqa: F811
+def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts):  # noqa: F811
 
     """
     Populate tgen ports info of T0 testbed and returns as a list
@@ -608,63 +608,61 @@ def tgen_ports(duthost, conn_graph_facts, fanout_graph_facts):      # noqa: F811
         'prefix': u'24',
         'speed': 'speed_400_gbps'}]
     """
-    speed_type = {
-                  '10000': 'speed_10_gbps',
-                  '25000': 'speed_25_gbps',
-                  '40000': 'speed_40_gbps',
-                  '50000': 'speed_50_gbps',
-                  '100000': 'speed_100_gbps',
-                  '200000': 'speed_200_gbps',
-                  '400000': 'speed_400_gbps',
-                  '800000': 'speed_800_gbps'}
 
+    speed_type = {
+        '10000': 'speed_10_gbps',
+        '25000': 'speed_25_gbps',
+        '40000': 'speed_40_gbps',
+        '50000': 'speed_50_gbps',
+        '100000': 'speed_100_gbps',
+        '200000': 'speed_200_gbps',
+        '400000': 'speed_400_gbps',
+        '800000': 'speed_800_gbps'}
+    config_facts = duthost.config_facts(host=duthost.hostname,
+                                        source="running")['ansible_facts']
     snappi_fanouts = get_peer_snappi_chassis(conn_data=conn_graph_facts,
                                              dut_hostname=duthost.hostname)
     pytest_assert(snappi_fanouts is not None, 'Fail to get snappi_fanout')
+    snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
     snappi_ports_all = []
     for snappi_fanout in snappi_fanouts:
         snappi_fanout_id = list(fanout_graph_facts.keys()).index(snappi_fanout)
-        snappi_fanout_list = SnappiFanoutManager(fanout_graph_facts)
         snappi_fanout_list.get_fanout_device_details(device_number=snappi_fanout_id)
         snappi_ports = snappi_fanout_list.get_ports(peer_device=duthost.hostname)
-        for sp in snappi_ports:
-            snappi_ports_all.append(sp)
-        port_speed = None
 
-        for i in range(len(snappi_ports)):
-            if port_speed is None:
-                port_speed = int(snappi_ports[i]['speed'])
-
-            elif port_speed != int(snappi_ports[i]['speed']):
-                """ All the ports should have the same bandwidth """
-                return None
-
-        config_facts = duthost.config_facts(host=duthost.hostname,
-                                            source="running")['ansible_facts']
-
-        for port in snappi_ports_all:
+        port_speeds = {int(p['speed']) for p in snappi_ports}
+        if len(port_speeds) != 1:
+            """ All the ports should have the same bandwidth """
+            return None
+        port_speed = port_speeds.pop()
+        un_ipv4, un_ipv6 = [], []
+        for port in snappi_ports:
             port['location'] = get_snappi_port_location(port)
-            port['speed'] = speed_type[port['speed']]
-
-        for port in snappi_ports_all:
+            port['speed'] = speed_type.get(str(port_speed), port['speed'])
             peer_port = port['peer_port']
             int_addrs = list(config_facts['INTERFACE'][peer_port].keys())
-            try:
-                ipv4_subnet = [ele for ele in int_addrs if "." in ele][0]
-                port['peer_ip'], port['prefix'] = ipv4_subnet.split("/")
-                port['ip'] = get_addrs_in_subnet(ipv4_subnet, 2)[1]
-            except Exception:
-                snappi_ports_all = pre_configure_dut_interface(duthost, snappi_ports_all, type='ipv4')
+            port['speed'] = speed_type.get(str(port_speed), port['speed'])
 
-        for port in snappi_ports_all:
-            peer_port = port['peer_port']
-            int_addrs = list(config_facts['INTERFACE'][peer_port].keys())
-            try:
-                ipv6_subnet = [ele for ele in int_addrs if ":" in ele][0]
-                port['peer_ipv6'], port['ipv6_prefix'] = ipv6_subnet.split("/")
-                port['ipv6'] = get_ipv6_addrs_in_subnet(ipv6_subnet, 2)[1]
-            except Exception:
-                snappi_ports_all = pre_configure_dut_interface(duthost, snappi_ports_all, type='ipv6')
+            ipv4_entry = next((a for a in int_addrs if '.' in a), None)
+            if ipv4_entry:
+                port['peer_ip'], port['prefix'] = ipv4_entry.split('/')
+                port['ip'] = get_addrs_in_subnet(ipv4_entry, 2)[1]
+                snappi_ports_all.append(port)
+            else:
+                un_ipv4.append(port)
+
+            ipv6_entry = next((a for a in int_addrs if ':' in a), None)
+            if ipv6_entry:
+                port['peer_ipv6'], port['ipv6_prefix'] = ipv6_entry.split('/')
+                port['ipv6'] = get_ipv6_addrs_in_subnet(ipv6_entry, 2)[1]
+                snappi_ports_all.append(port)
+            else:
+                un_ipv6.append(port)
+
+        if un_ipv4:
+            snappi_ports_all.extend(pre_configure_dut_interface(duthost, un_ipv4, type='ipv4'))
+        if un_ipv6:
+            snappi_ports_all.extend(pre_configure_dut_interface(duthost, un_ipv6, type='ipv6'))
     return snappi_ports_all
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The current tgen_ports() takes into account that the get_peer_snappi_chassis returns a single value, but the latest code returns get_peer_snappi_chassis as a list in case of multiple snappi chassis usage. This PR take into account the latest change.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement
Previously when one interface is not configured the fixture configures all the ports used in test, now it has been enhanced to preconfigure only the unconfigured ports

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To consider single dut to be connected to multiple snappi chassis
#### How did you do it?
Tested with two snappi chassis connected to same dut
#### How did you verify/test it?
#### Any platform specific information?
Tested on Arista-7060X6-64PE-C256S2
#### Supported testbed topology if it's a new test case?
T0/T1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
