### PR TITLE
[202305] Fix copp test setup failure

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -227,6 +227,7 @@ def _install_nano(dut, creds,  syncd_docker_name):
             cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
                     chmod 777 /tmp \
                     && rm -rf /var/lib/apt/lists/* \
+                    && sed -i '/bullseye-backports/ {{ /^[[:space:]]*#/! s/^/#/ }}' /etc/apt/sources.list \
                     && apt-get update \
                     && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
                     python3-dev python-setuptools wget cmake python-is-python3 \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
COPP test fail on 202305 due to below source returns 404. This PR fixes this issue by comment it out.
```
deb [arch=amd64] http://deb.debian.org/debian/ bullseye-backports main contrib non-free
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To fix the COPP test setup failure on 202305 due to below source returns 404.
```
deb [arch=amd64] http://deb.debian.org/debian/ bullseye-backports main contrib non-free
```

#### How did you do it?
Remove this source before `apt-get update`.

#### How did you verify/test it?
Verified on Celestica-E1031 M0 testbed.
```
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-ARP] PASSED                                                                                                 [  7%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-IP2ME] PASSED                                                                                               [ 14%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-SNMP] PASSED                                                                                                [ 21%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-SSH] PASSED                                                                                                 [ 28%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-DHCP] PASSED                                                                                                [ 35%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-DHCP6] PASSED                                                                                               [ 42%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-BGP] PASSED                                                                                                 [ 50%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-LACP] PASSED                                                                                                [ 57%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-LLDP] PASSED                                                                                                [ 64%]
copp/test_copp.py::TestCOPP::test_policer[bjw-can-e1031-1-UDLD] PASSED                                                                                                [ 71%]
copp/test_copp.py::TestCOPP::test_add_new_trap[bjw-can-e1031-1] XPASS (Test failed due to known issue on broadcom platform, xfail it on 202305 and 202311)            [ 78%]
copp/test_copp.py::TestCOPP::test_remove_trap[bjw-can-e1031-1-delete_feature_entry] XPASS (Test failed due to known issue on broadcom platform, xfail it on 20230...) [ 85%]
copp/test_copp.py::TestCOPP::test_remove_trap[bjw-can-e1031-1-disable_feature_status] XPASS (Test failed due to known issue on broadcom platform, xfail it on 202...) [ 92%]
copp/test_copp.py::TestCOPP::test_trap_config_save_after_reboot[bjw-can-e1031-1] PASSED                                                                               [100%]
=========================================================== 11 passed, 3 xpassed, 1 warning in 3873.25s (1:04:33) ===========================================================
```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
