### PR TITLE
Issue 21181: [sflow] test_sflow.py setup fails if VLAN1000 is not populated

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -117,7 +117,7 @@ def config_dut_ports(duthost, ports, vlan):
     # Even though port is deleted from vlan , the port shows its master as Bridge upon assigning ip address.
     # Hence config reload is done as workaround. ##FIXME
     for i in range(len(ports)):
-        duthost.command('config vlan member del %s %s' % (vlan, ports[i]))
+        duthost.command('config vlan member del %s %s' % (vlan, ports[i]), module_ignore_errors=True)
         duthost.command('config interface ip add %s %s/24' %
                         (ports[i], var['dut_intf_ips'][i]))
     duthost.command('config save -y')


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
sflow/test_sflow.py has a line of setup code that tries to remove entries from VLAN1000 which will fail if those entries don't already exist. It should instead just ignore those errors, since all it's doing is removing existing entreis so that it can add its own.

Closes #21181 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

This fix makes test_sflow.py easier to run by removing an unneeded assumption about testbed network design.

#### How did you do it?

Just ignore the error you would get when trying to remove a non-existent entry.

#### How did you verify/test it?

You can reproduce the issue by removing an entry from Vlan1000 and then running the test. Before this change, that will cause the test to fail. With this change, the test passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
