### PR TITLE
Catch import error for sai_qualify

### DIFF
--- a/tests/sai_qualify/sai_infra.py
+++ b/tests/sai_qualify/sai_infra.py
@@ -14,7 +14,13 @@
 import pytest
 import logging
 import time
-from apscheduler.schedulers.background import BackgroundScheduler
+
+try:
+    from apscheduler.schedulers.background import BackgroundScheduler
+    APSCHEDULER_AVAILABLE = True
+except ImportError:
+    APSCHEDULER_AVAILABLE = False
+    BackgroundScheduler = None
 
 from .conftest import DUT_WORKING_DIR
 from .conftest import USR_BIN_DIR
@@ -96,6 +102,10 @@ def start_warm_reboot_watcher(duthost, request, ptfhost):
         request: Pytest request.
         ptfhost (AnsibleHost): The PTF server.
     """
+    if not APSCHEDULER_AVAILABLE:
+        logger.error("APScheduler module is not available. Cannot start warm reboot watcher.")
+        pytest.fail("APScheduler module is required for warm reboot functionality but is not installed.")
+
     # install apscheduler before running
     logger.info("create and clean up the shared file with ptf")
     ptfhost.shell("touch {}".format("/tmp/warm_reboot"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
sai_qualify is skipped in conditional mark file, but pytest still needs to load this file, but it fails to import apscheduler.
We have to catch this import error to avoid collection failure for pytest.
```
_________________ ERROR collecting sai_qualify/test_brcm_t0.py _________________
ImportError while importing test module '/var/src/sonic-mgmt_testbed-bjw2-can-t1-7260-11/tests/sai_qualify/test_brcm_t0.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
sai_qualify/test_brcm_t0.py:7: in <module>
    from .sai_infra import run_case_from_ptf, store_test_result
sai_qualify/sai_infra.py:17: in <module>
    from apscheduler.schedulers.background import BackgroundScheduler
E   ModuleNotFoundError: No module named 'apscheduler'

```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix `No module named 'apscheduler'`
#### How did you do it?
Catch ImportError to avoid pytest collection failure.

#### How did you verify/test it?
Run it, it's skipped successfully, not failed anymore.

```
collected 5 items                                                                                                                                                                                                                                                                   

sai_qualify/test_sai_ptf_warm_reboot.py::test_sai[None-sainexthopgroup.L3IPv4EcmpHostTwoLagsTest] SKIPPED (It is not tested for now)                                                                                                                                          [ 20%]
sai_qualify/test_sai_ptf_warm_reboot.py::test_sai[None-sainexthopgroup.L3IPv4EcmpHostPortLagSharedMembersTest] SKIPPED (It is not tested for now)                                                                                                                             [ 40%]
sai_qualify/test_sai_ptf_warm_reboot.py::test_sai[None-sairif.RifToSubPortTest] SKIPPED (It is not tested for now)                                                                                                                                                            [ 60%]
sai_qualify/test_sai_ptf_warm_reboot.py::test_sai[None-sairif.SviHostTest] SKIPPED (It is not tested for now)                                                                                                                                                                 [ 80%]
sai_qualify/test_sai_ptf_warm_reboot.py::test_sai[None-sairif.SviLagHostTest] SKIPPED (It is not tested for now)                                                                                                                                                              [100%]
--------------------------------------------------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------------------------------------------------
05
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
