### PR TITLE
Fix test_voq_system_port_create speed check

### DIFF
--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -7,7 +7,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.sonic_db import AsicDbCli, VoqDbCli
 from tests.common.helpers.voq_helpers import check_voq_remote_neighbor, get_sonic_mac
 from tests.common.helpers.voq_helpers import check_local_neighbor_asicdb, get_device_system_ports, get_inband_info
-from tests.common.platform.interface_utils import get_port_map
+from tests.common.platform.interface_utils import get_port_map  # noqa:F401
 from tests.common.helpers.voq_helpers import check_rif_on_sup, check_voq_neighbor_on_sup
 from tests.common.helpers.voq_helpers import dump_and_verify_neighbors_on_asic
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fixes a regression introduced by [#19231], where test_voq_system_port_create compares remote system-port speed against the local device’s PORT table, causing false failures in multi-DUT VOQ topologies.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
During OC runs on T2 max and T2 min topologies, four test_voq_system_port_create failures were observed.
The root cause was that the speed value from SYSTEM_PORT facts did not match the ASIC DB PORT speed for some VOQ setups.

This issue was traced back to PR [#19231](https://github.com/sonic-net/sonic-mgmt/pull/19231)
, which introduced a regression by comparing remote system-port speeds to the local device’s PORT table.
For example:

cfg_port = "ixre-egl-board202|asic0|Ethernet0"   # Remote DUT
per_host = ixre-egl-board201                     # Local DUT


The test used:

for port in port_cfg_facts:
    if port == cfg_port.split("|")[2] and port in interface_list.keys():
        pytest_assert(port_cfg_facts[port]['speed'] == port_data['speed'], ...)


Since port_cfg_facts only contains PORT entries for per_host (201), it compared 201/Ethernet0 (400G) against the system port for 202/Ethernet0 (100G), resulting in false mismatches like:

E Failed: Speed do not match for port Ethernet0: ... speed in SAI = "100000"

#### How did you do it?
Updated the speed verification logic in test_voq_system_port_create to handle both local and remote DUTs correctly.
For CPU system ports, continue comparing SYSTEM_PORT speed with ASIC DB.
For non-CPU ports:
If the DUT in cfg_port matches the current per_host, fetch speed from the correct PORT table (all_cfg_facts[host_name][asic_idx]['ansible_facts']['PORT']).
If the DUT is remote, compare the ASIC DB speed with the SYSTEM_PORT model (dev_ports[cfg_port]['speed']) instead of the local PORT table.
This ensures that the test doesn’t incorrectly compare remote system ports against the local DUT’s PORT configuration.
#### How did you verify/test it?
Re-ran the OC regression on T2 max and T2 min topologies multi DUT voq setup and T2 single node max

Confirmed that all four previous test_voq_system_port_create failures are now resolved.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
Failure seen with #19231
<img width="1912" height="167" alt="voq" src="https://github.com/user-attachments/assets/4d2180ef-72b1-48b8-91c2-e3cbae6016ec" />
After submit
<img width="1835" height="496" alt="passed" src="https://github.com/user-attachments/assets/395e8b67-5eda-46de-980c-9c0e75cfd856" />

<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
