### PR TITLE
[arp test] Skip adding IP to interface in VLAN for topo type t0

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -153,13 +153,15 @@ def intfs_for_test(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
         intf1_indice = mg_facts['minigraph_ptf_indices'][intf1]
         intf2_indice = mg_facts['minigraph_ptf_indices'][intf2]
 
-    asic.config_ip_intf(intf1, "10.10.1.2/28", "add")
-    asic.config_ip_intf(intf2, "10.10.1.20/28", "add")
+    if tbinfo['topo']['type'] != 't0':
+        asic.config_ip_intf(intf1, "10.10.1.2/28", "add")
+        asic.config_ip_intf(intf2, "10.10.1.20/28", "add")
 
     yield intf1, intf2, intf1_indice, intf2_indice
 
-    asic.config_ip_intf(intf1, "10.10.1.2/28", "remove")
-    asic.config_ip_intf(intf2, "10.10.1.20/28", "remove")
+    if tbinfo['topo']['type'] != 't0':
+        asic.config_ip_intf(intf1, "10.10.1.2/28", "remove")
+        asic.config_ip_intf(intf2, "10.10.1.20/28", "remove")
 
     if tbinfo['topo']['type'] != 't0':
         if po1:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The current code always tries to add an IP to the interface selected for testing. For topo type T0, usually an interface in VLAN is selected for testing. Adding IP to interface in VLAN wouldn't work. Before fix https://github.com/sonic-net/sonic-utilities/pull/3901, the failure is sliently ignored because the rc code is 0. This issue was not being noticed for quite some time. The tests using this fixture can pass anyway on topo type t0.

```python
    if (interface_is_in_vlan(vlan_member_table, interface_name)):
        click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
        return
```
Here `click.echo` is used. The return code will be 0.

After fix https://github.com/sonic-net/sonic-utilities/pull/3901, adding IP to an interface in VLAN will explicitly fail with rc=2.
```python
    if (interface_is_in_vlan(vlan_member_table, base_interface_name)):
        ctx.fail("Interface {} is a member of vlan\nAborting!".format(base_interface_name))
        return
```

The tests using this fixture start to fail unnecessarily.

#### How did you do it?
This PR fixed this problem by skipping adding IP to interface selected for testing if topo type is t0.

#### How did you verify/test it?
Verified on KVM image.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
