### PR TITLE
Fix 1 test plan fail will cancel all peer test plans issue

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -371,7 +371,7 @@ steps:
           fi
       done
 
-      if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
+      if [ "$failure_count" -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
           echo "All testplan failed, cancel following steps"
           exit 3
       fi
@@ -405,7 +405,7 @@ steps:
           fi
       done
 
-      if [ $failure_count -eq "${#TEST_PLAN_ID_LIST[@]}" ]; then
+      if [ "$failure_count" -eq "${#TEST_PLAN_ID_LIST[@]}" ]; then
           echo "All testplan failed, cancel following steps"
           exit 3
       fi
@@ -438,7 +438,7 @@ steps:
           fi
       done
 
-      if [ $failure_count -eq ${#TEST_PLAN_ID_LIST[@]} ]; then
+      if [ "$failure_count" -eq "${#TEST_PLAN_ID_LIST[@]}" ]; then
           echo "All testplan failed, cancel following steps"
           exit 3
       fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
When we use `TEST_PLAN_NUM` and `.azure-pipelines/run-test-elastictest-template.yml` to create a batch of test plans, if 1 test plan fails, the others will be cancelled because test_plan.py will raise exception then run sys.exit. Previously this issue was fixed by https://github.com/sonic-net/sonic-mgmt/pull/12978 using `set -o` and failure counter, but `set -o` was changed back by https://github.com/sonic-net/sonic-mgmt/pull/15618.
#### How did you do it?
Change `set -e` back to `set -o` to make failure counter work again.
#### How did you verify/test it?
Verified in pipeline https://dev.azure.com/mssonic/build/_build/results?buildId=971751&view=logs&j=9657d7a6-3fe9-53eb-d67f-701685efa9c8&t=316819a7-603a-55dc-2941-0b950b5989c2
<img width="1559" height="97" alt="image" src="https://github.com/user-attachments/assets/9d8a7ce6-5324-4a8b-bdd9-063db101480a" />
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
