### PR TITLE
Enhance the ptf packet handling in fib and copp test

### DIFF
--- a/ansible/roles/test/files/ptftests/fib_test.py
+++ b/ansible/roles/test/files/ptftests/fib_test.py
@@ -79,6 +79,7 @@ class FibTest(BaseTest):
     ACTION_FWD = 'fwd'
     ACTION_DROP = 'drop'
     DEFAULT_SWITCH_TYPE = 'voq'
+    PTF_TIMEOUT = 30
 
     _required_params = [
         'fib_info_files',
@@ -395,7 +396,7 @@ class FibTest(BaseTest):
         if self.pkt_action == self.ACTION_FWD:
             try:
                 rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-                    self, masked_exp_pkt, dst_ports, timeout=1)
+                    self, masked_exp_pkt, dst_ports, timeout=self.PTF_TIMEOUT)
             except AssertionError:
                 logging.warning("Traffic wasn't sent successfully, trying again")
                 send_packet(self, src_port, pkt, count=5)
@@ -406,7 +407,7 @@ class FibTest(BaseTest):
                              .format('any', 'any', ip_src, ip_dst, sport, dport))
 
                 rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-                    self, masked_exp_pkt, dst_ports, timeout=1)
+                    self, masked_exp_pkt, dst_ports, timeout=self.PTF_TIMEOUT)
             rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)
             logging.info('Recieved packet at port {} and packet is {} bytes'.format(
@@ -502,7 +503,7 @@ class FibTest(BaseTest):
         if self.pkt_action == self.ACTION_FWD:
             try:
                 rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-                    self, masked_exp_pkt, dst_ports, timeout=1)
+                    self, masked_exp_pkt, dst_ports, timeout=self.PTF_TIMEOUT)
             except AssertionError:
                 logging.warning("Traffic wasn't sent successfully, trying again")
                 send_packet(self, src_port, pkt, count=5)
@@ -513,7 +514,7 @@ class FibTest(BaseTest):
                              .format('any', 'any', ip_src, ip_dst, sport, dport))
 
                 rcvd_port_index, rcvd_pkt = verify_packet_any_port(
-                    self, masked_exp_pkt, dst_ports, timeout=1)
+                    self, masked_exp_pkt, dst_ports, timeout=self.PTF_TIMEOUT)
 
             rcvd_port = dst_ports[rcvd_port_index]
             len_rcvd_pkt = len(rcvd_pkt)

--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -56,6 +56,7 @@ class ControlPlaneBaseTest(BaseTest):
     DEFAULT_PRE_SEND_INTERVAL_SEC = 1
     DEFAULT_SEND_INTERVAL_SEC = 30
     DEFAULT_RECEIVE_WAIT_TIME = 3
+    PTF_TIMEOUT = 30
 
     def __init__(self):
         BaseTest.__init__(self)
@@ -151,7 +152,7 @@ class ControlPlaneBaseTest(BaseTest):
                 pre_send_count += 1
 
             rcv_pkt_cnt = testutils.count_matched_packets_all_ports(
-                self, packet, [recv_intf[1]], recv_intf[0], timeout=5)
+                self, packet, [recv_intf[1]], recv_intf[0], timeout=self.PTF_TIMEOUT)
             self.log("Send %d and receive %d packets in the first second (PolicyTest)" % (
                 pre_send_count, rcv_pkt_cnt))
 
@@ -180,7 +181,7 @@ class ControlPlaneBaseTest(BaseTest):
         # Wait a little bit for all the packets to make it through
         time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)
         recv_count = testutils.count_matched_packets_all_ports(
-            self, packet, [recv_intf[1]], recv_intf[0], timeout=10)
+            self, packet, [recv_intf[1]], recv_intf[0], timeout=self.PTF_TIMEOUT)
         self.log("Received %d packets after sleep %ds" %
                  (recv_count, self.DEFAULT_RECEIVE_WAIT_TIME))
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
1. In fib test, set the ptf receive timeout to a bigger value to make sure jumbo packet would be handled in time
2. In copp test, set the ptf receive count timeout to a bigger value to make sure all the received packets could be handled in time


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Make the ptf packet handle more stable, sometimes the case would failed due to no packet received or no enough packet received.
#### How did you do it?
Increase the ptf timeout value during receiving packet in fib and crm test.
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
