### PR TITLE
Issue 21166: [dhcp_relay] Enable DHCP relay for T1 testbed tests

### DIFF
--- a/tests/dhcp_relay/conftest.py
+++ b/tests/dhcp_relay/conftest.py
@@ -47,22 +47,24 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="module", autouse=True)
 def check_dhcp_feature_status(duthost):
-    def is_dhcp_relay_enabled(duthost):
+    def is_dhcp_relay_enabled():
         feature_status_output = duthost.show_and_parse("show feature status")
         for feature in feature_status_output:
             if feature["feature"] == "dhcp_relay":
                 return feature["state"] == "enabled"
         return False
-    if not is_dhcp_relay_enabled(duthost):
-        try:
+
+    enabled_by_fixture = False
+    try:
+        if not is_dhcp_relay_enabled():
             duthost.shell("sudo config feature state dhcp_relay enabled")
-            py_assert(wait_until(30, 2, 0, is_dhcp_relay_enabled, duthost),
+            py_assert(wait_until(30, 2, 0, is_dhcp_relay_enabled),
                       "Failed to start dhcp_relay service")
-            yield
-        finally:
+            enabled_by_fixture = True
+        yield
+    finally:
+        if enabled_by_fixture:
             duthost.shell("sudo config feature state dhcp_relay disabled", module_ignore_errors=True)
-            return
-    yield
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
DHCP relay is not enabled for T1 topologies by default. Test will now try to enable dhcp_relay manually at startup, and will disable dhcp_relay at teardown if the feature was not already enabled to begin with.
Closes #21166 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Allow the test to be run successfully on T1 devices without requiring explicit configuration changes.

#### How did you do it?

Call `sudo config feature state dhcp_relay` with `enabled` before the test and `disabled` afterwards (so that you leave the dut in the same state you found it in).

#### How did you verify/test it?

Run the test on a T1 device which has only the default configuration.

Currently, the test will be skipped. With these changes, it will run the test instead.

Manually verified that the dhcp_relay feature is not still enabled at the end of the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
