### PR TITLE
Support SSH to neighbor VMs using test server as proxy

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -135,6 +135,8 @@
     pip_executable: pip3
   when: pip_executable is not defined and (host_distribution_version.stdout >= "20.04")
 
+- include_tasks: ssh-key.yml
+
 - include_tasks: docker.yml
   when: package_installation|bool
 

--- a/ansible/roles/vm_set/tasks/ssh-key.yml
+++ b/ansible/roles/vm_set/tasks/ssh-key.yml
@@ -1,0 +1,28 @@
+---
+# Tasks to ensure local SSH public key is in target host's authorized_keys
+
+- name: Read local SSH public key
+  delegate_to: localhost
+  slurp:
+    src: "{{ lookup('env', 'HOME') }}/.ssh/id_rsa.pub"
+  register: local_ssh_public_key
+  run_once: true
+
+- name: Ensure .ssh directory exists on target host
+  file:
+    path: "~/.ssh"
+    state: directory
+    mode: '0700'
+
+- name: Ensure authorized_keys file exists on target host
+  file:
+    path: "~/.ssh/authorized_keys"
+    state: touch
+    mode: '0600'
+  changed_when: false
+
+- name: Add local SSH public key to target host's authorized_keys
+  authorized_key:
+    user: "{{ ansible_user | default(ansible_user_id) }}"
+    key: "{{ local_ssh_public_key.content | b64decode }}"
+    state: present

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -85,6 +85,33 @@ function usage
   exit
 }
 
