### PR TITLE
xfail some generic_config_updater for ipv6-only topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2170,6 +2170,40 @@ generic_config_updater/test_dynamic_acl.py::test_gcu_acl_dhcp_rule_creation:
     reason: "DHCP is not enabled in isolated topo"
     conditions:
       - "'t0-isolated' in topo_name"
+  xfail:
+    reason: "xfail for IPv6-only topologies"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20920 and '-v6-' in topo_name"
+
+generic_config_updater/test_dynamic_acl.py::test_gcu_acl_drop_rule_removal[:
+  xfail:
+    reason: "xfail for IPv6-only topologies"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20920 and '-v6-' in topo_name"
+
+generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_priority_respected[:
+  xfail:
+    reason: "xfail for IPv6-only topologies"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20920 and '-v6-' in topo_name"
+
+generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_removal[:
+  xfail:
+    reason: "xfail for IPv6-only topologies"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20920 and '-v6-' in topo_name"
+
+generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_replacement[:
+  xfail:
+    reason: "xfail for IPv6-only topologies"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20920 and '-v6-' in topo_name"
+
+generic_config_updater/test_dynamic_acl.py::test_gcu_acl_scale_rules[:
+  xfail:
+    reason: "xfail for IPv6-only topologies"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/20920 and '-v6-' in topo_name"
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
xfail some generic_config_updater for ipv6-only topo, since they call for ipv4.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
