### PR TITLE
[AI - Snappi] Adding BGP convergence testcase for single session flap Up ( Case 2 )

### DIFF
--- a/tests/snappi_tests/dataplane/test_bgp_single_port_up.py
+++ b/tests/snappi_tests/dataplane/test_bgp_single_port_up.py
@@ -1,11 +1,7 @@
-from tests.common.telemetry import (
-    UNIT_SECONDS,       # noqa: F401, F403, F405, E402
-)
-from tests.common.telemetry.constants import (
-    METRIC_LABEL_TG_TRAFFIC_RATE,
-    METRIC_LABEL_TG_FRAME_BYTES,
-)
-from tests.snappi_tests.dataplane.imports import *   # noqa: F401, F403, F405
+from tests.common.telemetry import UNIT_SECONDS       # noqa: F401, F403, F405, E402
+from tests.common.telemetry.constants import METRIC_LABEL_TG_TRAFFIC_RATE,\
+    METRIC_LABEL_TG_FRAME_BYTES  # noqa: F401, F403, F405, E402
+from tests.snappi_tests.dataplane.imports import *    # noqa: F401, F403, F405, E402
 from snappi_tests.dataplane.files.helper import set_primary_chassis, create_snappi_config, create_traffic_items, \
     get_duthost_interface_details, configure_acl_for_route_withdrawl, start_stop, \
     get_stats, check_bgp_state  # noqa: F401, F403, F405, E402


