### PR TITLE
[202411][test_hash] Skip ip-proto hash key for topology with service port

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,13 @@ def pytest_addoption(parser):
     # FWUtil options
     parser.addoption('--fw-pkg', action='store', help='Firmware package file')
 
+    #####################################
+    # dash, vxlan, route shared options #
+    #####################################
+    parser.addoption("--skip_cleanup", action="store_true", help="Skip config cleanup after test (tests: dash, vxlan)")
+    parser.addoption("--num_routes", action="store", default=None, type=int,
+                     help="Number of routes (tests: route, vxlan)")
+
     ############################
     # pfc_asym options         #
     ############################

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -36,12 +36,6 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--skip_cleanup",
-        action="store_true",
-        help="Skip config cleanup after test"
-    )
-
-    parser.addoption(
         "--skip_dataplane_checking",
         action="store_true",
         help="Skip dataplane checking"

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -1,3 +1,4 @@
+import re
 import time
 import logging
 
@@ -331,6 +332,11 @@ def test_hash(add_default_route_to_dut, duthosts, fib_info_files_per_function, s
     else:
         src_ip_range = SRC_IPV6_RANGE
         dst_ip_range = DST_IPV6_RANGE
+
+    if re.match(r"t0-.*s\d+", updated_tbinfo["topo"]["name"]) and 'ip-proto' in hash_keys:
+        # For t0 topology type with service ports, use ip-proto as hash key cause traffic unbalance issue.
+        hash_keys.remove('ip-proto')
+
     ptf_runner(
         ptfhost,
         "ptftests",

--- a/tests/route/conftest.py
+++ b/tests/route/conftest.py
@@ -8,9 +8,6 @@ def pytest_addoption(parser):
 
     route_group = parser.getgroup("Route test suite options")
 
-    route_group.addoption("--num_routes", action="store", default=None, type=int,
-                          help="Number of routes for add/delete")
-
     route_group.addoption("--max_scale", action="store_true",
                           help="Test with maximum possible route scale")
 

--- a/tests/vxlan/conftest.py
+++ b/tests/vxlan/conftest.py
@@ -62,14 +62,6 @@ def pytest_addoption(parser):
     )
 
     vxlan_group.addoption(
-        "--num_routes",
-        action="store",
-        default=16000,
-        type=int,
-        help="number of routes for VNET VxLAN test"
-    )
-
-    vxlan_group.addoption(
         "--num_endpoints",
         action="store",
         default=4000,
@@ -123,12 +115,6 @@ def pytest_addoption(parser):
         type=str2bool,
         default=True,
         help="Test IPV6 in IPv6"
-    )
-
-    vxlan_group.addoption(
-        "--skip_cleanup",
-        action="store_true",
-        help="Do not cleanup after VNET VxLAN test"
     )
 
     vxlan_group.addoption(
@@ -261,6 +247,8 @@ def scaled_vnet_params(request):
     params = {}
     params[NUM_VNET_KEY] = request.config.option.num_vnet
     params[NUM_ROUTES_KEY] = request.config.option.num_routes
+    if params[NUM_ROUTES_KEY] is None:
+        params[NUM_ROUTES_KEY] = 16000
     params[NUM_ENDPOINTS_KEY] = request.config.option.num_endpoints
     return params
 


### PR DESCRIPTION


## What is the motivation for this PR?
[test_hash] Skip ip-proto hash key for topology with service port 
Manual cherry-pick of #19887

To fix the fib/test_fib.py::test_hash case on topology with service port.


## How did you do it?
Remove ip-proto from hash_keys when running test_hash case on t0-d18u8s4 and t0-isolated-d32u32s2 topology.

## How did you verify/test it?
Run fib/test_fib.py::testh_hash locally with the change and case can pass.

fib/test_fib.py::test_hash[ipv4]
----------------------------- live log call --------------------
07:36:26 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
PASSED                           [ 50%]
fib/test_fib.py::test_hash[ipv6]
----------------------------- live log call --------------------
07:43:27 ptf_runner.get_dut_type                  L0053 WARNING| DUT type file doesn't exist.
PASSED                           [ 100%]

Signed-off-by: zitingguo-ms <zitingguo@microsoft.com>
