### PR TITLE
[cisco] enable and fortify ECN config GCU testing

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2464,7 +2464,7 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
     reason: "This test is not run on this asic type, topology, or version currently"
     conditions_logical_operator: "OR"
     conditions:
-      - "asic_type in ['cisco-8000']"
+      - "hwsku in ['Cisco-8800-LC-48H-C48']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier..:
-->
### Description of PR

Summary:
Fixes the case where a WRED_PROFILE cannot be retrieved from the CONFIG_DB. Also enables some Cisco HW SKUs for ECN testing, and fixes some corner cases for the test itself. (What if, for example, the original value was 99 or 100, in the original version?)


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

To allow the ECN/GCU test to complete on Cisco platforms in a T2 topology to complete successfully

#### How did you do it?

Verified that the HW SKU was in fact supported. Skipped tests whenever a WRED_PROFILE could not be retrieved for a particular system.

#### How did you verify/test it?

Tested by changing the search string to FRED_PROFILE for a moment just to force empty values to be returned in some cases.
 
#### Any platform specific information?

See PR for specific HW SKU information

#### Supported testbed topology if it's a new test case?

T2 

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
