### PR TITLE
test_container_autorestart: ensure database container is covered

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -577,7 +577,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo, 
             # Wait for all critical services to be fully started
             logger.info("Waiting for all critical services to be fully started...")
             pytest_assert(wait_until(600, 20, 0, duthost.critical_services_fully_started),
-                         "Not all critical services are fully started after reboot")
+                          "Not all critical services are fully started after reboot")
 
             # Re-enable autorestart for all features
             logger.info("Re-enabling autorestart for all features...")

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -384,11 +384,12 @@ def verify_autorestart_with_critical_process(duthost, container_name, service_na
         # For containers without autorestart: killing critical process should NOT stop the container
         logger.info("Verifying container '{}' remains running (no autorestart by design)...".format(container_name))
         stopped = wait_until(CONTAINER_STOP_THRESHOLD_SECS,
-                            CONTAINER_CHECK_INTERVAL_SECS,
-                            0,
-                            check_container_state, duthost, container_name, False)
+                             CONTAINER_CHECK_INTERVAL_SECS,
+                             0,
+                             check_container_state, duthost, container_name, False)
         pytest_assert(not stopped,
-                     "Container '{}' stopped unexpectedly after killing process (should remain running)".format(container_name))
+                      "Container '{}' stopped unexpectedly after killing process "
+                      "(should remain running)".format(container_name))
         logger.info("Container '{}' remained running as expected (no autorestart triggered)".format(container_name))
 
 
@@ -572,9 +573,9 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
             logger.info("Manually restarting container '{}' to recover...".format(container_name))
             duthost.shell("sudo systemctl restart {}.service".format(service_name))
             restarted = wait_until(CONTAINER_RESTART_THRESHOLD_SECS,
-                                  CONTAINER_CHECK_INTERVAL_SECS,
-                                  0,
-                                  check_container_state, duthost, container_name, True)
+                                   CONTAINER_CHECK_INTERVAL_SECS,
+                                   0,
+                                   check_container_state, duthost, container_name, True)
             pytest_assert(restarted, "Failed to manually restart container '{}'".format(container_name))
             logger.info("Container '{}' was manually restarted successfully".format(container_name))
 

--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -581,7 +581,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
 
             # Perform config reload to restore system state (e.g., BGP sessions)
             logger.info("Performing config reload to restore system state...")
-            config_reload(duthost, config_source='config_db', safe_reload=True)
+            config_reload(duthost, config_source='config_db', safe_reload=True, wait_before_force_reload=600)
 
             # Re-enable autorestart after config reload
             enable_autorestart(duthost)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1714,7 +1714,7 @@ def generate_dut_feature_list(request, duts_selected, asics_selected):
     if meta is None:
         return tuple_list
 
-    skip_feature_list = ['database', 'database-chassis', 'gbsyncd']
+    skip_feature_list = ['database-chassis', 'gbsyncd']
 
     for a_dut_index, a_dut in enumerate(duts_selected):
         if len(asics_selected):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1714,7 +1714,7 @@ def generate_dut_feature_list(request, duts_selected, asics_selected):
     if meta is None:
         return tuple_list
 
-    skip_feature_list = ['database-chassis', 'gbsyncd']
+    skip_feature_list = ['gbsyncd']
 
     for a_dut_index, a_dut in enumerate(duts_selected):
         if len(asics_selected):


### PR DESCRIPTION
### Description of PR

Do not skip database container in test_critical_process_monitoring testcase. During recovery, first restart database container since it is stopped during test.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
