### PR TITLE
[manual] [PR:21582] fix: only disable route check for T2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2866,12 +2866,16 @@ def core_dump_and_config_check(duthosts, tbinfo, request,
 
 
 @pytest.fixture(scope="module", autouse=True)
-def temporarily_disable_route_check(request, duthosts):
+def temporarily_disable_route_check(request, tbinfo, duthosts):
     check_flag = False
     for m in request.node.iter_markers():
         if m.name == "disable_route_check":
             check_flag = True
             break
+
+    if 't2' not in tbinfo['topo']['name']:
+        logger.info("Topology is not T2, skipping temporarily_disable_route_check fixture")
+        check_flag = False
 
     def wait_for_route_check_to_pass(dut):
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Change the `temporarily_disable_route_check` fixture logic to only apply to T2 topology for now. 

Summary:
Fixes # (issue) Microsoft ADO 36101536

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The current disable-and-enable routeCheck monitor logic is causing test flakiness on some non-T2 platforms (see https://github.com/sonic-net/sonic-mgmt/pull/16876#issuecomment-3615140230). Certain platforms require additional time to restart the routeCheck monitor, which can leave it inactive when the next test begins and result in false failures. We would like to address this issue urgently in this PR.

In a follow-up PR, I will properly enhance the `temporarily_disable_route_check` fixture so that:
- Users can choose which topologies apply the disable-and-enable routeCheck behavior
- The fixture uses a `wait_until()` timeout to verify the routeCheck status is as expected before proceeding to the next step

#### How did you do it?

#### How did you verify/test it?
I ran the updated login on a non-T2 platform (Mx) and can confirm it's working well:
https://elastictest.org/scheduler/testplan/693272f7392767e9bf67e930
<img width="1609" height="202" alt="image" src="https://github.com/user-attachments/assets/e631a351-1372-412d-bca7-6b4ef5d8112a" />

I also verified the logic on T2 platform and can confirm it's still having this logic: https://elastictest.org/scheduler/testplan/6932767fbcc3fac23371a83c
<img width="1963" height="546" alt="image" src="https://github.com/user-attachments/assets/261dd79b-c847-4a82-9409-d87e48a3cfa8" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->