### PR TITLE
Skip ipv4 ntp test for mgmt ipv6 only setup

### DIFF
--- a/tests/ntp/test_ntp.py
+++ b/tests/ntp/test_ntp.py
@@ -58,20 +58,17 @@ def setup_ntp(ptfhost, duthosts, rand_one_dut_hostname, ptf_use_ipv6):
     dut_facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
     is_mgmt_ipv6_only = dut_facts.get('is_mgmt_ipv6_only', False)
 
-    # Force IPv6 usage if DUT management is IPv6-only
-    use_ipv6 = ptf_use_ipv6 or is_mgmt_ipv6_only
+    if not ptf_use_ipv6 and is_mgmt_ipv6_only:
+        pytest.skip("No IPv4 mgmt address on mgmt IPv6 only DUT host")
 
-    if is_mgmt_ipv6_only:
-        logger.info("DUT management is IPv6-only, forcing NTP to use PTF IPv6 address")
-
-    if use_ipv6 and not ptfhost.mgmt_ipv6:
+    if ptf_use_ipv6 and not ptfhost.mgmt_ipv6:
         pytest.skip("No IPv6 address on PTF host")
 
     logger.info("Using PTF %s address for NTP sync: %s",
-                "IPv6" if use_ipv6 else "IPv4",
-                ptfhost.mgmt_ipv6 if use_ipv6 else ptfhost.mgmt_ip)
+                "IPv6" if ptf_use_ipv6 else "IPv4",
+                ptfhost.mgmt_ipv6 if ptf_use_ipv6 else ptfhost.mgmt_ip)
 
-    with setup_ntp_context(ptfhost, duthost, use_ipv6) as result:
+    with setup_ntp_context(ptfhost, duthost, ptf_use_ipv6) as result:
         yield result
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip ipv4_allowed for mgmt ipv6 only setup because DUT cannot access PTF through IPv4.
PR20292 just forces ipv6 for ipv4 test case, which unnecessarily runs ipv6 case twice.
Fixes #21530

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR20292 just forces ipv6 for ipv4 test case, which unnecessarily runs ipv6 case twice.

#### How did you do it?
Skip ipv4_allowed for mgmt ipv6 only setup 

#### How did you verify/test it?
Run the test in mgmt ipv6 only setup, and it skips ipv4_allowed case and only runs the ipv6_only case.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
