### PR TITLE
Skip checking admin down ports on LT2 testbed

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -56,6 +56,12 @@ def xcvr_skip_list(duthosts, dpu_npu_port_list, tbinfo):
             sfp_list = ['Ethernet48', 'Ethernet49', 'Ethernet50', 'Ethernet51']
             logging.debug('Skipping sfp interfaces: {}'.format(sfp_list))
             intf_skip_list[dut.hostname].extend(sfp_list)
+        # For lt2-p32o64 topo, skip the admin down interfaces as transceiver may not be present
+        elif tbinfo['topo']['name'] == "lt2-p32o64":
+            intf_skip_list[dut.hostname].extend([
+                'Ethernet88', 'Ethernet96', 'Ethernet104', 'Ethernet112',
+                'Ethernet216', 'Ethernet224', 'Ethernet232', 'Ethernet240'
+                ])
 
     return intf_skip_list
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip the check on admin shutdown ports on LT2 topology.
The check needs to be skipped because it's possible that transceivers are not inserted into such ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
This PR is to skip the check on admin shutdown ports on LT2 topology.

#### How did you do it?
Add admin down ports to `xcvr_skip_list`.

#### How did you verify/test it?
The change is verified by running `test_xcvr_info_in_db`.
```
collected 1 item                                                                                                                                                                                                              

platform_tests/test_xcvr_info_in_db.py::test_xcvr_info_in_db[] PASSED                                                                                                                             [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new case.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
