### PR TITLE
Ignore log error related to pus for test_turn_on_off_psu_and_check_psustatus

### DIFF
--- a/tests/platform_tests/test_platform_info.py
+++ b/tests/platform_tests/test_platform_info.py
@@ -76,10 +76,10 @@ SKIP_ERROR_LOG_PSU_ABSENCE = [
     '.*ERR pmon#psud:.*Fail to read revision: No key REV_VPD_FIELD in.*',
     r'.*ERR pmon#psud: Failed to read from file /var/run/hw-management/power/psu\d_volt.*',
     r'.*ERR pmon#thermalctld: Failed to read from file \/var\/run\/hw-management\/thermal\/.*FileNotFoundError.*',
+    r'.*ERR pmon#thermalctld: Failed to read from file.*\/var\/run\/hw-management\/thermal\/psu.*ValueError.*',
     r'.*PSU power thresholds become invalid: threshold (\d+\.\d+|N/A) critical threshold N/A.*',
     r'.*ERR pmon#sensord: Error getting sensor data: pmbus\/#\d: Can\'t read',
-    r'.*ERR pmon#sensord: Error getting sensor data: dps\d+\/#\d: Kernel interface error',
-    r'.*ERR pmon#thermalctld: Failed to read from file.*\/var\/run\/hw-management\/thermal\/psu.*ValueError.*']
+    r'.*ERR pmon#sensord: Error getting sensor data: dps\d+\/#\d: Kernel interface error']
 
 SKIP_ERROR_LOG_SHOW_PLATFORM_TEMP.extend(SKIP_ERROR_LOG_COMMON)
 SKIP_ERROR_LOG_PSU_ABSENCE.extend(SKIP_ERROR_LOG_COMMON)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

When PSU is power off, some sysfs of psu files are removed by driver, so we need to add the relevant log error to error ignore list. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
