### PR TITLE
route/test_duplicate_routes.py Add Broadcom SAI specific log ignores

### DIFF
--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -101,6 +101,9 @@ def verify_expected_loganalyzer_logs(
         ".*ERR.* handleSaiFailure: Encountered failure in create operation.*",
         ".*ERR.* object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* already exists.*",  # TODO move to expectRegex
         ".*ERR.* addRoutePost: Failed to create route.*",  # TODO move to expectRegex
+        r".*ERR.* SAI_API_ROUTE:_brcm_sai_l3_route_config:\d+ L3 route add failed with error",
+        r".*ERR.* SAI_API_ROUTE:brcm_sai_xgs_route_create:\d+ L3 route add failed with error",
+        r".*ERR.* SAI_API_ROUTE:brcm_sai_create_route_entry:\d+ pd route create failed failed with error",
     ]
     if loganalyzer:
         # Skip if loganalyzer is disabled


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add Broadcom SAI specific log ignores to route/test_duplicate_routes.py

https://github.com/sonic-net/sonic-mgmt/pull/21030 has introduced a regression in Arista's 7060X6-16 switches after enabling `route/test_duplicate_route.py`. 

The test logic passes, but fails on a loganalyzer check on these syslogs:
```
ERR syncd#syncd: [none] SAI_API_ROUTE:_brcm_sai_l3_route_config:5863 L3 route add failed with error Entry exists (0xfffffff8).
ERR syncd#syncd: [none] SAI_API_ROUTE:brcm_sai_xgs_route_create:420 L3 route add failed with error -6.
ERR syncd#syncd: [none] SAI_API_ROUTE:brcm_sai_create_route_entry:387 pd route create failed failed with error -6.

```
The test fails on the exact same loganalyzer check with the same 3 ERR syslogs on all 4 testcases.

I think this expected since the test logic is indeed adding duplicate routes. The PR also included changes to add similar ERR logs to ignorelog, with a TODO to move them to expected. Adding Broadcom SAI specific logignores along side PR added ones.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
`route/test_duplicate_routes.py` is failling on `Arista-7060X6-16`.

#### How did you do it?
Add expected Broadcom SAI specific ERR syslogs along side other related ERR syslogs to logignore added in PR #21030 

#### How did you verify/test it?
Test no longer fails on `Arista-7060X6-16`

#### Any platform specific information?
Broadcom

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
