### PR TITLE
[Mellanox] Enable some platform API tests for Mellanox device

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -433,7 +433,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_model:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_get_revision:
@@ -455,7 +455,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_get_serial:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_get_status:
@@ -479,7 +479,7 @@ platform_tests/api/test_psu.py::TestPsuApi::test_power:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "asic_type in ['vs'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_psu.py::TestPsuApi::test_temperature:
@@ -499,7 +499,7 @@ platform_tests/api/test_psu.py::test_temperature:
     reason: "Test not supported on Mellanox Platforms."
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_psu_fans.py::TestPsuFans::test_get_error_description:
@@ -630,7 +630,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_los:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs'] or (asic_type in ['cisco-8000'] and release in ['202012'])"
+      - "asic_type in ['vs'] or (asic_type in ['cisco-8000'] and release in ['202012'])"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_power:
@@ -638,7 +638,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_rx_power:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_serial:
@@ -646,7 +646,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_serial:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_status:
@@ -662,7 +662,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_temperature:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_transceiver_dom_real_value:
@@ -695,7 +695,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_bias:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_fault:
@@ -711,7 +711,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_tx_power:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_get_voltage:
@@ -719,7 +719,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_get_voltage:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_is_replaceable:
@@ -745,7 +745,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_power_override:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'nvidia-bluefield', 'vs'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "asic_type in ['nvidia-bluefield', 'vs'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_reset:
@@ -775,7 +775,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel:
@@ -783,7 +783,7 @@ platform_tests/api/test_sfp.py::TestSfpApi::test_tx_disable_channel:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0', 'x86_64-cel_e1031-r0']"
+      - "asic_type in ['vs'] or (asic_type in ['barefoot'] and hwsku in ['newport']) or platform in ['armhf-nokia_ixs7215_52x-r0', 'x86_64-cel_e1031-r0']"
       - "is_multi_asic==True and release in ['201911']"
 
 #######################################
@@ -794,7 +794,7 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_critical_thres
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
+      - "asic_type in ['vs'] or platform in ['armhf-nokia_ixs7215_52x-r0']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_threshold:
@@ -802,7 +802,7 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_threshold:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_critical_threshold:
@@ -878,7 +878,7 @@ platform_tests/api/test_thermal.py::TestThermalApi::test_get_temperature:
     reason: "Unsupported platform API"
     conditions_logical_operator: or
     conditions:
-      - "asic_type in ['mellanox', 'vs']"
+      - "asic_type in ['vs']"
       - "is_multi_asic==True and release in ['201911']"
 
 platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold:

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -3,6 +3,7 @@ import pytest
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.platform_api import chassis, psu
+from tests.common.mellanox_data import is_mellanox_device
 from tests.common.utilities import skip_release
 from tests.platform_tests.cli.util import get_skip_mod_list
 from .platform_api_test_base import PlatformApiTestBase
@@ -26,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.topology('any'),
-    pytest.mark.disable_loganalyzer  # disable automatic loganalyzer
 ]
 
 STATUS_LED_COLOR_GREEN = "green"
@@ -88,8 +88,11 @@ class TestPsuApi(PlatformApiTestBase):
         is_supported = self.get_psu_facts(psu_info["duthost"], psu_info["psu_id"], True, psu_parameter)
         if is_supported:
             data = get_data(psu_info["api"], psu_info["psu_id"])
-            if self.expect(data is not None, "Failed to retrieve {} of PSU {}".format(message, psu_info["psu_id"])):
-                self.expect(isinstance(data, float), "PSU {} {} appears incorrect".format(psu_info["psu_id"], message))
+            if not is_mellanox_device(self.duthost):
+                if self.expect(
+                        data is not None, "Failed to retrieve {} of PSU {}".format(message, psu_info["psu_id"])):
+                    self.expect(
+                        isinstance(data, float), "PSU {} {} appears incorrect".format(psu_info["psu_id"], message))
 
         return data
 
@@ -209,6 +212,7 @@ class TestPsuApi(PlatformApiTestBase):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012", "201911", "201811"], ["arista"])
         voltage = current = power = None
