### PR TITLE
[202411]Add traffic retry to override the virtual environment stability issue

### DIFF
--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -240,6 +240,9 @@ class EverflowIPv4Tests(BaseEverflowTest):
         random_upstream_intf = random.choice(list(upstream_links_for_unselected_dut.keys()))
         rx_port_ptf_id = upstream_links_for_unselected_dut[random_upstream_intf]["ptf_port_id"]
         tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
+        try_num = 1
+        if everflow_dut.facts['asic_type'] == 'vs':
+            try_num = 5                                    
         # Adding retries is required by MSFT to overcome the issue of random packet loss on their simulator
         retry_call(
             self._run_everflow_test_scenarios,
@@ -256,7 +259,7 @@ class EverflowIPv4Tests(BaseEverflowTest):
                 'multi_binding_acl': True
             },
             exceptions=Exception,
-            tries=5,
+            tries=try_num,
             delay=10,
             logger=logger
         )

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -14,6 +14,7 @@ from . import everflow_test_utilities as everflow_utils
 import ptf.packet as scapy
 from tests.ptf_runner import ptf_runner
 from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, DEFAULT_SERVER_IP
+from retry.api import retry_call
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                   # noqa: F401
@@ -239,15 +240,25 @@ class EverflowIPv4Tests(BaseEverflowTest):
         random_upstream_intf = random.choice(list(upstream_links_for_unselected_dut.keys()))
         rx_port_ptf_id = upstream_links_for_unselected_dut[random_upstream_intf]["ptf_port_id"]
         tx_port_ptf_id = setup_info[dest_port_type]["dest_port_ptf_id"][0]
-        self._run_everflow_test_scenarios(
-            ptfadapter,
-            setup_info,
-            setup_mirror_session,
-            everflow_dut,
-            rx_port_ptf_id,
-            [tx_port_ptf_id],
-            dest_port_type,
-            multi_binding_acl=True
+        # Adding retries is required by MSFT to overcome the issue of random packet loss on their simulator
+        retry_call(
+            self._run_everflow_test_scenarios,
+            fargs=(
+                ptfadapter,
+                setup_info,
+                setup_mirror_session,
+                everflow_dut,
+                rx_port_ptf_id,
+                [tx_port_ptf_id],
+                dest_port_type
+            ),
+            fkwargs={
+                'multi_binding_acl': True
+            },
+            exceptions=Exception,
+            tries=5,
+            delay=10,
+            logger=logger
         )
 
     def test_everflow_basic_forwarding(self, setup_info, setup_mirror_session,              # noqa F811


### PR DESCRIPTION

### Description of PR
Add traffic retry in everflow multi binding acl case to override the virtual environment stability issue


Summary:
Fixes # (issue)

### Type of change


- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The everflow multibinding acl test case not stable on the MSFT VS environment.
#### How did you do it?
After discussion, add a retry when sending traffic.
#### How did you verify/test it?
Yes, it would pass in local setup.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation

