### PR TITLE
PFC WD Test setup: Find correct VLAN IPv6 address

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3312,7 +3312,19 @@ def setup_pfc_test(
             mg_facts['minigraph_vlan_interfaces'] = expected_vlan_ifaces
 
         # gather all vlan specific info
-        ip_index = 0 if ip_version == "IPv4" else 1
+        ip_index = -1
+        for intf in mg_facts['minigraph_vlan_interfaces']:
+            if type(ip_interface(str(intf['addr']))) is IPv4Interface\
+                    and ip_version == "IPv4":
+                ip_index = mg_facts['minigraph_vlan_interfaces'].index(intf)
+                break
+            elif type(ip_interface(str(intf['addr']))) is not IPv4Interface\
+                    and ip_version == "IPv6":
+                ip_index = mg_facts['minigraph_vlan_interfaces'].index(intf)
+                break
+        if ip_index == -1:
+            pytest.skip("No VLAN interface found for {}".format(ip_version))
+
         vlan_addr = mg_facts['minigraph_vlan_interfaces'][ip_index]['addr']
         vlan_prefix = mg_facts['minigraph_vlan_interfaces'][ip_index]['prefixlen']
         vlan_dev = mg_facts['minigraph_vlan_interfaces'][ip_index]['attachto']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

The incorrect address was found using a hardcoded index for the config facts. This PR finds the IPv6 address by searching the interface list instead.

Summary:
Fixes # 21067
https://github.com/sonic-net/sonic-mgmt/issues/21067

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Verified on a t0-56 that the ipv6 address is properly found.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
