### PR TITLE
Data plane Snappi-based Switch Capacity Test

### DIFF
--- a/tests/snappi_tests/dataplane/test_switch_capacity.py
+++ b/tests/snappi_tests/dataplane/test_switch_capacity.py
@@ -1,0 +1,452 @@
+from tests.snappi_tests.dataplane.imports import *  # noqa F403
+from snappi_tests.dataplane.files.helper import *  # noqa F403
+from itertools import product
+from tests.common.telemetry import (
+    METRIC_LABEL_DEVICE_ID,
+    METRIC_LABEL_DEVICE_PORT_ID,
+    METRIC_LABEL_DEVICE_PSU_ID,
+    METRIC_LABEL_DEVICE_QUEUE_ID,
+    METRIC_LABEL_DEVICE_SENSOR_ID,
+)
+from tests.common.telemetry.constants import (
+    METRIC_LABEL_DEVICE_PSU_MODEL,
+    METRIC_LABEL_DEVICE_PSU_SERIAL,
+    METRIC_LABEL_DEVICE_PSU_HW_REV,
+    METRIC_LABEL_DEVICE_QUEUE_CAST,
+)
+from tests.common.telemetry.metrics.device import DevicePortMetrics
+from tests.common.telemetry.metrics.device import DevicePSUMetrics
+from tests.common.telemetry.metrics.device import DeviceQueueMetrics
+from tests.common.telemetry.metrics.device import DeviceTemperatureMetrics
+
+logger = logging.getLogger(__name__)
+POLL_INTERVAL_SEC = 30
+
+ROUTE_RANGES = {"IPv6": [[["777:777:777::1", 64, 16]]], "IPv4": [[["100.1.1.1", 24, 16]]]}
+
+capacity_param_values = {
+    "subnet_type": ["IPv6"],
+    "test_duration": [1 * 60, 5 * 60, 15 * 60, 60 * 60, 24 * 60 * 60, 2 * 24 * 60 * 60],
+    "frame_size": [86, 128, 256, 512, 1024, 1518],
+    "traffic_rate": [10, 25, 50, 75, 100],
+}
+# Create combinations of parameters as tuples
+capacity_param_names = ",".join(capacity_param_values.keys())
+capacity_param_product = list(product(*capacity_param_values.values()))
+
+
+pytestmark = [pytest.mark.topology("nut")]
+
+
+@pytest.mark.parametrize(capacity_param_values, capacity_param_product)
+def test_switch_capacity(
+    duthosts,
+    snappi_api,
+    get_snappi_ports,
+    fanout_graph_facts_multidut,
+    db_reporter,
+    set_primary_chassis,
+    create_snappi_config,
+    subnet_type,
+    test_duration,
+    frame_size,
+    traffic_rate,
+):
+    """
+    Assess the capacity limits of SONiC switches using SNAPPI-driven traffic tests.
+
+    This test validates the maximum throughput and performance thresholds by
+    configuring traffic flows and measuring switch behavior under load.
+
+    Args:
+        duthosts (list): List of DUT (Device Under Test) hosts as pytest fixture.
+        snappi_api (object): SNAPPI API session for traffic configuration.
+        get_snappi_ports (callable): Fixture/function to retrieve SNAPPI ports.
+        fanout_graph_facts_multidut (dict): Fanout topology graph for multi-DUT setups.
+        db_reporter (object): Database reporter for logging test results.
+        set_primary_chassis (callable): Fixture to define primary chassis for tests.
+        create_snappi_config (callable): Callback to create SNAPPI traffic config.
+        subnet_type (str): Type of subnet configuration (e.g., 'IPv4', 'IPv6').
+        test_duration (int): Duration of the traffic test in seconds.
+        frame_size (int): Size of the traffic frames in bytes.
+        traffic_rate (float): Traffic rate as a percentage of line rate.
+
+    Returns:
+        None: This function does not return a value but logs test metrics.
+    """
+    logger.info("XXX" * 50)
+    logger.info(
+        f"Testing {subnet_type} traffic at {traffic_rate}% line rate "
+        f"for {test_duration} seconds with frame size {frame_size} bytes"
+        )
+    snappi_extra_params = SnappiTestParams()
+    snappi_ports = get_duthost_interface_details(duthosts, get_snappi_ports, subnet_type, protocol_type="bgp")
+    port_distrbution = (slice(0, len(snappi_ports) // 2), slice(len(snappi_ports) // 2, None))
+    tx_ports, rx_ports = snappi_ports[port_distrbution[0]], snappi_ports[port_distrbution[1]]
+
+    dut_tg_port_map = collections.defaultdict(list)
+    for intf in tx_ports + rx_ports:
+        dut_tg_port_map[intf["duthost"]].append((intf["peer_port"], f"Port_{intf['port_id']}"))
+    dut_tg_port_map = {duthost: dict(ports) for duthost, ports in dut_tg_port_map.items()}
+    ranges = ROUTE_RANGES[subnet_type]*(len(snappi_ports))
+    snappi_extra_params.protocol_config = {
+        "Tx": {
+            "route_ranges": ranges,
+            "protocol_type": "bgp",
+            "ports": tx_ports,
+            "subnet_type": subnet_type,
+            "is_rdma": False,
+        },
+        "Rx": {
+            "route_ranges": ranges,
+            "protocol_type": "bgp",
+            "ports": rx_ports,
+            "subnet_type": subnet_type,
+            "is_rdma": False,
+        },
+    }
+
+    snappi_config, snappi_obj_handles = create_snappi_config(snappi_extra_params)
+    snappi_extra_params.traffic_flow_config = [
+        {
+            "line_rate": traffic_rate,
+            "frame_size": frame_size,
+            "is_rdma": False,
+            "flow_name": "Switch_Capacity_Test",
+            "tx_names": snappi_obj_handles["Tx"]["network_group"] + snappi_obj_handles["Rx"]["network_group"],
+            "rx_names": snappi_obj_handles["Rx"]["network_group"] + snappi_obj_handles["Tx"]["network_group"],
+            "mesh_type": "mesh",
+        }
+    ]
+
+    snappi_config = create_traffic_items(snappi_config, snappi_extra_params)
+    snappi_api.set_config(snappi_config)
+
+    start_stop(snappi_api, operation="start", op_type="protocols")
+
+    # ***************************************************************************
+    # Using RestPy Code
+    ixnet_traffic_params = {"BiDirectional": True, "SrcDestMesh": "fullMesh"}
+    ixnet = snappi_api._ixnetwork
+    ixnet.Traffic.TrafficItem.find().update(**ixnet_traffic_params)
+    ixnet.Traffic.FrameOrderingMode = "RFC2889"
+    # ***************************************************************************
+
+    # Clear all switch counters.
+    [duthost.command("sudo sonic-clear counters \n") for duthost in duthosts]
+
+    start_stop(snappi_api, operation="start", op_type="traffic")
+    poll_stats(dut_tg_port_map, duration_sec=test_duration, interval_sec=POLL_INTERVAL_SEC, db_reporter=db_reporter)
+    db_reporter.report()
+    logger.info("Stopping transmit on all flows ...")
+
+    start_stop(snappi_api, operation="stop", op_type="traffic")
+    start_stop(snappi_api, operation="stop", op_type="protocols")
+
+
+def get_dut_stats(dut_tg_port_map):
+    """
+    Collect raw telemetry statistics from DUTs via CLI/telemetry show commands.
+
+    This function executes pre-defined telemetry commands on each DUT and
+    returns their parsed JSON output. It handles queue watermarks, PSU
+    information, temperature readings, and per-port statistics.
+
+    Args:
+        dut_tg_port_map (dict):
+            Mapping of DUT objects to interfaces dictionary.
+            Example:
+                {
+                    duthost1: {"Ethernet0": "peer0", "Ethernet4": "peer1"},
+                    duthost2: {"Ethernet8": "peer2"}
+                }
+
+    Returns:
+        dict:
+            Dictionary keyed by DUT hostname, with nested telemetry results.
+            Example:
+                {
+                    "dut1": {
+                        "queue": [...],
+                        "psu": [...],
+                        "temp": [...],
+                        "portstat": {...}
+                    },
+                    "dut2": {...}
+                }
+
+    Workflow:
+        1. Build set of telemetry commands to run.
+        2. For each DUT:
+             - Run commands via Ansible `command` module (`duthost.command`).
+             - Parse JSON output.
+             - For queue metrics, expand to (Port, queue_id, watermark) records.
+             - Store results in nested result dictionary.
+        3. Errors are logged and marked as `None` for that DUT/command.
+
+    Notes:
+        - `queue` output is filtered to only include queues belonging to DUT interfaces.
+        - `portstat` combines stats for the DUT's relevant interfaces.
+    """
+    # Telemetry commands to collect from the DUT
+    commands = {
+        "queue": "show queue watermark unicast --json",
+        "psu": "show platform psu --json",
+        "temp": "show platform temperature --json",
+        "portstat": "portstat -i {} -j",  # requires port list substitution
+    }
+
+    result = {}
+    for duthost, interfaces in dut_tg_port_map.items():
+        duthostname = duthost.hostname
+        logger.info(f"Collecting initial stats from {duthostname}")
+        result[duthostname] = {}
+
+        for command_name, command in commands.items():
+            logger.info(f"Running command '{command}' on {duthostname}")
+
+            # Special case: portstat must include comma-separated port list
+            if command_name == "portstat":
+                command = command.format(",".join(interfaces.keys()))
+
+            try:
+                raw_output = duthost.command(command)["stdout"]
+                json_output = json.loads(raw_output)
+
+                # Special handling for queue: flatten per-port queue stats
+                if command_name == "queue":
+                    json_output = [
+                        {"Port": d["Port"], "queue_id": key, "watermark_byte": d[key]}
+                        for d in json_output
+                        for key in d.keys()
+                        if d["Port"] in interfaces.keys() and (key.startswith("UC") or key.startswith("MC"))
+                    ]
+
+                result[duthostname][command_name] = json_output
+
+            except Exception as e:
+                logger.error(f"[{duthostname}] Failed to run '{command}': {e}")
+                result[duthostname][command_name] = None
+
+    return result
+
+
+def record_metrics(metric_obj, records, duthostname, label_template, label_map, field_map):
+    """
+    Record telemetry metrics in a generic, configurable way for any metric type.
+
+    This function abstracts the logic of iterating over telemetry records
+    (lists, dicts, or per-port stats), building label dictionaries,
+    and recording metrics via the appropriate Device*Metrics object.
+    It supports dynamic mappings for both labels (device, port, PSU, queues, sensors)
+    and fields (bps, counters, status, voltage, etc).
+
+    Args:
+        metric_obj:
+            A Device*Metrics object instance (e.g., DevicePortMetrics, DevicePSUMetrics).
+        records (dict | list):
+            Telemetry records retrieved from the DUT via CLI or telemetry API.
+            - If dict: keys are record identifiers (e.g., port names).
+            - If list: items are per-record dictionaries.
+        duthostname (str):
+            Hostname of the current DUT (Device Under Test).
+        label_template (dict):
+            Base set of labels (keys → telemetry label constants).
+            Values are copied and extended with record-specific values.
+        label_map (dict):
+            Mapping of label constants → record key name or lambda.
+            If string: `record[string]` is used
+            If callable: `lambda record, key` is executed
+        field_map (dict):
+            Mapping of metric method names from metric_obj (e.g., "rx_bps")
+            → record key name or lambda to extract value.
+
+    Returns:
+        None
+
+    Notes:
+        - If a mapping source is not found in the record, default values are used.
+        - This function is designed to work seamlessly across diverse
+          telemetry record types (port stats, PSU, queues, temperature, etc).
+    """
+    if not records:
+        return
+
+    # Handle dict style (like portstat) separately from list
+    items = records.items() if isinstance(records, dict) else enumerate(records)
+
+    for key, record in items:
+        labels = label_template.copy()
+        labels[METRIC_LABEL_DEVICE_ID] = duthostname
+
+        # Populate label fields
+        for label_key, src in label_map.items():
+            if callable(src):
+                labels[label_key] = src(record, key)
+            else:
+                labels[label_key] = record.get(src, "Unknown")
+
+        # Record metric values
+        for method_name, field in field_map.items():
+            value = record.get(field, 0) if isinstance(record, dict) else 0
+            getattr(metric_obj, method_name).record(value, labels)
+
+
+def poll_stats(dut_tg_port_map, duration_sec, interval_sec, db_reporter):
+    """
+    Periodically poll DUT telemetry and record metrics into the reporter.
+
+    Executes telemetry commands on DUTs (queue, PSU, temperature, port stats),
+    parses their outputs, and records metrics using configuration-driven
+    label and field mappings. The metrics are stored in db_reporter which can later
+    be consumed by reporting plugins or dashboards.
+
+    Args:
+        dut_tg_port_map (dict):
+            Mapping of DUT host objects → port/interface dictionaries.
+            This defines which DUTs and ports to poll.
+        duration_sec (int):
+            Total time in seconds for which polling will run.
+        interval_sec (int):
+            Time interval in seconds between consecutive polling iterations.
+        db_reporter:
+            Reporter instance that collects and aggregates metrics for persistence or export.
+
+    Returns:
+        None
+    """
+    label_templates = {
+        "portstat": {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_PORT_ID: None},
+        "psu": {
+            METRIC_LABEL_DEVICE_ID: None,
+            METRIC_LABEL_DEVICE_PSU_ID: None,
+            METRIC_LABEL_DEVICE_PSU_MODEL: None,
+            METRIC_LABEL_DEVICE_PSU_SERIAL: None,
+            METRIC_LABEL_DEVICE_PSU_HW_REV: None,
+        },
+        "queue": {
+            METRIC_LABEL_DEVICE_ID: None,
+            METRIC_LABEL_DEVICE_PORT_ID: None,
+            METRIC_LABEL_DEVICE_QUEUE_ID: None,
+            METRIC_LABEL_DEVICE_QUEUE_CAST: "unicast",
+        },
+        "temp": {METRIC_LABEL_DEVICE_ID: None, METRIC_LABEL_DEVICE_SENSOR_ID: None},
+    }
+
+    metrics = {
+        "portstat": DevicePortMetrics(reporter=db_reporter),
+        "psu": DevicePSUMetrics(reporter=db_reporter),
+        "queue": DeviceQueueMetrics(reporter=db_reporter),
+        "temp": DeviceTemperatureMetrics(reporter=db_reporter),
+    }
+
+    # --------------------------------------------------------------------------
+    # Telemetry Configurations:
+    # Each entry defines how raw JSON output from DUT maps to labels + metrics.
+    # --------------------------------------------------------------------------
+    configs = {
+        # -----------------
+        # Queue Watermarks:
+        # "show queue watermark unicast --json"
+        # Records the per-queue buffer usage (watermark in bytes).
+        "queue": dict(
+            metric_obj=metrics["queue"],
+            label_template=label_templates["queue"],
+            label_map={
+                METRIC_LABEL_DEVICE_PORT_ID: "Port",  # Port ID from record
+                METRIC_LABEL_DEVICE_QUEUE_ID: "queue_id",  # Queue ID from record
+                METRIC_LABEL_DEVICE_QUEUE_CAST: lambda r, _: "unicast",  # Constant label
+            },
+            field_map={
+                "watermark_bytes": "watermark_byte",  # Actual watermark value
+            },
+        ),
+        # -----------------
+        # PSU Metrics:
+        # "show platform psu --json"
+        # Records voltage, current, power, and status/LED for each power supply.
+        "psu": dict(
+            metric_obj=metrics["psu"],
+            label_template=label_templates["psu"],
+            label_map={
+                METRIC_LABEL_DEVICE_PSU_ID: "name",  # PSU slot name
+                METRIC_LABEL_DEVICE_PSU_MODEL: "model",  # PSU model
+                METRIC_LABEL_DEVICE_PSU_SERIAL: "serial",  # Serial number
+                METRIC_LABEL_DEVICE_PSU_HW_REV: "revision",  # Hardware revision
+            },
+            field_map={
+                "voltage": "voltage",  # PSU voltage reading
+                "current": "current",  # Current (Amps)
+                "power": "power",  # Power (Watts)
+                "status": lambda r: r.get("status", {}).get("value", 0),  # Operational status (OK/Fail)
+                "led": lambda r: r.get("led", {}).get("value", 0),  # LED state (color/status)
+            },
+        ),
+        # -----------------
+        # Temperature Metrics:
+        # "show platform temperature --json"
+        # Records temperature values and thresholds per temperature sensor.
+        "temp": dict(
+            metric_obj=metrics["temp"],
+            label_template=label_templates["temp"],
+            label_map={
+                METRIC_LABEL_DEVICE_SENSOR_ID: "Sensor",  # Sensor identifier
+            },
+            field_map={
+                "reading": "Temperature",  # Current temperature
+                "high_th": "High_TH",  # High threshold
+                "low_th": "Low_TH",  # Low threshold
+                "crit_high_th": "Crit_High_TH",  # Critical high threshold
+                "crit_low_th": "Crit_Low_TH",  # Critical low threshold
+                "warning": "Warning",  # Warning indicator
+            },
+        ),
+        # -----------------
+        # Port Stats:
+        # "portstat -i PORTS -j"
+        # Records per-port throughput, utilization, error, and drop counters.
+        "portstat": dict(
+            metric_obj=metrics["portstat"],
+            label_template=label_templates["portstat"],
+            label_map={
+                METRIC_LABEL_DEVICE_PORT_ID: lambda _, k: k,  # Key is the port name
+            },
+            field_map={
+                "rx_bps": "RX_BPS",  # RX throughput (bps)
+                "tx_bps": "TX_BPS",  # TX throughput (bps)
+                "rx_util": "RX_UTIL",  # RX utilization (% of line rate)
+                "tx_util": "TX_UTIL",  # TX utilization (% of line rate)
+                "rx_ok": "RX_OK",  # Successful RX packets
+                "tx_ok": "TX_OK",  # Successful TX packets
+                "rx_err": "RX_ERR",  # RX errors
+                "tx_err": "TX_ERR",  # TX errors
+                "rx_drop": "RX_DRP",  # Dropped RX packets
+                "tx_drop": "TX_DRP",  # Dropped TX packets
+                "rx_overrun": "RX_OVR",  # RX buffer overruns
+                "tx_overrun": "TX_OVR",  # TX buffer overruns
+            },
+        ),
+    }
+
+    end_time = time.time() + duration_sec
+    logger.info(f"Started polling every {interval_sec: .2f}s for {duration_sec}s")
+
+    while time.time() < end_time:
+        poll_start = time.time()
+        results = get_dut_stats(dut_tg_port_map)
+
+        for duthostname, outputs in results.items():
+            logger.info(f"Stats from {duthostname}: {outputs}")
+            for stat_type, cfg in configs.items():
+                record_metrics(
+                    cfg["metric_obj"],
+                    outputs.get(stat_type),
+                    duthostname,
+                    cfg["label_template"],
+                    cfg["label_map"],
+                    cfg["field_map"],
+                )
+
+        time.sleep(max(0, interval_sec - (time.time() - poll_start)))
+
+    logger.info(f"Finished polling after {duration_sec}s.")


### PR DESCRIPTION
Summary: Capacity Test : Track switch power usage, temperature, queue watermark and traffic load.
This test aims to evaluate the true capacities of SONiC switches.
The test implements a monitoring thread:
It tracks key metrics, including port counters, queue watermark, power usage, and sensor temperature across all SONiC switches in a testbed.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
Test details : https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/snappi/switch_capacity_test.md
This test aims to evaluate the true capacities of SONiC switches.

#### How did you do it?

#### How did you verify/test it?
TEST Script Run Log:
```
---------------------------- live log sessionstart -----------------------------
24/09/2025 00:24:31 conftest.pytest_sessionstart             L0491 INFO   | Invoking /var/azureuser/sonic-mgmt/tests/build-gnmi-stubs.sh with base directory: /var/azureuser/sonic-mgmt/tests
24/09/2025 00:24:31 conftest.pytest_sessionstart             L0501 INFO   | Output of /var/azureuser/sonic-mgmt/tests/build-gnmi-stubs.sh:
Creating directory: /var/azureuser/sonic-mgmt/tests/common/sai_validation/github.com/openconfig

24/09/2025 00:24:31 conftest.pytest_sessionstart             L0505 ERROR  | /var/azureuser/sonic-mgmt/tests/build-gnmi-stubs.sh failed with exit code 1
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
ansible: 2.13.13
rootdir: /var/azureuser/sonic-mgmt/tests
configfile: pytest.ini
plugins: allure-pytest-2.8.22, ansible-4.0.0, forked-1.6.0, html-4.1.1, metadata-3.1.1, repeat-0.9.3, stress-1.0.1, xdist-1.28.0
----------------------------- live log collection ------------------------------
24/09/2025 00:24:32 snappi.<module>                          L0052 INFO   | Logger instantiated
24/09/2025 00:24:33 __init__.pytest_collection_modifyitems   L0686 INFO   | Available basic facts that can be used in conditional skip:

collected 4 items

snappi_tests/dataplane/test_capacity.py::test_capacity[IPv6-60-86-10] 
-------------------------------- live log setup --------------------------------
24/09/2025 00:24:33 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
24/09/2025 00:24:33 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
24/09/2025 00:24:33 conftest.enhance_inventory               L0334 INFO   | Inventory file: ['../ansible/snappi-sonic']
24/09/2025 00:24:37 ptfhost_utils.run_icmp_responder_session L0310 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
24/09/2025 00:24:37 __init__._sanity_check                   L0432 INFO   | Skip sanity check according to command line argument
24/09/2025 00:24:37 conftest.collect_before_test             L2725 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
24/09/2025 00:24:38 conftest.collect_before_test             L2729 INFO   | Collecting core dumps before test on sonic-s6100-dut1
24/09/2025 00:24:39 conftest.collect_before_test             L2738 INFO   | Collecting running config before test on sonic-s6100-dut1
24/09/2025 00:24:42 conftest.temporarily_disable_route_check L3004 INFO   | Skipping temporarily_disable_route_check fixture
24/09/2025 00:24:42 conftest.generate_params_dut_hostname    L1526 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
24/09/2025 00:24:42 conftest.set_rand_one_dut_hostname       L0668 INFO   | Randomly select dut sonic-s6100-dut1 for testing
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
24/09/2025 00:24:42 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
24/09/2025 00:24:42 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
24/09/2025 00:24:42 snappi.api                               L0106 WARNING| Version check is disabled
24/09/2025 00:24:42 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
24/09/2025 00:24:42 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
24/09/2025 00:24:43 conftest.rand_one_dut_front_end_hostname L0704 INFO   | Randomly select dut sonic-s6100-dut1 for testing
24/09/2025 00:24:43 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
24/09/2025 00:24:43 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
24/09/2025 00:24:43 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
24/09/2025 00:24:44 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture set_primary_chassis setup starts --------------------
24/09/2025 00:24:44 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture set_primary_chassis setup ends --------------------
24/09/2025 00:24:44 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture create_snappi_config setup starts --------------------
24/09/2025 00:24:44 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture create_snappi_config setup ends --------------------
24/09/2025 00:24:44 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
24/09/2025 00:24:44 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060CX-32S-C32, Platform: x86_64-arista_7060_cx32s
24/09/2025 00:24:44 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Arista-7060CX-32S-C32
24/09/2025 00:24:44 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7f5ed6b5e670>
24/09/2025 00:24:44 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f5ed6b32e50>
24/09/2025 00:24:44 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f5ed6b5e5e0>
24/09/2025 00:24:44 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f5ed6b5e700>
24/09/2025 00:24:44 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:24:44 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:24:44 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_al5gt3lm
24/09/2025 00:24:44 conftest.setup_dualtor_mux_ports         L3464 INFO   | skip setup dualtor mux cables on non-dualtor testbed
24/09/2025 00:24:50 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.3}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2398}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 1.9, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------- live log call ---------------------------------
24/09/2025 00:24:50 test_capacity.test_capacity              L0070 INFO   | XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
24/09/2025 00:24:50 test_capacity.test_capacity              L0071 INFO   | Testing IPv6 traffic at 10% line rate for 60 seconds with frame size 86 bytes
24/09/2025 00:24:52 helper.create_snappi_l1config            L0239 INFO   | !!!!!!!!!!!!!!!!!!!!   xyz"
24/09/2025 00:24:52 helper._create_snappi_config             L0268 INFO   | !!!!!!!!!!!!!!!!!!!!!!   create_snappi_config
24/09/2025 00:24:52 connection._warn                         L0336 WARNING| Verification of certificates is disabled
24/09/2025 00:24:52 connection._info                         L0333 INFO   | Determining the platform and rest_port using the 10.36.77.53 address...
24/09/2025 00:24:52 connection._info                         L0333 INFO   | Connection established to `http://10.36.77.53:11099 on windows`
24/09/2025 00:24:52 connection._info                         L0333 INFO   | Using IxNetwork api server version 10.80.2412.12
24/09/2025 00:24:52 connection._info                         L0333 INFO   | User info IxNetwork/WIN-11RK5TNKNAN/8009
24/09/2025 00:24:52 snappi_api.info                          L1512 INFO   | snappi-1.35.0
24/09/2025 00:24:52 snappi_api.info                          L1512 INFO   | snappi_ixnetwork-1.34.0
24/09/2025 00:24:52 snappi_api.info                          L1512 INFO   | ixnetwork_restpy-1.8.0
24/09/2025 00:24:52 snappi_api.info                          L1512 INFO   | Config validation 0.012s
24/09/2025 00:24:53 snappi_api.info                          L1512 INFO   | Ports configuration 0.914s
24/09/2025 00:24:53 snappi_api.info                          L1512 INFO   | Captures configuration 0.033s
24/09/2025 00:24:53 vport._add_hosts                         L0248 INFO   | Adding hosts in vport
24/09/2025 00:24:53 vport._add_hosts                         L0261 INFO   | 0.0009701251983642578
24/09/2025 00:24:53 connection._info                         L0333 INFO   | [0.082s] Timer @ batchadd.py:387 -> Batch Add Completed
24/09/2025 00:24:53 snappi_api.info                          L1512 INFO   | Add location hosts [10.36.84.31, 10.36.78.53] 0.107s
24/09/2025 00:24:59 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.84.31, 10.36.78.53] 6.081s
24/09/2025 00:24:59 snappi_api.info                          L1512 INFO   | Add Host 6.211s
24/09/2025 00:25:01 snappi_api.info                          L1512 INFO   | Chassis Chain 2.041s
24/09/2025 00:25:02 snappi_api.info                          L1512 INFO   | Speed conversion is not require for (port.name, speed) : [('Port_1', 'novusHundredGigNonFanOut'), ('Port_2', 'novusHundredGigNonFanOut'), ('Port_3', 'novusHundredGigNonFanOut'), ('Port_4', 'novusHundredGigNonFanOut')]
24/09/2025 00:25:02 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.851s
24/09/2025 00:25:26 snappi_api.info                          L1512 INFO   | Location connect [Port_1, Port_2, Port_3, Port_4] 24.112s
24/09/2025 00:25:26 snappi_api.warning                       L1518 WARNING| Port_1 connectedLinkDown
24/09/2025 00:25:26 snappi_api.warning                       L1518 WARNING| Port_2 connectedLinkDown
24/09/2025 00:25:26 snappi_api.warning                       L1518 WARNING| Port_3 connectedLinkDown
24/09/2025 00:25:26 snappi_api.warning                       L1518 WARNING| Port_4 connectedLinkDown
24/09/2025 00:25:26 snappi_api.info                          L1512 INFO   | Location state check [Port_1, Port_2, Port_3, Port_4] 0.042s
24/09/2025 00:25:26 snappi_api.info                          L1512 INFO   | Location configuration 33.293s
24/09/2025 00:25:28 snappi_api.info                          L1512 INFO   | Layer1 configuration 1.906s
24/09/2025 00:25:28 snappi_api.info                          L1512 INFO   | Lag Configuration 0.008s
24/09/2025 00:25:28 snappi_api.info                          L1512 INFO   | Convert device config : 0.034s
24/09/2025 00:25:28 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
24/09/2025 00:25:29 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 1.252s
24/09/2025 00:25:29 snappi_api.info                          L1512 INFO   | Devices configuration 1.296s
24/09/2025 00:25:30 snappi_api.info                          L1512 INFO   | Flows configuration 0.589s
24/09/2025 00:25:30 snappi_api.info                          L1512 INFO   | Start interfaces 0.606s
24/09/2025 00:25:31 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
24/09/2025 00:25:31 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
24/09/2025 00:25:31 helper.start_stop                        L0494 INFO   | Start protocols
24/09/2025 00:26:24 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To start
24/09/2025 00:26:46 helper.start_stop                        L0494 INFO   | Start traffic
24/09/2025 00:26:48 snappi_api.info                          L1512 INFO   | Flows generate/apply 2.288s
24/09/2025 00:27:01 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.688s
24/09/2025 00:27:01 snappi_api.info                          L1512 INFO   | Captures start 0.000s
24/09/2025 00:27:05 snappi_api.info                          L1512 INFO   | Flows start 3.742s
24/09/2025 00:27:05 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To start
24/09/2025 00:27:25 test_capacity.poll_stats                 L0406 INFO   | Started polling every 30.00s for 60s
24/09/2025 00:27:25 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:27:25 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:27:27 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:27:29 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:27:29 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:27:31 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:27:33 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '50.75', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.375', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:01:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '1011.00 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '353,072,134', 'RX_OVR': '0', 'RX_UTIL': '8.09%', 'STATE': 'U', 'TX_BPS': '97.92 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '32', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '43.74 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '16', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1010.83 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '353,100,859', 'TX_OVR': '0', 'TX_UTIL': '8.09%'}, 'Ethernet4': {'RX_BPS': '1010.96 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '353,082,952', 'RX_OVR': '0', 'RX_UTIL': '8.09%', 'STATE': 'U', 'TX_BPS': '85.93 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '29', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '36.70 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '24', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1010.93 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '353,099,307', 'TX_OVR': '0', 'TX_UTIL': '8.09%'}}}
24/09/2025 00:27:55 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:27:55 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:27:57 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:27:59 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:27:59 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:28:01 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:28:03 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '48.125', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.5', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:02:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '1026.00 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '707,823,376', 'RX_OVR': '0', 'RX_UTIL': '8.21%', 'STATE': 'U', 'TX_BPS': '86.59 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '51', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '43.73 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '26', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1025.93 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '707,856,718', 'TX_OVR': '0', 'TX_UTIL': '8.21%'}, 'Ethernet4': {'RX_BPS': '1025.97 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '707,834,725', 'RX_OVR': '0', 'RX_UTIL': '8.21%', 'STATE': 'U', 'TX_BPS': '97.36 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '50', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '35.86 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '34', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1025.96 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '707,850,046', 'TX_OVR': '0', 'TX_UTIL': '8.21%'}}}
24/09/2025 00:28:25 test_capacity.poll_stats                 L0426 INFO   | Finished polling after 60s.
24/09/2025 00:28:25 db_reporter._report                      L0049 INFO   | DBReporter: Writing 142 metric records to file
24/09/2025 00:28:25 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 142 metric records to /tmp/telemetry_test_al5gt3lm/test_capacity.metrics.json
24/09/2025 00:28:25 test_capacity.test_capacity              L0111 INFO   | Stopping transmit on all flows ...
24/09/2025 00:28:25 helper.start_stop                        L0494 INFO   | Stop traffic
24/09/2025 00:28:31 snappi_api.info                          L1512 INFO   | Flows stop 6.295s
24/09/2025 00:28:31 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To stop
24/09/2025 00:28:51 helper.start_stop                        L0494 INFO   | Stop protocols
24/09/2025 00:28:52 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To stop
PASSED                                                                   [ 25%]
------------------------------ live log teardown -------------------------------
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: monit-memory_usage
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for monit:memory_usage: 70.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for monit:memory_usage: 10.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-bgpd
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:bgpd: 128.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-zebra
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:zebra: 128.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: free-used
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for free:used: 479.6
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-snmp
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:snmp: 4.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:snmp: 2.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-pmon
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:pmon: 8.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:pmon: 2.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-lldp
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:lldp: 4.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:lldp: 2.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-gnmi
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0064 WARNING| Skipping memory check for docker-gnmi due to zero value
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-radv
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:radv: 3.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:radv: 2.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-syncd
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:syncd: 18.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:syncd: 5.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-bgp
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:bgp: 14.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:bgp: 4.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-teamd
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:teamd: 5.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:teamd: 2.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-swss
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:swss: 8.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:swss: 3.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-database
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:database: 6.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:database: 2.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_bgp-used
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_bgp:used: 256.0
24/09/2025 00:29:20 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [3.8, 64.0])
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_bgp:used: 64.0
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_zebra-used
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_zebra:used: 128.0
24/09/2025 00:29:20 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [4.7, 64.0])
24/09/2025 00:29:20 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_zebra:used: 64.0
24/09/2025 00:29:20 __init__.pytest_runtest_teardown         L0124 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.3}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2398}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 1.9, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.3}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2397}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.0, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}}

