### PR TITLE
[dualtor-aa] Fix `test_neighbor_link_down`

### DIFF
--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -149,7 +149,7 @@ def verifyFdbArp(duthost, dst_ip, dst_mac, dst_intf):
 
 @pytest.mark.parametrize("drop_reason", ["L3_EGRESS_LINK_DOWN"])
 def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
-                            setup_standby_ports_on_rand_unselected_tor,                             # noqa: F811
+                            setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa: F811
                             toggle_all_simulator_ports_to_rand_selected_tor_m, mock_server,         # noqa: F811
                             send_dropped_traffic, drop_reason, generate_dropped_packet, tbinfo):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

`test_neighbor_link_down` fails on dualtor-aa, the test shutdown the downlink to the server, send traffic to the server, and verify that the traffic should be dropped and the drop counter should increase. On active-active dualtor, after downlink (mux port) is down, the ToR toggles to standby, the traffic will be forwarde to uplinks as the tunnel routes are added in such case. So no more drop counter increase.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>



#### How did you do it?
Let's set the mux ports in `manual` mode after toggle, the mux port will not toggle to standby after port down, and the traffic will be drop.

#### How did you verify/test it?
```
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED                                                                                                                              [100%]

======================================================================================================== 1 passed, 2 warnings in 314.98s (0:05:14) =========================================================================================================
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
