### PR TITLE
stabilize test_dscp_to_queue_mapping and skip warm-reboot step on smartswitch

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -188,14 +188,14 @@ def send_and_verify_traffic(ptfadapter,
     """
     pkt_egress_index = 0
     ptf_dst_port_list = []
-    ptfadapter.dataplane.flush()
     logger.info("Send packet(s) from port {} from downstream to upstream".format(ptf_src_port_id))
 
     try:
         for pkt, exp_pkt in zip(pkt_list, exp_pkt_list):
+            ptfadapter.dataplane.flush()
             testutils.send(ptfadapter, ptf_src_port_id, pkt, count=DEFAULT_PKT_COUNT)
             logger.info(f"Send packet: {pkt}, expected packet: {exp_pkt}")
-            result = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptf_dst_port_ids, timeout=1)
+            result = testutils.verify_packet_any_port(ptfadapter, exp_pkt, ports=ptf_dst_port_ids, timeout=5)
             if isinstance(result, bool):
                 logger.info("Return a dummy value for VS platform")
                 port_index = 0
@@ -493,7 +493,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         with allure.step("Run test"):
             self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module, dscp_mode)
 
-        if completeness_level != "basic":
+        if completeness_level != "basic" and \
+                not duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
             with allure.step("Do warm-reboot"):
                 reboot(duthost, localhost, reboot_type="warm", safe_reboot=True, check_intf_up_ports=True,
                        wait_warmboot_finalizer=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
1. To mitigate the impact of noise packets, flush the PTF dataplane before sending and verifying packets
2. Increase the timeout in case ptf can not handle all packets in the buffer during 1 second, when he ptf buffer has a lot of packets
3. Skip warm-reboot on smartswitch

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
Stabilize test_dscp_to_queue_mapping

#### How did you do it?
1. To mitigate the impact of noise packets, flush the PTF dataplane before sending and verifying packets
2. Increase the timeout in case ptf can not handle all packet in the buffer during 1 second, the ptf buffer has a lot of packets

#### How did you verify/test it?
run test_dscp_to_queue_mapping

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