+function generate_ssh_key
+{
+  # Check if running inside a Docker container
+  if [ ! -f /.dockerenv ]; then
+    echo "Not running inside a Docker container, skipping SSH key generation"
+    return
+  fi
+
+  # Check if SSH key files exist and are non-empty
+  if [ -s ~/.ssh/id_rsa ] && [ -s ~/.ssh/id_rsa.pub ]; then
+    echo "SSH keys already exist and are valid"
+    return
+  fi
+
+  # Generate SSH key
+  echo "Generating SSH key pair..."
+  mkdir -p ~/.ssh
+  ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N "" -q
+
+  if [ $? -eq 0 ]; then
+    echo "SSH key pair generated successfully"
+  else
+    echo "Failed to generate SSH key pair"
+    return 1
+  fi
+}
+
 function read_csv
 {
   # Filter testbed names in the first column in the testbed definition file
@@ -982,6 +1009,9 @@ vm_type=ceos
 vm_num=0
 msetnumber=1
 sonic_vm_dir=""
+
+# Generate SSH key if running in Docker container
+generate_ssh_key
 
 while getopts "t:m:k:n:s:d:" OPTION; do
     case $OPTION in

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -49,7 +49,7 @@ class SonicHost(AnsibleHostBase):
     """
     def __init__(self, ansible_adhoc, hostname,
                  shell_user=None, shell_passwd=None,
-                 ssh_user=None, ssh_passwd=None):
+                 ssh_user=None, ssh_passwd=None, ssh_proxy={}):
         AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
 
         self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
@@ -81,6 +81,16 @@ class SonicHost(AnsibleHostBase):
             evars = {
                 'ansible_ssh_user': ssh_user,
                 'ansible_ssh_pass': ssh_passwd,
+            }
+            self.host.options['variable_manager'].extra_vars.update(evars)
+
+        proxy_user = ssh_proxy.get('proxy_user', None)
+        proxy_host = ssh_proxy.get('proxy_host', None)
+        if proxy_user and proxy_host:
+            evars = {
+                'ansible_ssh_extra_args':
+                    "-o ProxyCommand='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no " +
+                    f"-W %h:%p {proxy_user}@{proxy_host}'"
             }
             self.host.options['variable_manager'].extra_vars.update(evars)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import random
 import re
 import sys
 
+import jinja2
+
 import pytest
 import yaml
 import copy
@@ -848,7 +850,7 @@ def k8scluster(k8smasters):
 
 
 @pytest.fixture(scope="session")
-def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
+def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request, localhost, vmhosts):
     """
     Shortcut fixture for getting VM host
     """
@@ -865,8 +867,16 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
         logger.info("No VMs exist for this topology: {}".format(tbinfo['topo']['properties']['topology']))
         return devices
 
-    def initial_neighbor(neighbor_name, vm_name):
-        logger.info(f"nbrhosts started: {neighbor_name}_{vm_name}")
+    # If use vmhosts as SSH proxy for nbrhosts, need to enable ssh key authentication with the server.
+    # Get the public SSH key from the localhost
+    # There are 2 places can generate the SSH key:
+    # 1. setup-container.sh tool. It always ensures that the SSH keys exists under ~/.ssh
+    # 2. The testbed-cli.sh tool also generates the SSH keys if not exist.
+    # The keys are ensured for the default user of the sonic-mgmt docker.
+    # If switch to a different user to run pytest, there could be a problem that the local SSH keys cannot be found.
+    public_key = localhost.shell("cat ~/.ssh/id_rsa.pub")['stdout'].strip()
+
+    def initial_neighbor(neighbor_name, vm_name, ssh_proxy={}):
         if neighbor_type == "eos":
             device = NeighborDevice(
                 {
@@ -876,7 +886,8 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                         creds['eos_login'],
                         creds['eos_password'],
                         shell_user=creds['eos_root_user'] if 'eos_root_user' in creds else None,
-                        shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None
+                        shell_passwd=creds['eos_root_password'] if 'eos_root_password' in creds else None,
+                        ssh_proxy=ssh_proxy
                     ),
                     'conf': tbinfo['topo']['properties']['configuration'][neighbor_name]
                 }
@@ -888,7 +899,8 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                         ansible_adhoc,
                         vm_name,
                         ssh_user=creds['sonic_login'] if 'sonic_login' in creds else None,
-                        ssh_passwd=creds['sonic_password'] if 'sonic_password' in creds else None
+                        ssh_passwd=creds['sonic_password'] if 'sonic_password' in creds else None,
+                        ssh_proxy=ssh_proxy
                     ),
                     'conf': tbinfo['topo']['properties']['configuration'][neighbor_name]
                 }
@@ -901,6 +913,7 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
                         vm_name,
                         creds['cisco_login'],
                         creds['cisco_password'],
+                        ssh_proxy=ssh_proxy
                     ),
                     'conf': tbinfo['topo']['properties']['configuration'][neighbor_name]
                 }
@@ -912,11 +925,63 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request):
 
     servers = []
     if 'servers' in tbinfo:
-        servers.extend(tbinfo['servers'].values())
+        for server_name, server_value in tbinfo['servers'].items():
+            server_value['server_name'] = server_name
+            servers.append(server_value)
     elif 'server' in tbinfo:
+        tbinfo['server_name'] = tbinfo['server']
         servers.append(tbinfo)
     else:
         logger.warning("Unknown testbed schema for setup nbrhosts")
+    inv_files = get_inventory_files(request)
+    for server in servers:
+        vm_base = int(server['vm_base'][2:])
+        vm_name_fmt = 'VM%0{}d'.format(len(server['vm_base']) - 2)
+        vms = MultiServersUtils.get_vms_by_dut_interfaces(
+                tbinfo['topo']['properties']['topology']['VMs'],
+                server['dut_interfaces']
+            ) if 'dut_interfaces' in server else tbinfo['topo']['properties']['topology']['VMs']
+        server_name = server['server_name']
+        vmhost = get_test_server_host(inv_files, server_name)
+
+        # Get vmhost connection details from inventory
+        vmhost_name = vmhost.get_name()
+        vmhost_var_ansible_host = ''
+        vmhost_var_ansible_ssh_proxy_host = ''
+        vmhost_var_vm_host_user = ''
+        for vh in vmhosts:
+            if vh.hostname == vmhost_name:
+                vmhost_host = vh.host.options['inventory_manager'].get_host(vmhost_name)
+                vmhost_visible_vars = vh.host.options['variable_manager'].get_vars(host=vmhost_host)
+                vmhost_var_ansible_host = vmhost_visible_vars.get('ansible_host', '')
+                vmhost_var_ansible_ssh_proxy_host = vmhost_visible_vars.get('ansible_ssh_proxy_host', '')
+                vmhost_var_vm_host_user = vmhost_visible_vars.get('vm_host_user', '')
+                vmhost_var_vm_host_user = jinja2.Template(vmhost_var_vm_host_user).render(**vmhost_visible_vars)
+
+                # Enable SSH key authentication on vmhost using authorized_key module
+                vh.authorized_key(
+                    user=vmhost_var_vm_host_user,
+                    key=public_key,
+                    state='present'
+                )
+                logger.info(f"Added SSH public key to {vmhost_name} using authorized_key module")
+
+                break
+        if not vmhost_var_vm_host_user or (not vmhost_var_ansible_host and not vmhost_var_ansible_ssh_proxy_host):
+            raise Exception(f"Missing required vmhost inventory variables for vmhost {vmhost_name}")
+        ssh_proxy = {
+            'proxy_user': vmhost_var_vm_host_user,
+            # When variable `ansible_ssh_proxy_host` is defined, use it as the proxy host. Else use `ansible_host`.
+            # Variable `ansible_ssh_proxy_host` can use value of `ansible_host` or `ansibl_hostv6`.
+            # Some vmhosts may only be accessible from IPv4, while others may only be accessible from IPv6.
+            # There is no standard way to know which one to use, so we let user to define it in inventory.
+            'proxy_host': vmhost_var_ansible_ssh_proxy_host \
+            if vmhost_var_ansible_ssh_proxy_host else vmhost_var_ansible_host,
+        }
+
+        for neighbor_name, neighbor in vms.items():
+            vm_name = vm_name_fmt % (vm_base + neighbor['vm_offset'])
+            futures.append(executor.submit(initial_neighbor, neighbor_name, vm_name, ssh_proxy=ssh_proxy))
 
     with SafeThreadPoolExecutor(max_workers=8) as executor:
         for server in servers:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -958,11 +958,13 @@ def nbrhosts(enhance_inventory, ansible_adhoc, tbinfo, creds, request, localhost
                     vmhost_var_vm_host_user = vmhost_visible_vars.get('vm_host_user', '')
 
                     ssh_proxy_user = jinja2.Template(vmhost_var_vm_host_user).render(**vmhost_visible_vars)
-                    # When variable `ansible_ssh_proxy_host` is defined, use it as the proxy host. Else use `ansible_host`.
+                    # When variable `ansible_ssh_proxy_host` is defined, use it as the proxy host.
+                    # Else use `ansible_host`.
                     # Variable `ansible_ssh_proxy_host` can use value of `ansible_host` or `ansibl_hostv6`.
                     # Some vmhosts may only be accessible by IPv4, while others may only be accessible by IPv6.
                     # There is no standard way to know which one to use, so we let user to define it in inventory.
-                    ssh_proxy_host = vmhost_var_ansible_ssh_proxy_host if vmhost_var_ansible_ssh_proxy_host else vmhost_var_ansible_host
+                    ssh_proxy_host = vmhost_var_ansible_ssh_proxy_host \
+                        if vmhost_var_ansible_ssh_proxy_host else vmhost_var_ansible_host
 
                     if ssh_proxy_user and ssh_proxy_host:
                         # Enable SSH key authentication on vmhost using authorized_key module


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

**Problem**

Some test scripts require SSH access to neighbor VMs to perform operations. Currently, this requires direct network connectivity between the sonic-mgmt container and the neighbor VMs' management ports.

In lab environments, the sonic-mgmt container may not run on the same test server hosting the neighbor VMs. When neighbor VMs are assigned private IP addresses accessible only from the test server itself, direct SSH connections from the sonic-mgmt container fail.

**Solution**

This change enables SSH access to neighbor VMs through the test server as a proxy. Since the sonic-mgmt container can access the test server's management interface, we leverage SSH's built-in proxy capability to route connections through the test server.

#### How did you do it?

The SSH key based authentication from sonic-mgmt container to test server is mandatory. The underlying ansible SSH plugins are not able to provide credential to login the proxy.

1. **SSH key generation in testbed-cli.sh**: Updated `testbed-cli.sh` to ensure SSH public and private keys are always present in the sonic-mgmt container. While `setup-container.sh` already handles this during container creation, this change ensures key availability when containers are created through other means. These keys are required for key-based authentication between the sonic-mgmt container and test server.

2. **SSH key deployment**: Modified `ansible/roles/vm_set/tasks/main.yml` to automatically add the sonic-mgmt container's SSH public key to the test server's `~/.ssh/authorized_keys` file. This enables key-based SSH authentication and is executed during `deploy-topo` or `restart-ptf` operations.

3. **conftest enhancement**: Enhanced `tests/conftest.py` to support scenarios where the testbed is deployed in one sonic-mgmt container but tests run in another. The SSH key of the sonic-mgmt container running tests may not be added to the test server's `~/.ssh/authorized_keys` file yet. The pytest code now ensures SSH key-based authentication is enabled from the test execution container to the test server.

4. **nbrhosts fixture enhancement**: Updated the `nbrhosts` fixture to retrieve the test server's username and IP address, then pass them to the neighbor VM host constructor via the `ssh_proxy` argument. The argument format is a dictionary: `ssh_proxy={"proxy_user": "username", "proxy_host": "10.0.10.1"}`.

5. **Neighbor VM host constructors**: Enhanced neighbor VM host constructors to accept the `ssh_proxy` argument and construct appropriate Ansible variables for the underlying SSH plugin. This enables the Ansible SSH plugin to establish connections to neighbor VMs through the test server proxy.

The implementation supports two Ansible SSH plugin types used by the pytest code:

- **Regular SSH plugin**: Configure the `ansible_ssh_extra_args` variable to pass SSH proxy information. The SSH plugin will combine the `ssh_args` in `ansible/ansible.cfg` file and this `ansible_ssh_extra_args` to construct SSH command for connecting to neighbor VMs. 
``` 
evars = { 'ansible_ssh_extra_args': '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ProxyCommand="ssh -W %h:%p {proxy_user}@{proxy_host}"' } 
self.host.options['variable_manager'].extra_vars.update(evars) 
```

- **Network CLI connection**: Set the `ansible_paramiko_proxy_command` variable: 
``` 
evars['ansible_paramiko_proxy_command'] = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -W %h:%p {proxy_user}@{proxy_host}' 
self.host.options['variable_manager'].extra_vars.update(evars) 
```

For test server in the `veos` or `veos_vtb` inventory file, added support of an optional host variable `ansible_ssh_proxy_host`. Its value should be either IPV4 or IPv6 of the test server's IP address. The reason is that some test server's IPv4 can only be used as SSH proxy and other test server's IPv6 can only be used as SSH proxy. There is no way to automatically figure out. So added this argument to manually specify which IP can be used for proxy purpose. When this variable is not provided, by default the ansible_host will be used. This new variable is only used by the pytest code, not used by the playbook yet.

#### How did you verify/test it?
Tested run `bgp/test_bgp_gr_helper.py` from a remote sonic-mgmt container only has direct access to the test server.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
