### PR TITLE
Smartswitch Privatelink DASH: add polling for first DASH object configuration

### DIFF
--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -50,9 +50,9 @@ def common_setup_teardown(
     dpuhost = dpuhosts[dpu_index]
     logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
-    pytest_assert(wait_until(300, 15, 0, configure_dash_appliance_and_check,
-            localhost, duthost, ptfhost, dpuhost, dpu_index),
-            "Cannot configure appliance DASH object")
+    pytest_assert(
+        wait_until(300, 15, 0, configure_dash_appliance_and_check, localhost, duthost, ptfhost, dpuhost, dpu_index),
+        "Cannot configure appliance DASH object")
 
     base_config_messages = {
         **pl.ROUTING_TYPE_PL_CONFIG,

--- a/tests/dash/test_fnic.py
+++ b/tests/dash/test_fnic.py
@@ -64,9 +64,9 @@ def common_setup_teardown(
     else:
         tunnel_config = pl.TUNNEL2_CONFIG
 
-    pytest_assert(wait_until(300, 15, 0, configure_dash_appliance_and_check,
-                            localhost, duthost, ptfhost, dpuhost, dpu_index),
-                            "Cannot configure appliance DASH object")
+    pytest_assert(
+        wait_until(300, 15, 0, configure_dash_appliance_and_check, localhost, duthost, ptfhost, dpuhost, dpu_index),
+        "Cannot configure appliance DASH object")
 
     base_config_messages = {
 

--- a/tests/dash/test_plnsg.py
+++ b/tests/dash/test_plnsg.py
@@ -60,9 +60,9 @@ def config_setup_teardown(
     else:
         tunnel_config = pl.TUNNEL4_CONFIG
 
-    pt_assert(wait_until(300, 15, 0, configure_dash_appliance_and_check,
-                        localhost, duthost, ptfhost, dpuhost, dpu_index),
-                        "Cannot configure appliance DASH object")
+    pt_assert(
+        wait_until(300, 15, 0, configure_dash_appliance_and_check, localhost, duthost, ptfhost, dpuhost, dpu_index),
+        "Cannot configure appliance DASH object")
 
     base_config_messages = {
         **pl.ROUTING_TYPE_PL_CONFIG,


### PR DESCRIPTION
### Description of PR
When I run Smartswitch DASH testing, I observed that the first DASH objects where not configured and some of the PL and FNIC tests were failing.
This change adds a polling mechanism to make sure that config is applied within 300 seconds.
I run PL, PL FNIC and PLNSG tests and found that the delay was about 147s on MtFuji smartswitch so 300s should be enough. Here are the logs from those runs:
PL Test
03/11/2025 18:48:54 utilities.wait_until                     L0136 DEBUG  | Wait until configure_dash_appliance_and_check is True, timeout is 300 seconds, checking interval is 15, delay is 0 seconds
03/11/2025 18:51:20 utilities.wait_until                     L0146 DEBUG  | Time elapsed: 146.123504 seconds
03/11/2025 18:51:28 utilities.wait_until                     L0161 DEBUG  | configure_dash_appliance_and_check is True, exit early with True

FNIC Test
03/11/2025 15:10:46 utilities.wait_until                     L0136 DEBUG  | Wait until configure_dash_appliance_and_check is True, timeout is 300 seconds, checking interval is 15, delay is 0 seconds
03/11/2025 15:10:46 utilities.wait_until                     L0146 DEBUG  | Time elapsed: 0.000000 seconds
03/11/2025 15:13:13 utilities.wait_until                     L0146 DEBUG  | Time elapsed: 146.903283 seconds

PL NSG Test
03/11/2025 16:50:43 utilities.wait_until                     L0136 DEBUG  | Wait until configure_dash_appliance_and_check is True, timeout is 300 seconds, checking interval is 15, delay is 0 seconds
03/11/2025 16:53:10 utilities.wait_until                     L0146 DEBUG  | Time elapsed: 146.949415 seconds
03/11/2025 16:53:18 utilities.wait_until                     L0161 DEBUG  | configure_dash_appliance_and_check is True, exit early with True

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506

### Approach
#### What is the motivation for this PR?
DASH tests were failing

#### How did you do it?
Added conditional wait for DASH object configuration

#### How did you verify/test it?
Run the tests multiple times.

#### Any platform specific information?
Smartswitch 

#### Supported testbed topology if it's a new test case?

### Documentation
