### PR TITLE
Remove pmon from privileged container list

### DIFF
--- a/tests/container_hardening/test_container_hardening.py
+++ b/tests/container_hardening/test_container_hardening.py
@@ -17,7 +17,8 @@ CONTAINER_NAME_REGEX = r"([a-zA-Z_-]+)(\d*)([a-zA-Z_-]+)(\d*)$"
 PRIVILEGED_CONTAINERS = [
     "syncd",
     "gbsyncd",
-    # gnmi is temporarily in privileged mode, remove when https://github.com/sonic-net/sonic-buildimage/issues/24542 is closed
+    # gnmi is temporarily in privileged mode, remove when
+    # https://github.com/sonic-net/sonic-buildimage/issues/24542 is closed
     "gnmi",
 ]
 


### PR DESCRIPTION
### Description of PR


Summary: we already removed pmon's flag `--privileged` when `docker run`, we use fine granularity linux capacities instead. So this testcase need to update to exclude pmon from privileged container list.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
