### PR TITLE
Fix GCU packet trimming tests for TH5

### DIFF
--- a/tests/generic_config_updater/test_packet_trimming_config_asymmetric.py
+++ b/tests/generic_config_updater/test_packet_trimming_config_asymmetric.py
@@ -41,12 +41,28 @@ def setup_env(duthost):
     Args:
         duthost: DUT.
     """
-    global TRIM_SIZE, TRIM_QUEUE, TRIM_SIZE_UPDATE, TRIM_QUEUE_UPDATE
-    if duthost.facts["asic_type"] == "broadcom":
+
+    if 'th5' == duthost.get_asic_name():
+
+        global TRIM_SIZE
+        global TRIM_SIZE_UPDATE
+        global TRIM_QUEUE
+        global TRIM_QUEUE_UPDATE
+
+        th5_queue = {
+            'Arista-7060X6-64PE-B-C448O16': 4,
+            'Arista-7060X6-64PE-B-C512S2': 4,
+        }
+
+        # TH5 trim queue defaults to 9 unless otherwise configured
+        # and does not support being modified at runtime
+        TRIM_QUEUE = th5_queue.get(duthost.facts['hwsku'], 9)
+        TRIM_QUEUE_UPDATE = TRIM_QUEUE
+
+        # TH5 supports only fixed size of 206
         TRIM_SIZE = 206
-        TRIM_QUEUE = 7
-        TRIM_SIZE_UPDATE = 206
-        TRIM_QUEUE_UPDATE = 7
+        TRIM_SIZE_UPDATE = TRIM_SIZE
+
     create_checkpoint(duthost)
 
     yield

--- a/tests/generic_config_updater/test_packet_trimming_config_symmetric.py
+++ b/tests/generic_config_updater/test_packet_trimming_config_symmetric.py
@@ -38,12 +38,28 @@ def setup_env(duthost):
     Args:
         duthost: DUT.
     """
-    global TRIM_SIZE, TRIM_QUEUE, TRIM_SIZE_UPDATE, TRIM_QUEUE_UPDATE
-    if duthost.facts["asic_type"] == "broadcom":
+
+    if 'th5' == duthost.get_asic_name():
+
+        global TRIM_SIZE
+        global TRIM_SIZE_UPDATE
+        global TRIM_QUEUE
+        global TRIM_QUEUE_UPDATE
+
+        th5_queue = {
+            'Arista-7060X6-64PE-B-C448O16': 4,
+            'Arista-7060X6-64PE-B-C512S2': 4,
+        }
+
+        # TH5 trim queue defaults to 9 unless otherwise configured
+        # and does not support being modified at runtime
+        TRIM_QUEUE = th5_queue.get(duthost.facts['hwsku'], 9)
+        TRIM_QUEUE_UPDATE = TRIM_QUEUE
+
+        # TH5 supports only fixed size of 206
         TRIM_SIZE = 206
-        TRIM_QUEUE = 7
-        TRIM_SIZE_UPDATE = 206
-        TRIM_QUEUE_UPDATE = 7
+        TRIM_SIZE_UPDATE = TRIM_SIZE
+
     create_checkpoint(duthost)
 
     yield


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Fixes failing test cases for TH5:
 - test_packet_trimming_config_symmetric.py
 - test_packet_trimming_config_asymmetric.py

This fixes packet size to the supported constant of 206, and configures the trim queue to either the asic default (9) or the per SKU configured value (4, for the C448 and C512)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202505

### Approach
#### How did you verify/test it?
Manual test runs
