### PR TITLE
Add retry for get impact area

### DIFF
--- a/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
+++ b/.azure-pipelines/impacted_area_testing/get-impacted-area.yml
@@ -129,11 +129,11 @@ steps:
         PR_CHECKERS=$(echo "${TEST_SCRIPTS}" | jq -c 'keys')
 
         if [[ $? -eq 0 ]] && echo "$PR_CHECKERS" | jq empty > /dev/null 2>&1; then
-          echo "PR_CHECKERS is valid JSON: $PR_CHECKERS"
+          echo "PR_CHECKERS is valid list: $PR_CHECKERS"
           echo "All validations passed successfully"
           break
         else
-          echo "PR_CHECKERS generation failed or invalid JSON: $PR_CHECKERS"
+          echo "PR_CHECKERS generation failed or invalid list: $PR_CHECKERS"
         fi
       else
         echo "TEST_SCRIPTS is not valid JSON: $TEST_SCRIPTS"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Get impacted area has a chance to get a valid json for TEST_SCRIPTS, and causing following steps fail to parse test scope and calculate instances. The reason may relate to azure agents, usually could be fixed by retry.
#### How did you do it?
Add retry for getting impacted area to stop bleeding.
#### How did you verify/test it?
Verified with sonic-mgmt and sonic-buildimage PR testing.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
