### PR TITLE
Issue 21185: [sflow] PTF script assumes port index map starts from 0

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -257,7 +257,6 @@ class SflowTest(BaseTest):
     def sendTraffic(self):
         src_ip_addr_templ = '192.168.{}.1'
         ip_dst_addr = '192.168.0.4'
-        src_mac = self.dataplane.get_mac(0, 0)
         pktlen = 100
         # send 100 * sampling_rate packets in each interface for better analysis
         for _ in range(0, 100, 1):
@@ -265,6 +264,7 @@ class SflowTest(BaseTest):
             for intf in self.interfaces:
                 ip_src_addr = src_ip_addr_templ.format(str(8 * index))
                 src_port = self.interfaces[intf]['ptf_indices']
+                src_mac = self.dataplane.get_mac(0, src_port)
                 tcp_pkt = testutils.simple_tcp_packet(pktlen=pktlen,
                                                       eth_dst=self.router_mac,
                                                       eth_src=src_mac,


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the sflow PTF script, the port map is assumed to start at zero, which is not always the case. The code calls 'self.dataplane.get_mac(0,0)' in order to get a source port MAC. A few lines later, the code gets the actual port to send the traffic, so we can use that source port MAC instead (which is more correct anyway).

Closes #21185 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Tests should not make assumptions about the underlying testbed network structure without a good reason. This change makes test_sflow.py more general.

#### How did you do it?

Instead of defaulting to port index zero and passing the same source port for every packet, we can use the source port for each given interface (since we're already looking them up) and pass that instead.

#### How did you verify/test it?

The test fails when run on a testbed with a PTF port index map that doesn't start at zero.

With these changes, the test passes on those testbeds.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
