### PR TITLE
expand intf config report for multi-asic systems

### DIFF
--- a/tests/generic_config_updater/test_pfcwd_status.py
+++ b/tests/generic_config_updater/test_pfcwd_status.py
@@ -153,7 +153,11 @@ def extract_pfcwd_config(duthost, start_pfcwd):
         pfcwd_config: dict of dicts with interface as the 1st level key and 'action', 'detect_time',
                       'restore_time' as the 2nd level keys
     """
-    output = duthost.command('show pfcwd config')
+    # Add flag to show all internal interfaces (for multi-asic systems)
+    cmd = 'show pfcwd config'
+    if duthost.is_multi_asic:
+        cmd += ' -d all'
+    output = duthost.command(cmd)
     pytest_assert('Ethernet' in output['stdout'], 'No ports found in the pfcwd config')
 
     pfcwd_config = defaultdict()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Adding use of internal interface info in setup of GCU test for PFC-WD status. This is because the FLEX_COUNTER_DB, used to check status initially, contains this information while the base "show pfcwd config" command does not. This causes the test to error out during the setup phase.

Summary:
Fixes internal Cisco issue as well as enables T2 topology support

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Making sure GCU tests run successfuly on T2/multi-asic systems

#### How did you do it?

Verified that the internal interface information was in fact included in the FLEX_COUNTER_DB and CONFIG_DB databases, then just adding the appropriate flag to the base command for setup.

#### How did you verify/test it?

Ran the fix on a dedicated T2 system

#### Any platform specific information?

None, except that the flag in question is only used on multi-asic systems.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->