### PR TITLE
[everflow][sn5640]: Add Mellanox ASIC skip condition for everflow IPv6 erspan_ipv6-default test

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1634,8 +1634,8 @@ everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan
     reason: "SAI_STATUS_NOT_SUPPORTED for everflow over IPv6 on Arista-7260CX3 and Arista-7060CX. Or skip everflow per interface IPv6 test on unsupported platforms x86_64-nvidia_sn5640-r0."
     conditions_logical_operator: or
     conditions:
-        - "platform in ['x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s'] and https://github.com/sonic-net/sonic-mgmt/issues/19096"
-        - "platform in ['x86_64-nvidia_sn5640-r0']"
+      - "platform in ['x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s'] and https://github.com/sonic-net/sonic-mgmt/issues/19096"
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
   xfail:
     reason: "xfail for IPv6-only topologies, need support for IPv6 bgp"
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add Mellanox ASIC skip condition to the exact match rule for test_everflow_per_interface[ipv6-erspan_ipv6-default] because exact match rules have higher priority than prefix match rules, causing the test to ignore the Mellanox skip condition in the prefix match configuration.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Skip everflow per interface IPv6 test on Mellanox ASICs
#### How did you do it?
Add Mellanox ASIC skip condition to the exact match rule for test_everflow_per_interface[ipv6-erspan_ipv6-default] because exact match rules have higher priority than prefix match rules, causing the test to ignore the Mellanox skip condition in the prefix match configuration.

#### How did you verify/test it?
```
================================================== short test summary info ===================================================
SKIPPED [1] everflow/test_everflow_per_interface.py: SAI_STATUS_NOT_SUPPORTED for everflow over IPv6 on Arista-7260CX3 and Arista-7060CX. Skip everflow per interface IPv6 test on unsupported platforms
=============================================== 1 skipped, 1 warning in 54.18s ===============================================
```
#### Any platform specific information?
str5-sn5640-2
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
