### PR TITLE
Enable retry for eos command

### DIFF
--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -5,6 +5,8 @@ import re
 import os
 
 from tests.common.devices.base import AnsibleHostBase
+from tests.common.errors import RunAnsibleModuleFail
+from retry import retry
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +83,7 @@ class EosHost(AnsibleHostBase):
     def __repr__(self):
         return self.__str__()
 
+    @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def shutdown(self, interface_name):
         out = self.eos_config(
             lines=['shutdown'],
@@ -92,6 +95,7 @@ class EosHost(AnsibleHostBase):
         intf_str = ','.join(interfaces)
         return self.shutdown(intf_str)
 
+    @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def no_shutdown(self, interface_name):
         out = self.eos_config(
             lines=['no shutdown'],
@@ -222,11 +226,13 @@ class EosHost(AnsibleHostBase):
         out = self.eos_config(lines=['agent {} shutdown'.format(agent)])
         return out
 
+    @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def start_bgpd(self):
         agent = 'Bgp' if self.is_multiagent() else 'Rib'
         out = self.eos_config(lines=['no agent {} shutdown'.format(agent)])
         return out
 
+    @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def no_shutdown_bgp(self, asn):
         out = self.eos_config(
             lines=['no shut'],
@@ -234,6 +240,7 @@ class EosHost(AnsibleHostBase):
         logging.info('No shut BGP [%s]' % asn)
         return out
 
+    @retry(RunAnsibleModuleFail, tries=3, delay=5)
     def no_shutdown_bgp_neighbors(self, asn, neighbors=[]):
         if not neighbors:
             return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enable retry for some EOS command.
Retry is enabled for below functions for now as we saw connection error frequently on these commands, and the failure will leave testbed in unhealthy state.
- no_shutdown
- shutdown
- start_bgpd
- no_shutdown_bgp
- no_shutdown_bgp_neighbors

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202503

### Approach
#### What is the motivation for this PR?
This PR is to enable retry for some EOS command.

#### How did you do it?
Leverage Python module `retry` to rerun the command if there is exception.

#### How did you verify/test it?
The change is verified by running on a physical testbed. Retry is working if connection issue happened.

```
22:18:47 api.__retry_internal                     L0040 WARNING| run module eos_config failed, Ansible Results =>
failed = True
module_stdout = 
module_stderr = command timeout triggered, timeout value is 60 secs.
See the timeout setting options in the Network Debug and Troubleshooting Guide.
msg = MODULE FAILURE
See stdout/stderr for the exact error
_ansible_no_log = None
changed = False
stdout =
stderr =
, retrying in 5 seconds...
22:19:53 api.__retry_internal                     L0040 WARNING| run module eos_config failed, Ansible Results =>
failed = True
module_stdout = 
module_stderr = command timeout triggered, timeout value is 60 secs.
See the timeout setting options in the Network Debug and Troubleshooting Guide.
msg = MODULE FAILURE
See stdout/stderr for the exact error
_ansible_no_log = None
changed = False
stdout =
stderr =
, retrying in 5 seconds...
22:20:58 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
```

#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
