### PR TITLE
Update fwutil test_fwutil_install_bad_path case regex

### DIFF
--- a/tests/platform_tests/fwutil/test_fwutil.py
+++ b/tests/platform_tests/fwutil/test_fwutil.py
@@ -60,7 +60,7 @@ def test_fwutil_install_bad_path(duthost, component):
     """Tests that fwutil install validates firmware paths correctly."""
     out = duthost.command(f"fwutil install chassis component {component} fw BAD.pkg",
                           module_ignore_errors=True)
-    pattern = re.compile(r'.*Error: Invalid value for "<fw_path>"*.')
+    pattern = re.compile(r'''.*Error: Invalid value for ['"]<fw_path>['"]''')
     assert find_pattern(out['stderr_lines'], pattern)
 
 


### PR DESCRIPTION
Update for Debian 13


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Update fwutil test_fwutil_install_bad_path case regex to make it compatible for the new output in Debian 13 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
After SONiC base Debian upgrade to Debian 13, the output during execute the fwutil command for a bad package had been updated, just like that:

fwutil install chassis component BIOS fw BAD.pkg
```
Usage: fwutil install chassis component <component_name> fw
           [OPTIONS] <fw_path>
Try 'fwutil install chassis component <component_name> fw --help' for help.
```

Error: Invalid value for '<fw_path>': Path 'BAD.pkg' does not exist.
#### How did you do it?
Update the regex in the script to make the test compatible for the new changes.
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
