### PR TITLE
Fix fib/test_fib.py test_vxlan_hash [ipv6-*]

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -936,28 +936,30 @@ class VxlanHashTest(HashTest):
         return masked_exp_pkt
 
     def check_ip_route(self, hash_key, src_port, dst_port_lists, outer_src_ip,
-                       outer_dst_ip, outer_src_ipv6, outer_dst_ipv6):
+                       outer_dst_ip):
         if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
             (matched_port, received) = self.check_ipv4_route(
                 hash_key=hash_key, src_port=src_port, dst_port_lists=dst_port_lists, outer_src_ip=outer_src_ip,
                 outer_dst_ip=outer_dst_ip)
         else:
             (matched_port, received) = self.check_ipv6_route(
-                hash_key=hash_key, src_port=src_port, dst_port_lists=dst_port_lists, outer_src_ip=outer_src_ipv6,
-                outer_dst_ip=outer_dst_ipv6)
+                hash_key=hash_key, src_port=src_port, dst_port_lists=dst_port_lists, outer_src_ip=outer_src_ip,
+                outer_dst_ip=outer_dst_ip)
         assert received
         logging.info("Received packet at " + str(matched_port))
         time.sleep(0.02)
         return (matched_port, received)
 
     def check_hash(self, hash_key):
-        # Use dummy IPv4 address for outer_src_ip and outer_dst_ip
+        # Use dummy IPv4/v6 address for outer_src_ip and outer_dst_ip
         # We don't care the actually value as long as the outer_dst_ip is routed by default routed
         # The outer_src_ip and outer_dst_ip are fixed
-        outer_src_ip = '80.1.0.31'
-        outer_dst_ip = '80.1.0.32'
-        outer_src_ipv6 = '80::31'
-        outer_dst_ipv6 = '80::32'
+        if self.ipver == 'ipv4-ipv4' or self.ipver == 'ipv4-ipv6':
+            outer_src_ip = '80.1.0.31'
+            outer_dst_ip = '80.1.0.32'
+        else:
+            outer_src_ip = '80::31'
+            outer_dst_ip = '80::32'
         src_port, exp_port_lists, next_hops = self.get_src_and_exp_ports(
             outer_dst_ip)
         if self.switch_type == "chassis-packet":
@@ -974,8 +976,7 @@ class VxlanHashTest(HashTest):
             logging.info('Checking hash key {}, src_port={}, exp_ports={}, outer_src_ip={}, outer_dst_ip={}'
                          .format(hash_key, src_port, exp_port_lists, outer_src_ip, outer_dst_ip))
             (matched_index, _) = self.check_ip_route(hash_key,
-                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip,
-                                                     outer_src_ipv6, outer_dst_ipv6)
+                                                     src_port, exp_port_lists, outer_src_ip, outer_dst_ip)
             hit_count_map[matched_index] = hit_count_map.get(
                 matched_index, 0) + 1
         logging.info("hash_key={}, hit count map: {}".format(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
outer_dst_ip is used in get_src_and_exp_ports even for IPv6 outer packet.
IPv4 and IPv6 default routes can contain different ports.
Fix this by using V6 version outer_dst_ip in ipv6-* cases.
Fixes #21527

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
fib/test_fib.py test_vxlan_hash [ipv6-*] failed on some platforms

#### How did you do it?
Use correct outer_dst_ip for IPv6 cases

#### How did you verify/test it?
The test passed for both IPv4 and IPv6 cases

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
