### PR TITLE
Add GCU test case for adding/removing DNS nameservers

### DIFF
--- a/tests/generic_config_updater/test_dns_nameserver.py
+++ b/tests/generic_config_updater/test_dns_nameserver.py
@@ -102,8 +102,7 @@ def add_dns_nameserver(duthost, dns_nameserver):
         output = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
         if output['rc'] != 0:
             logger.error(f"Failed to apply patch, rolling back: {output['stdout']}")
-            output = apply_patch(duthost, json_data=json_patch_bc,
-                                 dest_file=tmpfile)
+            apply_patch(duthost, json_data=json_patch_bc, dest_file=tmpfile)
         expect_op_success(duthost, output)
 
         pytest_assert(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Add a test case to verify the ability to add and remove DNS nameservers via incremental config.

#### How did you do it?

Model this after the NTP GCU test case, and add two random DNS nameservers and remove one.

#### How did you verify/test it?

Tested locally on KVM T0.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
