### PR TITLE
Cisco conversion testing

### DIFF
--- a/tests/cisco/__init__.py
+++ b/tests/cisco/__init__.py
@@ -1,0 +1,1 @@
+"""Cisco conversion tests."""

--- a/tests/cisco/conftest.py
+++ b/tests/cisco/conftest.py
@@ -1,0 +1,359 @@
+"""
+Pytest configuration for conversion tests.
+
+These tests are designed to test devices during the conversion process
+from vendor OS (e.g., Cisco IOS XR) to SONiC OS. The devices may not be
+running SONiC yet, so we need to skip SONiC-specific fact collection
+and provide alternative fixtures for non-SONiC devices.
+"""
+import pytest
+from tests.common.devices.cisco import CiscoHost
+
+
+DEFAULT_ANSIBLE_USER = "cisco"
+DEFAULT_ANSIBLE_PASSWORD = "password"
+
+
+def pytest_addoption(parser):
+    """Add conversion-specific command line options."""
+    parser.addoption(
+        '--dut_vendor',
+        action='store',
+        dest='dut_vendor',
+        default='cisco',
+        help="Vendor of the DUT (default: cisco for conversion tests). "
+             "Set to 'sonic' for SONiC devices."
+    )
+    parser.addoption(
+        '--full-migration',
+        action='store_true',
+        default=False,
+        help='Run all migration stages (stages 1-5) after artifact transfer stage.'
+    )
+
+
+@pytest.fixture(scope="session")
+def full_migration(request):
+    """Whether to run full migration stages after Stage 0 artifact transfer."""
+    return request.config.getoption("--full-migration")
+
+
+def pytest_configure(config):
+    """Configure pytest for conversion tests.
+    
+    For conversion tests, we default to non-sonic vendor unless explicitly
+    specified, since these tests target devices before/during conversion.
+    """
+    # Ensure dut_vendor is set for conversion tests
+    # This prevents SONiC fact collection from running on non-SONiC devices
+    if not hasattr(config.option, 'dut_vendor') or not config.option.dut_vendor:
+        config.option.dut_vendor = "cisco"
+
+
+@pytest.fixture(scope="session")
+def duthosts(request, tbinfo):
+    """
+    Minimal mock duthosts fixture to satisfy parent conftest dependencies.
+    
+    Conversion tests should use 'ciscohost' or 'duthost_console' fixtures instead.
+    This mock prevents errors from parent fixtures that depend on duthosts.
+    """
+    class MockDutHost:
+        """Mock DUT host object."""
+        def __init__(self, hostname):
+            self.hostname = hostname
+            self.critical_services = []
+            self.is_multi_asic = False
+            self.sonic_release = 'N/A'
+        
+        def __getattr__(self, name):
+            # Return a no-op function for any attribute access
+            def noop(*args, **kwargs):
+                return None
+            return noop
+        
+        def critical_services_tracking_list(self, *args, **kwargs):
+            """Mock critical services tracking - returns empty list."""
+            return []
+    
+    class MockDutHosts:
+        """Mock object that provides minimal duthosts interface."""
+        def __init__(self, dut_names):
+            self.dut_names = dut_names
+            self._dut_objects = [MockDutHost(name) for name in dut_names]
+        
+        def __iter__(self):
+            """Iterate over mock DUT objects, not strings."""
+            return iter(self._dut_objects)
+        
+        def __len__(self):
+            """Return the number of DUTs."""
+            return len(self.dut_names)
+        
+        def __getitem__(self, key):
+            """Return a minimal mock duthost object."""
+            # Support both index and hostname lookup
+            if isinstance(key, int):
+                return self._dut_objects[key]
+            # If it's a string hostname, find the matching object
+            for dut in self._dut_objects:
+                if dut.hostname == key:
+                    return dut
+            # If not found, create a new one
+            return MockDutHost(key)
+        
+        def shell(self, *args, **kwargs):
+            """Mock shell method - does nothing for non-SONiC devices."""
+            # Return a mock result that looks successful but does nothing
+            return {
+                'failed': False,
+                'rc': 0,
+                'stdout': '',
+                'stderr': ''
+            }
+        
+        def command(self, *args, **kwargs):
+            """Mock command method - does nothing for non-SONiC devices."""
+            return {
+                'failed': False,
+                'rc': 0,
+                'stdout': '',
+                'stderr': ''
+            }
+    
+    return MockDutHosts(tbinfo.get('duts', []))
+
+
+@pytest.fixture(scope="session")
+def ciscohost(ansible_adhoc, tbinfo):
+    """
+    Fixture to create a CiscoHost object for XR device testing in conversion tests.
+    
+    This provides SSH-based access to Cisco IOS XR devices using the CiscoHost class
+    which supports iosxr_command and iosxr_config Ansible modules.
+    
+    For multi-DUT testbeds (like Cisco 8800), this selects the supervisor card
+    for conversion operations.
+    
+    Use this fixture in conversion tests for clean SSH-based Cisco device access
+    without SONiC-specific mock methods.
+    
+    Returns:
+        CiscoHost: Host object for executing commands on Cisco XR device (supervisor)
+    """
+    
+    duts = tbinfo['duts']
+    dut_hostname = None
+    
+    # Select supervisor for multi-DUT testbeds, first DUT for single-DUT
+    if len(duts) == 1:
+        dut_hostname = duts[0]
+    else:
+        for dut in duts:
+            if '-sup-' in dut:
+                dut_hostname = dut
+                break
+        
+        # Final fallback
+        if not dut_hostname:
+            dut_hostname = duts[0]
+    
+    # Get credentials for the device  
+    ansible_user = DEFAULT_ANSIBLE_USER
+    ansible_passwd = DEFAULT_ANSIBLE_PASSWORD
+    
+    # Create and return CiscoHost instance
+    # Pass ansible_adhoc directly (not called), just like test_xr_ssh_basic.py does
+    cisco_host = CiscoHost(
+        ansible_adhoc=ansible_adhoc,
+        hostname=dut_hostname,
+        ansible_user=ansible_user,
+        ansible_passwd=ansible_passwd
+    )
+    
+    return cisco_host
+
+
+@pytest.fixture(scope="session")
+def duthost(duthosts, request, ansible_adhoc, tbinfo):
+    """
+    Override duthost to return a CiscoHost for conversion tests.
+    
+    This allows tests that use 'duthost' to work with Cisco devices
+    instead of SONiC devices. For multi-DUT testbeds, selects the supervisor.
+    
+    Returns:
+        CiscoHost: Cisco IOS XR host object (supervisor)
+    """
+    duts = tbinfo['duts']
+    dut_hostname = None
+    
+    # Select supervisor for multi-DUT testbeds, first DUT for single-DUT
+    if len(duts) == 1:
+        dut_hostname = duts[0]
+    else:
+        for dut in duts:
+            if '-sup-' in dut:
+                dut_hostname = dut
+                break
+        
+        # Final fallback
+        if not dut_hostname:
+            dut_hostname = duts[0]
+    
+    # Get credentials for the device
+    ansible_user = DEFAULT_ANSIBLE_USER
+    ansible_passwd = DEFAULT_ANSIBLE_PASSWORD
+    
+    # # Create and return CiscoHost instance
+    cisco_host = CiscoHost(
+        ansible_adhoc=ansible_adhoc,
+        hostname=dut_hostname,
+        ansible_user=ansible_user,
+        ansible_passwd=ansible_passwd
+    )
+    
+    # Add mock facts attribute to satisfy parent fixtures
+    # that expect SONiC-style facts dictionary
+    cisco_host.facts = {
+        'asic_type': 'cisco_xr',
+        'platform': 'cisco-8000',
+        'hwsku': 'Cisco-8800-RP',
+        'router_mac': '00:00:00:00:00:00',
+    }
+    
+    # Add os_version as a direct attribute (not just in facts dict)
+    cisco_host.os_version = 'IOS-XR'
+    
+    # Add commonly-accessed methods and properties to satisfy parent fixtures
+    
+    def get_up_time():
+        """Mock get_up_time for Cisco devices."""
+        return {"date_time": "00:00:00"}
+    
+    def show_and_parse(cmd, *args, **kwargs):
+        """Mock show_and_parse - returns empty dict."""
+        return {}
+    
+    def shell(cmd, *args, **kwargs):
+        """Mock shell method for Cisco devices."""
+        return {
+            'failed': False,
+            'rc': 0,
+            'stdout': '',
+            'stderr': ''
+        }
+    
+    def shell_cmds(cmds, *args, **kwargs):
+        """Mock shell_cmds for batch commands."""
+        return [{
+            'failed': False,
+            'rc': 0,
+            'stdout': '',
+            'stderr': ''
+        } for _ in cmds]
+    
+    def get_container_autorestart_states():
+        """Mock container autorestart states - returns empty dict."""
+        return {}
+    
+    def critical_services_tracking_list(*args, **kwargs):
+        """Mock critical services tracking - returns empty list."""
+        return []
+    
+    def copy(*args, **kwargs):
+        """Mock copy method for file operations."""
+        return {'changed': False}
+    
+    def get_asic_namespace_list():
+        """Mock namespace list - returns empty list."""
+        return []
+    
+    cisco_host.get_up_time = get_up_time
+    cisco_host.show_and_parse = show_and_parse
+    cisco_host.shell = shell
+    cisco_host.shell_cmds = shell_cmds
+    cisco_host.get_container_autorestart_states = get_container_autorestart_states
+    cisco_host.critical_services_tracking_list = critical_services_tracking_list
+    cisco_host.copy = copy
+    cisco_host.get_asic_namespace_list = get_asic_namespace_list
+    
+    # # Add properties
+    cisco_host.sonic_release = 'N/A'
+    cisco_host.critical_services = []
+    cisco_host.is_multi_asic = False
+    
+    return cisco_host
+
+
+@pytest.fixture(scope="session")
+def proxy_env():
+    """
+    Fixture to provide proxy environment variables for conversion tests.
+    
+    This is a simplified alternative to the main creds fixture that doesn't
+    require complex Ansible variable manager structures.
+    
+    Provides proxy configuration with multiple fallback layers:
+    1. Try to load from ansible group_vars if available
+    2. Fall back to environment variables  
+    3. Use Microsoft corporate proxy as final fallback
+    
+    Returns:
+        dict: Proxy environment variables (http_proxy, https_proxy, etc.)
+    """
+    import os
+    import glob
+    import yaml
+    import logging
+    
+    logger = logging.getLogger(__name__)
+    proxy_env = {}
+    
+    # Layer 1: Try to load proxy_env from ansible group_vars
+    try:
+        # Look for proxy_env in common ansible group var files
+        group_var_files = [
+            "../ansible/group_vars/all/*.yml",
+            "../ansible/vars/*.yml",
+            "../ansible/group_vars/sonic/*.yml"
+        ]
+        
+        for pattern in group_var_files:
+            files = glob.glob(pattern)
+            for f in files:
+                try:
+                    with open(f) as stream:
+                        data = yaml.safe_load(stream)
+                        if data and 'proxy_env' in data:
+                            proxy_env.update(data['proxy_env'])
+                            logger.info(f"Loaded proxy_env from {f}")
+                            break
+                except Exception as e:
+                    logger.debug(f"Could not load {f}: {e}")
+            
+            if proxy_env:  # Found proxy config, stop looking
+                break
+                
+    except Exception as e:
+        logger.debug(f"Could not load proxy_env from ansible vars: {e}")
+    
+    # Layer 2: Fall back to environment variables
+    if not proxy_env:
+        env_proxy_vars = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'no_proxy', 'NO_PROXY']
+        for var in env_proxy_vars:
+            if var in os.environ:
+                proxy_env[var.lower()] = os.environ[var]
+        
+        if proxy_env:
+            logger.info("Using proxy configuration from environment variables")
+    
+    # Layer 3: Use Microsoft corporate proxy as final fallback
+    if not proxy_env:
+        proxy_env = {
+            'no_proxy': 'localhost,127.0.0.1'
+        }
+        logger.info("Using Microsoft corporate proxy as fallback")
+    
+    logger.info(f"Proxy configuration: {list(proxy_env.keys())}")
+    return proxy_env

