### PR TITLE
[AI - Snappi] Adding BGP convergence testcase for Device Unisolation (Case 3)

### DIFF
--- a/tests/snappi_tests/dataplane/test_bgp_device_unisolation.py
+++ b/tests/snappi_tests/dataplane/test_bgp_device_unisolation.py
@@ -1,10 +1,5 @@
-from tests.common.telemetry import (
-    UNIT_SECONDS,       # noqa: F401, F403, F405, E402
-)
-from tests.common.telemetry.constants import (
-    METRIC_LABEL_TG_TRAFFIC_RATE,
-    METRIC_LABEL_TG_FRAME_BYTES,
-)
+from tests.common.telemetry import UNIT_SECONDS       # noqa: F401, F403, F405, E402
+from tests.common.telemetry.constants import METRIC_LABEL_TG_TRAFFIC_RATE, METRIC_LABEL_TG_FRAME_BYTES
 from tests.snappi_tests.dataplane.imports import *   # noqa: F401, F403, F405
 from snappi_tests.dataplane.files.helper import set_primary_chassis, create_snappi_config, create_traffic_items, \
     get_duthost_interface_details, configure_acl_for_route_withdrawl, start_stop, \


### PR DESCRIPTION
…( Case 3)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:  Adding BGP convergence for Device Unisolation
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
To implement the BGP case 1, as part of the Snappi-based BGP Convergence Test
#### How did you do it?
This case does 3 operation, config reload, all ports startup and bgp container restart
#### How did you verify/test it?
Tested with 2 BT0s and 1 BT1
#### Any platform specific information?
T1
#### Supported testbed topology if it's a new test case?

### Documentation
https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/snappi/bgp_convergence_test.md
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
###Output
azureuser@63282430c523:~/sonic-mgmt/tests$ python3 -m pytest --inventory ../ansible/snappi-sonic --host-pattern all --testbed vms-snappi-sonic-multidut --testbed_file ../ansible/testbed.yaml --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --skip_sanity --disable_loganalyzer --disable_memory_utilization --enable-snappi-dynamic-ports snappi_tests/dataplane/test_bgp_device_unisolation.py 

---------------------------------------------------------------------------- live log sessionstart -----------------------------------------------------------------------------
03/12/2025 01:06:28 conftest.pytest_sessionstart             L0492 INFO   | Invoking /var/azureuser/sonic-mgmt/tests/build-gnmi-stubs.sh with base directory: /var/azureuser/sonic-mgmt/tests
03/12/2025 01:06:28 conftest.pytest_sessionstart             L0502 INFO   | Output of /var/azureuser/sonic-mgmt/tests/build-gnmi-stubs.sh:
Creating directory: /var/azureuser/sonic-mgmt/tests/common/sai_validation/github.com/openconfig

03/12/2025 01:06:28 conftest.pytest_sessionstart             L0506 ERROR  | /var/azureuser/sonic-mgmt/tests/build-gnmi-stubs.sh failed with exit code 1
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /var/azureuser/sonic-mgmt/tests
configfile: pytest.ini
plugins: cov-5.0.0, allure-pytest-2.8.22, ansible-4.0.0, forked-1.6.0, html-4.1.1, metadata-3.1.1, repeat-0.9.3, stress-1.0.1, xdist-1.28.0
collected 1 item                                                                                                                                                               

