### PR TITLE
[sonic.py] Fix UTC timezone handling in get_networking_uptime method

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1101,8 +1101,8 @@ class SonicHost(AnsibleHostBase):
     def get_networking_uptime(self):
         start_time = self.get_service_props("networking", props=["ExecMainStartTimestamp", ])
         try:
-            return self.get_now_time() - datetime.strptime(start_time["ExecMainStartTimestamp"],
-                                                           "%a %Y-%m-%d %H:%M:%S %Z")
+            return self.get_now_time(utc_timezone=True) - datetime.strptime(start_time["ExecMainStartTimestamp"],
+                                                                            "%a %Y-%m-%d %H:%M:%S %Z")
         except Exception as e:
             logging.error("Exception raised while getting networking restart time: %s" % repr(e))
             return None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
By passing the `utc_timezone=True` parameter when calling `get_now_time`, it ensures that the time is returned in UTC format, making the time difference calculation in `get_networking_uptime` accurate and consistent.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In the failed test plan ([platform_tests/link_flap/test_cont_link_flap.py](https://elastictest.org/scheduler/testplan/68df43a6a4f6c38d9ee456ea?testcase=platform_tests%2flink_flap%2ftest_cont_link_flap.py&type=console)), we observed that the local time might not be UTC, whereas we expect all time difference calculations to use the UTC timezone to avoid discrepancies caused by different local timezones.

#### How did you do it?
By passing the `utc_timezone=True` parameter when calling `get_now_time`, it ensures that the returned value is always in UTC.

#### How did you verify/test it?


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
