### PR TITLE
Adding VNI and mac address validation for tunnel route

### DIFF
--- a/tests/vxlan/test_scale_ecmp.py
+++ b/tests/vxlan/test_scale_ecmp.py
@@ -467,6 +467,7 @@ def test_ecmp_scale_modify_mac(ptfhost, one_vnet_setup_teardown):
         "mac_vni_verify": "yes",
         "modified_mac_index": mod_idx,
         "modified_mac_value": new_mac,
+        "vni": VNI,
     }
 
     num_packets = num * PACKET_MULTIPLIER


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When adding a vxlan tunnel route, we are allowed to add a mac address and vni for the route. Adding a testcase to validate that when a specific mac address and vni are added to the route tunnel config, it gets used as inner dst mac and outer vni when forwarding packets.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To validate that setting mac and vni for a vxlan tunnel route is supported and honored
#### How did you do it?
Added mac and vni to route tunnel config.
#### How did you verify/test it?
Sent packet and added verification for packet with expected inner dst mac and vni
#### Any platform specific information?
Cisco-8000
#### Supported testbed topology if it's a new test case?
T0
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
