### PR TITLE
[202411] Fallback to legacy docker-sonic-mgmt

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -42,7 +42,7 @@ declare EXISTING_CONTAINER_NAME=""
 
 ENV_VARS=""
 CONTAINER_NAME=""
-IMAGE_ID=""
+IMAGE_ID="sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:master"
 LINK_DIR=""
 MOUNT_POINTS="-v \"/var/run/docker.sock:/var/run/docker.sock:rslave\""
 PUBLISH_PORTS=""


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
After the docker-sonic-mgmt is upgraded to Ubuntu 24.04, the new ansible requires python version >= 3.8 on target machine. The 202411 branch by default uses docker-ptf:202411 according to this code: https://github.com/sonic-net/sonic-mgmt/blob/202411/ansible/roles/vm_set/tasks/add_topo.yml#L10

The docker-ptf:202411 image is still Debian buster based. Its python version is still 3.7.

While the "add-topo" tries to run the ptf_portchannel module on PTF container to start portchannel in PTF container, this issue is hit.


#### How did you do it?
The easiest workaround is to fallback to the legacy docker-sonic-mgmt for 202411 branch.

This fix updated the setup-container.sh tool for 202411 branch to use "sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:master" by default. This is the legacy docker-sonic-mgmt last known good for 202411 branch.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
