### PR TITLE
fix: disable route check for po cleanup test cases

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -93,6 +93,14 @@ def backup_and_restore_config_db_session(duthosts):
         yield func
 
 
+def stop_route_checker_on_duthost(duthost):
+    duthost.command("sudo monit stop routeCheck", module_ignore_errors=True)
+
+
+def start_route_checker_on_duthost(duthost):
+    duthost.command("sudo monit start routeCheck", module_ignore_errors=True)
+
+
 def _disable_route_checker(duthost):
     """
         Some test cases will add static routes for test, which may trigger route_checker
@@ -102,9 +110,9 @@ def _disable_route_checker(duthost):
         Args:
             duthost: DUT fixture
     """
-    duthost.command('monit stop routeCheck', module_ignore_errors=True)
+    stop_route_checker_on_duthost(duthost)
     yield
-    duthost.command('monit start routeCheck', module_ignore_errors=True)
+    start_route_checker_on_duthost(duthost)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,8 @@ from tests.common.devices.duthosts import DutHosts
 from tests.common.devices.vmhost import VMHost
 from tests.common.devices.base import NeighborDevice
 from tests.common.devices.cisco import CiscoHost
-from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_session        # noqa: F401
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db_session, \
+    stop_route_checker_on_duthost, start_route_checker_on_duthost                           # noqa: F401
 from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                            # noqa: F401
 from tests.common.fixtures.ptfhost_utils import ptf_test_port_map_active_active             # noqa: F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder_session                  # noqa: F401
@@ -3019,7 +3020,7 @@ def temporarily_disable_route_check(request, duthosts):
 
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(duthost.shell, "sudo monit stop routeCheck")
+                    executor.submit(stop_route_checker_on_duthost, duthost)
 
             yield
 
@@ -3029,7 +3030,7 @@ def temporarily_disable_route_check(request, duthosts):
         finally:
             with SafeThreadPoolExecutor(max_workers=8) as executor:
                 for duthost in duthosts.frontend_nodes:
-                    executor.submit(duthost.shell, "sudo monit start routeCheck")
+                    executor.submit(start_route_checker_on_duthost, duthost)
     else:
         logger.info("Skipping temporarily_disable_route_check fixture")
         yield

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -1,5 +1,7 @@
 import pytest
 import logging
+
+from tests.common.fixtures.duthost_utils import stop_route_checker_on_duthost
 from tests.common.utilities import wait_until
 from tests.common import config_reload
 from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
@@ -35,6 +37,15 @@ def ignore_expected_loganalyzer_exceptions(enum_rand_one_per_hwsku_frontend_host
             ".*teamsyncd: :- cleanTeamSync.*"
         ]
         loganalyzer[enum_rand_one_per_hwsku_frontend_hostname].expect_regex.extend(expectRegex)
+
+
+@pytest.fixture(autouse=True)
+def disable_route_check_for_duthost(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    logging.info("Stopping route check on DUT {}".format(duthost.hostname))
+    stop_route_checker_on_duthost(duthost)
+
+    yield
 
 
 def check_kernel_po_interface_cleaned(duthost, asic_index):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
We are having a module level `pytest.mark.disable_route_check` marker in `pc/test_po_cleanup.py` test to temporarily disable the routeCheck monitor for the entire module. However, we are doing `config_reload()` in different test cases within this test module, and the routeCheck monitor will automatically startup after each `config_reload()`. 

Therefore, we want to keep the module level routeCheck disable marker (so the routeCheck monitor will always be started at the very end of the test module) and introduce an extra function-level routeCheck disable fixture to make sure the routeCheck monitor is always disabled before each test case.
 
Summary:
Fixes # (issue) Microsoft ADO 35884974

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Disable the routeCheck monitor before each test case in `pc/test_po_cleanup.py` to avoid getting any noisy error syslog.

#### How did you do it?
Introduced a function-level fixture to disable routeCheck monitor.

#### How did you verify/test it?
I ran the updated code and can confirm it's working well: https://elastictest.org/scheduler/testplan/6916acddbf375d1f9e5d1333

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
