### PR TITLE
Test buffer profile removal via rollback using GCU

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -272,11 +272,11 @@ def test_buffer_profile_create_remove_rollback(duthost, ensure_dut_readiness, cl
     tmpfile = generate_tmpfile(duthost)
     profile_name = "pg_lossless_99999_99m_profile"
     profile_data = {
-        "xon": "1234",
-        "xoff": "5678",
-        "size": "9999",
+        "dynamic_th": "-2",
         "pool": "ingress_lossless_pool",
-        "threshold_mode": "0"
+        "size": "0",
+        "xoff": "1020672",
+        "xon": "0"
     }
     # Step 1: Take checkpoint done by ensure_dut_readiness fixture, verify checkpoint creation
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add test case to verify buffer profile removal during GCU rollback operations

Fixes [sonic-utilities-4128](https://github.com/sonic-net/sonic-utilities/pull/4128)
ADO: 35983144
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
This test case validates the fix for sonic-utilities PR #4128, which enables Generic Config Updater (GCU) to properly remove entire BUFFER_PROFILE objects during rollback operations. Previously, GCU could only handle field-level changes within buffer profiles but failed when attempting to remove complete buffer profile entries, which is critical for rollback scenarios involving interface configuration changes.
#### How did you do it?
Implemented test_buffer_profile_add_remove_rollback which:

1. Creates a configuration checkpoint
1. Modifies an interface's cable length configuration (shutdown → change cable length → startup)
1. Verifies that a new buffer profile is automatically generated based on the new cable length
1. Performs a rollback to the original checkpoint
1. Validates that the newly generated buffer profile is successfully removed from APPL_DB

The test uses JSON patch operations for configuration changes and monitors APPL_DB to confirm buffer profile creation and removal.
#### How did you verify/test it?
- Verified the test successfully creates buffer profiles with different cable lengths
- Confirmed rollback operations complete without errors
- Validated that buffer profiles are properly cleaned up after rollback
- Tested on platforms with dynamic buffer management

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
