### PR TITLE
Normalize vpp topo name

### DIFF
--- a/tests/common/testbed.py
+++ b/tests/common/testbed.py
@@ -61,6 +61,7 @@ class TestbedInfo(object):
             # create yaml testbed file
             self.dump_testbeds_to_yaml()
         self.parse_topo()
+        self._normalize_topo_names()
 
     def _cidr_to_ip_mask(self, network):
         addr = ipaddress.IPNetwork(network)
@@ -395,6 +396,13 @@ class TestbedInfo(object):
                 tb['topo']['ptf_map'] = self.calculate_ptf_index_map(tb)
                 tb['topo']['ptf_map_disabled'] = self.calculate_ptf_index_map_disabled(tb)
                 tb['topo']['ptf_dut_intf_map'] = self.calculate_ptf_dut_intf_map(tb)
+
+    def _normalize_topo_names(self):
+        """Normalize topology names by removing the '-vpp' suffix if present."""
+        for tb_name, tb in list(self.testbed_topo.items()):
+            topo_name = tb["topo"]["name"]
+            if topo_name.endswith("-vpp"):
+                tb["topo"]["name"] = topo_name[:-4]  # Remove the last 4 characters ("-vpp")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
vpp testbed has topo name with vpp suffix for the reason that in azure pipeline, it can use a different profile with different resources. However, from sonic-mgmt test perspective, t1-lag-vpp is exactly the same as t1-lag with the same topology. In sonic-mgmt tests, there are places check topo name. We don't want to add special logic for vpp topos. So we want to normalize the special topo name.
#### How did you do it?
In TestbedInfo, remove -vpp suffix when the testbed is loaded.
#### How did you verify/test it?
Run vpp sonic-mgmt test.
#### Any platform specific information?
Specific to vpp platform
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