--- a/tests/cisco/conftest.py
+++ b/tests/cisco/conftest.py
@@ -348,12 +348,12 @@ def proxy_env():
         if proxy_env:
             logger.info("Using proxy configuration from environment variables")
     
-    # Layer 3: Use Microsoft corporate proxy as final fallback
+    # Layer 3: Fall back to a default no_proxy configuration (no proxy server configured)
     if not proxy_env:
         proxy_env = {
             'no_proxy': 'localhost,127.0.0.1'
         }
-        logger.info("Using Microsoft corporate proxy as fallback")
+        logger.info("No proxy configured; using default no_proxy for localhost only")
     
     logger.info(f"Proxy configuration: {list(proxy_env.keys())}")
     return proxy_env

--- a/tests/cisco/files/__init__.py
+++ b/tests/cisco/files/__init__.py
@@ -1,0 +1,1 @@
+"""Cisco conversion file assets."""

--- a/tests/cisco/files/common/__init__.py
+++ b/tests/cisco/files/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared Cisco conversion scripts and assets."""

--- a/tests/cisco/test_xr2sonic.py
+++ b/tests/cisco/test_xr2sonic.py
@@ -1,0 +1,1096 @@
+"""
+XR to SONiC Conversion Test for Cisco 8800 Chassis
+
+This test performs automated conversion from Cisco IOS XR to SONiC OS
+following a multi-stage migration process:
+1. Intermediate XR Upgrade (to migration-compatible XR version)
+2. Ownership Voucher (OV) Installation (enable customer mode)
+3. Authenticated Variable (AV) Installation + RP SONiC Migration
+4. Line Card (LC) SONiC Migration
+5. Post-Migration Validation
+
+Pattern-Based Command Execution:
+---------------------------------
+This test mimics the C# implementation's WriteLineAndWaitForRegexV2() behavior
+by using CiscoHost.exec_interactive() which:
+1. Executes SSH command with extended timeout
+2. Reads output continuously during command execution
+3. Can wait for specific patterns to appear in output
+4. Returns complete output with pattern_found indicator
+
+This ensures each migration stage completes and produces expected output
+before proceeding to the next stage, just like the C# console implementation.
+"""
+
+import pytest
+import logging
+import time
+from pathlib import Path
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.devices.sonic import SonicHost
+
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('t2'),
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.skip_check_dut_health,
+]
+
+# ============================================================================
+# CONSTANTS - File Paths and Locations
+# ============================================================================
+XR_PROVISION_ARTIFACTS_DIR = "/harddisk:/"  # XR uses /harddisk:/
+
+# Migration Scripts
+MIGRATION_SCRIPT_NAME = "sonic_migration_xr.py"
+MIGRATION_UTIL_SCRIPT_NAME = "sonic-migutil.py"
+MIGRATION_SCRIPT_LOCAL_SUBPATH = "cisco/files/common"
+
+# Firmware/Image Files
+ACS_REPO_BASE_URL = "http://your_repository/sonic/cisco/8000/"  # Base URL for repository
+SONIC_IMAGE_DOWNLOAD_NAME = "sonic-cisco-8000-20240532.40.bin"  # File to download from repo
+SONIC_IMAGE_NAME = "sonic-cisco-8000.bin"  # Required name on XR device for migration script
+INTERMEDIATE_XR_IMAGE_NAME = "8000-golden-x86_64-7.5.41.04I-GB_FPD_MACSEC.iso"
+ONIE_IMAGE_NAME = "onie-recovery-x86_64-cisco_8000-r0.efi64.pxe"
+
+# Voucher files
+VOUCHER_TARBALL_NAME = "vouchers.tar.gz"
+VOUCHER_TARBALL_PATH = "vouchers.tar.gz"
+VOUCHER_TARBALL_MD5_NAME = "vouchers.tar.gz.md5"
+VOUCHER_TARBALL_MD5_PATH = "vouchers.tar.gz.md5"
+
+# Default credentials used by the device after migration/rollback stages
+DEFAULT_SONIC_USERNAME = "admin"
+DEFAULT_SONIC_PASSWORD = "password"
+
+# Authenticated variable files
+AUTHENTICATED_VARIABLE_NAME = "dbcustomer_onie_sonic_rel.auth"
+AUTHENTICATED_VARIABLE_PATH = "dbcustomer_onie_sonic_rel.auth"
+# Note: MD5 file is named differently in the repo vs required name on device
+AUTHENTICATED_VARIABLE_MD5_DOWNLOAD_PATH = "dbcustomer_onie_sonic_rel.md5"  # Path in repo
+AUTHENTICATED_VARIABLE_MD5_NAME = "dbcustomer_onie_sonic_rel.auth.md5"  # Required name on device
+
+# ============================================================================
+# CONSTANTS - Commands and Patterns
+# ============================================================================
+INTERMEDIATE_XR_UPGRADE_CHECK_CMD = "run python /harddisk:/{0} --xr_upgrade --check --sonic_filename {1}"
+INTERMEDIATE_XR_INSTALL_CMD = "run python /harddisk:/{0} --xr_upgrade --sonic_filename {1}"
+OV_INSTALL_CMD = "run python /harddisk:/{0} --ov_install --sonic_filename {1}"
+AV_INSTALL_RP_MIGRATION_CMD = "run python /harddisk:/{0} --av_install --sonic_migration_rp --sonic_filename {1}"
+LC_MIGRATION_CMD = "sudo python /mnt/obfl/{0} --sonic_migration_lc --sonic_filename {1}"
+POST_MIGRATION_CHECK_CMD = "sudo python /mnt/obfl/{0} --sonic_migration_postcheck --sonic_filename {1}"
+
+# Success/Failure Messages
+INSTALL_SUCCESS_MESSAGE = "EXIT_ON_SUCCESS"
+INSTALL_FAILURE_MESSAGE = "EXIT_ON_FAILURE"
+ERROR_MESSAGE = "[ERROR]"
+UPGRADE_NOT_REQUIRED_MESSAGE = "Upgrade not required"
+OV_INSTALL_NOT_REQUIRED_MESSAGE = "OV installation not required"
+LC_MIGRATION_SUCCESS_MESSAGE = "INFO  all LCs are published their inventory"
+POST_MIGRATION_SUCCESS_REGEX = "All modules are migrated to sonic"
+POST_MIGRATION_FAILURE_REGEX = "All modules are not migrated to sonic"
+XR_UPGRADE_RELOAD_MESSAGE = "XR_UPGRADE: Device will now reload for IOS XR upgrade to"
+
+# ============================================================================
+# CONSTANTS - Timeouts (in seconds)
+# Based on C# reference values (safe timeouts)
+# C# values are more conservative than test_xr_migration.py empirical data
+# ============================================================================
+INTERMEDIATE_XR_UPGRADE_WAIT = 20 * 60  # 20 minutes wait after XR upgrade reboot
+OV_INSTALL_WAIT = 5 * 60  # 5 minutes wait after OV install
+AV_INSTALL_RP_MIGRATION_WAIT = 35 * 60  # 35 minutes wait after AV install and RP migration
+POST_MIGRATION_CHECK_WAIT = 10 * 60  # 10 minutes wait before post-migration checks
+
+
+# ============================================================================
+# HELPER FUNCTIONS - Pre-Conversion Setup
+# ============================================================================
+# NOTE: File Transfer Strategy for XR
+# ====================================
+# XR devices don't have curl/wget, so we use a two-step approach:
+# 1. Download files to localhost using curl (with proxy support) from repo
+# 2. Transfer from localhost to XR device using duthost.copy() (SCP)
+#
+# This approach works for:
+# - SONiC images (downloaded from repo)
+# - Firmware files (XR images, ONIE, vouchers, etc. - downloaded from repo)
+# - Migration scripts (copied from local tests/cisco/files/common/)
+#
+# For minigraphs:
+# - Devices are running XR, so we cannot backup minigraphs from them
+# - Instead, we use pre-saved minigraph files from tests/conversion/files/ngs_minigraphs/
+#   matching pattern: minigraph-8800-*.xml
+# ============================================================================
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+def download_file_from_repo(localhost, url, dest_path, proxy="", connect_timeout=30, max_time=600):
+    """
+    Download a file from repository using curl with automatic proxy fallback.
+    
+    Strategy: Try without proxy first, then retry with proxy if it fails.
+    This handles both local network access and external downloads gracefully.
+    
+    Args:
+        localhost: Localhost ansible connection
+        url: Full URL to download from
+        dest_path: Local destination path for the downloaded file
+        proxy: Proxy server URL (optional, e.g., 'http://proxy.example.com:8080')
+        connect_timeout: Connection timeout in seconds (default: 30)
+        max_time: Maximum time for the entire operation in seconds (default: 600)
+        
+    Returns:
+        dict: {'success': bool, 'rc': int, 'stdout': str, 'stderr': str, 'method': str}
+    """
+    logger.info(f"Downloading {Path(url).name} from {url}")
+    
+    # Use /usr/bin/curl explicitly to bypass any shell aliases or functions
+    # Also add --create-dirs to ensure destination directory exists
+    curl_binary = "/usr/bin/curl"
+    
+    # Attempt 1: Try without proxy (works for local network access)
+    logger.info("Attempting download without proxy...")
+    curl_cmd = f"{curl_binary} -k -L -f --create-dirs --connect-timeout {connect_timeout} --max-time {max_time} -o {dest_path} {url}"
+    logger.debug(f"Curl command: {curl_cmd}")
+    
+    # Use 'executable=/bin/bash' to ensure we're in bash and 'unalias curl' won't affect us
+    result = localhost.shell(curl_cmd, module_ignore_errors=True, executable="/bin/bash")
+    
+    if result['rc'] == 0:
+        # Verify file was actually downloaded
+        verify_result = localhost.shell(f"test -f {dest_path} && ls -lh {dest_path}", module_ignore_errors=True)
+        if verify_result['rc'] == 0:
+            logger.info(f"[OK] Successfully downloaded to {dest_path} (direct connection)")
+            logger.debug(f"File info: {verify_result.get('stdout', '')}")
+            return {
+                'success': True,
+                'rc': result['rc'],
+                'stdout': result.get('stdout', ''),
+                'stderr': result.get('stderr', ''),
+                'method': 'direct'
+            }
+        else:
+            logger.warning(f"Curl returned success but file not found at {dest_path}")
+    
+    # Attempt 2: If direct download failed and proxy is available, retry with proxy
+    if proxy:
+        logger.warning(f"Direct download failed, retrying with proxy: {proxy}")
+        curl_cmd_with_proxy = f"{curl_binary} -k -L -f --create-dirs --connect-timeout {connect_timeout} --max-time {max_time} -x {proxy} -o {dest_path} {url}"
+        logger.debug(f"Curl command with proxy: {curl_cmd_with_proxy}")
+        
+        result = localhost.shell(curl_cmd_with_proxy, module_ignore_errors=True, executable="/bin/bash")
+        
+        if result['rc'] == 0:
+            # Verify file was actually downloaded
+            verify_result = localhost.shell(f"test -f {dest_path} && ls -lh {dest_path}", module_ignore_errors=True)
+            if verify_result['rc'] == 0:
+                logger.info(f"[OK] Successfully downloaded to {dest_path} (via proxy)")
+                logger.debug(f"File info: {verify_result.get('stdout', '')}")
+                return {
+                    'success': True,
+                    'rc': result['rc'],
+                    'stdout': result.get('stdout', ''),
+                    'stderr': result.get('stderr', ''),
+                    'method': 'proxy'
+                }
+            else:
+                logger.warning(f"Curl with proxy returned success but file not found at {dest_path}")
+    
+    # Attempt 3: Try with wget as fallback (some environments have wget but not working curl)
+    logger.warning("Both curl attempts failed, trying wget as fallback...")
+    wget_cmd = f"/usr/bin/wget --no-check-certificate --timeout={connect_timeout} -T {max_time} -O {dest_path} {url}"
+    if proxy:
+        # Set proxy environment variable for wget
+        wget_cmd = f"https_proxy={proxy} http_proxy={proxy} {wget_cmd}"
+    
+    logger.debug(f"Wget command: {wget_cmd}")
+    result = localhost.shell(wget_cmd, module_ignore_errors=True, executable="/bin/bash")
+    
+    if result['rc'] == 0:
+        verify_result = localhost.shell(f"test -f {dest_path} && ls -lh {dest_path}", module_ignore_errors=True)
+        if verify_result['rc'] == 0:
+            logger.info(f"[OK] Successfully downloaded to {dest_path} (via wget)")
+            logger.debug(f"File info: {verify_result.get('stdout', '')}")
+            return {
+                'success': True,
+                'rc': result['rc'],
+                'stdout': result.get('stdout', ''),
+                'stderr': result.get('stderr', ''),
+                'method': 'wget'
+            }
+    
+    # All attempts failed
+    error_msg = result.get('stderr', result.get('stdout', 'Unknown error'))
+    logger.error(f"[FAIL] Download failed (tried curl direct, curl proxy, and wget): {error_msg}")
+    logger.error(f"Last return code: {result['rc']}")
+    return {
+        'success': False,
+        'rc': result['rc'],
+        'stdout': result.get('stdout', ''),
+        'stderr': result.get('stderr', ''),
+        'method': 'failed'
+    }
+
+
+def get_current_sonic_version(cisco_host):
+    """
+    Get current OS version from device.
+    
+    For SONiC devices, uses 'sonic_installer list' command.
+    For XR devices, uses 'show version' command.
+    
+    Args:
+        cisco_host: The Cisco host instance
+        
+    Returns:
+        String containing version information
+    """
+    # Try SONiC command first (using shell for SONiC-specific commands)
+    result = cisco_host.shell('sudo sonic-installer list | grep Current | cut -f2 -d " "', module_ignore_errors=True)
+    
+    # If SONiC command fails, device is likely running XR
+    if result.get('failed', False) or not result.get('stdout', '').strip():
+        # Use XR command via iosxr_command module
+        result = cisco_host.commands(commands=['show version brief'])
+        # iosxr_command returns stdout as a list
+        output = result.get('stdout', [''])[0] if isinstance(result.get('stdout'), list) else result.get('stdout', 'Unknown')
+        return output.strip()
+    
+    return result.get('stdout', 'Unknown').strip()
+
+
+def check_conversion_is_applicable(cisco_host):
+    """
+    Check if XR to SONiC conversion is applicable for this device.
+
+    Validates:
+    - Device is Cisco 8800 chassis
+    - Device is currently running XR (not already SONiC)
+    """
+    # Check if device is running Cisco IOS XR
+    result = cisco_host.commands(commands=['show version | include "Cisco IOS XR Software"'])
+    
+    # iosxr_command returns stdout as a list
+    version_output = result.get('stdout', [''])[0] if isinstance(result.get('stdout'), list) else result.get('stdout', '')
+    
+    if "Cisco IOS XR Software" not in version_output:
+        pytest.skip("Device is not running Cisco IOS XR - cannot perform XR to SONiC conversion")
+
+    # Check if device is already running SONiC
+    current_version = get_current_sonic_version(cisco_host)
+    if "SONiC" in current_version:
+        pytest.skip("Device already running SONiC - skipping XR to SONiC conversion")
+
+    logger.info(f"Device {cisco_host.hostname} is eligible for XR to SONiC conversion")
+    logger.info(f"Current XR version: {version_output.strip()}")
+
+
+def copy_minigraphs_to_provision_dir(cisco_host):
+    """
+    Copy all minigraph files to the provision directory.
+    
+    Transfers 4 minigraph files with pattern-based naming required by migration script:
+    - minigraph-8800-sup00.xml (supervisor slot 0)
+    - minigraph-8800-lc00.xml (line card slot 0)
+    - minigraph-8800-lc01.xml (line card slot 1)
+    - minigraph-8800-lc02.xml (line card slot 2)
+    """
+    base = Path(__file__).resolve().parent
+    mg_dir = base / "files" / "ngs_minigraphs"
+    
+    # Hardcoded minigraph files with pattern-based naming
+    minigraph_files = [
+        "minigraph-8800-sup00.xml",
+        "minigraph-8800-lc00.xml",
+        "minigraph-8800-lc01.xml",
+        "minigraph-8800-lc02.xml"
+    ]
+    
+    for mg_filename in minigraph_files:
+        src_file = mg_dir / mg_filename
+        dest_path = f"{XR_PROVISION_ARTIFACTS_DIR}{mg_filename}"
+        
+        pytest_assert(src_file.exists(), 
+                      f"Minigraph file not found: {src_file}")
+        
+        success = copy_file_with_retry(
+            cisco_host,
+            src=str(src_file),
+            dest=dest_path,
+            file_description=f"minigraph {mg_filename}",
+            max_retries=3,
+            delay_between_retries=5
+        )
+        
+        pytest_assert(success, f"Failed to transfer {mg_filename} after retries")
+        
+        # Wait between transfers to avoid SSH rate limiting
+        logger.info("Waiting 2 seconds to avoid SSH rate limiting...")
+        time.sleep(2)
+    
+    logger.info("All minigraphs transferred successfully")
+
+
+def copy_file_with_retry(cisco_host, src, dest, file_description, max_retries=3, delay_between_retries=5):
+    """
+    Copy a file to Cisco device with retry logic.
+    
+    Retries the copy operation if it fails, with delays between attempts.
+    Also verifies the file exists on the device after transfer.
+    
+    Args:
+        cisco_host: The Cisco host instance
+        src: Source file path (local)
+        dest: Destination file path (on device)
+        file_description: Human-readable description for logging
+        max_retries: Maximum number of retry attempts (default: 3)
+        delay_between_retries: Seconds to wait between retries (default: 5)
+    
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    for attempt in range(1, max_retries + 1):
+        try:
+            logger.info(f"Transferring {file_description} (attempt {attempt}/{max_retries})...")
+            
+            # Attempt the copy
+            result = cisco_host.copy(src=src, dest=dest)
+            
+            # Check if copy reported failure
+            if result.get('failed', False):
+                logger.warning(f"Copy reported failure: {result}")
+                if attempt < max_retries:
+                    logger.info(f"Waiting {delay_between_retries} seconds before retry...")
+                    time.sleep(delay_between_retries)
+                    continue
+                else:
+                    logger.error(f"Failed to transfer {file_description} after {max_retries} attempts")
+                    return False
+            
+            # Verify file exists on device with SSH retry logic
+            logger.info(f"Verifying {file_description} on device...")
+            dest_filename = dest.split('/')[-1]
+            
+            # Try verification with retries (SSH might not be immediately ready)
+            verification_attempts = 3
+            verification_successful = False
+            
+            for verify_attempt in range(1, verification_attempts + 1):
+                try:
+                    logger.info(f"Verification attempt {verify_attempt}/{verification_attempts}...")
+                    verify_result = cisco_host.commands(commands=[f'dir {dest}'])
+                    verify_output = verify_result.get('stdout', [''])[0] if isinstance(verify_result.get('stdout'), list) else verify_result.get('stdout', '')
+                    
+                    if dest_filename in verify_output or 'No such file' not in verify_output:
+                        logger.info(f"[OK] {file_description} transferred and verified successfully")
+                        verification_successful = True
+                        break
+                    else:
+                        logger.warning(f"File not found in dir output (verify attempt {verify_attempt})")
+                        if verify_attempt < verification_attempts:
+                            time.sleep(3)
+                            
+                except Exception as verify_error:
+                    # SSH connection errors are common - retry with backoff
+                    if "SSH protocol banner" in str(verify_error) or "Socket is closed" in str(verify_error):
+                        logger.warning(f"SSH connection issue during verification (attempt {verify_attempt}): {verify_error}")
+                        if verify_attempt < verification_attempts:
+                            logger.info(f"Waiting 5 seconds for SSH to stabilize...")
+                            time.sleep(5)
+                        else:
+                            logger.warning(f"SSH verification failed after {verification_attempts} attempts - assuming file transfer succeeded")
+                            # If copy succeeded but SSH verification failed, trust the copy operation
+                            # This is safer than failing the entire test
+                            verification_successful = True
+                            break
+                    else:
+                        # Other exceptions should be re-raised
+                        raise
+            
+            if verification_successful:
+                return True
+            else:
+                logger.warning(f"File verification inconclusive for {file_description}")
+                if attempt < max_retries:
+                    logger.info(f"Retrying entire copy operation after {delay_between_retries} seconds...")
+                    time.sleep(delay_between_retries)
+                    continue
+                else:
+                    logger.error(f"Failed to verify {file_description} after {max_retries} copy attempts")
+                    return False
+                    
+        except Exception as e:
+            logger.error(f"Exception during file transfer: {e}")
+            if attempt < max_retries:
+                logger.info(f"Waiting {delay_between_retries} seconds before retry...")
+                time.sleep(delay_between_retries)
+                continue
+            else:
+                logger.error(f"Failed to transfer {file_description} after {max_retries} attempts due to exception")
+                return False
+    
+    return False
+
+
+def download_and_transfer_artifacts(cisco_host, localhost, proxy_env):
+    """
+    Download and transfer all required files for XR to SONiC conversion:
+    - Migration scripts (sonic_migration_xr.py, sonic-migutil.py) - from local files
+    - SONiC image - from repo (downloaded as sonic-cisco-8000-20240532.40.bin, renamed to sonic-cisco-8000.bin)
+    - Intermediate XR image - from repo
+    - ONIE image - from repo
+    - Voucher tarball - from repo
+    - Voucher MD5 - from repo
+    - Authenticated variable file - from repo
+    - Authenticated variable MD5 - from repo
+    - Minigraphs for all modules - from local files
+    
+    Args:
+        cisco_host: The supervisor Cisco host instance
+        localhost: Localhost ansible connection for downloading files
+        proxy_env: Dictionary containing proxy environment variables
+    
+    Note: XR doesn't have curl, so we download to localhost first then SCP to XR device.
+    Note: SONiC image is renamed from SONIC_IMAGE_DOWNLOAD_NAME to SONIC_IMAGE_NAME as required by migration script.
+    """
+    
+    # Get proxy from environment or use default Microsoft corporate proxy
+    
+    # 1. Copy migration scripts from shared local files
+    tests_root = Path(__file__).resolve().parents[1]
+    scripts_path = tests_root / MIGRATION_SCRIPT_LOCAL_SUBPATH
+    pytest_assert(scripts_path.exists(), f"Migration scripts path not found: {scripts_path}")
+
+    success = copy_file_with_retry(
+        cisco_host,
+        src=str(scripts_path / MIGRATION_SCRIPT_NAME),
+        dest=f"{XR_PROVISION_ARTIFACTS_DIR}{MIGRATION_SCRIPT_NAME}",
+        file_description="migration script"
+    )
+    pytest_assert(success, f"Failed to transfer {MIGRATION_SCRIPT_NAME}")
+    time.sleep(2)
+    
+    success = copy_file_with_retry(
+        cisco_host,
+        src=str(scripts_path / MIGRATION_UTIL_SCRIPT_NAME),
+        dest=f"{XR_PROVISION_ARTIFACTS_DIR}{MIGRATION_UTIL_SCRIPT_NAME}",
+        file_description="migration utility script"
+    )
+    pytest_assert(success, f"Failed to transfer {MIGRATION_UTIL_SCRIPT_NAME}")
+    time.sleep(2)
+
+    # 2. Download SONiC image with special handling (download with one name, transfer with another)
+    logger.info(f"Downloading SONiC image from {ACS_REPO_BASE_URL}{SONIC_IMAGE_DOWNLOAD_NAME}")
+    temp_sonic_path = f"/tmp/{SONIC_IMAGE_DOWNLOAD_NAME}"
+    sonic_image_url = f"{ACS_REPO_BASE_URL}{SONIC_IMAGE_DOWNLOAD_NAME}"
+
+    https_proxy = proxy_env.get('https_proxy', '')
+    
+    result = download_file_from_repo(
+        localhost=localhost,
+        url=sonic_image_url,
+        dest_path=temp_sonic_path,
+        proxy=https_proxy,
+        max_time=600
+    )
+    
+    if not result['success']:
+        logger.error(f"Failed to download SONiC image: {result.get('stderr', '')}")
+        pytest_assert(False, "Failed to download SONiC image from repo")
+    
+    logger.info(f"SONiC image downloaded to localhost (method: {result['method']})")
+    
+    # Transfer with required name for migration script
+    logger.info(f"Transferring SONiC image to XR device as {SONIC_IMAGE_NAME}...")
+    success = copy_file_with_retry(
+        cisco_host,
+        src=temp_sonic_path,
+        dest=f"{XR_PROVISION_ARTIFACTS_DIR}{SONIC_IMAGE_NAME}",
+        file_description="SONiC image",
+        max_retries=3,
+        delay_between_retries=10  # Longer delay for large file
+    )
+    
+    # Cleanup temp file on localhost
+    localhost.shell(f"rm -f {temp_sonic_path}", module_ignore_errors=True)
+    
+    pytest_assert(success, f"Failed to transfer SONiC image after retries")
+    
+    # Wait to avoid SSH rate limiting on Cisco device
+    logger.info("Waiting 5 seconds to avoid SSH rate limiting...")
+    time.sleep(5)
+
+    # 3. Download other firmware files from repo to localhost, then transfer to XR device
+    # Files are stored with their download path (may include subdirectories) and destination filename
+    firmware_files = [
+        (INTERMEDIATE_XR_IMAGE_NAME, INTERMEDIATE_XR_IMAGE_NAME, "intermediate_xr"),
+        (ONIE_IMAGE_NAME, ONIE_IMAGE_NAME, "onie"),
+        (VOUCHER_TARBALL_PATH, VOUCHER_TARBALL_NAME, "vouchers"),
+        (VOUCHER_TARBALL_MD5_PATH, VOUCHER_TARBALL_MD5_NAME, "vouchers_md5"),
+        (AUTHENTICATED_VARIABLE_PATH, AUTHENTICATED_VARIABLE_NAME, "auth_variable"),
+        (AUTHENTICATED_VARIABLE_MD5_DOWNLOAD_PATH, AUTHENTICATED_VARIABLE_MD5_NAME, "auth_variable_md5")  # Download path != save name
+    ]
+
+    for download_path, dest_filename, file_type in firmware_files:
+        # Download from repo to localhost
+        file_url = f"{ACS_REPO_BASE_URL}{download_path}"
+        temp_file_path = f"/tmp/{dest_filename}"
+        
+        logger.info(f"Downloading {file_type} from {file_url}")
+        
+        result = download_file_from_repo(
+            localhost=localhost,
+            url=file_url,
+            dest_path=temp_file_path,
+            proxy=https_proxy,
+            max_time=600
+        )
+        
+        if not result['success']:
+            logger.error(f"Failed to download {file_type}: {result.get('stderr', '')}")
+            pytest_assert(False, f"Failed to download {file_type} from repo")
+        
+        logger.info(f"{file_type} downloaded to localhost (method: {result['method']})")
+        
+        # Transfer from localhost to XR device using SCP with retry
+        success = copy_file_with_retry(
+            cisco_host,
+            src=temp_file_path,
+            dest=f"{XR_PROVISION_ARTIFACTS_DIR}{dest_filename}",
+            file_description=file_type,
+            max_retries=3,
+            delay_between_retries=5
+        )
+        
+        # Cleanup temp file on localhost
+        localhost.shell(f"rm -f {temp_file_path}", module_ignore_errors=True)
+        
+        pytest_assert(success, f"Failed to transfer {file_type} after retries")
+        
+        # Wait between transfers to avoid SSH rate limiting on Cisco device
+        logger.info("Waiting 3 seconds to avoid SSH rate limiting...")
+        time.sleep(3)
+
+    # 4. Transfer minigraphs for all modules from local files
+    copy_minigraphs_to_provision_dir(cisco_host)
+
+    logger.info("All artifacts downloaded and transferred successfully")
+
+
+# ============================================================================
+# CONVERSION STAGE FUNCTIONS
+# ============================================================================
+
+
+def execute_intermediate_xr_upgrade(cisco_host, sonic_image_name):
+    """
+    Stage 1: Upgrade chassis to intermediate XR version.
+
+    This upgrades the device to a specific XR version (e.g., 7.5.41) that
+    supports the migration to SONiC.
+    
+    Uses pattern-based waiting to ensure
+    the upgrade command completes and produces expected output before proceeding.
+    """
+    logger.info("Starting Intermediate XR Upgrade...")
+
+    # Step 1: Run upgrade check
+    logger.info("Running XR upgrade pre-check...")
+    check_cmd = INTERMEDIATE_XR_UPGRADE_CHECK_CMD.format(MIGRATION_SCRIPT_NAME, sonic_image_name)
+    result = cisco_host.exec_interactive(
+        command=check_cmd,
+        expect_pattern=None,
+        timeout=300,  # 5 minutes for check
+        read_delay=2
+    )
+    
+    output = result.get('stdout', '') + "\n" + result.get('stderr', '')
+    
+    if result.get('failed', False) or ERROR_MESSAGE in output or INSTALL_SUCCESS_MESSAGE not in output:
+        logger.error(f"XR upgrade pre-check failed: {output}")
+        return False
+    
+    logger.info("XR upgrade pre-check passed")
+
+    # Step 2: Execute the upgrade
+    # Similar to test_xr_migration.py console flow:
+    # 1. Send upgrade command
+    # 2. Wait for "XR_UPGRADE: Device will now reload" message
+    # 3. Device reboots (SSH connection will drop)
+    # 4. Wait for device to come back online
+    # 5. SSH reconnects automatically (handled by Ansible connection)
+    logger.info("Executing intermediate XR upgrade command...")
+    cmd = INTERMEDIATE_XR_INSTALL_CMD.format(MIGRATION_SCRIPT_NAME, sonic_image_name)
+    
+    result = cisco_host.exec_interactive(
+        command=cmd,
+        expect_pattern=XR_UPGRADE_RELOAD_MESSAGE,  # Wait for reload message
+        timeout=600,  # 10 minutes to wait for command to trigger reload
+        read_delay=2
+    )
+    
+    output = result.get('stdout', '') + "\n" + result.get('stderr', '')
+    
+    # Check for errors first
+    if ERROR_MESSAGE in output or INSTALL_FAILURE_MESSAGE in output:
+        logger.error(f"Intermediate XR upgrade failed: {output}")
+        return False
+    
+    # Check what happened
+    if UPGRADE_NOT_REQUIRED_MESSAGE in output:
+        logger.info("Intermediate XR upgrade not required - already at correct version")
+        return True
+    
+    # If we got the reload message or success message, device will reboot
+    if result.get('pattern_found') or INSTALL_SUCCESS_MESSAGE in output or XR_UPGRADE_RELOAD_MESSAGE in output:
+        logger.info("Intermediate XR upgrade initiated - device will reboot")
+        logger.info("SSH connection will be disconnected during reload")
+        
+        # Wait for device to reload and come back online
+        # test_xr_migration.py uses 2000 second timeout for reload + login
+        # After reload, it waits for boot, does login sequence, then sleeps 120 seconds
+        logger.info(f"Waiting {INTERMEDIATE_XR_UPGRADE_WAIT} seconds for device to reload and stabilize...")
+        time.sleep(INTERMEDIATE_XR_UPGRADE_WAIT)
+        
+        # Verify device is accessible after upgrade
+        # SSH connection should automatically reconnect via Ansible
+        logger.info("Verifying device accessibility after XR upgrade...")
+        max_retries = 10
+        retry_interval = 5 * 60  # 5 minute between retries
+        
+        for attempt in range(1, max_retries + 1):
+            try:
+                logger.info(f"Attempting to connect (attempt {attempt}/{max_retries})...")
+                version_result = cisco_host.commands(commands=["show version"], module_ignore_errors=True)
+                
+                if version_result.get('failed', False) == False:
+                    logger.info("Device accessible after XR upgrade")
+                    # Additional 120 second stabilization like test_xr_migration.py
+                    logger.info("Waiting 120 seconds for system to stabilize...")
+                    time.sleep(120)
+                    logger.info("Intermediate XR upgrade completed successfully")
+                    return True
+                else:
+                    logger.warning(f"Device returned error: {version_result.get('msg', 'Unknown error')}")
+                    if attempt < max_retries:
+                        logger.info(f"Waiting {retry_interval} seconds before retry...")
+                        time.sleep(retry_interval)
+                    continue
+                    
+            except Exception as e:
+                logger.warning(f"Connection attempt {attempt} failed: {e}")
+                if attempt < max_retries:
+                    logger.info(f"Waiting {retry_interval} seconds before retry...")
+                    time.sleep(retry_interval)
+                else:
+                    logger.error(f"Failed to reconnect after {max_retries} attempts")
+                    return False
+        
+        logger.error("Failed to verify device accessibility after XR upgrade")
+        return False
+
+    logger.error(f"Unexpected response from intermediate XR upgrade: {output[:500]}")
+    return False
+
+
+def execute_ov_installation(cisco_host, sonic_image_name):
+    """
+    Stage 2: Ownership Voucher (OV) Installation.
+
+    Installs ownership vouchers to enable customer mode on the chassis.
+    
+    Similar to C# HwCiscoSpitfireSwitch.OvInstallation():
+    1. Execute OV install command
+    2. Wait for success/failure message (15 min timeout)
+    3. If success and not already installed:
+       - Sleep for OV_INSTALL_WAIT (5 min) for installation and reboot
+       - Reconnect via SSH (device reboots during OV installation)
+    """
+    logger.info("Starting Ownership Voucher (OV) Installation...")
+
+    cmd = OV_INSTALL_CMD.format(MIGRATION_SCRIPT_NAME, sonic_image_name)
+    
+    # Wait for either EXIT_ON_SUCCESS or EXIT_ON_FAILURE during execution
+    pattern = f"({INSTALL_SUCCESS_MESSAGE}|{INSTALL_FAILURE_MESSAGE})"
+    
+    result = cisco_host.exec_interactive(
+        command=cmd,
+        expect_pattern=pattern,
+        timeout=15 * 60,  # 15 minutes (WaitForSuccessMessageTimeoutMs in C#)
+        read_delay=2
+    )
+    
+    output = result.get('stdout', '') + "\n" + result.get('stderr', '')
+    
+    logger.info(f"OV installation output: {output[:500]}...")
+    
+    # Check if pattern was found
+    if not result.get('pattern_found'):
+        logger.error(f"Expected pattern '{pattern}' not found in OV installation output: {output}")
+        return False
+    
+    # Check for failure messages
+    if INSTALL_FAILURE_MESSAGE in output:
+        logger.error(f"OV installation failed: {output}")
+        return False
+    
+    # At this point we have EXIT_ON_SUCCESS
+    if INSTALL_SUCCESS_MESSAGE not in output:
+        logger.error(f"No success message found in OV installation output: {output}")
+        return False
+    
+    # Check if OV installation was already done
+    if OV_INSTALL_NOT_REQUIRED_MESSAGE in output:
+        logger.info("OV installation not required - already installed on device")
+        return True
+    
+    # OV installation will proceed - device will reboot
+    logger.info("Successfully executed OV installation script. OV Installation and device reboot will take place.")
+    
+    # C# sleeps for OvInstallTimeoutMs (5 min) before login to give time for install and reboot
+    logger.info(f"Sleeping for {OV_INSTALL_WAIT} seconds before reconnecting (device is rebooting)...")
+    time.sleep(OV_INSTALL_WAIT)
+    
+    # C# calls Login() to reconnect after OV installation reboot
+    # SSH connection should automatically reconnect via Ansible, but we verify
+    logger.info("Attempting to reconnect after OV installation and reboot...")
+    max_retries = 5
+    retry_interval = 60  # 1 minute between retries
+    
+    for attempt in range(1, max_retries + 1):
+        try:
+            logger.info(f"Connection attempt {attempt}/{max_retries}...")
+            version_result = cisco_host.commands(commands=["show version"], module_ignore_errors=True)
+            
+            if version_result.get('failed', False) == False:
+                logger.info("Successfully logged into device after OV installation and reboot")
+                return True
+            else:
+                logger.warning(f"Device returned error: {version_result.get('msg', 'Unknown error')}")
+                if attempt < max_retries:
+                    logger.info(f"Waiting {retry_interval} seconds before retry...")
+                    time.sleep(retry_interval)
+                continue
+                
+        except Exception as e:
+            logger.warning(f"Connection attempt {attempt} failed: {e}")
+            if attempt < max_retries:
+                logger.info(f"Waiting {retry_interval} seconds before retry...")
+                time.sleep(retry_interval)
+            else:
+                logger.error(f"Unable to login after OV installation and reboot of the device")
+                return False
+    
+    logger.error("Failed to reconnect after OV installation")
+    return False
+
+
+def execute_av_installation_and_rp_migration(cisco_host, sonic_image_name):
+    """
+    Stage 3: Authenticated Variable (AV) Installation + Route Processor (RP) SONiC Migration.
+
+    This is a critical stage that:
+    1. Installs authenticated variables
+    2. Migrates the Route Processor (supervisor) to SONiC
+    
+    - Uses WriteLineAndWaitForRegexV2() with TimeoutScope(WaitForSuccessMessageTimeoutMs = 15 min)
+    - Waits for ExecPromptRegex (command completion prompt)
+    - Checks buffer for InstallSuccessMessage
+    - Returns immediately after success (no sleep/login in this function)
+    - Calling code handles 35-minute wait and login verification
+    """
+    logger.info("Starting AV Installation and RP SONiC Migration...")
+
+    cmd = AV_INSTALL_RP_MIGRATION_CMD.format(MIGRATION_SCRIPT_NAME, sonic_image_name)
+    
+    # C# uses TimeoutScope = 15 minutes
+    # and waits for ExecPromptRegex (not a success/failure pattern)
+    result = cisco_host.exec_interactive(
+        command=cmd,
+        expect_pattern=None,  # C# waits for ExecPromptRegex which is just the prompt returning
+        timeout=15 * 60,  # 15 minutes (WaitForSuccessMessageTimeoutMs in C#)
+        read_delay=2
+    )
+    
+    output = result.get('stdout', '') + "\n" + result.get('stderr', '')
+    
+    logger.info(f"AV installation and RP migration output: {output[:500]}...")
+    
+    # C# checks if buffer contains InstallSuccessMessage after command returns
+    if INSTALL_SUCCESS_MESSAGE in output:
+        logger.info("Script execution is success. AV installation and RP sonic migration starts.")
+        # C# returns true immediately here - no sleep, no login verification
+        # The calling code (test_xr2sonic_migration) will:
+        # 1. Sleep for AV_INSTALL_RP_MIGRATION_WAIT (35 min)
+        # 2. Attempt login to verify RP migration
+        return True
+    
+    # Check for failure
+    if INSTALL_FAILURE_MESSAGE in output or ERROR_MESSAGE in output:
+        logger.error(f"AV installation and RP Sonic Migration failed: {output}")
+        return False
+    
+    logger.error(f"AV installation and RP migration failed - no success message found: {output}")
+    return False
+
+
+def execute_lc_migration(cisco_host, sonic_image_name):
+    """
+    Stage 4: Line Card (LC) SONiC Migration.
+
+    Migrates all line cards to SONiC OS.
+    
+    C# equivalent: WriteLineAndWaitForRegexV2(lcSonicMigrationCommand, LCMigrationSuccessMessage)
+    with TimeoutScope(LCMigrationTimeoutMs = 20 min)
+    
+    Matches C# LcSonicMigration() at lines 887-924:
+    - Uses pattern matching during execution (waits for LC_MIGRATION_SUCCESS_MESSAGE)
+    - Timeout: 20 minutes
+    - After success: Sleep 5 min (WaitBeforeLoginAfterLcMigration)
+    - Verify login successful
+    """
+    logger.info("Starting Line Card (LC) SONiC Migration...")
+
+    cmd = LC_MIGRATION_CMD.format(MIGRATION_SCRIPT_NAME, sonic_image_name)
+    
+    # Execute command and wait for LC migration success message DURING execution
+    # C#: WriteLineAndWaitForRegexV2(..., LCMigrationSuccessMessage) 
+    result = cisco_host.exec_interactive(
+        command=cmd,
+        expect_pattern=LC_MIGRATION_SUCCESS_MESSAGE,  # Wait for pattern during execution
+        timeout=20 * 60,  # 20 minutes (LCMigrationTimeoutMs)
+        read_delay=2
+    )
+    
+    output = result.get('stdout', '') + "\n" + result.get('stderr', '')
+    
+    # Check if pattern was found
+    if result.get('pattern_found') is not True:
+        logger.error(f"LC migration failed - did not find success message: {output}")
+        return False
+    
+    if result.get('failed', False) or ERROR_MESSAGE in output:
+        logger.error(f"LC migration failed: {output}")
+        return False
+    
+    logger.info("LC migration completed successfully - all LCs published their inventory")
+    
+    # C#: Sleep(WaitBeforeLoginAfterLcMigration) = 5 minutes
+    logger.info(f"Sleeping for {5 * 60} seconds before login (WaitBeforeLoginAfterLcMigration)...")
+    time.sleep(5 * 60)
+    
+    # C# attempts login after LC migration: supervisorSwitch.Login()
+    logger.info("Attempting login after LC migration...")
+    try:
+        # Use a basic Linux command that should work on SONiC
+        result = cisco_host.shell("whoami", module_ignore_errors=True)
+        if result.get('rc') == 0:
+            logger.info("Successfully logged in after LC migration")
+            return True
+        else:
+            logger.error("Unable to login after LC migration")
+            return False
+    except Exception as e:
+        logger.error(f"Failed to login after LC migration: {e}")
+        return False
+
+
+def execute_post_migration_checks(cisco_host, sonic_image_name):
+    """
+    Stage 5: Post-Migration Validation.
+
+    Verifies that all modules (supervisor + line cards) have been
+    successfully migrated to SONiC.
+    
+    Matches C# PostMigrationChecks() at lines 926-960:
+    - Uses pattern matching during execution
+    - Pattern: PostMigrationCheckSuccessRegex OR PostMigrationCheckFailureRegex
+    - Timeout: 10 minutes (PostMigrationCheckTimeoutMs)
+    """
+    logger.info("Running post-migration checks...")
+
+    cmd = POST_MIGRATION_CHECK_CMD.format(MIGRATION_SCRIPT_NAME, sonic_image_name)
+    
+    # C#: expectedRegex = FexRegex.Join(PostMigrationCheckSuccessRegex, PostMigrationCheckFailureRegex)
+    # C#: WriteLineAndWaitForRegexV2(postCheckCommand, expectedRegex) with TimeoutScope(10 min)
+    pattern = f"({POST_MIGRATION_SUCCESS_REGEX}|{POST_MIGRATION_FAILURE_REGEX})"
+    
+    result = cisco_host.exec_interactive(
+        command=cmd,
+        expect_pattern=pattern,
+        timeout=10 * 60,  # 10 minutes (PostMigrationCheckTimeoutMs)
+        read_delay=2
+    )
+    
+    output = result.get('stdout', '') + "\n" + result.get('stderr', '')
+    
+    # Check if pattern was found
+    if result.get('pattern_found') is not True:
+        logger.error(f"Post-migration checks timed out - no success/failure message found: {output}")
+        return False
+    
+    # Check for errors
+    if result.get('failed', False) or ERROR_MESSAGE in output:
+        logger.error(f"Error occurred during post-migration checks: {output}")
+        return False
+    
+    # Check which pattern matched
+    if POST_MIGRATION_SUCCESS_REGEX in output:
+        logger.info("Post-migration checks PASSED - all modules migrated to SONiC")
+        return True
+
+    if POST_MIGRATION_FAILURE_REGEX in output:
+        logger.error("Post-migration checks FAILED - not all modules migrated")
+        return False
+
+    logger.error(f"Unable to determine post-migration check status: {output}")
+    return False
+
+
+# ============================================================================
+# MAIN TEST FUNCTION
+# ============================================================================
+
+def test_xr2sonic(ciscohost, localhost, ansible_adhoc, proxy_env, full_migration):
+    """
+    Main test function for XR to SONiC conversion on Cisco 8800 chassis.
+
+    Test Flow:
+    1. Validate conversion is applicable
+    2. Download and transfer all required artifacts
+    3. Execute Intermediate XR Upgrade
+    4. Execute OV Installation
+    5. Execute AV Installation + RP Migration
+    6. Execute LC Migration
+    7. Execute Post-Migration Checks
+    8. Validate final SONiC version
+    
+        By default, this test stops after Stage 0 (artifact transfer) for safety.
+        Use --full-migration to run stages 1-5.
+    """
+    cisco_host = ciscohost
+
+    # Pre-conversion checks
+    check_conversion_is_applicable(cisco_host)
+
+    # Log current version
+    logger.info("=== Pre-Conversion State ===")
+    version = get_current_sonic_version(cisco_host)
+    logger.info(f"{cisco_host.hostname}: {version}")
+
+    # Stage 0: Download and transfer artifacts
+    logger.info("=== Stage 0: Downloading Artifacts ===")
+    download_and_transfer_artifacts(cisco_host, localhost, proxy_env)
+    
+    # Verify files were transferred successfully
+    logger.info("=== Verifying Transferred Files ===")
+    files_to_verify = [
+        MIGRATION_SCRIPT_NAME,
+        MIGRATION_UTIL_SCRIPT_NAME,
+        SONIC_IMAGE_NAME,
+        INTERMEDIATE_XR_IMAGE_NAME,
+        ONIE_IMAGE_NAME,
+        VOUCHER_TARBALL_NAME,
+        VOUCHER_TARBALL_MD5_NAME,
+        AUTHENTICATED_VARIABLE_NAME,
+        AUTHENTICATED_VARIABLE_MD5_NAME,
+        "minigraph-8800-sup00.xml",
+        "minigraph-8800-lc00.xml",
+        "minigraph-8800-lc01.xml",
+        "minigraph-8800-lc02.xml"
+    ]
+    
+    for filename in files_to_verify:
+        dest_path = f"{XR_PROVISION_ARTIFACTS_DIR}{filename}"
+        logger.info(f"Verifying {filename} on device...")
+        verify_result = cisco_host.commands(commands=[f'dir {dest_path}'])
+        verify_output = verify_result.get('stdout', [''])[0] if isinstance(verify_result.get('stdout'), list) else verify_result.get('stdout', '')
+        
+        if filename in verify_output or 'No such file' not in verify_output:
+            logger.info(f"[OK] Verified: {filename}")
+            logger.debug(f"  {verify_output.strip()}")
+        else:
+            logger.error(f"[FAIL] Missing: {filename}")
+            pytest_assert(False, f"File not found on device: {filename}")
+    
+    logger.info("=== Stage 0 Completed Successfully ===")
+    logger.info("All required files have been downloaded and transferred to the device.")
+    logger.info(f"Files are located in: {XR_PROVISION_ARTIFACTS_DIR}")
+    
+    if not full_migration:
+        logger.info("=== SAFETY MODE: Stopping after Stage 0 ===")
+        logger.info("Full migration is disabled. To proceed with migration stages 1-5,")
+        logger.info("run pytest with --full-migration.")
+        pytest.skip("Stopping after Stage 0 (artifact transfer) - full migration is disabled")
+        return
+
+    # Stage 1: Intermediate XR Upgrade
+    logger.info("=== Stage 1: Intermediate XR Upgrade ===")
+    success = execute_intermediate_xr_upgrade(cisco_host, SONIC_IMAGE_NAME)
+    pytest_assert(success, "Intermediate XR upgrade failed")
+
+    # Stage 2: OV Installation
+    logger.info("=== Stage 2: OV Installation ===")
+    success = execute_ov_installation(cisco_host, SONIC_IMAGE_NAME)
+    pytest_assert(success, "OV installation failed")
+
+    # Stage 3: AV Installation + RP Migration
+    logger.info("=== Stage 3: AV Installation + RP Migration ===")
+    success = execute_av_installation_and_rp_migration(cisco_host, SONIC_IMAGE_NAME)
+    pytest_assert(success, "AV installation and RP migration failed")
+    
+    # C# flow: After AvInstallationAndRpSonicMigration() returns, the calling code:
+    # 1. Sleeps for AvInstallAndRpSonicMigrationTimeoutMs (35 min)
+    # 2. Attempts login to verify RP migration was successful
+    logger.info(f"Sleeping for {AV_INSTALL_RP_MIGRATION_WAIT} seconds for AV Installation and RP migration to complete...")
+    time.sleep(AV_INSTALL_RP_MIGRATION_WAIT)
+    
+    # After RP migration, the device is now running SONiC with default credentials
+    # Create SonicHost instance to interact with the SONiC device
+    logger.info("Creating SonicHost instance for SONiC device...")
+    sonic_host = SonicHost(
+        ansible_adhoc=ansible_adhoc,
+        hostname=cisco_host.hostname,
+        ssh_user=DEFAULT_SONIC_USERNAME,
+        ssh_passwd=DEFAULT_SONIC_PASSWORD
+    )
+    logger.info("SonicHost instance created successfully")
+    
+    # Verify SONiC is accessible and get version
+    logger.info("Verifying RP migration to SONiC...")
+    current_version = get_current_sonic_version(sonic_host)
+    pytest_assert("SONiC" in current_version, f"RP migration failed - not running SONiC: {current_version}")
+    logger.info(f"RP successfully migrated to SONiC: {current_version}")
+
+    # From this point forward, use sonic_host instead of cisco_host
+    # Stage 4: LC Migration
+    logger.info("=== Stage 4: LC Migration ===")
+    success = execute_lc_migration(sonic_host, SONIC_IMAGE_NAME)
+    pytest_assert(success, "LC migration failed")
+
+    # C#: Sleep(WaitBeforePerformingPostMigrationCheck) = 10 minutes
+    # This delay is for obfl directory mounting time before post-migration checks
+    logger.info(
+        f"Sleeping for {POST_MIGRATION_CHECK_WAIT} seconds before post-migration checks "
+        "(WaitBeforePerformingPostMigrationCheck)..."
+    )
+    time.sleep(POST_MIGRATION_CHECK_WAIT)
+
+    # Stage 5: Post-Migration Checks
+    logger.info("=== Stage 5: Post-Migration Checks ===")
+    success = execute_post_migration_checks(sonic_host, SONIC_IMAGE_NAME)
+    pytest_assert(success, "Post-migration checks failed")
+
+    # Final validation
+    logger.info("=== Final Validation ===")
+    current_version = get_current_sonic_version(sonic_host)
+    pytest_assert("SONiC" in current_version,
+                 f"Expected SONiC in version string for {sonic_host.hostname}, got {current_version}")
+    logger.info(f"{sonic_host.hostname}: {current_version}")
+
+    logger.info("=== XR to SONiC Conversion Completed Successfully ===")

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -6,6 +6,7 @@ import functools
 import time
 from paramiko import SSHClient, AutoAddPolicy
 from tests.common.devices.base import AnsibleHostBase
