### PR TITLE
Adding ECMP endpoint scale tests for T0 topology

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_ecmp_ptftest.py
@@ -1,5 +1,8 @@
 # ptftests/vxlan_ecmp_ptftest.py
 from datetime import datetime
+import time
+import json
+import os
 import scapy.all as scapy
 import ptf
 import logging
@@ -25,17 +28,36 @@ class VxlanEcmpTest(BaseTest):
     def setUp(self):
         self.dataplane = ptf.dataplane_instance
         params = test_params_get()
-        self.endpoints = params.get("endpoints", [])
+        if "params_file" in params:
+            with open(params["params_file"], "r") as f:
+                params = json.load(f)
+
+        if "endpoints_file" in params and os.path.exists(params["endpoints_file"]):
+            with open(params["endpoints_file"], "r") as f:
+                self.endpoints = json.load(f)
+        else:
+            self.endpoints = params.get("endpoints", [])
+
         self.dst_ip = params.get("dst_ip")
-        self.src_ip = params.get("src_ip")
+        self.src_ip = params.get("ptf_src_ip")
         self.dut_vtep = params.get("dut_vtep")
         self.router_mac = params.get("router_mac")
         self.num_packets = int(params.get("num_packets", 6))
-        self.vxlan_port = params.get("vxlan_port", 4789)
-        self.send_port = params.get("ptf_ingress_port")
+        self.vxlan_port = int(params.get("vxlan_port", 4789))
+        self.send_port = int(params.get("ptf_ingress_port", 0))
         self.tcp_sport = 1234
         self.tcp_dport = 5000
+        self.batch_size = 200
+
         self.dataplane.flush()
+
+        logger.info("=== VXLAN ECMP PTF Test Setup ===")
+        logger.info(f"Endpoints: {len(self.endpoints)}")
+        logger.info(f"Destination IP: {self.dst_ip}, Source IP: {self.src_ip}")
+        logger.info(f"DUT VTEP: {self.dut_vtep}, Router MAC: {self.router_mac}")
+        logger.info(f"Packets to send: {self.num_packets}, Ingress port: {self.send_port}")
+        logger.info(f"VXLAN UDP Port: {self.vxlan_port}")
+        logger.info("=================================")
 
     def _next_port(self, key="sport"):
         """Simple port generator for varying TCP ports."""
@@ -49,48 +71,79 @@ class VxlanEcmpTest(BaseTest):
     def runTest(self):
         counts = {}
         src_mac = self.dataplane.get_mac(0, self.send_port)
-        logger.info(f"Sending {self.num_packets} packets on port {self.send_port}, "
-                    f"hashing over unique TCP ports")
 
-        # --- Send packets ---
-        for _ in range(self.num_packets):
-            sport = self._next_port("sport")
-            dport = self._next_port("dport")
-            pkt_opts = {
-                "eth_dst": self.router_mac,
-                "eth_src": src_mac,
-                "ip_dst": self.dst_ip,
-                "ip_src": self.src_ip,
-                "ip_id": 105,
-                "ip_ttl": 64,
-                "tcp_sport": sport,
-                "tcp_dport": dport,
-                "pktlen": 100,
-            }
-            inner_pkt = simple_tcp_packet(**pkt_opts)
-            send_packet(self, self.send_port, inner_pkt)
+        total_sent = 0
+        logger.info(f"Starting VXLAN ECMP test: {self.num_packets} packets total, {self.batch_size} per batch")
+        logger.info(f"Source {self.src_ip} → Destination {self.dst_ip}, ingress port {self.send_port}")
 
-        # --- Capture VXLAN traffic ---
-        timeout = 8
-        start = datetime.now()
-        while (datetime.now() - start).total_seconds() < timeout:
-            res = dp_poll(self, timeout=1)
-            if not isinstance(res, self.dataplane.PollSuccess):
-                continue
-            ether = scapy.Ether(res.packet)
-            if scapy.IP in ether and scapy.UDP in ether and ether[scapy.UDP].dport == self.vxlan_port:
-                vtep_dst = ether[scapy.IP].dst
-                if vtep_dst in self.endpoints:
-                    counts[vtep_dst] = counts.get(vtep_dst, 0) + 1
+        # --- Send & capture in batches ---
+        while total_sent < self.num_packets:
+            send_now = min(self.batch_size, self.num_packets - total_sent)
+            logger.info(f"--- Sending batch {total_sent + 1} to {total_sent + send_now} ---")
 
