### PR TITLE
Avoid static MAC collision with dynamic MACs in FDB tests

### DIFF
--- a/tests/fdb/test_fdb_flush.py
+++ b/tests/fdb/test_fdb_flush.py
@@ -264,7 +264,9 @@ class TestFdbFlush:
             self.curr_exist_cores = existing_core_dumps
 
     def create_fdb_oper_files(self, duthost):
-        mac_addresses = ["00-11-22-33-55-66", "00-11-22-33-55-67", "00-11-22-33-55-68"]
+        # Keep static MACs on 00:11:22:33:44:XX to avoid collision with PTF dynamic MACs (00:11:22:33:55:XX).
+        # Use 44 in the 5th octet; dynamic FDB MACs use 55 and can collide on larger testbeds.
+        mac_addresses = ["00-11-22-33-44-66", "00-11-22-33-44-67", "00-11-22-33-44-68"]
         vlan_id = 1000
         fdb_static_set = []
         fdb_static_del = []


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Overlapping of Static and Dynamic MAC addresses.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
In the FDB flush tests, the dynamic and static MAC addresses were unintentionally overlapping.

Dynamic MACs generated by the PTF follow the pattern:00:11:22:33:55:{port_index} where port_index ranges from 0 to max_ptf_index (e.g., 31, 63, …255).

This produces dynamic MACs from 00:11:22:33:55:00 up to 00:11:22:33:55:FF. Static MACs used in the tests were hardcoded as:
00:11:22:33:55:66, 00:11:22:33:55:67, 00:11:22:33:55:68.

On larger testbeds (e.g., port numbers ≥ 102), the dynamic MAC for ports such as eth102, eth103, and eth104 maps to: 00:11:22:33:55:66, 00:11:22:33:55:67, 00:11:22:33:55:68, directly colliding with the static MAC entries.

This collision caused failures when configuring static MACs, because a matching dynamic MAC already existed in the FDB.
#### How did you do it?
To eliminate the overlap:
Dynamic MACs remain: 00:11:22:33:55:XX (5th octet = 55)
Static MACs are updated to use a different 5th octet:
00:11:22:33:44:66, 00:11:22:33:44:67,00:11:22:33:44:68

Since the dynamic and static MACs differ in the 5th octet (55 vs 44), no conflict will occur, regardless of testbed size.
#### How did you verify/test it?
Verified on Cisco-8122-O128S2
#### Any platform specific information?
Cisco-8122-O128S2
#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->