### PR TITLE
Fix l2/test_l2_configure.py incomplete cleanup

### DIFF
--- a/tests/l2/test_l2_configure.py
+++ b/tests/l2/test_l2_configure.py
@@ -75,7 +75,7 @@ def setup_env(duthosts, rand_one_dut_hostname, tbinfo):
 
     # Clean up pytest cache so l2 testbed does not carry over to other tests
     folder = "_cache"
-    if os.patch.exists(folder):
+    if os.path.exists(folder):
         os.system("rm -rf {}".format(folder))
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test configures the DUT into a l2 testbed. It saves some of the setup to the pytest cache which is not cleaned up after the test. This causes subsequent tests to operate with incorrect info.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
`lldp/test_lldp.py` is failing on a test-specific loganalyzer check.

#### How did you do it?
Clean up `l2/test_l2_configure.py` properly.

#### How did you verify/test it?
`lldp/test_lldp.py` no longer fails on the `Arista-7060X6-16PE-384C-B-O128S2` `t0-isolated-d96u32s2` topology.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