-        if not counts:
-            raise AssertionError("No VXLAN packets captured")
+            # Send packets for this batch
+            for _ in range(send_now):
+                sport = self._next_port("sport")
+                dport = self._next_port("dport")
+                pkt = simple_tcp_packet(
+                    eth_dst=self.router_mac,
+                    eth_src=src_mac,
+                    ip_dst=self.dst_ip,
+                    ip_src=self.src_ip,
+                    ip_id=105,
+                    ip_ttl=64,
+                    tcp_sport=sport,
+                    tcp_dport=dport,
+                    pktlen=100,
+                )
+                send_packet(self, self.send_port, pkt)
+
+            total_sent += send_now
+            logger.info(f"Batch sent ({total_sent}/{self.num_packets}). Polling for VXLAN packets...")
+
+            # Poll for VXLAN packets from this batch
+            poll_start = datetime.now()
+            poll_timeout = 8  # seconds per batch
+            while (datetime.now() - poll_start).total_seconds() < poll_timeout:
+                res = dp_poll(self, timeout=2)
+                if not isinstance(res, self.dataplane.PollSuccess):
+                    continue
+
+                ether = scapy.Ether(res.packet)
+                if scapy.IP in ether and scapy.UDP in ether and ether[scapy.UDP].dport == self.vxlan_port:
+                    vtep_dst = ether[scapy.IP].dst
+                    if vtep_dst in self.endpoints:
+                        counts[vtep_dst] = counts.get(vtep_dst, 0) + 1
+
+            logger.info(f"Completed batch {total_sent}/{self.num_packets}.")
+            time.sleep(0.3)  # small pause before next burst
+
+        # --- Post-send validation ---
+        total_received = sum(counts.values())
+        logger.info(f"VXLAN packets received: {total_received} / {self.num_packets}")
+        logger.info(f"Endpoints hit: {len(counts)} / {len(self.endpoints)}")
+        logger.info(f"Count per endpoint : {counts}")
+
+        # --- Validation ---
+        if total_received == 0:
+            raise AssertionError("No VXLAN packets captured (tunnel not active or misconfigured)")
+
+        if total_received < self.num_packets:
+            drop_pct = 100.0 * (self.num_packets - total_received) / self.num_packets
+            raise AssertionError(
+                f"Packet loss detected: sent={self.num_packets}, received={total_received} ({drop_pct:.2f}% loss)"
+            )
 
         missing = set(self.endpoints) - set(counts.keys())
         if missing:
-            raise AssertionError(f"Missing {len(missing)} endpoints: {list(missing)[:10]} ...")
+            logger.error(f"Missing endpoints ({len(missing)}): {sorted(list(missing))[:10]} ...")
+            raise AssertionError(f"Endpoints not used in ECMP: {len(missing)}")
 
-        logger.info(f"VXLAN ECMP test passed: {len(counts)} / {len(self.endpoints)} endpoints used")
+        logger.info(
+            f"VXLAN ECMP test passed: all {len(self.endpoints)} endpoints hit, "
+            f"{total_received}/{self.num_packets} packets received, no loss."
+        )
 
     def tearDown(self):
         self.dataplane.flush()
+        logger.info("Dataplane flushed — VXLAN ECMP test complete")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR adds VXLAN ECMP tests for T0 topology. It allows for testing of scaled endpoints.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [X] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To ensure VXLAN ECMP at scale can be validated for T0 topologies.
#### How did you do it?
Added tests to configure large number of endpoints and test traffic to them.
#### How did you verify/test it?
Ran on physical T0 testbed.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0 physical testbeds
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
