### PR TITLE
[ipfwd] fix ipfwd test

### DIFF
--- a/tests/ipfwd/test_nhop_group.py
+++ b/tests/ipfwd/test_nhop_group.py
@@ -584,7 +584,10 @@ def test_nhop_group_member_order_capability(duthost, tbinfo, ptfadapter, gather_
                               .format(flow_count, iter_count))
         finally:
             asic.start_service("bgp")
-            time.sleep(15)
+            config_facts = duthost.config_facts(host=duthost.hostname, source="running")["ansible_facts"]
+            bgp_neighbors = config_facts.get("BGP_NEIGHBOR", {}).keys()
+            pytest_assert(wait_until(60, 5, 0, duthost.check_bgp_session_state, bgp_neighbors),
+                          "bgp did not come up in expected time")
             nhop.delete_routes()
             pytest_assert(wait_until(60, 5, 0, validate_asic_route, duthost, ip_prefix, False),
                           f"Static route: {ip_prefix} is failed to be removed!")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In the ipfwd test, bgp container will be stopped and restarted. Currently, we wait for 15 second for bgp container fully initialize, which is sometimes not enough. Change the sleep to wait_until bgp up, and increase the wait time to 60 seconds.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Sleep 15 second is not enough to guarantee bgp container fully initialized

#### How did you do it?
Change sleep to wait_until

#### How did you verify/test it?
Run tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
