### PR TITLE
chore: disable arp setting on ipv6

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1548,6 +1548,10 @@ def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True)
         So the dest for 200.0.0.1 will be 203.0.0.1/32
     '''
     ip_addr = ip_address(addr)
+    if (ip_addr.version == 6):
+        logger.info("Skip arp setting up for ipv6 since ipv6 does not support arp")
+        return
+
     DEST_TO_GATEWAY_MAP[addr] = {}
     DEST_TO_GATEWAY_MAP[addr]['dest'] = str(ip_addr + 3*256*256*256)
     DEST_TO_GATEWAY_MAP[addr]['intf'] = intf


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently, when the test is running ipv6, arp command will try to run hence cause failure

```
cmd = arp -i Ethernet188 -s fc00::31 aa:bb:cc:dd:ee:ff
start = 2025-10-13 15:11:43.564937
end = 2025-10-13 15:11:43.569747
delta = 0:00:00.004810
msg = non-zero return code
invocation = {'module_args': {'_raw_params': ' arp -i Ethernet188 -s fc00::31 aa:bb:cc:dd:ee:ff', '_uses_shell': True, 'warn': False, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = None
stdout =
stderr =
fc00::31: Unknown host
```

Discussed with @rraghav-cisco  that we should skip this step for ipv6

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
<img width="1903" height="82" alt="image" src="https://github.com/user-attachments/assets/31d022d7-9c4f-4bf7-af52-329521c29d5d" />

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
