### PR TITLE
[chassis]: GCU: Update command to use -d all to show interfaces for multi-ASIC

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -365,6 +365,7 @@ def check_show_ip_intf(duthost, intf_name, expected_content_list, unexpected_con
     Vlan1000                          fc02:1000::1/64                             up/up         N/A             N/A
                                       fe80::5054:ff:feda:c6af%Vlan1000/64                       N/A             N/A
     """
+    address_family = "ip" if is_ipv4 else "ipv6"
     # Use -d all flag for multi-ASIC systems to show interfaces from all namespaces
     display_option = "-d all" if duthost.is_multi_asic else ""
     output = duthost.shell("show {} interfaces {} | grep -w {} || true".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/21365

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
The test case fails on Chassis when a backend portcahnnel interface is selected for test.
To list the ip interfaces, -d all option needs to be used for multi-asic systems to list backend interfaces.

#### How did you do it?
Updated the command to use multi-asic options, -d all

#### How did you verify/test it?
Run test on Chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
