### PR TITLE
[mellanox] Add mellanox data for two simx platform

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -87,6 +87,9 @@ SWITCH_MODELS = {
             }
         }
     },
+    "x86_64-nvidia_sn5600_simx-r0": {
+        "chip_type": "spectrum4"
+    },
     "x86_64-nvidia_sn5640-r0": {
         "chip_type": "spectrum5",
         "reboot": {
@@ -263,6 +266,9 @@ SWITCH_MODELS = {
                 "number": 1
             }
         }
+    },
+    "x86_64-mlnx_msn2700_simx-r0": {
+        "chip_type": "spectrum1"
     },
     "x86_64-mlnx_msn2700a1-r0": {
         "chip_type": "spectrum1",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
 Add data for x86_64-mlnx_msn2700_simx-r0 and x86_64-nvidia_sn5600_simx-r0, because test_buffer tests need the data.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
 Add data for x86_64-mlnx_msn2700_simx-r0 and x86_64-nvidia_sn5600_simx-r0

#### How did you do it?
 add data for x86_64-mlnx_msn2700_simx-r0 and x86_64-nvidia_sn5600_simx-r0

#### How did you verify/test it?
Run test_buffer.py on the two platforms

#### Any platform specific information?
x86_64-mlnx_msn2700_simx-r0 and x86_64-nvidia_sn5600_simx-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