snappi_tests/dataplane/test_capacity.py::test_capacity[IPv6-60-86-100] 
-------------------------------- live log setup --------------------------------
24/09/2025 00:29:20 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
24/09/2025 00:29:20 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
24/09/2025 00:29:20 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
24/09/2025 00:29:20 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060CX-32S-C32, Platform: x86_64-arista_7060_cx32s
24/09/2025 00:29:20 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Arista-7060CX-32S-C32
24/09/2025 00:29:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7f5ed6b5e670>
24/09/2025 00:29:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f5ed6b32e50>
24/09/2025 00:29:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f5ed6b5e5e0>
24/09/2025 00:29:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f5ed6b5e700>
24/09/2025 00:29:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:29:20 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:29:20 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_sov45u73
24/09/2025 00:29:20 conftest.setup_dualtor_mux_ports         L3464 INFO   | skip setup dualtor mux cables on non-dualtor testbed
24/09/2025 00:29:27 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.4}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2401}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.0, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------- live log call ---------------------------------
24/09/2025 00:29:27 test_capacity.test_capacity              L0070 INFO   | XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
24/09/2025 00:29:27 test_capacity.test_capacity              L0071 INFO   | Testing IPv6 traffic at 100% line rate for 60 seconds with frame size 86 bytes
24/09/2025 00:29:28 helper.create_snappi_l1config            L0239 INFO   | !!!!!!!!!!!!!!!!!!!!   xyz"
24/09/2025 00:29:28 helper._create_snappi_config             L0268 INFO   | !!!!!!!!!!!!!!!!!!!!!!   create_snappi_config
24/09/2025 00:29:28 snappi_api.info                          L1512 INFO   | Config validation 0.005s
24/09/2025 00:29:28 snappi_api.info                          L1512 INFO   | Ports configuration 0.068s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Captures configuration 0.035s
24/09/2025 00:29:29 vport._add_hosts                         L0248 INFO   | Adding hosts in vport
24/09/2025 00:29:29 vport._add_hosts                         L0261 INFO   | 0.0007033348083496094
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.78.53] 0.016s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Add Host 0.039s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Chassis Chain 0.021s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Speed change not require due to redundant Layer1 config
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.019s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Location configuration 0.121s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.064s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Lag Configuration 0.007s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Convert device config : 0.221s
24/09/2025 00:29:29 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
24/09/2025 00:29:30 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 1.165s
24/09/2025 00:29:30 snappi_api.info                          L1512 INFO   | Devices configuration 1.396s
24/09/2025 00:29:31 snappi_api.info                          L1512 INFO   | Flows configuration 0.970s
24/09/2025 00:29:32 snappi_api.info                          L1512 INFO   | Start interfaces 0.632s
24/09/2025 00:29:32 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
24/09/2025 00:29:32 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
24/09/2025 00:29:32 helper.start_stop                        L0494 INFO   | Start protocols
24/09/2025 00:29:52 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To start
24/09/2025 00:30:14 helper.start_stop                        L0494 INFO   | Start traffic
24/09/2025 00:30:19 snappi_api.info                          L1512 INFO   | Flows generate/apply 4.767s
24/09/2025 00:30:32 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.518s
24/09/2025 00:30:32 snappi_api.info                          L1512 INFO   | Captures start 0.000s
24/09/2025 00:30:35 snappi_api.info                          L1512 INFO   | Flows start 3.738s
24/09/2025 00:30:35 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To start
24/09/2025 00:30:55 test_capacity.poll_stats                 L0406 INFO   | Started polling every 30.00s for 60s
24/09/2025 00:30:55 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:30:55 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:30:58 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:31:00 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:31:00 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:31:01 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:31:03 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '35.625', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.5', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '10114.80 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '3,502,580,730', 'RX_OVR': '0', 'RX_UTIL': '80.92%', 'STATE': 'U', 'TX_BPS': '69.53 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '30', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '85.23 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '37', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '10119.88 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '3,503,299,678', 'TX_OVR': '0', 'TX_UTIL': '80.96%'}, 'Ethernet4': {'RX_BPS': '10114.63 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '3,502,700,493', 'RX_OVR': '0', 'RX_UTIL': '80.92%', 'STATE': 'U', 'TX_BPS': '102.41 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '38', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '69.13 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '36', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '10114.53 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '3,502,831,885', 'TX_OVR': '0', 'TX_UTIL': '80.92%'}}}
24/09/2025 00:31:25 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:31:25 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:31:28 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:31:29 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:31:29 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:31:31 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:31:33 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '35.625', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.5', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:05:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '10135.15 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '7,041,974,268', 'RX_OVR': '0', 'RX_UTIL': '81.08%', 'STATE': 'U', 'TX_BPS': '75.80 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '42', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '79.86 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '57', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '10134.32 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '7,042,304,653', 'TX_OVR': '0', 'TX_UTIL': '81.07%'}, 'Ethernet4': {'RX_BPS': '10134.84 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '7,042,082,849', 'RX_OVR': '0', 'RX_UTIL': '81.08%', 'STATE': 'U', 'TX_BPS': '75.88 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '50', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '79.87 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '57', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '10134.53 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '7,042,196,139', 'TX_OVR': '0', 'TX_UTIL': '81.08%'}}}
24/09/2025 00:31:55 test_capacity.poll_stats                 L0426 INFO   | Finished polling after 60s.
24/09/2025 00:31:55 db_reporter._report                      L0049 INFO   | DBReporter: Writing 142 metric records to file
24/09/2025 00:31:55 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 142 metric records to /tmp/telemetry_test_sov45u73/test_capacity.metrics.json
24/09/2025 00:31:55 test_capacity.test_capacity              L0111 INFO   | Stopping transmit on all flows ...
24/09/2025 00:31:55 helper.start_stop                        L0494 INFO   | Stop traffic
24/09/2025 00:32:02 snappi_api.info                          L1512 INFO   | Flows stop 6.310s
24/09/2025 00:32:02 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To stop
24/09/2025 00:32:22 helper.start_stop                        L0494 INFO   | Stop protocols
24/09/2025 00:32:22 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To stop
PASSED                                                                   [ 50%]
------------------------------ live log teardown -------------------------------
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: monit-memory_usage
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for monit:memory_usage: 70.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for monit:memory_usage: 10.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-bgpd
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:bgpd: 128.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-zebra
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:zebra: 128.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: free-used
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for free:used: 480.2
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-snmp
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:snmp: 4.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:snmp: 2.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-pmon
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:pmon: 8.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:pmon: 2.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-lldp
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:lldp: 4.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:lldp: 2.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-gnmi
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0064 WARNING| Skipping memory check for docker-gnmi due to zero value
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-radv
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:radv: 3.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:radv: 2.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-syncd
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:syncd: 18.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:syncd: 5.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-bgp
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:bgp: 14.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:bgp: 4.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-teamd
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:teamd: 5.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:teamd: 2.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-swss
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:swss: 8.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:swss: 3.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-database
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:database: 6.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:database: 2.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_bgp-used
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_bgp:used: 256.0
24/09/2025 00:32:49 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [3.8, 64.0])
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_bgp:used: 64.0
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_zebra-used
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_zebra:used: 128.0
24/09/2025 00:32:49 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [4.7, 64.0])
24/09/2025 00:32:49 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_zebra:used: 64.0
24/09/2025 00:32:49 __init__.pytest_runtest_teardown         L0124 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.4}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2401}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.0, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.4}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2399}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.0, 'database': 1.7}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}}

