### PR TITLE
Update blocking-mode reboot test for Trixie

### DIFF
--- a/tests/reboot/test_reboot_blocking_mode.py
+++ b/tests/reboot/test_reboot_blocking_mode.py
@@ -1,5 +1,6 @@
 import pytest
 import re
+from tests.common.reboot import reboot
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.processes_utils import wait_critical_processes
 
@@ -40,16 +41,16 @@ def restore_systemctl_reboot_and_reboot(duthost):
         "sudo sed -i 's#/usr/local/bin/disabled_watchdogutil#/usr/local/bin/watchdogutil#g' /usr/local/bin/reboot")
     debian_version = duthost.command("grep VERSION_CODENAME /etc/os-release")['stdout'].lower()
     if "trixie" in debian_version:
-        execute_command_ignore_error(duthost, "sudo reboot")
+        reboot(duthost, safe_reboot=True)
     else:
         execute_command(duthost, "sudo reboot")
 
-    timeout = None
-    if duthost.is_supervisor_node():
-        timeout = 900
-    elif duthost.is_multi_asic:
-        timeout = 420
-    wait_critical_processes(duthost, timeout=timeout)
+        timeout = None
+        if duthost.is_supervisor_node():
+            timeout = 900
+        elif duthost.is_multi_asic:
+            timeout = 420
+        wait_critical_processes(duthost, timeout=timeout)
 
 
 def mock_reboot_config_file(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Similar to #21394, the behavior of `sudo reboot` is changed with Trixie, in that the SSH connection may get disconnected before the `sudo reboot` command completes with an exit code. This will mean that Ansible will consider the host to be unreachable and throw an exception.

#### How did you do it?

The common reboot infra that we have runs `sudo reboot` in its own thread. That means that the `HostUnreachable` exception that Ansible raises will get raised in that thread, but won't affect the main thread; this, in a way, handles this particular behavior change. Therefore, for the blocking reboot test case, reuse that common infra when running on a Trixie image and we need to reboot the device (this probably can be done unconditionally, but make it conditional for now).

#### How did you verify/test it?

Tested with a subset of T0 KVM tests: https://elastictest.org/scheduler/testplan/6936fccd392767e9bf67ecb8

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
