### PR TITLE
Replace per port SFP presence check with global command in check_interface_status

### DIFF
--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -104,7 +104,7 @@ def check_interface_status(dut, asic_index, interfaces, xcvr_skip_list):
     output = dut.command("show interface description")
     intf_status = parse_intf_status(output["stdout_lines"][2:])
     sfp_presence_output = dut.show_and_parse("show interfaces transceiver presence")
-    logging.info("SFP presence: {sfp_presence_output}")
+    logging.info(f"SFP presence: {sfp_presence_output}")
     sfp_presence_dict = {entry['port']: entry.get('presence', '').lower() for entry in sfp_presence_output}
 
     for intf in interfaces:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The `test_restart_swss` is intermittently failing with "Not all interface information are detected within 300 seconds" error on some HWSKUs.

This PR optimizes the SFP (transceiver) presence checking logic in `interface_utils.py` by replacing individual per-port commands with a single global command that retrieves presence status for all interfaces at once.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Fix an intermittent failure in `test_restart_swss` testcase.

#### How did you do it?
The issue seems to stem from a significant delay between capturing the link status of a port and actually checking it. In the `check_interface_status` function (https://github.com/sonic-net/sonic-mgmt/blob/c7d26dbee7a15e97ccb209b8462d06f11c050d5c/tests/common/platform/interface_utils.py#L88C5-L88C27), the process is:

1. Run `show interface description` to get the current status.
2. Loop through each port to:
   - Confirm both admin and oper status are up.
   - Run `show interface transceiver presence EthernetXX` for each port - This takes ~1s for every port

On HWSKUs with many ports (e.g., 512 logical ports), this can lead to a situation where the oper status for the last few ports appears down simply because too much time has passed since the initial status capture. Unfortunately, by the time the loop reaches those ports, the 300s timeout (https://github.com/sonic-net/sonic-mgmt/blob/c7d26dbee7a15e97ccb209b8462d06f11c050d5c/tests/platform_tests/test_sequential_restart.py#L79) may already be exceeded, preventing retries.

In order to fix this issue, a single global `show interfaces transceiver presence` command is executed instead of per-port command.

#### How did you verify/test it?
Ran the failing testcase and ensured that the test passes with the fix

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
ADO - 34399249
