### PR TITLE
srv6 uN tests for cisco 8122 device

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3918,24 +3918,24 @@ srv6/test_srv6_dataplane.py:
     reason: "Only target mellanox and brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128"
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['mellanox', 'broadcom'] or release not in ['202412']"
-      - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku"
-      - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']"
+      - "(asic_type not in ['mellanox', 'broadcom'] or release not in ['202412']) and not (asic_type == 'cisco-8000' and 'Cisco-8122' in hwsku)"
+      - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku and not (asic_type == 'cisco-8000' and 'Cisco-8122' in hwsku)"
+      - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32'] and not (asic_type == 'cisco-8000' and 'Cisco-8122' in hwsku)"
 
 srv6/test_srv6_static_config.py:
   skip:
     reason: "Requires particular image support, skip in PR testing. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128"
     conditions_logical_operator: or
     conditions:
-      - "release not in ['202412']"
-      - "'Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku"
-      - "topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']"
+      - "(release not in ['202412']) and not (asic_type == 'cisco-8000' and 'Cisco-8122' in hwsku)"
+      - "('Arista-7060X6-64PE' in hwsku and 'Arista-7060X6-64PE-B' not in hwsku) and not (asic_type == 'cisco-8000' and 'Cisco-8122' in hwsku)"
+      - "(topo_name in ['t0-isolated-d96u32s2', 't1-isolated-d128', 't1-isolated-d32']) and not (asic_type == 'cisco-8000' and 'Cisco-8122' in hwsku)"
 
 srv6/test_srv6_static_config.py::test_uDT46_config:
   skip:
     reason: "Unsupported platform"
     conditions:
-      - "asic_type in ['mellanox']"
+      - "asic_type in ['mellanox', 'cisco-8000']"
 
 srv6/test_srv6_vlan_forwarding.py:
   skip:

--- a/tests/srv6/srv6_utils.py
+++ b/tests/srv6/srv6_utils.py
@@ -551,6 +551,11 @@ def get_srv6_mysid_entry_usage(duthost):
             - 'total_count': Total number of entries
         Returns None if failed to get the information
     """
+
+    #skip cisco-8000 because crm cmd is not ready yet
+    if duthost.facts["asic_type"] == "cisco-8000":
+        return { 'used_count': 0, 'available_count': 0, 'total_count': 0 }
+
     try:
         # Get SRv6 MySID Entry usage information using show_and_parse
         usage_list = duthost.show_and_parse('crm show resources srv6-my-sid-entry')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Enable SRv6 uN mgmt test for Cisco 8122

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

```
srv6/test_srv6_basic_sanity.py::test_interface_on_each_node SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.)                                                                           [  4%]
srv6/test_srv6_basic_sanity.py::test_check_bgp_neighbors SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.)                                                                              [  8%]
srv6/test_srv6_basic_sanity.py::test_check_routes SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.)                                                                                     [ 13%]
srv6/test_srv6_basic_sanity.py::test_traffic_check_normal SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes (SRv6 data plane required).)                                                                  [ 17%]
srv6/test_srv6_basic_sanity.py::test_traffic_check_local_link_fail_case SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.)                                                               [ 21%]
srv6/test_srv6_basic_sanity.py::test_traffic_check_remote_igp_fail_case SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.)                                                               [ 26%]
srv6/test_srv6_basic_sanity.py::test_traffic_check_remote_bgp_fail_case SKIPPED (It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.)                                                               [ 30%]
srv6/test_srv6_dataplane.py::TestSRv6DataPlaneBase::test_srv6_full_func[pipe-srh-None] PASSED                                                                                                                                             [ 34%]
srv6/test_srv6_dataplane.py::TestSRv6DataPlaneBase::test_srv6_full_func[pipe-no_srh-None] PASSED                                                                                                                                          [ 39%]
srv6/test_srv6_dataplane.py::test_srv6_dataplane_after_config_reload[lightning-01-None-True] SKIPPED (skip, cisco-8000 does not support srh)                                                                                              [ 43%]
srv6/test_srv6_dataplane.py::test_srv6_dataplane_after_config_reload[lightning-01-None-False] PASSED                                                                                                                                      [ 47%]
srv6/test_srv6_dataplane.py::test_srv6_dataplane_after_bgp_restart[lightning-01-None-True] SKIPPED (skip, cisco-8000 does not support srh)                                                                                                [ 52%]
srv6/test_srv6_dataplane.py::test_srv6_dataplane_after_bgp_restart[lightning-01-None-False] PASSED                                                                                                                                        [ 56%]
srv6/test_srv6_dataplane.py::test_srv6_dataplane_after_reboot[lightning-01-None-True] SKIPPED (skip, cisco-8000 does not support srh)                                                                                                     [ 60%]
srv6/test_srv6_dataplane.py::test_srv6_dataplane_after_reboot[lightning-01-None-False] 
----------------------------------------------------------------------------------------------------------------- live log call -----------------------------------------------------------------------------------------------------------------
24/09/2025 05:49:05 reboot.try_create_dut_console            L0678 WARNING| Fail to create dut console. Please check console config or if console works ro not. 'ManagementIp'
24/09/2025 05:49:05 reboot.collect_console_log               L0693 WARNING| dut console is not ready, we cannot get log by console
PASSED                                                                                                                                                                                                                                    [ 65%]
--------------------------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------------------------
24/09/2025 05:55:18 memory_utilization.check_memory_threshol L0064 WARNING| Skipping memory check for monit-memory_usage due to zero value

srv6/test_srv6_dataplane.py::test_srv6_no_sid_blackhole[lightning-01-None-True] SKIPPED (skip, cisco-8000 does not support srh)                                                                                                           [ 69%]
srv6/test_srv6_dataplane.py::test_srv6_no_sid_blackhole[lightning-01-None-False] PASSED                                                                                                                                                   [ 73%]
--------------------------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------------------------
24/09/2025 05:56:44 conftest.core_dump_and_config_check      L2885 WARNING| Core dump or config check failed for srv6/test_srv6_dataplane.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"lightning-01": []}}, "config_db_check": {"failed": true, "pre_only_config": {"lightning-01": {"null": {}}}, "cur_only_config": {"lightning-01": {"null": {}}}, "inconsistent_config": {"lightning-01": {"null": {"CRM": {"pre_value": {"Config": {"acl_counter_high_threshold": "85", "acl_counter_low_threshold": "70", "acl_counter_threshold_type": "percentage", "acl_entry_high_threshold": "85", "acl_entry_low_threshold": "70", "acl_entry_threshold_type": "percentage", "acl_group_high_threshold": "85", "acl_group_low_threshold": "70", "acl_group_threshold_type": "percentage", "acl_table_high_threshold": "85", "acl_table_low_threshold": "70", "acl_table_threshold_type": "percentage", "dnat_entry_high_threshold": "85", "dnat_entry_low_threshold": "70", "dnat_entry_threshold_type": "percentage", "fdb_entry_high_threshold": "85", "fdb_entry_low_threshold": "70", "fdb_entry_threshold_type": "percentage", "ipmc_entry_high_threshold": "85", "ipmc_entry_low_threshold": "70", "ipmc_entry_threshold_type": "percentage", "ipv4_neighbor_high_threshold": "85", "ipv4_neighbor_low_threshold": "70", "ipv4_neighbor_threshold_type": "percentage", "ipv4_nexthop_high_threshold": "85", "ipv4_nexthop_low_threshold": "70", "ipv4_nexthop_threshold_type": "percentage", "ipv4_route_high_threshold": "85", "ipv4_route_low_threshold": "70", "ipv4_route_threshold_type": "percentage", "ipv6_neighbor_high_threshold": "85", "ipv6_neighbor_low_threshold": "70", "ipv6_neighbor_threshold_type": "percentage", "ipv6_nexthop_high_threshold": "85", "ipv6_nexthop_low_threshold": "70", "ipv6_nexthop_threshold_type": "percentage", "ipv6_route_high_threshold": "85", "ipv6_route_low_threshold": "70", "ipv6_route_threshold_type": "percentage", "mpls_inseg_high_threshold": "85", "mpls_inseg_low_threshold": "70", "mpls_inseg_threshold_type": "percentage", "mpls_nexthop_high_threshold": "85", "mpls_nexthop_low_threshold": "70", "mpls_nexthop_threshold_type": "percentage", "nexthop_group_high_threshold": "85", "nexthop_group_low_threshold": "70", "nexthop_group_member_high_threshold": "85", "nexthop_group_member_low_threshold": "70", "nexthop_group_member_threshold_type": "percentage", "nexthop_group_threshold_type": "percentage", "polling_interval": "300", "snat_entry_high_threshold": "85", "snat_entry_low_threshold": "70", "snat_entry_threshold_type": "percentage"}}, "cur_value": {"Config": {"acl_counter_high_threshold": "85", "acl_counter_low_threshold": "70", "acl_counter_threshold_type": "percentage", "acl_entry_high_threshold": "85", "acl_entry_low_threshold": "70", "acl_entry_threshold_type": "percentage", "acl_group_high_threshold": "85", "acl_group_low_threshold": "70", "acl_group_threshold_type": "percentage", "acl_table_high_threshold": "85", "acl_table_low_threshold": "70", "acl_table_threshold_type": "percentage", "dnat_entry_high_threshold": "85", "dnat_entry_low_threshold": "70", "dnat_entry_threshold_type": "percentage", "fdb_entry_high_threshold": "85", "fdb_entry_low_threshold": "70", "fdb_entry_threshold_type": "percentage", "ipmc_entry_high_threshold": "85", "ipmc_entry_low_threshold": "70", "ipmc_entry_threshold_type": "percentage", "ipv4_neighbor_high_threshold": "85", "ipv4_neighbor_low_threshold": "70", "ipv4_neighbor_threshold_type": "percentage", "ipv4_nexthop_high_threshold": "85", "ipv4_nexthop_low_threshold": "70", "ipv4_nexthop_threshold_type": "percentage", "ipv4_route_high_threshold": "85", "ipv4_route_low_threshold": "70", "ipv4_route_threshold_type": "percentage", "ipv6_neighbor_high_threshold": "85", "ipv6_neighbor_low_threshold": "70", "ipv6_neighbor_threshold_type": "percentage", "ipv6_nexthop_high_threshold": "85", "ipv6_nexthop_low_threshold": "70", "ipv6_nexthop_threshold_type": "percentage", "ipv6_route_high_threshold": "85", "ipv6_route_low_threshold": "70", "ipv6_route_threshold_type": "percentage", "mpls_inseg_high_threshold": "85", "mpls_inseg_low_threshold": "70", "mpls_inseg_threshold_type": "percentage", "mpls_nexthop_high_threshold": "85", "mpls_nexthop_low_threshold": "70", "mpls_nexthop_threshold_type": "percentage", "nexthop_group_high_threshold": "85", "nexthop_group_low_threshold": "70", "nexthop_group_member_high_threshold": "85", "nexthop_group_member_low_threshold": "70", "nexthop_group_member_threshold_type": "percentage", "nexthop_group_threshold_type": "percentage", "polling_interval": "1", "snat_entry_high_threshold": "85", "snat_entry_low_threshold": "70", "snat_entry_threshold_type": "percentage"}}}}}}}}

srv6/test_srv6_static_config.py::test_uN_config[lightning-01-None] PASSED                                                                                                                                                                 [ 78%]
srv6/test_srv6_static_config.py::test_uDT46_config[lightning-01-None] SKIPPED (Unsupported platform)                                                                                                                                      [ 82%]
srv6/test_srv6_vlan_forwarding.py::test_srv6_uN_forwarding_towards_vlan[True] SKIPPED (Only target mellanox/brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, ...) [ 86%]
srv6/test_srv6_vlan_forwarding.py::test_srv6_uN_forwarding_towards_vlan[False] SKIPPED (Only target mellanox/brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32,...) [ 91%]
srv6/test_srv6_vlan_forwarding.py::test_srv6_uN_no_vlan_flooding[True] SKIPPED (Only target mellanox/brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isol...) [ 95%]
srv6/test_srv6_vlan_forwarding.py::test_srv6_uN_no_vlan_flooding[False] SKIPPED (Only target mellanox/brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-iso...) [100%]

=============================================================================================================== warnings summary ================================================================================================================
../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:471: CryptographyDeprecationWarning: Blowfish has been deprecated
    cipher=algorithms.Blowfish,

../../usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485
  /usr/local/lib/python3.8/dist-packages/scapy/layers/ipsec.py:485: CryptographyDeprecationWarning: CAST5 has been deprecated
    cipher=algorithms.CAST5,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------------------------------------------------------- generated xml file: /data/tests/logs/tr_2025-09-24-05-34-25.xml ----------------------------------------------------------------------------------------
============================================================================================================ short test summary info ============================================================================================================
SKIPPED [6] srv6/test_srv6_basic_sanity.py: It's a new test case, skip it for other topologies except cisco vs nodes and force nodes.
SKIPPED [1] srv6/test_srv6_basic_sanity.py: It's a new test case, skip it for other topologies except cisco vs nodes (SRv6 data plane required).
SKIPPED [1] srv6/test_srv6_dataplane.py:365: skip, cisco-8000 does not support srh
SKIPPED [1] srv6/test_srv6_dataplane.py:399: skip, cisco-8000 does not support srh
SKIPPED [1] srv6/test_srv6_dataplane.py:433: skip, cisco-8000 does not support srh
SKIPPED [1] srv6/test_srv6_dataplane.py:471: skip, cisco-8000 does not support srh
SKIPPED [1] srv6/test_srv6_static_config.py:65: Unsupported platform
SKIPPED [2] srv6/test_srv6_vlan_forwarding.py:195: Only target mellanox/brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128
SKIPPED [2] srv6/test_srv6_vlan_forwarding.py:207: Only target mellanox/brcm platform with 202412 image at this time. Skip for non Arista-7060X6-64PE-B-* TH5 SKUs. Skip for t0-isolated-d96u32, t1-isolated-d32/128
============================================================================================ 7 passed, 16 skipped, 3 warnings in 1527.18s (0:25:27) =============================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_srv6_uN_no_vlan_flooding[False]>
DEBUG:tests.conftest:append custom_msg: {'dut_check_result': {'config_db_check_failed': True, 'core_dump_check_failed': False}}
INFO:root:Can not get Allure report URL. Please check logs
+ [[ xgroup != x\d\e\b\u\g ]]
+ [[ xTrue == x\F\a\l\s\e ]]
+ exit 0
vxr@vxr-vm:/data/tests$ 
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