+from tests.common.helpers.interactive_ssh import exec_interactive_ssh
 from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 
 # If the version of the Python interpreter is greater or equal to 3, set the unicode variable to the str class.
@@ -91,7 +92,13 @@ class CiscoHost(AnsibleHostBase):
         self.localhost = ansible_adhoc(inventory='localhost', connection='local', host_pattern="localhost")["localhost"]
 
     def __getattr__(self, module_name):
+        # List of standard Ansible modules allowed for Cisco devices
+        allowed_modules = ['copy', 'shell', 'command', 'file', 'fetch', 'stat', 'template']
+        # Network modules that work with network_cli connection
+        network_modules = ['net_put', 'net_get']
+        
         if module_name.startswith('iosxr_'):
+            # IOS XR specific modules - use network_cli connection
             evars = {
                 'ansible_connection': 'network_cli',
                 'ansible_network_os': module_name.split('_', 1)[0],
@@ -100,6 +107,30 @@ class CiscoHost(AnsibleHostBase):
                 'ansible_ssh_user': self.ansible_user,
                 'ansible_ssh_pass': self.ansible_passwd,
             }
+            self.host.options['variable_manager'].extra_vars.update(evars)
+            return super(CiscoHost, self).__getattr__(module_name)
+        elif module_name in network_modules:
+            # Network file transfer modules - use network_cli connection
+            evars = {
+                'ansible_connection': 'network_cli',
+                'ansible_network_os': 'iosxr',
+                'ansible_user': self.ansible_user,
+                'ansible_password': self.ansible_passwd,
+                'ansible_ssh_user': self.ansible_user,
+                'ansible_ssh_pass': self.ansible_passwd,
+            }
+            self.host.options['variable_manager'].extra_vars.update(evars)
+            return super(CiscoHost, self).__getattr__(module_name)
+        elif module_name in allowed_modules:
+            # Standard Ansible modules - use default SSH connection
+            evars = {
+                'ansible_user': self.ansible_user,
+                'ansible_password': self.ansible_passwd,
+                'ansible_ssh_user': self.ansible_user,
+                'ansible_ssh_pass': self.ansible_passwd,
+            }
+            self.host.options['variable_manager'].extra_vars.update(evars)
+            return super(CiscoHost, self).__getattr__(module_name)
         else:
             raise Exception("Does not have module: {}".format(module_name))
         self.host.options['variable_manager'].extra_vars.update(evars)
