### PR TITLE
Issue 20758: Changes to run telemetry/test_events.py on v6 topos

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -3240,13 +3240,21 @@ print(device_prefix)
         ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
         ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
 
-        mgmt_interface = self.shell("show ip interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+        # Use 'ip addr' instead of 'show ip[v6] interface' because the latter
+        # filters out site-local v6 addresses (fec0::/10) that may legitimately
+        # be configured as mgmt.
+        mgmt_interface = self.shell(
+            "ip -4 -o addr show eth0 scope global", module_ignore_errors=True
+        )["stdout"]
         if mgmt_interface:
             match = ipv4_regex.search(mgmt_interface)
             if match:
                 return {"mgmt_ip": match.group(1), "version": "v4"}
 
-        mgmt_interface = self.shell("show ipv6 interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+        # Exclude link-local (fe80::/10) — not routable, can't be the mgmt addr.
+        mgmt_interface = self.shell(
+            "ip -6 -o addr show eth0 | grep -v 'scope link'", module_ignore_errors=True
+        )["stdout"]
         if mgmt_interface:
             match = ipv6_regex.search(mgmt_interface)
             if match:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5455,18 +5455,6 @@ telemetry/test_events.py:
       - "asic_type in ['vs']"
       - https://github.com/sonic-net/sonic-buildimage/issues/19943
 
-telemetry/test_events.py::test_events:
-  xfail:
-    reason: "xfail for IPv6-only topologies, issue https://github.com/sonic-net/sonic-mgmt/issues/20758"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20758 and '-v6-' in topo_name"
-  skip:
-    reason: "dut ipv6 mgmt ip not supported"
-    conditions_logical_operator: and
-    conditions:
-      - "is_mgmt_ipv6_only==True"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
-
 telemetry/test_telemetry.py:
   skip:
     reason: "Skip telemetry test for 201911 and older branches"

--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -126,7 +126,8 @@ def generate_client_cli(duthost, gnxi_path, method=METHOD_GET, xpath="COUNTERS/E
     # 3. Executes the py_gnmicli.py script.
     cmdFormat = '. /root/env-python3/bin/activate && cd {7}gnmi_cli_py' \
                 ' && python py_gnmicli.py -g -t {0} -p {1} -m {2} -x {3} -xt {4}{5} -o {6}'
-    cmd = cmdFormat.format(duthost.mgmt_ip, env.gnmi_port,
+    mgmt_ip = duthost.get_mgmt_ip()["mgmt_ip"]
+    cmd = cmdFormat.format(mgmt_ip, env.gnmi_port,
                            method, xpath, target, ns,
                            "ndastreamingservertest", gnxi_path)
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

telemetry/test_events.py needs to be enhanced to run on ipv6 topos. `is_mgmt_ipv6_only` was added [here](https://github.com/sonic-net/sonic-mgmt/pull/20292), which can be used to check for ipv6-only topos. This can be used in this test to pass the correct ip address into the gnxi tool, which has already been enhanced to handle ipv6 addresses.

Changes were required to `is_bgp_state_idle()` in tests/common/devices/sonic.py to check for active neighbors in both address families.

The conditional skip has been removed.

Closes #20758 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Increase IPv6-only coverage.

#### How did you do it?

* extend bgp idle check to check ipv6 routes as well as ipv4
* use ipv6 mgmt addr in test_events.py when running on ipv6 topo
* remove conditional skip for test_events.py on ipv6 topo

#### How did you verify/test it?

Run the test on a virtual device with an ipv6-only topo. It fails before this change and passes after it.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
