### PR TITLE
Issue #21205: Fix swss memory usage check failure in test_bgp_stress_link_flap in sonic-vpp

### DIFF
--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -317,11 +317,11 @@ def test_bgp_stress_link_flap(duthosts, rand_one_dut_hostname, setup, nbrhosts, 
         flap_tasks.clear()
 
     asyncio.run(flap_interfaces())
+
     if asic_type == "vpp":
         sleep_time = 180
     else:
         sleep_time = 60
-
     logger.info("Test Completed, waiting for {} seconds to stabilize the system".format(sleep_time))
     time.sleep(sleep_time)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #21205 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Makes test_bgp_stress_link_flap more robust in sonic-vpp 
#### How did you do it?
Increase delay for sonic-vpp before teardown.
#### How did you verify/test it?
Run the test multiple times and it passed
#### Any platform specific information?
specific to sonic-vpp platform
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
