### PR TITLE
Set PTF_IMAGE_TAG to empty so branch value is used

### DIFF
--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -75,7 +75,7 @@ parameters:
 
   - name: PTF_IMAGE_TAG
     type: string
-    default: "latest"
+    default: ""
 
   - name: PTF_MODIFIED
     type: string


### PR DESCRIPTION
### Description of PR

All branches (master and release) use master branch pipeline code. Setting PTF_IMAGE_TAG to "" (empty) would let elastic-test's test_plan trigger to add-topo or restart-ptf to use the value on the respective branch from add_topo / renumber_topo on that branch. 

With this all the release branch builds would use branch-based tag name for release branches and latest for master branch.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

With this all the release branch builds would use branch-based tag name for release branches and latest for master branch.

#### How did you do it?

NA

#### How did you verify/test it?

NA

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA

### Documentation

NA