### PR TITLE
[Snappi] Adding PFC Response time testcase

### DIFF
--- a/tests/common/snappi_tests/traffic_generation.py
+++ b/tests/common/snappi_tests/traffic_generation.py
@@ -11,6 +11,10 @@ import pandas as pd
 from datetime import datetime
 from tests.common.utilities import (wait, wait_until)   # noqa: F401
 from tabulate import tabulate
+from scapy.all import *
+import scapy.contrib.mac_control
+import pandas as pd
+import struct
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.snappi_tests.common_helpers import config_capture_settings, get_egress_queue_count, \
@@ -32,6 +36,8 @@ from tests.common.snappi_tests.port import SnappiPortConfig
 
 # Imported to support rest_py in ixnetwork
 from ixnetwork_restpy.assistants.statistics.statviewassistant import StatViewAssistant
+from ixnetwork_restpy.testplatform.testplatform import TestPlatform
+from ixnetwork_restpy import SessionAssistant
 from random import getrandbits
 
 
@@ -497,6 +503,45 @@ def _rand_ipv6():
     return "2007:db8:%x:%x:%x:%x:%x:%x" % tuple(getrandbits(16) for _ in range(6))
 
 
+def generate_pre_pause_flows(testbed_config,
+                              snappi_extra_params,
+                              intf_type):
+    """
+    Generate background configurations of flows. Test flows and background flows are also known as data flows.
+    Args:
+        testbed_config (obj): testbed L1/L2/L3 configuration
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+        intf_type : IP or VLAN interface type
+    """
+    base_flow_config = snappi_extra_params.base_flow_config
+    pytest_assert(base_flow_config is not None, "Cannot find base flow configuration")
+    bg_flow_config = snappi_extra_params.traffic_flow_config.background_flow_config
+    pytest_assert(bg_flow_config is not None, "Cannot find background flow configuration")
+
+    bg_flow = testbed_config.flows.flow(name='{}'.format(bg_flow_config["flow_name"]))[-1]
+    bg_flow.tx_rx.port.tx_name = testbed_config.ports[base_flow_config["rx_port_id"]].name
+    bg_flow.tx_rx.port.rx_name = testbed_config.ports[base_flow_config["tx_port_id"]].name
+
+    eth, ipv4 = bg_flow.packet.ethernet().ipv4()
+    if intf_type == 'VLAN' or intf_type == 'vlan':
+        eth.src.value = base_flow_config["rx_mac"]
+        eth.dst.value = base_flow_config["tx_mac"]
+    elif intf_type == 'IP' or intf_type == 'ip':
+        eth.src.value = base_flow_config["tx_mac"]
+        eth.dst.value = base_flow_config["rx_mac"]
+    else:
+        pytest_assert(False, "Invalid interface type given")
+
+    ipv4.src.value = base_flow_config["rx_port_config"].ip
+    ipv4.dst.value = base_flow_config["tx_port_config"].ip
+
+    bg_flow.size.fixed = bg_flow_config["flow_pkt_size"]
+    bg_flow.rate.percentage = bg_flow_config["flow_rate_percent"]
+    bg_flow.duration.fixed_packets.packets = bg_flow_config["flow_pkt_count"]
+    bg_flow.metrics.enable = True
+    bg_flow.metrics.loss = True
+
+
 def generate_srv6_encap_flow(testbed_config,
                              snappi_test_params: SnappiTestParams):
     """
@@ -643,6 +688,260 @@ def check_for_crc_errors(api, snappi_extra_params):
                 if row['Stat Name'] == m_port['location']:
                     pytest.fail("{} CRC Errors detected on Peer Port: {}, Peer Device: {}, snappi port: {}".format(
                                 row['CRC Errors'], m_port['peer_port'], m_port['peer_device'], row['Port Name']))
+
+
+def aresone_offset(x):
+    res = int(float(x) * 0.078125)
+    if res >= 20:
+        raise Exception('odd time offset value: {} resulted in {} ns'.format(x, res))
+    return res
+
+
+def novus_offset(x):
+    res = int(float(x >> 5) * 2.5)
+    if res >= 20:
+        raise Exception('odd time offset value: {} resulted in {} ns'.format(x, res))
+    return res
+
+
+# aresone - 0.625, novus - 2.5
+IXIA_TIME_CONSTANTS = {
+    "aresone": aresone_offset,
+    "novus": novus_offset
+}
+
+
+def hw_pcap_to_dt(v):
+    return pd.to_datetime(int(v * 10 ** 6), unit='ns')
+
+
+def hw_pcap_to_ns(v):
+    return int(v * 10 ** 6)
+
+
+def decode_hw_ts(p, layer, card):
+    if p.haslayer(layer):
+        data = bytes(p[layer].payload)[:24]
+        s1, s2, s3, s4, s5, s6, offset, p1, p2, p3, seq, ts = struct.unpack("!IIBBBBBBBBII", data)
+        if s3 != 0x49 or s4 != 0x78 or s5 != 0x69:
+            raise Exception('wrong ixia signature in {}: {}, {}, {}'.format(data, s3, s4, s5))
+
+        t = ts * 20 + IXIA_TIME_CONSTANTS[card](offset)
+        return t
+    raise Exception('layer {} not present in {}'.format(layer, p))
+
+
+def hw_pcap_to_dataframe(filename, card, limit=0, type="IP"):
+    res = []
+    n = 0
+    for p in PcapReader(filename):
+        if p.haslayer(type):
+            res.append({
+                "sent": decode_hw_ts(p, type, card),
+                "received": hw_pcap_to_ns(p.time),
+                "wirelen": p.wirelen,
+                "timestamp": hw_pcap_to_dt(p.time),
+                "type": "ip",
+                "latency": hw_pcap_to_ns(p.time) - decode_hw_ts(p, type, card)
+            })
+        if p.haslayer(scapy.contrib.mac_control.MACControlClassBasedFlowControl):
+            q = p[scapy.contrib.mac_control.MACControlClassBasedFlowControl]
+            res.append({
+                "received": hw_pcap_to_ns(p.time),
+                "wirelen": p.wirelen,
+                "timestamp": hw_pcap_to_dt(p.time),
+                "type": "pfc",
+                "c0_pause_time": q.c0_pause_time,
+                "c0_enabled": q.c0_enabled,
+            })
+        n = n + 1
+        if limit and n >= limit:
+            break
+    return pd.DataFrame.from_records(res)
+
+
+def run_response_time_test(duthost,
+                           api,
+                           config,
+                           all_flow_names,
+                           packet_count,
+                           pause_rate,
+                           snappi_extra_params):
+    """
+    Run traffic and return per-flow statistics, and capture packets if needed.
+    Args:
+        duthost (obj): DUT host object
+        api (obj): snappi session
+        config (obj): experiment config (testbed config + flow config)
+        all_flow_names (list): list of names of all the flows
+        packet_count (int): Number of pre pause packets
+        snappi_extra_params (SnappiTestParams obj): additional parameters for Snappi traffic
+    Returns:
+        per-flow statistics (list)
+    """
+    duthost.command('sudo pfcwd stop \n')
+    time.sleep(10)
+    base_flow_config = snappi_extra_params.base_flow_config
+
+    # Enabling capture
+    logger.info("Enabling packet capture on the pre-pause Rx Port ...")
+    capture = config.captures.capture()[-1]
+    capture.name = "Capture 1"
+    capture.port_names = [base_flow_config["tx_port_name"], base_flow_config["rx_port_name"]]
+    capture.format = capture.PCAP
+    api.set_config(config)
+
+    username = api._username
+    ip = api._address
+    password = api._password
+    test_platform = TestPlatform(ip)
+    test_platform.Authenticate(username, password)
+
+    id = test_platform.Sessions.find()[-1].Id
+    session = SessionAssistant(IpAddress=ip, UserName=username, SessionId=id, Password=password)
+    ixnetwork = session.Ixnetwork
+    ixnetwork.Traffic.EnableMinFrameSize = False
+    ixnetwork.Traffic.EnableStaggeredStartDelay = False  #
+
+    ixnetwork.Globals.Statistics.Advanced.Timestamp.TimestampPrecision = 9
+    port1 = ixnetwork.Vport.find(Name=base_flow_config["tx_port_name"])[0]
+    port2 = ixnetwork.Vport.find(Name=base_flow_config["rx_port_name"])[0]
+    port2.TxMode = 'interleaved'
+    port2.Capture.SoftwareEnabled = False
+    port2.Capture.DataReceiveTimestamp = 'hwTimestamp'
+    port2.Capture.HardwareEnabled = False
+    port1.Capture.SoftwareEnabled = False
+    port1.Capture.HardwareEnabled = True
+    port1.Capture.DataReceiveTimestamp = 'hwTimestamp'
+    port1.Capture.Filter.CaptureFilterEnable = True
+
+    port1.Capture.Filter.CaptureFilterPattern = 'pattern1'
+    if port1.Name == 'Port 1':
+        port1.Capture.FilterPallette.Pattern1 = '15010102'
+    else:
+        port1.Capture.FilterPallette.Pattern1 = '16010102'
+    port1.Capture.FilterPallette.PatternMask1 = 'FFFFFF00'
+    port1.Capture.Filter.CaptureFilterExpressionString = 'P2'
+
+    logger.info("Wait for Arp to Resolve ...")
+    wait_for_arp(api, max_attempts=30, poll_interval_sec=2)
+
+    pre_pause_ti = ixnetwork.Traffic.TrafficItem.find(Name='Pre-Pause')[0]
+    pre_pause_ti.TransmitMode = 'interleaved'
+
+    # adding endpointset
+    pre_pause_ti.ConfigElement.find()[0].TransmissionControl.Type = 'fixedFrameCount'
+    pre_pause_ti.ConfigElement.find()[0].TransmissionControl.FrameCount = 100
+    pre_pause_ti.EndpointSet.add(Name="Pause Storm", Sources=port2.Protocols.find(),
+                                 Destinations=port1.Protocols.find())
+    # pause traffic
+    ce = pre_pause_ti.ConfigElement.find()[1]
+    ce.TransmissionControl.Type = 'continuous'
+
+    ce.FrameRate.Rate = pause_rate
+    pfc_template = ixnetwork.Traffic.ProtocolTemplate.find(StackTypeId='^pfcPause$')
+    ethernet_template = ce.Stack.find(StackTypeId='^ethernet$')
+    PFC_stack = ce.Stack.read(ethernet_template.AppendProtocol(pfc_template))
+    ethernet_template.Remove()
+    PFC_stack.find(StackTypeId='^pfcPause$').Field.find()[4].SingleValue = 8
+    PFC_stack.find(StackTypeId='^pfcPause$').Field.find()[5].SingleValue = '0'
+    PFC_stack.find(StackTypeId='^pfcPause$').Field.find()[8].SingleValue = 'ffff'
+
+    pre_pause_ti.Generate()
+    ixnetwork.Traffic.Apply()
+    logger.info("Starting transmit on pause and pre-pause ...")
+    pre_pause_ti.StartStatelessTrafficBlocking()
+    time.sleep(10)
+    pre_pause_ti.StopStatelessTrafficBlocking()
+    TI_Statistics = StatViewAssistant(ixnetwork, 'Traffic Item Statistics')
+    last_time_stamp = float(TI_Statistics.Rows[1]["Last TimeStamp"].split(':')[-1]) * 1000
+    ce.TransmissionControl.StartDelayUnits = 'milliseconds'
+    ce.TransmissionControl.StartDelay = int(last_time_stamp)
+
+    logger.info("Starting transmit on test flow ...")
+    test_flow_ti = ixnetwork.Traffic.TrafficItem.find(Name='Test Flow Prio 3')[0]
+    test_flow_ti.Generate()
+    pre_pause_ti.Generate()
+    ixnetwork.Traffic.Apply()
+    test_flow_ti.StartStatelessTrafficBlocking()
+    time.sleep(10)
+    # start capture on tx port of test flow
+    logger.info("Starting packet capture ...")
+    ixnetwork.StartCapture()
+
+    # starting pause and pre-pause
+    time.sleep(10)
+    logger.info("Starting transmit on pause and pre-pause ...")
+    pre_pause_ti.StartStatelessTrafficBlocking()
+    TI_Statistics = StatViewAssistant(ixnetwork, 'Traffic Item Statistics')
+    t = 0
+    while True:
+        TI_Statistics = StatViewAssistant(ixnetwork, 'Traffic Item Statistics')
+        if int(float(TI_Statistics.Rows[0]["Rx Frame Rate"])) == 0:
+            logger.info('Test Flow stopped receiving packets')
+            break
+        logger.info('Polling for Test Flow to stop receiving ...........{} m sec'.format(t * 1000))
+        pytest_assert(t < 20, 'Test Flow is still receiving for 10 seconds after starting pre-pause')
+        time.sleep(0.05)
+        t = t + 0.05
+    # TI_Statistics = StatViewAssistant(ixnetwork, 'Traffic Item Statistics')
+    lastStreamPacketTimestamp = TI_Statistics.Rows[0]["Last TimeStamp"]
+
+    print(' Stopping Traffic')
+    ixnetwork.Traffic.StopStatelessTrafficBlocking()
+    # Stopping and getting packets
+    time.sleep(10)
+    logger.info("Stopping packet capture ...")
+    ixnetwork.StopCapture()
+    time.sleep(20)
+
+    pathp = ixnetwork.Globals.PersistencePath
+    res = ixnetwork.SaveCaptureFiles(Arg1=pathp)[0]
+
+    cf = "moveFile.cap"
+    session.Session.DownloadFile(res, cf)
+
+    host1_df = hw_pcap_to_dataframe(cf, "novus", 100, "IP")
+    logger.info(host1_df)
+
+    lineRate = 100
+    ns_per_bit = 1.0 / lineRate
+    ns_per_byte = ns_per_bit * 8
+    numPrePauseFrames = 1
+
+    prePausePacketSize = pre_pause_ti.ConfigElement.find()[0].FrameSize.FixedSize
+    pausePacketTxDelay = numPrePauseFrames * (prePausePacketSize + 20)
+    pausePacketTxDelay = pausePacketTxDelay - 20
+    pausePacketTxDelay = pausePacketTxDelay - (prePausePacketSize / 2)
+
+    packetTimeOnWire = ns_per_byte * (prePausePacketSize + 20)
+    packetDurationOnWire = ns_per_byte * prePausePacketSize
+
+    pd.DataFrame.from_records(host1_df)
+    lastPrePausePacketTxTimeStamp = host1_df['sent'].loc[host1_df.index[packet_count - 1]]
+    pauseFrameTimestamp = lastPrePausePacketTxTimeStamp + packetTimeOnWire
+    pauseFrameTxTimestamp = pauseFrameTimestamp + packetDurationOnWire
+
+    responseTime = float(lastStreamPacketTimestamp.split(':')[-1]) * 1000000000 - pauseFrameTxTimestamp
+    logger.info('----------------------------------------------')
+    logger.info("Last Pre Pause Timestamp   : {} ns|".format(float(lastPrePausePacketTxTimeStamp)))
+    last_data_packet_timestamp = float(lastStreamPacketTimestamp.split(':')[-1]) * 1000000000
+    logger.info("Last Data Packet Timestamp : {} ns|".format(last_data_packet_timestamp))
+    logger.info("Pause Tx Timestamp         : {} ns|".format(pauseFrameTxTimestamp))
+    logger.info("Response Time              : {} ns|".format(responseTime))
+    logger.info('----------------------------------------------')
+
+    # Dump per-flow statistics
+    logger.info("Dumping per-flow statistics")
+    request = api.metrics_request()
+    request.flow.flow_names = all_flow_names
+    flow_metrics = api.get_metrics(request).flow_metrics
+    logger.info("Stopping transmit on all remaining flows")
+    cs = api.control_state()
+    cs.traffic.flow_transmit.state = cs.traffic.flow_transmit.START
+    api.set_control_state(cs)
+
+    return flow_metrics
 
 
 def run_traffic(duthost,
@@ -1553,6 +1852,24 @@ def verify_egress_queue_frame_count(duthost,
                 total_egress_packets, _ = get_egress_queue_count(duthost, peer_port, prios[prio])
                 pytest_assert(total_egress_packets == test_tx_frames[prio],
                               "Queue counters should increment for invalid PFC pause frames")
+
+
+def verify_pre_pause(flow_metrics,
+                     pre_pause_flow_name,
+                     pre_pause_packets):
+    """
+    Verify pause flow statistics i.e. all pause frames should be dropped
+    Args:
+        flow_metrics (list): per-flow statistics
+        pre_pause_flow_name (str): name of the pre pause flow
+        pre_pause_packets (int): number of pre pause packets sent
+    Returns:
+    """
+    pre_pause_flow_row = next(metric for metric in flow_metrics if metric.name == pre_pause_flow_name)
+    pre_pause_flow_rx_frames = pre_pause_flow_row.frames_rx
+
+    pytest_assert(pre_pause_flow_rx_frames == pre_pause_packets,
+                  "Received desired number of pre pause packets")
 
 
 def tgen_curr_stats(traf_metrics, flow_metrics, data_flow_names):

--- a/tests/snappi_tests/pfc/files/helper.py
+++ b/tests/snappi_tests/pfc/files/helper.py
@@ -3,12 +3,12 @@ import time
 import sys
 from tests.common.cisco_data import is_cisco_device
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts  # noqa: F401
-from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector,\
-    get_lossless_buffer_size, get_pg_dropped_packets,\
-    disable_packet_aging, enable_packet_aging, sec_to_nanosec,\
-    get_pfc_frame_count, packet_capture, config_capture_pkt,\
+from tests.common.snappi_tests.common_helpers import pfc_class_enable_vector, \
+    get_lossless_buffer_size, get_pg_dropped_packets, \
+    disable_packet_aging, enable_packet_aging, sec_to_nanosec, \
+    get_pfc_frame_count, packet_capture, config_capture_pkt, \
     traffic_flow_mode, calc_pfc_pause_flow_rate, get_tx_frame_count      # noqa: F401
 from tests.common.snappi_tests.port import select_ports, select_tx_port  # noqa: F401
 from tests.common.snappi_tests.snappi_helpers import get_dut_port_id, wait_for_arp  # noqa: F401
@@ -16,8 +16,8 @@ from tests.common.snappi_tests.traffic_generation import setup_base_traffic_conf
     generate_background_flows, generate_pause_flows, run_traffic, verify_pause_flow, verify_basic_test_flow, \
     verify_background_flow, verify_pause_frame_count_dut, verify_egress_queue_frame_count, \
     verify_in_flight_buffer_pkts, verify_unset_cev_pause_frame_count, verify_tx_frame_count_dut, \
-    verify_rx_frame_count_dut, run_response_time_test, generate_pre_pause_flows, verify_pre_pause  # noqa F401
-    verify_rx_frame_count_dut, verify_test_flow_stats_for_macsec, verify_background_flow_stats_for_macsec, \
+    verify_rx_frame_count_dut, run_response_time_test, generate_pre_pause_flows, verify_pre_pause, \
+    verify_test_flow_stats_for_macsec, verify_background_flow_stats_for_macsec, \
     verify_pause_flow_for_macsec, verify_macsec_stats   # noqa: F401
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
 from tests.common.snappi_tests.read_pcap import validate_pfc_frame, validate_pfc_frame_cisco
@@ -82,7 +82,7 @@ def run_pfc_test(api,
     Returns:
         N/A
     """
