### PR TITLE
Fix race condition of featured initialization and generation of golden_config_db

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -651,6 +651,14 @@
         become: true
         when: "('t2' in topo or num_asics > 1) and type == 'kvm'"
 
+      - name: Wait for essential services to start
+        shell: systemctl is-active --quiet pmon
+        register: pmon_status
+        retries: 30
+        delay: 10
+        until: pmon_status.rc == 0
+        when: "('t2' in topo or num_asics > 1) and type == 'kvm'"
+
       - name: Copy dhcp_server config hwsku {{ hwsku }}
         copy: src=golden_config_db/dhcp_server_mx.json
               dest=/tmp/dhcp_server.json


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR will add a waiting time period after we preloaded the minigraph on vs T2 and multi-asic platforms so that before we generate the golden-config-db, the system has initialized. To judge whether the system has initialized, I used pmon.service as the anchor. As long as pmon is active, the system will be stable enough.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Fix the incorrect golden_config_db.json generated on the device.

#### How did you do it?

Add waiting action to avoid race condition.

#### How did you verify/test it?

Using the new code to bring up VS T2.

#### Any platform specific information?

VS only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
