### PR TITLE
[docker-ptf] Modify docker container pull setting

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -163,10 +163,10 @@
       image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
       # Set pull to 'missing' when ptf_modified is True (PR test with preloaded image)
       # to avoid pulling and overwriting the local image. For nightly tests where
-      # ptf_modified is False/undefined, use 'yes' to always pull the latest image.
+      # ptf_modified is False/undefined, use 'always' to always pull the latest image.
       # The ptf_modified flag is passed from Azure Pipelines through Elastictest's
       # add_topo_params as "-e ptf_modified=True" when testing PR built docker-ptf images.
-      pull: "{{ 'missing' if (ptf_modified | default(false) | bool) else 'yes' }}"
+      pull: "{{ 'missing' if (ptf_modified | default(false) | bool) else 'always' }}"
       state: started
       restart: no
       network_mode: none


### PR DESCRIPTION
### Description of PR

Set pull to 'missing' to avoid pulling and overwriting the local image if there is a preloaded image present. This is used for testing PR built image which is preloaded in elastic test when PTF_MODIFIED is True. This mechanism is used to test PR built `docker-ptf` image.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

See description above

#### How did you do it?

Modified pull setting value.

#### How did you verify/test it?

NA

#### Any platform specific information?

NA

#### Supported testbed topology if it's a new test case?

NA