-
+    ptype = "--snappi_macsec" in sys.argv
     if snappi_extra_params is None:
         snappi_extra_params = SnappiTestParams()
 

--- a/tests/snappi_tests/pfc/test_pfc_response_time.py
+++ b/tests/snappi_tests/pfc/test_pfc_response_time.py
@@ -1,0 +1,98 @@
+import pytest
+import logging
+from tests.common.helpers.assertions import pytest_require
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+    fanout_graph_facts_multidut, fanout_graph_facts                      # noqa F401
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
+    snappi_api, get_snappi_ports, is_snappi_multidut, \
+    get_snappi_ports_single_dut, snappi_testbed_config, \
+    get_snappi_ports_multi_dut, snappi_dut_base_config, cleanup_config, get_snappi_ports_for_rdma  # noqa: F401
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+    lossy_prio_list                         # noqa F401
+from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
+from tests.snappi_tests.pfc.files.helper import run_pfc_response_time_test
+
+pytestmark = [pytest.mark.topology('tgen')]
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize('intf_type', ['IP'])
+@pytest.mark.parametrize("multidut_port_info", MULTIDUT_PORT_INFO[MULTIDUT_TESTBED])
+def test_response_time(snappi_api,                   # noqa F811
+                       conn_graph_facts,                             # noqa: F811
+                       fanout_graph_facts_multidut,                # noqa: F811
+                       get_snappi_ports,                           # noqa: F811
+                       enum_one_dut_lossless_prio,
+                       duthosts,
+                       lossless_prio_list,           # noqa F811
+                       lossy_prio_list,              # noqa F811
+                       prio_dscp_map,
+                       multidut_port_info,
+                       tbinfo,
+                       intf_type):               # noqa F811
+    """
+    Test if IEEE 802.3X pause (a.k.a., global pause) will impact any priority
+
+    Args:
+        snappi_api (pytest fixture): SNAPPI session
+        snappi_testbed_config (pytest fixture): testbed configuration information
+        conn_graph_facts (pytest fixture): connection graph
+        fanout_graph_facts (pytest fixture): fanout graph
+        duthosts (pytest fixture): list of DUTs
+        lossless_prio_list (pytest fixture): list of all the lossless priorities
+        lossy_prio_list (pytest fixture): list of all the lossy priorities
+        prio_dscp_map (pytest fixture): priority vs. DSCP map (key = priority).
+        intf_type (pytest paramenter): IP or VLAN interface type
+    Returns:
+        N/A
+    """
+
+    snappi_port_list = get_snappi_ports
+
+    tbname = tbinfo.get('conf-name', None)
+
+    tx_port_count = 1
+    rx_port_count = 1
+
+    pytest_require(len(snappi_port_list) >= tx_port_count + rx_port_count,
+                   "Need Minimum of 2 ports defined in ansible/files/*links.csv file")
+
+    for testbed_subtype, rdma_ports in multidut_port_info.items():
+        pytest_require(len(rdma_ports['tx_ports']) >= tx_port_count,
+                       'MULTIDUT_PORT_INFO doesn\'t have the required Tx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                       format(MULTIDUT_TESTBED, testbed_subtype))
+
+        pytest_require(len(rdma_ports['rx_ports']) >= rx_port_count,
+                       'MULTIDUT_PORT_INFO doesn\'t have the required Rx ports defined for \
+                      testbed {}, subtype {} in variables.py'.
+                       format(tbname, testbed_subtype))
+        logger.info('Running test for testbed subtype: {}'.format(testbed_subtype))
+        if is_snappi_multidut(duthosts):
+            snappi_ports = get_snappi_ports_for_rdma(snappi_port_list, rdma_ports,
+                                                     tx_port_count, rx_port_count, MULTIDUT_TESTBED)
+        else:
+            snappi_ports = snappi_port_list
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(duthosts,
+                                                                                snappi_ports,
+                                                                                snappi_api)
+
+    _, lossless_prio = enum_one_dut_lossless_prio.split('|')
+    lossless_prio = int(lossless_prio)
+    test_prio_list = [lossless_prio]
+    bg_prio_list = [p for p in all_prio_list]
+    bg_prio_list.remove(lossless_prio)
+
+    run_pfc_response_time_test(api=snappi_api,
+                               testbed_config=testbed_config,
+                               port_config_list=port_config_list,
+                               conn_data=conn_graph_facts,
+                               fanout_data=fanout_graph_facts,
+                               duthost=duthosts[0],
+                               global_pause=False,
+                               pause_prio_list=test_prio_list,
+                               test_prio_list=test_prio_list,
+                               bg_prio_list=bg_prio_list,
+                               prio_dscp_map=prio_dscp_map,
+                               test_traffic_pause=False,
+                               intf_type=intf_type,)

--- a/tests/snappi_tests/pfc/test_pfc_response_time.py
+++ b/tests/snappi_tests/pfc/test_pfc_response_time.py
@@ -1,13 +1,13 @@
 import pytest
 import logging
 from tests.common.helpers.assertions import pytest_require
-from tests.common.fixtures.conn_graph_facts import conn_graph_facts,\
+from tests.common.fixtures.conn_graph_facts import conn_graph_facts, \
     fanout_graph_facts_multidut, fanout_graph_facts                      # noqa F401
-from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port,\
+from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     snappi_api, get_snappi_ports, is_snappi_multidut, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
     get_snappi_ports_multi_dut, snappi_dut_base_config, cleanup_config, get_snappi_ports_for_rdma  # noqa: F401
-from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list,\
+from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, all_prio_list, lossless_prio_list, \
     lossy_prio_list                         # noqa F401
 from tests.snappi_tests.variables import MULTIDUT_PORT_INFO, MULTIDUT_TESTBED
 from tests.snappi_tests.pfc.files.helper import run_pfc_response_time_test
@@ -22,11 +22,10 @@ def test_response_time(snappi_api,                   # noqa F811
                        conn_graph_facts,                             # noqa: F811
                        fanout_graph_facts_multidut,                # noqa: F811
                        get_snappi_ports,                           # noqa: F811
-                       enum_one_dut_lossless_prio,
                        duthosts,
                        lossless_prio_list,           # noqa F811
                        lossy_prio_list,              # noqa F811
-                       prio_dscp_map,
+                       prio_dscp_map,       # noqa F811
                        multidut_port_info,
                        tbinfo,
                        intf_type):               # noqa F811
@@ -77,11 +76,8 @@ def test_response_time(snappi_api,                   # noqa F811
                                                                                 snappi_ports,
                                                                                 snappi_api)
 
-    _, lossless_prio = enum_one_dut_lossless_prio.split('|')
-    lossless_prio = int(lossless_prio)
-    test_prio_list = [lossless_prio]
-    bg_prio_list = [p for p in all_prio_list]
-    bg_prio_list.remove(lossless_prio)
+    test_prio_list = [lossless_prio_list[0]]
+    bg_prio_list = [lossless_prio_list[1]]
 
     run_pfc_response_time_test(api=snappi_api,
                                testbed_config=testbed_config,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding PFC response time testcase
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on single dut setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output

snappi_tests/pfc/test_pfc_response_time.py::test_response_time[multidut_port_info0-IP] 
------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------
31/10/2025 01:15:05 __init__.set_default                     L0053 INFO   | Completeness level not set during test execution. Setting to default level: CompletenessLevel.basic
31/10/2025 01:15:05 __init__.check_test_completeness         L0151 INFO   | Test has no defined levels. Continue without test completeness checks
31/10/2025 01:15:05 conftest.enhance_inventory               L0346 INFO   | Inventory file: ['../ansible/snappi-sonic']
31/10/2025 01:15:08 ptfhost_utils.run_icmp_responder_session L0326 INFO   | Skip running icmp_responder at session level, it is only for dualtor testbed with active-active mux ports.
31/10/2025 01:15:08 __init__._sanity_check                   L0442 INFO   | Skip sanity check according to command line argument
31/10/2025 01:15:08 conftest.collect_before_test             L2768 INFO   | Dumping Disk and Memory Space information before test on sonic-s6100-dut1
31/10/2025 01:15:08 conftest.collect_before_test             L2772 INFO   | Collecting core dumps before test on sonic-s6100-dut1
31/10/2025 01:15:09 conftest.collect_before_test             L2781 INFO   | Collecting running config before test on sonic-s6100-dut1
31/10/2025 01:15:11 conftest.temporarily_disable_route_check L3063 INFO   | Skipping temporarily_disable_route_check fixture
31/10/2025 01:15:11 conftest.generate_params_dut_hostname    L1571 INFO   | Using DUTs ['sonic-s6100-dut1'] in testbed 'vms-snappi-sonic'
31/10/2025 01:15:11 conftest.set_rand_one_dut_hostname       L0685 INFO   | Randomly select dut sonic-s6100-dut1 for testing
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture enable_packet_aging_after_test setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture enable_packet_aging_after_test setup ends --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossless_prio setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossless_prio setup ends --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture rand_lossy_prio setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture rand_lossy_prio setup ends --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture start_pfcwd_after_test setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture start_pfcwd_after_test setup ends --------------------
31/10/2025 01:15:11 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_ip setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_ip setup ends --------------------
31/10/2025 01:15:11 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture snappi_api_serv_port setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture snappi_api_serv_port setup ends --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0081 INFO   | -------------------- fixture snappi_api setup starts --------------------
31/10/2025 01:15:11 __init__._fixture_generator_decorator    L0085 INFO   | -------------------- fixture snappi_api setup ends --------------------
31/10/2025 01:15:12 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports setup starts --------------------
31/10/2025 01:15:12 conftest.rand_one_dut_front_end_hostname L0721 INFO   | Randomly select dut sonic-s6100-dut1 for testing
31/10/2025 01:15:12 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture get_snappi_ports_single_dut setup starts --------------------
31/10/2025 01:15:12 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports_single_dut setup ends --------------------
31/10/2025 01:15:12 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture get_snappi_ports setup ends --------------------
31/10/2025 01:15:12 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossless_prio_list setup starts --------------------
31/10/2025 01:15:13 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossless_prio_list setup ends --------------------
31/10/2025 01:15:13 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture prio_dscp_map setup starts --------------------
31/10/2025 01:15:14 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture prio_dscp_map setup ends --------------------
31/10/2025 01:15:14 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture all_prio_list setup starts --------------------
31/10/2025 01:15:14 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture all_prio_list setup ends --------------------
31/10/2025 01:15:14 __init__._fixture_func_decorator         L0069 INFO   | -------------------- fixture lossy_prio_list setup starts --------------------
31/10/2025 01:15:14 __init__._fixture_func_decorator         L0076 INFO   | -------------------- fixture lossy_prio_list setup ends --------------------
31/10/2025 01:15:14 __init__.loganalyzer                     L0077 INFO   | Log analyzer is disabled
31/10/2025 01:15:14 __init__.memory_utilization              L0143 INFO   | Hostname: sonic-s6100-dut1, Hwsku: Accton-AS7726-32X, Platform: x86_64-accton_as7726_32x-r0
31/10/2025 01:15:14 memory_utilization.parse_and_register_co L0365 INFO   | Loading memory monitoring commands for hwsku: Accton-AS7726-32X
31/10/2025 01:15:14 memory_utilization.register_command      L0023 INFO   | Registering command: name=monit, cmd=sudo monit validate, memory_params={'memory_usage': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 10}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 70}}}, memory_check=<function parse_monit_validate_output at 0x7fd32fe8f9d0>
31/10/2025 01:15:14 memory_utilization.register_command      L0023 INFO   | Registering command: name=top, cmd=top -b -n 1, memory_params={'bgpd': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}, 'zebra': {'memory_increase_threshold': {'type': 'value', 'value': 128}, 'memory_high_threshold': None}}, memory_check=<function parse_top_output at 0x7fd32fe8f1f0>
31/10/2025 01:15:14 memory_utilization.register_command      L0023 INFO   | Registering command: name=free, cmd=free -m, memory_params={'used': {'memory_increase_threshold': {'type': 'percentage', 'value': '20%'}, 'memory_high_threshold': None}}, memory_check=<function parse_free_output at 0x7fd32fe8f940>
31/10/2025 01:15:14 memory_utilization.register_command      L0023 INFO   | Registering command: name=docker, cmd=docker stats --no-stream, memory_params={'snmp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'pmon': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'lldp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 4}}, 'gnmi': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}, 'radv': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 3}}, 'syncd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 5}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 18}}, 'bgp': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 4}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 14}}, 'teamd': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 5}}, 'swss': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 3}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 8}}, 'database': {'memory_increase_threshold': {'type': 'percentage_points', 'value': 2}, 'memory_high_threshold': {'type': 'percentage_points', 'value': 6}}}, memory_check=<function parse_docker_stats_output at 0x7fd32fe8fa60>
31/10/2025 01:15:14 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_bgp, cmd=vtysh -c "show memory bgp", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 256}}}, memory_check=<function parse_frr_memory_output at 0x7fd32fe8faf0>
31/10/2025 01:15:14 memory_utilization.register_command      L0023 INFO   | Registering command: name=frr_zebra, cmd=vtysh -c "show memory zebra", memory_params={'used': {'memory_increase_threshold': [{'type': 'percentage', 'value': '50%'}, {'type': 'value', 'value': 64}, {'type': 'comparison', 'value': 'max'}], 'memory_high_threshold': {'type': 'value', 'value': 128}}}, memory_check=<function parse_frr_memory_output at 0x7fd32fe8faf0>
31/10/2025 01:15:14 conftest.setup_dualtor_mux_ports         L3523 INFO   | skip setup dualtor mux cables on non-dualtor testbed
31/10/2025 01:15:19 memory_utilization.parse_frr_memory_outp L0631 INFO   | Total FRR memory used: 108.1 MB, holding: 105906176.0 bytes, small: 0.0 bytes, ordinary: 7455744.0 bytes
31/10/2025 01:15:20 memory_utilization.parse_frr_memory_outp L0631 INFO   | Total FRR memory used: 228.8 MB, holding: 234881024.0 bytes, small: 0.0 bytes, ordinary: 4998144.0 bytes
31/10/2025 01:15:20 __init__.pytest_runtest_setup            L0064 INFO   | Before test: collected memory_values {'before_test': {'sonic-s6100-dut1': {'monit': {'memory_usage': 27.0}, 'top': {'zebra': 71.8, 'bgpd': 48.8}, 'free': {'used': 3962}, 'docker': {'radv': 0.2, 'snmp': 0.4, 'lldp': 0.3, 'syncd': 2.9, 'teamd': 0.2, 'swss': 0.4, 'bgp': 1.0, 'pmon': 0.7, 'database': 0.9}, 'frr_bgp': {'used': 108.1}, 'frr_zebra': {'used': 228.8}}}, 'after_test': {'sonic-s6100-dut1': {}}}
------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------
31/10/2025 01:15:20 test_pfc_response_time.test_response_tim L0068 INFO   | Running test for testbed subtype: single-dut-single-asic
31/10/2025 01:15:21 snappi_fixtures.__intf_config_multidut   L0979 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet64 with IP 20.1.1.0/31
31/10/2025 01:15:22 snappi_fixtures.__intf_config_multidut   L0979 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet68 with IP 20.1.1.2/31
31/10/2025 01:15:24 snappi_fixtures.__intf_config_multidut   L0979 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet72 with IP 20.1.1.4/31
31/10/2025 01:15:25 snappi_fixtures.__intf_config_multidut   L0979 INFO   | Configuring Dut: sonic-s6100-dut1 with port Ethernet76 with IP 20.1.1.6/31
31/10/2025 01:15:43 traffic_generation.run_response_time_tes L0730 INFO   | Enabling packet capture on the pre-pause Rx Port ...
31/10/2025 01:15:43 connection._warn                         L0332 WARNING| Verification of certificates is disabled
31/10/2025 01:15:43 connection._info                         L0329 INFO   | Determining the platform and rest_port using the 10.36.78.117 address...
31/10/2025 01:15:43 connection._warn                         L0332 WARNING| Unable to connect to http://10.36.78.117:443.
31/10/2025 01:15:43 connection._info                         L0329 INFO   | Connection established to `https://10.36.78.117:443 on linux`
31/10/2025 01:15:57 connection._info                         L0329 INFO   | Using IxNetwork api server version 10.80.2411.54
31/10/2025 01:15:57 connection._info                         L0329 INFO   | User info IxNetwork/ixnetworkweb/admin-2-3563
31/10/2025 01:15:58 snappi_api.info                          L1419 INFO   | snappi-1.27.1
31/10/2025 01:15:58 snappi_api.info                          L1419 INFO   | snappi_ixnetwork-1.27.2
31/10/2025 01:15:58 snappi_api.info                          L1419 INFO   | ixnetwork_restpy-1.6.1
31/10/2025 01:15:58 snappi_api.info                          L1419 INFO   | Config validation 0.014s
31/10/2025 01:16:01 snappi_api.info                          L1419 INFO   | Ports configuration 1.608s
31/10/2025 01:16:01 snappi_api.warning                       L1425 WARNING| pcap format is not supported for IxNetwork, setting capture format to pcapng
31/10/2025 01:16:03 snappi_api.info                          L1419 INFO   | Captures configuration 2.089s
31/10/2025 01:16:05 snappi_api.info                          L1419 INFO   | Add location hosts [10.36.78.53] 2.257s
31/10/2025 01:16:08 snappi_api.info                          L1419 INFO   | Location hosts ready [10.36.78.53] 2.230s
31/10/2025 01:16:08 snappi_api.info                          L1419 INFO   | Speed conversion is not require for (port.name, speed) : [('Port 0', 'novusHundredGigNonFanOut'), ('Port 1', 'novusHundredGigNonFanOut'), ('Port 2', 'novusHundredGigNonFanOut'), ('Port 3', 'novusHundredGigNonFanOut')]
31/10/2025 01:16:08 snappi_api.info                          L1419 INFO   | Aggregation mode speed change 0.554s
31/10/2025 01:16:09 snappi_api.info                          L1419 INFO   | Location preemption [10.36.78.53;6;5, 10.36.78.53;6;6, 10.36.78.53;6;7, 10.36.78.53;6;8] 0.143s
31/10/2025 01:16:38 snappi_api.info                          L1419 INFO   | Location connect [Port 0, Port 1, Port 2, Port 3] 28.447s
31/10/2025 01:16:38 snappi_api.warning                       L1425 WARNING| Port 0 connectedLinkDown
31/10/2025 01:16:38 snappi_api.warning                       L1425 WARNING| Port 1 connectedLinkDown
31/10/2025 01:16:38 snappi_api.warning                       L1425 WARNING| Port 2 connectedLinkDown
31/10/2025 01:16:38 snappi_api.warning                       L1425 WARNING| Port 3 connectedLinkDown
31/10/2025 01:16:38 snappi_api.info                          L1419 INFO   | Location state check [Port 0, Port 1, Port 2, Port 3] 0.287s
31/10/2025 01:16:38 snappi_api.info                          L1419 INFO   | Location configuration 35.349s
31/10/2025 01:16:47 snappi_api.info                          L1419 INFO   | Layer1 configuration 8.641s
31/10/2025 01:16:47 snappi_api.info                          L1419 INFO   | Lag Configuration 0.091s
31/10/2025 01:16:47 snappi_api.info                          L1419 INFO   | Convert device config : 0.255s
31/10/2025 01:16:47 snappi_api.info                          L1419 INFO   | Create IxNetwork device config : 0.000s
31/10/2025 01:16:48 snappi_api.info                          L1419 INFO   | Push IxNetwork device config : 0.823s
31/10/2025 01:16:48 snappi_api.info                          L1419 INFO   | Devices configuration 1.165s
31/10/2025 01:16:52 snappi_api.info                          L1419 INFO   | Flows configuration 3.651s
31/10/2025 01:17:01 snappi_api.info                          L1419 INFO   | Start interfaces 9.243s
31/10/2025 01:17:02 snappi_api.info                          L1419 INFO   | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
31/10/2025 01:17:06 traffic_generation.run_response_time_tes L0770 INFO   | Wait for Arp to Resolve ...
31/10/2025 01:17:15 traffic_generation.run_response_time_tes L0796 INFO   | Starting transmit on pause and pre-pause ...
31/10/2025 01:17:38 traffic_generation.run_response_time_tes L0805 INFO   | Starting transmit on test flow ...
31/10/2025 01:18:00 traffic_generation.run_response_time_tes L0813 INFO   | Starting packet capture ...
31/10/2025 01:18:10 traffic_generation.run_response_time_tes L0818 INFO   | Starting transmit on pause and pre-pause ...
31/10/2025 01:18:14 traffic_generation.run_response_time_tes L0827 INFO   | Polling for Test Flow to stop transmitting ...........0 m sec
31/10/2025 01:18:15 traffic_generation.run_response_time_tes L0827 INFO   | Polling for Test Flow to stop transmitting ...........50.0 m sec
31/10/2025 01:18:16 traffic_generation.run_response_time_tes L0827 INFO   | Polling for Test Flow to stop transmitting ...........100.0 m sec
31/10/2025 01:18:16 traffic_generation.run_response_time_tes L0827 INFO   | Polling for Test Flow to stop transmitting ...........150.00000000000003 m sec
31/10/2025 01:18:17 traffic_generation.run_response_time_tes L0825 INFO   | Test Flow stopped sending packets
31/10/2025 01:18:35 traffic_generation.run_response_time_tes L0838 INFO   | Stopping packet capture ...
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0849 INFO   |            sent     received  wirelen                     timestamp type  latency
0   23260527852  23260528835       66 1970-01-01 00:00:23.260528835   ip      983
1   23260527912  23260528895       66 1970-01-01 00:00:23.260528895   ip      983
2   23260527985  23260528965       66 1970-01-01 00:00:23.260528965   ip      980
3   23260528057  23260529040       66 1970-01-01 00:00:23.260529040   ip      983
4   23260528117  23260529102       66 1970-01-01 00:00:23.260529102   ip      985
..          ...          ...      ...                           ...  ...      ...
95  23260534385  23260535370       66 1970-01-01 00:00:23.260535370   ip      985
96  23260534457  23260535440       66 1970-01-01 00:00:23.260535440   ip      983
97  23260534517  23260535500       66 1970-01-01 00:00:23.260535500   ip      983
98  23260534590  23260535575       66 1970-01-01 00:00:23.260535575   ip      985
99  23260534662  23260535645       66 1970-01-01 00:00:23.260535645   ip      983

[100 rows x 6 columns]
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0870 INFO   | ----------------------------------------------
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0871 INFO   | Last Pre Pause Timestamp   : 23260534662.0 ns|
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0873 INFO   | Last Data Packet Timestamp : 23396528277.0 ns|
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0874 INFO   | Pause Tx Timestamp         : 23260534673.84 ns|
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0875 INFO   | Response Time              : 135993603.15999985 ns|
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0876 INFO   | ----------------------------------------------
31/10/2025 01:18:56 traffic_generation.run_response_time_tes L0879 INFO   | Dumping per-flow statistics
31/10/2025 01:18:57 traffic_generation.run_response_time_tes L0883 INFO   | Stopping transmit on all remaining flows
31/10/2025 01:19:09 snappi_api.info                          L1419 INFO   | Flows clear statistics 10.950s
31/10/2025 01:19:09 snappi_api.info                          L1419 INFO   | Captures start 0.000s
31/10/2025 01:19:12 snappi_api.info                          L1419 INFO   | Flows start 3.222s
PASSED                                                                                                                                                                             [100%]
----------------------------------------------------------------------------------- live log teardown ---------------------------------------