### PR TITLE
Enhance PTF container network setup by sending gratuitous ARP

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -333,9 +333,44 @@
     include_tasks: ptf_change_mac.yml
     when: topo != 'fullmesh'
 
-  - name: Send arp ping packet to gw for flushing the ARP table
-    command: docker exec -i ptf_{{ vm_set_name }} python -c "from scapy.all import *; arping('{{ mgmt_gw }}')"
+  # ptf container may reuse the same ip address with a new random mac address
+  # for ptf container's mgmt network interface, so we need to send gratuitous
+  # ARP to announce PTF container MAC to network
+  - name: Send gratuitous ARP to announce PTF container MAC to network
+    shell: |
+      docker exec -i ptf_{{ vm_set_name }} python3 << 'GARP_EOF'
+      from scapy.all import *
+      my_ip = "{{ ptf_ip.split('/')[0] }}"
+      gw_ip = "{{ mgmt_gw }}"
+      my_mac = get_if_hwaddr("mgmt")
+      # Send broadcast ARP reply (gratuitous ARP) to announce IP->MAC mapping
+      pkt = Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(op=2, psrc=my_ip, hwsrc=my_mac, pdst=gw_ip, hwdst="ff:ff:ff:ff:ff:ff")
+      sendp(pkt, iface="mgmt", count=10, verbose=0)
+      print("Gratuitous ARP sent successfully")
+      GARP_EOF
     become: yes
+    failed_when: false
+
+  - name: Wait for PTF container network to become fully operational
+    shell: |
+      echo "Waiting for PTF network to stabilize..."
+      for attempt in $(seq 1 30); do
+        if docker exec ptf_{{ vm_set_name }} ping -c 1 -W 2 {{ mgmt_gw }} | grep -q "1 received"; then
+          echo "Network ready after $attempt attempts"
+          exit 0
+        fi
+        echo "Attempt $attempt/30: Network not ready, waiting 2 seconds..."
+        sleep 2
+      done
+      echo "Warning: Network not ready after 60 seconds, continuing anyway..."
+      exit 1
+    become: yes
+    register: network_ready
+    failed_when: false
+
+  - name: Display PTF network readiness status
+    debug:
+      msg: "stdout: {{ network_ready.stdout_lines }} stderr: {{ network_ready.stderr_lines }}"
 
   - name: Start ptf_tgen service
     include_tasks: start_ptf_tgen.yml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Broadcast the ptf network information to the network(specially the gateway) to reflect the latest network information of ptf container
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The gateway in the test environment might track stale network information of ptf container. After test topology is freshly deployed, the ptf container network information(e.g. mac address, ptf container may use the same ip address but different mac addresses) might take some time to be refreshed in the gateway. Before that, ptf container is unable get its management fully operationaly
#### How did you do it?
Broadcast the latest ptf mgmt network information to the network when the topo is deployed to update the ptf information
#### How did you verify/test it?
verified in physical setups
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
