### PR TITLE
Fix qos buffer issue

### DIFF
--- a/tests/qos/buffer_helpers.py
+++ b/tests/qos/buffer_helpers.py
@@ -5,6 +5,8 @@ import logging
 import copy
 from jinja2 import Template
 from tests.common.mellanox_data import is_mellanox_device
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 
 PORT_CABLE_LEN_JSON_TEMPLATE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "files/mellanox")
 
@@ -25,11 +27,17 @@ class DutDbInfo:
     def get_config_db(self):
         return ast.literal_eval(self.duthost.shell('sonic-db-dump -n CONFIG_DB -y ')['stdout'])
 
+    def get_state_db(self):
+        return ast.literal_eval(self.duthost.shell('sonic-db-dump -n STATE_DB -y')['stdout'])
+
     def get_port_info_from_config_db(self, port):
         return self.config_db.get("PORT|{}".format(port)).get("value")
 
     def get_profile_name_from_appl_db(self, table, port, ids):
         return self.appl_db.get("{}:{}:{}".format(table, port, ids)).get("value").get("profile")
+
+    def get_port_info_from_state_db(self, port):
+        return self.state_db.get("PORT_TABLE|{}".format(port)).get("value")
 
     def get_buffer_profile_oid_in_pg_from_asic_db(self, buffer_item_asic_key, asic_key_name):
         return self.asic_db.get(buffer_item_asic_key).get("value").get(asic_key_name)
@@ -51,6 +59,7 @@ class DutDbInfo:
         self.config_db = self.get_config_db()
         self.appl_db = self.get_appl_db()
         self.asic_db = self.get_asic_db()
+        self.state_db = self.get_state_db()
 
 
 def get_ports_with_config_exceed_max_headroom(duthost):
@@ -69,6 +78,8 @@ def get_ports_with_config_exceed_max_headroom(duthost):
 
 
 def change_ports_cable_len(duthost, port_cable_info):
+    cmd_get_pool_size = 'redis-cli -n 0 hget "BUFFER_POOL_TABLE:ingress_lossless_pool" size'
+    original_pool_size = duthost.shell(cmd_get_pool_size)['stdout']
     ports_cable_len_j2_file_name = "ports_cable_len.j2"
     with open(os.path.join(PORT_CABLE_LEN_JSON_TEMPLATE_PATH, ports_cable_len_j2_file_name)) as template_file:
         t = Template(template_file.read())
@@ -81,6 +92,16 @@ def change_ports_cable_len(duthost, port_cable_info):
 
     duthost.shell(cmd_gen_port_cable_len_config)
     duthost.shell("sudo config load {} -y".format(ports_cable_len_config_json_file_name))
+
+    def _check_pool_size_is_updated(duthost, original_pool_size):
+        logger.info(f"original_pool_size is {original_pool_size}")
+        new_pool_size = duthost.shell(cmd_get_pool_size)['stdout']
+        logger.info(f"new_pool_size is {new_pool_size}")
+        return new_pool_size != original_pool_size
+
+    pytest_assert(
+        wait_until(20, 2, 0, _check_pool_size_is_updated, duthost, original_pool_size),
+        "Failed to update the buffer pool size after changing the cable length")
 
 
 def gen_ports_cable_info(ports_with_config_exceed_max_headroom_ports, map_port_to_cable_len, updated_cable_len):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. **test_buffer_deployment**: When the port's autoneg is enabled, follow these steps to create the profile: First, if adv_speeds are configured, use the maximum one of adv_speeds. If not, check if supported_speeds are configured and use their maximum supported speed. If neither are configured, default to the configured speed. So add the corresponding logic for port with autoneg is enabled.

2. **test_change_speed_cable, test_lossless_pg**: When original cable len is too long such as 300m, adding additional pg such 6 will lead the headroom size exceeding the max one, so change the original speed to a smaller one such as 50m to avoid the issue.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Fix qos bufer issue

#### How did you do it?
1. **test_buffer_deployment**: When the port's autoneg is enabled, follow these steps to create the profile: First, if adv_speeds are configured, use the maximum one of adv_speeds. If not, check if supported_speeds are configured and use their maximum supported speed. If neither are configured, default to the configured speed. So add the corresponding logic for port with autoneg is enabled.

2. **test_change_speed_cable, test_lossless_pg:** When original cable len is too long such as 300m, adding additional pg such 6 will lead the headroom size exceeding the max one, so change the original speed to a smaller one such as 50m to avoid the issue.

#### How did you verify/test it?
Run these qos buffer cases

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
