### PR TITLE
Update platform api to also support ipv6

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -8,6 +8,7 @@ import collections
 import ipaddress
 import time
 import json
+import re
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from paramiko.ssh_exception import AuthenticationException
@@ -823,6 +824,30 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                               cmd_desc="netstat")
 
     return duthosts
+
+
+@pytest.fixture(scope="module")
+def duthost_mgmt_ip(duthost):
+    """
+    Gets the management IP address (v4 or v6) on eth0.
+    Defaults to IPv4 on a dual stack configuration.
+    """
+    ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
+    ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
+
+    mgmt_interface = duthost.shell("show ip interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+    if mgmt_interface:
+        match = ipv4_regex.search(mgmt_interface)
+        if match:
+            return {"mgmt_ip": match.group(1), "version": "v4"}
+
+    mgmt_interface = duthost.shell("show ipv6 interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+    if mgmt_interface:
+        match = ipv6_regex.search(mgmt_interface)
+        if match:
+            return {"mgmt_ip": match.group(1), "version": "v6"}
+
+    pt_assert(False, "Failed to find duthost mgmt ip")
 
 
 def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Change platform api server so that HTTP requests can be received though IPv6 as an option.

This will fix `platform_tests/api/*` tests using a mgmt IPv6 configuration.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
