### PR TITLE
enable BGPMON and BGPSENTINEL for case test_bgp_stress_link_flap

### DIFF
--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -784,10 +784,9 @@ def test_bgp_stress_link_flap_with_monitor(duthosts, rand_one_dut_hostname, setu
 
         # Wait for BGP Monitor sessions to establish
         logger.info("Waiting for BGP Monitor sessions to establish...")
-        if wait_until(60, 5, 0, is_bgp_monitor_session_established, duthost, bgp_monitor_ips):
-            logger.info("BGP Monitor sessions established successfully")
-        else:
-            logger.warning("BGP Monitor sessions did not establish within timeout")
+        pytest_assert(wait_until(300, 10, 0, is_bgp_monitor_session_established, duthost, bgp_monitor_ips),
+                      "BGP Monitor sessions did not establish within timeout")
+        logger.info("BGP Monitor sessions established successfully")
 
         # Run the stress link flap test
         _run_stress_link_flap_test(duthost, setup, nbrhosts, fanouthosts, test_type, normalized_level)
@@ -798,10 +797,9 @@ def test_bgp_stress_link_flap_with_monitor(duthosts, rand_one_dut_hostname, setu
                       "Not all BGP sessions are established on DUT after test")
 
         # Verify BGP Monitor sessions are still established
-        if is_bgp_monitor_session_established(duthost, bgp_monitor_ips):
-            logger.info("BGP Monitor sessions remain established after stress test")
-        else:
-            logger.warning("BGP Monitor sessions not established after stress test")
+        pytest_assert(is_bgp_monitor_session_established(duthost, bgp_monitor_ips),
+                      "BGP Monitor sessions not established after stress test")
+        logger.info("BGP Monitor sessions remain established after stress test")
 
     finally:
         # Cleanup BGP Monitor configuration
@@ -876,10 +874,9 @@ def test_bgp_stress_link_flap_with_sentinel_and_monitor(duthosts, rand_one_dut_h
 
         # Wait for BGP Monitor sessions to establish
         logger.info("Waiting for BGP Monitor sessions to establish...")
-        if wait_until(60, 5, 0, is_bgp_monitor_session_established, duthost, bgp_monitor_ips):
-            logger.info("BGP Monitor sessions established successfully")
-        else:
-            logger.warning("BGP Monitor sessions did not establish within timeout")
+        pytest_assert(wait_until(300, 10, 0, is_bgp_monitor_session_established, duthost, bgp_monitor_ips),
+                      "BGP Monitor sessions did not establish within timeout")
+        logger.info("BGP Monitor sessions established successfully")
 
         # Run the stress link flap test
         _run_stress_link_flap_test(duthost, setup, nbrhosts, fanouthosts, test_type, normalized_level)
@@ -890,10 +887,9 @@ def test_bgp_stress_link_flap_with_sentinel_and_monitor(duthosts, rand_one_dut_h
                       "Not all BGP sessions are established on DUT after test")
 
         # Verify BGP Monitor sessions are still established
-        if is_bgp_monitor_session_established(duthost, bgp_monitor_ips):
-            logger.info("BGP Monitor sessions remain established after stress test")
-        else:
-            logger.warning("BGP Monitor sessions not established after stress test")
+        pytest_assert(is_bgp_monitor_session_established(duthost, bgp_monitor_ips),
+                      "BGP Monitor sessions not established after stress test")
+        logger.info("BGP Monitor sessions remain established after stress test")
 
     finally:
         # Cleanup both BGP Sentinel and Monitor configurations


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
35019730

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
BGPMON and BGPSENTINEL are enabled in production and need to be enabled in longevity test cases as well.

#### How did you do it?
enable BGPMON and BGPSENTINEL for case test_bgp_stress_link_flap

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/6970875b46c56df48226abbf
https://elastictest.org/scheduler/testplan/6970875807a007e859c9022a
https://elastictest.org/scheduler/testplan/6970875646c56df48226abbd
https://elastictest.org/scheduler/testplan/69708753ccb6a14c76b7ad9c

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
