### PR TITLE
Fix ansible_hosts for docker-sonic-mgmt based on Ubuntu 24.04

### DIFF
--- a/ansible/devutil/devices/ansible_hosts.py
+++ b/ansible/devutil/devices/ansible_hosts.py
@@ -55,6 +55,15 @@ except Exception as e:
     logging.error("Hack for https://github.com/ansible/pytest-ansible/issues/47 failed: {}".format(repr(e)))
 
 
+try:
+    # Initialize ansible plugin loader to avoid issues with ansbile-core 2.18
+    from ansible.plugins.loader import init_plugin_loader
+    init_plugin_loader()
+except ImportError:
+    # Nothing need to do for ansible-core 2.13
+    pass
+
+
 class UnsupportedAnsibleModule(Exception):
     pass
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The base class defined in ansible/devutil/devices/ansible_hosts.py hit issue with loading plugin if run in docker-sonic-mgmt based on Ubuntu 24.04. Consequently, the upgrade_sonic.py script won't work.

#### How did you do it?
This change fixed the plugin loading issue by calling init_plugin_loader() in ansible_hosts.py file.

#### How did you verify/test it?
This change was tested in docker-sonic-mgmt based on both Ubuntu 20.04 and 24.04.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
