### PR TITLE
Adding Cisco-8000 Specific Packet Formatting in everflow_policer_test.py

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -265,10 +265,10 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["marvell-prestera", "marvell"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
-        if self.asic_type in ["cisco-8000"]:  #adding cisco-8000 specific masks 
+        if self.asic_type in ["cisco-8000"]:
             erspan_bit_offset = 42
-            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 19 , 2) # Mask encap value 
-            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 22 , 10) # Mask the session_id
+            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 19, 2)  # Mask encap value
+            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 22, 10)  # Mask the session_id
         if exp_pkt.haslayer(scapy.ERSPAN_III):
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "span_id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "timestamp")
@@ -292,9 +292,9 @@ class EverflowPolicerTest(BaseTest):
             elif self.asic_type == "barefoot":
                 pkt = scapy.Ether(pkt).load
             elif self.asic_type == "cisco-8000":
-                pkt = scapy.Ether(pkt)[scapy.GRE].payload 
+                pkt = scapy.Ether(pkt)[scapy.GRE].payload
                 pkt = bytes(pkt)
-                pkt = scapy.Ether(pkt[8:]) # Mask the ERSPAN II header 
+                pkt = scapy.Ether(pkt[8:])  # Mask the ERSPAN II header
             else:
                 pkt = scapy.Ether(pkt)[scapy.GRE].payload
 

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -241,6 +241,17 @@ class EverflowPolicerTest(BaseTest):
                                                 inner_frame=bytes(payload),
                                                 ip_id=0,
                                                 sgt_other=0x4)
+        elif self.asic_type in ["cisco-8000"]:
+            exp_pkt = testutils.ipv4_erspan_pkt(eth_src=self.router_mac,
+                                                ip_src=self.session_src_ip,
+                                                ip_dst=self.session_dst_ip,
+                                                ip_dscp=self.session_dscp,
+                                                ip_ttl=self.session_ttl-1,
+                                                inner_frame=bytes(payload),
+                                                ip_id=0,
+                                                version=1)
+
+            exp_pkt['ERSPAN II'].ver = 1 
         else:
             exp_pkt['GRE'].proto = 0x88be
 
@@ -254,7 +265,10 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["marvell-prestera", "marvell"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
-
+        if self.asic_type in ["cisco-8000"]:
+            erspan_bit_offset = 42
+            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 19 , 2) # Mask encap value 
+            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 22 , 10) # Mask the session_id
         if exp_pkt.haslayer(scapy.ERSPAN_III):
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "span_id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "timestamp")
@@ -277,6 +291,10 @@ class EverflowPolicerTest(BaseTest):
                 pkt = scapy.Ether(pkt[8:])
             elif self.asic_type == "barefoot":
                 pkt = scapy.Ether(pkt).load
+            elif self.asic_type == "cisco-8000":
+                pkt = scapy.Ether(pkt)[scapy.GRE].payload 
+                pkt = bytes(pkt)
+                pkt = scapy.Ether(pkt[8:]) # Mask the ERSPAN II header 
             else:
                 pkt = scapy.Ether(pkt)[scapy.GRE].payload
 

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -251,7 +251,7 @@ class EverflowPolicerTest(BaseTest):
                                                 ip_id=0,
                                                 version=1)
 
-            exp_pkt['ERSPAN II'].ver = 1 
+            exp_pkt['ERSPAN II'].ver = 1
         else:
             exp_pkt['GRE'].proto = 0x88be
 

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -256,7 +256,7 @@ class EverflowPolicerTest(BaseTest):
             exp_pkt['GRE'].proto = 0x88be
 
         masked_exp_pkt = Mask(exp_pkt)
-        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst") 
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
         masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "flags")
         masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
 

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -267,7 +267,7 @@ class EverflowPolicerTest(BaseTest):
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
         if self.asic_type in ["cisco-8000"]:
             erspan_bit_offset = 42
-            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 19, 2)  # Mask encap value
+            masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 19, 2)  # Mask the encap value
             masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 22, 10)  # Mask the session_id
         if exp_pkt.haslayer(scapy.ERSPAN_III):
             masked_exp_pkt.set_do_not_care_scapy(scapy.ERSPAN_III, "span_id")

