### PR TITLE
Issue 21169: [ptf] Use teamd for PTF portchannel

### DIFF
--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -77,7 +77,9 @@ def exec_command(module, cmd, ignore_error=False, msg="executing command"):
 def get_portchannel_status(module, name):
     output = exec_command(
         module, cmd="supervisorctl status portchannel-%s" % name)
-    m = re.search(r'^([\w|-]*)\s+(\w*).*$', output.decode("utf-8"))
+    if isinstance(output, bytes):
+        output = output.decode("utf-8")
+    m = re.search(r'^([\w|-]*)\s+(\w*).*$', output)
     return m.group(2)
 
 

--- a/tests/common/helpers/portchannel_to_vlan.py
+++ b/tests/common/helpers/portchannel_to_vlan.py
@@ -61,19 +61,36 @@ def populate_fdb(ptfadapter, vlan_ports_list, vlan_intfs_dict):
 
 def ptf_teardown(ptfhost, ptf_lag_map):
     """
-    Restore ptf configuration
+    Restore PTF configuration
+
+    Automatically detects whether the LAG was created with teamd or kernel bonding
+    and uses the appropriate cleanup method.
 
     Args:
         ptfhost: PTF host object
         ptf_lag_map: imformation about lag in ptf
     """
-    ptfhost.set_dev_no_master(PTF_LAG_NAME)
+    # Check if LAG was created with teamd by looking for supervisor process
+    teamd_check = ptfhost.shell(
+        "supervisorctl status portchannel-{} 2>/dev/null".format(PTF_LAG_NAME),
+        module_ignore_errors=True
+    )
+    teamd_running = teamd_check["rc"] == 0
 
-    for ptf_lag_member in ptf_lag_map[PTF_LAG_NAME]["port_list"]:
-        ptfhost.set_dev_no_master(ptf_lag_member)
-        ptfhost.set_dev_up_or_down(ptf_lag_member, True)
+    if teamd_running:
+        logging.info("Cleaning up teamd-based LAG")
+        portchannel_config = {PTF_LAG_NAME: {"intfs": []}}
+        ptfhost.ptf_portchannel(cmd="stop", portchannel_config=portchannel_config)
+    else:
+        logging.info("Cleaning up kernel bonding LAG")
+        ptfhost.set_dev_no_master(PTF_LAG_NAME)
 
-    ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
+        for ptf_lag_member in ptf_lag_map[PTF_LAG_NAME]["port_list"]:
+            ptfhost.set_dev_no_master(ptf_lag_member)
+            ptfhost.set_dev_up_or_down(ptf_lag_member, True)
+
+        ptfhost.shell("ip link del {}".format(PTF_LAG_NAME))
+
     ptfhost.ptf_nn_agent()
 
 
@@ -121,9 +138,67 @@ def setup_dut_lag(duthost, dut_ports, vlan, src_vlan_id):
     return lag_port_map
 
 
