### PR TITLE
Change PTF_MODIFIED parameter type

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -78,8 +78,8 @@ parameters:
     default: "latest"
 
   - name: PTF_MODIFIED
-    type: boolean
-    default: false
+    type: string
+    default: "False"
 
   - name: IMAGE_URL
     type: string


### PR DESCRIPTION
### Description of PR

Change PTF_MODIFIED parameter type to string.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Azure CI does not allow passing runtime variable of string type to a Boolean template parameter.

#### How did you do it?

Convert it to string.

#### How did you verify/test it?

TBD

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA