### PR TITLE
Add DSCP remap QOS Test.

### DIFF
--- a/tests/common/helpers/ptf_tests_helper.py
+++ b/tests/common/helpers/ptf_tests_helper.py
@@ -13,6 +13,164 @@ from tests.common.config_reload import config_reload
 logger = logging.getLogger(__name__)
 
 
+# ============================================================================
+# Helper Functions for PTF Port Mapping and Interface Selection
+# ============================================================================
+
+def get_dut_to_ptf_port_mapping(duthost, tbinfo):
+    """
+    Get mapping of DUT interfaces/PortChannels to PTF ports.
+    Only includes interfaces or PortChannels that have IP addresses configured.
+
+    Args:
+        duthost: DUT host object
+        tbinfo: Testbed info
+
+    Returns:
+        dict: {interface_name: ptf_index} for interfaces with IP
+              {portchannel_name: -1} for PortChannels with IP
+    """
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    all_indices = mg_facts.get('minigraph_ptf_indices', {})
+    mapping = {}
+
+    # Add interfaces with IP addresses
+    for intf in mg_facts.get('minigraph_interfaces', []):
+        interface_name = intf.get('attachto')
+        if interface_name and intf.get('addr'):
+            ptf_index = all_indices.get(interface_name)
+            if ptf_index is not None:
+                mapping[interface_name] = ptf_index
+
+    # Add PortChannels with IP addresses (PTF index = -1)
+    for intf in mg_facts.get('minigraph_portchannel_interfaces', []):
+        portchannel_name = intf.get('attachto')
+        if portchannel_name and intf.get('addr'):
+            mapping[portchannel_name] = -1
+
+    return mapping
+
+
+def get_interface_ip_address(interface_name, mg_facts):
+    """
+    Get IP address for an interface from minigraph facts.
+
+    Args:
+        interface_name: Interface or PortChannel name
+        mg_facts: Minigraph facts dictionary
+
+    Returns:
+        str: IP address or None if not found
+    """
+    # Check in minigraph_interfaces
+    for intf in mg_facts.get('minigraph_interfaces', []):
+        if intf.get('attachto') == interface_name and intf.get('addr'):
+            return str(intf['addr'])
+
+    # Check in minigraph_portchannel_interfaces
+    for intf in mg_facts.get('minigraph_portchannel_interfaces', []):
+        if intf.get('attachto') == interface_name and intf.get('addr'):
+            return str(intf['addr'])
+
+    return None
+
+
+def select_test_interface_and_ptf_port(duthost, tbinfo):
+    """
+    Select a random test interface/PortChannel and its corresponding PTF port.
+
+    Args:
+        duthost: DUT host object
+        tbinfo: Testbed info
+
+    Returns:
+        tuple: (interface_name, ptf_index) for interfaces
+               (portchannel_name, -1) for PortChannels
+               (None, None) if not found
+    """
+    dut_to_ptf_mapping = get_dut_to_ptf_port_mapping(duthost, tbinfo)
+    if not dut_to_ptf_mapping:
+        return None, None
+
+    interface_name = random.choice(list(dut_to_ptf_mapping.keys()))
+    ptf_port_index = dut_to_ptf_mapping[interface_name]
+
+    logger.info("Selected: {} (PTF port: {})".format(interface_name, ptf_port_index))
+    return interface_name, ptf_port_index
+
+
+def detect_portchannel_egress_member(duthost, tbinfo, ptf_adapter, portchannel_name, test_packet):
+    """
+    Detect which PortChannel member interface is actually used for egress traffic.
+
+    Args:
+        duthost: DUT host object
+        tbinfo: Testbed info
+        ptf_adapter: PTF adapter object
+        portchannel_name: PortChannel name
+        test_packet: Test packet to send
+
+    Returns:
+        tuple: (member_interface, ptf_port) or (None, None)
+    """
+    import ptf.testutils as testutils
+
+    logger.info("Detecting egress member for {}".format(portchannel_name))
+
+    # Get PortChannel members
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+    portchannels = mg_facts.get('minigraph_portchannels', {})
+
+    if portchannel_name not in portchannels:
+        return None, None
+
+    members = portchannels[portchannel_name].get('members', [])
+    if not members:
+        return None, None
+
+    # Get PTF ports for members
+    ptf_indices = mg_facts.get('minigraph_ptf_indices', {})
+    member_ptf_ports = [(m, ptf_indices[m]) for m in members if m in ptf_indices]
+
+    if not member_ptf_ports:
+        return None, None
+
+    # Try each member port
+    num_test_packets = 100
+    timeout = 10.0
+
+    for member_name, member_ptf_port in member_ptf_ports:
+        logger.info("Trying {} (PTF port {})".format(member_name, member_ptf_port))
+        ptf_adapter.dataplane.flush()
+
+        # Send test packets
+        for i in range(num_test_packets):
+            testutils.send_packet(ptf_adapter, member_ptf_port, test_packet)
+
+        # Check if packets received
+        packets_received = 0
+
+        def check_packets_received():
+            nonlocal packets_received
+            while True:
+                result = testutils.dp_poll(ptf_adapter, device_number=0, timeout=0.1)
+                if isinstance(result, ptf_adapter.dataplane.PollSuccess):
+                    if result.port == member_ptf_port:
+                        packets_received += 1
+                else:
+                    break
+            return packets_received >= num_test_packets
+
+        if wait_until(timeout=timeout, interval=1, delay=1, condition=check_packets_received):
+            logger.info("Found egress member: {} (PTF port {})".format(member_name, member_ptf_port))
+            ptf_adapter.dataplane.flush()
+            return member_name, member_ptf_port
+
+    # No working member found
+    ptf_adapter.dataplane.flush()
+    return None, None
+
+
 @pytest.fixture(scope="module")
 def downstream_links(rand_selected_dut, tbinfo, nbrhosts):
     """

--- a/tests/qos/qos_helpers.py
+++ b/tests/qos/qos_helpers.py
@@ -320,6 +320,292 @@ def disable_voq_watchdog(duthosts, get_src_dst_asic_and_duts):
     modify_voq_watchdog(duthosts, get_src_dst_asic_and_duts, enable=True)
 
 
+def update_tc_to_dscp_map(duthost, tc_to_dscp_map, map_name='REMAP_TEST', interface=None):
+    """
+    Add TC_TO_DSCP_MAP to DUT and optionally apply to interface via PORT_QOS_MAP.
+
+    Args:
+        duthost: DUT host object
+        tc_to_dscp_map (dict): TC to DSCP mappings (string keys/values)
+        map_name (str): QoS profile name (default: 'REMAP_TEST')
+        interface (str): Interface name to apply map to (optional)
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        # Validate input
+        if not isinstance(tc_to_dscp_map, dict) or not tc_to_dscp_map:
+            logger.error("tc_to_dscp_map must be a non-empty dictionary")
+            return False
+
+        logger.info("Adding TC_TO_DSCP_MAP '{}' ({} entries){}".format(
+            map_name, len(tc_to_dscp_map),
+            " to interface '{}'".format(interface) if interface else " globally"))
+
+        # Step 1: Add TC_TO_DSCP_MAP globally
+        config_data = {'TC_TO_DSCP_MAP': {map_name: tc_to_dscp_map}}
+        cmd = "sonic-cfggen -a '{}' -w".format(json.dumps(config_data))
+        result = duthost.shell(cmd, module_ignore_errors=True)
+
+        if result['rc'] != 0:
+            logger.error("Failed to add TC_TO_DSCP_MAP: {}".format(result.get('stderr', 'Unknown error')))
+            return False
+
+        # Step 2: Update PORT_QOS_MAP if interface specified
+        if interface:
+            port_qos_config = {'PORT_QOS_MAP': {interface: {'tc_to_dscp_map': map_name}}}
+            cmd = "sonic-cfggen -a '{}' -w".format(json.dumps(port_qos_config))
+            result = duthost.shell(cmd, module_ignore_errors=True)
+
+            if result['rc'] != 0:
+                logger.error("Failed to update PORT_QOS_MAP for {}: {}".format(
+                    interface, result.get('stderr', 'Unknown error')))
+                return False
+
+        # Verify update
+        config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
+        updated_map = config_facts.get('TC_TO_DSCP_MAP', {}).get(map_name, {})
+
+        if not updated_map:
+            logger.warning("Verification failed: TC_TO_DSCP_MAP '{}' not found".format(map_name))
+            return False
+
+        logger.info("Verification successful: TC_TO_DSCP_MAP '{}' has {} entries".format(
+            map_name, len(updated_map)))
+
+        # Verify PORT_QOS_MAP if interface specified
+        if interface:
+            port_qos_map = config_facts.get('PORT_QOS_MAP', {}).get(interface, {})
+            if port_qos_map.get('tc_to_dscp_map') != map_name:
+                logger.warning("Verification failed: PORT_QOS_MAP['{}'] does not refer to '{}'".format(
+                    interface, map_name))
+                return False
+            logger.info("Verification successful: PORT_QOS_MAP['{}'] refers to '{}'".format(
+                interface, map_name))
+
+        return True
+
+    except Exception as e:
+        logger.error("Failed to update TC to DSCP map: {}".format(str(e)))
+        return False
+
+
+def remove_qos_map(duthost, map_type, map_name):
+    """
+    Remove a QoS map from DUT configuration.
+
+    This function first checks if the map is referenced in PORT_QOS_MAP and removes
+    those references before removing the map.
+
+    Args:
+        duthost: DUT host object
+        map_type (str): Type of map to remove ('DSCP_TO_TC_MAP', 'TC_TO_QUEUE_MAP', 'TC_TO_DSCP_MAP')
+        map_name (str): Name of the map to remove (e.g., 'REMAP_TEST')
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        logger.info("Removing {} '{}' from DUT".format(map_type, map_name))
+
+        # Validate input
+        valid_map_types = ['DSCP_TO_TC_MAP', 'TC_TO_QUEUE_MAP', 'TC_TO_DSCP_MAP']
+        if map_type not in valid_map_types:
+            logger.error("Invalid map_type '{}'. Must be one of: {}".format(
+                map_type, ', '.join(valid_map_types)))
+            return False
+
+        if not isinstance(map_name, str) or not map_name:
+            logger.error("map_name must be a non-empty string")
+            return False
+
+        # Convert map type to PORT_QOS_MAP field name
+        port_qos_field = map_type.lower()
+
+        # Remove references from PORT_QOS_MAP to avoid dangling leafrefs
+        logger.info("Checking for {} references in PORT_QOS_MAP".format(map_type))
+        config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
+        port_qos_map = config_facts.get('PORT_QOS_MAP', {})
+
+        removed_refs = []
+        for intf, qos_map in port_qos_map.items():
+            if qos_map.get(port_qos_field) == map_name:
+                cmd = "sonic-db-cli CONFIG_DB hdel 'PORT_QOS_MAP|{}' {}".format(intf, port_qos_field)
+                result = duthost.shell(cmd, module_ignore_errors=True)
+                if result['rc'] == 0:
+                    removed_refs.append(intf)
+                    logger.info("Removed {} reference from {}".format(port_qos_field, intf))
+                else:
+                    logger.warning("Failed to remove {} reference from {}: {}".format(
+                        port_qos_field, intf, result.get('stderr', 'Unknown error')))
+
+        if removed_refs:
+            logger.info("Removed {} references from {} interface(s)".format(
+                port_qos_field, len(removed_refs)))
+        else:
+            logger.info("No {} references found in PORT_QOS_MAP".format(port_qos_field))
+
+        # Remove the map using sonic-cfggen
+        config_data = {map_type: {map_name: None}}
+        cmd = "sonic-cfggen -a '{}' -w".format(json.dumps(config_data))
+        result = duthost.shell(cmd, module_ignore_errors=True)
+
+        if result['rc'] != 0:
+            logger.warning("Failed to remove {} '{}': {}".format(
+                map_type, map_name, result.get('stderr', 'Unknown error')))
+            return False
+
+        logger.info("Successfully removed {} '{}'".format(map_type, map_name))
+
+        # Verify removal
+        config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
+        remaining_map = config_facts.get(map_type, {}).get(map_name)
+
+        if remaining_map is None:
+            logger.info("Verification successful: {} '{}' removed".format(map_type, map_name))
+            return True
+        else:
+            logger.warning("Verification failed: {} '{}' still exists".format(map_type, map_name))
+            return False
+
+    except Exception as e:
+        logger.error("Failed to remove QoS map: {}".format(str(e)))
+        return False
+
+
+def clear_queue_counters(duthost):
+    """
+    Clear queue counters on DUT.
+
+    Args:
+        duthost: DUT host object
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        logger.info("Clearing queue counters...")
+        result = duthost.shell("sonic-clear queuecounters", module_ignore_errors=True)
+
+        if result['rc'] != 0:
+            logger.error("Failed to clear queue counters: {}".format(result.get('stderr', 'Unknown error')))
+            return False
+
+        logger.info("Queue counters cleared successfully")
+        return True
+
+    except Exception as e:
+        logger.error("Failed to clear queue counters: {}".format(str(e)))
+        return False
+
+
+def get_queue_counter(duthost, port, queue):
+    """
+    Get packet counter for a specific queue on a port.
+
+    Args:
+        duthost: DUT host object
+        port (str): Interface name (e.g., 'Ethernet0')
+        queue (int): Queue number (0-8)
+
+    Returns:
+        int: Packet count for the queue, or 0 if not found
+    """
+    try:
+        cmd = "show queue counters {}".format(port)
+        output = duthost.shell(cmd, module_ignore_errors=True)
+
+        if output['rc'] != 0:
+            logger.warning("Failed to get queue counters for {}: {}".format(
+                port, output.get('stderr', 'Unknown error')))
+            return 0
+
+        # Parse output to find the queue counter
+        # Output format:
+        #          Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+        #     ---------  -----  --------------  ---------------  -----------  ------------
+        #     Ethernet0    UC0               0                0            0             0
+
+        txq = "UC{}".format(queue)
+        for line in output['stdout_lines']:
+            fields = line.split()
+            if len(fields) >= 3 and fields[0] == port and fields[1] == txq:
+                try:
+                    counter = int(fields[2].replace(',', ''))
+                    logger.info("Queue counter for {}:{} = {}".format(port, txq, counter))
+                    return counter
+                except (ValueError, IndexError):
+                    logger.warning("Failed to parse queue counter from line: {}".format(line))
+                    return 0
+
+        logger.warning("Queue {} not found for port {}".format(txq, port))
+        return 0
+
+    except Exception as e:
+        logger.error("Failed to get queue counter: {}".format(str(e)))
+        return 0
+
+
+def get_dscp_for_tc(dscp_to_tc_map, tc_value):
+    """
+    Find DSCP value that maps to a given TC value.
+
+    Args:
+        dscp_to_tc_map (dict): DSCP_TO_TC_MAP configuration
+        tc_value (int): TC value to find DSCP for
+
+    Returns:
+        int: DSCP value that maps to the TC, or None if not found
+    """
+    try:
+        # Reverse lookup: find DSCP that maps to this TC
+        for dscp_str, tc_str in dscp_to_tc_map.items():
+            if int(tc_str) == tc_value:
+                logger.info("Found DSCP {} maps to TC {}".format(dscp_str, tc_value))
+                return int(dscp_str)
+
+        logger.warning("No DSCP found that maps to TC {}".format(tc_value))
+        return None
+
+    except Exception as e:
+        logger.error("Failed to get DSCP for TC {}: {}".format(tc_value, str(e)))
+        return None
+
+
+def get_outgoing_dscp(incoming_dscp, dscp_to_tc_map, tc_to_dscp_map):
+    """Calculate outgoing DSCP: incoming_dscp -> TC -> outgoing_dscp.
+
+    Args:
+        incoming_dscp (int): Incoming DSCP value (0-63)
+        dscp_to_tc_map (dict): DSCP_TO_TC_MAP configuration
+        tc_to_dscp_map (dict): TC_TO_DSCP_MAP configuration
+
+    Returns:
+        int: Outgoing DSCP value, or None if mapping not found
+    """
+    # Find TC value for incoming DSCP
+    tc_value = None
+    for dscp_str, tc_str in dscp_to_tc_map.items():
+        if int(dscp_str) == incoming_dscp:
+            tc_value = int(tc_str)
+            break
+
+    if tc_value is None:
+        logger.warning("No TC mapping found for incoming DSCP={}".format(incoming_dscp))
+        return None
+
+    # Find outgoing DSCP for TC value
+    outgoing_dscp_str = tc_to_dscp_map.get(str(tc_value))
+    if outgoing_dscp_str is None:
+        logger.warning("No outgoing DSCP mapping found for TC={}".format(tc_value))
+        return None
+
+    outgoing_dscp = int(outgoing_dscp_str)
+    logger.info("DSCP mapping: {} -> TC={} -> {}".format(incoming_dscp, tc_value, outgoing_dscp))
+    return outgoing_dscp
+
+
 def get_upstream_vm_offset(nbrhosts, tbinfo):
     """
     Get ports offset of exabgp port

--- a/tests/qos/test_qos_remap.py
+++ b/tests/qos/test_qos_remap.py
@@ -1,0 +1,324 @@
+"""
+Test cases for testing QoS remapping functionality in SONiC.
+This module tests DSCP to TC mapping, TC to priority mapping, and TC to DSCP mapping.
+"""
+
+import logging
+import pytest
+import ipaddress
+
+from tests.common.helpers.ptf_tests_helper import (
+    select_test_interface_and_ptf_port,
+    get_interface_ip_address,
+    detect_portchannel_egress_member
+)
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
+from .qos_helpers import (
+    update_tc_to_dscp_map,
+    remove_qos_map,
+    clear_queue_counters,
+    get_queue_counter,
+    get_dscp_for_tc,
+    get_outgoing_dscp
+)
+from ptf import testutils
+from scapy.all import IP, Ether
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any')
+]
+
+# Default Azure DSCP to TC mapping
+DEFAULT_AZURE_DSCP_TO_TC = {
+    "0": "1", "3": "3", "4": "4", "5": "2", "8": "0", "46": "5", "48": "6"
+}
+
+# Default Azure TC to Queue mapping
+DEFAULT_AZURE_TC_TO_QUEUE = {
+    "0": "0", "1": "1", "2": "2", "3": "3", "4": "4", "5": "5", "6": "6", "7": "7"
+}
+
+# Custom TC to DSCP mapping
+CUSTOM_TC_TO_DSCP = {
+    "0": "1", "1": "10", "2": "12", "3": "14", "4": "16", "5": "18", "6": "20", "7": "22"
+}
+
+# Global variables for packet counts - easy to change for testing
+QUEUE_COUNTER_VERIFICATION_PACKETS = 1000
+DSCP_REMAPPING_VERIFICATION_PACKETS = 100
+
+
+class TestQosRemap:
+    """Test class for QoS remapping functionality"""
+
+    @pytest.fixture(autouse=True)
+    def cleanup_qos_maps(self, duthost):
+        """
+        Fixture to cleanup QoS maps after each test.
+
+        This fixture:
+        1. Runs after each test method
+        2. Removes TC_TO_DSCP_MAP from DUT
+        3. Ensures clean state for next test
+        """
+        yield  # Run test first
+
+        # Cleanup after test
+        logger.info("Cleaning up QoS maps after test")
+        try:
+            # Remove the TC_TO_DSCP_MAP entry
+            result = remove_qos_map(duthost, 'TC_TO_DSCP_MAP', 'REMAP_TEST')
+            if result:
+                logger.info("✓ Cleaned up TC_TO_DSCP_MAP 'REMAP_TEST'")
+            else:
+                logger.warning("Failed to cleanup TC_TO_DSCP_MAP 'REMAP_TEST'")
+
+            logger.info("Cleanup completed")
+        except Exception as e:
+            logger.error("Error during cleanup: {}".format(str(e)))
+
+    def setup_qos_mappings(self, duthost, interface_name):
+        """Setup QoS mappings on DUT for the specified interface.
+
+        Apply tc_to_dscp_map to the given interface.
+
+        Args:
+            duthost: DUT host object
+            interface_name: Interface name to apply QoS mappings to
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        # Apply tc_to_dscp_map
+        logger.info("Applying tc_to_dscp_map (custom) to interface {}".format(interface_name))
+
+        if not update_tc_to_dscp_map(duthost, CUSTOM_TC_TO_DSCP, map_name='REMAP_TEST', interface=interface_name):
+            logger.error("Failed to apply TC_TO_DSCP_MAP to {}".format(interface_name))
+            return False
+        logger.info("✓ TC_TO_DSCP_MAP applied to {}".format(interface_name))
+
+        logger.info("QoS mappings setup complete")
+        return True
+
+    def test_qos_mappings(self, duthost, tbinfo, ptfadapter):
+        """Setup and test QoS mappings with queue counter verification and DSCP remapping with dataplane poll."""
+
+        # Check if DUT is running supported Broadcom ASIC
+        if duthost.facts["asic_type"].lower() != "broadcom":
+            pytest.skip(f"Test only supports Broadcom ASICs. Current ASIC: {duthost.facts['asic_type']}")
+
+        # Skip in case of Q3d
+        asic_name = duthost.get_asic_name().lower()
+        if asic_name in ["q3d"]:
+            pytest.skip("Test is not suppported for Q3d.")
+
+        # Randomly select interface or PortChannel
+        interface_name, ptf_port_index = select_test_interface_and_ptf_port(duthost, tbinfo)
+        pytest_assert(interface_name and ptf_port_index is not None,
+                      "Could not find interface with PTF port mapping")
+
+        # Get IP address for the selected interface
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        interface_ip = get_interface_ip_address(interface_name, mg_facts)
+        pytest_assert(interface_ip, "Could not find IP address for interface {}".format(interface_name))
+        logger.info("Selected: {} (PTF port: {}), IP: {}".format(interface_name, ptf_port_index, interface_ip))
+
+        # Calculate source and destination IPs
+        interface_network = ipaddress.ip_interface(interface_ip)
+        src_ip = str(interface_network.ip - 1)
+        dst_ip = str(interface_network.ip + 1)
+        router_mac = duthost.facts["router_mac"]
+
+        # If PortChannel, detect actual egress member
+        portchannels = mg_facts.get('minigraph_portchannels', {})
+        if interface_name in portchannels:
+            logger.info("{} is a PortChannel, detecting egress member".format(interface_name))
+
+            # Create test packet for detection
+            test_packet = testutils.simple_tcp_packet(
+                eth_dst=router_mac, ip_src=src_ip, ip_dst=dst_ip,
+                ip_dscp=0, tcp_sport=1234, tcp_dport=80)
+
+            # Detect actual egress member
+            detected_interface, detected_ptf_port = detect_portchannel_egress_member(
+                duthost, tbinfo, ptfadapter, interface_name, test_packet
+            )
+            if detected_interface and detected_ptf_port is not None:
+                logger.info("Detected egress member: {} (PTF port {})".format(
+                    detected_interface, detected_ptf_port))
+                interface_name = detected_interface
+                ptf_port_index = detected_ptf_port
+            else:
+                pytest.fail("Could not detect egress member for PortChannel {}".format(interface_name))
+        else:
+            logger.info("Using interface {} (PTF port {})".format(interface_name, ptf_port_index))
+
+        # Setup QoS mappings on the final interface
+        logger.info("Setting up QoS mappings on interface: {}".format(interface_name))
+        pytest_assert(self.setup_qos_mappings(duthost, interface_name),
+                      "Failed to setup QoS mappings on interface {}".format(interface_name))
+
+        logger.info("Starting QoS mapping verification for interface: {}".format(interface_name))
+
+        # Verify that interface has DSCP_TO_TC and TC_TO_QUEUE set to AZURE
+        config_facts = duthost.asic_instance().config_facts(source="running")["ansible_facts"]
+        port_qos_map = config_facts.get('PORT_QOS_MAP', {})
+        pytest_assert(port_qos_map, "PORT_QOS_MAP not found in DUT config")
+
+        interface_qos_map = port_qos_map.get(interface_name, {})
+        pytest_assert(interface_qos_map, "Interface {} not found in PORT_QOS_MAP".format(interface_name))
+
+        dscp_to_tc_profile = interface_qos_map.get('dscp_to_tc_map')
+        tc_to_queue_profile = interface_qos_map.get('tc_to_queue_map')
+
+        pytest_assert(dscp_to_tc_profile == 'AZURE',
+                      "Interface {} dscp_to_tc_map is '{}', expected 'AZURE'".format(
+                          interface_name, dscp_to_tc_profile))
+        pytest_assert(tc_to_queue_profile == 'AZURE',
+                      "Interface {} tc_to_queue_map is '{}', expected 'AZURE'".format(
+                          interface_name, tc_to_queue_profile))
+
+        logger.info("✓ Interface {} has DSCP_TO_TC_MAP='AZURE' and TC_TO_QUEUE_MAP='AZURE'".format(interface_name))
+
+        # Use default Azure profile for dscp_to_tc and tc_to_queue in all phases
+        dscp_to_tc_map = DEFAULT_AZURE_DSCP_TO_TC
+        tc_to_queue_map = DEFAULT_AZURE_TC_TO_QUEUE
+
+        # Use custom tc_to_dscp mapping in all phases
+        tc_to_dscp_map = CUSTOM_TC_TO_DSCP
+
+        logger.info("Interface: {} IP: {}".format(interface_name, interface_ip))
+        logger.info("Packet IPs: {} -> {}".format(src_ip, dst_ip))
+        logger.info("Router MAC: {}".format(router_mac))
+
+        # ========== PHASE 1: Queue Counter Verification ==========
+        logger.info("\n" + "="*80)
+        logger.info("PHASE 1: Queue Counter Verification (1000 packets per TC)")
+        logger.info("="*80)
+
+        for tc_value in range(7):
+            logger.info("\n=== Queue Verification TC={} ===".format(tc_value))
+
+            # Clear counters and get expected queue
+            pytest_assert(clear_queue_counters(duthost), "Failed to clear queue counters")
+            expected_queue = int(tc_to_queue_map.get(str(tc_value), tc_value))
+
+            # Get DSCP for this TC and send packets
+            incoming_dscp = get_dscp_for_tc(dscp_to_tc_map, tc_value)
+            pytest_assert(incoming_dscp is not None, "Could not find DSCP for TC {}".format(tc_value))
+
+            pkt = testutils.simple_tcp_packet(
+                eth_dst=router_mac, ip_src=src_ip, ip_dst=dst_ip,
+                ip_dscp=incoming_dscp, tcp_sport=1234, tcp_dport=80)
+
+            for _ in range(QUEUE_COUNTER_VERIFICATION_PACKETS):
+                testutils.send_packet(ptfadapter, ptf_port_index, pkt)
+
+            logger.info("Sent {} packets with DSCP={} (TC={})".format(
+                QUEUE_COUNTER_VERIFICATION_PACKETS, incoming_dscp, tc_value))
+
+            # Wait for packets to be processed and queue counter to reach expected count
+            def check_queue_counter():
+                counter = get_queue_counter(duthost, interface_name, expected_queue)
+                if counter >= QUEUE_COUNTER_VERIFICATION_PACKETS:
+                    logger.info("✓ Queue {} received {} packets".format(expected_queue, counter))
+                    return True
+                else:
+                    logger.debug("Queue {} received {} packets, waiting for more...".format(expected_queue, counter))
+                    return False
+
+            wait_until(timeout=30, interval=1, delay=1, condition=check_queue_counter)
+
+            # Final verification
+            queue_counter = get_queue_counter(duthost, interface_name, expected_queue)
+            pytest_assert(
+                queue_counter >= QUEUE_COUNTER_VERIFICATION_PACKETS,
+                "Queue {} received {} packets, expected >= {}".format(
+                    expected_queue, queue_counter, QUEUE_COUNTER_VERIFICATION_PACKETS))
+
+        logger.info("\n=== Phase 1 Complete ===\n")
+
+        # ========== PHASE 2: DSCP Remapping ==========
+        logger.info("="*80)
+        logger.info("PHASE 2: DSCP Remapping Verification")
+        logger.info("="*80)
+
+        # Increase buffer size for PTF dataplane to handle more packets
+        logger.info("Increasing dataplane queue length for packet buffering")
+        ptfadapter.dataplane.qlen = 10000
+
+        for tc_value in range(7):
+            logger.info("\n=== DSCP Remapping Verification TC={} ===".format(tc_value))
+
+            # Get incoming and outgoing DSCP
+            incoming_dscp = get_dscp_for_tc(dscp_to_tc_map, tc_value)
+            pytest_assert(incoming_dscp is not None, "Could not find DSCP for TC {}".format(tc_value))
+
+            outgoing_dscp = get_outgoing_dscp(incoming_dscp, dscp_to_tc_map, tc_to_dscp_map)
+            logger.info("DSCP remapping: {} -> {}".format(incoming_dscp, outgoing_dscp))
+
+            # Send test packets
+            pkt = testutils.simple_tcp_packet(
+                eth_dst=router_mac, ip_src=src_ip, ip_dst=dst_ip,
+                ip_dscp=incoming_dscp, tcp_sport=1234, tcp_dport=80)
+
+            for _ in range(DSCP_REMAPPING_VERIFICATION_PACKETS):
+                testutils.send_packet(ptfadapter, ptf_port_index, pkt)
+
+            logger.info("Sent {} packets with DSCP={}".format(DSCP_REMAPPING_VERIFICATION_PACKETS, incoming_dscp))
+
+            # Poll dataplane for packets and verify DSCP remapping
+            captured_packet_count = 0
+
+            def check_captured_packets():
+                nonlocal captured_packet_count
+
+                # Poll all available packets from dataplane
+                while True:
+                    result = ptfadapter.dataplane.poll(
+                        device_number=0,
+                        port_number=ptf_port_index,
+                        timeout=1
+                    )
+
+                    if isinstance(result, ptfadapter.dataplane.PollFailure):
+                        # No more packets available
+                        break
+
+                    if isinstance(result, ptfadapter.dataplane.PollSuccess):
+                        rcv_pkt = Ether(result.packet)
+
+                        # Extract IP layer and check DSCP
+                        if IP in rcv_pkt:
+                            ip_layer = rcv_pkt[IP]
+                            packet_dscp = ip_layer.tos >> 2  # Extract DSCP from TOS field
+
+                            # Check if packet matches expected criteria
+                            if (ip_layer.src == src_ip and
+                                    ip_layer.dst == dst_ip and
+                                    packet_dscp == outgoing_dscp):
+                                captured_packet_count += 1
+
+                if captured_packet_count >= DSCP_REMAPPING_VERIFICATION_PACKETS:
+                    logger.info("✓ Captured {} packets with correct DSCP={}".format(
+                        captured_packet_count, outgoing_dscp))
+                    return True
+                else:
+                    logger.debug("Captured {} packets with DSCP={}, waiting for more...".format(
+                        captured_packet_count, outgoing_dscp))
+                    return False
+
+            wait_until(timeout=30, interval=1, delay=1, condition=check_captured_packets)
+
+            # Final verification
+            pytest_assert(
+                captured_packet_count >= DSCP_REMAPPING_VERIFICATION_PACKETS,
+                "Expected >= {} packets with DSCP={}, got {}".format(
+                    DSCP_REMAPPING_VERIFICATION_PACKETS, outgoing_dscp, captured_packet_count))
+
+        logger.info("\n" + "="*80)
+        logger.info("All QoS mapping tests complete!")
+        logger.info("="*80)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Introduce complete QoS remapping test framework for SONiC that validates DSCP-to-TC mapping, TC-to-Queue mapping, and TC-to-DSCP mapping functionality with packet capture verification.

- Phase 1: Queue counter validation
- Phase 2: DSCP remapping verification via packet capture

**Key Components:**
- `qos_remap_config.json` with REMAP_TEST profile for all three QoS mappings
- Helper functions for queue counters, DSCP lookup, and packet capture
- Automatic cleanup fixture ensuring clean test state

Summary:
Complete QoS test infrastructure with packet-level DSCP verification
Fixes [#21146](https://github.com/sonic-net/sonic-mgmt/issues/21146)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Add a test to make sure custom QoS mappings work properly.

#### How did you do it?

- Changed QoS mappings for testing
- Sent test traffic through the system
- Checked if traffic goes to the right places based on the new settings

#### How did you verify/test it?

- Queue check: Looked at queue counters to make sure traffic goes to the correct queue
- DSCP check: Checked outgoing packets have the right DSCP values
- Full test: Made sure traffic flows correctly with custom settings

#### Any platform specific information?
Works on Broadcom platform

#### Supported testbed topology if it's a new test case?
Any
