### PR TITLE
Test to validate if cron job run is a success

### DIFF
--- a/tests/cron/test_cron.py
+++ b/tests/cron/test_cron.py
@@ -1,0 +1,44 @@
+import logging
+import pytest
+
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+
+logger = logging.getLogger(__name__)
+
+CRON_FILE = "/etc/cron.d/logrotate"
+CRON_LOG = "/var/log/cron.log"
+EXPECTED_MODE = "0644"
+
+CRON_ERROR_KEYWORDS = [
+    "INSECURE MODE",
+]
+
+
+@pytest.mark.topology("any")
+def test_cron_job_exec_successfully(duthost, loganalyzer):
+    # Validate cron file permission
+    stat = duthost.stat(path=CRON_FILE)["stat"]
+    if stat["exists"]:
+        mode = stat["mode"][-4:]
+        pytest_assert(
+            mode == EXPECTED_MODE,
+            f"{CRON_FILE} exists but permission is incorrect: {mode} (expected {EXPECTED_MODE})",
+        )
+    else:
+        # This test is intended for releases earlier than 202205
+        logger.warning(f"{CRON_FILE} does not exist on DUT - skipping permission check.")
+
+    # Find cron logs for error
+    pattern = "|".join(CRON_ERROR_KEYWORDS)
+    cmd = "sudo zgrep -iE '{}' /var/log/cron.log*".format(pattern)
+    logger.info(f"Running cron log check with command: {cmd}")
+    result = duthost.shell(cmd, module_ignore_errors=True)
+    output = result["stdout"].strip()
+
+    pytest_assert(
+        output == "",
+        f"Unexpected cron errors found in {CRON_LOG}*: \n{output}",
+    )
+
+    logger.info("Cron job log check completed successfully (no known error patterns found).")

--- a/tests/cron/test_cron.py
+++ b/tests/cron/test_cron.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +15,7 @@ CRON_ERROR_KEYWORDS = [
 
 
 @pytest.mark.topology("any")
-def test_cron_job_exec_successfully(duthost, loganalyzer):
+def test_cron_job(duthost, loganalyzer):
     # Validate cron file permission
     stat = duthost.stat(path=CRON_FILE)["stat"]
     if stat["exists"]:
@@ -26,13 +25,12 @@ def test_cron_job_exec_successfully(duthost, loganalyzer):
             f"{CRON_FILE} exists but permission is incorrect: {mode} (expected {EXPECTED_MODE})",
         )
     else:
-        # This test is intended for releases earlier than 202205
-        logger.warning(f"{CRON_FILE} does not exist on DUT - skipping permission check.")
+        logger.warning(f"{CRON_FILE} does not exist - skipping permission check.")
 
     # Find cron logs for error
     pattern = "|".join(CRON_ERROR_KEYWORDS)
     cmd = "sudo zgrep -iE '{}' /var/log/cron.log*".format(pattern)
-    logger.info(f"Running cron log check with command: {cmd}")
+    logger.info(f"Running cron log check: {cmd}")
     result = duthost.shell(cmd, module_ignore_errors=True)
     output = result["stdout"].strip()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/19527

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Write a test to make sure that the cron job run is successfull. This test case do following
- Check the crond job file permission
- Check that there are no unexpected errors in crond.log file
`eg: "Dec  7 06:26:01.731856 vlab-01 INFO cron[427]: (systemlogrotate) INSECURE MODE (group/other writable) (/etc/cron.d/logrotate) "`
#### How did you do it?

#### How did you verify/test it?
```
1. skip permission check
WARNING  test_cron:test_cron.py:29 /etc/cron.d/logrotate does not exist on DUT — skipping permission check.

 tests/cron/test_cron.py::test_cron_job_exec_successfully ✓                                           100% ██████████

2. incorrect permission
E           Failed: /etc/cron.d/logrotate exists but permission is incorrect: 0664 (expected 0644)

duthost    = <MultiAsicSonicHost vlab-01>
loganalyzer = {'vlab-01': <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer object at 0x74dc5de1eff0>}
mode       = '0664'
stat       = {'atime': 1765303116.269168, 'attr_flags': '', 'attributes': [], 'block_size': 4096, ...}

cron/test_cron.py:25: Failed

 tests/cron/test_cron.py::test_cron_job_exec_successfully ⨯                                            100% █████████

3. found error in cron.log
E       Failed: Unexpected cron errors found in /var/log/cron.log*:
E       /var/log/cron.log.1:2025 Dec  9 17:59:01.821214 vlab-01 INFO cron[664]: (*system*logrotate) INSECURE MODE (group/other writable) (/etc/cron.d/logrotate)
E       /var/log/cron.log.2.gz:2025 Dec  9 17:50:01.804985 vlab-01 INFO cron[663]: (*system*logrotate) INSECURE MODE (group/other writable) (/etc/cron.d/logrotate)

cmd        = "sudo zgrep -iE 'INSECURE MODE' /var/log/cron.log*"
duthost    = <MultiAsicSonicHost vlab-01>
loganalyzer = {'vlab-01': <tests.common.plugins.loganalyzer.loganalyzer.LogAnalyzer object at 0x7c2378251ca0>}
mode       = '0644'
output     = '/var/log/cron.log.1:2025 Dec  9 17:59:01.821214 vlab-01 INFO cron[664]: (*system*logrotate) INSECURE MODE (group/othe...:58:01.820610 vlab-01 INFO cron[664]: (*system*logrotate) INSECURE MODE (group/other writable) (/etc/cron.d/logrotate)'
pattern    = 'INSECURE MODE'
result     = {'changed': True, 'stdout': '/var/log/cron.log.1:2025 Dec  9 17:59:01.821214 vlab-01 INFO cron[664]: (*system*logrotat...E MODE (group/other writable) (/etc/cron.d/logrotate)'], 'stderr_lines': [], '_ansible_no_log': False, 'failed': False}
stat       = {'atime': 1765303248.481168, 'attr_flags': '', 'attributes': [], 'block_size': 4096, ...}

cron/test_cron.py:40: Failed

 tests/cron/test_cron.py::test_cron_job_exec_successfully ⨯                                            100% █████████
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
