### PR TITLE
[dualtor] fix `test_server_down`

### DIFF
--- a/tests/dualtor_mgmt/test_server_failure.py
+++ b/tests/dualtor_mgmt/test_server_failure.py
@@ -2,8 +2,7 @@ import logging
 import pytest
 import random
 
-from tests.common.dualtor.mux_simulator_control import toggle_simulator_port_to_upper_tor, \
-                                                       simulator_flap_counter, simulator_server_down    # noqa: F401
+from tests.common.dualtor.mux_simulator_control import simulator_flap_counter, simulator_server_down    # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.dualtor.dual_tor_utils import show_muxcable_status                                    # noqa: F401
 from tests.common.dualtor.dual_tor_common import active_active_ports                                    # noqa: F401
@@ -33,10 +32,11 @@ pytestmark = [
 
 
 @pytest.mark.enable_active_active
-def test_server_down(cable_type, duthosts, tbinfo, active_active_ports, active_standby_ports,               # noqa: F811
-                     simulator_flap_counter, simulator_server_down, toggle_simulator_port_to_upper_tor,     # noqa: F811
-                     loganalyzer, validate_active_active_dualtor_setup, upper_tor_host, lower_tor_host,     # noqa: F811
-                     simulator_server_down_active_active):                                                  # noqa: F811
+@pytest.mark.dualtor_active_standby_toggle_to_upper_tor
+def test_server_down(cable_type, duthosts, tbinfo, active_active_ports, active_standby_ports,               # noqa F811
+                     simulator_flap_counter, simulator_server_down,                                         # noqa F811
+                     loganalyzer, validate_active_active_dualtor_setup, upper_tor_host, lower_tor_host,     # noqa F811
+                     simulator_server_down_active_active):                                                  # noqa F811
     """
     Verify that mux cable is not toggled excessively.
     """
@@ -59,8 +59,6 @@ def test_server_down(cable_type, duthosts, tbinfo, active_active_ports, active_s
     if cable_type == CableType.active_standby:
         test_iface = random.choice(active_standby_ports)
         logging.info("Selected %s interface %s to test", cable_type, test_iface)
-        # Set upper_tor as active
-        toggle_simulator_port_to_upper_tor(test_iface)
         pytest_assert(wait_until(30, 1, 0, upper_tor_mux_state_verification, 'active', 'healthy'),
                       "mux_cable status is unexpected. Should be (active, healthy). Test can't proceed. ")
         mux_flap_counter_0 = simulator_flap_counter(test_iface)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix `test_server_down` to use the correct fixture to do the toggle.
The deprecated toggle fixture `toggle_simulator_port_to_upper_tor` doesn't do port status check after toggle, which might lead the DUTs in unexpected mux status and test failure.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As the motivation.

#### How did you verify/test it?
```
dualtor_mgmt/test_server_failure.py::test_server_down[active-standby] PASSED                                                                                                                                                                                                                                                                    [ 50%]
dualtor_mgmt/test_server_failure.py::test_server_reboot[active-standby] PASSED                                                                                                                                                                                                                                                                  [100%]

================================================================================================================================================================== warnings summary ===================================================================================================================================================================
=============================================================================================================================================== 2 passed, 2 deselected, 1 warning in 526.75s (0:08:46) ================================================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