### PR DESCRIPTION
… Up ( Case 2)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Adding BGP convergence for single session flap testcase with Port UP and Route Injection
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To implement the BGP case 2, as part of the Snappi-based BGP Convergence Test
#### How did you do it?
This case flaps one of the Rx port up and injects route from one of the Rx port
#### How did you verify/test it?
Tested with 2 BT0s and 1 BT1
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/snappi/bgp_convergence_test.md
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output
-------------------------------- live log call ---------------------------------
11/11/2025 17:37:41 test_bgp_single_port_up.get_convergence_ L0126 INFO   | Starting Single Port Flap (Up) Test
11/11/2025 17:37:41 connection._warn                         L0336 WARNING| Verification of certificates is disabled
11/11/2025 17:37:41 connection._info                         L0333 INFO   | Determining the platform and rest_port using the 10.36.77.57 address...
11/11/2025 17:37:41 connection._warn                         L0336 WARNING| Unable to connect to http://10.36.77.57:11015.
11/11/2025 17:37:41 connection._info                         L0333 INFO   | Connection established to `https://10.36.77.57:11015 on windows`
11/11/2025 17:37:41 connection._info                         L0333 INFO   | Using IxNetwork api server version 10.80.2413.2
11/11/2025 17:37:41 connection._info                         L0333 INFO   | User info IxNetwork/ST-KAMAL/8010
11/11/2025 17:37:41 snappi_api.info                          L1512 INFO   | snappi-1.40.0
11/11/2025 17:37:41 snappi_api.info                          L1512 INFO   | snappi_ixnetwork-1.39.2
11/11/2025 17:37:41 snappi_api.info                          L1512 INFO   | ixnetwork_restpy-1.7.0
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Config validation 0.009s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Ports configuration 0.101s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Captures configuration 0.046s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.78.53] 0.015s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Speed conversion is not require for (port.name, speed) : [('Port_1', 'novusHundredGigNonFanOut'), ('Port_3', 'novusHundredGigNonFanOut'), ('Port_5', 'novusHundredGigNonFanOut'), ('Port_7', 'novusHundredGigNonFanOut'), ('Port_2', 'novusHundredGigNonFanOut'), ('Port_4', 'novusHundredGigNonFanOut'), ('Port_6', 'novusHundredGigNonFanOut'), ('Port_8', 'novusHundredGigNonFanOut')]
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.355s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Location configuration 0.446s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.098s
11/11/2025 17:37:42 snappi_api.info                          L1512 INFO   | Lag Configuration 0.006s
11/11/2025 17:37:43 snappi_api.info                          L1512 INFO   | Convert device config : 0.465s
11/11/2025 17:37:43 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
11/11/2025 17:37:46 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 2.764s
11/11/2025 17:37:46 snappi_api.info                          L1512 INFO   | Devices configuration 3.237s
11/11/2025 17:37:47 snappi_api.info                          L1512 INFO   | Flows configuration 1.358s
11/11/2025 17:38:00 snappi_api.info                          L1512 INFO   | Start interfaces 12.725s
11/11/2025 17:38:00 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
11/11/2025 17:38:00 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
11/11/2025 17:38:00 helperv2.start_stop                      L0650 INFO   | Start protocols
11/11/2025 17:38:04 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For protocols To start
11/11/2025 17:38:29 helperv2.check_bgp_state                 L0690 INFO   | BGP v6 Session State is UP
11/11/2025 17:38:29 test_bgp_single_port_up.get_convergence_ L0135 INFO   | Shutting down Ethernet68 port of sonic-s6100-dut1 dut before starting traffic 
11/11/2025 17:38:33 helperv2.start_stop                      L0650 INFO   | Start traffic
11/11/2025 17:38:38 snappi_api.info                          L1512 INFO   | Flows generate/apply 5.078s
11/11/2025 17:38:51 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.751s
11/11/2025 17:38:51 snappi_api.info                          L1512 INFO   | Captures start 0.000s
11/11/2025 17:38:54 snappi_api.info                          L1512 INFO   | Flows start 3.397s
11/11/2025 17:38:54 snappi_api.info                          L1512 INFO   | IxNet - The frame size was increased to 86 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
11/11/2025 17:39:20 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic to stabilize
11/11/2025 17:39:50 test_bgp_single_port_up.get_convergence_ L0150 INFO   | Starting Up Ethernet68 port of sonic-s6100-dut1 dut !!
11/11/2025 17:39:52 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For statistics to be collected
11/11/2025 17:40:32 test_bgp_single_port_up.get_convergence_ L0178 INFO   | Delta Frames : 2628589
11/11/2025 17:40:35 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For statistics to be Cleared
11/11/2025 17:41:05 test_bgp_single_port_up.get_convergence_ L0187 INFO   | Traffic has converged back after link flap Up
11/11/2025 17:41:05 test_bgp_single_port_up.get_convergence_ L0188 INFO   | --------------------------   Convergence Numbers   ----------------------------------
11/11/2025 17:41:05 test_bgp_single_port_up.get_convergence_ L0189 INFO   | Convergence Time for Single Port Flap Up: 55.726086588240875 (ms)
11/11/2025 17:41:05 test_bgp_single_port_up.get_convergence_ L0190 INFO   | --------------------------------------------------------------------------------------
11/11/2025 17:41:05 helperv2.start_stop                      L0650 INFO   | Stop traffic
11/11/2025 17:41:11 snappi_api.info                          L1512 INFO   | Flows stop 6.177s
11/11/2025 17:41:21 db_reporter._report                      L0049 INFO   | DBReporter: Writing 1 metric records to file
11/11/2025 17:41:21 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 1 metric records to /tmp/telemetry_test_54hcvt1u/test_bgp_single_port_up.metrics.json
11/11/2025 17:41:21 helperv2.start_stop                      L0650 INFO   | Stop protocols
11/11/2025 17:41:21 utilities.wait                           L0120 INFO   | Pause 1 seconds, reason: For protocols To stop
11/11/2025 17:41:22 helperv2.start_stop                      L0650 INFO   | Stop traffic
11/11/2025 17:41:33 test_bgp_single_port_up.get_convergence_ L0207 INFO   | Starting up Ethernet68 port of sonic-s6100-dut1 dut !!
PASSED                                                                   [ 50%]
------------------------------ live log teardown -------------------------------
snappi_tests/dataplane/test_bgp_single_port_up.py::test_bgp_sessions[Route Injection-64-10-IPv6] 
-------------------------------- live log setup --------------------------------
-------------------------------- live log call ---------------------------------
11/11/2025 17:42:09 test_bgp_single_port_up.get_convergence_ L0217 INFO   | Starting Single Port (Route Injection) Test
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Config validation 0.012s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Ports configuration 0.085s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Captures configuration 0.043s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.78.53] 0.015s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Speed change not require due to redundant Layer1 config
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.028s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Location configuration 0.108s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.081s
11/11/2025 17:42:10 snappi_api.info                          L1512 INFO   | Lag Configuration 0.007s
11/11/2025 17:42:11 snappi_api.info                          L1512 INFO   | Convert device config : 0.826s
11/11/2025 17:42:11 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
11/11/2025 17:42:14 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 2.829s
11/11/2025 17:42:14 snappi_api.info                          L1512 INFO   | Devices configuration 3.664s
11/11/2025 17:42:17 snappi_api.info                          L1512 INFO   | Flows configuration 2.937s
11/11/2025 17:42:22 snappi_api.info                          L1512 INFO   | Start interfaces 5.626s
11/11/2025 17:42:24 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
11/11/2025 17:42:24 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
11/11/2025 17:42:24 helperv2.start_stop                      L0650 INFO   | Start protocols
11/11/2025 17:42:33 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For protocols To start
11/11/2025 17:42:43 test_bgp_single_port_up.get_convergence_ L0224 INFO   | 

