### PR TITLE
Issue #21208: Enable sFlow for VS tests

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -196,7 +196,7 @@ def config_sflow(duthost, sflow_status='enable'):
 @pytest.fixture(scope='module')
 def config_sflow_feature(request, duthost):
     # Enable sFlow feature on DUT if enable_sflow_feature argument was passed
-    if request.config.getoption("--enable_sflow_feature") or duthost.facts['asic_type'] == 'vs':
+    if request.config.getoption("--enable_sflow_feature"):
         feature_status, _ = duthost.get_feature_status()
         if feature_status['sflow'] == 'disabled':
             duthost.shell("sudo config feature state sflow enabled")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, sflow/test_sflow.py is disabled for virtual devices and is not being tested. However, the test runs and passes just fine on virtual devices when the sflow feature is enabled. Remove the skip condition and enable sflow during the test when run on virtual devices.

Closes #21208 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

`sflow/test_sflow.py` is currently not being tested in CI/CD because it gets skipped for VS devices.

#### How did you do it?

Remove the conditional skip and unconditionally enable the `sflow` feature on VS devices before running the test.

#### How did you verify/test it?

Run the test with the changes on a VS device and verify that everything passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
