### PR TITLE
KeyError: 'secret_group_vars' in bgp/test_bgp_operation_in_ro.py 

### DIFF
--- a/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
+++ b/tests/common/plugins/pdu_controller/snmp_pdu_controllers.py
@@ -164,8 +164,8 @@ class snmpPduController(PduControllerBase):
         return value
 
     def _get_pdu_snmp_creds(self, pdu, perm):
-        context = {'secret_group_vars': pdu['secret_group_vars']}
-        if 'pdu_{}_snmp_version'.format(perm) in pdu:
+        if 'pdu_{}_snmp_version'.format(perm) in pdu and 'secret_group_vars' in pdu:
+            context = {'secret_group_vars': pdu['secret_group_vars']}
             version = pdu['pdu_{}_snmp_version'.format(perm)]
             if version == 'v2c':
                 if 'pdu_snmp_{}community'.format(perm) not in pdu:
@@ -213,7 +213,11 @@ class snmpPduController(PduControllerBase):
 
         else:
             snmp_community = pdu['snmp_{}community'.format(perm)]
-            snmp_auth = cmdgen.CommunityData(self._render_value(snmp_community, context))
+            if 'secret_group_vars' in pdu:
+                context = {'secret_group_vars': pdu['secret_group_vars']}
+                snmp_auth = cmdgen.CommunityData(self._render_value(snmp_community, context))
+            else:
+                snmp_auth = cmdgen.CommunityData(snmp_community)
         setattr(self, "{}_snmp_auth".format(perm), snmp_auth)
         return True
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
[This](https://github.com/sonic-net/sonic-mgmt/commit/79a14f892477c09aea37002a115548f8666573b9) changes added new functionality but removed check on '**secret_group_vars'**
Need to rerun back check on '**secret_group_vars'**

```
 def _get_pdu_snmp_creds(self, pdu, perm):
       context = {'secret_group_vars': pdu['secret_group_vars']}
E       KeyError: 'secret_group_vars'
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Failed testcases  with KeyError: 'secret_group_vars'
#### How did you do it?
Retuned back check
#### How did you verify/test it?
Run testcase

