### PR TITLE
fix: fix arp_update complains missing interface entry for static route

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1515,6 +1515,7 @@ def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True)
     if setup:
         cmd = "add"
     asic_arg = ""
+
     if namespace is not None:
         asic_arg = f"ip netns exec {namespace}"
     int_arg = ""
@@ -1526,11 +1527,18 @@ def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True)
         arp_opt = f"-d {addr}"
 
     try:
-        dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
-        dut.shell(
-            "{} config route {} prefix {}/32 nexthop {} {}".format(
-                asic_arg, cmd, DEST_TO_GATEWAY_MAP[addr]['dest'], addr,
-                DEST_TO_GATEWAY_MAP[addr]['intf']))
+        if setup:
+            dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
+            dut.shell(
+                f"{asic_arg} config route {cmd} prefix {DEST_TO_GATEWAY_MAP[addr]['dest']}/32 nexthop "
+                f"{addr} {DEST_TO_GATEWAY_MAP[addr]['intf']}"
+            )
+        else:
+            dut.shell(
+                f"{asic_arg} config route {cmd} prefix {DEST_TO_GATEWAY_MAP[addr]['dest']}/32 nexthop "
+                f"{addr} {DEST_TO_GATEWAY_MAP[addr]['intf']}"
+            )
+            dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
     except RunAnsibleModuleFail:
         if setup:
             raise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix missing interface entry
Fixes # (issue) 36037511



Fix

```
E               2025 Nov 26 22:08:52.060655 ERR swss2#arp_update[16275]: 178 missing interface entry for static route 20.1.1.1
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
For tear down, we need to remove the route first before the arp. Otherwise swss will throw error
#### How did you do it?

#### How did you verify/test it?

MS Only: https://elastictest.org/scheduler/testplan/692f7c4c8a84f286cc565304

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
