### PR TITLE
Issue 21191: [sflow] Add acceptable range to incorrent num samples log

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -33,6 +33,12 @@ import logging
 import ast
 import subprocess
 
+# Checking samples with tolerance of 40 % as the sampling is random and not deterministic.
+# Over many samples it should converge to a mean of 1:N
+NUM_SAMPLES = 100
+MIN_EXPECTED_SAMPLES = 0.6 * NUM_SAMPLES
+MAX_EXPECTED_SAMPLES = 1.4 * NUM_SAMPLES
+
 
 class SflowTest(BaseTest):
     def __init__(self):
@@ -234,23 +240,19 @@ class SflowTest(BaseTest):
         logging.info("packets collected from interfaces ifindex : %s" %
                      data['flow_port_count'])
         logging.info("Expected number of packets from each port : %s to %s" % (
-            100 * 0.6, 100 * 1.4))
+            MIN_EXPECTED_SAMPLES, MAX_EXPECTED_SAMPLES))
         for port in self.interfaces:
             # NOTE: hsflowd is sending index instead of ifindex.
             index = self.interfaces[port]['port_index']
             logging.info("....%s : Flow packets collected from port %s = %s" % (
                 collector, port, data['flow_port_count'][index]))
             if port in self.enabled_intf:
-                # Checking samples with tolerance of 40 % as the sampling is random and not deterministic.
-                # Over many samples it should converge to a mean of 1:N
-                # Number of packets sent = 100 * sampling rate of interface
-                min_samples = 100 * 0.6
-                max_samples = 100 * 1.4
+                # Number of packets sent = NUM_SAMPLES * sampling rate of interface
                 self.assertTrue(
-                    min_samples <= data['flow_port_count'][index] <= max_samples,
+                    MIN_EXPECTED_SAMPLES <= data['flow_port_count'][index] <= MAX_EXPECTED_SAMPLES,
                     "Expected Number of samples are not collected from Interface %s in collector %s , Received %s"
                     " which is outside the acceptable range of %s to %s"
-                    % (port, collector, data['flow_port_count'][index], min_samples, max_samples))
+                    % (port, collector, data['flow_port_count'][index], MIN_EXPECTED_SAMPLES, MAX_EXPECTED_SAMPLES))
             else:
                 self.assertTrue(data['flow_port_count'][index] == 0,
                                 "Packets are collected from Non Sflow interface %s in collector %s" % (port, collector))
@@ -261,8 +263,8 @@ class SflowTest(BaseTest):
         src_ip_addr_templ = '192.168.{}.1'
         ip_dst_addr = '192.168.0.4'
         pktlen = 100
-        # send 100 * sampling_rate packets in each interface for better analysis
-        for _ in range(0, 100, 1):
+        # send NUM_SAMPLES * sampling_rate packets in each interface for better analysis
+        for _ in range(0, NUM_SAMPLES, 1):
             index = 0
             for intf in self.interfaces:
                 ip_src_addr = src_ip_addr_templ.format(str(8 * index))


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In the sflow PTF script, the error message for an incorrect number of samples does not include the acceptable range, which makes it hard to quickly tell what the issue was.

Closes #21191 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Improve usefulness of logging.
#### How did you do it?
Add the range check values the log statement.
#### How did you verify/test it?
Ran the test under a failing condition and verified that the logging displays the range correctly.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
