### PR TITLE
support IPv6 addresses by wrapping them in brackets if necessary.

### DIFF
--- a/tests/gnmi/conftest.py
+++ b/tests/gnmi/conftest.py
@@ -3,6 +3,7 @@ import logging
 import os
 import glob
 import grpc
+import ipaddress
 
 from grpc_tools import protoc
 
@@ -223,10 +224,14 @@ def grpc_channel(duthosts, rand_one_dut_hostname):
     duthost = duthosts[rand_one_dut_hostname]
 
     # Get DUT gRPC server address and port
-    if ":" in duthost.mgmt_ip and not duthost.mgmt_ip.startswith('['):
-        ip = f"[{duthost.mgmt_ip}]"
-    else:
-        ip = duthost.mgmt_ip
+    ip = duthost.mgmt_ip
+    # Format IPv6 addresses with brackets for URL
+    try:
+        if isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address):
+            ip = f"[{ip}]"
+    except ValueError:
+        # If parsing fails, use the address as-is
+        pass
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     port = env.gnmi_port
     target = f"{ip}:{port}"

--- a/tests/gnmi/grpc_utils.py
+++ b/tests/gnmi/grpc_utils.py
@@ -2,6 +2,7 @@ import sys
 import os
 import grpc
 import logging
+import ipaddress
 
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 
@@ -36,10 +37,14 @@ def create_grpc_channel(duthost):
         grpc.Channel: Configured gRPC channel
     """
     # Get DUT gRPC server address and port
-    if ":" in duthost.mgmt_ip and not duthost.mgmt_ip.startswith('['):
-        ip = f"[{duthost.mgmt_ip}]"
-    else:
-        ip = duthost.mgmt_ip
+    ip = duthost.mgmt_ip
+    # Format IPv6 addresses with brackets for URL
+    try:
+        if isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address):
+            ip = f"[{ip}]"
+    except ValueError:
+        # If parsing fails, use the address as-is
+        pass
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
     port = env.gnmi_port
     target = f"{ip}:{port}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: support IPv6 addresses by wrapping them in brackets if necessary.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202511

### Approach
#### What is the motivation for this PR?
regression failure on ipv6 only mgmt ip on dut was introduced by CR https://github.com/sonic-net/sonic-mgmt/pull/21303. This PR is to address the test failure of test_gnoi_system_time on dut with ipv6 mgmt ip only
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
