### PR TITLE
Add headroom qos params for t0-isolated-d96u32s2, t1-isolated-d128

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4042,7 +4042,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   xfail:
     reason: "Headroom pool size not supported."
     conditions:
-      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060X6-16PE-384C-B-O128S2']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060X6-16PE-384C-B-O128S2', 'Arista-7060X6-64PE-B-O128']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiLosslessVoq:
   skip:

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -852,14 +852,55 @@ qos_params:
                     pgs:
                     - 3
                     - 4
-                    pkts_num_hdrm_full: 1185
-                    pkts_num_hdrm_partial: 47
+                    pgs_num: 25
+                    pkts_num_hdrm_full: 1755
+                    pkts_num_hdrm_partial: 1208
                     pkts_num_trig_pfc: 132925
+                    pkts_num_trig_pfc_multi:
+                    - 132925
+                    - 66500
+                    - 33287
+                    - 16680
+                    - 8377
+                    - 4226
+                    - 2150
+                    - 1112
+                    - 593
+                    - 333
+                    - 204
+                    - 139
+                    - 106
+                    - 90
+                    - 82
+                    - 78
+                    - 76
+                    - 75
+                    - 75
+                    - 74
+                    - 74
+                    - 74
+                    - 74
+                    - 74
+                    - 74
+                    src_port_ids:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                    - 6
+                    - 7
+                    - 8
+                    - 9
+                    - 10
+                    - 11
+                    - 12
+                    - 13
                 lossy_queue_1:
                     dscp: 8
                     ecn: 1
                     pg: 0
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_egr_drp: 132859
                 pkts_num_egr_mem: 376
                 pkts_num_leak_out: 0
@@ -868,7 +909,7 @@ qos_params:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_ingr_drp: 134681
                     pkts_num_trig_pfc: 132925
                 wm_pg_shared_lossless:
@@ -887,14 +928,14 @@ qos_params:
                     packet_size: 64
                     pg: 0
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_egr_drp: 132859
                 wm_q_shared_lossless:
                     cell_size: 254
                     dscp: 3
                     ecn: 1
                     pkts_num_fill_min: 0
-                    pkts_num_margin: 8
+                    pkts_num_margin: 2
                     pkts_num_trig_ingr_drp: 134681
                     queue: 3
                 wm_q_shared_lossy:
@@ -902,21 +943,21 @@ qos_params:
                     dscp: 8
                     ecn: 1
                     pkts_num_fill_min: 7
-                    pkts_num_margin: 8
+                    pkts_num_margin: 2
                     pkts_num_trig_egr_drp: 132859
                     queue: 0
                 xoff_1:
                     dscp: 3
                     ecn: 1
                     pg: 3
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_ingr_drp: 134681
                     pkts_num_trig_pfc: 132925
                 xoff_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_ingr_drp: 134681
                     pkts_num_trig_pfc: 132925
                 xon_1:
@@ -924,17 +965,17 @@ qos_params:
                     ecn: 1
                     pg: 3
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_pfc: 132925
                 xon_2:
                     dscp: 4
                     ecn: 1
                     pg: 4
                     pkts_num_dismiss_pfc: 14
-                    pkts_num_margin: 4
+                    pkts_num_margin: 2
                     pkts_num_trig_pfc: 132925
             cell_size: 254
-            hdrm_pool_wm_multiplier: 1
+            hdrm_pool_wm_multiplier: 2
             wrr:
                 dscp_list: [0, 47, 3, 4, 46, 44]
                 ecn: 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This adds the qos params necessary to run the headroom related tests on t0-isolated-d96u32s2 and t1-isolated-d128

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### How did you verify/test it?
Manually tested