### PR TITLE
Moving  excluded scripts from excludes list to test_mark_conditional.yml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3193,11 +3193,12 @@ qos:
 
 qos/test_buffer.py:
   skip:
-    reason: "These tests don't apply to cisco 8000 platforms or T2 or M* since they support only traditional model."
+    reason: "These tests don't apply to cisco 8000 platforms or T2 or M* since they support only traditional model and it is skipped for '202412' for now"
     conditions_logical_operator: or
     conditions:
       - "asic_type in ['cisco-8000'] or topo_type == 't2'"
       - "topo_type in ['m0', 'mx', 'm1']"
+      - "release in ['202412']"
 
 qos/test_buffer.py::test_buffer_model_test:
   skip:


### PR DESCRIPTION
 **Description of PR**

**Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


 **Back port request**
 
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Summary:**
Moving excluded Scripts from excludes list to test_conditional_mark.yml .This improves debuggability and speeds up issue resolution.The scripts are given below
mvrf/test_mgmtvrf.py
pfcwd/test_pfcwd_warm_reboot.py
qos/test_buffer.py
qos/test_pfc_counters.py
qos/test_qos_sai.py

 **What is the motivation for this PR?**
The motivation is to moving excluded scripts from excludes list to test_conditional_mark.yml

**How did you do it?**
I moved excluded scripts from excludes list and updated to test_conditional_mark.yml

**How did you verify/test it?**
Verified that the updated messages are correctly reflected in the test_conditional_mark.yml by reviewing the changes locally.
