### PR TITLE
[ansible]: Fix test_bgp_speaker by updating regex to match new output in frr-10.4.1

### DIFF
--- a/ansible/library/bgp_facts.py
+++ b/ansible/library/bgp_facts.py
@@ -132,7 +132,7 @@ class BgpModule(object):
             r'.*(Opens|Notifications|Updates|Keepalives|Route Refresh|Capability|Total):.*')
         regex_mrai = re.compile(
             r'.*Minimum time between advertisement runs is (\d{1,4})')
-        regex_accepted = re.compile(r'.*(\d+) accepted prefixes')
+        regex_accepted = re.compile(r'.*(\d+) accepted')
         regex_conn_est = re.compile(r'.*Connections established (\d+)')
         regex_conn_dropped = re.compile(
             r'.*Connections established \d+; dropped (\d+)')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This caused the sanity test to fail in the [sonic-frr 10.4.1 upgrade PR](https://github.com/sonic-net/sonic-buildimage/pull/24330).

The test_bgp_speaker was failing for frr-10.4.1 due to a change in BGP output:
"%u accepted prefixes" has been replaced with "  %u accepted, %u sent prefixes\n".
Currently the regex uses "accepted prefixes" as the key word, which only matches the former format.
Using "accepted" as key word can work for both current and future versions.

The change in FRR is : 
         &emsp;&emsp;frr-10.3: https://github.com/FRRouting/frr/blob/stable/10.3/bgpd/bgp_vty.c#L14024
         &emsp;&emsp;frr-10.4.1: https://github.com/FRRouting/frr/blob/stable/10.4/bgpd/bgp_vty.c#L14200


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Approach
#### What is the motivation for this PR?
To adapt the test to the new output format in frr-10.4.1  .

#### How did you do it?
Update the regex to fit both current and future versions.
