### PR TITLE
Adding VxLAN underlay ECMP tests

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/vxlan_traffic.py
@@ -48,6 +48,7 @@ import six
 from datetime import datetime
 import logging
 import random
+import math
 from ipaddress import ip_address, IPv4Address, IPv6Address
 import ptf
 import ptf.packet as scapy
@@ -139,12 +140,18 @@ class VXLAN(BaseTest):
             2. Load the configs from the input files.
             3. Ready the mapping of destination->nexthops.
         '''
+        self.PACKETS_PER_ITERATION = 1000  # Number of packets to send before polling for responses
+        self.check_underlay_ecmp = True
         self.dataplane = ptf.dataplane_instance
         self.test_params = test_params_get()
         self.random_src_ip = self.test_params['random_src_ip']
         self.random_dport = self.test_params['random_dport']
         self.random_sport = self.test_params['random_sport']
         self.tolerance = self.test_params['tolerance']
+        self.underlay_tolerance = self.test_params.get("underlay_tolerance")
+        self.underlay_tolerance_within_lag = self.test_params.get("underlay_tolerance_within_lag")
+        if not self.underlay_tolerance or not self.underlay_tolerance_within_lag:
+            self.check_underlay_ecmp = False
         self.dut_mac = self.test_params['dut_mac']
         self.vxlan_port = self.test_params['vxlan_port']
         self.expect_encap_success = self.test_params['expect_encap_success']
@@ -167,6 +174,8 @@ class VXLAN(BaseTest):
             self.topo_data = json.load(fp)
 
         self.fill_loopback_ip()
+        self.create_port_index_to_lag_map()
+        self.create_port_index_to_name_map()
         self.nbr_info = self.config_data['neighbors']
         self.packets = []
         self.dataplane.flush()
@@ -193,12 +202,67 @@ class VXLAN(BaseTest):
             if isinstance(ip_address(entry['addr']), IPv6Address):
                 self.loopback_ipv6 = entry['addr']
 
+    def create_port_index_to_lag_map(self):
+        """
+            For each member of a PortChannel, map the PTF index of that member port to the PortChannel name.
+        """
+        self.port_index_to_lag = {}
+        mg_facts = self.topo_data['minigraph_facts']
+        for lag_name, lag_info in mg_facts['minigraph_portchannels'].items():
+            for member in lag_info['members']:
+                ptf_port = mg_facts['minigraph_ptf_indices'][member]
+                self.port_index_to_lag[ptf_port] = lag_name
+
+    def create_port_index_to_name_map(self):
+        """
+            For each port, map its PTF index to its name.
+        """
+        self.port_index_to_name = {}
+        mg_facts = self.topo_data['minigraph_facts']
+        for intf_name, ptf_port in mg_facts['minigraph_ptf_indices'].items():
+            self.port_index_to_name[ptf_port] = intf_name
+
+    def get_egress_iface_counts(self, egress_ifaces, port_index_to_count):
+        """
+            For a given endpoint, get the mapping of egress interfaces to the total number of packets
+            sent out of those interfaces.
+        """
+        egress_iface_to_count = {}
+        for iface in egress_ifaces:
+            egress_iface_to_count[iface] = 0
+        for port_index, count in port_index_to_count.items():
+            intf_name = self.port_index_to_lag.get(port_index)
+            if not intf_name:
+                # This port is not a member of any LAG. Get its name directly.
+                intf_name = self.port_index_to_name[port_index]
+            egress_iface_to_count[intf_name] += count
+        return egress_iface_to_count
+
+    def get_lag_member_counts(self, egress_ifaces, port_index_to_count):
+        """
+            For each PortChannel in "egress_ifaces", create a mapping of member ports to their packet counts.
+        """
+        lag_to_member_to_count = {}
+        for iface in egress_ifaces:
+            if not iface.startswith("PortChannel"):
+                continue
+            lag_to_member_to_count[iface] = {}
+            members = self.topo_data['minigraph_facts']['minigraph_portchannels'][iface]['members']
+            for member in members:
+                port_index = self.topo_data['minigraph_facts']['minigraph_ptf_indices'][member]
+                count = port_index_to_count.get(port_index, 0)
+                lag_to_member_to_count[iface][member] = count
+        return lag_to_member_to_count
+
     def runTest(self):
         '''
             Main code of this script.
             Run the encap test for every destination, and its nexthops.
         '''
         mg_facts = self.topo_data['minigraph_facts']
+        self.endpoint_to_egress_interfaces = self.config_data.get("endpoint_to_egress_interfaces")
+        if not self.endpoint_to_egress_interfaces:
+            self.check_underlay_ecmp = False
         for t0_intf in self.test_params['t0_ports']:
             # find the list of neigh addresses for the t0_ports.
             # For each neigh address(Addr1):
@@ -285,6 +349,69 @@ class VXLAN(BaseTest):
                     nhs,
                     returned_ip_addresses))
 
+    def verify_underlay_ecmp_distribution_among_egress_ifaces(self, endpoint, egress_iface_to_count):
+        """
+            Verify that the distribution of packets among the egress interfaces for a given endpoint
+            is within the expected tolerance.
+        """
+        total_packets = sum(egress_iface_to_count.values())
+        if total_packets < MINIMUM_PACKETS_FOR_ECMP_VALIDATION:
+            Logger.warning(
+                f"Skipping underlay ECMP distribution check among egress interfaces for {endpoint} "
+                f"due to insufficient number of packets ({total_packets}).")
+            return
+        num_egress_ifaces = len(egress_iface_to_count)
+        if num_egress_ifaces == 0:
+            return  # Nothing to check.
+        expected_per_iface = total_packets / num_egress_ifaces
+        lower_bound = (1.0 - self.underlay_tolerance) * expected_per_iface
+        upper_bound = (1.0 + self.underlay_tolerance) * expected_per_iface
+
+        for iface, count in egress_iface_to_count.items():
+            if not (lower_bound <= count <= upper_bound):
+                raise RuntimeError(
+                    f"Underlay ECMP distribution among egress interfaces failed for endpoint {endpoint}. "
+                    f"Interface {iface} received {count} packet(s), expected between {lower_bound} and {upper_bound}."
+                )
+
+    def verify_underlay_ecmp_distribution_within_lag(self, endpoint, lag, member_counts):
+        """
+            Verify that the distribution of packets among the member ports of a given PortChannel for a given endpoint
+            is within the expected tolerance.
+        """
+        total_packets = sum(member_counts.values())
+        if total_packets < MINIMUM_PACKETS_FOR_ECMP_VALIDATION:
+            Logger.warning(
+                f"Skipping underlay ECMP distribution check within {lag} for {endpoint} "
+                f"due to insufficient number of packets ({total_packets}).")
+            return
+        num_members = len(member_counts)
+        assert num_members > 0, f"{lag} has no members."
+        expected_per_member = total_packets / num_members
+        lower_bound = (1.0 - self.underlay_tolerance_within_lag) * expected_per_member
+        upper_bound = (1.0 + self.underlay_tolerance_within_lag) * expected_per_member
+
+        for member, count in member_counts.items():
+            if not (lower_bound <= count <= upper_bound):
+                raise RuntimeError(
+                    f"Underlay ECMP distribution within {lag} failed for endpoint {endpoint}. "
+                    f"Member port {member} received {count} packet(s), "
+                    f"expected between {lower_bound} and {upper_bound}."
+                )
+
+    def verify_underlay_ecmp(self, endpoint_to_port_index_to_count):
+        """
+            Verify underlay ECMP for all endpoints using the collected packet counts per port.
+        """
+        for endpoint, port_index_to_count in endpoint_to_port_index_to_count.items():
+            egress_ifaces = self.endpoint_to_egress_interfaces[endpoint]
+            egress_iface_to_count = self.get_egress_iface_counts(egress_ifaces, port_index_to_count)
+            self.verify_underlay_ecmp_distribution_among_egress_ifaces(endpoint, egress_iface_to_count)
+
+            lag_to_member_to_count = self.get_lag_member_counts(egress_ifaces, port_index_to_count)
+            for lag, member_counts in lag_to_member_to_count.items():
+                self.verify_underlay_ecmp_distribution_within_lag(endpoint, lag, member_counts)
+
     def test_encap(
             self,
             ptf_port,
@@ -329,7 +456,10 @@ class VXLAN(BaseTest):
                 # 1 second per packet(1000 packets is 20 minutes).
                 packet_count = 4
             returned_ip_addresses = {}
+            # For each VNET endpoint, count the number of packets received per port
+            endpoint_to_port_index_to_count = {}
             for host_address in test_nhs:
+                endpoint_to_port_index_to_count[host_address] = {}
                 check_ecmp = True
                 # This will ensure that every nh is used atleast once.
                 Logger.info(
@@ -337,180 +467,190 @@ class VXLAN(BaseTest):
                     packet_count,
                     str(ptf_port),
                     destination)
-                for _ in range(packet_count):
-                    if random_sport:
-                        tcp_sport = get_incremental_value('tcp_sport')
-                    else:
-                        tcp_sport = VARS['tcp_sport']
-                    if random_dport:
-                        tcp_dport = get_incremental_value('tcp_dport')
-                    else:
-                        tcp_dport = VARS['tcp_dport']
-                    if isinstance(ip_address(destination), IPv4Address) and \
-                            isinstance(ip_address(ptf_addr), IPv4Address):
-                        if random_src_ip:
-                            ptf_addr = get_ip_address(
-                                "v4", hostid=3, netid=170)
-                        pkt_opts = {
-                            "pktlen": pkt_len,
-                            "eth_dst": self.dut_mac,
-                            "eth_src": self.ptf_mac_addrs['eth%d' % ptf_port],
-                            "ip_dst": destination,
-                            "ip_src": ptf_addr,
-                            "ip_id": 105,
-                            "ip_ttl": 64,
-                            "tcp_sport": tcp_sport,
-                            "tcp_dport": tcp_dport}
-                        pkt_opts.update(options)
-                        pkt = simple_tcp_packet(**pkt_opts)
-                        pkt_opts['ip_ttl'] = 63
-                        pkt_opts['eth_src'] = self.dut_mac
-                        exp_pkt = simple_tcp_packet(**pkt_opts)
-                    elif isinstance(ip_address(destination), IPv6Address) and \
-                            isinstance(ip_address(ptf_addr), IPv6Address):
-                        if random_src_ip:
-                            ptf_addr = get_ip_address(
-                                "v6", hostid=4, netid=170)
-                        pkt_opts = {
-                            "pktlen": pkt_len,
-                            "eth_dst": self.dut_mac,
-                            "eth_src": self.ptf_mac_addrs['eth%d' % ptf_port],
-                            "ipv6_dst": destination,
-                            "ipv6_src": ptf_addr,
-                            "ipv6_hlim": 64,
-                            "tcp_sport": tcp_sport,
-                            "tcp_dport": VARS['tcp_dport']}
-                        pkt_opts.update(options_v6)
-                        pkt = simple_tcpv6_packet(**pkt_opts)
-                        pkt_opts['ipv6_hlim'] = 63
-                        pkt_opts['eth_src'] = self.dut_mac
-                        exp_pkt = simple_tcpv6_packet(**pkt_opts)
-                    else:
-                        raise RuntimeError(
-                            "Invalid mapping of destination and PTF address.")
-                    udp_sport = 1234    # it will be ignored in the test later.
-                    udp_dport = self.vxlan_port
-                    if isinstance(ip_address(host_address), IPv4Address):
-                        encap_pkt = simple_vxlan_packet(
-                            eth_src=self.dut_mac,
-                            eth_dst=self.random_mac,
-                            ip_id=0,
-                            ip_ihl=5,
-                            ip_src=self.loopback_ipv4,
-                            ip_dst=host_address,
-                            ip_ttl=128,
-                            udp_sport=udp_sport,
-                            udp_dport=udp_dport,
-                            with_udp_chksum=False,
-                            vxlan_vni=vni,
-                            inner_frame=exp_pkt,
-                            **options)
-                        encap_pkt[scapy.IP].flags = 0x2
-                    elif isinstance(ip_address(host_address), IPv6Address):
-                        encap_pkt = simple_vxlanv6_packet(
-                            eth_src=self.dut_mac,
-                            eth_dst=self.random_mac,
-                            ipv6_src=self.loopback_ipv6,
-                            ipv6_dst=host_address,
-                            udp_sport=udp_sport,
-                            udp_dport=udp_dport,
-                            with_udp_chksum=False,
-                            vxlan_vni=vni,
-                            inner_frame=exp_pkt,
-                            **options_v6)
-                    send_packet(self, ptf_port, pkt)
-
-                # After we sent all packets, wait for the responses.
-                if expect_success:
-                    wait_timeout = 2
-                    loop_timeout = max(packet_count * 5, 1000)   # milliseconds
-                    start_time = datetime.now()
-                    vxlan_count = 0
-                    Logger.info("Loop time:out %s milliseconds", loop_timeout)
-                    while (datetime.now() - start_time).total_seconds() *\
-                            1000 < loop_timeout and vxlan_count < packet_count:
-                        result = dp_poll(
-                            self, timeout=wait_timeout
-                        )
-                        if isinstance(result, self.dataplane.PollSuccess):
-                            if not isinstance(
-                                result, self.dataplane.PollSuccess) or \
-                                    result.port not in self.t2_ports or \
-                                    "VXLAN" not in scapy.Ether(result.packet):
-                                continue
-                            else:
-                                vxlan_count += 1
-                                scapy_pkt = scapy.Ether(result.packet)
-                                # Store every destination that was received.
-                                if isinstance(
-                                        ip_address(host_address), IPv6Address):
-                                    dest_ip = scapy_pkt['IPv6'].dst
-                                else:
-                                    dest_ip = scapy_pkt['IP'].dst
-                                try:
-                                    returned_ip_addresses[dest_ip] = \
-                                        returned_ip_addresses[dest_ip] + 1
-                                except KeyError:
-                                    returned_ip_addresses[dest_ip] = 1
+                total_vxlan_count = 0
+                # We send a fixed number of packets per iteration and then process responses
+                # to avoid overflowing ingress buffers (so that responses are not dropped by the kernel).
+                number_of_iterations = math.ceil(packet_count / self.PACKETS_PER_ITERATION)
+                for i in range(number_of_iterations):
+                    packets_to_send = min(self.PACKETS_PER_ITERATION,
+                                          packet_count - i * self.PACKETS_PER_ITERATION)
+                    for _ in range(packets_to_send):
+                        # Sending packets
+                        if random_sport:
+                            tcp_sport = get_incremental_value('tcp_sport')
                         else:
-                            Logger.info("No packet came in %s seconds",
-                                        wait_timeout)
-                            break
-                    if not vxlan_count or not returned_ip_addresses:
+                            tcp_sport = VARS['tcp_sport']
+                        if random_dport:
+                            tcp_dport = get_incremental_value('tcp_dport')
+                        else:
+                            tcp_dport = VARS['tcp_dport']
+                        if isinstance(ip_address(destination), IPv4Address) and \
+                                isinstance(ip_address(ptf_addr), IPv4Address):
+                            if random_src_ip:
+                                ptf_addr = get_ip_address(
+                                    "v4", hostid=3, netid=170)
+                            pkt_opts = {
+                                "pktlen": pkt_len,
+                                "eth_dst": self.dut_mac,
+                                "eth_src": self.ptf_mac_addrs['eth%d' % ptf_port],
+                                "ip_dst": destination,
+                                "ip_src": ptf_addr,
+                                "ip_id": 105,
+                                "ip_ttl": 64,
+                                "tcp_sport": tcp_sport,
+                                "tcp_dport": tcp_dport}
+                            pkt_opts.update(options)
+                            pkt = simple_tcp_packet(**pkt_opts)
+                            pkt_opts['ip_ttl'] = 63
+                            pkt_opts['eth_src'] = self.dut_mac
+                            exp_pkt = simple_tcp_packet(**pkt_opts)
+                        elif isinstance(ip_address(destination), IPv6Address) and \
+                                isinstance(ip_address(ptf_addr), IPv6Address):
+                            if random_src_ip:
+                                ptf_addr = get_ip_address(
+                                    "v6", hostid=4, netid=170)
+                            pkt_opts = {
+                                "pktlen": pkt_len,
+                                "eth_dst": self.dut_mac,
+                                "eth_src": self.ptf_mac_addrs['eth%d' % ptf_port],
+                                "ipv6_dst": destination,
+                                "ipv6_src": ptf_addr,
+                                "ipv6_hlim": 64,
+                                "tcp_sport": tcp_sport,
+                                "tcp_dport": VARS['tcp_dport']}
+                            pkt_opts.update(options_v6)
+                            pkt = simple_tcpv6_packet(**pkt_opts)
+                            pkt_opts['ipv6_hlim'] = 63
+                            pkt_opts['eth_src'] = self.dut_mac
+                            exp_pkt = simple_tcpv6_packet(**pkt_opts)
+                        else:
+                            raise RuntimeError(
+                                "Invalid mapping of destination and PTF address.")
+                        udp_sport = 1234    # it will be ignored in the test later.
+                        udp_dport = self.vxlan_port
+                        if isinstance(ip_address(host_address), IPv4Address):
+                            encap_pkt = simple_vxlan_packet(
+                                eth_src=self.dut_mac,
+                                eth_dst=self.random_mac,
+                                ip_id=0,
+                                ip_ihl=5,
+                                ip_src=self.loopback_ipv4,
+                                ip_dst=host_address,
+                                ip_ttl=128,
+                                udp_sport=udp_sport,
+                                udp_dport=udp_dport,
+                                with_udp_chksum=False,
+                                vxlan_vni=vni,
+                                inner_frame=exp_pkt,
+                                **options)
+                            encap_pkt[scapy.IP].flags = 0x2
+                        elif isinstance(ip_address(host_address), IPv6Address):
+                            encap_pkt = simple_vxlanv6_packet(
+                                eth_src=self.dut_mac,
+                                eth_dst=self.random_mac,
+                                ipv6_src=self.loopback_ipv6,
+                                ipv6_dst=host_address,
+                                udp_sport=udp_sport,
+                                udp_dport=udp_dport,
+                                with_udp_chksum=False,
+                                vxlan_vni=vni,
+                                inner_frame=exp_pkt,
+                                **options_v6)
+                        send_packet(self, ptf_port, pkt)
+
+                    # After we sent at most PACKETS_PER_ITERATION packets, wait for the responses.
+                    if expect_success:
+                        wait_timeout = 2
+                        loop_timeout = max(packets_to_send * 5, 1000)   # milliseconds
+                        start_time = datetime.now()
+                        vxlan_count = 0
+                        Logger.info("Loop time:out %s milliseconds", loop_timeout)
+                        while (datetime.now() - start_time).total_seconds() *\
+                                1000 < loop_timeout and vxlan_count < packets_to_send:
+                            result = dp_poll(
+                                self, timeout=wait_timeout
+                            )
+                            if isinstance(result, self.dataplane.PollSuccess):
+                                if not isinstance(
+                                    result, self.dataplane.PollSuccess) or \
+                                        result.port not in self.t2_ports or \
+                                        "VXLAN" not in scapy.Ether(result.packet):
+                                    continue
+                                else:
+                                    vxlan_count += 1
+                                    scapy_pkt = scapy.Ether(result.packet)
+                                    # Store every destination that was received.
+                                    if isinstance(
+                                            ip_address(host_address), IPv6Address):
+                                        dest_ip = scapy_pkt['IPv6'].dst
+                                    else:
+                                        dest_ip = scapy_pkt['IP'].dst
+                                    try:
+                                        returned_ip_addresses[dest_ip] = \
+                                            returned_ip_addresses[dest_ip] + 1
+                                    except KeyError:
+                                        returned_ip_addresses[dest_ip] = 1
+                                    current_count = endpoint_to_port_index_to_count[host_address].get(result.port, 0)
+                                    endpoint_to_port_index_to_count[host_address][result.port] = current_count + 1
+                            else:
+                                Logger.info("No packet came in %s seconds",
+                                            wait_timeout)
+                                break
+                        total_vxlan_count += vxlan_count
+                        Logger.info(
+                            "Vxlan packets received:%s, loop time:%s "
+                            "seconds", vxlan_count,
+                            (datetime.now() - start_time).total_seconds())
+                    else:
+                        check_ecmp = False
+                        Logger.info("Verifying no packet")
+
+                        masked_exp_pkt = Mask(encap_pkt)
+                        masked_exp_pkt.set_ignore_extra_bytes()
+                        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+                        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+                        if isinstance(ip_address(host_address), IPv4Address):
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "dst")
+                        else:
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "dst")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.UDP, "sport")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.UDP, "chksum")
+
+                        try:
+                            verify_no_packet_any(self, masked_exp_pkt, self.t2_ports)
+                        except BaseException:
+                            raise RuntimeError(
+                                "Verify_no_packet failed. Args:ports:{} sent:{}\n,"
+                                "expected:{}\n, encap_pkt:{}\n".format(
+                                    self.t2_ports,
+                                    repr(pkt),
+                                    repr(exp_pkt),
+                                    repr(encap_pkt)))
+                # Sent all packets for this nexthop.
+                if expect_success:
+                    if not total_vxlan_count or not returned_ip_addresses:
                         raise RuntimeError(
                             "Didnot get any reply for this destination:{}"
                             " Its active endpoints:{}".format(
                                 destination, test_nhs))
-                    Logger.info(
-                        "Vxlan packets received:%s, loop time:%s "
-                        "seconds", vxlan_count,
-                        (datetime.now() - start_time).total_seconds())
                     Logger.info("received = {}".format(returned_ip_addresses))
 
-                else:
-                    check_ecmp = False
-                    Logger.info("Verifying no packet")
-
-                    masked_exp_pkt = Mask(encap_pkt)
-                    masked_exp_pkt.set_ignore_extra_bytes()
-                    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
-                    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-                    if isinstance(ip_address(host_address), IPv4Address):
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IP,
-                                                             "chksum")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "dst")
-                    else:
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
-                                                             "hlim")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
-                                                             "dst")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.UDP,
-                                                             "sport")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.UDP,
-                                                             "chksum")
-
-                    try:
-                        verify_no_packet_any(
-                            self,
-                            masked_exp_pkt,
-                            self.t2_ports)
-                    except BaseException:
-                        raise RuntimeError(
-                            "Verify_no_packet failed. Args:ports:{} sent:{}\n,"
-                            "expected:{}\n, encap_pkt:{}\n".format(
-                                self.t2_ports,
-                                repr(pkt),
-                                repr(exp_pkt),
-                                repr(encap_pkt)))
-
-            # Verify ECMP:
+            # Verify overlay ECMP:
             if check_ecmp:
                 self.verify_all_addresses_used_equally(
                     nhs,
                     returned_ip_addresses,
                     packet_count,
                     self.downed_endpoints)
+
+            Logger.info(f"VNET endpoint to port index to count mapping: {endpoint_to_port_index_to_count}")
+
+            # Verify underlay ECMP:
+            if self.check_underlay_ecmp and check_ecmp:
+                self.verify_underlay_ecmp(endpoint_to_port_index_to_count)
 
             pkt.load = '0' * 60 + str(len(self.packets))
             b = base64.b64encode(bytes(str(pkt), 'utf-8'))  # bytes
@@ -581,7 +721,10 @@ class VxLAN_in_VxLAN(VXLAN):
                 # 1 second per packet(1000 packets is 20 minutes).
                 packet_count = 4
             returned_ip_addresses = {}
+            # For each VNET endpoint, count the number of packets received per port
+            endpoint_to_port_index_to_count = {}
             for host_address in test_nhs:
+                endpoint_to_port_index_to_count[host_address] = {}
                 check_ecmp = True
                 # This will ensure that every nh is used atleast once.
                 Logger.info(
@@ -589,185 +732,194 @@ class VxLAN_in_VxLAN(VXLAN):
                     packet_count,
                     str(ptf_port),
                     destination)
-                for _ in range(packet_count):
-                    udp_sport = get_incremental_value('udp_sport')
-                    if isinstance(ip_address(destination), IPv4Address) and \
-                            isinstance(ip_address(ptf_addr), IPv4Address):
-                        if random_src_ip:
-                            ptf_addr = get_ip_address(
-                                "v4", hostid=3, netid=170)
-                        pkt_opts = {
-                            'eth_src': self.random_mac,
-                            'eth_dst': self.dut_mac,
-                            'ip_id': 0,
-                            'ip_ihl': 5,
-                            'ip_src': ptf_addr,
-                            'ip_dst': destination,
-                            'ip_ttl': 63,
-                            'udp_sport': udp_sport,
-                            'udp_dport': udp_dport,
-                            'with_udp_chksum': False,
-                            'vxlan_vni': vni,
-                            'inner_frame': innermost_frame}
-                        pkt_opts.update(**options)
-                        pkt = simple_vxlan_packet(**pkt_opts)
+                total_vxlan_count = 0
+                # We send a fixed number of packets per iteration and then process responses
+                # to avoid overflowing ingress buffers (so that responses are not dropped by the kernel).
+                number_of_iterations = math.ceil(packet_count / self.PACKETS_PER_ITERATION)
+                for i in range(number_of_iterations):
+                    packets_to_send = min(self.PACKETS_PER_ITERATION,
+                                          packet_count - i * self.PACKETS_PER_ITERATION)
+                    for _ in range(packets_to_send):
+                        udp_sport = get_incremental_value('udp_sport')
+                        if isinstance(ip_address(destination), IPv4Address) and \
+                                isinstance(ip_address(ptf_addr), IPv4Address):
+                            if random_src_ip:
+                                ptf_addr = get_ip_address(
+                                    "v4", hostid=3, netid=170)
+                            pkt_opts = {
+                                'eth_src': self.random_mac,
+                                'eth_dst': self.dut_mac,
+                                'ip_id': 0,
+                                'ip_ihl': 5,
+                                'ip_src': ptf_addr,
+                                'ip_dst': destination,
+                                'ip_ttl': 63,
+                                'udp_sport': udp_sport,
+                                'udp_dport': udp_dport,
+                                'with_udp_chksum': False,
+                                'vxlan_vni': vni,
+                                'inner_frame': innermost_frame}
+                            pkt_opts.update(**options)
+                            pkt = simple_vxlan_packet(**pkt_opts)
 
-                        pkt_opts['ip_ttl'] = 62
-                        pkt_opts['eth_dst'] = self.random_mac
-                        pkt_opts['eth_src'] = self.dut_mac
-                        exp_pkt = simple_vxlan_packet(**pkt_opts)
-                    elif isinstance(ip_address(destination), IPv6Address) and \
-                            isinstance(ip_address(ptf_addr), IPv6Address):
-                        if random_src_ip:
-                            ptf_addr = get_ip_address(
-                                "v6", hostid=4, netid=170)
-                        pkt_opts = {
-                            "pktlen": pkt_len,
-                            "eth_dst": self.dut_mac,
-                            "eth_src": self.ptf_mac_addrs['eth%d' % ptf_port],
-                            "ipv6_dst": destination,
-                            "ipv6_src": ptf_addr,
-                            "ipv6_hlim": 64,
-                            "udp_sport": udp_sport,
-                            "udp_dport": udp_dport,
-                            'inner_frame': innermost_frame}
-                        pkt_opts.update(**options_v6)
+                            pkt_opts['ip_ttl'] = 62
+                            pkt_opts['eth_dst'] = self.random_mac
+                            pkt_opts['eth_src'] = self.dut_mac
+                            exp_pkt = simple_vxlan_packet(**pkt_opts)
+                        elif isinstance(ip_address(destination), IPv6Address) and \
+                                isinstance(ip_address(ptf_addr), IPv6Address):
+                            if random_src_ip:
+                                ptf_addr = get_ip_address(
+                                    "v6", hostid=4, netid=170)
+                            pkt_opts = {
+                                "pktlen": pkt_len,
+                                "eth_dst": self.dut_mac,
+                                "eth_src": self.ptf_mac_addrs['eth%d' % ptf_port],
+                                "ipv6_dst": destination,
+                                "ipv6_src": ptf_addr,
+                                "ipv6_hlim": 64,
+                                "udp_sport": udp_sport,
+                                "udp_dport": udp_dport,
+                                'inner_frame': innermost_frame}
+                            pkt_opts.update(**options_v6)
 
-                        pkt = simple_vxlanv6_packet(**pkt_opts)
-                        pkt_opts.update(options_v6)
+                            pkt = simple_vxlanv6_packet(**pkt_opts)
+                            pkt_opts.update(options_v6)
 
-                        pkt_opts['eth_dst'] = self.random_mac
-                        pkt_opts['eth_src'] = self.dut_mac
-                        pkt_opts['ipv6_hlim'] = 63
-                        exp_pkt = simple_vxlanv6_packet(**pkt_opts)
-                    else:
-                        raise RuntimeError(
-                            "Invalid mapping of destination and PTF address.")
-                    udp_sport = 1234    # it will be ignored in the test later.
-                    udp_dport = self.vxlan_port
-                    if isinstance(ip_address(host_address), IPv4Address):
-                        encap_pkt = simple_vxlan_packet(
-                            eth_src=self.dut_mac,
-                            eth_dst=self.random_mac,
-                            ip_id=0,
-                            ip_ihl=5,
-                            ip_src=self.loopback_ipv4,
-                            ip_dst=host_address,
-                            ip_ttl=63,
-                            udp_sport=udp_sport,
-                            udp_dport=udp_dport,
-                            with_udp_chksum=False,
-                            vxlan_vni=vni,
-                            inner_frame=exp_pkt,
-                            **options)
-                        encap_pkt[scapy.IP].flags = 0x2
-                    elif isinstance(ip_address(host_address), IPv6Address):
-                        encap_pkt = simple_vxlanv6_packet(
-                            eth_src=self.dut_mac,
-                            eth_dst=self.random_mac,
-                            ipv6_src=self.loopback_ipv6,
-                            ipv6_dst=host_address,
-                            udp_sport=udp_sport,
-                            udp_dport=udp_dport,
-                            with_udp_chksum=False,
-                            vxlan_vni=vni,
-                            inner_frame=exp_pkt,
-                            **options_v6)
-                    send_packet(self, ptf_port, pkt)
-
-                # After we sent all packets, wait for the responses.
-                if expect_success:
-                    wait_timeout = 2
-                    loop_timeout = max(packet_count * 5, 1000)   # milliseconds
-                    start_time = datetime.now()
-                    vxlan_count = 0
-                    Logger.info("Loop time:out %s milliseconds", loop_timeout)
-                    while (datetime.now() - start_time).total_seconds() *\
-                            1000 < loop_timeout and vxlan_count < packet_count:
-                        result = dp_poll(
-                            self, timeout=wait_timeout
-                        )
-                        if isinstance(result, self.dataplane.PollSuccess):
-                            if not isinstance(
-                                result, self.dataplane.PollSuccess) or \
-                                    result.port not in self.t2_ports or \
-                                    "VXLAN" not in scapy.Ether(result.packet):
-                                continue
-                            else:
-                                vxlan_count += 1
-                                scapy_pkt = scapy.Ether(result.packet)
-                                # Store every destination that was received.
-                                if isinstance(
-                                        ip_address(host_address), IPv6Address):
-                                    dest_ip = scapy_pkt['IPv6'].dst
-                                else:
-                                    dest_ip = scapy_pkt['IP'].dst
-                                try:
-                                    returned_ip_addresses[dest_ip] = \
-                                        returned_ip_addresses[dest_ip] + 1
-                                except KeyError:
-                                    returned_ip_addresses[dest_ip] = 1
+                            pkt_opts['eth_dst'] = self.random_mac
+                            pkt_opts['eth_src'] = self.dut_mac
+                            pkt_opts['ipv6_hlim'] = 63
+                            exp_pkt = simple_vxlanv6_packet(**pkt_opts)
                         else:
-                            Logger.info("No packet came in %s seconds",
-                                        wait_timeout)
-                            break
-                    if not vxlan_count or not returned_ip_addresses:
+                            raise RuntimeError(
+                                "Invalid mapping of destination and PTF address.")
+                        udp_sport = 1234    # it will be ignored in the test later.
+                        udp_dport = self.vxlan_port
+                        if isinstance(ip_address(host_address), IPv4Address):
+                            encap_pkt = simple_vxlan_packet(
+                                eth_src=self.dut_mac,
+                                eth_dst=self.random_mac,
+                                ip_id=0,
+                                ip_ihl=5,
+                                ip_src=self.loopback_ipv4,
+                                ip_dst=host_address,
+                                ip_ttl=63,
+                                udp_sport=udp_sport,
+                                udp_dport=udp_dport,
+                                with_udp_chksum=False,
+                                vxlan_vni=vni,
+                                inner_frame=exp_pkt,
+                                **options)
+                            encap_pkt[scapy.IP].flags = 0x2
+                        elif isinstance(ip_address(host_address), IPv6Address):
+                            encap_pkt = simple_vxlanv6_packet(
+                                eth_src=self.dut_mac,
+                                eth_dst=self.random_mac,
+                                ipv6_src=self.loopback_ipv6,
+                                ipv6_dst=host_address,
+                                udp_sport=udp_sport,
+                                udp_dport=udp_dport,
+                                with_udp_chksum=False,
+                                vxlan_vni=vni,
+                                inner_frame=exp_pkt,
+                                **options_v6)
+                        send_packet(self, ptf_port, pkt)
+
+                    # After we sent at most PACKETS_PER_ITERATION packets, wait for the responses.
+                    if expect_success:
+                        wait_timeout = 2
+                        loop_timeout = max(packets_to_send * 5, 1000)   # milliseconds
+                        start_time = datetime.now()
+                        vxlan_count = 0
+                        Logger.info("Loop time:out %s milliseconds", loop_timeout)
+                        while (datetime.now() - start_time).total_seconds() *\
+                                1000 < loop_timeout and vxlan_count < packets_to_send:
+                            result = dp_poll(
+                                self, timeout=wait_timeout
+                            )
+                            if isinstance(result, self.dataplane.PollSuccess):
+                                if not isinstance(
+                                    result, self.dataplane.PollSuccess) or \
+                                        result.port not in self.t2_ports or \
+                                        "VXLAN" not in scapy.Ether(result.packet):
+                                    continue
+                                else:
+                                    vxlan_count += 1
+                                    scapy_pkt = scapy.Ether(result.packet)
+                                    # Store every destination that was received.
+                                    if isinstance(
+                                            ip_address(host_address), IPv6Address):
+                                        dest_ip = scapy_pkt['IPv6'].dst
+                                    else:
+                                        dest_ip = scapy_pkt['IP'].dst
+                                    try:
+                                        returned_ip_addresses[dest_ip] = \
+                                            returned_ip_addresses[dest_ip] + 1
+                                    except KeyError:
+                                        returned_ip_addresses[dest_ip] = 1
+                                    current_count = endpoint_to_port_index_to_count[host_address].get(result.port, 0)
+                                    endpoint_to_port_index_to_count[host_address][result.port] = current_count + 1
+                            else:
+                                Logger.info("No packet came in %s seconds",
+                                            wait_timeout)
+                                break
+                        total_vxlan_count += vxlan_count
+                        Logger.info(
+                            "Vxlan packets received:%s, loop time:%s "
+                            "seconds", vxlan_count,
+                            (datetime.now() - start_time).total_seconds())
+                    else:
+                        check_ecmp = False
+                        Logger.info("Verifying no packet")
+
+                        masked_exp_pkt = Mask(encap_pkt)
+                        masked_exp_pkt.set_ignore_extra_bytes()
+                        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
+                        masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
+                        if isinstance(ip_address(host_address), IPv4Address):
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "chksum")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "dst")
+                        else:
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "hlim")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "chksum")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6, "dst")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.UDP, "sport")
+                            masked_exp_pkt.set_do_not_care_scapy(scapy.UDP, "chksum")
+                        try:
+                            verify_no_packet_any(
+                                self,
+                                masked_exp_pkt,
+                                self.t2_ports)
+                        except BaseException:
+                            raise RuntimeError(
+                                "Verify_no_packet failed. Args:ports:{} sent:{}\n,"
+                                "expected:{}\n, encap_pkt:{}\n".format(
+                                    self.t2_ports,
+                                    repr(pkt),
+                                    repr(exp_pkt),
+                                    repr(encap_pkt)))
+                # Sent all packets for this nexthop.
+                if expect_success:
+                    if not total_vxlan_count or not returned_ip_addresses:
                         raise RuntimeError(
                             "Didnot get any reply for this destination:{}"
                             " Its active endpoints:{}".format(
                                 destination, test_nhs))
-                    Logger.info(
-                        "Vxlan packets received:%s, loop time:%s "
-                        "seconds", vxlan_count,
-                        (datetime.now() - start_time).total_seconds())
                     Logger.info("received = {}".format(returned_ip_addresses))
-
-                else:
-                    check_ecmp = False
-                    Logger.info("Verifying no packet")
-
-                    masked_exp_pkt = Mask(encap_pkt)
-                    masked_exp_pkt.set_ignore_extra_bytes()
-                    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")
-                    masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "dst")
-                    if isinstance(ip_address(host_address), IPv4Address):
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "ttl")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IP,
-                                                             "chksum")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IP, "dst")
-                    else:
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
-                                                             "hlim")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
-                                                             "chksum")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.IPv6,
-                                                             "dst")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.UDP,
-                                                             "sport")
-                        masked_exp_pkt.set_do_not_care_scapy(scapy.UDP,
-                                                             "chksum")
-
-                    try:
-                        verify_no_packet_any(
-                            self,
-                            masked_exp_pkt,
-                            self.t2_ports)
-                    except BaseException:
-                        raise RuntimeError(
-                            "Verify_no_packet failed. Args:ports:{} sent:{}\n,"
-                            "expected:{}\n, encap_pkt:{}\n".format(
-                                self.t2_ports,
-                                repr(pkt),
-                                repr(exp_pkt),
-                                repr(encap_pkt)))
-
-            # Verify ECMP:
+            # Verify overlay ECMP:
             if check_ecmp:
                 self.verify_all_addresses_used_equally(
                     nhs,
                     returned_ip_addresses,
                     packet_count,
                     self.downed_endpoints)
+
+            Logger.info(f"VNET endpoint to port index to count mapping: {endpoint_to_port_index_to_count}")
+
+            # Verify underlay ECMP:
+            if self.check_underlay_ecmp and check_ecmp:
+                self.verify_underlay_ecmp(endpoint_to_port_index_to_count)
 
             pkt.load = '0' * 60 + str(len(self.packets))
             b = base64.b64encode(bytes(str(pkt), 'utf-8'))  # bytes

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5282,6 +5282,12 @@ vxlan/test_vxlan_route_advertisement.py::Test_VxLAN_route_Advertisement::test_sc
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20725 and '-v6-' in topo_name"
 
+vxlan/test_vxlan_underlay_ecmp.py:
+  skip:
+    reason: "VxLAN underlay ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on some platforms."
+    conditions:
+      - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
+
 #######################################
 #####           wan_lacp          #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -1632,7 +1632,7 @@ vxlan/test_vxlan_ecmp.py::Test_VxLAN_entropy:
     conditions:
       - "asic_type in ['vpp']"
 
-vxlan/test_vxlan_ecmp.py::Test_VxLAN_underlay_ecmp:
+vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp:
   skip:
     reason: >
             Failed/Errored: To be included

--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -58,9 +58,7 @@ import re
 import pytest
 import copy
 
-from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
-from tests.common.utilities import wait_until
 from tests.ptf_runner import ptf_runner
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
@@ -133,6 +131,37 @@ def setup_crm_interval(duthost, interval):
     return current_polling_seconds
 
 
+def get_all_endpoints(dest_to_nh_map):
+    """
+    From the dest_to_nh_map, get the list of all endpoints (nexthops).
+    Returns the set of all endpoints.
+    """
+    endpoints = set()
+    for _, dest_map in dest_to_nh_map.items():
+        for _, nh_list in dest_map.items():
+            for nh in nh_list:
+                endpoints.add(nh)
+    return endpoints
+
+
+def get_egress_interfaces(duthost, address, outer_layer_version):
+    """
+    Parse the output of "show ip route <address>" to get the list of all possible egress interfaces
+    for a packet that is routed to "address".
+    Returns the list of all possible egress interfaces for "address".
+    """
+    ip = "ip" if outer_layer_version == "v4" else "ipv6"
+    output = duthost.shell(f"show {ip} route {address}")["stdout_lines"]
+    interfaces = []
+    for line in output:
+        line = line.lstrip()
+        if line.startswith("*"):
+            iface = line.split()[-1]  # The interface is the last word in the line (if the route is active)
+            if iface.startswith("PortChannel") or iface.startswith("Ethernet"):
+                interfaces.append(iface)
+    return interfaces
+
+
 @pytest.fixture(name="setUp", scope="module")
 def fixture_setUp(duthosts,
                   ptfhost,
@@ -158,6 +187,8 @@ def fixture_setUp(duthosts,
     asic_type = duthosts[rand_one_dut_hostname].facts["asic_type"]
     if asic_type in ["cisco-8000", "mellanox", "vs", "vpp"]:
         data['tolerance'] = 0.03
+        data['underlay_tolerance'] = 0.25  # Comes from DEFAULT_BALANCING_RANGE in ptftests/fib_test.py
+        data['underlay_tolerance_within_lag'] = 0.25  # Comes from DEFAULT_BALANCING_RANGE in ptftests/fib_test.py
     else:
         raise RuntimeError("Pls update this script for your platform.")
 
@@ -393,14 +424,39 @@ class Test_VxLAN():
                                    random_sport=False,
                                    random_src_ip=False,
                                    tolerance=None,
+                                   underlay_tolerance=None,
+                                   underlay_tolerance_within_lag=None,
+                                   check_underlay_ecmp=False,
                                    payload=None):
         '''
            Just a wrapper for dump_info_to_ptf to avoid entering 30 lines
            everytime.
         '''
 
+        if check_underlay_ecmp:
+            outer_layer_version = ecmp_utils.get_outer_layer_version(encap_type)
+            # For each VNET endpoint (nexthop), get the list of all interfaces from which VxLAN packets to
+            # that endpoint can be sent out. This is typically the same as all PortChannel interfaces to T2 neighbors.
+            endpoints = get_all_endpoints(self.vxlan_test_setup[encap_type]['dest_to_nh_map'])
+            self.vxlan_test_setup["endpoint_to_egress_interfaces"] = {}
+            for endpoint in endpoints:
+                self.vxlan_test_setup["endpoint_to_egress_interfaces"][endpoint] = \
+                    get_egress_interfaces(self.vxlan_test_setup["duthost"], endpoint, outer_layer_version)
+                if not self.vxlan_test_setup["endpoint_to_egress_interfaces"][endpoint]:
+                    Logger.warning(f"No routes to {endpoint} through PortChannel or Ethernet interfaces.")
+        else:
+            self.vxlan_test_setup["endpoint_to_egress_interfaces"] = {}
+
         if tolerance is None:
             tolerance = self.vxlan_test_setup['tolerance']
+        if check_underlay_ecmp:
+            if underlay_tolerance is None:
+                underlay_tolerance = self.vxlan_test_setup["underlay_tolerance"]
+            if underlay_tolerance_within_lag is None:
+                underlay_tolerance_within_lag = self.vxlan_test_setup["underlay_tolerance_within_lag"]
+        else:
+            underlay_tolerance = 0.0
+            underlay_tolerance_within_lag = 0.0
         if ecmp_utils.Constants['DEBUG']:
             config_filename = "/tmp/vxlan_configs.json"
         else:
@@ -413,6 +469,7 @@ class Test_VxLAN():
                 'dest_to_nh_map': self.vxlan_test_setup[encap_type]['dest_to_nh_map'],
                 'neighbors': self.vxlan_test_setup[encap_type]['neighbor_config'],
                 'intf_to_ip_map': self.vxlan_test_setup[encap_type]['intf_to_ip_map'],
+                'endpoint_to_egress_interfaces': self.vxlan_test_setup["endpoint_to_egress_interfaces"]
             },
             indent=4), dest=config_filename)
 
@@ -442,6 +499,8 @@ class Test_VxLAN():
             "random_sport": random_sport,
             "random_src_ip": random_src_ip,
             "tolerance": tolerance,
+            "underlay_tolerance": underlay_tolerance,
+            "underlay_tolerance_within_lag": underlay_tolerance_within_lag,
             "downed_endpoints": list(self.vxlan_test_setup['list_of_downed_endpoints'])
         }
         Logger.info("ptf arguments:%s", ptf_params)
@@ -1442,465 +1501,6 @@ class Test_VxLAN_ecmp_random_hash(Test_VxLAN):
             encap_type,
             True,
             packet_count=1000)
-
-
-@pytest.mark.skipif(
-    "config.option.include_long_tests is False",
-    reason="This test will be run only if "
-           "'--include_long_tests=True' is provided.")
-class Test_VxLAN_underlay_ecmp(Test_VxLAN):
-    '''
-        Class for all test cases that modify the underlay default route.
-    '''
-    @pytest.mark.parametrize("ecmp_path_count", [1, 2])
-    def test_vxlan_modify_underlay_default(self, setUp, minigraph_facts, encap_type, ecmp_path_count):
-        '''
-            tc12: modify the underlay default route nexthop/s. send packets to
-            route 3's prefix dst.
-        '''
-        self.vxlan_test_setup = setUp
-        '''
-        First step: pick one or two of the interfaces connected to t2, and
-        bring them down. verify that the encap is still working, and ptf
-        receives the traffic.  Bring them back up.
-        After that, bring down all the other t2 interfaces, other than
-        the ones used in the first step. This will force a modification
-        to the underlay default routes nexthops.
-        '''
-
-        all_t2_intfs = list(ecmp_utils.get_portchannels_to_neighbors(
-            self.vxlan_test_setup['duthost'],
-            "T2",
-            minigraph_facts))
-
-        if not all_t2_intfs:
-            all_t2_intfs = ecmp_utils.get_ethernet_to_neighbors(
-                "T2",
-                minigraph_facts)
-        Logger.info("Dumping T2 link info: %s", all_t2_intfs)
-        if not all_t2_intfs:
-            raise RuntimeError(
-                "No interface found connected to t2 neighbors. "
-                "pls check the testbed, aborting.")
-
-        # Keep a copy of the internal housekeeping list of t2 ports.
-        # This is the full list of DUT ports connected to T2 neighbors.
-        # It is one of the arguments to the ptf code.
-        all_t2_ports = list(self.vxlan_test_setup[encap_type]['t2_ports'])
-
-        # A distinction in this script between ports and interfaces:
-        # Ports are physical (Ethernet) only.
-        # Interfaces have IP address(Ethernet or PortChannel).
-        try:
-            selected_intfs = []
-            # Choose some intfs based on the parameter ecmp_path_count.
-            # when ecmp_path_count == 1, it is non-ecmp. The switching
-            # happens between ecmp and non-ecmp. Otherwise, the switching
-            # happens within ecmp only.
-            for i in range(ecmp_path_count):
-                selected_intfs.append(all_t2_intfs[i])
-
-            for intf in selected_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface shutdown {}".format(intf))
-            downed_ports = ecmp_utils.get_corresponding_ports(
-                selected_intfs,
-                minigraph_facts)
-            self.vxlan_test_setup[encap_type]['t2_ports'] = \
-                list(set(all_t2_ports) - set(downed_ports))
-            downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
-                selected_intfs, minigraph_facts)
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost'],
-                    down_list=downed_bgp_neighbors),
-                "BGP neighbors didn't come up after all "
-                "interfaces have been brought up.")
-            time.sleep(10)
-            self.dump_self_info_and_run_ptf(
-                "tc12",
-                encap_type,
-                True,
-                packet_count=1000)
-
-            Logger.info(
-                "Reverse the action: bring up the selected_intfs"
-                " and shutdown others.")
-            for intf in selected_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            Logger.info("Shutdown other interfaces.")
-            remaining_interfaces = list(
-                set(all_t2_intfs) - set(selected_intfs))
-            for intf in remaining_interfaces:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface shutdown {}".format(intf))
-            downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
-                remaining_interfaces,
-                minigraph_facts)
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost'],
-                    down_list=downed_bgp_neighbors),
-                "BGP neighbors didn't come up after all interfaces have been"
-                "brought up.")
-            self.vxlan_test_setup[encap_type]['t2_ports'] = \
-                ecmp_utils.get_corresponding_ports(
-                    selected_intfs,
-                    minigraph_facts)
-
-            '''
-            Need to update the bfd_responder to listen only on the sub-set of
-            T2 ports that are active. If we still receive packets on the
-            downed ports, we have a problem!
-            '''
-            ecmp_utils.update_monitor_file(
-                self.vxlan_test_setup['ptfhost'],
-                self.vxlan_test_setup['monitor_file'],
-                self.vxlan_test_setup[encap_type]['t2_ports'],
-                list(self.vxlan_test_setup['list_of_bfd_monitors']))
-            time.sleep(10)
-            self.dump_self_info_and_run_ptf(
-                "tc12",
-                encap_type,
-                True,
-                packet_count=1000)
-
-            Logger.info("Recovery. Bring all up, and verify traffic works.")
-            for intf in all_t2_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            Logger.info("Wait for all bgp is up.")
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost']),
-                "BGP neighbors didn't come up after "
-                "all interfaces have been brought up.")
-            Logger.info("Verify traffic flows after recovery.")
-            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
-            ecmp_utils.update_monitor_file(
-                self.vxlan_test_setup['ptfhost'],
-                self.vxlan_test_setup['monitor_file'],
-                self.vxlan_test_setup[encap_type]['t2_ports'],
-                list(self.vxlan_test_setup['list_of_bfd_monitors']))
-            time.sleep(10)
-            self.dump_self_info_and_run_ptf(
-                "tc12",
-                encap_type,
-                True,
-                packet_count=1000)
-
-        except Exception:
-            # If anything goes wrong in the try block, atleast bring the intf
-            # back up.
-            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
-            ecmp_utils.update_monitor_file(
-                self.vxlan_test_setup['ptfhost'],
-                self.vxlan_test_setup['monitor_file'],
-                self.vxlan_test_setup[encap_type]['t2_ports'],
-                list(self.vxlan_test_setup['list_of_bfd_monitors']))
-            for intf in all_t2_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost']),
-                "BGP neighbors didn't come up after all interfaces "
-                "have been brought up.")
-            raise
-
-    def test_vxlan_remove_add_underlay_default(self,
-                                               setUp,
-                                               minigraph_facts,
-                                               encap_type):
-        '''
-           tc13: remove the underlay default route.
-           tc14: add the underlay default route.
-        '''
-        self.vxlan_test_setup = setUp
-        Logger.info(
-            "Find all the underlay default routes' interfaces. This means all "
-            "T2 interfaces.")
-        all_t2_intfs = list(ecmp_utils.get_portchannels_to_neighbors(
-            self.vxlan_test_setup['duthost'],
-            "T2",
-            minigraph_facts))
-        if not all_t2_intfs:
-            all_t2_intfs = ecmp_utils.get_ethernet_to_neighbors(
-                "T2",
-                minigraph_facts)
-        Logger.info("Dumping T2 link info: %s", all_t2_intfs)
-        if not all_t2_intfs:
-            raise RuntimeError(
-                "No interface found connected to t2 neighbors."
-                "Pls check the testbed, aborting.")
-        try:
-            Logger.info("Bring down the T2 interfaces.")
-            for intf in all_t2_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface shutdown {}".format(intf))
-            downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
-                all_t2_intfs,
-                minigraph_facts)
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost'],
-                    down_list=downed_bgp_neighbors),
-                "BGP neighbors have not reached the required state after "
-                "T2 intf are shutdown.")
-            Logger.info("Verify that traffic is not flowing through.")
-            self.dump_self_info_and_run_ptf("tc13", encap_type, False)
-
-            # tc14: Re-add the underlay default route.
-            Logger.info("Bring up the T2 interfaces.")
-            for intf in all_t2_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            Logger.info("Wait for all bgp is up.")
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost']),
-                "BGP neighbors didn't come up after all interfaces"
-                " have been brought up.")
-            Logger.info("Verify the traffic is flowing through, again.")
-            self.dump_self_info_and_run_ptf(
-                "tc14",
-                encap_type,
-                True,
-                packet_count=1000)
-        except Exception:
-            Logger.info(
-                "If anything goes wrong in the try block,"
-                " atleast bring the intf back up.")
-            for intf in all_t2_intfs:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            pytest_assert(
-                wait_until(
-                    300,
-                    30,
-                    0,
-                    ecmp_utils.bgp_established,
-                    self.vxlan_test_setup['duthost']),
-                "BGP neighbors didn't come up after all"
-                " interfaces have been brought up.")
-            raise
-
-    def test_underlay_specific_route(self, setUp, minigraph_facts, encap_type):
-        '''
-            Create a more specific underlay route to c1.
-            Verify c1 packets are received only on the c1's nexthop interface
-        '''
-        self.vxlan_test_setup = setUp
-        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
-        endpoint_nhmap = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet]
-        backup_t2_ports = self.vxlan_test_setup[encap_type]['t2_ports']
-        # Gathering all T2 Neighbors
-        all_t2_neighbors = ecmp_utils.get_all_bgp_neighbors(
-            minigraph_facts,
-            "T2")
-
-        # Choosing a specific T2 Neighbor to add static route
-        t2_neighbor = list(all_t2_neighbors.keys())[0]
-
-        # Gathering PTF indices corresponding to specific T2 Neighbor
-        ret_list = ecmp_utils.gather_ptf_indices_t2_neighbor(
-            minigraph_facts,
-            all_t2_neighbors,
-            t2_neighbor,
-            encap_type)
-        outer_layer_version = ecmp_utils.get_outer_layer_version(encap_type)
-        '''
-            Addition & Modification of static routes - endpoint_nhmap will be
-            prefix to endpoint mapping. Static routes are added towards
-            endpoint with T2 VM's ip as nexthop
-        '''
-        gateway = all_t2_neighbors[t2_neighbor][outer_layer_version].lower()
-        for _, nexthops in list(endpoint_nhmap.items()):
-            for nexthop in nexthops:
-                if outer_layer_version == "v6":
-                    vtysh_config_commands = []
-                    vtysh_config_commands.append("ipv6 route {}/{} {}".format(
-                        nexthop,
-                        "64",
-                        gateway))
-                    vtysh_config_commands.append("ipv6 route {}/{} {}".format(
-                        nexthop,
-                        "68",
-                        gateway))
-                    self.vxlan_test_setup['duthost'].copy(
-                        content="\n".join(vtysh_config_commands),
-                        dest="/tmp/specific_route_v6.txt")
-                    self.vxlan_test_setup['duthost'].command(
-                        "docker cp /tmp/specific_route_v6.txt bgp:/")
-                    self.vxlan_test_setup['duthost'].command(
-                        "vtysh -f /specific_route_v6.txt")
-                elif outer_layer_version == "v4":
-                    static_route = []
-                    static_route.append(
-                        "sudo config route add prefix {}/{} nexthop {}".format(
-                            ".".join(nexthop.split(".")[:-1])+".0", "24",
-                            gateway))
-                    static_route.append(
-                        "sudo config route add prefix {}/{} nexthop {}".format(
-                            nexthop,
-                            ecmp_utils.HOST_MASK[outer_layer_version],
-                            gateway))
-
-                    self.vxlan_test_setup['duthost'].shell_cmds(cmds=static_route)
-        self.vxlan_test_setup[encap_type]['t2_ports'] = ret_list
-
-        '''
-            Traffic verification to see if specific route is preferred before
-            deletion of static route
-        '''
-        self.dump_self_info_and_run_ptf(
-            "underlay_specific_route",
-            encap_type,
-            True)
-        # Deletion of all static routes
-        gateway = all_t2_neighbors[t2_neighbor][outer_layer_version].lower()
-        for _, nexthops in list(endpoint_nhmap.items()):
-            for nexthop in nexthops:
-                if ecmp_utils.get_outer_layer_version(encap_type) == "v6":
-                    vtysh_config_commands = []
-                    vtysh_config_commands.append(
-                        "no ipv6 route {}/{} {}".format(
-                            nexthop, "64", gateway))
-                    vtysh_config_commands.append(
-                        "no ipv6 route {}/{} {}".format(
-                            nexthop, "68", gateway))
-                    self.vxlan_test_setup['duthost'].copy(
-                        content="\n".join(vtysh_config_commands),
-                        dest="/tmp/specific_route_v6.txt")
-                    self.vxlan_test_setup['duthost'].command(
-                        "docker cp /tmp/specific_route_v6.txt bgp:/")
-                    self.vxlan_test_setup['duthost'].command(
-                        "vtysh -f /specific_route_v6.txt")
-
-                elif ecmp_utils.get_outer_layer_version(encap_type) == "v4":
-                    static_route = []
-                    static_route.append(
-                        "sudo config route del prefix {}/{} nexthop {}".format(
-                            ".".join(
-                                nexthop.split(".")[:-1])+".0", "24", gateway))
-                    static_route.append(
-                        "sudo config route del prefix {}/{} nexthop {}".format(
-                            nexthop,
-                            ecmp_utils.HOST_MASK[outer_layer_version],
-                            gateway))
-
-                    self.vxlan_test_setup['duthost'].shell_cmds(cmds=static_route)
-        self.vxlan_test_setup[encap_type]['t2_ports'] = backup_t2_ports
-
-        Logger.info(
-            "Allow some time for recovery of default route"
-            " after deleting the specific route.")
-        time.sleep(10)
-
-        '''
-        Traffic verification to see if default route is preferred after
-        deletion of static route
-        '''
-        self.dump_self_info_and_run_ptf(
-            "underlay_specific_route",
-            encap_type,
-            True)
-
-    def test_underlay_portchannel_shutdown(self,
-                                           setUp,
-                                           minigraph_facts,
-                                           encap_type):
-        '''
-            Bring down one of the port-channels.
-            Packets are equally recieved at c1, c2 or c3
-        '''
-        self.vxlan_test_setup = setUp
-
-        # Verification of traffic before shutting down port channel
-        self.dump_self_info_and_run_ptf("tc12", encap_type, True)
-
-        # Gathering all portchannels
-        all_t2_portchannel_intfs = \
-            list(ecmp_utils.get_portchannels_to_neighbors(
-                self.vxlan_test_setup['duthost'],
-                "T2",
-                minigraph_facts))
-        all_t2_portchannel_members = {}
-        for each_pc in all_t2_portchannel_intfs:
-            all_t2_portchannel_members[each_pc] =\
-                minigraph_facts['minigraph_portchannels'][each_pc]['members']
-
-        selected_portchannel = list(all_t2_portchannel_members.keys())[0]
-
-        try:
-            # Shutting down the ethernet interfaces
-            for intf in all_t2_portchannel_members[selected_portchannel]:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface shutdown {}".format(intf))
-
-            all_t2_ports = list(self.vxlan_test_setup[encap_type]['t2_ports'])
-            downed_ports = ecmp_utils.get_corresponding_ports(
-                all_t2_portchannel_members[selected_portchannel],
-                minigraph_facts)
-            self.vxlan_test_setup[encap_type]['t2_ports'] = \
-                list(set(all_t2_ports) - set(downed_ports))
-
-            # Verification of traffic
-            ecmp_utils.update_monitor_file(
-                self.vxlan_test_setup['ptfhost'],
-                self.vxlan_test_setup['monitor_file'],
-                self.vxlan_test_setup[encap_type]['t2_ports'],
-                list(self.vxlan_test_setup['list_of_bfd_monitors']))
-            time.sleep(10)
-            self.dump_self_info_and_run_ptf("tc12", encap_type, True)
-
-            for intf in all_t2_portchannel_members[selected_portchannel]:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
-            ecmp_utils.update_monitor_file(
-                self.vxlan_test_setup['ptfhost'],
-                self.vxlan_test_setup['monitor_file'],
-                self.vxlan_test_setup[encap_type]['t2_ports'],
-                list(self.vxlan_test_setup['list_of_bfd_monitors']))
-            time.sleep(10)
-            self.dump_self_info_and_run_ptf("tc12", encap_type, True)
-        except BaseException:
-            for intf in all_t2_portchannel_members[selected_portchannel]:
-                self.vxlan_test_setup['duthost'].shell(
-                    "sudo config interface startup {}".format(intf))
-            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
-            ecmp_utils.update_monitor_file(
-                self.vxlan_test_setup['ptfhost'],
-                self.vxlan_test_setup['monitor_file'],
-                self.vxlan_test_setup[encap_type]['t2_ports'],
-                list(self.vxlan_test_setup['list_of_bfd_monitors']))
-            raise
 
 
 @pytest.mark.skipif(

--- a/tests/vxlan/test_vxlan_underlay_ecmp.py
+++ b/tests/vxlan/test_vxlan_underlay_ecmp.py
@@ -1,0 +1,479 @@
+import pytest
+import time
+import logging
+
+from tests.common.utilities import wait_until
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                             # noqa: F401
+from tests.vxlan.test_vxlan_ecmp import Test_VxLAN, fixture_encap_type, _ignore_route_sync_errlogs  # noqa: F401
+from tests.vxlan.test_vxlan_ecmp import fixture_setUp, _reset_test_routes, ecmp_utils               # noqa: F401
+from tests.vxlan.test_vxlan_ecmp import default_routes, routes_for_cleanup                          # noqa: F401
+
+
+Logger = logging.getLogger(__name__)
+
+pytestmark = [
+    # This script supports any T1 topology: t1, t1-64-lag, t1-56-lag, t1-lag.
+    pytest.mark.topology("t1", "t1-64-lag", "t1-56-lag", "t1-lag")
+]
+
+
+class Test_VxLAN_underlay_ecmp(Test_VxLAN):
+    '''
+        Class for all test cases that modify the underlay default route.
+    '''
+    @pytest.mark.parametrize("ecmp_path_count", [1, 2])
+    def test_vxlan_modify_underlay_default(self, setUp, minigraph_facts, encap_type, ecmp_path_count):
+        '''
+            tc12: modify the underlay default route nexthop/s. send packets to
+            route 3's prefix dst.
+        '''
+        self.vxlan_test_setup = setUp
+        '''
+        First step: pick one or two of the interfaces connected to t2, and
+        bring them down. verify that the encap is still working, and ptf
+        receives the traffic.  Bring them back up.
+        After that, bring down all the other t2 interfaces, other than
+        the ones used in the first step. This will force a modification
+        to the underlay default routes nexthops.
+        '''
+
+        all_t2_intfs = list(ecmp_utils.get_portchannels_to_neighbors(
+            self.vxlan_test_setup['duthost'],
+            "T2",
+            minigraph_facts))
+
+        if not all_t2_intfs:
+            all_t2_intfs = ecmp_utils.get_ethernet_to_neighbors(
+                "T2",
+                minigraph_facts)
+        Logger.info("Dumping T2 link info: %s", all_t2_intfs)
+        if not all_t2_intfs:
+            raise RuntimeError(
+                "No interface found connected to t2 neighbors. "
+                "pls check the testbed, aborting.")
+
+        # Keep a copy of the internal housekeeping list of t2 ports.
+        # This is the full list of DUT ports connected to T2 neighbors.
+        # It is one of the arguments to the ptf code.
+        all_t2_ports = list(self.vxlan_test_setup[encap_type]['t2_ports'])
+
+        # A distinction in this script between ports and interfaces:
+        # Ports are physical (Ethernet) only.
+        # Interfaces have IP address(Ethernet or PortChannel).
+        try:
+            selected_intfs = []
+            # Choose some intfs based on the parameter ecmp_path_count.
+            # when ecmp_path_count == 1, it is non-ecmp. The switching
+            # happens between ecmp and non-ecmp. Otherwise, the switching
+            # happens within ecmp only.
+            for i in range(ecmp_path_count):
+                selected_intfs.append(all_t2_intfs[i])
+
+            for intf in selected_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface shutdown {}".format(intf))
+            downed_ports = ecmp_utils.get_corresponding_ports(
+                selected_intfs,
+                minigraph_facts)
+            self.vxlan_test_setup[encap_type]['t2_ports'] = \
+                list(set(all_t2_ports) - set(downed_ports))
+            downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
+                selected_intfs, minigraph_facts)
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost'],
+                    down_list=downed_bgp_neighbors),
+                "BGP neighbors didn't come up after all "
+                "interfaces have been brought up.")
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf(
+                "tc12",
+                encap_type,
+                True,
+                packet_count=10000,
+                check_underlay_ecmp=True)
+
+            Logger.info(
+                "Reverse the action: bring up the selected_intfs"
+                " and shutdown others.")
+            for intf in selected_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            Logger.info("Shutdown other interfaces.")
+            remaining_interfaces = list(
+                set(all_t2_intfs) - set(selected_intfs))
+            for intf in remaining_interfaces:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface shutdown {}".format(intf))
+            downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
+                remaining_interfaces,
+                minigraph_facts)
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost'],
+                    down_list=downed_bgp_neighbors),
+                "BGP neighbors didn't come up after all interfaces have been"
+                "brought up.")
+            self.vxlan_test_setup[encap_type]['t2_ports'] = \
+                ecmp_utils.get_corresponding_ports(
+                    selected_intfs,
+                    minigraph_facts)
+
+            '''
+            Need to update the bfd_responder to listen only on the sub-set of
+            T2 ports that are active. If we still receive packets on the
+            downed ports, we have a problem!
+            '''
+            ecmp_utils.update_monitor_file(
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf(
+                "tc12",
+                encap_type,
+                True,
+                packet_count=10000,
+                check_underlay_ecmp=True)
+
+            Logger.info("Recovery. Bring all up, and verify traffic works.")
+            for intf in all_t2_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            Logger.info("Wait for all bgp is up.")
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost']),
+                "BGP neighbors didn't come up after "
+                "all interfaces have been brought up.")
+            Logger.info("Verify traffic flows after recovery.")
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
+            ecmp_utils.update_monitor_file(
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf(
+                "tc12",
+                encap_type,
+                True,
+                packet_count=10000,
+                check_underlay_ecmp=True)
+
+        except Exception:
+            # If anything goes wrong in the try block, atleast bring the intf
+            # back up.
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
+            ecmp_utils.update_monitor_file(
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
+            for intf in all_t2_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost']),
+                "BGP neighbors didn't come up after all interfaces "
+                "have been brought up.")
+            raise
+
+    def test_vxlan_remove_add_underlay_default(self,
+                                               setUp,
+                                               minigraph_facts,
+                                               encap_type):
+        '''
+           tc13: remove the underlay default route.
+           tc14: add the underlay default route.
+        '''
+        self.vxlan_test_setup = setUp
+        Logger.info(
+            "Find all the underlay default routes' interfaces. This means all "
+            "T2 interfaces.")
+        all_t2_intfs = list(ecmp_utils.get_portchannels_to_neighbors(
+            self.vxlan_test_setup['duthost'],
+            "T2",
+            minigraph_facts))
+        if not all_t2_intfs:
+            all_t2_intfs = ecmp_utils.get_ethernet_to_neighbors(
+                "T2",
+                minigraph_facts)
+        Logger.info("Dumping T2 link info: %s", all_t2_intfs)
+        if not all_t2_intfs:
+            raise RuntimeError(
+                "No interface found connected to t2 neighbors."
+                "Pls check the testbed, aborting.")
+        try:
+            Logger.info("Bring down the T2 interfaces.")
+            for intf in all_t2_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface shutdown {}".format(intf))
+            downed_bgp_neighbors = ecmp_utils.get_downed_bgp_neighbors(
+                all_t2_intfs,
+                minigraph_facts)
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost'],
+                    down_list=downed_bgp_neighbors),
+                "BGP neighbors have not reached the required state after "
+                "T2 intf are shutdown.")
+            Logger.info("Verify that traffic is not flowing through.")
+            self.dump_self_info_and_run_ptf("tc13", encap_type, False, check_underlay_ecmp=True)
+
+            # tc14: Re-add the underlay default route.
+            Logger.info("Bring up the T2 interfaces.")
+            for intf in all_t2_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            Logger.info("Wait for all bgp is up.")
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost']),
+                "BGP neighbors didn't come up after all interfaces"
+                " have been brought up.")
+            Logger.info("Verify the traffic is flowing through, again.")
+            self.dump_self_info_and_run_ptf(
+                "tc14",
+                encap_type,
+                True,
+                packet_count=10000,
+                check_underlay_ecmp=True)
+        except Exception:
+            Logger.info(
+                "If anything goes wrong in the try block,"
+                " atleast bring the intf back up.")
+            for intf in all_t2_intfs:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            pytest_assert(
+                wait_until(
+                    300,
+                    30,
+                    0,
+                    ecmp_utils.bgp_established,
+                    self.vxlan_test_setup['duthost']),
+                "BGP neighbors didn't come up after all"
+                " interfaces have been brought up.")
+            raise
+
+    def test_underlay_specific_route(self, setUp, minigraph_facts, encap_type):
+        '''
+            Create a more specific underlay route to c1.
+            Verify c1 packets are received only on the c1's nexthop interface
+        '''
+        self.vxlan_test_setup = setUp
+        vnet = list(self.vxlan_test_setup[encap_type]['vnet_vni_map'].keys())[0]
+        endpoint_nhmap = self.vxlan_test_setup[encap_type]['dest_to_nh_map'][vnet]
+        backup_t2_ports = self.vxlan_test_setup[encap_type]['t2_ports']
+        # Gathering all T2 Neighbors
+        all_t2_neighbors = ecmp_utils.get_all_bgp_neighbors(
+            minigraph_facts,
+            "T2")
+
+        # Choosing a specific T2 Neighbor to add static route
+        t2_neighbor = list(all_t2_neighbors.keys())[0]
+
+        # Gathering PTF indices corresponding to specific T2 Neighbor
+        ret_list = ecmp_utils.gather_ptf_indices_t2_neighbor(
+            minigraph_facts,
+            all_t2_neighbors,
+            t2_neighbor,
+            encap_type)
+        outer_layer_version = ecmp_utils.get_outer_layer_version(encap_type)
+        '''
+            Addition & Modification of static routes - endpoint_nhmap will be
+            prefix to endpoint mapping. Static routes are added towards
+            endpoint with T2 VM's ip as nexthop
+        '''
+        gateway = all_t2_neighbors[t2_neighbor][outer_layer_version].lower()
+        for _, nexthops in list(endpoint_nhmap.items()):
+            for nexthop in nexthops:
+                if outer_layer_version == "v6":
+                    vtysh_config_commands = []
+                    vtysh_config_commands.append("ipv6 route {}/{} {}".format(
+                        nexthop,
+                        "64",
+                        gateway))
+                    vtysh_config_commands.append("ipv6 route {}/{} {}".format(
+                        nexthop,
+                        "68",
+                        gateway))
+                    self.vxlan_test_setup['duthost'].copy(
+                        content="\n".join(vtysh_config_commands),
+                        dest="/tmp/specific_route_v6.txt")
+                    self.vxlan_test_setup['duthost'].command(
+                        "docker cp /tmp/specific_route_v6.txt bgp:/")
+                    self.vxlan_test_setup['duthost'].command(
+                        "vtysh -f /specific_route_v6.txt")
+                elif outer_layer_version == "v4":
+                    static_route = []
+                    static_route.append(
+                        "sudo config route add prefix {}/{} nexthop {}".format(
+                            ".".join(nexthop.split(".")[:-1])+".0", "24",
+                            gateway))
+                    static_route.append(
+                        "sudo config route add prefix {}/{} nexthop {}".format(
+                            nexthop,
+                            ecmp_utils.HOST_MASK[outer_layer_version],
+                            gateway))
+
+                    self.vxlan_test_setup['duthost'].shell_cmds(cmds=static_route)
+        self.vxlan_test_setup[encap_type]['t2_ports'] = ret_list
+
+        '''
+            Traffic verification to see if specific route is preferred before
+            deletion of static route
+        '''
+        self.dump_self_info_and_run_ptf(
+            "underlay_specific_route",
+            encap_type,
+            True,
+            check_underlay_ecmp=True)
+        # Deletion of all static routes
+        gateway = all_t2_neighbors[t2_neighbor][outer_layer_version].lower()
+        for _, nexthops in list(endpoint_nhmap.items()):
+            for nexthop in nexthops:
+                if ecmp_utils.get_outer_layer_version(encap_type) == "v6":
+                    vtysh_config_commands = []
+                    vtysh_config_commands.append(
+                        "no ipv6 route {}/{} {}".format(
+                            nexthop, "64", gateway))
+                    vtysh_config_commands.append(
+                        "no ipv6 route {}/{} {}".format(
+                            nexthop, "68", gateway))
+                    self.vxlan_test_setup['duthost'].copy(
+                        content="\n".join(vtysh_config_commands),
+                        dest="/tmp/specific_route_v6.txt")
+                    self.vxlan_test_setup['duthost'].command(
+                        "docker cp /tmp/specific_route_v6.txt bgp:/")
+                    self.vxlan_test_setup['duthost'].command(
+                        "vtysh -f /specific_route_v6.txt")
+
+                elif ecmp_utils.get_outer_layer_version(encap_type) == "v4":
+                    static_route = []
+                    static_route.append(
+                        "sudo config route del prefix {}/{} nexthop {}".format(
+                            ".".join(
+                                nexthop.split(".")[:-1])+".0", "24", gateway))
+                    static_route.append(
+                        "sudo config route del prefix {}/{} nexthop {}".format(
+                            nexthop,
+                            ecmp_utils.HOST_MASK[outer_layer_version],
+                            gateway))
+
+                    self.vxlan_test_setup['duthost'].shell_cmds(cmds=static_route)
+        self.vxlan_test_setup[encap_type]['t2_ports'] = backup_t2_ports
+
+        Logger.info(
+            "Allow some time for recovery of default route"
+            " after deleting the specific route.")
+        time.sleep(10)
+
+        '''
+        Traffic verification to see if default route is preferred after
+        deletion of static route
+        '''
+        self.dump_self_info_and_run_ptf(
+            "underlay_specific_route",
+            encap_type,
+            True,
+            check_underlay_ecmp=True)
+
+    def test_underlay_portchannel_shutdown(self,
+                                           setUp,
+                                           minigraph_facts,
+                                           encap_type):
+        '''
+            Bring down one of the port-channels.
+            Packets are equally recieved at c1, c2 or c3
+        '''
+        self.vxlan_test_setup = setUp
+
+        # Verification of traffic before shutting down port channel
+        self.dump_self_info_and_run_ptf("tc12", encap_type, True, check_underlay_ecmp=True)
+
+        # Gathering all portchannels
+        all_t2_portchannel_intfs = \
+            list(ecmp_utils.get_portchannels_to_neighbors(
+                self.vxlan_test_setup['duthost'],
+                "T2",
+                minigraph_facts))
+        all_t2_portchannel_members = {}
+        for each_pc in all_t2_portchannel_intfs:
+            all_t2_portchannel_members[each_pc] =\
+                minigraph_facts['minigraph_portchannels'][each_pc]['members']
+
+        selected_portchannel = list(all_t2_portchannel_members.keys())[0]
+
+        try:
+            # Shutting down the ethernet interfaces
+            for intf in all_t2_portchannel_members[selected_portchannel]:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface shutdown {}".format(intf))
+
+            all_t2_ports = list(self.vxlan_test_setup[encap_type]['t2_ports'])
+            downed_ports = ecmp_utils.get_corresponding_ports(
+                all_t2_portchannel_members[selected_portchannel],
+                minigraph_facts)
+            self.vxlan_test_setup[encap_type]['t2_ports'] = \
+                list(set(all_t2_ports) - set(downed_ports))
+
+            # Verification of traffic
+            ecmp_utils.update_monitor_file(
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("tc12", encap_type, True, check_underlay_ecmp=True)
+
+            for intf in all_t2_portchannel_members[selected_portchannel]:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
+            ecmp_utils.update_monitor_file(
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
+            time.sleep(10)
+            self.dump_self_info_and_run_ptf("tc12", encap_type, True, check_underlay_ecmp=True)
+        except BaseException:
+            for intf in all_t2_portchannel_members[selected_portchannel]:
+                self.vxlan_test_setup['duthost'].shell(
+                    "sudo config interface startup {}".format(intf))
+            self.vxlan_test_setup[encap_type]['t2_ports'] = all_t2_ports
+            ecmp_utils.update_monitor_file(
+                self.vxlan_test_setup['ptfhost'],
+                self.vxlan_test_setup['monitor_file'],
+                self.vxlan_test_setup[encap_type]['t2_ports'],
+                list(self.vxlan_test_setup['list_of_bfd_monitors']))
+            raise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Microsoft ADO ID: 35967425
Adding tests for VxLAN underlay ECMP distribution.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Currently, we don't have tests that check the underlay ECMP distribution for VxLAN packets.

#### How did you do it?
1. Added VxLAN underlay ECMP distribution checks to `vxlan_traffic.py`. These checks are only run if requested.
2. Modified `vxlan_traffic.py` to send packets in batches of 1000 and then poll for responses after sending each batch. This was required to support large number of test packets and to avoid responses being dropped by the kernel. The previous method was to send all packets and then wait for all of the responses, which caused some responses to be lost when the number of packets was large (e.g., 10000).
3. Unskipped and moved tests in `Test_VxLAN_underlay_ecmp` to a new file to avoid the tests being stopped due to long running time. These tests check different scenarios (e.g., changing the default route, shutting down one or two PortChannel interfaces to T2 neighbors, etc.). Also changed the packet count used in these tests from 1000 to 10000.
4. Changed the code in `test_vxlan_ecmp.py` to pass underlay routing information to `vxlan_traffic.py`.

#### How did you verify/test it?
Tests passed on a Cisco T1 switch:
```
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v4_in_v4-1] PASSED                                    [  5%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v4_in_v4-2] PASSED                                    [ 10%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_remove_add_underlay_default[v4_in_v4]
----------------------------------------------------------------------- live log call -----------------------------------------------------------------------
19/11/2025 16:46:08 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to 100.0.2.10 through PortChannel or Ethernet interfaces.
19/11/2025 16:46:10 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to 100.0.1.10 through PortChannel or Ethernet interfaces.
PASSED                                                                                                                                                [ 15%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_specific_route[v4_in_v4] PASSED                                            [ 20%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_portchannel_shutdown[v4_in_v4] PASSED                                      [ 25%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v4_in_v6-1] PASSED                                    [ 30%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v4_in_v6-2] PASSED                                    [ 35%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_remove_add_underlay_default[v4_in_v6]
----------------------------------------------------------------------- live log call -----------------------------------------------------------------------
19/11/2025 17:11:16 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to fddd:a100:a0::a6:10 through PortChannel or Ethernet interfaces.
19/11/2025 17:11:18 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to fddd:a100:a0::a7:10 through PortChannel or Ethernet interfaces.
PASSED                                                                                                                                                [ 40%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_specific_route[v4_in_v6] PASSED                                            [ 45%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_portchannel_shutdown[v4_in_v6] PASSED                                      [ 50%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v6_in_v4-1] PASSED                                    [ 55%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v6_in_v4-2] PASSED                                    [ 60%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_remove_add_underlay_default[v6_in_v4]
----------------------------------------------------------------------- live log call -----------------------------------------------------------------------
19/11/2025 17:36:27 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to 100.0.11.10 through PortChannel or Ethernet interfaces.
19/11/2025 17:36:29 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to 100.0.12.10 through PortChannel or Ethernet interfaces.
PASSED                                                                                                                                                [ 65%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_specific_route[v6_in_v4] PASSED                                            [ 70%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_portchannel_shutdown[v6_in_v4] ^[[>0;10;1cPASSED [ 75%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v6_in_v6-1] PASSED                                    [ 80%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_modify_underlay_default[v6_in_v6-2] PASSED                                    [ 85%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_vxlan_remove_add_underlay_default[v6_in_v6]
----------------------------------------------------------------------- live log call -----------------------------------------------------------------------
19/11/2025 18:01:22 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to fddd:a100:a0::a17:10 through PortChannel or Ethernet interfaces.
19/11/2025 18:01:24 test_vxlan_ecmp.dump_self_info_and_run_p L0446 WARNING| No routes to fddd:a100:a0::a16:10 through PortChannel or Ethernet interfaces.
PASSED                                                                                                                                                [ 90%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_specific_route[v6_in_v6] PASSED                                            [ 95%]
vxlan/test_vxlan_underlay_ecmp.py::Test_VxLAN_underlay_ecmp::test_underlay_portchannel_shutdown[v6_in_v6] PASSED                                      [100%]
```
Test running time: 1:45:03

All tests in `vxlan/test_vxlan_ecmp.py` also passed on the same Cisco T1 switch. Total running time for these tests was 1:13:54.

#### Any platform specific information?
These tests are only for Mellanox and Cisco switches.

#### Supported testbed topology if it's a new test case?
T1 and its variations.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A