### PR TITLE
Update test_bgp_stress_link_flap and test_bgp_peer_shutdown to handle v6 only topology.

### DIFF
--- a/tests/bgp/constants.py
+++ b/tests/bgp/constants.py
@@ -4,3 +4,4 @@ TS_MAINTENANCE = "System Mode: Maintenance"
 TS_INCONSISTENT = "System Mode: Not consistent"
 TS_NO_NEIGHBORS = "System Mode: No external neighbors"
 TS_UNEXPECTED = "TSC not consistent across asic namespaces"
+SHOW_IP_INTERFACE_CMD = {'v4': "show ip interface", 'v6': "show ipv6 interface"}

--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -30,7 +30,7 @@ LOOP_TIMES_LEVEL_MAP = {
 
 
 @pytest.fixture(scope='module')
-def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
+def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts, show_ip_interface_cmd):
     duthost = duthosts[rand_one_dut_hostname]
 
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
@@ -53,7 +53,7 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts):
     pytest_assert(wait_until(30, 5, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                   "Not all BGP sessions are established on DUT")
 
-    ip_intfs = duthost.show_and_parse('show ip interface')
+    ip_intfs = duthost.show_and_parse(show_ip_interface_cmd)
     logger.debug("setup ip_intfs {}".format(ip_intfs))
 
     # Create a mapping of neighbor IP to interfaces and their details

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -89,7 +89,7 @@ class BGPNeighbor(object):
     def __init__(self, duthost, ptfhost, name,
                  neighbor_ip, neighbor_asn,
                  dut_ip, dut_asn, port, neigh_type=None,
-                 namespace=None, is_multihop=False, is_passive=False, debug=False):
+                 namespace=None, is_multihop=False, is_passive=False, debug=False, router_id=None):
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.ptfip = ptfhost.mgmt_ip
@@ -104,6 +104,7 @@ class BGPNeighbor(object):
         self.is_passive = is_passive
         self.is_multihop = not is_passive and is_multihop
         self.debug = debug
+        self.router_id = router_id or neighbor_ip
 
     def start_session(self):
         """Start the BGP session."""
@@ -138,7 +139,7 @@ class BGPNeighbor(object):
             name=self.name,
             state="started",
             local_ip=self.ip,
-            router_id=self.ip,
+            router_id=self.router_id,
             peer_ip=self.peer_ip,
             local_asn=self.asn,
             peer_asn=self.peer_asn,

--- a/tests/common/helpers/generators.py
+++ b/tests/common/helpers/generators.py
@@ -1,4 +1,5 @@
 from netaddr import IPNetwork
+from tests.common.utilities import is_ipv6_address
 import json
 
 ZERO_ADDR = r'0.0.0.0/0'
@@ -32,9 +33,8 @@ def route_through_default_routes(host, ip_addr):
     @return: True if the given up goes to default route, False otherwise
     """
     ip_cmd_suffix = ""
-    if ":" in ip_addr:
+    if is_ipv6_address(ip_addr):
         ip_cmd_suffix = "v6"
-
     output = host.shell("show ip{} route {} json".format(ip_cmd_suffix, ip_addr))['stdout']
     routes_info = json.loads(output)
     ret = True

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -336,12 +336,6 @@ bgp/test_bgp_operation_in_ro.py:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/23462"
 
-bgp/test_bgp_peer_shutdown.py::test_bgp_peer_shutdown:
-  xfail:
-    reason: "xfail for IPv6-only topologies, is with it parse everthing as IPv4"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/19907 and '-v6-' in topo_name"
-
 bgp/test_bgp_port_disable.py:
   skip:
     reason: "Not supperted on master."


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
-->

Summary:
Update tests to handle v6 only topology.
* test_bgp_stress_link_flap 
* test_bgp_peer_shutdown

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
adjust the test for v6 only topology
#### How did you do it?
adjust the relevant command
#### How did you verify/test it?
run it over the next topologies:
    t0-isolated-v6-d32u32s2
    t0-isolated-d32u32s2
    t1-isolated-v6-d56u1-lag
    t1-isolated-d56u1-lag
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
