### PR TITLE
Add hostname to syslog logging configuration in pfc_gen.py

### DIFF
--- a/ansible/roles/test/files/mlnx/docker-tests-pfcgen-asic/pfc_gen.py
+++ b/ansible/roles/test/files/mlnx/docker-tests-pfcgen-asic/pfc_gen.py
@@ -11,6 +11,7 @@ The idea is
 import re
 import sys
 import time
+import socket
 from python_sdk_api.sx_api import *  # noqa: F401 F403
 import argparse
 import logging
@@ -250,8 +251,10 @@ def main():
 
     logger = logging.getLogger('MyLogger')
     logger.setLevel(logging.DEBUG)
-    # Configure logging
+    # Configure logging with hostname
     handler = logging.handlers.SysLogHandler(address=(args.rsyslog_server, 514))
+    formatter = logging.Formatter('{} %(message)s'.format(socket.gethostname()))
+    handler.setFormatter(formatter)
     logger.addHandler(handler)
 
     if args.disable:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add hostname to syslog logging configuration in pfc_gen.py

https://github.com/sonic-net/sonic-buildimage/pull/24394 changed
the rsyslog configuration in new image which requires hostname to be
included when writing syslog, otherwise the message will
be silently ignored

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Fix the issue that fanout switch unable to write syslog on dut in pfc_gen.py

#### How did you do it?

add hostname in the syslogger in pfc_gen.py

#### How did you verify/test it?
run test on physical setups

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
