### PR TITLE
fix the error ignore regex in test_vlan_interface_tc1_suite

### DIFF
--- a/tests/generic_config_updater/test_vlan_interface.py
+++ b/tests/generic_config_updater/test_vlan_interface.py
@@ -418,8 +418,8 @@ def test_vlan_interface_tc1_suite(rand_selected_dut, vlan_info, loganalyzer, tbi
         if tbinfo["topo"]["name"] == "m0-2vlan":
             loganalyzer[duthost.hostname].ignore_regex.extend(IGNORE_REG_LIST)
         loganalyzer[duthost.hostname].ignore_regex.extend([
-            ".*ERR GenericConfigUpdater: Change Applier: service invoked: \
-        generic_config_updater.services_validator.vlanintf_validator failed.*"
+            ".*ERR GenericConfigUpdater: Change Applier: service invoked: "
+            "generic_config_updater.services_validator.vlanintf_validator failed.*"
         ])
     vlan_interface_tc1_add_duplicate(rand_selected_dut, vlan_info)
     vlan_interface_tc1_xfail(rand_selected_dut, vlan_info)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix for multi-line error log to ignore in test_vlan_interface_tc1_suite.
Because of the invalid indentation, the error log contained an unexpected sequence of spaces.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
