### PR TITLE
Fix VLAN key error issue on ptf topo, because there is no vlan config on ptf topo

### DIFF
--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -1029,7 +1029,7 @@ class QosSaiBase(QosBase):
                     dutLagInterfaces.append(src_mgFacts["minigraph_ptf_indices"][intf])
 
             config_facts = duthosts.config_facts(host=src_dut.hostname, source="running")
-            vlan_info = config_facts[src_dut.hostname]['VLAN']
+            vlan_info = config_facts[src_dut.hostname].get('VLAN', {})
             port_speeds = self.__buildPortSpeeds(config_facts[src_dut.hostname])
             low_speed_portIds = []
             if src_dut.facts['hwsku'] in self.BREAKOUT_SKUS and 'backend' not in topo:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When running the QoS SAI test on the PTF topology, the “VLAN Key" error will occur because the PTF topology lacks VLAN configuration. If the 'VLAN' key is not present, return {}.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Fix key error when running qos sai on ptf topo

#### How did you do it?
when key 'VLAN' does not exist, return {}

#### How did you verify/test it?
run qos sai test on ptf topo

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