--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -256,7 +256,7 @@ class EverflowPolicerTest(BaseTest):
             exp_pkt['GRE'].proto = 0x88be
 
         masked_exp_pkt = Mask(exp_pkt)
-        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst") 
         masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "flags")
         masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
 
@@ -265,7 +265,7 @@ class EverflowPolicerTest(BaseTest):
         if self.asic_type in ["marvell-prestera", "marvell"]:
             masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "id")
             masked_exp_pkt.set_do_not_care_scapy(scapy.GRE, "seqnum_present")
-        if self.asic_type in ["cisco-8000"]:
+        if self.asic_type in ["cisco-8000"]:  #adding cisco-8000 specific masks 
             erspan_bit_offset = 42
             masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 19 , 2) # Mask encap value 
             masked_exp_pkt.set_do_not_care(erspan_bit_offset * 8 + 22 , 10) # Mask the session_id

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1862,7 +1862,7 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer:
   skip:
-    reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms and Broadcom DNX platforms."
+    reason: "Skipping test since mirror with policer is not supported on Cisco 8122 platforms and Broadcom DNX platforms."
     conditions_logical_operator: "OR"
     conditions:
       - "asic_subtype in ['broadcom-dnx']"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1865,8 +1865,8 @@ everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_e
     reason: "Skipping test since mirror with policer is not supported on Cisco 8000 platforms and Broadcom DNX platforms."
     conditions_logical_operator: "OR"
     conditions:
-      - "asic_type in ['cisco-8000']"
       - "asic_subtype in ['broadcom-dnx']"
+      - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
 
 everflow/test_everflow_testbed.py::TestEverflowV4IngressAclIngressMirror::test_everflow_dscp_with_policer[erspan_ipv4-cli-downstream-default]:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The following updates have been made in everflow_policer_test.py to enable policing through packet matching on Cisco-8000 (Q200) platforms. The test case is skipped on Cisco-8000 (G200) platforms, as this functionality is not supported there ->

cisco-8000 generates erspan II encapsulated mirrored packets (verified through packet capture) -> created ipv4 erspan pkt template for cisco-8000 instead of standard GRE packet format

TTL is reduced by 1 due to internal recirculation of mirrored packets

Configured ERSPAN II version to 1

Masked session_id as it is dynamically set and encap value as it is set to 0 by default

Added cisco-8000 specific payload matching by masking erspan II header

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR updates everflow_policer_test.py to enable accurate policing validation on Cisco-8000 (Q200) platforms. Cisco-8000 uses ERSPAN II encapsulation for mirrored packets, which differs from the standard ERSPAN/GRE format used in other platforms. These differences caused previous packet-matching logic to fail, requiring platform-specific handling. The test is skipped on Cisco-8000 (G200) platforms where this functionality is not supported.

#### How did you do it?
Added ERSPAN II–specific packet template for Cisco-8000 to replace the standard GRE packet format.
Set ERSPAN II version = 1 to align with Cisco-8000 encapsulation behavior.
Masked fields that dynamically change, including session_id and encap (defaults to 0 on Cisco-8000).
Implemented payload matching logic that masks ERSPAN II header fields unique to Cisco-8000.
Accounted for the TTL decrement by 1 due to internal recirculation of mirrored packets.
Skipped the test on Cisco-8000 (G200) platforms where ERSPAN II policing is not supported.

Attaching test logs - [Cisco_Q200_Policer_Testlogs.txt](https://github.com/user-attachments/files/24224282/PR-1810.Q200_Policer.txt)


#### How did you verify/test it?
Captured mirrored packets on Cisco-8000 (Q200) testbeds to confirm ERSPAN II encapsulation format.
Validated that the updated packet template matches the actual ERSPAN II structure generated by the platform.
Verified that TTL decrement behavior aligns with platform-specific recirculation.
Confirmed that masked fields do not impact packet comparison accuracy.
Ensured test passes on Q200 platforms and is appropriately skipped on G200 platforms.

#### Any platform specific information?
these changes apply specifically to Cisco-8000 (Q200) platforms and the test remains unsupported and is skipped on Cisco-8000 (G200) platforms.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
