### PR TITLE
fix: ignore BGP error syslog for Cisco 8800

### DIFF
--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -29,11 +29,11 @@ def _ignore_allow_list_errlogs(duthosts, rand_one_dut_front_end_hostname, logana
     """Ignore expected failures logs during test execution."""
     if loganalyzer:
         IgnoreRegex = [
-            ".*ERR bgp#bgpcfgd: BGPAllowListMgr::Default action community value is not found.*",
+            ".*ERR bgp[0-9]*#bgpcfgd: BGPAllowListMgr::Default action community value is not found.*",
         ]
         duthost = duthosts[rand_one_dut_front_end_hostname]
         """Cisco 8111-O64 has different allow list config"""
-        if duthost.facts['hwsku'] == 'Cisco-8111-O64':
+        if duthost.facts['hwsku'] in {'Cisco-8111-O64', 'Cisco-88-LC0-36FH-M-O36', 'Cisco-88-LC0-36FH-O36'}:
             loganalyzer[rand_one_dut_front_end_hostname].ignore_regex.extend(IgnoreRegex)
     return
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Ignore the BGPAllowListMgr error syslog when running `generic_config_updater/test_bgp_prefix.py` test on Cisco 8800 platform

Summary:
Fixes # (issue) Microsoft ADO 36101544

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
We want to ignore the BGPAllowListMgr error syslog when running `generic_config_updater/test_bgp_prefix.py` test on Cisco 8800 platform as it's not harmful.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
