### PR TITLE
Update memory threshold for sn5640

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -290,7 +290,25 @@
           ],
           "memory_high_threshold": {
             "type": "value",
-            "value": 384
+            "value": 420
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
+    },
+    {
+      "name": "frr_zebra",
+      "cmd": "vtysh -c \"show memory zebra\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "percentage", "value": "50%"},
+            {"type": "value", "value": 64},
+            {"type": "comparison", "value": "max"}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 134
           }
         }
       },


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update memory threshold of frr_bgp and frr_zebra for Mellanox sn5640, due to it always had more ports up in the setup.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Memory threshold of frr_bgp and frr_zebra for Mellanox sn5640 are not enough.
#### How did you do it?
Update memory threshold of frr_bgp and frr_zebra for Mellanox sn5640
#### How did you verify/test it?
Run it locally
#### Any platform specific information?
Mellanox SN5640.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