+def setup_ptf_lag_teamd(ptfhost, lag_name, lag_ip, port_list):
+    """
+    Setup PTF LAG using teamd (for virtual interfaces)
+
+    teamd is compatible with virtual interfaces (veth pairs) and provides
+    proper LACP negotiation without requiring hardware-level MII detection.
+
+    Args:
+        ptfhost: PTF host object
+        lag_name: name of the LAG interface
+        lag_ip: IP address to assign to LAG
+        port_list: list of port names
+    """
+    # Extract interface indices from eth<N> format for teamd config
+    port_indices = []
+    for port_name in port_list:
+        port_indices.append(int(port_name.replace("eth", "")))
+
+    portchannel_config = {
+        lag_name: {
+            "intfs": port_indices
+        }
+    }
+
+    ptfhost.ptf_portchannel(cmd="start", portchannel_config=portchannel_config)
+
+    # Add IP address to the LAG interface
+    ptfhost.shell("ip addr add {} dev {}".format(lag_ip, lag_name))
+
+
+def setup_ptf_lag_kbond(ptfhost, lag_name, lag_ip, port_list):
+    """
+    Setup PTF LAG using kernel bonding (for physical interfaces)
+
+    Traditional kernel bonding approach that works well with physical interfaces
+    that provide proper hardware-level MII detection and link state information.
+
+    Args:
+        ptfhost: PTF host object
+        lag_name: name of the LAG interface
+        lag_ip: IP address to assign to LAG
+        port_list: list of port names
+    """
+    # Create kernel bond with LACP
+    ptfhost.create_lag(lag_name, lag_ip, "802.3ad")
+
+    for port_name in port_list:
+        ptfhost.add_intf_to_lag(lag_name, port_name)
+
+    ptfhost.startup_lag(lag_name)
+
+
 def setup_ptf_lag(ptfhost, ptf_ports, vlan):
     """
-    Setup ptf lag
+    Setup PTF LAG with automatic detection of virtual vs physical interfaces
+
+    This function automatically detects whether the PTF interfaces are virtual
+    (veth pairs in containers/VMs) or physical hardware interfaces, and uses
+    the appropriate LAG implementation:
+    - teamd for virtual interfaces
+    - kernel bonding for physical interfaces
 
     Args:
         ptfhost: PTF host object
@@ -136,23 +211,32 @@ def setup_ptf_lag(ptfhost, ptf_ports, vlan):
     ip_splits = vlan["ip"].split("/")
     vlan_ip = ipaddress.ip_address(UNICODE_TYPE(ip_splits[0]))
     lag_ip = "{}/{}".format(vlan_ip + 1, ip_splits[1])
-    # Add lag
-    ptfhost.create_lag(PTF_LAG_NAME, lag_ip, "802.3ad")
 
     port_list = []
-    # Add member to lag
     for _, port_name in list(ptf_ports[ATTR_PORT_BEHIND_LAG].items()):
-        ptfhost.add_intf_to_lag(PTF_LAG_NAME, port_name)
         port_list.append(port_name)
+
+    # Detect interface type: check if first port is virtual
+    first_port = port_list[0]
+    speed_result = ptfhost.shell(
+        "cat /sys/class/net/{}/speed 2>/dev/null || echo '-1'".format(first_port),
+        module_ignore_errors=True
+    )
+    # Virtual interfaces typically have speed: -1 (unknown/virtual)
+    is_virtual = speed_result["stdout"].strip() == "-1"
+
+    if is_virtual:
+        logging.info("Detected virtual interfaces, using teamd for LAG setup")
+        setup_ptf_lag_teamd(ptfhost, PTF_LAG_NAME, lag_ip, port_list)
+    else:
+        logging.info("Detected physical interfaces, using kernel bonding for LAG setup")
+        setup_ptf_lag_kbond(ptfhost, PTF_LAG_NAME, lag_ip, port_list)
 
     lag_port_map = {}
     lag_port_map[PTF_LAG_NAME] = {
         "port_list": port_list,
     }
-
-    ptfhost.startup_lag(PTF_LAG_NAME)
     ptfhost.ptf_nn_agent()
-    # Wait for lag sync
     time.sleep(10)
 
     return lag_port_map

--- a/tests/snmp/test_snmp_fdb.py
+++ b/tests/snmp/test_snmp_fdb.py
@@ -144,6 +144,11 @@ def test_snmp_fdb_send_tagged(ptfadapter, duthosts, rand_one_dut_hostname,      
         'ansible_facts']
     config_portchannels = cfg_facts.get('PORTCHANNEL', {})
     assert wait_until(60, 2, 0, is_port_channel_up, duthost, config_portchannels), "Portchannel is not up"
+
+    # Flush dataplane at the start to ensure clean state
+    # This prevents socket send errors from stale port configurations
+    ptfadapter.dataplane.flush()
+
     send_cnt = 0
     send_portchannels_cnt = 0
     vlan_ports_list = running_vlan_ports_list(duthosts, rand_one_dut_hostname, rand_selected_dut, tbinfo, ports_list)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PTF containers use veth interfaces, which makes creating portchannels with them tricky, since they lack the hardware information needed for LACP negotiation. teamd works around this limitation, so modify the test infra to detect when virtual interfaces are being added to a LAG and use teamd instead of kernel bonding in that case.

Closes #21169 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

This fix is necessary to set up LAG connections on PTF containers.

#### How did you do it?

Detect when virtual interfaces are being used as LAG pairs on the PTF and switch to using `teamd` if they are. I left the original kernel bonding code in place for backwards compatibility.

#### How did you verify/test it?

Manually verified that the LACP negotiation terminates correctly.

Verified that `snmp/test_snmp_fdb.py` fails without these changes when using a PTF container, and passes with them.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
