### PR TITLE
[dhcp_relay] skip test_dhcp_relay_monitor_checksum_validation

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -904,6 +904,12 @@ dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter:
     conditions:
       - "release in ['201811', '201911', '202012']"
 
+dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_monitor_checksum_validation:
+  skip:
+    reason: "Current isc-dhcp-relay do not support dropping packets with unexpected checksum"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/24660"
+
 dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_on_dualtor_standby:
   skip:
     reason: "The test case only tests DHCP relay on the dualtor standby dut"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Current isc-dhcp-relay do not support dropping packets with wrong ip and udp checksum, this skipping this test. Issue tracking this https://github.com/sonic-net/sonic-buildimage/issues/24660.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

### Approach
#### What is the motivation for this PR?
isc-dhcp-relay does not supports it yet, so skip the test

#### How did you do it?
skip the test

#### How did you verify/test it?
run the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
