### PR TITLE
Snappi: Remove temp files in disable_pfcwd fixture.

### DIFF
--- a/tests/common/snappi_tests/qos_fixtures.py
+++ b/tests/common/snappi_tests/qos_fixtures.py
@@ -143,6 +143,7 @@ def reapply_pfcwd(duthost, pfcwd_config):
     if type(pfcwd_config) is dict:
         duthost.copy(content=json.dumps({"PFC_WD": pfcwd_config}, indent=4), dest=file_prefix)
         duthost.shell(f"config load {file_prefix} -y")
+        duthost.shell(f"rm {file_prefix} -y")
     elif type(pfcwd_config) is list:
         output = duthost.shell("ip netns | awk '{print $1}'")['stdout']
         all_asic_list = output.split("\n")
@@ -155,6 +156,7 @@ def reapply_pfcwd(duthost, pfcwd_config):
             duthost.copy(content=json.dumps({"PFC_WD": config}, indent=4), dest=filename)
             all_files.append(filename)
         duthost.shell("config load {} -y".format(",".join(all_files)))
+        duthost.shell("rm -r {}".format(" ".join(all_files)))
     else:
         raise RuntimeError(f"Script problem: Got an unsupported type of pfcwd_config:{pfcwd_config}")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [X] 202405
- [X] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
The fixture disable_pfcwd creates some temporary files to save and load pfcwd configurations. But doesn't remove them. This fixutre is extensively used in many scripts. This causes a large number of these files to be created in the home dir of the admin user in the DUT. This PR is to remove the temporary files after they are loaded.

#### How did you do it?
I have added a oneliner call to remove the files.

#### How did you verify/test it?
Ran it in T2 testbed, and verified that the remove is executed:
```10/11/2025 19:26:30 base._run                                L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [c30-lc2] AnsibleModule::shell, args=["config load 1762802786.803447_pfcwd_None.json,1762802786.803447_pfcwd_asic0.js
on,1762802786.803447_pfcwd_asic1.json,1762802786.803447_pfcwd_asic2.json -y"], kwargs={}
10/11/2025 19:26:34 base._run                                L0108 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [c30-lc2] AnsibleModule::shell Result => {"changed": true, "stdout": "Running command: /usr/local/bin/sonic-cfggen -j
 1762802786.803447_pfcwd_None.json --write-to-db\nRunning command: /usr/local/bin/sonic-cfggen -n asic0 -j 1762802786.803447_pfcwd_asic0.json --write-to-db\nRunning command: /usr/local/bin/sonic-cfggen -n asic1 -j 1762802786.803447_pfcwd_asic1.json --wri
te-to-db\nRunning command: /usr/local/bin/sonic-cfggen -n asic2 -j 1762802786.803447_pfcwd_asic2.json --write-to-db", "stderr": "", "rc": 0, "cmd": "config load 1762802786.803447_pfcwd_None.json,1762802786.803447_pfcwd_asic0.json,1762802786.803447_pfcwd_
asic1.json,1762802786.803447_pfcwd_asic2.json -y", "start": "2025-07-10 12:11:47.958379", "end": "2025-07-10 12:11:51.429221", "delta": "0:00:03.470842", "msg": "", "invocation": {"module_args": {"_raw_params": "config load 1762802786.803447_pfcwd_None.j
son,1762802786.803447_pfcwd_asic0.json,1762802786.803447_pfcwd_asic1.json,1762802786.803447_pfcwd_asic2.json -y", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "c
reates": null, "removes": null, "stdin": null}}, "stdout_lines": ["Running command: /usr/local/bin/sonic-cfggen -j 1762802786.803447_pfcwd_None.json --write-to-db", "Running command: /usr/local/bin/sonic-cfggen -n asic0 -j 1762802786.803447_pfcwd_asic0.j
son --write-to-db", "Running command: /usr/local/bin/sonic-cfggen -n asic1 -j 1762802786.803447_pfcwd_asic1.json --write-to-db", "Running command: /usr/local/bin/sonic-cfggen -n asic2 -j 1762802786.803447_pfcwd_asic2.json --write-to-db"], "stderr_lines":
 [], "_ansible_no_log": null, "failed": false}
10/11/2025 19:26:34 base._run                                L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [c30-lc2] AnsibleModule::shell, args=["rm -r 1762802786.803447_pfcwd_None.json 1762802786.803447_pfcwd_asic0.json 1762802786.803447_pfcwd_asic1.json 1762802786.803447_pfcwd_asic2.json"], kwargs={}
10/11/2025 19:26:34 base._run                                L0108 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [c30-lc2] AnsibleModule::shell Result => {"changed": true, "stdout": "", "stderr": "", "rc": 0, "cmd": "rm -r 1762802786.803447_pfcwd_None.json 1762802786.803447_pfcwd_asic0.json 1762802786.803447_pfcwd_asic1.json 1762802786.803447_pfcwd_asic2.json", "start": "2025-07-10 12:11:51.796996", "end": "2025-07-10 12:11:51.800532", "delta": "0:00:00.003536", "msg": "", "invocation": {"module_args": {"_raw_params": "rm -r 1762802786.803447_pfcwd_None.json 1762802786.803447_pfcwd_asic0.json 1762802786.803447_pfcwd_asic1.json 1762802786.803447_pfcwd_asic2.json", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": [], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
10/11/2025 19:26:34 base._run                                L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [c30-lc4] AnsibleModule::shell, args=["ip netns | awk '{print $1}'"], kwargs={}
10/11/2025 19:26:34 base._run                                L0108 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#136: [c30-lc4] AnsibleModule::shell Result => {"changed": true, "stdout": "asic2\nasic0\nasic1", "stderr": "", "rc": 0, "cmd": "ip netns | awk '{print $1}'", "start": "2025-07-10 12:11:49.098526", "end": "2025-07-10 12:11:49.103001", "delta": "0:00:00.004475", "msg": "", "invocation": {"module_args": {"_raw_params": "ip netns | awk '{print $1}'", "_uses_shell": true, "warn": false, "stdin_add_newline": true, "strip_empty_ends": true, "argv": null, "chdir": null, "executable": null, "creates": null, "removes": null, "stdin": null}}, "stdout_lines": ["asic2", "asic0", "asic1"], "stderr_lines": [], "_ansible_no_log": null, "failed": false}
```
Ran these tests:
```
=========================================================================================================================== PASSES ===========================================================================================================================
_____________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-c30-lc2|3] _____________________________________________________________________________________________
_____________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info0-c30-lc2|4] _____________________________________________________________________________________________
_____________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info1-c30-lc2|3] _____________________________________________________________________________________________
_____________________________________________________________________________________________ test_pfc_pause_single_lossless_prio[multidut_port_info1-c30-lc2|4] _____________________________________________________________________________________________
---------------------------------------------------------------------------- generated xml file: /mnt/logs/ixia/remove_temp_fiels/2025-11-10-19-11-12/tr_2025-11-10-19-11-12.xml -----------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
================================================================================================================== short test summary info ===================================================================================================================
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-c30-lc2|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info0-c30-lc2|4]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info1-c30-lc2|3]
PASSED snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py::test_pfc_pause_single_lossless_prio[multidut_port_info1-c30-lc2|4]
========================================================================================================= 4 passed, 4 warnings in 2042.38s (0:34:02) =========================================================================================================
sonic@snappi-sonic-mgmt-msft-t2-400g:/data/tests$ 
```

#### Any platform specific information?
N/A