### PR TITLE
update watchdog test cfg for nexthop devices

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -212,7 +212,7 @@ x86_64-8102_28fh_dpu_o-r0:
     too_big_timeout: 6554
 
 # Nexthop watchdog
-x86_64-nexthop_40(1|2)0-r.*:
+x86_64-nexthop_.*:
   default:
     valid_timeout: 10
     greater_timeout: 16777


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Updates test_watchdog config filter for all nexthop devices. Currently it does not match new nexthop-5010 device.

Summary:
Fixes #21060

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
New nexthop devices are not using the correct watchdog values, and are not compatible with the default.

#### How did you do it?
Generalize the watchdog config regex for all nexthop devices.

#### How did you verify/test it?
Run sonic-mgmt test_watchdog.py on nexthop devices, including `x86_64-nexthop_5010-r.*` Make sure all tests in test_watchdog.py pass without causing additional test failures.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
