### PR TITLE
enable ipv6-only topo for test_vlan.py

### DIFF
--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -4,7 +4,7 @@ import collections
 import ipaddress
 import time
 import sys
-from netaddr import valid_ipv4
+from netaddr import valid_ipv4, valid_ipv6
 import logging
 
 from tests.common.helpers.assertions import pytest_require
@@ -294,27 +294,43 @@ def running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, 
         vlanid = v['vlanid']
         if 'VLAN_INTERFACE' not in cfg_facts:
             break
+        ip = None
         for addr in cfg_facts['VLAN_INTERFACE']['Vlan'+vlanid]:
-            # address could be IPV6 and IPV4, only need IPV4 here
+            # address could be IPV6 and IPV4, prefer IPV4 but accept IPV6
             if addr and valid_ipv4(addr.split('/')[0]):
                 ip = addr
                 break
-        else:
+        # If no IPv4 found, look for IPv6
+        if ip is None:
+            for addr in cfg_facts['VLAN_INTERFACE']['Vlan'+vlanid]:
+                if addr and valid_ipv6(addr.split('/')[0]):
+                    ip = addr
+                    break
+        # Skip this VLAN if neither IPv4 nor IPv6 found
+        if ip is None:
             continue
         if k not in vlan_members:
             continue
+        # Determine IP version
+        ip_version = 'ipv4' if valid_ipv4(ip.split('/')[0]) else 'ipv6'
         for port in vlan_members[k]:
             if 'tagging_mode' not in vlan_members[k][port]:
                 continue
             mode = vlan_members[k][port]['tagging_mode']
-            config_ports_vlan[port].append({'vlanid': int(vlanid), 'ip': ip, 'tagging_mode': mode})
+            config_ports_vlan[port].append({
+                'vlanid': int(vlanid),
+                'ip': ip,
+                'ip_version': ip_version,
+                'tagging_mode': mode
+            })
 
     if config_portchannels:
         for po in config_portchannels:
             vlan_port = {
                 'dev': po,
                 'port_index': [config_port_indices[member] for member in list(config_portchannels[po].keys())],
-                'permit_vlanid': []
+                'permit_vlanid': [],
+                'ip_version': None
             }
             if po in config_ports_vlan:
                 vlan_port['pvid'] = 0
@@ -324,6 +340,9 @@ def running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, 
                     if vlan['tagging_mode'] == 'untagged':
                         vlan_port['pvid'] = vlan['vlanid']
                     vlan_port['permit_vlanid'].append(vlan['vlanid'])
+                    # Store IP version (use the first one found)
+                    if vlan_port['ip_version'] is None and 'ip_version' in vlan:
+                        vlan_port['ip_version'] = vlan['ip_version']
             if 'pvid' in vlan_port:
                 vlan_ports_list.append(vlan_port)
 
@@ -331,7 +350,8 @@ def running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, 
         vlan_port = {
             'dev': port,
             'port_index': [config_port_indices[port]],
-            'permit_vlanid': []
+            'permit_vlanid': [],
+            'ip_version': None
         }
         if port in config_ports_vlan:
             vlan_port['pvid'] = 0
@@ -341,6 +361,9 @@ def running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, 
                 if vlan['tagging_mode'] == 'untagged':
                     vlan_port['pvid'] = vlan['vlanid']
                 vlan_port['permit_vlanid'].append(vlan['vlanid'])
+                # Store IP version (use the first one found)
+                if vlan_port['ip_version'] is None and 'ip_version' in vlan:
+                    vlan_port['ip_version'] = vlan['ip_version']
         if 'pvid' in vlan_port:
             vlan_ports_list.append(vlan_port)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
To enable proper ipv6-only topo test for test_vlan.py

#### How did you do it?
Added treatment for ipv6, so it's not just looking for ipv4.

#### How did you verify/test it?
Ran on ipv6-only topo testbed.
<img width="2988" height="330" alt="image" src="https://github.com/user-attachments/assets/23f15f5a-c4c9-4059-93a2-0a383aea3807" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