+        self.duthost = duthost
         psu_info = {
             "duthost": duthost,
             "api": platform_api_conn,
@@ -224,6 +228,9 @@ class TestPsuApi(PlatformApiTestBase):
             power = self.get_psu_parameter(psu_info, "power", psu.get_power, "power")
 
             failure_occured = self.get_len_failed_expectations() > failure_count
+            if is_mellanox_device(self.duthost):
+                logger.info("Skipping power value validation for Mellanox device")
+                return True
             if current and voltage and power:
                 is_within_tolerance = abs(power - (voltage*current)) < power*0.1
                 if not failure_occured and not is_within_tolerance:
@@ -258,10 +265,11 @@ class TestPsuApi(PlatformApiTestBase):
                 low_threshold = self.get_psu_parameter(psu_info, "voltage_low_threshold",
                                                        psu.get_voltage_low_threshold, "low voltage threshold")
 
-                if high_threshold and low_threshold:
-                    self.expect(voltage < high_threshold and voltage > low_threshold,
-                                "Voltage {} of PSU {} is not in between {} and {}"
-                                .format(voltage, psu_id, low_threshold, high_threshold))
+                if not is_mellanox_device(self.duthost):
+                    if high_threshold and low_threshold:
+                        self.expect(voltage < high_threshold and voltage > low_threshold,
+                                    "Voltage {} of PSU {} is not in between {} and {}"
+                                    .format(voltage, psu_id, low_threshold, high_threshold))
 
         self.assert_expectations()
 
@@ -300,6 +308,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
+    @pytest.mark.disable_loganalyzer
     def test_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):     # noqa: F811
         ''' PSU status led test '''
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
@@ -412,6 +421,7 @@ class TestPsuApi(PlatformApiTestBase):
 
         self.assert_expectations()
 
+    @pytest.mark.disable_loganalyzer
     def test_master_led(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):  # noqa: F811
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         FAULT_LED_COLOR_LIST = [

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -19,7 +19,7 @@ from tests.common.platform.transceiver_utils import is_sw_control_enabled,\
     get_port_expected_error_state_for_mellanox_device_on_sw_control_enabled
 from tests.common.mellanox_data import is_mellanox_device
 from collections import defaultdict
-
+from tests.platform_tests.mellanox.conftest import is_sw_control_feature_enabled  # noqa: F401
 
 from .platform_api_test_base import PlatformApiTestBase
 
@@ -808,12 +808,18 @@ class TestSfpApi(PlatformApiTestBase):
             logger.info("No interfaces to flap after SFP reset")
         self.assert_expectations()
 
-    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):    # noqa: F811
+    def test_tx_disable(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
+                        platform_api_conn, is_sw_control_feature_enabled):    # noqa: F811
         """This function tests both the get_tx_disable() and tx_disable() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx"])
+        if is_mellanox_device(duthost):
+            port_indices_to_tested = self.get_port_indices_to_tested_for_mellanox_device(
+                duthost, is_sw_control_feature_enabled)
+        else:
+            port_indices_to_tested = self.sfp_setup["sfp_test_port_indices"]
 
-        for i in self.sfp_setup["sfp_test_port_indices"]:
+        for i in port_indices_to_tested:
             # First ensure that the transceiver type supports setting TX disable
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
@@ -836,12 +842,17 @@ class TestSfpApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_tx_disable_channel(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost,
-                                platform_api_conn):     # noqa: F811
+                                platform_api_conn, is_sw_control_feature_enabled):     # noqa: F811
         """This function tests both the get_tx_disable_channel() and tx_disable_channel() APIs"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release_for_platform(duthost, ["202012"], ["arista", "mlnx", "nokia"])
+        if is_mellanox_device(duthost):
+            port_indices_to_tested = self.get_port_indices_to_tested_for_mellanox_device(
+                duthost, is_sw_control_feature_enabled)
+        else:
+            port_indices_to_tested = self.sfp_setup["sfp_test_port_indices"]
 
-        for i in self.sfp_setup["sfp_test_port_indices"]:
+        for i in port_indices_to_tested:
             # First ensure that the transceiver type supports setting TX disable on individual channels
             info_dict = sfp.get_transceiver_info(platform_api_conn, i)
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
@@ -1024,3 +1035,13 @@ class TestSfpApi(PlatformApiTestBase):
                 self.expect(thermal and thermal == thermal_list[thermal_index],
                             "Thermal {} is incorrect for sfp {}".format(thermal_index, sfp_id))
         self.assert_expectations()
+
+    def get_port_indices_to_tested_for_mellanox_device(self, duthost, is_sw_control_feature_enabled):  # noqa: F811
+        port_indices_to_tested = []
+        if is_sw_control_feature_enabled:
+            port_indices_to_tested = [port_index for port_index in self.sfp_setup["sfp_test_port_indices"]
+                                      if is_sw_control_enabled(duthost, port_index)]
+        if not port_indices_to_tested:
+            pytest.skip("Skipping test on Mellanox device with no port indices to test")
+        logging.info(f"Port indices to tested for Mellanox device: {port_indices_to_tested}")
+        return port_indices_to_tested


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. Remove the corresponding skip condition
2. For test_tx_disable and test_tx_disable_channel, only when the port with software control enabled can support
3. For the test only calls get api, we don't need to disable loganalyzer. Disable loganalyzer for test wih set operation
4. For test_get_high_critical_threshold, test_get_high_threshold and test_power, we don't need to care the value, just verify that calling the corresponding APIs does not raise exception

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Enable some platform API tests for Mellanox device

#### How did you do it?
1. Remove the corresponding skip condition
2. Update the relevant tests accordingly

#### How did you verify/test it?
Run the tests on mellanox platform

#### Any platform specific information?
 mellanox platform

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