snappi_tests/dataplane/test_bgp_device_unisolation.py::test_bgp_sessions[config_reload-sonic-s6100-dut2-64-10-IPv6] 
-------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------
03/12/2025 01:06:30 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
03/12/2025 01:06:30 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
03/12/2025 01:06:30 conftest.enhance_inventory               L0335 INFO   | Inventory file: ['../ansible/snappi-sonic']
03/12/2025 01:06:43 ptfhost_utils.run_icmp_responder_session L0310 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
03/12/2025 01:06:43 __init__._sanity_check                   L0432 INFO   | Skip sanity check according to command line argument
03/12/2025 01:06:43 conftest.collect_before_test             L2726 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
03/12/2025 01:06:43 conftest.collect_before_test             L2726 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut2
03/12/2025 01:06:43 conftest.collect_before_test             L2726 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut3
03/12/2025 01:06:44 conftest.collect_before_test             L2730 INFO   | Collecting core dumps before test on sonic-s6100-dut3
03/12/2025 01:06:45 conftest.collect_before_test             L2730 INFO   | Collecting core dumps before test on sonic-s6100-dut2
03/12/2025 01:06:45 conftest.collect_before_test             L2730 INFO   | Collecting core dumps before test on sonic-s6100-dut1
03/12/2025 01:06:46 conftest.collect_before_test             L2739 INFO   | Collecting running config before test on sonic-s6100-dut1
03/12/2025 01:06:46 conftest.collect_before_test             L2739 INFO   | Collecting running config before test on sonic-s6100-dut3
03/12/2025 01:06:46 conftest.collect_before_test             L2739 INFO   | Collecting running config before test on sonic-s6100-dut2
03/12/2025 01:06:54 conftest.temporarily_disable_route_check L3005 INFO   | Skipping temporarily_disable_route_check fixture
03/12/2025 01:06:54 conftest.generate_params_dut_hostname    L1527 INFO   | Using DUTs ['sonic-s6100-dut1', 'sonic-s6100-dut2', 'sonic-s6100-dut3'] in testbed 'vms-snappi-sonic-multidut'
03/12/2025 01:06:54 conftest.set_rand_one_dut_hostname       L0669 INFO   | Randomly select dut sonic-s6100-dut3 for testing
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
03/12/2025 01:06:54 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
03/12/2025 01:06:54 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
03/12/2025 01:06:54 snappi.api                               L0106 WARNING| Version check is disabled
03/12/2025 01:06:54 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
03/12/2025 01:06:54 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_multi_dut setup starts --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_multi_dut setup ends --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture set_primary_chassis setup starts --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture set_primary_chassis setup ends --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture create_snappi_config setup starts --------------------
03/12/2025 01:06:56 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture create_snappi_config setup ends --------------------
03/12/2025 01:06:56 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
03/12/2025 01:06:56 __init__.memory_utilization              L0130 INFO   | Memory utilization monitoring is disabled
03/12/2025 01:06:56 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_a3zn101a
03/12/2025 01:06:56 conftest.setup_dualtor_mux_ports         L3465 INFO   | skip setup dualtor mux cables on non-dualtor testbed
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
03/12/2025 01:07:01 connection._warn                         L0336 WARNING| Verification of certificates is disabled
03/12/2025 01:07:01 connection._info                         L0333 INFO   | Determining the platform and rest_port using the 10.36.84.34 address...
03/12/2025 01:07:01 connection._warn                         L0336 WARNING| Unable to connect to http://10.36.84.34:443.
03/12/2025 01:07:01 connection._info                         L0333 INFO   | Connection established to `https://10.36.84.34:443 on linux`
03/12/2025 01:07:16 connection._info                         L0333 INFO   | Using IxNetwork api server version 11.10.2512.2
03/12/2025 01:07:16 connection._info                         L0333 INFO   | User info IxNetwork/ixnetworkweb/admin-86-3594832
03/12/2025 01:07:16 snappi_api.info                          L1512 INFO   | snappi-1.41.0
03/12/2025 01:07:16 snappi_api.info                          L1512 INFO   | snappi_ixnetwork-1.41.0
03/12/2025 01:07:16 snappi_api.info                          L1512 INFO   | ixnetwork_restpy-1.7.0
03/12/2025 01:07:17 snappi_api.info                          L1512 INFO   | Config validation 0.016s
03/12/2025 01:07:23 snappi_api.info                          L1512 INFO   | Ports configuration 5.784s
03/12/2025 01:07:23 snappi_api.info                          L1512 INFO   | Captures configuration 0.153s
03/12/2025 01:07:24 connection._info                         L0333 INFO   | [0.438s] Timer @ batchadd.py:385 -> Batch Add Completed
03/12/2025 01:07:24 snappi_api.info                          L1512 INFO   | Add location hosts [10.36.84.32, 10.36.84.36, 10.36.84.37] 0.459s
03/12/2025 01:07:30 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.84.32, 10.36.84.36, 10.36.84.37] 6.456s
03/12/2025 01:07:36 snappi_api.info                          L1512 INFO   | Speed conversion is not require for (port.name, speed) : [('Port_1', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_2', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_3', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_4', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_13', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_14', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_15', 'aresOne-M-EightByOneHundredGigPAM4-106G'), ('Port_16', 'aresOne-M-EightByOneHundredGigPAM4-106G')]
03/12/2025 01:07:36 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 1.071s
03/12/2025 01:07:58 snappi_api.info                          L1512 INFO   | Location connect [Port_1, Port_2, Port_3, Port_4, Port_5, Port_6, Port_7, Port_8, Port_9, Port_10, Port_11, Port_12, Port_13, Port_14, Port_15, Port_16] 21.870s
03/12/2025 01:07:58 snappi_api.info                          L1512 INFO   | Location state check [Port_1, Port_2, Port_3, Port_4, Port_5, Port_6, Port_7, Port_8, Port_9, Port_10, Port_11, Port_12, Port_13, Port_14, Port_15, Port_16] 0.194s
03/12/2025 01:07:58 snappi_api.info                          L1512 INFO   | Location configuration 34.569s
03/12/2025 01:08:00 snappi_api.info                          L1512 INFO   | Layer1 configuration 1.936s
03/12/2025 01:08:00 snappi_api.info                          L1512 INFO   | Lag Configuration 0.057s
03/12/2025 01:08:00 snappi_api.info                          L1512 INFO   | Convert device config : 0.178s
03/12/2025 01:08:00 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
03/12/2025 01:08:04 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 3.752s
03/12/2025 01:08:04 snappi_api.info                          L1512 INFO   | Devices configuration 3.988s
03/12/2025 01:08:06 snappi_api.info                          L1512 INFO   | Flows configuration 2.575s
03/12/2025 01:08:29 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
03/12/2025 01:08:29 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
03/12/2025 01:08:29 helperv2.start_stop                      L0682 INFO   | Start protocols
03/12/2025 01:08:37 utilities.wait                           L0120 INFO   | Pause 10 seconds, reason: For protocols To start
03/12/2025 01:09:09 helperv2.check_bgp_state                 L0722 INFO   | BGP v6 Session State is UP
03/12/2025 01:09:09 test_bgp_device_unisolation.get_converge L0174 INFO   | 

