### PR TITLE
Add ptf modified param from pr test template

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -46,8 +46,8 @@ parameters:
   default: {}
 
 - name: PTF_MODIFIED
-  type: boolean
-  default: false
+  type: string
+  default: "False"
 
 
 jobs:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
PTF_MODIFIED flag was defined and used in buildimage PR test, if PTF_MODIFIED is True, PR test will use the ptf image built in image, if PTF_MODIFIED is False, PR test will pull remote ptf image.
Now we are planning to let buildimage PR test use mgmt PR test template to avoid conflict and difference, so we need to add PTF_MODIFIED flag in mgmt PR test template to let it be able to pass from buildimage.
#### How did you do it?
Add ptf modified param in sonic-mgmt pr test template
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