snappi_tests/dataplane/test_capacity.py::test_capacity[IPv6-60-512-10] 
-------------------------------- live log setup --------------------------------
24/09/2025 00:32:49 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
24/09/2025 00:32:49 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
24/09/2025 00:32:49 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
24/09/2025 00:32:49 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060CX-32S-C32, Platform: x86_64-arista_7060_cx32s
24/09/2025 00:32:49 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Arista-7060CX-32S-C32
24/09/2025 00:32:49 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7f5ed6b5e670>
24/09/2025 00:32:49 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f5ed6b32e50>
24/09/2025 00:32:49 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f5ed6b5e5e0>
24/09/2025 00:32:49 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f5ed6b5e700>
24/09/2025 00:32:49 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:32:49 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:32:49 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_meo3q7vb
24/09/2025 00:32:49 conftest.setup_dualtor_mux_ports         L3464 INFO   | skip setup dualtor mux cables on non-dualtor testbed
24/09/2025 00:32:55 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.4}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2402}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.0, 'database': 1.7}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------- live log call ---------------------------------
24/09/2025 00:32:55 test_capacity.test_capacity              L0070 INFO   | XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
24/09/2025 00:32:55 test_capacity.test_capacity              L0071 INFO   | Testing IPv6 traffic at 10% line rate for 60 seconds with frame size 512 bytes
24/09/2025 00:32:57 helper.create_snappi_l1config            L0239 INFO   | !!!!!!!!!!!!!!!!!!!!   xyz"
24/09/2025 00:32:57 helper._create_snappi_config             L0268 INFO   | !!!!!!!!!!!!!!!!!!!!!!   create_snappi_config
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Config validation 0.005s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Ports configuration 0.065s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Captures configuration 0.036s
24/09/2025 00:32:57 vport._add_hosts                         L0248 INFO   | Adding hosts in vport
24/09/2025 00:32:57 vport._add_hosts                         L0261 INFO   | 0.0009188652038574219
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.78.53] 0.017s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Add Host 0.041s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Chassis Chain 0.021s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Speed change not require due to redundant Layer1 config
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.019s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Location configuration 0.115s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.064s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Lag Configuration 0.008s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Convert device config : 0.222s
24/09/2025 00:32:57 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
24/09/2025 00:32:59 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 1.168s
24/09/2025 00:32:59 snappi_api.info                          L1512 INFO   | Devices configuration 1.400s
24/09/2025 00:32:59 snappi_api.info                          L1512 INFO   | Flows configuration 0.575s
24/09/2025 00:33:00 snappi_api.info                          L1512 INFO   | Start interfaces 0.645s
24/09/2025 00:33:00 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
24/09/2025 00:33:00 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
24/09/2025 00:33:00 helper.start_stop                        L0494 INFO   | Start protocols
24/09/2025 00:33:16 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To start
24/09/2025 00:33:38 helper.start_stop                        L0494 INFO   | Start traffic
24/09/2025 00:33:43 snappi_api.info                          L1512 INFO   | Flows generate/apply 4.916s
24/09/2025 00:33:56 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.523s
24/09/2025 00:33:56 snappi_api.info                          L1512 INFO   | Captures start 0.000s
24/09/2025 00:33:59 snappi_api.info                          L1512 INFO   | Flows start 3.486s
24/09/2025 00:33:59 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To start
24/09/2025 00:34:19 test_capacity.poll_stats                 L0406 INFO   | Started polling every 30.00s for 60s
24/09/2025 00:34:19 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:34:19 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:34:22 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:34:24 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:34:24 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:34:26 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:34:27 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.625', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:08:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '1198.59 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '69,543,051', 'RX_OVR': '0', 'RX_UTIL': '9.59%', 'STATE': 'U', 'TX_BPS': '43.08 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '32', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '29.41 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '16', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1198.64 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '69,549,778', 'TX_OVR': '0', 'TX_UTIL': '9.59%'}, 'Ethernet4': {'RX_BPS': '1198.54 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '69,545,224', 'RX_OVR': '0', 'RX_UTIL': '9.59%', 'STATE': 'U', 'TX_BPS': '53.98 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '33', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '29.41 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '16', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1198.43 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '69,550,033', 'TX_OVR': '0', 'TX_UTIL': '9.59%'}}}
24/09/2025 00:34:49 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:34:49 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:34:52 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:34:54 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:34:54 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:34:56 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:34:57 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '36.5', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.375', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:09:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '1201.83 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '140,085,600', 'RX_OVR': '0', 'RX_UTIL': '9.61%', 'STATE': 'U', 'TX_BPS': '53.93 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '53', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '29.41 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '26', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1201.93 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '140,092,968', 'TX_OVR': '0', 'TX_UTIL': '9.62%'}, 'Ethernet4': {'RX_BPS': '1201.92 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '140,089,237', 'RX_OVR': '0', 'RX_UTIL': '9.62%', 'STATE': 'U', 'TX_BPS': '53.96 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '54', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '29.41 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '26', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '1201.99 MB/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '140,096,040', 'TX_OVR': '0', 'TX_UTIL': '9.62%'}}}
24/09/2025 00:35:19 test_capacity.poll_stats                 L0426 INFO   | Finished polling after 60s.
24/09/2025 00:35:19 db_reporter._report                      L0049 INFO   | DBReporter: Writing 142 metric records to file
24/09/2025 00:35:19 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 142 metric records to /tmp/telemetry_test_meo3q7vb/test_capacity.metrics.json
24/09/2025 00:35:19 test_capacity.test_capacity              L0111 INFO   | Stopping transmit on all flows ...
24/09/2025 00:35:19 helper.start_stop                        L0494 INFO   | Stop traffic
24/09/2025 00:35:25 snappi_api.info                          L1512 INFO   | Flows stop 5.317s
24/09/2025 00:35:25 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To stop
24/09/2025 00:35:45 helper.start_stop                        L0494 INFO   | Stop protocols
24/09/2025 00:35:45 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To stop
PASSED                                                                   [ 75%]
------------------------------ live log teardown -------------------------------
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: monit-memory_usage
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for monit:memory_usage: 70.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for monit:memory_usage: 10.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-bgpd
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:bgpd: 128.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-zebra
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:zebra: 128.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: free-used
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for free:used: 480.4
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-snmp
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:snmp: 4.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:snmp: 2.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-pmon
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:pmon: 8.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:pmon: 2.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-lldp
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:lldp: 4.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:lldp: 2.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-gnmi
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0064 WARNING| Skipping memory check for docker-gnmi due to zero value
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-radv
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:radv: 3.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:radv: 2.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-syncd
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:syncd: 18.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:syncd: 5.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-bgp
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:bgp: 14.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:bgp: 4.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-teamd
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:teamd: 5.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:teamd: 2.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-swss
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:swss: 8.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:swss: 3.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-database
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:database: 6.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:database: 2.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_bgp-used
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_bgp:used: 256.0
24/09/2025 00:36:12 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [3.8, 64.0])
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_bgp:used: 64.0
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_zebra-used
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_zebra:used: 128.0
24/09/2025 00:36:12 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [4.7, 64.0])
24/09/2025 00:36:12 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_zebra:used: 64.0
24/09/2025 00:36:12 __init__.pytest_runtest_teardown         L0124 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.4}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2402}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.0, 'database': 1.7}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.4}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2395}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.1, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}}

