### PR TITLE
Fix platform_tests/api and gnmi test mgmt IP for T2

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -3340,6 +3340,28 @@ print(device_prefix)
 
         logging.info("Successfully cleaned up all console sessions")
 
+    def get_mgmt_ip(self):
+        """
+        Gets the management IP address (v4 or v6) on eth0.
+        Defaults to IPv4 on a dual stack configuration.
+        """
+        ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
+        ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
+
+        mgmt_interface = self.shell("show ip interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+        if mgmt_interface:
+            match = ipv4_regex.search(mgmt_interface)
+            if match:
+                return {"mgmt_ip": match.group(1), "version": "v4"}
+
+        mgmt_interface = self.shell("show ipv6 interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+        if mgmt_interface:
+            match = ipv6_regex.search(mgmt_interface)
+            if match:
+                return {"mgmt_ip": match.group(1), "version": "v6"}
+
+        assert False, "Failed to find duthost mgmt ip"  # noqa: F631
+
 
 def assert_exit_non_zero(shell_output):
     if shell_output['rc'] != 0:

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -8,7 +8,6 @@ import collections
 import ipaddress
 import time
 import json
-import re
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from paramiko.ssh_exception import AuthenticationException
@@ -939,31 +938,6 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                               cmd_desc="netstat")
 
     return duthosts
-
-
-@pytest.fixture(scope="module")
-def duthost_mgmt_ip(duthosts, enum_rand_one_per_hwsku_hostname):
-    """
-    Gets the management IP address (v4 or v6) on eth0.
-    Defaults to IPv4 on a dual stack configuration.
-    """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
-    ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
-
-    mgmt_interface = duthost.shell("show ip interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
-    if mgmt_interface:
-        match = ipv4_regex.search(mgmt_interface)
-        if match:
-            return {"mgmt_ip": match.group(1), "version": "v4"}
-
-    mgmt_interface = duthost.shell("show ipv6 interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
-    if mgmt_interface:
-        match = ipv6_regex.search(mgmt_interface)
-        if match:
-            return {"mgmt_ip": match.group(1), "version": "v6"}
-
-    pt_assert(False, "Failed to find duthost mgmt ip")
 
 
 def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,

--- a/tests/common/helpers/gnmi_utils.py
+++ b/tests/common/helpers/gnmi_utils.py
@@ -404,14 +404,12 @@ def verify_tcp_port(localhost, ip, port):
     logger.info("TCP: " + res['stdout'] + res['stderr'])
 
 
-def gnmi_capabilities(duthost, localhost, duthost_mgmt_ip=None):
+def gnmi_capabilities(duthost, localhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    if duthost_mgmt_ip:
-        ip = duthost_mgmt_ip['mgmt_ip']
-        addr = f"[{ip}]" if duthost_mgmt_ip['version'] == 'v6' else f"{ip}"
-    else:
-        ip = duthost.mgmt_ip
-        addr = ip
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    ip = duthost_mgmt_info['mgmt_ip']
+    addr = f"[{ip}]" if duthost_mgmt_info['version'] == 'v6' else f"{ip}"
+
     port = env.gnmi_port
     # Run gnmi_cli in gnmi container as workaround
     cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, addr, port)

--- a/tests/gnmi/test_gnmi.py
+++ b/tests/gnmi/test_gnmi.py
@@ -6,7 +6,6 @@ from tests.common.helpers.gnmi_utils import gnmi_capabilities, add_gnmi_client_c
 from .helper import gnmi_set, dump_gnmi_log
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.fixtures.duthost_utils import duthost_mgmt_ip       # noqa: F401
 
 
 logger = logging.getLogger(__name__)
@@ -18,12 +17,12 @@ pytestmark = [
 ]
 
 
-def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost, duthost_mgmt_ip):  # noqa: F811
+def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost):
     '''
     Verify GNMI capabilities
     '''
     duthost = duthosts[rand_one_dut_hostname]
-    ret, msg = gnmi_capabilities(duthost, localhost, duthost_mgmt_ip)
+    ret, msg = gnmi_capabilities(duthost, localhost)
     assert ret == 0, (
         "GNMI capabilities command failed (non-zero return code).\n"
         "- Error message: {}"
@@ -40,7 +39,7 @@ def test_gnmi_capabilities(duthosts, rand_one_dut_hostname, localhost, duthost_m
     ).format(msg)
 
 
-def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localhost, duthost_mgmt_ip):  # noqa: F811
+def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localhost):
     '''
     Verify GNMI capabilities with different roles
     '''
