### PR TITLE
Added detailed reason for assert failure for macsec

### DIFF
--- a/tests/macsec/test_interop_protocol.py
+++ b/tests/macsec/test_interop_protocol.py
@@ -216,6 +216,4 @@ class TestInteropProtocol():
             sysDescr = ".1.3.6.1.2.1.1.1.0"
             result = get_snmp_output(dut_loip, duthost, nbr,
                                      creds_all_duts, sysDescr)
-            assert not result["failed"], (
-                "Operation failed. Reason: '{}'.".format(result["failed_reason"])
-            )
+            assert not result["failed"], "Operation failed. Result: {}".format(result)


### PR DESCRIPTION
 **Description of PR**
**Added detailed reason for Assert failure**

**Type of change**

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


**Back port request**

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Summary:**
Enhanced assertion messages in selected test cases to provide clearer failure context. This improves debuggability and speeds up issue resolution when tests fail.
Added detailed assertion failure messages in test scripts to make it easier to understand why tests fails.

**What is the motivation for this PR?**
The motivation is to improve test debuggability by adding detailed failure reasons in assertions for selected test cases. This enhancement makes it easier to identify the root cause of test failures in logs, thereby reducing triage time and simplifying test maintenance.

**How did you do it?**
I updated the assertion statements in the following test files to include descriptive error messages:
tests/macsec/test_interop_protocol.py

 **How did you verify/test it?**
Verified that the updated assertion messages are correctly reflected in the test code by reviewing the changes locally