@@ -1365,3 +1396,184 @@ class CiscoHost(AnsibleHostBase):
             return False, output
         except Exception as e:
             return False, "Failed to reboot the device {}. due to {}".format(self.hostname, str(e))
+
+    def copy(self, src=None, dest=None, content=None, **kwargs):
+        """
+        Copy file to Cisco IOS XR device using SFTP (Paramiko).
+        
+        IOS XR devices don't support standard Ansible copy/net_put properly,
+        so we use Paramiko's SFTP to transfer files directly to the device.
+        
+        Args:
+            src (str): Local file path to copy to device
+            dest (str): Destination path on the device (e.g., 'disk0:/filename' or 'harddisk:/filename')
+            content (str): Content to write to file (will create temp file first)
+            **kwargs: Additional arguments
+            
+        Returns:
+            dict: Result dictionary with 'changed', 'failed', etc.
+            
+        Examples:
+            # Copy file from local to device
+            result = ciscohost.copy(src='/tmp/config.txt', dest='disk0:/config.txt')
+            
+            # Write content to file
+            result = ciscohost.copy(content='test data', dest='harddisk:/test.txt')
+        """
+        import tempfile
+        import os
+        
+        # Prepare source file
+        temp_file_created = False
+        if content is not None:
+            # Create a temporary file with the content
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as temp_file:
+                temp_file.write(content)
+                src_file = temp_file.name
+            temp_file_created = True
+        elif src is not None:
+            src_file = src
+        else:
+            raise ValueError("Either 'src' or 'content' must be specified")
+        
+        if dest is None:
+            raise ValueError("'dest' must be specified")
+        
+        ssh_client = None
+        try:
+            # Use Paramiko SFTP to transfer the file
+            ssh_client = SSHClient()
+            ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+            ssh_client.connect(
+                self.mgmt_ip,
+                username=self.ansible_user,
+                password=self.ansible_passwd,
+                look_for_keys=False,
+                allow_agent=False
+            )
+            
+            sftp = ssh_client.open_sftp()
+            sftp.put(src_file, dest)
+            sftp.close()
+            
+            return {
+                'failed': False,
+                'changed': True,
+                'dest': dest,
+                'src': src_file,
+                'rc': 0,
+                'stdout': '',
+                'stderr': ''
+            }
+            
+        except Exception as e:
+            error_msg = f'SFTP transfer failed: {str(e)}'
+            logger.error(f"Failed to copy file to {self.hostname}: {error_msg}")
+            return {
+                'failed': True,
+                'changed': False,
+                'dest': dest,
+                'src': src_file,
+                'rc': 1,
+                'stdout': '',
+                'stderr': error_msg
+            }
+        finally:
+            # Close SSH connection
+            if ssh_client:
+                try:
+                    ssh_client.close()
+                except Exception:
+                    pass
+            
+            # Clean up temp file if we created one
+            if temp_file_created:
+                try:
+                    os.unlink(src_file)
+                except Exception:
+                    pass
+
+    def exec_interactive(self, command, expect_pattern=None, response="", timeout=30, read_delay=1):
+        """
+        Execute an interactive command on Cisco IOS XR device using Paramiko shell.
+        
+        This method handles interactive commands that require user confirmation or input.
+        It can wait for a specific pattern (regex) and send an automated response.
+        
+        Args:
+            command (str): Command to execute (e.g., 'delete /harddisk:/file.txt')
+            expect_pattern (str, optional): Regex pattern to wait for before sending response.
+                                           If None, just executes command without waiting.
+                                           Common patterns:
+                                           - r'\[confirm\]' - for delete/reload commands
+                                           - r'\(yes/no\)' - for confirmation prompts
+                                           - r'Password:' - for password prompts
+            response (str): Response to send when pattern is matched (default: "" = Enter key)
+            timeout (int): Maximum seconds to wait for pattern (default: 30)
+            read_delay (float): Delay in seconds between command/response and reading output (default: 1)
+            
+        Returns:
+            dict: Result dictionary with 'failed', 'rc', 'stdout', 'stderr'
+            
+        Examples:
+            # Delete a file (wait for [confirm] and press Enter)
+            result = ciscohost.exec_interactive(
+                'delete /harddisk:/test.txt',
+                expect_pattern=r'\[confirm\]',
+                response=''
+            )
+            
+            # Reload device (wait for confirmation and respond 'yes')
+            result = ciscohost.exec_interactive(
+                'reload',
+                expect_pattern=r'Proceed with reload\? \[confirm\]',
+                response='yes\n'
+            )
+            
+            # Copy file with prompts
+            result = ciscohost.exec_interactive(
+                'copy tftp://1.2.3.4/file.bin /harddisk:/',
+                expect_pattern=r'Destination filename',
+                response='file.bin\n'
+            )
+            
+            # Just execute command without waiting for pattern
+            result = ciscohost.exec_interactive('show version')
+        """
+        return exec_interactive_ssh(
+            ssh_host=self.mgmt_ip,
+            username=self.ansible_user,
+            password=self.ansible_passwd,
+            command=command,
+            expect_pattern=expect_pattern,
+            response=response,
+            timeout=timeout,
+            read_delay=read_delay,
+            logger=logger,
+            host_for_error=self.hostname,
+            debug=True,
+        )
+
+    def delete_file(self, filepath):
+        """
+        Delete a file on Cisco IOS XR device using interactive shell.
+        
+        IOS XR 'delete' command requires confirmation even with 'noprompt',
+        so we use exec_interactive to handle the interactive prompt.
+        
+        Args:
+            filepath (str): Full path to file on device (e.g., '/harddisk:/filename')
+            
+        Returns:
+            dict: Result dictionary with 'failed', 'rc', 'stdout', 'stderr'
+            
+        Example:
+            result = ciscohost.delete_file('/harddisk:/test.txt')
+        """
+        logger.info(f"Deleting file: {filepath}")
+        return self.exec_interactive(
+            command=f"delete {filepath}",
+            expect_pattern=r'\[confirm\]',
+            response='',  # Just press Enter to confirm
+            timeout=10
+        )

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -4,7 +4,7 @@ import sys
 import logging
 import functools
 import time
