### PR TITLE
[COPP] Improve RX PPS Calcuation for COPP Tests

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -191,7 +191,7 @@ class ControlPlaneBaseTest(BaseTest):
         # Wait a little bit for all the packets to make it through
         time.sleep(self.DEFAULT_RECEIVE_WAIT_TIME)
         recv_count = testutils.count_matched_packets_all_ports(
-             self, packet, [recv_intf[1]], recv_intf[0], timeout=self.PTF_TIMEOUT)
+            self, packet, [recv_intf[1]], recv_intf[0], timeout=self.PTF_TIMEOUT)
         self.log("Received %d packets after sleep %ds" % (recv_count, self.DEFAULT_RECEIVE_WAIT_TIME))
 
         ptf_tx_count = int(post_test_ptf_tx_counter[1] - pre_test_ptf_tx_counter[1])


### PR DESCRIPTION
### Description of PR
The current calculation method for the RX PPS rate for the COPP tests is not very accurate (in some cases 130-150% above nominal) due to the reliance of sampling received packets at the ptf container on the testbed server after sending the packet stream, while also using a timeout to wait for said packets to finish arriving. This does not capture the in-flight RX PPS rate, but rather takes an average outside of the actual packet transmission window, and incurs additional inaccuracies due to the wait time at the end.

A more accurate approach implemented here is to take two snapshots of the RX packet count at the NN agent on the dut itself while the packet stream is already running, and calculate the difference.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
To fix neighbor_miss tests failing for TH5 duts on 202412, and enhance the COPP tests overall for more accurate results.

#### How did you do it?
Updated the calculation method used to get the RX PPS rate for the COPP tests.

#### How did you verify/test it?
Ran the copp tests and verified that the resulting RX PPS values were within range.