### PR TITLE
Change function name from testWrArp to wrArp

### DIFF
--- a/tests/arp/test_wr_arp.py
+++ b/tests/arp/test_wr_arp.py
@@ -8,7 +8,7 @@ from tests.common.storage_backend.backend_utils import skip_test_module_over_bac
 from tests.ptf_runner import ptf_runner
 from tests.common.utilities import wait_until
 from tests.common.arp_utils import setupFerret, teardownRouteToPtfhost, setupRouteToPtfhost, \
-    PTFRUNNER_QLEN, VXLAN_CONFIG_FILE, DEFAULT_TEST_DURATION, testWrArp
+    PTFRUNNER_QLEN, VXLAN_CONFIG_FILE, DEFAULT_TEST_DURATION, wrArp
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ def test_wr_arp(request, duthost, ptfhost, creds):
         Returns:
             None
     '''
-    testWrArp(request, duthost, ptfhost, creds)
+    wrArp(request, duthost, ptfhost, creds)
 
 
 def test_wr_arp_advance(request, duthost, ptfhost, creds):

--- a/tests/common/arp_utils.py
+++ b/tests/common/arp_utils.py
@@ -179,7 +179,7 @@ def tear_down(duthost, route, ptfIp, gwIp):
     teardownRouteToPtfhost(duthost, route, ptfIp, gwIp)
 
 
-def testWrArp(request, duthost, ptfhost, creds):
+def wrArp(request, duthost, ptfhost, creds):
     testDuration = request.config.getoption('--test_duration', default=DEFAULT_TEST_DURATION)
     ptfIp = ptfhost.host.options['inventory_manager'].get_host(ptfhost.hostname).vars['ansible_host']
     dutIp = duthost.host.options['inventory_manager'].get_host(duthost.hostname).vars['ansible_host']

--- a/tests/vxlan/test_vnet_vxlan.py
+++ b/tests/vxlan/test_vnet_vxlan.py
@@ -15,7 +15,7 @@ from .vnet_utils import generate_dut_config_files, safe_open_template, \
 
 from tests.common.flow_counter.flow_counter_utils \
     import RouteFlowCounterTestContext, is_route_flow_counter_supported  # noqa: F401
-from tests.common.arp_utils import set_up, tear_down, testWrArp
+from tests.common.arp_utils import set_up, tear_down, wrArp
 from tests.common.config_reload import config_reload
 
 logger = logging.getLogger(__name__)
@@ -158,7 +158,7 @@ def vxlan_status(setup, request, duthosts, rand_one_dut_hostname,
     elif request.param == "WR_ARP":
         route, ptfIp, gwIp = set_up(duthost, ptfhost, tbinfo)
         try:
-            testWrArp(request, duthost, ptfhost, creds)
+            wrArp(request, duthost, ptfhost, creds)
         finally:
             tear_down(duthost, route, ptfIp, gwIp)
 


### PR DESCRIPTION
The function name `testWrArp` is being treated as a test case, changing it to wrArp.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The function `testWrArp` is being treated as a test case, changing the name to avoid that

Fixes # (issue)
Changing the name testWrArp to wrArp

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
