### PR TITLE
xfail generic_config_updater/test_pfcwd_status due to know issue

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2289,6 +2289,10 @@ generic_config_updater/test_pfcwd_status.py:
       - "release in ['202211']"
       - hwsku in ['Mellanox-SN5600-C224O8', 'Mellanox-SN5600-C256S1', 'Mellanox-SN5640-C448O16', 'Mellanox-SN5640-C512S2',
                    'Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8', 'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
+  xfail:
+    reason: "Due to known issue https://github.com/sonic-net/sonic-buildimage/issues/23907"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/23907"
 
 generic_config_updater/test_pg_headroom_update.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Test generic_config_updater/test_pfcwd_status.py is failing because of issue [Bug: GCU Config Rollback failure - system limitation](https://github.com/sonic-net/sonic-buildimage/issues/23907)

#### How did you do it?
To unblock PR testing, need to xfail this test for now.

#### How did you verify/test it?
Depend on PR testing to validate that the test is xfailed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