03/12/2025 01:09:09 test_bgp_device_unisolation.get_converge L0175 INFO   | -------------------------------------
03/12/2025 01:09:09 test_bgp_device_unisolation.get_converge L0176 INFO   | Sarting config_reload test
03/12/2025 01:09:09 test_bgp_device_unisolation.get_converge L0177 INFO   | -------------------------------------
03/12/2025 01:09:09 test_bgp_device_unisolation.get_converge L0178 INFO   | 

03/12/2025 01:09:09 helperv2.start_stop                      L0682 INFO   | Start traffic
03/12/2025 01:09:14 snappi_api.info                          L1512 INFO   | Flows generate/apply 4.904s
03/12/2025 01:09:27 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.304s
03/12/2025 01:09:27 snappi_api.info                          L1512 INFO   | Captures start 0.000s
03/12/2025 01:09:33 snappi_api.info                          L1512 INFO   | Flows start 6.334s
03/12/2025 01:09:36 snappi_api.info                          L1512 INFO   | IxNet - The frame size was increased to 86 bytes to accommodate encapsulation requirements.  - The frame size was adjusted to conform to the encapsulation requirements
03/12/2025 01:09:36 helperv2.wait_for                        L0628 INFO   | 

Waiting for Traffic to Start ...
03/12/2025 01:09:46 helperv2.wait_for                        L0632 INFO   | Done waiting for Traffic to Start
03/12/2025 01:09:47 test_bgp_device_unisolation.get_converge L0185 INFO   | No Loss observed before config_reload on DUT sonic-s6100-dut2
03/12/2025 01:09:47 test_bgp_device_unisolation.get_converge L0188 INFO   | Reloading config on DUT sonic-s6100-dut2
03/12/2025 01:10:36 helperv2.wait_for                        L0628 INFO   | 

Waiting for Traffic to Converge ...
03/12/2025 01:12:20 helperv2.wait_for                        L0632 INFO   | Done waiting for Traffic to Converge
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0210 INFO   | Frames Tx Rate : 47169812.0
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0211 INFO   | Frames Rx Rate : 47169811.0
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0212 INFO   | Frame Rate Difference : 1
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0219 INFO   | Traffic has converged after config_reload on DUT sonic-s6100-dut2
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0221 INFO   | Delta Frames : 5749212424
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0222 INFO   | --------------------------   Convergence Numbers   ----------------------------------
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0223 INFO   | Convergence Time for config_reload : 121883.30163368046 (ms)
03/12/2025 01:12:22 test_bgp_device_unisolation.get_converge L0224 INFO   | --------------------------------------------------------------------------------------
03/12/2025 01:12:22 helperv2.start_stop                      L0682 INFO   | Stop traffic
03/12/2025 01:12:28 snappi_api.info                          L1512 INFO   | Flows stop 5.513s
03/12/2025 01:12:28 helperv2.wait_for                        L0628 INFO   | 

