### PR TITLE
Cisco-8000:Snappi:Fix the arp deletion code in cisco-8000 fixture.

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1559,7 +1559,7 @@ def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True)
         arp_opt = f"-d {addr}"
 
     try:
-        dut.shell(f"{asic_arg} arp {int_arg} {arp_opt}")
+        dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
         dut.shell(
             "{} config route {} prefix {}/32 nexthop {} {}".format(
                 asic_arg, cmd, DEST_TO_GATEWAY_MAP[addr]['dest'], addr,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the cisco-specific function: gen_data_flow_dest_ip(), we also have a code to delete arp entries created by the same function. But that code is not really correct. It was not caught due to the try-except block protecting it. Essentially, the arguments to the arp delete CLI is wrong. This PR fixes this issue, with the correct arguments to the arp delete.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The arp delete will not work with the current code. This PR is fixing the arguments to the arp delete.

#### How did you do it?
By calculating the correct arguments to the arp delete.

#### How did you verify/test it?
Ran it on T1 and T2 devices.

#### Any platform specific information?
Specific to cisco-8000 only.

@sdszhang , @auspham : FYI.