### PR TITLE
Issue 21314: Remove --enable_sflow_feature from sflow tests

### DIFF
--- a/tests/sflow/conftest.py
+++ b/tests/sflow/conftest.py
@@ -1,15 +1,3 @@
 """
     Pytest configuration used by the sFlow tests.
 """
-
-
-def pytest_addoption(parser):
-    """
-        Adds options to pytest that are used by the sFlow tests.
-    """
-    parser.addoption(
-        "--enable_sflow_feature",
-        action="store_true",
-        default=False,
-        help="Enable sFlow feature on DUT",
-    )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, sflow/test_sflow.py accepts a flag --enable_sflow_feature which will start the sflow feature when it is passed in. This is not necessary; if the feature is compiled in and available, then the test should enable it automatically when run, and if it was enabled by the test, we should disable it when it is finished.

Note that the test calls config reload at the end of the test anyways, so in practice it's not necessary to disable the feature after the test completes.

Closes #21314 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Clean up sflow test.

#### How did you do it?

Remove the flag and instead start the feature unconditionally for the test.

#### How did you verify/test it?

Should pass CI/CD

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
