### PR TITLE
Enable dip_sip and mtu test on DT2 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3208,7 +3208,7 @@ ipfwd/test_dip_sip.py:
     conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-8122_64eh_o-r0', 'x86_64-8122_64ehf_o-r0']"
-      - "topo_type not in ['t0', 't1', 't2', 'm0', 'mx', 'm1']"
+      - "topo_type not in ['t0', 't1', 't2', 'm0', 'mx', 'm1', 'lt2', 'ft2']"
 
 ipfwd/test_dir_bcast.py:
   skip:
@@ -3232,7 +3232,7 @@ ipfwd/test_mtu.py:
   skip:
     reason: "Unsupported topology."
     conditions:
-      - "topo_type not in ['t1', 't2']"
+      - "topo_type not in ['t1', 't2', 'lt2', 'ft2']"
 
 ipfwd/test_nhop_group.py::test_nhop_group_interface_flap:
   xfail:

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -13,7 +13,7 @@ STATIC_ROUTE_IPV6 = '2001:db8:1::1/128'
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1')
+    pytest.mark.topology('t0', 't1', 't2', 'm0', 'mx', 'm1', 'lt2', 'ft2')
 ]
 
 

--- a/tests/ipfwd/test_mtu.py
+++ b/tests/ipfwd/test_mtu.py
@@ -7,7 +7,7 @@ from tests.ptf_runner import ptf_runner
 from datetime import datetime
 
 pytestmark = [
-    pytest.mark.topology('t1', 't2', 'm1'),
+    pytest.mark.topology('t1', 't2', 'm1', 'lt2', 'ft2'),
     pytest.mark.device_type('vs')
 ]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enable two tests on LT2 and FT2.
- tests/ipfwd/test_dip_sip.py
- tests/ipfwd/test_mtu.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
This PR is to enable two tests on LT2 and FT2.

#### How did you do it?
1. Update `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` to add `LT2` and `FT2` into supported topologies
2. Update test code to add `LT2` and `FT2` to topology marker

#### How did you verify/test it?
The change is verified on a physical testbed.

```
collected 1 item                                                                                                                                                                                                              

ipfwd/test_dip_sip.py::test_dip_sip[None] PASSED                                                                                                                                                      [100%]

```
```
collected 2 items                                                                                                                                                                                                             

ipfwd/test_mtu.py::test_mtu[1514] PASSED                                                                                                                                                         [ 50%]
ipfwd/test_mtu.py::test_mtu[9114]  ^HPASSED                                                                                                                                                         [100%]
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
