### PR TITLE
[DASH] Update the dash eni counter test to align with the latest PL test change

### DIFF
--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -120,7 +120,8 @@ def set_do_not_care_layer(mask, layer, field_name, n=1):
 
 def inbound_pl_packets(
     config, floating_nic=False, inner_packet_type="udp", vxlan_udp_dport=4789, inner_sport=4567, inner_dport=6789,
-    vxlan_udp_base_src_port=VXLAN_UDP_BASE_SRC_PORT, vxlan_udp_src_port_mask=VXLAN_UDP_SRC_PORT_MASK):
+    vxlan_udp_base_src_port=VXLAN_UDP_BASE_SRC_PORT, vxlan_udp_src_port_mask=VXLAN_UDP_SRC_PORT_MASK
+):
     inner_sip = get_pl_overlay_dip(  # not a typo, inner DIP/SIP are reversed for inbound direction
         pl.PE_CA, pl.PL_OVERLAY_DIP, pl.PL_OVERLAY_DIP_MASK
     )

--- a/tests/dash/test_dash_eni_counter.py
+++ b/tests/dash/test_dash_eni_counter.py
@@ -6,10 +6,9 @@ import configs.privatelink_config as pl
 import ptf.testutils as testutils
 import pytest
 from constants import LOCAL_PTF_INTF, LOCAL_DUT_INTF, REMOTE_DUT_INTF, REMOTE_PTF_RECV_INTF, \
-    REMOTE_PTF_SEND_INTF, VXLAN_UDP_BASE_SRC_PORT
+    REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
-from tests.common import config_reload
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. After the PR https://github.com/sonic-net/sonic-mgmt/pull/19700 is merged. The fixture set_vxlan_udp_sport_range is changed to function level, and it requires a config reload in each function teardown. 
Since there are a lot of test cases in tests/dash/test_dash_eni_counter.py which uses the set_vxlan_udp_sport_range, the test run time is significantly increased.
Actually for the test_dash_eni_counter.py, the configuration of the source port is not required. So, remove the fixture from the test and update the packet.py to accept user specified values of the base port and mask.

2. Also update the PE1_VNET_MAPPING_CONFIG to PE_VNET_MAPPING_CONFIG as it is changed in PR#19700.

3. Fix packet.py to make it work for the tcp inner_packet_type.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Align the test_dash_eni_counter.py test to with the change in PR#19700
#### How did you do it?
See the summary.
#### How did you verify/test it?
Run the test_dash_eni_counter.py and other dash tests on SN4280 testbed, all passed.
#### Any platform specific information?
Only for smartswitch.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
