### PR TITLE
smartswicth ha config generated for ha pair

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import time
 import json
 
+from tests.common.config_reload import config_reload
 from pathlib import Path
 from collections import defaultdict
 from tests.common.helpers.constants import DEFAULT_NAMESPACE
@@ -394,6 +395,7 @@ def setup_ha_config(duthosts):
         # Load and persist
         dut.shell(f"sudo config load -y {tmpfile}")
         dut.shell("sudo config save -y")
+        config_reload(dut, safe_reload=True)
 
         # Allow processes to settle
         time.sleep(10)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The new fixure  automatically applies High Availability (HA) configuration to both SONiC devices (DUT01 and DUT02).
Each switch receives its own DPU, remote-DPU, and global HA parameters so they can form an HA pair and coordinate DASH dataplane operations across the cluster.

Summary:The goal is creating HA between DPU0 in DUT01 (active) and DPU0 in DUT02 (standby) for the smartswitch
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The motivation is to automate and standardize the deployment of DASH High-Availability (HA) configuration across multiple SONiC devices (DUT01 and DUT02).
#### How did you do it?
Implemented optimized config generators
generate_full_config() → Builds DUT01 DASH-HA config
generate_dut2_full_config() → Builds DUT02 DASH-HA config
Both include DPU, REMOTE_DPU, VDPU, HA_GLOBAL, VNET, VXLAN, loopbacks, and interface entries.
#### How did you verify/test it?
verified using 
#### Any platform specific information?
smartswicth