snappi_tests/dataplane/test_capacity.py::test_capacity[IPv6-60-512-100] 
-------------------------------- live log setup --------------------------------
24/09/2025 00:36:12 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
24/09/2025 00:36:12 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
24/09/2025 00:36:12 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
24/09/2025 00:36:12 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Arista-7060CX-32S-C32, Platform: x86_64-arista_7060_cx32s
24/09/2025 00:36:12 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Arista-7060CX-32S-C32
24/09/2025 00:36:12 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7f5ed6b5e670>
24/09/2025 00:36:12 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7f5ed6b32e50>
24/09/2025 00:36:12 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7f5ed6b5e5e0>
24/09/2025 00:36:12 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7f5ed6b5e700>
24/09/2025 00:36:12 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:36:12 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7f5ed6b5e790>
24/09/2025 00:36:12 db_reporter.__init__                     L0040 INFO   | DBReporter initialized: output_dir=/tmp/telemetry_test_vgzygwnr
24/09/2025 00:36:12 conftest.setup_dualtor_mux_ports         L3464 INFO   | skip setup dualtor mux cables on non-dualtor testbed
24/09/2025 00:36:19 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.5}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2402}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.1, 'database': 1.7}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {}}}
-------------------------------- live log call ---------------------------------
24/09/2025 00:36:19 test_capacity.test_capacity              L0070 INFO   | XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
24/09/2025 00:36:19 test_capacity.test_capacity              L0071 INFO   | Testing IPv6 traffic at 100% line rate for 60 seconds with frame size 512 bytes
24/09/2025 00:36:20 helper.create_snappi_l1config            L0239 INFO   | !!!!!!!!!!!!!!!!!!!!   xyz"
24/09/2025 00:36:20 helper._create_snappi_config             L0268 INFO   | !!!!!!!!!!!!!!!!!!!!!!   create_snappi_config
24/09/2025 00:36:20 snappi_api.info                          L1512 INFO   | Config validation 0.008s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Ports configuration 0.065s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Captures configuration 0.036s
24/09/2025 00:36:21 vport._add_hosts                         L0248 INFO   | Adding hosts in vport
24/09/2025 00:36:21 vport._add_hosts                         L0261 INFO   | 0.0008776187896728516
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Location hosts ready [10.36.78.53] 0.017s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Add Host 0.040s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Chassis Chain 0.021s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Speed change not require due to redundant Layer1 config
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Aggregation mode speed change 0.018s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Location configuration 0.113s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Layer1 configuration 0.065s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Lag Configuration 0.007s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Convert device config : 0.201s
24/09/2025 00:36:21 snappi_api.info                          L1512 INFO   | Create IxNetwork device config : 0.001s
24/09/2025 00:36:22 snappi_api.info                          L1512 INFO   | Push IxNetwork device config : 1.242s
24/09/2025 00:36:22 snappi_api.info                          L1512 INFO   | Devices configuration 1.454s
24/09/2025 00:36:23 snappi_api.info                          L1512 INFO   | Flows configuration 0.507s
24/09/2025 00:36:23 snappi_api.info                          L1512 INFO   | Start interfaces 0.702s
24/09/2025 00:36:24 snappi_api.info                          L1512 INFO   | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
24/09/2025 00:36:24 snappi_api.info                          L1512 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
24/09/2025 00:36:24 helper.start_stop                        L0494 INFO   | Start protocols
24/09/2025 00:36:41 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To start
24/09/2025 00:37:04 helper.start_stop                        L0494 INFO   | Start traffic
24/09/2025 00:37:09 snappi_api.info                          L1512 INFO   | Flows generate/apply 4.950s
24/09/2025 00:37:21 snappi_api.info                          L1512 INFO   | Flows clear statistics 12.462s
24/09/2025 00:37:21 snappi_api.info                          L1512 INFO   | Captures start 0.000s
24/09/2025 00:37:25 snappi_api.info                          L1512 INFO   | Flows start 3.636s
24/09/2025 00:37:25 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To start
24/09/2025 00:37:45 test_capacity.poll_stats                 L0406 INFO   | Started polling every 30.00s for 60s
24/09/2025 00:37:45 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:37:45 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:37:47 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:37:49 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:37:49 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:37:51 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:37:53 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '45.875', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.375', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '11993.90 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '714,844,801', 'RX_OVR': '0', 'RX_UTIL': '95.95%', 'STATE': 'U', 'TX_BPS': '44.31 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '22', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '43.68 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '17', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '9955.73 MB/s', 'TX_DRP': '120,288,527', 'TX_ERR': '0', 'TX_OK': '593,458,600', 'TX_OVR': '0', 'TX_UTIL': '79.65%'}, 'Ethernet4': {'RX_BPS': '11993.54 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '714,867,956', 'RX_OVR': '0', 'RX_UTIL': '95.95%', 'STATE': 'U', 'TX_BPS': '80.35 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '35', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '43.68 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '17', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '9956.07 MB/s', 'TX_DRP': '120,291,536', 'TX_ERR': '0', 'TX_OK': '593,441,871', 'TX_OVR': '0', 'TX_UTIL': '79.65%'}}}
24/09/2025 00:38:15 test_capacity.get_stats                  L0171 INFO   | Collecting initial stats from sonic-s6100-dut1
24/09/2025 00:38:15 test_capacity.get_stats                  L0175 INFO   | Running command 'show queue watermark unicast --json' on sonic-s6100-dut1
24/09/2025 00:38:17 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform psu --json' on sonic-s6100-dut1
24/09/2025 00:38:19 test_capacity.get_stats                  L0201 ERROR  | [sonic-s6100-dut1] Failed to run 'show platform psu --json': Expecting value: line 1 column 1 (char 0)
24/09/2025 00:38:19 test_capacity.get_stats                  L0175 INFO   | Running command 'show platform temperature --json' on sonic-s6100-dut1
24/09/2025 00:38:21 test_capacity.get_stats                  L0175 INFO   | Running command 'portstat -i {} -j' on sonic-s6100-dut1
24/09/2025 00:38:22 test_capacity.poll_stats                 L0413 INFO   | Stats from sonic-s6100-dut1: {'queue': [{'Port': 'Ethernet0', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet0', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet0', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC1', 'watermark_byte': '1277120'}, {'Port': 'Ethernet4', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet4', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet8', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet8', 'queue_id': 'UC6', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC0', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC1', 'watermark_byte': '2057536'}, {'Port': 'Ethernet12', 'queue_id': 'UC2', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC3', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC4', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC5', 'watermark_byte': '0'}, {'Port': 'Ethernet12', 'queue_id': 'UC6', 'watermark_byte': '0'}], 'psu': None, 'temp': [{'Crit_High_TH': '85.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Back-panel temp sensor', 'Temperature': '30.5', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Board sensor', 'Temperature': '37.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '80.0', 'Crit_Low_TH': '-5.0', 'High_TH': '75.0', 'Low_TH': '0.0', 'Sensor': 'Cpu board temp sensor', 'Temperature': '33.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '95.0', 'Crit_Low_TH': '-5.0', 'High_TH': '90.0', 'Low_TH': '0.0', 'Sensor': 'Cpu temp sensor', 'Temperature': '45.875', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '65.0', 'Low_TH': '0.0', 'Sensor': 'Front-panel temp sensor', 'Temperature': '38.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 hotspot sensor', 'Temperature': '45.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 1 inlet sensor', 'Temperature': '30.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '100.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 hotspot sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '75.0', 'Crit_Low_TH': '-5.0', 'High_TH': '70.0', 'Low_TH': '0.0', 'Sensor': 'Power supply 2 inlet sensor', 'Temperature': '0.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip left sensor', 'Temperature': '43.375', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}, {'Crit_High_TH': '105.0', 'Crit_Low_TH': '-5.0', 'High_TH': '95.0', 'Low_TH': '0.0', 'Sensor': 'Switch chip right sensor', 'Temperature': '43.0', 'Timestamp': '20250923 23:12:25', 'Warning': 'False'}], 'portstat': {'Ethernet0': {'RX_BPS': '12019.38 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '1,420,175,974', 'RX_OVR': '0', 'RX_UTIL': '96.16%', 'STATE': 'U', 'TX_BPS': '78.84 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '39', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet12': {'RX_BPS': '43.41 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '27', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '9979.82 MB/s', 'TX_DRP': '238,707,731', 'TX_ERR': '0', 'TX_OK': '1,179,092,333', 'TX_OVR': '0', 'TX_UTIL': '79.84%'}, 'Ethernet4': {'RX_BPS': '12019.07 MB/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '1,420,199,039', 'RX_OVR': '0', 'RX_UTIL': '96.15%', 'STATE': 'U', 'TX_BPS': '79.85 B/s', 'TX_DRP': '0', 'TX_ERR': '0', 'TX_OK': '56', 'TX_OVR': '0', 'TX_UTIL': '0.00%'}, 'Ethernet8': {'RX_BPS': '43.41 B/s', 'RX_DRP': '0', 'RX_ERR': '0', 'RX_OK': '27', 'RX_OVR': '0', 'RX_UTIL': '0.00%', 'STATE': 'U', 'TX_BPS': '9979.43 MB/s', 'TX_DRP': '238,734,480', 'TX_ERR': '0', 'TX_OK': '1,179,051,043', 'TX_OVR': '0', 'TX_UTIL': '79.84%'}}}
24/09/2025 00:38:45 test_capacity.poll_stats                 L0426 INFO   | Finished polling after 60s.
24/09/2025 00:38:45 db_reporter._report                      L0049 INFO   | DBReporter: Writing 142 metric records to file
24/09/2025 00:38:45 db_reporter._report                      L0097 INFO   | DBReporter: Successfully wrote 142 metric records to /tmp/telemetry_test_vgzygwnr/test_capacity.metrics.json
24/09/2025 00:38:45 test_capacity.test_capacity              L0111 INFO   | Stopping transmit on all flows ...
24/09/2025 00:38:45 helper.start_stop                        L0494 INFO   | Stop traffic
24/09/2025 00:38:51 snappi_api.info                          L1512 INFO   | Flows stop 6.534s
24/09/2025 00:38:51 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For traffic To stop
24/09/2025 00:39:12 helper.start_stop                        L0494 INFO   | Stop protocols
24/09/2025 00:39:12 utilities.wait                           L0120 INFO   | Pause 20 seconds, reason: For protocols To stop
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: monit-memory_usage
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for monit:memory_usage: 70.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for monit:memory_usage: 10.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-bgpd
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:bgpd: 128.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: top-zebra
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for top:zebra: 128.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: free-used
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for free:used: 480.4
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-snmp
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:snmp: 4.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:snmp: 2.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-pmon
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:pmon: 8.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:pmon: 2.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-lldp
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:lldp: 4.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:lldp: 2.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-gnmi
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0064 WARNING| Skipping memory check for docker-gnmi due to zero value
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-radv
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:radv: 3.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:radv: 2.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-syncd
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:syncd: 18.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:syncd: 5.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-bgp
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:bgp: 14.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:bgp: 4.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-teamd
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:teamd: 5.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:teamd: 2.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-swss
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:swss: 8.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:swss: 3.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: docker-database
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for docker:database: 6.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for docker:database: 2.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_bgp-used
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_bgp:used: 256.0
24/09/2025 00:39:38 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [3.8, 64.0])
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_bgp:used: 64.0
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0053 INFO   | Checking thresholds for command: frr_zebra-used
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0075 INFO   | Calculated high threshold for frr_zebra:used: 128.0
24/09/2025 00:39:38 memory_utilization._parse_threshold      L0216 INFO   | Selected max threshold from list: 64.0 (from values: [4.7, 64.0])
24/09/2025 00:39:38 memory_utilization.check_memory_threshol L0093 INFO   | Calculated increase threshold for frr_zebra:used: 64.0
24/09/2025 00:39:38 __init__.pytest_runtest_teardown         L0124 INFO   | After test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.5}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2402}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.1, 'database': 1.7}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}, 'after_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 34.5}, 'top': {'zebra': 74.3, 'bgpd': 71.0}, 'free': {'used': 2400}, 'docker': {'snmp': 0.8, 'lldp': 0.7, 'pmon': 2.3, 'radv': 0.4, 'syncd': 6.5, 'teamd': 0.4, 'bgp': 2.6, 'swss': 2.1, 'database': 1.8}, 'frr_bgp': {'used': 7.5}, 'frr_zebra': {'used': 9.4}}}}
24/09/2025 00:39:38 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture snappi_api teardown starts --------------------
24/09/2025 00:39:38 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture snappi_api teardown ends --------------------
24/09/2025 00:39:38 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture start_pfcwd_after_test teardown starts --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture start_pfcwd_after_test teardown ends --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossy_prio teardown starts --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossy_prio teardown ends --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture rand_lossless_prio teardown starts --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture rand_lossless_prio teardown ends --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0093 INFO   | -------------------- fixture enable_packet_aging_after_test teardown starts --------------------
24/09/2025 00:39:40 __init__._fixture_generator_decorator    L0102 INFO   | -------------------- fixture enable_packet_aging_after_test teardown ends --------------------
24/09/2025 00:39:40 conftest.temporarily_disable_route_check L3006 INFO   | Skipping temporarily_disable_route_check fixture
24/09/2025 00:39:40 conftest.collect_after_test              L2793 INFO   | Dumping Disk and Memory Space information after test on sonic-s6100-dut1
24/09/2025 00:39:41 conftest.collect_after_test              L2797 INFO   | Collecting core dumps after test on sonic-s6100-dut1
24/09/2025 00:39:42 conftest.collect_after_test              L2808 INFO   | Collecting running config after test on sonic-s6100-dut1
24/09/2025 00:39:43 conftest.core_dump_and_config_check      L2949 WARNING| Core dump or config check failed for snappi_tests/dataplane/test_capacity.py, results: {"core_dump_check": {"failed": false, "new_core_dumps": {"sonic-s6100-dut1": []}}, "config_db_check": {"failed": true, "pre_only_config": {"sonic-s6100-dut1": {"null": {}}}, "cur_only_config": {"sonic-s6100-dut1": {"null": {"VLAN_INTERFACE": {"Vlan2": {}, "Vlan2|192.168.1.1/24": {}}, "VLAN": {"Vlan2": {"vlanid": "2"}}, "BGP_NEIGHBOR": {"300:0:0:1::2": {"admin_status": "up", "asn": "65300", "holdtime": "10", "keepalive": "3", "local_addr": "300:0:0:1::1", "name": "snappi-sonic1", "nhopself": "0", "rrclient": "0"}, "300:0:0:2::2": {"admin_status": "up", "asn": "65300", "holdtime": "10", "keepalive": "3", "local_addr": "300:0:0:2::1", "name": "snappi-sonic2", "nhopself": "0", "rrclient": "0"}, "300:0:0:3::2": {"admin_status": "up", "asn": "65300", "holdtime": "10", "keepalive": "3", "local_addr": "300:0:0:3::1", "name": "snappi-sonic3", "nhopself": "0", "rrclient": "0"}, "300::2": {"admin_status": "up", "asn": "65300", "holdtime": "10", "keepalive": "3", "local_addr": "300::1", "name": "snappi-sonic0", "nhopself": "0", "rrclient": "0"}}, "PFC_WD": {"Ethernet0": {"action": "drop", "detection_time": "200", "restoration_time": "200"}, "Ethernet12": {"action": "drop", "detection_time": "200", "restoration_time": "200"}, "Ethernet4": {"action": "drop", "detection_time": "200", "restoration_time": "200"}, "Ethernet8": {"action": "drop", "detection_time": "200", "restoration_time": "200"}, "GLOBAL": {"POLL_INTERVAL": "200"}}}}}, "inconsistent_config": {"sonic-s6100-dut1": {"null": {"PORT_QOS_MAP": {"pre_value": {"Ethernet0": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet104": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet4": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "global": {"dscp_to_tc_map": "AZURE"}}, "cur_value": {"Ethernet0": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet12": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet4": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "Ethernet8": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}, "global": {"dscp_to_tc_map": "AZURE"}}}, "DEVICE_METADATA": {"pre_value": {"localhost": {"bgp_asn": "None", "buffer_model": "traditional", "cloudtype": "None", "default_bgp_status": "up", "default_pfcwd_status": "enable", "deployment_id": "None", "docker_routing_config_mode": "separated", "hostname": "7060CX-S1", "hwsku": "Arista-7060CX-32S-C32", "mac": "44:4c:a8:ca:41:94", "platform": "x86_64-arista_7060_cx32s", "region": "None", "synchronous_mode": "enable", "type": "ToRRouter"}}, "cur_value": {"localhost": {"bgp_asn": "64003", "buffer_model": "traditional", "cloudtype": "Public", "default_bgp_status": "up", "default_pfcwd_status": "enable", "deployment_id": "1", "docker_routing_config_mode": "separated", "hostname": "7060CX-S1", "hwsku": "Arista-7060CX-32S-C32", "mac": "44:4c:a8:ca:41:94", "platform": "x86_64-arista_7060_cx32s", "region": "None", "synchronous_mode": "enable", "type": "ToRRouter"}}}, "INTERFACE": {"pre_value": {"Ethernet0": {}, "Ethernet104": {}, "Ethernet4": {}, "Ethernet0|192.168.1.1/24": {}, "Ethernet104|21.1.1.1/24": {}, "Ethernet4|192.168.2.1/24": {}}, "cur_value": {"Ethernet0": {}, "Ethernet12": {}, "Ethernet4": {}, "Ethernet8": {}, "Ethernet0|300::1/126": {}, "Ethernet12|300:0:0:3::1/126": {}, "Ethernet4|300:0:0:1::1/126": {}, "Ethernet8|300:0:0:2::1/126": {}}}, "DEVICE_NEIGHBOR": {"pre_value": {"Ethernet0": {"name": "IXIA-Chassis1", "port": "Port0"}, "Ethernet104": {"name": "IXIA-Chassis1", "port": "Port2"}, "Ethernet4": {"name": "IXIA-Chassis1", "port": "Port1"}}, "cur_value": {"Ethernet0": {"name": "IXIA-Chassis1", "port": "Port0"}, "Ethernet12": {"name": "IXIA-Chassis1", "port": "Port3"}, "Ethernet4": {"name": "IXIA-Chassis1", "port": "Port1"}, "Ethernet8": {"name": "IXIA-Chassis1", "port": "Port2"}}}, "QUEUE": {"pre_value": {"Ethernet0|0": {"scheduler": "scheduler.0"}, "Ethernet0|1": {"scheduler": "scheduler.0"}, "Ethernet0|2": {"scheduler": "scheduler.0"}, "Ethernet0|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet0|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet0|5": {"scheduler": "scheduler.0"}, "Ethernet0|6": {"scheduler": "scheduler.0"}, "Ethernet104|0": {"scheduler": "scheduler.0"}, "Ethernet104|1": {"scheduler": "scheduler.0"}, "Ethernet104|2": {"scheduler": "scheduler.0"}, "Ethernet104|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet104|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet104|5": {"scheduler": "scheduler.0"}, "Ethernet104|6": {"scheduler": "scheduler.0"}, "Ethernet4|0": {"scheduler": "scheduler.0"}, "Ethernet4|1": {"scheduler": "scheduler.0"}, "Ethernet4|2": {"scheduler": "scheduler.0"}, "Ethernet4|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet4|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet4|5": {"scheduler": "scheduler.0"}, "Ethernet4|6": {"scheduler": "scheduler.0"}}, "cur_value": {"Ethernet0|0": {"scheduler": "scheduler.0"}, "Ethernet0|1": {"scheduler": "scheduler.0"}, "Ethernet0|2": {"scheduler": "scheduler.0"}, "Ethernet0|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet0|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet0|5": {"scheduler": "scheduler.0"}, "Ethernet0|6": {"scheduler": "scheduler.0"}, "Ethernet12|0": {"scheduler": "scheduler.0"}, "Ethernet12|1": {"scheduler": "scheduler.0"}, "Ethernet12|2": {"scheduler": "scheduler.0"}, "Ethernet12|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet12|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet12|5": {"scheduler": "scheduler.0"}, "Ethernet12|6": {"scheduler": "scheduler.0"}, "Ethernet4|0": {"scheduler": "scheduler.0"}, "Ethernet4|1": {"scheduler": "scheduler.0"}, "Ethernet4|2": {"scheduler": "scheduler.0"}, "Ethernet4|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet4|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet4|5": {"scheduler": "scheduler.0"}, "Ethernet4|6": {"scheduler": "scheduler.0"}, "Ethernet8|0": {"scheduler": "scheduler.0"}, "Ethernet8|1": {"scheduler": "scheduler.0"}, "Ethernet8|2": {"scheduler": "scheduler.0"}, "Ethernet8|3": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet8|4": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}, "Ethernet8|5": {"scheduler": "scheduler.0"}, "Ethernet8|6": {"scheduler": "scheduler.0"}}}, "PORT": {"pre_value": {"Ethernet0": {"admin_status": "up", "alias": "Ethernet1/1", "description": "IXIA-Chassis1:Port0", "fec": "rs", "index": "1", "lanes": "33,34,35,36", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet100": {"alias": "Ethernet26/1", "description": "Ethernet26/1", "fec": "rs", "index": "26", "lanes": "5,6,7,8", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet104": {"admin_status": "up", "alias": "Ethernet27/1", "description": "IXIA-Chassis1:Port2", "fec": "rs", "index": "27", "lanes": "9,10,11,12", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet108": {"alias": "Ethernet28/1", "description": "Ethernet28/1", "fec": "rs", "index": "28", "lanes": "13,14,15,16", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet112": {"alias": "Ethernet29/1", "description": "Ethernet29/1", "fec": "rs", "index": "29", "lanes": "17,18,19,20", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet116": {"alias": "Ethernet30/1", "description": "Ethernet30/1", "fec": "rs", "index": "30", "lanes": "21,22,23,24", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet12": {"alias": "Ethernet4/1", "description": "Ethernet4/1", "fec": "rs", "index": "4", "lanes": "45,46,47,48", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet120": {"alias": "Ethernet31/1", "description": "Ethernet31/1", "fec": "rs", "index": "31", "lanes": "25,26,27,28", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet124": {"alias": "Ethernet32/1", "description": "Ethernet32/1", "fec": "rs", "index": "32", "lanes": "29,30,31,32", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet16": {"alias": "Ethernet5/1", "description": "Ethernet5/1", "fec": "rs", "index": "5", "lanes": "49,50,51,52", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet20": {"alias": "Ethernet6/1", "description": "Ethernet6/1", "fec": "rs", "index": "6", "lanes": "53,54,55,56", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet24": {"alias": "Ethernet7/1", "description": "Ethernet7/1", "fec": "rs", "index": "7", "lanes": "57,58,59,60", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet28": {"alias": "Ethernet8/1", "description": "Ethernet8/1", "fec": "rs", "index": "8", "lanes": "61,62,63,64", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet32": {"alias": "Ethernet9/1", "description": "Ethernet9/1", "fec": "rs", "index": "9", "lanes": "65,66,67,68", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet36": {"alias": "Ethernet10/1", "description": "Ethernet10/1", "fec": "rs", "index": "10", "lanes": "69,70,71,72", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet4": {"admin_status": "up", "alias": "Ethernet2/1", "description": "IXIA-Chassis1:Port1", "fec": "rs", "index": "2", "lanes": "37,38,39,40", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet40": {"alias": "Ethernet11/1", "description": "Ethernet11/1", "fec": "rs", "index": "11", "lanes": "73,74,75,76", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet44": {"alias": "Ethernet12/1", "description": "Ethernet12/1", "fec": "rs", "index": "12", "lanes": "77,78,79,80", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet48": {"alias": "Ethernet13/1", "description": "Ethernet13/1", "fec": "rs", "index": "13", "lanes": "81,82,83,84", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet52": {"alias": "Ethernet14/1", "description": "Ethernet14/1", "fec": "rs", "index": "14", "lanes": "85,86,87,88", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet56": {"alias": "Ethernet15/1", "description": "Ethernet15/1", "fec": "rs", "index": "15", "lanes": "89,90,91,92", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet60": {"alias": "Ethernet16/1", "description": "Ethernet16/1", "fec": "rs", "index": "16", "lanes": "93,94,95,96", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet64": {"alias": "Ethernet17/1", "description": "Ethernet17/1", "fec": "rs", "index": "17", "lanes": "97,98,99,100", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet68": {"alias": "Ethernet18/1", "description": "Ethernet18/1", "fec": "rs", "index": "18", "lanes": "101,102,103,104", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet72": {"alias": "Ethernet19/1", "description": "Ethernet19/1", "fec": "rs", "index": "19", "lanes": "105,106,107,108", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet76": {"alias": "Ethernet20/1", "description": "Ethernet20/1", "fec": "rs", "index": "20", "lanes": "109,110,111,112", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet8": {"alias": "Ethernet3/1", "description": "Ethernet3/1", "fec": "rs", "index": "3", "lanes": "41,42,43,44", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet80": {"alias": "Ethernet21/1", "description": "Ethernet21/1", "fec": "rs", "index": "21", "lanes": "113,114,115,116", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet84": {"alias": "Ethernet22/1", "description": "Ethernet22/1", "fec": "rs", "index": "22", "lanes": "117,118,119,120", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet88": {"alias": "Ethernet23/1", "description": "Ethernet23/1", "fec": "rs", "index": "23", "lanes": "121,122,123,124", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet92": {"alias": "Ethernet24/1", "description": "Ethernet24/1", "fec": "rs", "index": "24", "lanes": "125,126,127,128", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet96": {"alias": "Ethernet25/1", "description": "Ethernet25/1", "fec": "rs", "index": "25", "lanes": "1,2,3,4", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}}, "cur_value": {"Ethernet0": {"admin_status": "up", "alias": "Ethernet1/1", "description": "IXIA-Chassis1:Port0", "fec": "rs", "index": "1", "lanes": "33,34,35,36", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet100": {"alias": "Ethernet26/1", "description": "Ethernet26/1", "fec": "rs", "index": "26", "lanes": "5,6,7,8", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet104": {"alias": "Ethernet27/1", "description": "Ethernet27/1", "fec": "rs", "index": "27", "lanes": "9,10,11,12", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet108": {"alias": "Ethernet28/1", "description": "Ethernet28/1", "fec": "rs", "index": "28", "lanes": "13,14,15,16", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet112": {"alias": "Ethernet29/1", "description": "Ethernet29/1", "fec": "rs", "index": "29", "lanes": "17,18,19,20", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet116": {"alias": "Ethernet30/1", "description": "Ethernet30/1", "fec": "rs", "index": "30", "lanes": "21,22,23,24", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet12": {"admin_status": "up", "alias": "Ethernet4/1", "description": "IXIA-Chassis1:Port3", "fec": "rs", "index": "4", "lanes": "45,46,47,48", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet120": {"alias": "Ethernet31/1", "description": "Ethernet31/1", "fec": "rs", "index": "31", "lanes": "25,26,27,28", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet124": {"alias": "Ethernet32/1", "description": "Ethernet32/1", "fec": "rs", "index": "32", "lanes": "29,30,31,32", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet16": {"alias": "Ethernet5/1", "description": "Ethernet5/1", "fec": "rs", "index": "5", "lanes": "49,50,51,52", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet20": {"alias": "Ethernet6/1", "description": "Ethernet6/1", "fec": "rs", "index": "6", "lanes": "53,54,55,56", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet24": {"alias": "Ethernet7/1", "description": "Ethernet7/1", "fec": "rs", "index": "7", "lanes": "57,58,59,60", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet28": {"alias": "Ethernet8/1", "description": "Ethernet8/1", "fec": "rs", "index": "8", "lanes": "61,62,63,64", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet32": {"alias": "Ethernet9/1", "description": "Ethernet9/1", "fec": "rs", "index": "9", "lanes": "65,66,67,68", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet36": {"alias": "Ethernet10/1", "description": "Ethernet10/1", "fec": "rs", "index": "10", "lanes": "69,70,71,72", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet4": {"admin_status": "up", "alias": "Ethernet2/1", "description": "IXIA-Chassis1:Port1", "fec": "rs", "index": "2", "lanes": "37,38,39,40", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet40": {"alias": "Ethernet11/1", "description": "Ethernet11/1", "fec": "rs", "index": "11", "lanes": "73,74,75,76", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet44": {"alias": "Ethernet12/1", "description": "Ethernet12/1", "fec": "rs", "index": "12", "lanes": "77,78,79,80", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet48": {"alias": "Ethernet13/1", "description": "Ethernet13/1", "fec": "rs", "index": "13", "lanes": "81,82,83,84", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet52": {"alias": "Ethernet14/1", "description": "Ethernet14/1", "fec": "rs", "index": "14", "lanes": "85,86,87,88", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet56": {"alias": "Ethernet15/1", "description": "Ethernet15/1", "fec": "rs", "index": "15", "lanes": "89,90,91,92", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet60": {"alias": "Ethernet16/1", "description": "Ethernet16/1", "fec": "rs", "index": "16", "lanes": "93,94,95,96", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet64": {"admin_status": "up", "alias": "Ethernet17/1", "description": "Ethernet17/1", "fec": "rs", "index": "17", "lanes": "97,98,99,100", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet68": {"admin_status": "up", "alias": "Ethernet18/1", "description": "Ethernet18/1", "fec": "rs", "index": "18", "lanes": "101,102,103,104", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet72": {"alias": "Ethernet19/1", "description": "Ethernet19/1", "fec": "rs", "index": "19", "lanes": "105,106,107,108", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet76": {"alias": "Ethernet20/1", "description": "Ethernet20/1", "fec": "rs", "index": "20", "lanes": "109,110,111,112", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet8": {"admin_status": "up", "alias": "Ethernet3/1", "description": "IXIA-Chassis1:Port2", "fec": "rs", "index": "3", "lanes": "41,42,43,44", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet80": {"alias": "Ethernet21/1", "description": "Ethernet21/1", "fec": "rs", "index": "21", "lanes": "113,114,115,116", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet84": {"alias": "Ethernet22/1", "description": "Ethernet22/1", "fec": "rs", "index": "22", "lanes": "117,118,119,120", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet88": {"alias": "Ethernet23/1", "description": "Ethernet23/1", "fec": "rs", "index": "23", "lanes": "121,122,123,124", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet92": {"alias": "Ethernet24/1", "description": "Ethernet24/1", "fec": "rs", "index": "24", "lanes": "125,126,127,128", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}, "Ethernet96": {"alias": "Ethernet25/1", "description": "Ethernet25/1", "fec": "rs", "index": "25", "lanes": "1,2,3,4", "mtu": "9100", "pfc_asym": "off", "speed": "100000"}}}, "BUFFER_QUEUE": {"pre_value": {"Ethernet0|0-2": {"profile": "egress_lossy_profile"}, "Ethernet0|3-4": {"profile": "egress_lossless_profile"}, "Ethernet0|5-6": {"profile": "egress_lossy_profile"}, "Ethernet104|0-2": {"profile": "egress_lossy_profile"}, "Ethernet104|3-4": {"profile": "egress_lossless_profile"}, "Ethernet104|5-6": {"profile": "egress_lossy_profile"}, "Ethernet4|0-2": {"profile": "egress_lossy_profile"}, "Ethernet4|3-4": {"profile": "egress_lossless_profile"}, "Ethernet4|5-6": {"profile": "egress_lossy_profile"}}, "cur_value": {"Ethernet0|0-2": {"profile": "egress_lossy_profile"}, "Ethernet0|3-4": {"profile": "egress_lossless_profile"}, "Ethernet0|5-6": {"profile": "egress_lossy_profile"}, "Ethernet12|0-2": {"profile": "egress_lossy_profile"}, "Ethernet12|3-4": {"profile": "egress_lossless_profile"}, "Ethernet12|5-6": {"profile": "egress_lossy_profile"}, "Ethernet4|0-2": {"profile": "egress_lossy_profile"}, "Ethernet4|3-4": {"profile": "egress_lossless_profile"}, "Ethernet4|5-6": {"profile": "egress_lossy_profile"}, "Ethernet8|0-2": {"profile": "egress_lossy_profile"}, "Ethernet8|3-4": {"profile": "egress_lossless_profile"}, "Ethernet8|5-6": {"profile": "egress_lossy_profile"}}}, "BUFFER_PG": {"pre_value": {"Ethernet0|0": {"profile": "ingress_lossy_profile"}, "Ethernet0|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet100|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet104|0": {"profile": "ingress_lossy_profile"}, "Ethernet104|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet108|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet112|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet116|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet120|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet124|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet12|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet16|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet20|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet24|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet28|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet32|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet36|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet40|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet44|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet48|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet4|0": {"profile": "ingress_lossy_profile"}, "Ethernet4|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet52|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet56|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet60|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet64|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet68|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet72|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet76|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet80|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet84|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet88|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet8|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet92|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet96|3-4": {"profile": "pg_lossless_100000_5m_profile"}}, "cur_value": {"Ethernet0|0": {"profile": "ingress_lossy_profile"}, "Ethernet0|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet100|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet104|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet108|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet112|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet116|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet120|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet124|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet12|0": {"profile": "ingress_lossy_profile"}, "Ethernet12|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet16|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet20|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet24|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet28|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet32|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet36|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet40|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet44|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet48|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet4|0": {"profile": "ingress_lossy_profile"}, "Ethernet4|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet52|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet56|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet60|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet64|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet68|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet72|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet76|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet80|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet84|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet88|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet8|0": {"profile": "ingress_lossy_profile"}, "Ethernet8|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet92|3-4": {"profile": "pg_lossless_100000_5m_profile"}, "Ethernet96|3-4": {"profile": "pg_lossless_100000_5m_profile"}}}}}}}}


=============================== warnings summary ===============================
../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.ptfadapter
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.ansible_fixtures
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.loganalyzer
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.sanity_check
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.plugins.test_completeness
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.dualtor
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755
  /usr/local/lib/python3.8/dist-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.common.fixtures.duthost_utils
    self.import_plugin(import_spec)

../../../../usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236
  /usr/local/lib/python3.8/dist-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
    "class": algorithms.Blowfish,

common/plugins/loganalyzer/system_msg_handler.py:1
  /var/azureuser/sonic-mgmt/tests/common/plugins/loganalyzer/system_msg_handler.py:1: DeprecationWarning: invalid escape sequence \ 
    '''

../../.local/lib/python3.8/site-packages/ixnetwork_restpy/testplatform/testplatform.py:30
  /var/azureuser/.local/lib/python3.8/site-packages/ixnetwork_restpy/testplatform/testplatform.py:30: PytestCollectionWarning: cannot collect test class 'TestPlatform' because it has a __init__ constructor (from: snappi_tests/dataplane/test_capacity.py)
    class TestPlatform(Base):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---------------------------- live log sessionfinish ----------------------------
24/09/2025 00:39:43 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================== 4 passed, 10 warnings in 912.12s (0:15:12) ==================

```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