-from paramiko import SSHClient, AutoAddPolicy
+from paramiko import SSHClient, WarningPolicy
 from tests.common.devices.base import AnsibleHostBase
 from tests.common.helpers.interactive_ssh import exec_interactive_ssh
 from ansible.utils.unsafe_proxy import AnsibleUnsafeText
@@ -133,8 +133,6 @@ class CiscoHost(AnsibleHostBase):
             return super(CiscoHost, self).__getattr__(module_name)
         else:
             raise Exception("Does not have module: {}".format(module_name))
-        self.host.options['variable_manager'].extra_vars.update(evars)
-        return super(CiscoHost, self).__getattr__(module_name)
 
     def __str__(self):
         return '<CiscoHost {}>'.format(self.hostname)
@@ -1443,7 +1441,8 @@ class CiscoHost(AnsibleHostBase):
         try:
             # Use Paramiko SFTP to transfer the file
             ssh_client = SSHClient()
-            ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+            # WarningPolicy logs unknown host keys instead of silently accepting (test-only infrastructure)
+            ssh_client.set_missing_host_key_policy(WarningPolicy())
             ssh_client.connect(
                 self.mgmt_ip,
                 username=self.ansible_user,
@@ -1479,7 +1478,7 @@ class CiscoHost(AnsibleHostBase):
                 'stderr': error_msg
             }
         finally:
