### PR TITLE
Add "-n" to traceroute to speed up sanity check

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -96,11 +96,11 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False, check_ptf_mgmt=True
             # check PTF device reachability
             if ptf.mgmt_ip:
                 cmds.append("ping {} -c 1 -W 3".format(ptf.mgmt_ip))
-                cmds.append("traceroute {}".format(ptf.mgmt_ip))
+                cmds.append("traceroute -n {}".format(ptf.mgmt_ip))
 
             if ptf.mgmt_ipv6:
                 cmds.append("ping6 {} -c 1 -W 3".format(ptf.mgmt_ipv6))
-                cmds.append("traceroute6 {}".format(ptf.mgmt_ipv6))
+                cmds.append("traceroute6 -n {}".format(ptf.mgmt_ipv6))
 
         results = dut.shell_cmds(cmds=cmds, module_ignore_errors=True, verbose=False)['results']
         outputs = []


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
In sanity check, command `traceroute` is executed in the `print_logs` function to check PTF device reachability. However, the `traceroute` command is executed without the `-n` argument. Then it tries to resolve the DNS name of involved IP addresses. Usually the DNS resolve will timeout because PTF IP is usually not resolvable. Because of this, the `print_logs` function need more than 30 seconds to complete.

#### How did you do it?
This change added "-n" argument to the traceroute command. With this change, usually 40 seconds less is required to run sanity check.

#### How did you verify/test it?
Tested on KVM testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
