### PR TITLE
Fix LLDP swss autorestart assumption

### DIFF
--- a/tests/lldp/test_lldp.py
+++ b/tests/lldp/test_lldp.py
@@ -241,7 +241,6 @@ def test_lldp_neighbor_post_swss_reboot(duthosts, enum_rand_one_per_hwsku_fronte
                                         sonic, collect_techsupport_all_duts, enum_frontend_asic_index,
                                         tbinfo, request, restart_swss_container, loganalyzer):
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
     ignoreRegex = [
         ".*ERR.*",
         "crash",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix lldp bad swss autorestart state assumption

Fix incorrect assumption that swss autorestart is enabled for all
testbeds - the test assumes all testbeds has swss autorestart enabled
and restores it to enabled at the end. Our testbeds have autorestart
disabled.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
CONFIG_DB check fails after test

#### How did you do it?
Check the AutoRestart setting for swss at the start of the test and restore it, instead of always enabling AutoRestart for swss at the end of the test.

#### How did you verify/test it?
Test no longer fails CONFIG_DB check

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
