### PR TITLE
[fanout] Bugfix for SONiC 202505 fanout config template

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -3,10 +3,10 @@
         "localhost": {
             "default_pfcwd_status": "disable",
             "hwsku": "{{ fanout_hwsku }}",
-            "hostname": "{{ inventory_hostname }}",
 {% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] %}
-            "type": "LeafRouter"
+            "type": "LeafRouter",
 {% endif %}
+            "hostname": "{{ inventory_hostname }}"
         }
     },
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Current config template could generate a broken json format when 'marvell-teralynx' not in asic_type like below. There is an extra comma at the end of line hostname. This PR is for fixing the issue.

```
    "DEVICE_METADATA": {
        "localhost": {
            "default_pfcwd_status": "disable",
            "hwsku": "dummy-hwsku",
            "hostname": "dummy-hostname",
        }
    }
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Current config template could generate a broken json format when 'marvell-teralynx' not in asic_type like below. There is an extra comma at the end of line hostname. This PR is for fixing the issue.

#### How did you do it?
Modify the sequence of `type` and `hostname`.

#### How did you verify/test it?
Verified by deploy an Arista fanout switch.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
