### PR TITLE
Add check to verify status is True in test_psu/test_get_status

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -157,6 +157,7 @@ class TestPsuApi(PlatformApiTestBase):
             status = psu.get_status(platform_api_conn, i)
             if self.expect(status is not None, "Unable to retrieve PSU {} status".format(i)):
                 self.expect(isinstance(status, bool), "PSU {} status appears incorrect".format(i))
+                self.expect(status is True, "PSU {} status is not True (Power Not Good)".format(i))
         self.assert_expectations()
 
     def test_get_position_in_parent(self, platform_api_conn):     # noqa: F811


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Fixes: #21431
Summary: Assert PSU status is True for healthy units.

This PR closes a test gap in the platform testing framework by explicitly asserting the `True` status for Power Supply Units (PSUs) when the `getStatus()` function is called. Previously, the test only verified that a boolean value was returned, failing to check the logical correctness (i.e., verifying the PSU is reporting a healthy status).

The added assertion ensures that during the initial test setup where PSU health is assumed to be healthy, the software logic correctly translates that state to `True`.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202503

### Approach
#### What is the motivation for this PR?

The existing tests in `test_get_status` did not validate the actual value returned by `psu.get_status`, relying only on type checking (`isinstance(status, bool)`). This change ensures that if a PSU is present and not explicitly skipped, the logic correctly reports its nominal health as `True`, preventing silent failures where healthy hardware reports a unhealthy state.

#### How did you do it?
By adding an explicit assertion (`self.expect`) after the existing type check to validate the returned value against `True`.

#### How did you verify/test it?

This change was verified by running the affected test suite against a DUT where the PSUs were healthy and present. The test successfully passed, confirming that the `getStatus` call returns `True` for nominal PSUs. The test was also run against a PSU in a known mocked bad state to ensure the test correctly reports failure.

#### Any platform specific information?
No. This change is framework-level and applies to all platforms implementing the common PSU testing interface.

#### Supported testbed topology if it's a new test case?

N/A (Improvement to existing test).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A