11/11/2025 17:42:43 test_bgp_single_port_up.get_convergence_ L0225 INFO   | Configuring ACL for packet drop on one of the BGP peer
11/11/2025 17:42:45 test_bgp_single_port_up.get_convergence_ L0229 INFO   | sudo config acl add table AI_ACL_TABLE l3v6
11/11/2025 17:42:47 test_bgp_single_port_up.get_convergence_ L0232 INFO   | sudo config acl add table AI_ACL_TABLE L3v6 -p Ethernet76 -s egress
11/11/2025 17:42:56 test_bgp_single_port_up.get_convergence_ L0240 INFO   | Withdrawing Routes from Rx_Network_Group_1
11/11/2025 17:42:57 snappi_api.info                          L1512 INFO   | Setting route state 0.628s
11/11/2025 17:42:57 utilities.wait                           L0120 INFO   | Pause 30 seconds, reason: For routes to be withdrawn
11/11/2025 17:43:27 helperv2.start_stop                      L0650 INFO   | Start traffic
11/11/2025 17:43:32 snappi_api.info                          L1512 INFO   | Flows generate/apply 5.031s
11/11/2025 17:43:42 snappi_api.info                          L1512 INFO   | Flows clear statistics 10.512s
11/11/2025 17:43:42 snappi_api.info                          L1512 INFO   | Captures start 0.000s
11/11/2025 17:43:46 snappi_api.info                          L1512 INFO   | Flows start 3.400s
11/11/2025 17:43:46 snappi_api.info                          L1512 INFO   | IxNet - The frame size was increased to 86 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
11/11/2025 17:44:11 test_bgp_single_port_up.get_convergence_ L0249 INFO   | Removing acl table AI_ACL_TABLE
11/11/2025 17:44:13 test_bgp_single_port_up.get_convergence_ L0251 INFO   | Injecting Routes from Rx_Network_Group_1
11/11/2025 17:44:14 snappi_api.info                          L1512 INFO   | Setting route state 0.639s
11/11/2025 17:44:14 utilities.wait                           L0120 INFO   | Pause 30 seconds, reason: For routes to be Advertised
11/11/2025 17:44:54 test_bgp_single_port_up.get_convergence_ L0261 INFO   | Delta Frames : 119
11/11/2025 17:44:54 test_bgp_single_port_up.get_convergence_ L0264 INFO   | PACKET LOSS DURATION After Route Injection (ms): 0.0025227999636716803
11/11/2025 17:44:57 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For clear stats
11/11/2025 17:45:27 test_bgp_single_port_up.get_convergence_ L0272 INFO   | Total Tx and Rx Rates are equal after route injection
11/11/2025 17:45:29 test_bgp_single_port_up.get_convergence_ L0274 INFO   | 

11/11/2025 17:45:29 test_bgp_single_port_up.get_convergence_ L0275 INFO   | --------------------------   Convergence Numbers   ----------------------------------
11/11/2025 17:45:29 test_bgp_single_port_up.get_convergence_ L0276 INFO   | Convergence Time for Single Route Injection : 0.0025227999636716803 (ms)
11/11/2025 17:45:29 test_bgp_single_port_up.get_convergence_ L0277 INFO   | Time taken to apply acl and route Injection on snappi port: 2.8168253898620605 (s)
11/11/2025 17:45:29 test_bgp_single_port_up.get_convergence_ L0279 INFO   | --------------------------------------------------------------------------------------
11/11/2025 17:45:29 helperv2.start_stop                      L0650 INFO   | Stop traffic
11/11/2025 17:45:35 snappi_api.info                          L1512 INFO   | Flows stop 5.862s
11/11/2025 17:45:46 db_reporter._report                      L0049 INFO   | DBReporter: Writing 1 metric records to file
11/11/2025 17:45:46 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 1 metric records to /tmp/telemetry_test_8hu22ctk/test_bgp_single_port_up.metrics.json
11/11/2025 17:45:46 helperv2.start_stop                      L0650 INFO   | Stop protocols
11/11/2025 17:45:46 utilities.wait                           L0120 INFO   | Pause 1 seconds, reason: For protocols To stop
11/11/2025 17:45:47 helperv2.start_stop                      L0650 INFO   | Stop traffic
11/11/2025 17:45:47 test_bgp_single_port_up.get_convergence_ L0297 INFO   | Removing acl table AI_ACL_TABLE
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------