### PR TITLE
Re-install python requests package while redeploy topo

### DIFF
--- a/ansible/roles/vm_set/tasks/docker.yml
+++ b/ansible/roles/vm_set/tasks/docker.yml
@@ -98,7 +98,7 @@
     become: yes
     environment: "{{ proxy_env | default({}) }}"
     ignore_errors: yes
-  - name: Install python packages requests=2.32.4
+  - name: Install python packages requests=2.32.5
     pip: name=requests version=2.32.5 executable={{ pip_executable }} extra_args="--ignore-installed --no-deps"
     become: yes
     environment: "{{ proxy_env | default({}) }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
To fix below potential python package install failure during redeploy topo, install package `request` via command `sudo pip install --ignore-installed --no-deps requests==2.32.5`

```
TASK [vm_set : Install python packages] ****************************************
Friday 05 December 2025  11:49:31 +0000 (0:00:01.035)       0:00:10.286 ******* 
fatal: [BJW2-CAN-SERV-5]: FAILED! => {"changed": false, "cmd": ["/usr/bin/pip3", "install", "-U", "--force-reinstall", "docker==7.1.0"], "msg": "stdout: Collecting docker==7.1.0\n  Using cached docker-7.1.0-py3-none-any.whl (147 kB)\nCollecting urllib3>=1.26.0\n  Using cached urllib3-2.5.0-py3-none-any.whl (129 kB)\nCollecting requests>=2.26.0\n  Using cached requests-2.32.5-py3-none-any.whl (64 kB)\nCollecting certifi>=2017.4.17\n  Using cached certifi-2025.11.12-py3-none-any.whl (159 kB)\nCollecting charset_normalizer<4,>=2\n  Using cached charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (153 kB)\nCollecting idna<4,>=2.5\n  Using cached idna-3.11-py3-none-any.whl (71 kB)\nInstalling collected packages: urllib3, idna, charset_normalizer, certifi, requests, docker\n  Attempting uninstall: urllib3\n    Found existing installation: urllib3 2.5.0\n    Uninstalling urllib3-2.5.0:\n      Successfully uninstalled urllib3-2.5.0\n  Attempting uninstall: idna\n    Found existing installation: idna 3.11\n    Uninstalling idna-3.11:\n      Successfully uninstalled idna-3.11\n  Attempting uninstall: charset_normalizer\n    Found existing installation: charset-normalizer 3.4.4\n    Uninstalling charset-normalizer-3.4.4:\n      Successfully uninstalled charset-normalizer-3.4.4\n  Attempting uninstall: certifi\n    Found existing installation: certifi 2025.11.12\n    Uninstalling certifi-2025.11.12:\n      Successfully uninstalled certifi-2025.11.12\n  Attempting uninstall: requests\n    Found existing installation: requests 2.32.5\n\n:stderr: WARNING: Error parsing requirements for requests: [Errno 2] No such file or directory: '/usr/local/lib/python3.10/dist-packages/requests-2.32.5.dist-info/METADATA'\n    WARNING: No metadata found in /usr/local/lib/python3.10/dist-packages\n    WARNING: No metadata found in /usr/local/lib/python3.10/dist-packages\n    WARNING: No metadata found in /usr/local/lib/python3.10/dist-packages\n    WARNING: No metadata found in /usr/local/lib/python3.10/dist-packages\n    WARNING: No metadata found in /usr/local/lib/python3.10/dist-packages\n    WARNING: No metadata found in /usr/local/lib/python3.10/dist-packages\nERROR: Cannot uninstall requests 2.32.5, RECORD file not found. You might be able to recover from this via: 'pip install --force-reinstall --no-deps requests==2.32.5'.\n"}
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

To fix below potential python package install failure during redeploy topo.

#### How did you do it?
Install package `request` via command `sudo pip install --ignore-installed --no-deps requests==2.32.5`


#### How did you verify/test it?
Verified by remove-topo and add-topo.

```
TASK [vm_set : remove old python packages] **********************************************************************************************************************************
Friday 05 December 2025  12:17:07 +0000 (0:00:00.045)       0:01:55.327 ******* 
ok: [BJW2-CAN-SERV-5]

TASK [vm_set : Install python packages requests=2.32.5] *********************************************************************************************************************
Friday 05 December 2025  12:17:08 +0000 (0:00:01.032)       0:01:56.360 ******* 
changed: [BJW2-CAN-SERV-5]

TASK [vm_set : Install python packages docker==7.1.0] ***********************************************************************************************************************
Friday 05 December 2025  12:17:13 +0000 (0:00:05.316)       0:02:01.676 ******* 
changed: [BJW2-CAN-SERV-5]

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
