### PR TITLE
Set VRF capacity specific to platforms

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1281,8 +1281,8 @@ class TestVrfCapacity():
         platform = duthost.facts["platform"]
         asic_type = duthost.facts['asic_type']
         if (asic_type in ["marvell-teralynx"] and
-            platform in ["x86_64-wistron_6512_32r-r0", 
-                         "x86_64-wistron_sw_to3200k-r0", 
+            platform in ["x86_64-wistron_6512_32r-r0",
+                         "x86_64-wistron_sw_to3200k-r0",
                          "x86_64-cel_midstone-r0"]):
             self.VRF_CAPACITY = 256
 


### PR DESCRIPTION
Summary/Description:
Some platforms (chipset + profile) may support different Max # of VRF's. PTF usage of higher vrf count can lead to failures.

 Type of change:
Set a platform specific limit based on board identifier.

 What is the motivation for this PR?
PTF failure 
 How did you do it?
 How did you verify/test it?
PTF tests executed for vrf on T0 topology for select platforms.
 Any platform specific information?
### Description of PR

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511


### Approach
Set a platform specific limit  based on boards identifiers
#### What is the motivation for this PR?
 test_vrf::TestVrfCapacity::vrf_count() test case uses a hardcoded vrf capacity limit. This change set it to a platform specific limit. 

#### How did you do it?
Set platform specific limit

#### How did you verify/test it?
ptf script run on the affected platforms. 

#### Any platform specific information?
Platform specific limit set for VRF capacity limit in the test case. 
#### Supported testbed topology if it's a new test case?
NA
### Documentation