### PR TITLE
skip test_multicast_smac_drop for Cisco-8101-O8C48

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -170,6 +170,13 @@ drop_packets/test_drop_counters.py::test_multicast_smac_drop[port_channel_member
     conditions:
       - "hwsku in ['Cisco-8101-O8C48']"
 
+drop_packets/test_drop_counters.py::test_multicast_smac_drop[rif_members]:
+  skip:
+    reason: "No rif_members available"
+    strict: True
+    conditions:
+      - "hwsku in ['Cisco-8101-O8C48']"
+
 drop_packets/test_drop_counters.py::test_multicast_smac_drop[vlan_members]:
   skip:
     reason: "Test case is only suitable for t0 type topology since it requires vlan interfaces"
@@ -178,13 +185,6 @@ drop_packets/test_drop_counters.py::test_multicast_smac_drop[vlan_members]:
     conditions:
       - "hwsku in ['Cisco-8101-O8C48']"
       - "topo_type not in ['t0']"
-
-drop_packets/test_drop_counters.py::test_multicast_smac_drop[rif_members]:
-  skip:
-    reason: "No rif_members available"
-    strict: True
-    conditions:
-      - "hwsku in ['Cisco-8101-O8C48']"
 
 drop_packets/test_drop_counters.py::test_no_egress_drop_on_down_link:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

Move pytest skip logic for Cisco-8101 test case "test_multicast_smac_drop" from runtime skips to conditional markers. This change improves efficiency by preventing unnecessary test execution and early skipping during collection, reducing overall test runtime and resource usage.

Skip info in current nightly report:
```

<testcase classname="drop_packets.test_drop_counters"
          name="test_multicast_smac_drop[port_channel_members-str3-8101-01]"
          file="drop_packets/drop_packets.py"
          line="560"
          time="14.142">
    <properties>
        <property name="start" value="2025-11-12 04:57:54.564568"/>
        <property name="end" value="2025-11-12 04:58:08.707999"/>
    </properties>
    <skipped type="pytest.skip"
             message="Test case requires explicit fanout support">
        /var/src/sonic-mgmt_vms61-t1-8101-02/tests/drop_packets/drop_packets.py:567: Test case requires explicit fanout support
    </skipped>
</testcase>

<testcase classname="drop_packets.test_drop_counters"
          name="test_multicast_smac_drop[vlan_members-str3-8101-01]"
          file="drop_packets/drop_packets.py"
          line="560"
          time="5.312">
    <properties>
        <property name="start" value="2025-11-12 04:58:08.708850"/>
        <property name="end" value="2025-11-12 04:58:14.021222"/>
    </properties>
    <skipped type="pytest.skip"
             message="Test case is only suitable for t0 type topology since it requires vlan interfaces">
        /var/src/sonic-mgmt_vms61-t1-8101-02/tests/drop_packets/drop_packets.py:561: Test case is only suitable for t0 type topology since it requires vlan interfaces
    </skipped>
</testcase>

<testcase classname="drop_packets.test_drop_counters"
          name="test_multicast_smac_drop[rif_members-str3-8101-01]"
          file="drop_packets/drop_packets.py"
          line="560"
          time="5.214">
    <properties>
        <property name="start" value="2025-11-12 04:58:14.021779"/>
        <property name="end" value="2025-11-12 04:58:19.236809"/>
    </properties>
    <skipped type="pytest.skip"
             message="No rif_members available">
        /var/src/sonic-mgmt_vms61-t1-8101-02/tests/drop_packets/drop_packets.py:561: No rif_members available
    </skipped>
</testcase>

```

#### How did you do it?

move skip rule to condition mark

#### How did you verify/test it?

locally run

#### Any platform specific information?

only for Cisco-8101-O8C48

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
