### PR TITLE
Fix test_power_off_reboot to properly power on subsets of PSUs

### DIFF
--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -51,6 +51,7 @@ def _power_off_reboot_helper(kwargs, power_on_event=None):
     """
     pdu_ctrl = kwargs["pdu_ctrl"]
     all_outlets = kwargs["all_outlets"]
+    power_on_seq = kwargs["power_on_seq"]
     for outlet in all_outlets:
         logging.debug("turning off {}".format(outlet))
         pdu_ctrl.turn_off_outlet(outlet)
@@ -64,8 +65,8 @@ def _power_off_reboot_helper(kwargs, power_on_event=None):
     for outlet in outlet_status:
         logging.debug("After turn off outlet, its status is {}".format(outlet))
 
-    logging.info("Power on {}".format(all_outlets))
-    for outlet in all_outlets:
+    logging.info("Power on {}".format(power_on_seq))
+    for outlet in power_on_seq:
         logging.debug("turning on {}".format(outlet))
         pdu_ctrl.turn_on_outlet(outlet)
 
@@ -133,11 +134,10 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
         # Following is to accomodate for chassis, when no '--power_off_delay' option is given on pipeline run
         power_off_delay = 60
     all_outlets = pdu_ctrl.get_outlet_status()
+    pytest_assert(all_outlets, "No outlets found for %s" % duthost.hostname)
+
     # If PDU supports returning output_watts, making sure that all PSUs has power.
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
-    for psu, pdus in psu_to_pdus.items():
-        pytest_assert(any(int(pdu.get('output_watts', '1')) !=
-                      0 for pdu in pdus), "Not all PSUs are getting power")
 
     # Purpose of this list is to control sequence of turning on PSUs in power off testing.
     # If there are 2 PSUs, then 3 scenarios would be covered:
@@ -145,36 +145,32 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     # 2. Turn off all PSUs, turn on PSU2, then check.
     # 3. Turn off all PSUs, turn on one of the PSU, then turn on the other PSU, then check.
     power_on_seq_list = []
-    if all_outlets:
-        power_on_seq_list = [pdus for pdus in psu_to_pdus.values()]
+    for psu, pdus in psu_to_pdus.items():
+        pytest_assert(any(int(pdu.get('output_watts', '1')) !=
+                      0 for pdu in pdus), "Not all PSUs are getting power")
+        if not is_chassis:
+            power_on_seq_list.append(pdus)
+    # if there is exactly one sequence then we don't need to repeat it
+    if len(power_on_seq_list) != 1:
         power_on_seq_list.append(all_outlets)
-
     logging.info("Got all power on sequences {}".format(power_on_seq_list))
 
     poweroff_reboot_kwargs = {"dut": duthost}
 
     try:
-        if is_chassis:
+        if not is_chassis:
+            duthosts = None
+
+        for power_on_seq in power_on_seq_list:
             poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
             poweroff_reboot_kwargs["all_outlets"] = all_outlets
-            poweroff_reboot_kwargs["power_on_seq"] = all_outlets
+            poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
             poweroff_reboot_kwargs["delay_time"] = power_off_delay
             reboot_and_check(
                 localhost, duthost, conn_graph_facts.get(
                     "device_conn", {}).get(duthost.hostname, {}),
                 xcvr_skip_list, REBOOT_TYPE_POWEROFF,
                 _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts)
-        else:
-            for power_on_seq in power_on_seq_list:
-                poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
-                poweroff_reboot_kwargs["all_outlets"] = all_outlets
-                poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
-                poweroff_reboot_kwargs["delay_time"] = power_off_delay
-                reboot_and_check(
-                    localhost, duthost, conn_graph_facts.get(
-                        "device_conn", {}).get(duthost.hostname, {}),
-                    xcvr_skip_list, REBOOT_TYPE_POWEROFF,
-                    _power_off_reboot_helper, poweroff_reboot_kwargs)
 
     except Exception as e:
         logging.debug("Restore power after test failure")

--- a/tests/platform_tests/test_power_off_reboot.py
+++ b/tests/platform_tests/test_power_off_reboot.py
@@ -134,7 +134,7 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
         # Following is to accomodate for chassis, when no '--power_off_delay' option is given on pipeline run
         power_off_delay = 60
     all_outlets = pdu_ctrl.get_outlet_status()
-    pytest_assert(all_outlets, "No outlets found for %s" % duthost.hostname)
+    pytest_assert(all_outlets, "No outlets found for {}".format(duthost.hostname))
 
     # If PDU supports returning output_watts, making sure that all PSUs has power.
     psu_to_pdus = get_grouped_pdus_by_psu(pdu_ctrl)
@@ -147,30 +147,30 @@ def test_power_off_reboot(duthosts, localhost, enum_supervisor_dut_hostname, con
     power_on_seq_list = []
     for psu, pdus in psu_to_pdus.items():
         pytest_assert(any(int(pdu.get('output_watts', '1')) !=
-                      0 for pdu in pdus), "Not all PSUs are getting power")
+                      0 for pdu in pdus), "PSU {} is not getting power".format(psu))
         if not is_chassis:
             power_on_seq_list.append(pdus)
-    # if there is exactly one sequence then we don't need to repeat it
+    # Append all_outlets unless it would duplicate the single existing entry
+    # For chassis the list is empty here, so all_outlets becomes the only entry
     if len(power_on_seq_list) != 1:
         power_on_seq_list.append(all_outlets)
     logging.info("Got all power on sequences {}".format(power_on_seq_list))
 
     poweroff_reboot_kwargs = {"dut": duthost}
+    poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
+    poweroff_reboot_kwargs["all_outlets"] = all_outlets
+    poweroff_reboot_kwargs["delay_time"] = power_off_delay
 
     try:
-        if not is_chassis:
-            duthosts = None
+        duthosts_arg = duthosts if is_chassis else None
 
         for power_on_seq in power_on_seq_list:
-            poweroff_reboot_kwargs["pdu_ctrl"] = pdu_ctrl
-            poweroff_reboot_kwargs["all_outlets"] = all_outlets
             poweroff_reboot_kwargs["power_on_seq"] = power_on_seq
-            poweroff_reboot_kwargs["delay_time"] = power_off_delay
             reboot_and_check(
                 localhost, duthost, conn_graph_facts.get(
                     "device_conn", {}).get(duthost.hostname, {}),
                 xcvr_skip_list, REBOOT_TYPE_POWEROFF,
-                _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts)
+                _power_off_reboot_helper, poweroff_reboot_kwargs, duthosts=duthosts_arg)
 
     except Exception as e:
         logging.debug("Restore power after test failure")


### PR DESCRIPTION
This fix is meant to restore the test functionality where power on sequences are subsets of all PSUs instead restoring power on all PSUs at once every time.

It also fixes the duplicate entries in power_on_seq_list when there is only one PSU. That is, when there is only 1 PSU we shouldn't do the subset of PSUs followed by all PSUs since that is the same thing.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #21637 
https://github.com/sonic-net/sonic-mgmt/issues/21637

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Ran the test on chassis and pizza box to see it would still succeed.
Ran the test on boxes with 1 and 2 PSUs to see it would still succeed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
