### PR TITLE
Skipping test_gnmi_countersdb.py on multi-asic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2699,7 +2699,7 @@ gnmi/test_gnmi_configdb.py::test_gnmi_configdb_subscribe_authenticate:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
 
 gnmi/test_gnmi_countersdb.py:
-  skip:
+  xfail:
     reason: "This test does not supported multi-asic. Skipping test for multi-asic DUTs."
     conditions:
       - "is_multi_asic==True"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

`test_gnmi_countersdb.py` does not support multi-asic.  Similarly to `test_gnmi_configdb.py` which is already skipped
(https://github.com/sonic-net/sonic-mgmt/pull/15883) this needs multi-asic implementation in the gnmi helpers.

Additionally, we observe a hang during this test:
https://github.com/sonic-net/sonic-mgmt/issues/18195

Issue https://github.com/sonic-net/sonic-mgmt/issues/21246 tracks adding multi-asic support for this test.

Fixes # 18195

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Xfail test on multi-asic until proper support is added.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