@@ -49,7 +48,7 @@ def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localho
     with allure.step("Verify GNMI capabilities with noaccess role"):
         role = "gnmi_noaccess"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost, duthost_mgmt_ip)
+        ret, msg = gnmi_capabilities(duthost, localhost)
         assert ret != 0, (
             "GNMI capabilities authenticate with noaccess role command unexpectedly succeeded "
             "(zero return code) for a client with noaccess role.\n"
@@ -63,7 +62,7 @@ def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localho
     with allure.step("Verify GNMI capabilities with readonly role"):
         role = "gnmi_readonly"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost, duthost_mgmt_ip)
+        ret, msg = gnmi_capabilities(duthost, localhost)
         assert ret == 0, (
             "GNMI capabilities authenticate readonly command failed (non-zero return code).\n"
             "- Error message: {}"
@@ -80,7 +79,7 @@ def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localho
     with allure.step("Verify GNMI capabilities with readwrite role"):
         role = "gnmi_readwrite"
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost, duthost_mgmt_ip)
+        ret, msg = gnmi_capabilities(duthost, localhost)
         assert ret == 0, (
             "GNMI capabilities authenticate readwrite role command failed (non-zero return code).\n"
             "- Error message: {}"
@@ -97,7 +96,7 @@ def test_gnmi_capabilities_authenticate(duthosts, rand_one_dut_hostname, localho
     with allure.step("Verify GNMI capabilities with empty role"):
         role = ""
         add_gnmi_client_common_name(duthost, "test.client.gnmi.sonic", role)
-        ret, msg = gnmi_capabilities(duthost, localhost, duthost_mgmt_ip)
+        ret, msg = gnmi_capabilities(duthost, localhost)
         assert ret == 0, (
             "GNMI capabilities authenticate with empty role command failed (non-zero return code).\n"
             "- Error message: {}"

--- a/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
+++ b/tests/gnmi/test_mimic_hwproxy_cert_rotation.py
@@ -6,7 +6,6 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.helpers.gnmi_utils import GNMIEnvironment, gnmi_capabilities
 from tests.common.utilities import get_image_type
-from tests.common.fixtures.duthost_utils import duthost_mgmt_ip      # noqa: F401
 
 
 logger = logging.getLogger(__name__)
@@ -30,8 +29,7 @@ def check_telemetry_status(duthost):
     return "RUNNING" in output['stdout']
 
 
-def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost, ptfhost,
-                                     duthost_mgmt_ip):  # noqa: F811
+def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost, ptfhost):
     duthost = duthosts[rand_one_dut_hostname]
 
     # Use bash -c to run the pipeline properly
@@ -89,7 +87,7 @@ def test_mimic_hwproxy_cert_rotation(duthosts, rand_one_dut_hostname, localhost,
             enable_feature = 'sudo config feature state gnmi enabled'
             duthost.command(enable_feature, module_ignore_errors=True)
             assert wait_until(60, 3, 0, check_gnmi_status, duthost), "GNMI service failed to start"
-            ret, msg = gnmi_capabilities(duthost, localhost, duthost_mgmt_ip)
+            ret, msg = gnmi_capabilities(duthost, localhost)
             assert ret == 0, msg
             assert "sonic-db" in msg, msg
             assert "JSON_IETF" in msg, msg


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #21508 

**(Currently testing)**

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Refactor `duthost_mgmt_ip` fixture to be a function inside `duthost` (SonicHost). This is a cleaner way to obtain the mgmt IP of a specific duthost without excess fixture calls.

This method will also select the appropriate linecard duthost for T2 chassis linecards, and originally intends to fix platform_tests/api and gnmi T2 test regressions.

#### How did you do it?

#### How did you verify/test it?

Tested on a Arista T2 and m0 with mgmt IPv4 configuration

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
