### PR TITLE
Double the packet number during test ip protocol hash in ecmp inner hashing test

### DIFF
--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -444,9 +444,8 @@ def check_pbh_counters(duthost, outer_ipver, inner_ipver, balancing_test_times,
         for group in ports_groups:
             exp_ports_multiplier += len(group)
         hash_keys_multiplier = len(hash_keys)
-        # for hash key "ip-proto", the traffic sends always in one way
-        exp_count = (balancing_test_times * symmetric_multiplier * exp_ports_multiplier * (hash_keys_multiplier - 1)
-                     + (balancing_test_times * exp_ports_multiplier))
+        # All hash keys now send traffic with symmetric_multiplier (including ip-proto with doubled iterations)
+        exp_count = balancing_test_times * symmetric_multiplier * exp_ports_multiplier * hash_keys_multiplier
         pbh_statistic_output = duthost.shell("show pbh statistic")['stdout']
         for outer_encap_format in OUTER_ENCAP_FORMATS:
             regex = r'{}\s+{}_{}_{}\s+(\d+)\s+\d+'.format(TABLE_NAME, outer_encap_format, outer_ipver, inner_ipver)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Currently at topology t0-64, the packet number sent during the test of ip protocol hashing in ecmp inner hashing test is only 160 in total. 
Total number 160 over 4 ecmp pathes, each path only expected to forward 40 packets. 
The packet number is too small to make an evenly hashing result. 
The changes are focusing on doubling the packet number.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Make the inner hash for ip protocol more even.
#### How did you do it?
Double send packet number for ip protocol case
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
