### PR TITLE
Fix tacacs tests for mgmt ipv6 only setup

### DIFF
--- a/tests/common/fixtures/tacacs.py
+++ b/tests/common/fixtures/tacacs.py
@@ -51,11 +51,12 @@ def setup_tacacs(ptfhost, duthosts, selected_dut, selected_rand_dut, tacacs_cred
 
     tacacs_server_ip = ""
     tacacs_server_passkey = ""
+    duthost_mgmt_info = duthost.get_mgmt_ip()
     if use_lab_tacacs_server:
         tacacs_server_ip = creds['lab_tacacs_server']
         tacacs_server_passkey = creds['lab_tacacs_passkey']
     else:
-        tacacs_server_ip = ptfhost.mgmt_ip
+        tacacs_server_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_info["version"] == "v6" else ptfhost.mgmt_ip
         tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
 
     logger.warning("Setup TACACS server: use_lab_tacacs_server:{}, tacacs_server_ip:{}, tacacs_server_passkey:{}"

--- a/tests/common/helpers/tacacs/tacacs_helper.py
+++ b/tests/common/helpers/tacacs/tacacs_helper.py
@@ -370,12 +370,8 @@ def check_nss_config(duthost):
 @pytest.fixture(scope="module")
 def check_tacacs(ptfhost, duthosts, enum_rand_one_per_hwsku_hostname, tacacs_creds):    # noqa: F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    # Check if DUT management is IPv6-only
-    dut_facts = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts']
-    is_mgmt_ipv6_only = dut_facts.get('is_mgmt_ipv6_only', False)
-    if is_mgmt_ipv6_only:
-        pytest.skip("Skip TACACS test for IPv6-only DUT management interface.")
-    tacacs_server_ip = ptfhost.mgmt_ip
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    tacacs_server_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_info["version"] == "v6" else ptfhost.mgmt_ip
     tacacs_server_passkey = tacacs_creds[duthost.hostname]['tacacs_passkey']
 
     # Accounting test case randomly failed, need debug info to confirm NSS config file missing issue.

--- a/tests/tacacs/test_accounting.py
+++ b/tests/tacacs/test_accounting.py
@@ -245,11 +245,12 @@ def test_accounting_tacacs_only_some_tacacs_server_down(
                                                     skip_in_container_test):
     """
         Setup multiple tacacs server for this UT.
-        Tacacs server 127.0.0.1 not accessible.
+        Tacacs server 127.0.0.1/::1 not accessible.
     """
-    invalid_tacacs_server_ip = "127.0.0.1"
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    tacacs_server_ip = ptfhost.mgmt_ip
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    invalid_tacacs_server_ip = "::1" if duthost_mgmt_info["version"] == "v6" else "127.0.0.1"
+    tacacs_server_ip = ptfhost.mgmt_ipv6 if duthost_mgmt_info["version"] == "v6" else ptfhost.mgmt_ip
 
     # when tacacs config change multiple time in short time
     # auditd service may been request reload during reloading


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use mgmt_ipv6 of PTF for mgmt IPv6 only setup.
Also use mgmt_ipv4 of PTF as second tacacs server IP.
Revert the skip for mgmt ipv6 only setup added in PR20292.
Fixes #21558

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix tacacs tests for mgmt ipv6 only setup

#### How did you do it?
Use mgmt_ipv6 of PTF for mgmt IPv6 only setup.
Also use mgmt_ipv4 of PTF as second tacacs server IP.

#### How did you verify/test it?
Run the test, it should pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
