### PR TITLE
Add support for QSFP+C xcvr in test_get_transceiver_info in test_sfp.py

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -498,7 +498,7 @@ class TestSfpApi(PlatformApiTestBase):
                         UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_AMPH_BACKPLANE_KEYS
                     else:
 
-                        if info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X"]:
+                        if info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C"]:
                             active_apsel_hostlane_count = 8
                             UPDATED_EXPECTED_XCVR_INFO_KEYS = self.EXPECTED_XCVR_INFO_KEYS + \
                                 self.EXPECTED_XCVR_NEW_CMIS_INFO_KEYS + \
@@ -531,8 +531,8 @@ class TestSfpApi(PlatformApiTestBase):
                     unexpected_keys = set(actual_keys) - set(UPDATED_EXPECTED_XCVR_INFO_KEYS +
                                                              self.NEWLY_ADDED_XCVR_INFO_KEYS)
                     for key in unexpected_keys:
-                        # hardware_rev is applicable only for QSFP-DD or OSFP
-                        if key == 'hardware_rev' and info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X"]:
+                        # hardware_rev is applicable only for QSFP-DD, OSFP or QSFP+C
+                        if key == 'hardware_rev' and info_dict["type_abbrv_name"] in ["QSFP-DD", "OSFP-8X", "QSFP+C"]:
                             continue
                         self.expect(False, "Transceiver {} info contains unexpected field '{}'".format(i, key))
         self.assert_expectations()


### PR DESCRIPTION
### Description of PR
Summary:
This PR adds support for QSFP+C transceivers in the `test_get_transceiver_info` test case within `platform_tests/api/test_sfp.py`.

Fixes #21396

### Type of change

- [x] **Bug fix**
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] **Test case improvement**


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
The `test_get_transceiver_info` test case was failing and not correctly validating transceiver details for the **QSFP+C** form factor. 

#### How did you do it?
Modified the logic within `test_get_transceiver_info` in `test_sfp.py` to correctly recognize and handle the specific attributes associated with QSFP+C transceivers when calling the platform API for transceiver information.

#### How did you verify/test it?
The change was verified by successfully executing the test case on a device with a QSFP+C transceiver inserted.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
NA