### PR TITLE
[qos] WRRtest: pace egress with a shaper instead of scale_factor tolerance

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -4405,6 +4405,11 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         prio_list = self.test_params.get('dscp_list', [])
         q_pkt_cnt = self.test_params.get('q_pkt_cnt', [])
         q_list = self.test_params.get('q_list', [])
+        # Egress shaper (bytes/sec) on the dst port; paces the release so a high-
+        # speed port does not overrun the fanout->PTF path (0 disables). The
+        # base-class helper is broadcom-only and leaves the per-queue DWRR
+        # schedulers untouched, so the weight arbitration under test is preserved.
+        egress_shaper_rate = int(self.test_params.get('egress_shaper_rate', 125000000))
 
         self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id], enable_port_by_unblock_queue=False)
 
@@ -4473,6 +4478,11 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
 
         xmit_counters_base, _ = sai_thrift_read_port_counters(self.dst_client, asic_type, port_list['dst'][dst_port_id])
 
+        # Pace egress on the dst port so the released burst does not overrun the
+        # fanout->PTF path (broadcom-only; no-op otherwise). Applied while the
+        # port is still up so the rate limiter is armed before traffic is released.
+        dut_port = self.get_dut_port(dst_port_id)
+        self.apply_egress_shaper(dut_port, egress_shaper_rate)
         self.sai_thrift_port_tx_disable(self.dst_client, asic_type, [dst_port_id], disable_port_by_block_queue=False)
 
         try:
@@ -4632,7 +4642,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
                     logging.info(
                         "On J2C+ can't control how packets are dequeued (CS00012272267) - so ignoring diff check now")
                 elif not dry_run:
-                    assert diff < limit, "Difference for %d is %d which exceeds limit %d" % (
+                    assert diff <= limit, "Difference for %d is %d which exceeds limit %d" % (
                         dscp, diff, limit)
 
             # Read counters
@@ -4648,6 +4658,7 @@ class WRRtest(sai_base_test.ThriftInterfaceDataPlane):
         finally:
             self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id],
                                            enable_port_by_unblock_queue=False)
+            self.clear_egress_shaper(dut_port, egress_shaper_rate)
 
 
 class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):


### PR DESCRIPTION
### Description of PR

Make `WRRtest` robust to ptf-side packet loss on high-speed ports.

Original approach in this PR tolerated the loss with a `scale_factor`.
Per review feedback, this has been reworked to **pace the dst port with a
reusable egress shaper** instead, so the released burst does not overrun the
fanout→PTF path and the strict per-queue checks stay strict.

- `apply_egress_shaper()` is armed on the dst port while it is still
  tx-enabled (before `tx_disable`) and cleared in `finally`. The helper is
  Broadcom-only (no-op otherwise) and sets only the **port-level** scheduler,
  leaving the per-queue DWRR schedulers — the weight arbitration under test —
  untouched.
- Rate defaults to 1 Gbps (validated for zero ptf-side loss on Broadcom HW),
  overridable per-yaml via `egress_shaper_rate` in the `wrr`/`wrr_chg` block.
- Per-dscp bound relaxed to `diff <= limit`.

**Depends on #25453**, which introduces the reusable
`apply_egress_shaper()` / `clear_egress_shaper()` base-class helpers in
`sai_base_test.py`. This PR should be rebased once #25453 merges — the helpers
then come from master and no code is duplicated here. Kept as **draft** until
then.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Approach
Reuse the egress-shaper framework (from #25453) for the DWRR testlet in place
of the `scale_factor` loss tolerance.
