### PR TITLE
Fix snmp_facts for creating IPv6 UdpTransportTarget

### DIFF
--- a/ansible/library/snmp_facts.py
+++ b/ansible/library/snmp_facts.py
@@ -952,7 +952,7 @@ def main_legacy(module):
 
     errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
         snmp_auth,
-        cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=m_args['timeout']),
+        _create_transport_target(m_args['host'], 161, m_args['timeout']),
         cmdgen.MibVariable(p.csqIfQosGroupStatsValue,),
         lookupMib=False,
     )
@@ -991,7 +991,7 @@ def main_legacy(module):
 
     errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
         snmp_auth,
-        cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=m_args['timeout']),
+        _create_transport_target(m_args['host'], 161, m_args['timeout']),
         cmdgen.MibVariable(p.ipCidrRouteDest,),
         cmdgen.MibVariable(p.ipCidrRouteStatus,),
         lookupMib=False,
@@ -1070,7 +1070,7 @@ def main_legacy(module):
 
         errorIndication, errorStatus, errorIndex, varTable = cmdGen.nextCmd(
             snmp_auth,
-            cmdgen.UdpTransportTarget((m_args['host'], 161), timeout=m_args['timeout']),
+            _create_transport_target(m_args['host'], 161, m_args['timeout']),
             cmdgen.MibVariable(p.dot1qTpFdbPort,),
             lookupMib=False,
         )


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In PR https://github.com/sonic-net/sonic-mgmt/pull/21045, I made mistakes while resolving the conflicts with https://github.com/sonic-net/sonic-mgmt/pull/20292. Some code added in #20292 was accidentally reverted.

#### How did you do it?
This change is to add back the code introduced in #20292 for creating SNMP UdpTransportTarget. Then the snmp_facts module will work with IPv6 only scenario again.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
