### PR TITLE
Skip dash t1 tests on Arista platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -679,9 +679,11 @@ dash/test_dash_disable_enable_eni.py:
 
 dash/test_dash_eni_counter.py:
   skip:
+    conditions_logical_operator: or
     reason: "Currently dash tests are not supported on KVM"
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
+      - "'arista' in platform"
 
 dash/test_dash_privatelink.py:
   skip:
@@ -690,6 +692,7 @@ dash/test_dash_privatelink.py:
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
       - "hwsku not in ['Cisco-8102-28FH-DPU-O-T1', 'Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28', 'Cisco-8102-28FH-DPU-O']"
+      - "'arista' in platform"
 
 dash/test_dash_smartswitch_vnet.py:
   skip:
@@ -698,6 +701,7 @@ dash/test_dash_smartswitch_vnet.py:
     conditions:
       - "asic_type in ['vs'] and https://github.com/sonic-net/sonic-mgmt/issues/16407"
       - "hwsku not in ['Cisco-8102-28FH-DPU-O-T1', 'Mellanox-SN4280-O8C40', 'Mellanox-SN4280-O28']"
+      - "'arista' in platform"
 
 dash/test_dash_vnet.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Most dash tests filter on 'dpu' topology, but test_dash_privatelink.py and dash/test_dash_smartswitch_vnet.py allow t1 topologies.  Our t1 topos are not SmartSwitch/DPU so we should skip these tests as well (not sure about other vendors)

There is some inconsistency in the supported topologies for these tests and between master and 202505 branchs as per https://github.com/sonic-net/sonic-mgmt/issues/21244.  This should be handled before making any additional `tests_mark_conditions.yaml` changes.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