-            # Close SSH connection
+            # Close SSH connection — ignore errors during cleanup to avoid masking the original exception
             if ssh_client:
                 try:
                     ssh_client.close()

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -22,6 +22,7 @@ from tests.common.cache import cached
 from tests.common.helpers.constants import DEFAULT_ASIC_ID, DEFAULT_NAMESPACE
 from tests.common.helpers.platform_api.chassis import is_inband_port
 from tests.common.helpers.parallel import parallel_run_threaded
+from tests.common.helpers.interactive_ssh import exec_interactive_ssh
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common import constants
 from typing import TypedDict
@@ -119,6 +120,45 @@ class SonicHost(AnsibleHostBase):
 
     def __repr__(self):
         return self.__str__()
+    
+    def exec_interactive(self, command, expect_pattern=None, response="", timeout=30, read_delay=1):
+        """
+        Execute an interactive command on SONiC device using Paramiko shell.
+        
+        Note: This is primarily used for migration scripts that run from XR but are executed
+        when the device is already running SONiC. It provides the same interface as CiscoHost.
+        
+        Args:
+            command (str): Command to execute
+            expect_pattern (str, optional): Regex pattern to wait for before sending response
+            response (str): Response to send when pattern is matched (default: "" = Enter key)
+            timeout (int): Maximum seconds to wait for pattern or command completion (default: 30)
+            read_delay (float): Delay in seconds between command/response and reading output (default: 1)
+            
+        Returns:
+            dict: Result dictionary with 'failed', 'rc', 'stdout', 'stderr', 'pattern_found'
+        """
+        im = self.host.options['inventory_manager']
+        vm = self.host.options['variable_manager']
+        hostvars = vm.get_vars(host=im.get_host(hostname=self.hostname))
+
+        ssh_user = hostvars.get('ansible_ssh_user', 'admin')
+        ssh_pass = hostvars.get('ansible_ssh_pass', 'password')
+        ssh_host = hostvars.get('ansible_host', self.hostname)
+
+        return exec_interactive_ssh(
+            ssh_host=ssh_host,
+            username=ssh_user,
+            password=ssh_pass,
+            command=command,
+            expect_pattern=expect_pattern,
+            response=response,
+            timeout=timeout,
+            read_delay=read_delay,
+            logger=logger,
+            host_for_error=self.hostname,
+            debug=False,
+        )
 
     @property
     def facts(self):

