### PR TITLE
Add extra check before rolling FEC back to none for test_replace_fec 

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -185,7 +185,7 @@ def get_fec_oper(duthost, interface):
         The operational FEC of the interface
     """
     show_fec_oper_cmd = SHOW_FEC_OPER_CMD_TEMPLATE.format(interface)
-    logging.info("Get output of '{}'".format(show_fec_oper_cmd))
+    logger.info("Get output of '{}'".format(show_fec_oper_cmd))
     fec_status = duthost.show_and_parse(show_fec_oper_cmd)
     return fec_status[0].get("fec oper", "N/A")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->


Summary:
Fixes # (issue)

When FEC is not configured in CONFIG_DB (i.e. `show interface status` shows FEC as `N/A`), the default FEC is vendor/platform dependent. However, today's rollback logic in this testcase incorrectly assumes it's always `none`, which can cause issues (e.g. link down) due to incorrectly setting FEC to `none` for some vendors/platforms whose default FEC is not `none`.

Fix is to add check on operational FEC before deciding rolling back to FEC=`none`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
