### PR TITLE
[cisco] tweak lossless drop tuning pkts value

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -57,7 +57,7 @@ class QosParamCisco(object):
         # 2: Number of packets margin for the quantized queue watermark tests.
         asic_params = {"gb": (6144000, 3072, 384, 1350, 2, 3),
                        "gr": (24576000, 18000, 384, 1350, 2, 3),
-                       "gr2": (None, 1, 512, 64, 1, 3)}
+                       "gr2": (None, 1, 512, 64, 1, 4)}
         self.supports_autogen = dutAsic in asic_params and topo == "topo-any"
         if self.supports_autogen:
             # Asic dependent parameters


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

The queue shared watermark test fails intermittently on Cisco G200 platforms due to a slight tuning error. The lossless drop tuning value is one packet smaller than it should be. 


Summary:
Fixes # MIGSOFTWAR-28269 (internal to Cisco)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

Shared watermark tests were failing intermittently, and the evidence pointed to tuning parameters in the vendor-specific processor tuning code.

#### How did you do it?

By running the testQosSaiQSharedWatermark test repeatedly for lossless traffic, saving all output to files, and examining the values of the expected watermark value. We noticed that the distribution of values was quite normal, with the median being exactly one packet short. 

#### How did you verify/test it?

Re-running the failing test and observing no failures. Note that we ran not just the failing test repeatedly, but also the entire QosSai suite as well.

#### Any platform specific information?

None

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
