### PR TITLE
Issue 21168: [sflow] wait_for() instead of time.sleep()

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -23,6 +23,7 @@
 """
 
 import ptf
+import os
 import json
 from ptf.base_tests import BaseTest
 import ptf.testutils as testutils
@@ -54,7 +55,7 @@ class SflowTest(BaseTest):
         if 'enabled_sflow_interfaces' in self.test_params:
             self.enabled_intf = self.test_params['enabled_sflow_interfaces']
         self.agent_id = self.test_params['agent_id']
-        self.active_col = self.test_params['active_collectors']
+        self.active_col = ast.literal_eval(self.test_params['active_collectors'])
         self.sflow_interfaces = []
         self.sflow_ports_file = self.test_params['sflow_ports_file']
         if 'polling_int' in self.test_params:
@@ -70,6 +71,12 @@ class SflowTest(BaseTest):
         self.collectors = ['collector0', 'collector1']
         for param, value in self.test_params.items():
             logging.info("%s : %s" % (param, value))
+        samples_per_collector = 0
+        if 'enabled_sflow_interfaces' in self.test_params:
+            samples_per_collector = EXPECTED_FLOW_SAMPLES_PER_INTF * len(self.enabled_intf)
+        else:
+            samples_per_collector = EXPECTED_FLOW_SAMPLES_PER_INTF * len(self.interfaces)
+        self.total_expected_flow_samples = samples_per_collector * len(self.active_col)
 
     def tearDown(self):
         self.cmd(["supervisorctl", "stop", "arp_responder"])
@@ -97,7 +104,7 @@ class SflowTest(BaseTest):
 
     # --------------------------------------------------------------------------
 
-    def read_data(self, collector, event, sflow_port=['6343']):
+    def read_data(self, collector, ready_event, stop_event, sflow_port=['6343']):
         """
         Starts sflowtool with the corresponding port and saves the data to file for processing
         """
@@ -116,12 +123,13 @@ class SflowTest(BaseTest):
             port_sample[collector]['FlowSample'] = {}
             port_sample[collector]['CounterSample'] = {}
             logging.info("Collector %s starts collecting ......" % collector)
+            ready_event.set()
             timeout = 240
-            logging.info("Waiting for event to be set under {} seconds; Event is {}".format(
-                timeout, event.isSet()))
-            # Wait for event to be set from Main Thread or to pass out by timeout
-            event_is_set = event.wait(timeout=timeout)
-            logging.info("{}; Event set: {}".format(
+            logging.info("Waiting for stop_event to be set under {} seconds; stop_event is {}".format(
+                timeout, stop_event.isSet()))
+            # Wait for stop_event to be set from Main Thread or to pass out by timeout
+            event_is_set = stop_event.wait(timeout=timeout)
+            logging.info("{}; stop_event set: {}".format(
                 threading.current_thread().getName(), event_is_set))
 
         process.terminate()
@@ -149,15 +157,51 @@ class SflowTest(BaseTest):
         logging.info("%s Sampled Packets : Total flow samples -> %s Total counter samples -> %s" %
                      (collector, flow_count, counter_count))
         return (port_sample)
+
+    def count_packets_received(self, collector_name):
+        """
+        Count packets received by checking the collector's output file
+
+        Args:
+            collector_name: 'collector0' or 'collector1'
+
+        Returns:
+            tuple: flow_count, counter_count
+        """
+        outfile = f'/tmp/{collector_name}'
+        flow_count = 0
+        counter_count = 0
+        try:
+            if os.path.exists(outfile):
+                with open(outfile, 'r') as f:
+                    lines = f.readlines()
+                for line in lines:
+                    try:
+                        j = json.dumps(ast.literal_eval(line.strip()))
+                        datagram = json.loads(j)
+                        samples = datagram.get("samples", [])
+                        for sample in samples:
+                            sample_type = sample.get("sampleType", "")
+                            if sample_type == "FLOWSAMPLE":
+                                flow_count += 1
+                            elif sample_type == "COUNTERSSAMPLE":
+                                counter_count += 1
+                    except (ValueError, SyntaxError, json.JSONDecodeError):
+                        # Skip malformed lines
+                        continue
+        except (OSError, IOError):
+            # File doesn't exist or can't be read
+            pass
+        total_count = flow_count + counter_count
+        return flow_count, counter_count, total_count
     # --------------------------------------------------------------------------
 
-    def collector_0(self, event):
-        self.collector0_samples = self.read_data('collector0', event)
+    def collector_0(self, ready_event, stop_event):
+        self.collector0_samples = self.read_data('collector0', ready_event, stop_event)
     # --------------------------------------------------------------------------
 
-    def collector_1(self, event):
-        self.collector1_samples = self.read_data('collector1', event, ['6344'])
-
+    def collector_1(self, ready_event, stop_event):
+        self.collector1_samples = self.read_data('collector1', ready_event, stop_event, ['6344'])
     # --------------------------------------------------------------------------
 
     def packet_analyzer(self, port_sample, collector, poll_test):
@@ -287,17 +331,22 @@ class SflowTest(BaseTest):
 
     def runTest(self):
         self.generate_ArpResponderConfig()
-        time.sleep(1)
+        collector0_ready = threading.Event()
+        collector1_ready = threading.Event()
         stop_collector = threading.Event()
         thr1 = threading.Thread(target=self.collector_0,
-                                name='Collector0_thread', args=(stop_collector,))
+                                name='Collector0_thread', args=(collector0_ready, stop_collector,))
         thr2 = threading.Thread(target=self.collector_1,
-                                name='Collector1_thread', args=(stop_collector,))
+                                name='Collector1_thread', args=(collector1_ready, stop_collector,))
         thr1.start()
-        time.sleep(2)
         thr2.start()
-        # wait for the collectors to initialise
-        time.sleep(5)
+
+        # Wait for both collectors to be ready
+        if not collector0_ready.wait(timeout=30):
+            raise Exception("Collector 0 failed to initialize")
+        if not collector1_ready.wait(timeout=30):
+            raise Exception("Collector 1 failed to initialize")
+
         if self.poll_tests:
             if self.polling_int == 0:
                 time.sleep(20)
@@ -308,7 +357,30 @@ class SflowTest(BaseTest):
                 time.sleep(self.polling_int)
         else:
             self.sendTraffic()
-            time.sleep(10)  # For Test Stability
+
+            # Wait for packets to arrive. If we don't see any packets for 30 seconds, fail the test.
+            # Otherwise, as long as packets are arriving, keep waiting.
+            last_update_time = time.time()
+            last_packet_count = 0
+            while time.time() < last_update_time + 30:
+                time.sleep(5)
+                current_packet_count = 0
+                for collector in self.active_col:
+                    flow_count, _, _ = self.count_packets_received(collector)
+                    current_packet_count += flow_count
+                if current_packet_count > last_packet_count:
+                    last_packet_count = current_packet_count
+                    # If we're receiving packets but haven't seen all the ones we expect, just wait longer.
+                    # If we've seen as many as we expect, let the timeout expire to see if we get any extra.
+                    if last_packet_count < self.total_expected_flow_samples:
+                        last_update_time = time.time()
+                    logging.info("%s/%s packets received, waiting for more..." % (
+                        last_packet_count, self.total_expected_flow_samples))
+                elif last_packet_count > 0:
+                    # We're not receiving any new packets, time to count the samples
+                    logging.info("No new packets received, stopping...")
+                    break
+
         stop_collector.set()
         thr1.join()
         thr2.join()

--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -51,10 +51,16 @@ class SflowTest(BaseTest):
         self.router_mac = self.test_params['router_mac']
         self.dst_port = self.test_params['dst_port']
 
+        self.enabled_intf = []
         if 'enabled_sflow_interfaces' in self.test_params:
-            self.enabled_intf = self.test_params['enabled_sflow_interfaces']
+            intf_param = self.test_params['enabled_sflow_interfaces']
+            self.enabled_intf = ast.literal_eval(intf_param) if isinstance(intf_param, str) else intf_param
         self.agent_id = self.test_params['agent_id']
-        self.active_col = ast.literal_eval(self.test_params['active_collectors'])
+        if 'active_collectors' in self.test_params:
+            col_param = self.test_params['active_collectors']
+            self.active_col = ast.literal_eval(col_param) if isinstance(col_param, str) else col_param
+        else:
+            self.active_col = []
         self.sflow_interfaces = []
         self.sflow_ports_file = self.test_params['sflow_ports_file']
         if 'polling_int' in self.test_params:
@@ -70,11 +76,8 @@ class SflowTest(BaseTest):
         self.collectors = ['collector0', 'collector1']
         for param, value in self.test_params.items():
             logging.info("%s : %s" % (param, value))
-        samples_per_collector = 0
-        if 'enabled_sflow_interfaces' in self.test_params:
-            samples_per_collector = EXPECTED_FLOW_SAMPLES_PER_INTF * len(self.enabled_intf)
-        else:
-            samples_per_collector = EXPECTED_FLOW_SAMPLES_PER_INTF * len(self.interfaces)
+
+        samples_per_collector = NUM_SAMPLES * len(self.enabled_intf)
         self.total_expected_flow_samples = samples_per_collector * len(self.active_col)
 
     def tearDown(self):

--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -142,8 +142,8 @@ class SflowTest(BaseTest):
                                 sample['agent_id'] = agent
                                 port_sample[collector]['CounterSample'].append(sample)
                     except (ValueError, SyntaxError) as e:
-                        # sflowtool can spit out bad lines if it recieves chopped or malformed packets
-                        logging.warning("Skipping malformed line in %s: %s (error: %s)", collector, line[:100], str(e))
+                        # sflowtool output can include stderr
+                        logging.warning("Skipping line in %s: %s (error: %s)", collector, line[:100], str(e))
                         continue
         except OSError as e:
             # if sflowtool hasn't started writing yet this is expected

--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -305,6 +305,12 @@ class SflowTest(BaseTest):
         src_ip_addr_templ = '192.168.{}.1'
         ip_dst_addr = '192.168.0.4'
         pktlen = 100
+        # VS tap interfaces have limited kernel receive queue depth.
+        # Sending large bursts (e.g. 512 packets) all at once causes ~20% drops
+        # before packets reach the TC ingress filter/sampler.
+        # Send in small batches with a brief pause to allow the queue to drain.
+        BATCH_SIZE = 32
+        BATCH_SLEEP = 0.001  # 1ms between batches
         # send NUM_SAMPLES * sampling_rate packets in each interface for better analysis
         for _ in range(0, NUM_SAMPLES, 1):
             index = 0
@@ -319,7 +325,13 @@ class SflowTest(BaseTest):
                                                       ip_dst=ip_dst_addr,
                                                       ip_ttl=64)
                 no_of_packets = self.interfaces[intf]['sample_rate']
-                testutils.send(self, src_port, tcp_pkt, count=no_of_packets)
+                remaining = no_of_packets
+                while remaining > 0:
+                    burst = min(BATCH_SIZE, remaining)
+                    testutils.send(self, src_port, tcp_pkt, count=burst)
+                    remaining -= burst
+                    if remaining > 0:
+                        time.sleep(BATCH_SLEEP)
                 index += 1
             pktlen += 10  # send traffic with different packet sizes
 

--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -373,10 +373,6 @@ class SflowTest(BaseTest):
                         last_update_time = time.time()
                     logging.info("%s/%s packets received, waiting for more..." % (
                         last_packet_count, self.total_expected_flow_samples))
-                elif last_packet_count > 0:
-                    # We're not receiving any new packets, time to count the samples
-                    logging.info("No new packets received, stopping...")
-                    break
 
         stop_collector.set()
         thr1.join()

--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -35,7 +35,9 @@ import subprocess
 
 # Checking samples with tolerance of 40 % as the sampling is random and not deterministic.
 # Over many samples it should converge to a mean of 1:N
-NUM_SAMPLES = 100
+# Use 200 samples so the ±40% bounds are ~5.7σ away (vs ~4σ at 100), making flaky
+# bound violations essentially impossible.
+NUM_SAMPLES = 200
 MIN_EXPECTED_SAMPLES = 0.6 * NUM_SAMPLES
 MAX_EXPECTED_SAMPLES = 1.4 * NUM_SAMPLES
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -447,25 +447,26 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
 
         tc_before = _tc_filter_pkts(var['sflow_ports'])
 
-        result = ptf_runner(host=ptfhost,
-                            testdir="ptftests",
-                            platform_dir="ptftests",
-                            testname="sflow_test",
-                            params=params,
-                            socket_recv_size=16384,
-                            log_file="/tmp/{}.{}.log".format(
-                                request.cls.__name__, request.function.__name__),
-                            is_python3=True)
-
-        tc_after = _tc_filter_pkts(var['sflow_ports'])
-        for intf, before in tc_before.items():
-            after = tc_after.get(intf)
-            if before is not None and after is not None:
-                delta = after - before
-                sent = var['sflow_ports'][intf]['sample_rate'] * 100
-                logger.warn(
-                    f'TC filter [{intf}]: matched {delta} pkts, PTF sent ~{sent} '
-                    f'({100 * delta // sent if sent else 0}% reached TC filter)')
+        try:
+            result = ptf_runner(host=ptfhost,
+                                testdir="ptftests",
+                                platform_dir="ptftests",
+                                testname="sflow_test",
+                                params=params,
+                                socket_recv_size=16384,
+                                log_file="/tmp/{}.{}.log".format(
+                                    request.cls.__name__, request.function.__name__),
+                                is_python3=True)
+        finally:
+            tc_after = _tc_filter_pkts(var['sflow_ports'])
+            for intf, before in tc_before.items():
+                after = tc_after.get(intf)
+                if before is not None and after is not None:
+                    delta = after - before
+                    sent = var['sflow_ports'][intf]['sample_rate'] * 100
+                    logger.warning(
+                        f'TC filter [{intf}]: matched {delta} pkts, PTF sent ~{sent} '
+                        f'({100 * delta // sent if sent else 0}% reached TC filter)')
 
         return result
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -433,15 +433,41 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
         if collector_ips:
             wait_until_hsflowd_ready(duthost, collector_ips)
 
-        return ptf_runner(host=ptfhost,
-                          testdir="ptftests",
-                          platform_dir="ptftests",
-                          testname="sflow_test",
-                          params=params,
-                          socket_recv_size=16384,
-                          log_file="/tmp/{}.{}.log".format(
-                              request.cls.__name__, request.function.__name__),
-                          is_python3=True)
+        def _tc_filter_pkts(interfaces):
+            """Read TC ingress filter matched-packet counters for the given interfaces."""
+            counts = {}
+            for intf in interfaces:
+                out = duthost.shell(
+                    f'sudo tc -s filter show dev {intf} ingress 2>/dev/null',
+                    module_ignore_errors=True
+                )['stdout']
+                m = re.search(r'Sent \d+ bytes (\d+) pkts', out)
+                counts[intf] = int(m.group(1)) if m else None
+            return counts
+
+        tc_before = _tc_filter_pkts(var['sflow_ports'])
+
+        result = ptf_runner(host=ptfhost,
+                            testdir="ptftests",
+                            platform_dir="ptftests",
+                            testname="sflow_test",
+                            params=params,
+                            socket_recv_size=16384,
+                            log_file="/tmp/{}.{}.log".format(
+                                request.cls.__name__, request.function.__name__),
+                            is_python3=True)
+
+        tc_after = _tc_filter_pkts(var['sflow_ports'])
+        for intf, before in tc_before.items():
+            after = tc_after.get(intf)
+            if before is not None and after is not None:
+                delta = after - before
+                sent = var['sflow_ports'][intf]['sample_rate'] * 100
+                logger.warn(
+                    f'TC filter [{intf}]: matched {delta} pkts, PTF sent ~{sent} '
+                    f'({100 * delta // sent if sent else 0}% reached TC filter)')
+
+        return result
 
     return _partial_ptf_runner
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -441,7 +441,7 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
                     f'sudo tc -s filter show dev {intf} ingress 2>/dev/null',
                     module_ignore_errors=True
                 )['stdout']
-                m = re.search(r'Sent \d+ bytes (\d+) pkts', out)
+                m = re.search(r'Sent \d+ bytes (\d+) pkts?', out)
                 counts[intf] = int(m.group(1)) if m else None
             return counts
 

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -33,21 +33,59 @@ logger = logging.getLogger(__name__)
 
 def is_hsflowd_ready(duthost):
     """
