### PR TITLE
add topology marker to switchover impact test

### DIFF
--- a/tests/dualtor_io/test_switchover_impact.py
+++ b/tests/dualtor_io/test_switchover_impact.py
@@ -17,6 +17,11 @@ from tests.common.helpers.assertions import pytest_assert
 import logging
 
 
+pytestmark = [
+    pytest.mark.topology("dualtor")
+]
+
+
 @pytest.mark.parametrize("switchover", ["planned"])
 def test_tor_switchover_impact(request,                                                    # noqa: F811
                                upper_tor_host, lower_tor_host,                             # noqa: F811


### PR DESCRIPTION
### Description of PR
Adds missing topology marker for switchover impact test

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Add missing topology marker for switchover impact test

#### How did you do it?
added pytestmark for topology

#### How did you verify/test it?