Waiting for Traffic to Stop ...
03/12/2025 01:12:29 helperv2.wait_for                        L0632 INFO   | Done waiting for Traffic to Stop
03/12/2025 01:12:29 db_reporter._report                      L0049 INFO   | DBReporter: Writing 1 metric records to file
03/12/2025 01:12:29 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 1 metric records to /tmp/telemetry_test_a3zn101a/test_bgp_device_unisolation.metrics.json
03/12/2025 01:12:29 helperv2.start_stop                      L0682 INFO   | Stop protocols
03/12/2025 01:12:29 utilities.wait                           L0120 INFO   | Pause 1 seconds, reason: For protocols To stop
03/12/2025 01:12:30 helperv2.start_stop                      L0682 INFO   | Stop traffic
03/12/2025 01:12:31 helperv2.wait_for                        L0628 INFO   | 

Waiting for Traffic to Stop ...
03/12/2025 01:12:32 helperv2.wait_for                        L0632 INFO   | Done waiting for Traffic to Stop
PASSED                                                                                                                                                                   [100%]
------------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------------
03/12/2025 01:12:32 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
03/12/2025 01:13:10 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
03/12/2025 01:13:10 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
03/12/2025 01:13:17 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
03/12/2025 01:13:17 conftest.temporarily_disable_route_check L3007 INFO   | Skipping temporarily_disable_route_check fixture
03/12/2025 01:13:25 conftest.collect_after_test              L2794 INFO   | Dumping Disk and Memory Space information after test on sonic-s6100-dut1
03/12/2025 01:13:25 conftest.collect_after_test              L2794 INFO   | Dumping Disk and Memory Space information after test on sonic-s6100-dut2
03/12/2025 01:13:25 conftest.collect_after_test              L2794 INFO   | Dumping Disk and Memory Space information after test on sonic-s6100-dut3
03/12/2025 01:13:27 conftest.collect_after_test              L2798 INFO   | Collecting core dumps after test on sonic-s6100-dut1
03/12/2025 01:13:28 conftest.collect_after_test              L2798 INFO   | Collecting core dumps after test on sonic-s6100-dut2
03/12/2025 01:13:28 conftest.collect_after_test              L2798 INFO   | Collecting core dumps after test on sonic-s6100-dut3
03/12/2025 01:13:28 conftest.collect_after_test              L2809 INFO   | Collecting running config after test on sonic-s6100-dut1
03/12/2025 01:13:29 conftest.collect_after_test              L2809 INFO   | Collecting running config after test on sonic-s6100-dut2
03/12/2025 01:13:29 conftest.collect_after_test              L2809 INFO   | Collecting running config after test on sonic-s6100-dut3


=============================================================================== warnings summary ===============================================================================
../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.ptfadapter
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.ansible_fixtures
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.test_completeness
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.fixtures.duthost_utils
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

common/plugins/loganalyzer/system_msg_handler.py:1
  /var/azureuser/sonic-mgmt/tests/common/plugins/loganalyzer/system_msg_handler.py:1: DeprecationWarning: invalid escape sequence \ 
    '''

../../.local/lib/python3.8/site-packages/ixnetwork_restpy/testplatform/testplatform.py:30
  /var/azureuser/.local/lib/python3.8/site-packages/ixnetwork_restpy/testplatform/testplatform.py:30: PytestCollectionWarning: cannot collect test class 'TestPlatform' because it has a __init__ constructor (from: snappi_tests/dataplane/test_bgp_device_unisolation.py)
    class TestPlatform(Base):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------------------------------------------------------- live log sessionfinish ----------------------------------------------------------------------------
03/12/2025 01:13:30 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================== 1 passed, 10 warnings in 422.33s (0:07:02) ==================================================================
INFO:root:Can not get Allure report URL. Please check logs