### PR TITLE
Enable dshell script code for T0/T1

### DIFF
--- a/tests/snappi_tests/cisco/helper.py
+++ b/tests/snappi_tests/cisco/helper.py
@@ -21,15 +21,15 @@ def disable_voq_watchdog(duthosts):
 
 def modify_voq_watchdog_cisco_8000(duthost, enable):
     asics = duthost.get_asic_ids()
-
-    '''
-    # Enable when T0/T1 supports voq_watchdog
-    #if not asics:
-    #    copy_set_voq_watchdog_script_cisco_8000(duthost, "", enable=enable)
-    '''
-
     if not wait_until(300, 20, 0, check_dshell_ready, duthost):
         raise RuntimeError("Debug shell is not ready on {}".format(duthost.hostname))
+
+    # Enable when T0/T1 supports voq_watchdog
+    if asics == [None]:
+        copy_set_voq_watchdog_script_cisco_8000(duthost, "", enable=enable)
+        duthost.shell("sudo show platform npu script -s set_voq_watchdog.py")
+        return
+
     for asic in asics:
         copy_set_voq_watchdog_script_cisco_8000(duthost, asic, enable=enable)
         duthost.shell(f"sudo show platform npu script -n asic{asic} -s set_voq_watchdog.py")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The cisco/helper.py::modify_voq_watchdog_cisco_8000() function is not enabled for single-asic, and fails for them. This PR enables the function for single-asic cisco platforms.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411
- [X] 202505

### Approach
#### What is the motivation for this PR?
Pls see description, the function fails for single-asic platforms. Need to fix this.

#### How did you do it?
Enabled the commented code, and fixed it for correct asic-checks.

#### How did you verify/test it?
Ran it in my single-asic platform testbed.
```
SKIPPED [1] snappi_tests/pfc/test_pfc_pause_response_with_snappi.py: got empty parameter set ['enum_pfc_pause_delay_test_params'], function test_pfc_pause_multi_lossless_headroom at /data/tests/snappi_tests/pfc/test_pfc_pause_response_with_snappi.py:93
SKIPPED [2] common/helpers/assertions.py:19: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] common/helpers/assertions.py:19: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_actions.py:90: Need Minimum of 2 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_actions.py:217: Need Minimum of 2 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:344: Forward action is not supported in cisco-8000.
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_actions.py:511: Need Minimum of 3 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_actions.py:648: Forward action is not supported in cisco-8000.
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_actions.py:818: Need Minimum of 2 ports of speed 100G defined in ansible/files/*links.csv file
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:141: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:141: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:189: Reboot type warm is not supported on cisco-8000 switches
SKIPPED [2] snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py:189: Reboot type fast is not supported on cisco-8000 switches
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:27: got empty parameter set ['multidut_port_info'], function test_mixed_speed_pfcwd_enable at /data/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:26
SKIPPED [1] snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:163: got empty parameter set ['multidut_port_info'], function test_mixed_speed_pfcwd_disable at /data/tests/snappi_tests/pfcwd/test_pfcwd_mixed_speed.py:162
================================================================================================= 82 passed, 62 skipped, 61 warnings in 35777.49s (9:56:17) ==================================================================================================
```
#### Any platform specific information?
Specific to Cisco-8000 only.