### PR TITLE
Print stdout and stderr properly on a SSH command failure

### DIFF
--- a/tests/tacacs/utils.py
+++ b/tests/tacacs/utils.py
@@ -107,8 +107,7 @@ def ssh_run_command(ssh_client, command, expect_exit_code=0, verify=False):
             # do get evaluated, then the state of the object will be different,
             # which will cause issues for other functions that use those
             # objects.
-            pytest_assert(
-                exit_code == expect_exit_code,
+            pytest.fail(
                 f"Command: '{command}' failed with exit code: {exit_code}, "
                 f"stdout: {stdout.readlines()}, stderr: {stderr.readlines()}")
     return exit_code, stdout, stderr


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

Currently, when printing out the stdout and stderr on a SSH command failure (run as part of tacacs tests), all that gets printed is that it's a paramiko channel object with some metadata about it, which is not helpful. Get the actual text and print it out.

The tricky part of this is that the `readlines()` method must be called only when failing, because if `readlines()` is called on Paramiko, then subsequent calls to the channel object will return different results, since that data has been consumed. Because of that, wrap it in an if-block so that it goes into that code path only when failing for certain.

#### How did you do it?

#### How did you verify/test it?

Verified locally by forcing a failure in `tacacs/test_authorization.py` and making sure that stdout and stderr shows the actual content.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