--- a/tests/common/helpers/interactive_ssh.py
+++ b/tests/common/helpers/interactive_ssh.py
@@ -1,0 +1,157 @@
+import logging
+import re
+import socket
+import time
+
+from paramiko import SSHClient, AutoAddPolicy
+
+
+def exec_interactive_ssh(ssh_host, username, password, command, expect_pattern=None, response="",
+                         timeout=30, read_delay=1, logger=None, host_for_error=None, debug=False):
+    """Execute an interactive command over SSH and optionally handle prompt/response flows."""
+    log = logger or logging.getLogger(__name__)
+
+    ssh_client = None
+    output = ""
+    pattern_found = None
+
+    try:
+        ssh_client = SSHClient()
+        ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+        ssh_client.connect(
+            ssh_host,
+            username=username,
+            password=password,
+            look_for_keys=False,
+            allow_agent=False
+        )
+
+        shell = ssh_client.invoke_shell()
+        time.sleep(read_delay)
+
+        if shell.recv_ready():
+            shell.recv(65535)
+
+        if not command.endswith('\n'):
+            command += '\n'
+        shell.send(command)
+        if debug:
+            log.debug(f"Sent command: {command.strip()}")
+
+        start_time = time.time()
+
+        if expect_pattern:
+            pattern_found = False
+            compiled_pattern = re.compile(expect_pattern)
+
+            while time.time() - start_time < timeout:
+                time.sleep(0.5)
+
+                if shell.recv_ready():
+                    chunk = shell.recv(4096).decode('utf-8', errors='ignore')
+                    output += chunk
+                    if debug:
+                        log.debug(f"Received chunk: {chunk[:100]}")
+
+                    if compiled_pattern.search(output):
+                        pattern_found = True
+                        if debug:
+                            log.debug(f"Pattern '{expect_pattern}' found in output")
+
+                        if not response.endswith('\n'):
+                            response += '\n'
+                        shell.send(response)
+                        if debug:
+                            log.debug(f"Sent response: {response.strip()}")
+                        time.sleep(read_delay)
+
+                        time.sleep(read_delay)
+                        while shell.recv_ready():
+                            output += shell.recv(4096).decode('utf-8', errors='ignore')
+                            time.sleep(0.2)
+                        break
+
+            if not pattern_found:
+                log.warning(f"Pattern '{expect_pattern}' not found within {timeout}s timeout")
+                while shell.recv_ready():
+                    output += shell.recv(4096).decode('utf-8', errors='ignore')
+                    time.sleep(0.2)
+        else:
+            last_data_time = time.time()
+            idle_timeout = min(max(timeout * 0.2, 30), 120)
+
+            if debug:
+                log.debug(f"No pattern expected - will wait up to {idle_timeout}s of idle time or {timeout}s total")
+
+            shell.settimeout(0.5)
+
+            while time.time() - start_time < timeout:
+                try:
+                    chunk = shell.recv(4096)
+                    if chunk:
+                        output += chunk.decode('utf-8', errors='ignore')
+                        last_data_time = time.time()
+                        if debug:
+                            log.debug(f"Received chunk: {chunk[:100]}")
+                    elif shell.exit_status_ready():
+                        if debug:
+                            log.debug("Channel EOF - command completed")
+                        break
+                except socket.timeout:
+                    idle_time = time.time() - last_data_time
+                    if idle_time > idle_timeout:
+                        if debug:
+                            log.debug(
+                                f"No data received for {idle_time:.1f}s (>{idle_timeout}s idle timeout) - "
+                                "command appears complete"
+                            )
+                        break
+                    if shell.closed:
+                        if debug:
+                            log.debug("Channel closed - command completed")
+                        break
+                except Exception as error:
+                    log.warning(f"Exception while reading: {error}")
+                    break
+
+            shell.settimeout(0.2)
+            for _ in range(5):
+                try:
+                    chunk = shell.recv(4096)
+                    if chunk:
+                        output += chunk.decode('utf-8', errors='ignore')
+                        if debug:
+                            log.debug(f"Final read: received {len(chunk)} bytes")
+                except (socket.timeout, Exception):
+                    pass
+
+        shell.close()
+
+        log.info(f"Interactive command completed. Output length: {len(output)} chars")
+        if pattern_found is not None:
+            log.info(f"Expected pattern found: {pattern_found}")
+
+        return {
+            'failed': False,
+            'rc': 0,
+            'stdout': output,
+            'stderr': '',
+            'pattern_found': pattern_found
+        }
+
+    except Exception as error:
+        error_msg = f'Interactive command failed: {str(error)}'
+        error_host = host_for_error or ssh_host
+        log.error(f"exec_interactive error on {error_host}: {error_msg}")
+        return {
+            'failed': True,
+            'rc': 1,
+            'stdout': output,
+            'stderr': error_msg
+        }
+    finally:
+        if ssh_client:
+            try:
+                ssh_client.close()
+            except Exception:
+                pass