-    Check if hsflowd is running.
+    Check if hsflowd is running and fully initialized.
     """
-    # Check if the sflow container is running
     if not duthost.is_container_running("sflow"):
+        logger.info("is_hsflowd_ready: sflow container not running")
         return False
 
-    # Check if hsflowd is running inside the container
     result = duthost.command("docker exec sflow pgrep hsflowd")
     if result['failed']:
+        logger.info("is_hsflowd_ready: hsflowd process not found")
         return False
     hsflowd_pid = result['stdout_lines'][0]
     if not hsflowd_pid:
+        logger.info("is_hsflowd_ready: hsflowd pid is empty")
         return False
 
+    result = duthost.command("docker exec sflow test -f /etc/hsflowd.auto", module_ignore_errors=True)
+    if result['failed'] or result['rc'] != 0:
+        logger.info("is_hsflowd_ready: hsflowd.auto does not exist")
+        return False
+
+    logger.info("is_hsflowd_ready: all checks passed")
     return True
+
+
+# ----------------------------------------------------------------------------------
+
+
+def wait_for_system_ready(duthost, timeout=180):
+    """
+    Wait for SYSTEM_READY|SYSTEM_STATE to be set to "UP" in Redis STATE_DB.
+
+    hsflowd and other services wait for this key to be set before becoming fully operational.
+
+    Args:
+        duthost: DUT host object
+        timeout: Maximum seconds to wait
+    """
+    def check_system_ready():
+        result = duthost.shell(
+            'redis-cli -n 6 HGET "SYSTEM_READY|SYSTEM_STATE" Status',
+            module_ignore_errors=True
+        )
+        if result['rc'] == 0 and result['stdout'].strip() == 'UP':
+            logger.info("SYSTEM_READY|SYSTEM_STATE is UP")
+            return True
+        logger.info("SYSTEM_READY|SYSTEM_STATE is not UP yet")
+        return False
+
+    if not wait_until(timeout, 5, 0, check_system_ready):
+        logger.warn(f"SYSTEM_READY|SYSTEM_STATE is not UP after {timeout}s, test may not behave predictably")
+
+
+# ----------------------------------------------------------------------------------
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -207,13 +245,23 @@ def config_sflow_agent(duthosts, rand_one_dut_hostname):
 
 
 def config_sflow(duthost, sflow_status='enable'):
+    """
+    Enable or disable sflow on the DUT.
+
+    Args:
+        duthost: DUT host object
+        sflow_status: 'enable' or 'disable'
+    """
     duthost.shell('config sflow %s' % sflow_status)
     expected = 'up' if sflow_status == 'enable' else 'down'
     wait_until(30, 5, 0, lambda: re.search(
         r"sFlow Admin State:\s+%s" % expected,
         duthost.shell('show sflow')['stdout']))
-    if sflow_status == 'enable' and not wait_until(180, 10, 0, is_hsflowd_ready, duthost):
-        pytest.fail("hsflowd is not running")
+
+    if sflow_status == 'enable':
+        wait_for_system_ready(duthost)
+        if not wait_until(180, 10, 0, is_hsflowd_ready, duthost):
+            pytest.fail("hsflowd is not running")
 
 # ----------------------------------------------------------------------------------
 
@@ -393,15 +441,13 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
 
 def check_sflow_traffic(duthost, partial_ptf_runner, enabled_sflow_interfaces="[]",
                         active_collectors="[]", agent_id=None, polling_int=None):
-    def check_sflow_traffic_on_ptf():
-        kwargs = {'enabled_sflow_interfaces': enabled_sflow_interfaces,
-                  'active_collectors': active_collectors}
-        if agent_id is not None:
-            kwargs['agent_id'] = agent_id
-        if polling_int is not None:
-            kwargs['polling_int'] = polling_int
-        return partial_ptf_runner(**kwargs)
-    return wait_until(180, 10, 0, check_sflow_traffic_on_ptf)
+    kwargs = {'enabled_sflow_interfaces': enabled_sflow_interfaces,
+              'active_collectors': active_collectors}
+    if agent_id is not None:
+        kwargs['agent_id'] = agent_id
+    if polling_int is not None:
+        kwargs['polling_int'] = polling_int
+    return partial_ptf_runner(**kwargs)
 
 
 # ----------------------------------------------------------------------------------
@@ -744,6 +790,7 @@ class TestReboot():
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
         force_active_tor(duthost, "all")
+        wait_for_system_ready(duthost)
         assert wait_until(60, 5, 0, verify_sflow_config_apply, duthost)
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'], polling_int=80)
@@ -777,6 +824,7 @@ class TestReboot():
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
         force_active_tor(duthost, "all")
+        wait_for_system_ready(duthost)
         verify_show_sflow(duthost, status='down')
         for intf in var['sflow_ports']:
             var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost, intf)
@@ -799,6 +847,7 @@ class TestReboot():
         reboot(duthost, localhost, reboot_type='fast')
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        wait_for_system_ready(duthost)
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
         for intf in var['sflow_ports']:
@@ -824,6 +873,7 @@ class TestReboot():
         reboot(duthost, localhost, reboot_type='warm')
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        wait_for_system_ready(duthost)
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
         for intf in var['sflow_ports']:

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -421,7 +421,8 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
                   'router_mac': var['router_mac'],
                   'dst_port': var['ptf_test_indices'][2],
                   'agent_id': var['lo_ip'],
-                  'sflow_ports_file': "/tmp/sflow_ports.json"}
+                  'sflow_ports_file': "/tmp/sflow_ports.json",
+                  'kvm_support': True}
         params.update(kwargs)
 
         # Make sure hsflowd daemon has processed collector config before

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -31,6 +31,25 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
+def is_hsflowd_ready(duthost):
+    """
+    Check if hsflowd is running.
+    """
+    # Check if the sflow container is running
+    if not duthost.is_container_running("sflow"):
+        return False
+
+    # Check if hsflowd is running inside the container
+    result = duthost.command("docker exec sflow pgrep hsflowd")
+    if result['failed']:
+        return False
+    hsflowd_pid = result['stdout_lines'][0]
+    if not hsflowd_pid:
+        return False
+
+    return True
+
+
 @pytest.fixture(scope='module', autouse=True)
 def setup(duthosts, rand_one_dut_hostname, ptfhost, tbinfo, config_sflow_feature):
     duthost = duthosts[rand_one_dut_hostname]
@@ -193,6 +212,9 @@ def config_sflow(duthost, sflow_status='enable'):
     wait_until(30, 5, 0, lambda: re.search(
         r"sFlow Admin State:\s+%s" % expected,
         duthost.shell('show sflow')['stdout']))
+    if sflow_status == 'enable' and not wait_until(180, 10, 0, is_hsflowd_ready, duthost):
+        pytest.fail("hsflowd is not running")
+
 # ----------------------------------------------------------------------------------
 
 
@@ -356,17 +378,31 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
         if collector_ips:
             wait_until_hsflowd_ready(duthost, collector_ips)
 
-        ptf_runner(host=ptfhost,
-                   testdir="ptftests",
-                   platform_dir="ptftests",
-                   testname="sflow_test",
-                   params=params,
-                   socket_recv_size=16384,
-                   log_file="/tmp/{}.{}.log".format(
-                       request.cls.__name__, request.function.__name__),
-                   is_python3=True)
+        return ptf_runner(host=ptfhost,
+                          testdir="ptftests",
+                          platform_dir="ptftests",
+                          testname="sflow_test",
+                          params=params,
+                          socket_recv_size=16384,
+                          log_file="/tmp/{}.{}.log".format(
+                              request.cls.__name__, request.function.__name__),
+                          is_python3=True)
 
     return _partial_ptf_runner
+
+
+def check_sflow_traffic(duthost, partial_ptf_runner, enabled_sflow_interfaces="[]",
+                        active_collectors="[]", agent_id=None, polling_int=None):
+    def check_sflow_traffic_on_ptf():
+        kwargs = {'enabled_sflow_interfaces': enabled_sflow_interfaces,
+                  'active_collectors': active_collectors}
+        if agent_id is not None:
+            kwargs['agent_id'] = agent_id
+        if polling_int is not None:
+            kwargs['polling_int'] = polling_int
+        return partial_ptf_runner(**kwargs)
+    return wait_until(180, 10, 0, check_sflow_traffic_on_ptf)
+
 
 # ----------------------------------------------------------------------------------
 
@@ -455,9 +491,10 @@ class TestSflowCollector():
         for intf in var['sflow_ports']:
             verify_sflow_interfaces(duthost, intf, 'up', SFLOW_RATE_DEFAULT)
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0']"), \
+               "No sflow samples received in collector"
 
     def test_collector_del_add(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
@@ -469,16 +506,17 @@ class TestSflowCollector():
                        'show sflow')['stdout'])) == 0)
         verify_show_sflow(duthost, status='up', collector=[])
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="[]")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys())), \
+               "Unexpected sflow samples received"
         # re-add collector
         config_sflow_collector(duthost, 'collector0', 'add')
         verify_show_sflow(duthost, status='up', collector=['collector0'])
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0']"), \
+               "No sflow samples received in collector"
 
     def test_two_collectors(self, sflowbase_config, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
@@ -486,26 +524,29 @@ class TestSflowCollector():
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
-        # Remove second collector anc check samples are received in only 1st collector
+        # Remove second collector and check samples are received in only 1st collector
         config_sflow_collector(duthost, 'collector1', 'del')
         verify_show_sflow(duthost, status='up', collector=['collector0'])
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0']"), \
+               "No sflow samples received in collector"
 
         # Re-add second collector and check if samples are received in both collectors again
         config_sflow_collector(duthost, 'collector1', 'add')
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'])
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
         # Add third collector and check only 2 collectors can be configured
         out = duthost.command(
@@ -516,9 +557,10 @@ class TestSflowCollector():
         config_sflow_collector(duthost, 'collector0', 'del')
         verify_show_sflow(duthost, status='up', collector=['collector1'])
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector1']"), \
+               "Received an uneexpected number of sflow samples"
 
 
 # ------------------------------------------------------------------------------
@@ -535,27 +577,30 @@ class TestSflowPolling():
         duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 20")
         verify_show_sflow(duthost, status='up', polling_int=20)
-        partial_ptf_runner(
-            polling_int=20,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=20,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
     def testDisablePolling(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 0")
 
         verify_show_sflow(duthost, status='up', polling_int=0)
-        partial_ptf_runner(
-            polling_int=0,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=0,
+                                   active_collectors="['collector0','collector1']"), \
+               "Received an uneexpected number of sflow samples"
 
     def testDifferentPollingInt(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 60")
 
         verify_show_sflow(duthost, status='up', polling_int=60)
-        partial_ptf_runner(
-            polling_int=60,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=60,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
 # ------------------------------------------------------------------------------
 
@@ -583,9 +628,10 @@ class TestSflowInterface():
             verify_sflow_interfaces(duthost, intf, 'up', SFLOW_RATE_DEFAULT)
 
         # Traffic test for the enabled sflow interfaces
-        partial_ptf_runner(
-            enabled_sflow_interfaces=enabled_sflow_intf_list,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=enabled_sflow_intf_list,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
     def testIntfSamplingRate(self, sflowbase_config, duthosts, rand_one_dut_hostname,
                              ptfhost, partial_ptf_runner, selected_portchannel_members,
@@ -612,9 +658,10 @@ class TestSflowInterface():
         # Traffic test for the enabled sflow interfaces
         ptfhost.copy(content=var['portmap'], dest="/tmp/sflow_ports.json")
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        partial_ptf_runner(
-            enabled_sflow_interfaces=enabled_sflow_intf_list,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=enabled_sflow_intf_list,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
         # Revert sflow rate for interface in first portchannel
         for intf in first_portchannel_members:
@@ -629,9 +676,10 @@ class TestSflowInterface():
         # Traffic test for the enabled sflow interfaces
         var['portmap'] = json.dumps(var['sflow_ports'])
         ptfhost.copy(content=var['portmap'], dest="/tmp/sflow_ports.json")
-        partial_ptf_runner(
-            enabled_sflow_interfaces=enabled_sflow_intf_list,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=enabled_sflow_intf_list,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
 # ------------------------------------------------------------------------------
 
@@ -650,32 +698,34 @@ class TestAgentId():
         duthost.shell(" config sflow agent-id del")
         duthost.shell(" config sflow agent-id  add Loopback0")
         verify_show_sflow(duthost, status='up', agent_id='Loopback0')
-        partial_ptf_runner(
-            polling_int=20,
-            agent_id=agent_ip,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=20,
+                                   agent_id=agent_ip,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
     def testDelAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost, status='up', agent_id='default')
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
-        agent_ip = get_default_agent(duthost)
         # Verify  whether the samples are received with previously configured agent ip
-        partial_ptf_runner(
-            polling_int=20,
-            agent_id=agent_ip,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=20,
+                                   agent_id=agent_ip,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
     def testAddAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
         duthost = duthosts[rand_one_dut_hostname]
         agent_ip = var['mgmt_ip']
         duthost.shell(" config sflow agent-id  add  eth0")
         verify_show_sflow(duthost, status='up', agent_id='eth0')
-        partial_ptf_runner(
-            polling_int=20,
-            agent_id=agent_ip,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=20,
+                                   agent_id=agent_ip,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
 # ------------------------------------------------------------------------------
 
@@ -704,13 +754,15 @@ class TestReboot():
             verify_sflow_interfaces(duthost, intf, 'up', SFLOW_RATE_DEFAULT)
         var['portmap'] = json.dumps(var['sflow_ports'])
         ptfhost.copy(content=var['portmap'], dest="/tmp/sflow_ports.json")
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
         # Test Polling
-        partial_ptf_runner(
-            polling_int=80,
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   polling_int=80,
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
     def testRebootSflowDisable(self, sflowbase_config, duthosts, rand_one_dut_hostname,
                                force_active_tor, localhost, partial_ptf_runner, ptfhost):
@@ -732,9 +784,9 @@ class TestReboot():
                 duthost, intf)
         var['portmap'] = json.dumps(var['sflow_ports'])
         ptfhost.copy(content=var['portmap'], dest="/tmp/sflow_ports.json")
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="[]")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys())), \
+               "Received unexpected sflow samples"
 
     def testFastreboot(self, sflowbase_config, config_sflow_agent, duthosts,
                        rand_one_dut_hostname, localhost, partial_ptf_runner, ptfhost):
@@ -756,9 +808,10 @@ class TestReboot():
             verify_sflow_interfaces(duthost, intf, 'up', SFLOW_RATE_DEFAULT)
         var['portmap'] = json.dumps(var['sflow_ports'])
         ptfhost.copy(content=var['portmap'], dest="/tmp/sflow_ports.json")
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"
 
     def testWarmreboot(self, sflowbase_config, duthosts, rand_one_dut_hostname,
                        localhost, partial_ptf_runner, ptfhost):
@@ -780,6 +833,7 @@ class TestReboot():
             verify_sflow_interfaces(duthost, intf, 'up', SFLOW_RATE_DEFAULT)
         var['portmap'] = json.dumps(var['sflow_ports'])
         ptfhost.copy(content=var['portmap'], dest="/tmp/sflow_ports.json")
-        partial_ptf_runner(
-            enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
-            active_collectors="['collector0','collector1']")
+        assert check_sflow_traffic(duthost, partial_ptf_runner,
+                                   enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
+                                   active_collectors="['collector0','collector1']"), \
+               "Missing sflow samples in either or both collectors"

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -439,10 +439,13 @@ def partial_ptf_runner(request, duthosts, rand_one_dut_hostname, ptfhost, tbinfo
     return _partial_ptf_runner
 
 
-def check_sflow_traffic(duthost, partial_ptf_runner, enabled_sflow_interfaces="[]",
-                        active_collectors="[]", agent_id=None, polling_int=None):
-    kwargs = {'enabled_sflow_interfaces': enabled_sflow_interfaces,
-              'active_collectors': active_collectors}
+def check_sflow_traffic(duthost, partial_ptf_runner, enabled_sflow_interfaces=None,
+                        active_collectors=None, agent_id=None, polling_int=None):
+    kwargs = {}
+    if enabled_sflow_interfaces is not None:
+        kwargs['enabled_sflow_interfaces'] = enabled_sflow_interfaces
+    if active_collectors is not None:
+        kwargs['active_collectors'] = active_collectors
     if agent_id is not None:
         kwargs['agent_id'] = agent_id
     if polling_int is not None:
@@ -756,6 +759,7 @@ class TestAgentId():
         verify_show_sflow(duthost, status='up', agent_id='default')
         wait_until(30, 5, 0, verify_sflow_config_apply, duthost)
         # Verify  whether the samples are received with previously configured agent ip
+        agent_ip = get_default_agent(duthost)
         assert check_sflow_traffic(duthost, partial_ptf_runner,
                                    polling_int=20,
                                    agent_id=agent_ip,

--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -31,7 +31,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
-def is_hsflowd_ready(duthost):
+def is_hsflowd_ready(duthost, collector_ips=[]):
     """
     Check if hsflowd is running and fully initialized.
     """
@@ -52,6 +52,15 @@ def is_hsflowd_ready(duthost):
     if result['failed'] or result['rc'] != 0:
         logger.info("is_hsflowd_ready: hsflowd.auto does not exist")
         return False
+
+    for ip in collector_ips:
+        result = duthost.shell(
+                f"docker exec sflow grep -q 'collector={ip}' /etc/hsflowd.auto 2>/dev/null",
+                module_ignore_errors=True
+            )
+        if result['failed'] or result['rc'] != 0:
+            logger.info("is_hsflowd_ready: hsflowd.auto does not include collector {ip}")
+            return False
 
     logger.info("is_hsflowd_ready: all checks passed")
     return True
@@ -258,11 +267,6 @@ def config_sflow(duthost, sflow_status='enable'):
         r"sFlow Admin State:\s+%s" % expected,
         duthost.shell('show sflow')['stdout']))
 
-    if sflow_status == 'enable':
-        wait_for_system_ready(duthost)
-        if not wait_until(180, 10, 0, is_hsflowd_ready, duthost):
-            pytest.fail("hsflowd is not running")
-
 # ----------------------------------------------------------------------------------
 
 
@@ -280,6 +284,7 @@ def config_sflow_feature(request, duthosts, rand_one_dut_hostname):
         duthost.shell("sudo config feature state sflow enabled")
         wait_until(30, 5, 0, lambda: duthost.get_feature_status()[0].get(
             'sflow') == 'enabled')
+        wait_for_system_ready(duthost)
 
     yield
 
@@ -358,6 +363,7 @@ def config_sflow_collector(duthost, collector, config):
     if config == 'add':
         duthost.shell('config sflow collector add %s %s --port %s ' %
                       (collector['name'], collector['ip_addr'], collector['port']))
+        wait_until(30, 5, 0, is_hsflowd_ready, duthost, [collector['ip_addr']])
     elif config == 'del':
         duthost.shell('config sflow collector  del %s' % collector['name'])
 # ----------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_sflow.py uses sleep() to orchestrate test steps, which is flaky and prone to timing issues. Replace sleep() coordination with wait_for() where relevant. Use thread events to wait for collector threads to be ready.

Closes #21168 

Also, there's an issue with SYSTEM_READY status not being set correctly, which is causing hsflowd to wait around for 180s before sending any samples. This causes intermittent failures in the first few test cases, and is presumably the issue for which this test is being skipped in [Issue 21701](https://github.com/sonic-net/sonic-mgmt/issues/21701). This PR addresses that problem by adding an explicit wait_until for that condition, so that if the condition is never met we will just match the timeout being used by hsflowd and the test will run as normal.

Closes #21701 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

I was having problems getting this test to pass on our testing infrastructure. I ended up having to increase several sleep() call durations to get it working, which was not something we wanted to upstream and was also just kicking the can down the road. Due to the nature of the feature under test, there will always be some variability, but a lot of that can be reduced by figuring out what actual conditions we need to wait on. The result should be a little faster too, since we don't end up waiting when we don't have to.

#### How did you do it?

I changed the main test cases to wait_for the results of the PTF script, so that if sample hits outside the accepted bounds it has a chance to retry (since the sampling is non-deterministic, we expect to occasionally have test runs which fall outside the accepted bounds).

I added logic to verify that the sflow container is up, and that  `hsflowd` is up, after configuring the feature (so that the PTF script is guaranteed to run after the sflow feature on the test device is up and running).

I added thread synchronization to the collector threads, so that the main thread will wait for the collectors to start up before sending traffic.

For the flow sample case, I added logic to count the number of samples seen so far and wait dynamically based on whether sample packets are arriving or not. If no packets ever arrive (if the device is not responding, for instance) the test times out and fails. As long as packets are arriving the collectors will keep waiting indefinitely. If the expected number of packets is seen, and more packets keep arriving, the test will wait for a short period to try and catch cases where too many packets are being sent.

#### How did you verify/test it?

Verified that the test passes successfully with the changes, and that no unexpected log messages are seen. Stepped through the new logic in a debugger to manually verify that the codepaths are working as intended.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