#### Supported testbed topology if it's a new test case?
t1-smartswitch-ha
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
verification logs for the new smartswicth HA config
(Pdb) cfg1 {'DPU': {'dpu0_0': {'dpu_id': '0', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.1', 'state': 'up', 'swbus_port': '23606', 'vdpu_id': 'vdpu0_0', 'vip_ipv4': '3.2.1.0', 'midplane_ipv4': '169.254.200.1'}, 'dpu0_1': {'dpu_id': '1', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.2', 'state': 'up', 'swbus_port': '23607', 'vdpu_id': 'vdpu0_1', 'vip_ipv4': '3.2.1.1', 'midplane_ipv4': '169.254.200.2'}, 'dpu0_2': {'dpu_id': '2', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.3', 'state': 'up', 'swbus_port': '23608', 'vdpu_id': 'vdpu0_2', 'vip_ipv4': '3.2.1.2', 'midplane_ipv4': '169.254.200.3'}, 'dpu0_3': {'dpu_id': '3', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.4', 'state': 'up', 'swbus_port': '23609', 'vdpu_id': 'vdpu0_3', 'vip_ipv4': '3.2.1.3', 'midplane_ipv4': '169.254.200.4'}, 'dpu0_4': {'dpu_id': '4', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.5', 'state': 'up', 'swbus_port': '23610', 'vdpu_id': 'vdpu0_4', 'vip_ipv4': '3.2.1.4', 'midplane_ipv4': '169.254.200.5'}, 'dpu0_5': {'dpu_id': '5', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.6', 'state': 'up', 'swbus_port': '23611', 'vdpu_id': 'vdpu0_5', 'vip_ipv4': '3.2.1.5', 'midplane_ipv4': '169.254.200.6'}, 'dpu0_6': {'dpu_id': '6', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.7', 'state': 'up', 'swbus_port': '23612', 'vdpu_id': 'vdpu0_6', 'vip_ipv4': '3.2.1.6', 'midplane_ipv4': '169.254.200.7'}, 'dpu0_7': {'dpu_id': '7', 'gnmi_port': '50051', 'local_port': '8080', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.200.8', 'state': 'up', 'swbus_port': '23613', 'vdpu_id': 'vdpu0_7', 'vip_ipv4': '3.2.1.7', 'midplane_ipv4': '169.254.200.8'}}, 'REMOTE_DPU': {'dpu1_0': {'dpu_id': '0', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.1', 'swbus_port': '23606', 'type': 'cluster'}, 'dpu1_1': {'dpu_id': '1', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.2', 'swbus_port': '23607', 'type': 'cluster'}, 'dpu1_2': {'dpu_id': '2', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.3', 'swbus_port': '23608', 'type': 'cluster'}, 'dpu1_3': {'dpu_id': '3', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.4', 'swbus_port': '23609', 'type': 'cluster'}, 'dpu1_4': {'dpu_id': '4', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.5', 'swbus_port': '23610', 'type': 'cluster'}, 'dpu1_5': {'dpu_id': '5', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.6', 'swbus_port': '23611', 'type': 'cluster'}, 'dpu1_6': {'dpu_id': '6', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.7', 'swbus_port': '23612', 'type': 'cluster'}, 'dpu1_7': {'dpu_id': '7', 'npu_ipv4': '10.1.1.32', 'pa_ipv4': '20.0.201.8', 'swbus_port': '23613', 'type': 'cluster'}}, 'VDPU': {'vdpu0_0': {'main_dpu_ids': 'dpu0_0'}, 'vdpu1_0': {'main_dpu_ids': 'dpu1_0'}}, 'DASH_HA_GLOBAL_CONFIG': {'GLOBAL': {'dpu_bfd_probe_interval_in_ms': '1000', 'dpu_bfd_probe_multiplier': '3', 'cp_data_channel_port': '6000', 'dp_channel_dst_port': '7000', 'dp_channel_src_port_min': '7001', 'dp_channel_src_port_max': '7010', 'dp_channel_probe_interval_ms': '500', 'vnet_name': 'Vnet_55', 'dp_channel_probe_fail_threshold': '5'}}, 'INTERFACE': {'Ethernet216': {}, 'Ethernet216|192.168.200.2/24': {}}, 'LOOPBACK_INTERFACE': {'Loopback0': {}, 'Loopback0|10.1.0.32/32': {}, 'Loopback0|FC00:1::32/128': {}}, 'VLAN': {'Vlan55': {'description': 'DPU Management VLAN', 'vlanid': '55'}}, 'VLAN_INTERFACE': {'Vlan55': {}, 'Vlan55|20.0.200.14/28': {}}, 'VLAN_MEMBER': {'Vlan55|Ethernet224': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet232': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet240': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet248': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet256': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet264': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet272': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet280': {'tagging_mode': 'untagged'}}, 'FEATURE': {'dash-ha': {'auto_restart': 'disabled', 'delayed': 'False', 'has_global_scope': 'False', 'has_per_asic_scope': 'False', 'has_per_dpu_scope': 'True', 'high_mem_alert': 'disabled', 'state': 'enabled', 'support_syslog_rate_limit': 'true'}}, 'VNET': {'Vnet_55': {'scope': 'default', 'vni': '10000', 'vxlan_tunnel': 't4'}}, 'VXLAN_TUNNEL': {'t4': {'src_ip': '10.1.0.32'}}} 

(Pdb) cfg2 {'DPU': {'dpu1_0': {'dpu_id': '0', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.1', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.1', 'state': 'up', 'swbus_port': '23606', 'vdpu_id': 'vdpu1_0', 'vip_ipv4': '3.2.1.0'}, 'dpu1_1': {'dpu_id': '1', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.2', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.2', 'state': 'up', 'swbus_port': '23607', 'vdpu_id': 'vdpu1_1', 'vip_ipv4': '3.2.1.1'}, 'dpu1_2': {'dpu_id': '2', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.3', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.3', 'state': 'up', 'swbus_port': '23608', 'vdpu_id': 'vdpu1_2', 'vip_ipv4': '3.2.1.2'}, 'dpu1_3': {'dpu_id': '3', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.4', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.4', 'state': 'up', 'swbus_port': '23609', 'vdpu_id': 'vdpu1_3', 'vip_ipv4': '3.2.1.3'}, 'dpu1_4': {'dpu_id': '4', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.5', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.5', 'state': 'up', 'swbus_port': '23610', 'vdpu_id': 'vdpu1_4', 'vip_ipv4': '3.2.1.4'}, 'dpu1_5': {'dpu_id': '5', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.6', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.6', 'state': 'up', 'swbus_port': '23611', 'vdpu_id': 'vdpu1_5', 'vip_ipv4': '3.2.1.5'}, 'dpu1_6': {'dpu_id': '6', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.7', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.7', 'state': 'up', 'swbus_port': '23612', 'vdpu_id': 'vdpu1_6', 'vip_ipv4': '3.2.1.6'}, 'dpu1_7': {'dpu_id': '7', 'gnmi_port': '50051', 'local_port': '8080', 'midplane_ipv4': '169.254.200.8', 'orchagent_zmq_port': '8100', 'pa_ipv4': '20.0.201.8', 'state': 'up', 'swbus_port': '23613', 'vdpu_id': 'vdpu1_7', 'vip_ipv4': '3.2.1.7'}}, 'REMOTE_DPU': {'dpu0_0': {'dpu_id': '0', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.1', 'swbus_port': '23606', 'type': 'cluster'}, 'dpu0_1': {'dpu_id': '1', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.2', 'swbus_port': '23607', 'type': 'cluster'}, 'dpu0_2': {'dpu_id': '2', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.3', 'swbus_port': '23608', 'type': 'cluster'}, 'dpu0_3': {'dpu_id': '3', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.4', 'swbus_port': '23609', 'type': 'cluster'}, 'dpu0_4': {'dpu_id': '4', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.5', 'swbus_port': '23610', 'type': 'cluster'}, 'dpu0_5': {'dpu_id': '5', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.6', 'swbus_port': '23611', 'type': 'cluster'}, 'dpu0_6': {'dpu_id': '6', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.7', 'swbus_port': '23612', 'type': 'cluster'}, 'dpu0_7': {'dpu_id': '7', 'npu_ipv4': '10.1.0.32', 'pa_ipv4': '20.0.200.8', 'swbus_port': '23613', 'type': 'cluster'}}, 'VDPU': {'vdpu0_0': {'main_dpu_ids': 'dpu0_0'}, 'vdpu1_0': {'main_dpu_ids': 'dpu1_0'}}, 'DASH_HA_GLOBAL_CONFIG': {'GLOBAL': {'dpu_bfd_probe_interval_in_ms': '1000', 'dpu_bfd_probe_multiplier': '3', 'cp_data_channel_port': '6000', 'dp_channel_dst_port': '7000', 'dp_channel_src_port_min': '7001', 'dp_channel_src_port_max': '7010', 'dp_channel_probe_interval_ms': '500', 'vnet_name': 'Vnet_55', 'dp_channel_probe_fail_threshold': '5'}}, 'LOOPBACK_INTERFACE': {'Loopback0': {}, 'Loopback0|10.1.1.32/32': {}, 'Loopback0|FC00:1::32/128': {}}, 'VLAN': {'Vlan55': {'description': 'DPU Management VLAN', 'vlanid': '55'}}, 'VLAN_INTERFACE': {'Vlan55': {}, 'Vlan55|20.0.200.14/28': {}}, 'VLAN_MEMBER': {'Vlan55|Ethernet224': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet232': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet240': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet248': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet256': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet264': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet272': {'tagging_mode': 'untagged'}, 'Vlan55|Ethernet280': {'tagging_mode': 'untagged'}}, 'FEATURE': {'dash-ha': {'auto_restart': 'disabled', 'delayed': 'False', 'has_global_scope': 'False', 'has_per_asic_scope': 'False', 'has_per_dpu_scope': 'True', 'high_mem_alert': 'disabled', 'state': 'enabled', 'support_syslog_rate_limit': 'true'}}, 'VNET': {'Vnet_55': {'scope': 'default', 'vni': '10000', 'vxlan_tunnel': 't4'}}, 'VXLAN_TUNNEL': {'t4': {'src_ip': '10.1.1.32'}}}