--- a/tests/common/helpers/interactive_ssh.py
+++ b/tests/common/helpers/interactive_ssh.py
@@ -3,7 +3,7 @@ import re
 import socket
 import time
 
-from paramiko import SSHClient, AutoAddPolicy
+from paramiko import SSHClient, WarningPolicy
 
 
 def exec_interactive_ssh(ssh_host, username, password, command, expect_pattern=None, response="",
@@ -17,7 +17,8 @@ def exec_interactive_ssh(ssh_host, username, password, command, expect_pattern=N
 
     try:
         ssh_client = SSHClient()
-        ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+        # WarningPolicy logs unknown host keys instead of silently accepting (test-only infrastructure)
+        ssh_client.set_missing_host_key_policy(WarningPolicy())
         ssh_client.connect(
             ssh_host,
             username=username,
@@ -123,7 +124,7 @@ def exec_interactive_ssh(ssh_host, username, password, command, expect_pattern=N
                         if debug:
                             log.debug(f"Final read: received {len(chunk)} bytes")
                 except (socket.timeout, Exception):
-                    pass
+                    pass  # Best-effort final drain; errors are non-critical
 
         shell.close()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This pull request introduces comprehensive support for Cisco device conversion testing, focusing on enabling robust test infrastructure for devices transitioning from vendor OS (such as Cisco IOS XR) to SONiC OS. The main changes include the addition of conversion-specific pytest configuration and fixtures, enhancements to the `CiscoHost` class for file transfer and interactive command execution, and the introduction of shared assets and documentation files.

**Cisco conversion test infrastructure:**

* Added a new `tests/cisco/conftest.py` with custom pytest fixtures and configuration for conversion tests, including mock SONiC fixtures, Cisco device access (`ciscohost`), and proxy environment variable handling. This supports testing devices before and during migration to SONiC.
* Introduced minimal `__init__.py` files in `tests/cisco/`, `tests/cisco/files/`, and `tests/cisco/files/common/` to document and initialize the new test directories. [[1]](diffhunk://#diff-324d49582d3491b762113d7b1c769a05e7597a26f70b3cd11b38a16d7299d3d0R1) [[2]](diffhunk://#diff-fbe4d5cd98e76791084799e2b6fb0a9ca05a567c23ab9d8e5778cba78b6d597eR1) [[3]](diffhunk://#diff-f4b3537985ee1e8e1a9d9c3a0498a8fc22ae87fede05240a099641eab44a148eR1)

**Enhancements to Cisco device abstraction:**

* Improved the `CiscoHost` class in `tests/common/devices/cisco.py` to support:
  - SFTP file transfer via a new `copy` method using Paramiko, addressing Ansible module limitations on Cisco XR.
  - Interactive SSH command execution with a new `exec_interactive` method, enabling automation of commands requiring user prompts.
  - File deletion with confirmation handling via a new `delete_file` method.
  - More flexible Ansible module dispatching, supporting both standard and network modules with appropriate connection settings. [[1]](diffhunk://#diff-c095509420ebda518bd0f980951dcd4726a837fcb58b085c10a64d19ccf1d4c4R95-R101) [[2]](diffhunk://#diff-c095509420ebda518bd0f980951dcd4726a837fcb58b085c10a64d19ccf1d4c4L103-R135)
  - Use of `WarningPolicy` for SSH host key handling, improving test safety.

**Supporting changes:**

* Updated imports in `tests/common/devices/sonic.py` and `tests/common/devices/cisco.py` to provide access to the new interactive SSH helper. [[1]](diffhunk://#diff-9d6b9fc0608a7d8f921e93d64c0e9016d19d528ef9a2ad5858d00c5a85a968fdR25) [[2]](diffhunk://#diff-c095509420ebda518bd0f980951dcd4726a837fcb58b085c10a64d19ccf1d4c4L7-R9)

These changes collectively provide a robust foundation for conversion testing, allowing for seamless operation on Cisco devices regardless of their current OS state.

What's included:

   - tests/cisco/test_xr2sonic.py — Main test with a 6-stage migration flow:
    - Stage 0: Download & transfer artifacts (SONiC image, firmware, migration scripts, minigraphs, vouchers)
    - Stage 1: Intermediate XR upgrade
    - Stage 2: Ownership Voucher (OV) installation
    - Stage 3: Authenticated Variable (AV) install + RP SONiC migration
    - Stage 4: Line Card (LC) migration
    - Stage 5: Post-migration validation
    - By default stops after Stage 0 for safety; use --full-migration to run all stages
   - tests/cisco/conftest.py — Fixtures for Cisco device access (ciscohost, duthost), mock duthosts, and proxy configuration
   - tests/common/devices/cisco.py — Extended CiscoHost with SFTP file transfer (copy()), interactive SSH command execution, and XR-specific helpers
   - tests/common/devices/sonic.py — Added exec_interactive() to SonicHost for interactive command execution (used post-RP-migration)
   - tests/common/helpers/interactive_ssh.py — Paramiko-based interactive SSH utility for pattern-matching command flows


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
