### PR TITLE
Don't always add Ethernet-IB attributes to the lab file for VOQ

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -688,30 +688,20 @@ def makeLab(data, devices, testbed, outfile):
                                             (asic_id * num_cores_per_asic) for asic_id in range(num_asics)]
                                     entry += "\tswitchids=\"" + str(switchids) + "\""
 
-                                    if voq_inband_ip is None:
-                                        voq_inband_ip = [
-                                            "1.1.1.{}/32"
-                                            .format(start_switchid + asic_id) for asic_id in range(num_asics)]
-                                    entry += "\tvoq_inband_ip=\"" + \
-                                        str(voq_inband_ip) + "\""
+                                    if voq_inband_ip is not None:
+                                        entry += "\tvoq_inband_ip=\"" + \
+                                            str(voq_inband_ip) + "\""
 
-                                    if voq_inband_ipv6 is None:
-                                        voq_inband_ipv6 = [
-                                            "1111::1:{}/128"
-                                            .format(start_switchid + asic_id) for asic_id in range(num_asics)]
-                                    entry += "\tvoq_inband_ipv6=\"" + \
-                                        str(voq_inband_ipv6) + "\""
+                                    if voq_inband_ipv6 is not None:
+                                        entry += "\tvoq_inband_ipv6=\"" + \
+                                            str(voq_inband_ipv6) + "\""
 
-                                    if voq_inband_intf is None:
-                                        voq_inband_intf = [
-                                            "Ethernet-IB{}"
-                                            .format(asic_id) for asic_id in range(num_asics)]
-                                    entry += "\tvoq_inband_intf=\"" + \
-                                        str(voq_inband_intf) + "\""
+                                    if voq_inband_intf is not None:
+                                        entry += "\tvoq_inband_intf=\"" + \
+                                            str(voq_inband_intf) + "\""
 
-                                    if voq_inband_type is None:
-                                        voq_inband_type = "port"
-                                    entry += "\tvoq_inband_type=" + voq_inband_type
+                                    if voq_inband_type is not None:
+                                        entry += "\tvoq_inband_type=" + voq_inband_type
 
                                     if max_cores is None:
                                         max_cores = 48


### PR DESCRIPTION
With the introduction of single-asic VOQ systems for UT2 we will no longer always have a `Ethernet-IB` port on these systems. This change updates the `TestbedProcessing.py` script to only add the `voq_inband*` attributes to the lab file if there is a `Ethernet-IB` port present.

Without this change we'll end up seeing `VoqInbandInterface` entries in the Minigraph.xml generated from deploy-mg which will cause crashes on single-asic VOQ systems that don't have `Ethernet-IB` ports.