### PR TITLE
Issue 22187: [sflow] Remove unnecessary 'config reload' call

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -112,16 +112,10 @@ def setup_ptf(ptfhost, collector_ports):
 
 
 def config_dut_ports(duthost, ports, vlan):
-    # https://github.com/sonic-net/sonic-buildimage/issues/2665
-    # Introducing config vlan member add and remove for the test port due to above mentioned PR.
-    # Even though port is deleted from vlan , the port shows its master as Bridge upon assigning ip address.
-    # Hence config reload is done as workaround. ##FIXME
     for i in range(len(ports)):
         duthost.command('config vlan member del %s %s' % (vlan, ports[i]), module_ignore_errors=True)
         duthost.command('config interface ip add %s %s/24' %
                         (ports[i], var['dut_intf_ips'][i]))
-    duthost.command('config save -y')
-    config_reload(duthost, config_source='config_db', wait=120)
     time.sleep(5)
 
 # ----------------------------------------------------------------------------------$


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
There is an extra 'config reload' call in the test_sflow.py test setup code. It was added as a workaround for a bug that was filed in 2019, and the workaround was supposed to have been removed in 2021, but the commend and the 'config reload' call are still there. The test passes fine without it, and it adds several minutes of overhead.

Closes [#22187](https://github.com/sonic-net/sonic-mgmt/issues/21187)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Speed up the test by removing outdated workaround.
#### How did you do it?
Remove the `config save`/`config reload` and the associated comment. I left the `sleep()` call in place, we should clean up the test timing separately.
#### How did you verify/test it?
Run the test after removing `config reload` and see that it passes.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
