### PR TITLE
[Mellanox] Increase margin from 3 to 4 for HdrmPoolSizeTest

### DIFF
--- a/tests/qos/files/mellanox/qos_param_generator.py
+++ b/tests/qos/files/mellanox/qos_param_generator.py
@@ -186,6 +186,8 @@ class QosParamMellanox(object):
             hdrm_pool_size['pgs_num'] = (2 if not self.dualTor else 4) * len(self.qos_parameters['src_port_ids'])
             hdrm_pool_size['cell_size'] = self.cell_size
             hdrm_pool_size['margin'] = 3
+            if self.asic_type == "spc3":
+                hdrm_pool_size['margin'] = 4
         else:
             self.qos_params_mlnx[self.speed_cable_len].pop('hdrm_pool_size')
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

For HdrmPoolSizeTest, sometime the headroom size in the failed case will accept an additional 3 cells, thus preventing ingress packet drop. Since this difference of 3 cells is tolerable, increase the margin by 1.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Stabilize the test of HdrmPoolSizeTest for mellanox device 

#### How did you do it?
Increase the margin by 1

#### How did you verify/test it?
Run the test on spc3

#### Any platform specific information?
spc3

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
