### PR TITLE
chore: Enable iface_namingmode gnmi and bgpmon for DT2 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -407,7 +407,7 @@ bgp/test_bgpmon.py:
     reason: "Not supported on T2 topology or topology backend
              or Skip for IPv6-only topologies, since there are v6 verison of the test"
     conditions:
-      - "'backend' in topo_name or 't2' in topo_name"
+      - "'backend' in topo_name or topo_type in ['t2']"
       - "'-v6-' in topo_name"
 
 bgp/test_bgpmon_v6.py::test_bgpmon_no_ipv6_resolve_via_default:
@@ -2330,7 +2330,7 @@ gnmi/test_gnmi_configdb.py:
     reason: "This feature is not supported for multi asic. Skipping these test for T2 and multi asic."
     conditions_logical_operator: or
     conditions:
-      - "'t2' in topo_name"
+      - "topo_type in ['t2']"
       - "is_multi_asic==True"
       - "release in ['202412']"
 

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -224,6 +224,13 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
     # There is a chance that the network connection lost between PTF and switch due to table entry timeout
     # It would lead to execution failure of py_gnmicli.py. The ping action would trigger arp and mac table refresh.
     ptfhost.shell(f"ping {ip} -c 3", module_ignore_errors=True)
+
+    # Health check to make sure the gnmi server is listening on port
+    health_check_cmd = f"sudo ss -ltnp | grep {env.gnmi_port} | grep ${env.gnmi_program}"
+
+    wait_until(120, 1, 5,
+               lambda: len(duthost.shell(health_check_cmd, module_ignore_errors=True)['stdout_lines']) > 0)
+
     output = ptfhost.shell(cmd, module_ignore_errors=True)
     error = "GRPC error\n"
     if error in output['stdout']:

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -1014,7 +1014,7 @@ class TestShowVlan():
 
 
 # Tests to be run in t1 topology
-@pytest.mark.topology('t1')
+@pytest.mark.topology('t1', 'lt2', 'ft2')
 class TestConfigInterface():
     def check_speed_change(self, duthost, asic_index, interface, change_speed):
         db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'\
@@ -1352,7 +1352,7 @@ def test_show_acl_table(setup, setup_config_mode, tbinfo):
     Checks whether 'show acl table DATAACL' lists the interface names
     as per the configured naming mode
     """
-    if tbinfo['topo']['type'] not in ['t1', 't2']:
+    if tbinfo['topo']['type'] not in ['t1', 't2', 'lt2', 'ft2']:
         pytest.skip('Unsupported topology')
 
     if not setup['physical_interfaces']:
@@ -1391,7 +1391,7 @@ def test_show_interfaces_neighbor_expected(setup, setup_config_mode, tbinfo, dut
     Checks whether 'show interfaces neighbor expected' lists the
     interface names as per the configured naming mode
     """
-    if tbinfo['topo']['type'] not in ['t1', 't2']:
+    if tbinfo['topo']['type'] not in ['t1', 't2', 'lt2', 'ft2']:
         pytest.skip('Unsupported topology')
 
     dutHostGuest, mode, ifmode = setup_config_mode
@@ -1441,7 +1441,7 @@ def test_show_interfaces_neighbor_expected(setup, setup_config_mode, tbinfo, dut
                 )
 
 
-@pytest.mark.topology('t1', 't2')
+@pytest.mark.topology('t1', 't2', 'lt2', 'ft2')
 class TestNeighbors():
 
     @pytest.fixture(scope="class", autouse=True)
@@ -1531,7 +1531,7 @@ class TestNeighbors():
                     ).format(addr, detail['interface'], ndp_output)
 
 
-@pytest.mark.topology('t1', 't2')
+@pytest.mark.topology('t1', 't2', 'lt2', 'ft2')
 class TestShowIP():
 
     @pytest.fixture(scope="class", autouse=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable iface_namingmode gnmi and bgpmon
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

MS ONLY:
- FT2: https://elastictest.org/scheduler/testplan/68fab89a752d8286080258af?
- LT2: https://elastictest.org/scheduler/testplan/68fa24d535e8cabda801281d

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
