### PR TITLE
Fix IDF Isolation test failures on LT2

### DIFF
--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -63,11 +63,11 @@ def check_idf_isolation_support(duthost):
     return True
 
 
-def dut_nbrs(duthost, nbrhosts):
+def dut_t1_nbrs(duthost, nbrhosts):
     mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     nbrs_to_dut = {}
     for host in list(nbrhosts.keys()):
-        if host in mg_facts['minigraph_devices']:
+        if host in mg_facts['minigraph_devices'] and host.endswith('T1'):
             new_nbrhost = {host: nbrhosts[host]}
             nbrs_to_dut.update(new_nbrhost)
     return nbrs_to_dut
@@ -103,7 +103,7 @@ def test_idf_isolated_no_export(rand_one_downlink_duthost,
 
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in unisolated state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
     try:
@@ -156,7 +156,7 @@ def test_idf_isolated_withdraw_all(duthosts, rand_one_downlink_duthost,
 
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in unisolated state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
     try:
@@ -201,7 +201,7 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in normal state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
     orig_v6_routes = parse_routes_on_neighbors(duthost, nbrs, 6)
     try:
@@ -217,12 +217,12 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4, exp_community):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6, exp_community):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -240,12 +240,12 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes seen at the start of the test are re-advertised to neighbors
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")
@@ -265,7 +265,7 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
     # Ensure that the DUT is not in maintenance already before start of the test
     pytest_assert(IDF_UNISOLATED == get_idf_isolation_state(duthost),
                   "DUT is not in normal state")
-    nbrs = dut_nbrs(duthost, nbrhosts)
+    nbrs = dut_t1_nbrs(duthost, nbrhosts)
     try:
         # Get all routes on neighbors before doing TSA
         orig_v4_routes = parse_routes_on_neighbors(duthost, nbrs, 4)
@@ -295,12 +295,12 @@ def test_idf_isolation_withdraw_all_with_config_reload(duthosts, rand_one_downli
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")
 
-        if not wait_until(300, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v6_routes, cur_v6_routes, 6):
             if not check_and_log_routes_diff(duthost, nbrhosts, orig_v6_routes, cur_v6_routes, 6):
                 pytest.fail("Not all ipv6 routes are announced to neighbors")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes IDF isolation test failures on LT2

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
test_seq_idf_isolation.py fails on LT2

#### How did you do it?
Since IDF isolation script only applies to T1 neighbors, filter only T1 neighbors before prefix/community validation on neighbors

#### How did you verify/test it?
Ran test_seq_idf_isolation.py on LT2

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
