### PR TITLE
Add support to accept PTF_MODIFIED and pass it to test plan creation

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -77,6 +77,10 @@ parameters:
     type: string
     default: "latest"
 
+  - name: PTF_MODIFIED
+    type: boolean
+    default: false
+
   - name: IMAGE_URL
     type: string
     default: ""
@@ -294,6 +298,7 @@ steps:
       --vm-type ${{ parameters.VM_TYPE }} \
       --num-asic ${{ parameters.NUM_ASIC }} \
       --ptf_image_tag ${{ parameters.PTF_IMAGE_TAG }} \
+      --ptf-modified ${{ parameters.PTF_MODIFIED }} \
       --image_url ${{ parameters.IMAGE_URL }} \
       --upgrade-image-param="${{ parameters.UPGRADE_IMAGE_PARAM }}" \
       --hwsku ${{ parameters.HWSKU }} \

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -269,6 +269,7 @@ class TestPlanManager(object):
         retry_cases_include = parse_list_from_str(kwargs.get("retry_cases_include", None))
         retry_cases_exclude = parse_list_from_str(kwargs.get("retry_cases_exclude", None))
         ptf_image_tag = kwargs.get("ptf_image_tag", None)
+        ptf_modified = kwargs.get("ptf_modified", False)
         build_reason = kwargs.get("build_reason", "PullRequest")
         lock_wait_timeout_seconds = kwargs.get("lock_wait_timeout_seconds", 0)
         # If not set lock tb timeout, set to 2 hours for pr test plans by default
@@ -363,6 +364,7 @@ class TestPlanManager(object):
                     "scripts_exclude": scripts_exclude
                 },
                 "ptf_image_tag": ptf_image_tag,
+                "ptf_modified": ptf_modified,
                 "image": {
                     "url": image_url,
                     "upgrade_image_param": kwargs.get("upgrade_image_param", None),
@@ -818,6 +820,17 @@ if __name__ == "__main__":
         help="PTF image tag"
     )
     parser_create.add_argument(
+        "--ptf-modified",
+        type=ast.literal_eval,
+        dest="ptf_modified",
+        nargs='?',
+        const=False,
+        default=False,
+        required=False,
+        choices=[True, False],
+        help="Whether to use locally modified PTF image"
+    )
+    parser_create.add_argument(
         "--image_url",
         type=str,
         dest="image_url",
@@ -1174,6 +1187,7 @@ if __name__ == "__main__":
                     vm_type=args.vm_type,
                     testbed_name=args.testbed_name,
                     ptf_image_tag=args.ptf_image_tag,
+                    ptf_modified=args.ptf_modified,
                     image_url=args.image_url,
                     upgrade_image_param=args.upgrade_image_param,
                     hwsku=args.hwsku,


### PR DESCRIPTION
### Description of PR

The PR -

- Enables pipeline to accept PTF_MODIFIED parameter
- Enables test_plan.py to accept --ptf-modified argument and pass it to elastic test scheduler for test plan creation.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

The change is part of other PRs in buildimage and elastictest to enable testing PR modified docker-ptf image rather than using the docker-ptf:latest image.

#### How did you do it?

NA

#### How did you verify/test it?

NA - will be tested together with buildimage PR change and elastictest change.

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA