### PR TITLE
 Fix invalid port generation in hash_test (replace randint(0,65536) with 65535)

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -404,7 +404,7 @@ class HashTest(BaseTest):
         ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        outer_sport = (random.randint(0, 65536) if hash_key == 'outer-src-port' else 1234)
+        outer_sport = (random.randint(0, 65535) if hash_key == 'outer-src-port' else 1234)
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
         dst_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
@@ -468,7 +468,7 @@ class HashTest(BaseTest):
         ) if hash_key == 'dst-ip' else self.dst_ip_interval.get_first_ip()
         sport = random.randint(0, 65535) if hash_key == 'src-port' else 1234
         dport = random.randint(0, 65535) if hash_key == 'dst-port' else 80
-        outer_sport = random.randint(0, 65536) if hash_key == 'outer-src-port' else 1234
+        outer_sport = random.randint(0, 65535) if hash_key == 'outer-src-port' else 1234
         src_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \
             if hash_key == 'src-mac' else self.base_mac
         dst_mac = (self.base_mac[:-5] + "%02x" % random.randint(0, 255) + ":" + "%02x" % random.randint(0, 255)) \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix invalid port generation in hash_test (replace randint(0,65536) with 65535)
This should fix the issue mentioned in https://github.com/sonic-net/sonic-mgmt/issues/21086

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x ] 202505

### Approach
#### What is the motivation for this PR?

- random.randint(0, 65536) is inclusive and occasionally produced port value 65536,
  which is outside the valid 16-bit port range. Scapy then raised:
    ValueError: 'H' format requires 0 <= number <= 65535
  causing hash/vxlan tests to fail (example: fib/test_fib.py:693).
This should fix the issue mentioned in https://github.com/sonic-net/sonic-mgmt/issues/21086

#### How did you do it?
Replace occurrences of random.randint(0, 65536) with random.randint(0, 65535)
  in ansible/roles/test/files/ptftests/py3/hash_test.py (check_ipv4_route and check_ipv6_route).

#### How did you verify/test it?
Ran OC runs in T2 topo, attached the test results

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
error see prior to commit
<img width="1208" height="885" alt="Error1" src="https://github.com/user-attachments/assets/20a0b25a-73d3-4574-b569-aa342d4cce68" />
Full OC runs after commit
<img width="1889" height="767" alt="FiB-passed" src="https://github.com/user-attachments/assets/b5c9d6aa-6586-4771-9470-e197449dbab4" />

