### PR TITLE
Fix generic_config_updater/test_eth_interface.py test_replace_fec to handle interfaces not supporting none FEC

### DIFF
--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -322,8 +322,11 @@ def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
             pytest_assert(current_status_fec == fec,
                           "Failed to properly configure interface FEC to requested value {}".format(fec))
 
-            # The rollback after the test cannot revert the fec, when fec is not configured in config_db.json
-            if intf_init_status[port].get("fec", "N/A") == "N/A":
+            # The rollback after the test cannot revert the fec, when fec is not configured in config_db.json.
+            # For ports with PAM4 speeds, only "rs" fec is supported. Even when fec is not configured in
+            # config_db.json, operational fec can only be "rs" fec. Configuring "none" fec may fail.
+            if intf_init_status[port].get("fec", "N/A") == "N/A" and \
+                    is_valid_fec_state_db(duthost, "none", port, namespace=asic_namespace):
                 out = duthost.command("config interface {} fec {} none".format(namespace_prefix, port))
                 pytest_assert(out["rc"] == 0, "Failed to set {} fec to none. Error: {}".format(port, out["stderr"]))
         else:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

For PAM4 speeds, `rs` FEC is mandatory. As a result, instead of
`none` FEC, `rs` FEC will be the default FEC if FEC is not configured.
However, `generic_config_updater/test_eth_interface.py` `test_replace_fec`
doesn't consider this case and unconditionally configuring `none` FEC
when the FEC is not configured at the beginning of the test. This leads
`configure interface fec none` to fail.

This PR is updating the test to handle this case.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] msft-202503

### Approach
#### What is the motivation for this PR?
Fix the test issue and improve the pass rate

#### How did you do it?
Fix the test to consider the case where `none` FEC is not supported, e.g. PAM4 speeds

#### How did you verify/test it?
Verified the failed test can pass with this change

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
