### PR TITLE
[Smartswitch] Update the DPU reload test for watchdog reboot

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -494,7 +494,7 @@ def post_test_switch_check(duthost, localhost,
     return
 
 
-def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause):
+def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout):
     """
     Runs all required checks for a given DPU
     Args:
@@ -507,8 +507,9 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause):
     """
 
     logging.info(f"Checking {dpu_name} is UP post test")
+    dpu_online_timeout = DPU_MAX_ONLINE_TIMEOUT + extra_dpu_online_timeout
     pytest_assert(
-        wait_until(DPU_MAX_ONLINE_TIMEOUT, DPU_MAX_TIME_INT, 0,
+        wait_until(dpu_online_timeout, DPU_MAX_TIME_INT, 0,
                    check_dpu_module_status, duthost, "on", dpu_name),
         f"DPU {dpu_name} is not operationally UP post the operation"
     )
@@ -533,7 +534,7 @@ def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause):
 
 
 def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,
-                         num_dpu_modules, reboot_cause):
+                         num_dpu_modules, reboot_cause, extra_dpu_online_timeout=0):
     """
     Checks DPU OFF/ON and reboot cause status Post Test
     Args:
@@ -551,7 +552,8 @@ def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,
         logging.info("Post test DPUs check in parallel")
         for dpu in dpu_on_list:
             executor.submit(post_test_dpu_check, duthost,
-                            dpuhosts, dpu, reboot_cause)
+                            dpuhosts, dpu, reboot_cause,
+                            extra_dpu_online_timeout)
 
     logging.info("Checking all powered on DPUs connectivity")
     ping_status = check_dpu_ping_status(duthost, ip_address_list)

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -494,7 +494,7 @@ def post_test_switch_check(duthost, localhost,
     return
 
 
-def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout):
+def post_test_dpu_check(duthost, dpuhosts, dpu_name, reboot_cause, extra_dpu_online_timeout=0):
     """
     Runs all required checks for a given DPU
     Args:

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -9,6 +9,7 @@ import time
 from tests.common.cisco_data import is_cisco_device
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.reboot import reboot, REBOOT_TYPE_COLD, SONIC_SSH_PORT, SONIC_SSH_REGEX
+from tests.common.helpers.dut_utils import is_mellanox_devices
 from tests.smartswitch.common.device_utils_dpu import check_dpu_link_and_status,\
     pre_test_check, post_test_switch_check, post_test_dpus_check,\
     dpus_shutdown_and_check, dpus_startup_and_check,\
@@ -26,6 +27,7 @@ memory_exhaustion_cmd = "sudo nohup bash -c 'sleep 5 && tail /dev/zero' &"
 DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
 DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
 MAX_COOL_OFF_TIME = 300
+EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
 
 
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
@@ -218,11 +220,16 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
         dpus_startup_and_check(duthost, dpu_on_list, num_dpu_modules)
 
     logging.info("Executing post test dpu check")
+    if is_mellanox_devices(duthost.facts['hwsku']):
+        reboot_cause_pattern = r"Watchdog"
+    else:
+        reboot_cause_pattern = r"reboot"
     post_test_dpus_check(duthost, dpuhosts,
                          dpu_on_list, ip_address_list,
                          num_dpu_modules,
-                         re.compile(r"reboot|Non-Hardware",
-                                    re.IGNORECASE))
+                         re.compile(reboot_cause_pattern,
+                                    re.IGNORECASE),
+                         EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG)
 
 
 @pytest.mark.disable_loganalyzer
@@ -269,10 +276,16 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
         dpus_startup_and_check(duthost, dpu_on_list, num_dpu_modules)
 
     logging.info("Executing post test dpu check")
-    post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,
+    if is_mellanox_devices(duthost.facts['hwsku']):
+        reboot_cause_pattern = r"Watchdog"
+    else:
+        reboot_cause_pattern = r"reboot"
+    post_test_dpus_check(duthost, dpuhosts,
+                         dpu_on_list, ip_address_list,
                          num_dpu_modules,
-                         re.compile(r"reboot|Non-Hardware",
-                                    re.IGNORECASE))
+                         re.compile(reboot_cause_pattern,
+                                    re.IGNORECASE),
+                         EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG)
 
 
 def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -220,10 +220,9 @@ def test_dpu_status_post_dpu_kernel_panic(duthosts, dpuhosts,
         dpus_startup_and_check(duthost, dpu_on_list, num_dpu_modules)
 
     logging.info("Executing post test dpu check")
+    reboot_cause_pattern = r"reboot|Non-Hardware"
     if is_mellanox_devices(duthost.facts['hwsku']):
         reboot_cause_pattern = r"Watchdog"
-    else:
-        reboot_cause_pattern = r"reboot"
     post_test_dpus_check(duthost, dpuhosts,
                          dpu_on_list, ip_address_list,
                          num_dpu_modules,
@@ -276,10 +275,10 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
         dpus_startup_and_check(duthost, dpu_on_list, num_dpu_modules)
 
     logging.info("Executing post test dpu check")
+    reboot_cause_pattern = r"reboot|Non-Hardware"
     if is_mellanox_devices(duthost.facts['hwsku']):
         reboot_cause_pattern = r"Watchdog"
-    else:
-        reboot_cause_pattern = r"reboot"
+
     post_test_dpus_check(duthost, dpuhosts,
                          dpu_on_list, ip_address_list,
                          num_dpu_modules,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update the test tests/smartswitch/platform_tests/test_reload_dpu.py for watchdog reboot.

1. Added reboot cause values specific to Nvidia plarform.
For Nvidia DPU, the watchdog reboot cause is "Watchdog".

2. Increase the DPU online timeout when it is watchdog reboot.
It will take more time as there is a timeout in watchdog before triggering the reboot.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
DPU reload test for watchdog reboot
#### How did you do it?

#### How did you verify/test it?
Run the test tests/smartswitch/platform_tests/test_reload_dpu.py with Nvidia SN4280, all passed.
#### Any platform specific information?
Only for smartswitch
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
