### PR TITLE
Add support to download docker-ptf.gz

### DIFF
--- a/ansible/vars/docker_registry.yml
+++ b/ansible/vars/docker_registry.yml
@@ -1,1 +1,1 @@
-docker_registry_host: soniccr1.azurecr.io:443
+docker_registry_host: sonicdev-microsoft.azurecr.io:443

--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -109,6 +109,8 @@ def download_artifacts(url, content_type, platform, buildid, num_asic, access_to
                 filename = 'sonic-vs.img.gz'
         elif platform == "vpp":
             filename = 'sonic-vpp.img.gz'
+        elif platform == "ptf":
+            filename = 'docker-ptf.gz'
         else:
             filename = "sonic-{}.bin".format(platform)
 
@@ -196,7 +198,7 @@ def main():
     parser.add_argument('--branch', metavar='branch',
                         type=str, help='branch name')
     parser.add_argument('--platform', metavar='platform', type=str,
-                        choices=['broadcom', 'mellanox', 'vs', 'vpp'],
+                        choices=['broadcom', 'mellanox', 'vs', 'vpp', 'ptf'],
                         help='platform to download')
     parser.add_argument('--content', metavar='content', type=str,
                         choices=['all', 'image'], default='image',
@@ -228,7 +230,10 @@ def main():
     else:
         buildid = int(args.buildid)
 
-    artifact_name = "sonic-buildimage.{}".format(args.platform)
+    if args.platform == 'ptf':
+        artifact_name = "sonic-buildimage.vs"  # PTF images are typically built with VS platform
+    else:
+        artifact_name = "sonic-buildimage.{}".format(args.platform)
 
     (dl_url, artifact_size) = get_download_url(buildid, artifact_name,
                                                url_prefix=args.url_prefix,


### PR DESCRIPTION
### Description of PR

The PR modifies getbuild.py to add support to download docker-ptf.gz from the published buildimage artifact.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

For PR builds this will later be used to download, load and test docker-ptf from a PR build rather than the master/latest tag.

#### How did you do it?

NA

#### How did you verify/test it?

Manually

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA