### PR TITLE
[dualtor][mux_simulator] Recover unhealthy mux bridge flows during init

### DIFF
--- a/ansible/roles/vm_set/files/mux_simulator.py
+++ b/ansible/roles/vm_set/files/mux_simulator.py
@@ -577,6 +577,18 @@ class Muxes(object):
             if mux.isvalid:
                 self.muxes[bridge] = mux
 
+        self._recover_unhealthy_muxes()
+
+    def _recover_unhealthy_muxes(self):
+        """Recover unhealthy muxes by resetting their flows."""
+        unhealthy_muxes = [mux for mux in self.muxes.values() if not mux.status['healthy']]
+        if len(unhealthy_muxes) == 0:
+            return
+
+        app.logger.info('Recovering unhealthy muxes: {}'.format(
+            [mux.bridge for mux in unhealthy_muxes]))
+        list(self.thread_pool.map(lambda mux: mux.reset_flows(), unhealthy_muxes))
+
     def _mux_bridges(self):
         """Only collect bridges belong to self.vm_set
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Enable `mux_simulator` fix any unhealthy mux bridge during init.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
If any mux bridge is unhealthy during init, let's reset it.

#### How did you verify/test it?
Restart `mux_simulator` on testbed with unhealthy mux bridge, and the mux bridge is recoverd.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
