### PR TITLE
Fix test_bfd test failure due to IPv6 status not change

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -414,6 +414,7 @@ def warm_up_ipv6_neighbors(duthost, neighbor_addrs):
         logger.info(f"Warming up IPv6 neighbor {addr}")
         duthost.shell(f"ping -6 -c 1 -W 1 {addr}", module_ignore_errors=True)
 
+    time.sleep(5)  # Wait for NDP entries to be populated
     ndp_output = duthost.shell("ip -6 neigh show", module_ignore_errors=False)['stdout']
     logger.info(f"NDP entries:\n{ndp_output}")
     for addr in neighbor_addrs:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_bfd_basic[ipv6-dut_init_first] and test_bfd_basic[ipv6-ptf_init_first] will fail due to the IPv6 NDP status not change to REACHABLE

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
test_bfd_basic[ipv6-dut_init_first] and test_bfd_basic[ipv6-ptf_init_first] will fail due to the IPv6 NDP status not change to REACHABLE

#### How did you do it?
Add a sleep 5s statement.

#### How did you verify/test it?
On physical testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
