### PR TITLE
Fix UnboundLocalError in test_buffer_deployment

### DIFF
--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -3185,16 +3185,16 @@ def test_buffer_deployment(duthosts, rand_one_dut_hostname, conn_graph_facts, tb
                     "Buffer profile {} {} doesn't align with ASIC_TABLE {}"
                     .format(expected_profile, profile_info, buffer_profile_asic_info))
 
-                    if is_ingress_lossless:
-                        if not lossless_pool_oid:
-                            lossless_pool_oid = buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID']
-                        else:
-                            pytest_assert(
-                                lossless_pool_oid == buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID'],
-                                "Buffer profile {} has different buffer pool id {} from others {}"
-                                .format(expected_profile,
-                                        buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID'],
-                                        lossless_pool_oid))
+                if is_ingress_lossless:
+                    if not lossless_pool_oid:
+                        lossless_pool_oid = buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID']
+                    else:
+                        pytest_assert(
+                            lossless_pool_oid == buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID'],
+                            "Buffer profile {} has different buffer pool id {} from others {}"
+                            .format(expected_profile,
+                                    buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID'],
+                                    lossless_pool_oid))
                 profiles_checked[expected_profile] = buffer_profile_oid
             else:
                 pytest_assert(profiles_checked[expected_profile] == buffer_profile_oid,


### PR DESCRIPTION
…deployment‘

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

This PR fixes an UnboundLocalError that occurs in the test_buffer_deployment test case when buffer_profile_oid is None.

During test execution on some testbed, the test failed when processing `pg_lossless_XXXX_profile` because:
1. The profile is an ingress lossless profile (`is_ingress_lossless = True`)
2. `buffer_profile_oid` returned None from `_check_port_buffer_info_and_get_profile_oid`
3. `buffer_profile_asic_info` was never defined
4. Code attempted to access `buffer_profile_asic_info['SAI_BUFFER_PROFILE_ATTR_POOL_ID']`, causing the error


#### How did you do it?

- Moved the lossless pool OID validation logic (lines 3088-3096) inside the `if buffer_profile_oid:` block
- Ensures `buffer_profile_asic_info` is only accessed when it has been properly defined
- Maintains the assignment of `profiles_checked[expected_profile]` outside the block to preserve existing behavior
This fix ensures the test handles cases where buffer_profile_oid is None without crashing, allowing the test to continue or fail gracefully with proper assertion messages.

#### How did you verify/test it?

local  test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
