### PR TITLE
Enable traffic shift test on LT2/FT2

### DIFF
--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -64,6 +64,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
     asn = mg_facts['minigraph_bgp_asn']
+    confed_asn = dut_host.get_bgp_confed_asn()
     all_routes = {}
     BGP_ENTRY_HEADING = r"BGP routing table entry for "
     BGP_COMMUNITY_HEADING = r"Community: "
@@ -83,7 +84,15 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
         # get hostname('ARISTA11T0') by VM name('VM0122')
         hostname = host_name_map[node['host'].hostname]
         host = node['host']
-        peer_ips = node['conf']['bgp']['peers'][asn]
+        peer_in_bgp_confed = node['conf']['bgp'].get('peer_in_bgp_confed', False)
+        try:
+            peer_ips = node['conf']['bgp']['peers'][asn]
+        except KeyError as e:
+            if peer_in_bgp_confed:
+                peer_ips = node['conf']['bgp']['peers'][int(confed_asn)]
+            else:
+                raise e
+
         for ip in peer_ips:
             if ipaddress.IPNetwork(ip).version == 4:
                 peer_ip_v4 = ip

--- a/tests/bgp/test_traffic_shift.py
+++ b/tests/bgp/test_traffic_shift.py
@@ -17,7 +17,7 @@ from tests.bgp.traffic_checker import get_traffic_shift_state, check_tsa_persist
 from tests.bgp.constants import TS_NORMAL, TS_MAINTENANCE, TS_NO_NEIGHBORS
 
 pytestmark = [
-    pytest.mark.topology('t1')
+    pytest.mark.topology('t1', 'lt2', 'ft2')
 ]
 
 logger = logging.getLogger(__name__)
@@ -302,6 +302,9 @@ def test_load_minigraph_with_traffic_shift_away(duthosts, enum_rand_one_per_hwsk
     Verify all routes are announced to bgp monitor, and only loopback routes are announced to neighs
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    if tbinfo['topo']['type'] in ['lt2', 'ft2'] and duthost.get_bgp_confed_asn():
+        pytest.skip("Skip test on LT2/FT2 as BGP confederation configuration can only be loaded from golden config")
+
     # Initially make sure both supervisor and line cards are in BGP operational normal state
     if tbinfo['topo']['type'] == 't2':
         initial_tsa_check_before_and_after_test(duthosts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to enable tests/bgp/test_traffic_shift.py on LT2 and FT2 topology.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202503

### Approach
#### What is the motivation for this PR?
This PR is to enable tests/bgp/test_traffic_shift.py on LT2 and FT2 topology.

#### How did you do it?
1. Update route check functionality to support BGP confederation
2. Add LT2 and FT2 into supported topo.

#### How did you verify/test it?
The change is verified on a physical testbed

```
collected 5 items                                                                                                                                                                                                             

bgp/test_traffic_shift.py::test_TSA[default]  ^HPASSED                                                                                                                                                   [ 20%]
bgp/test_traffic_shift.py::test_TSB[default]  ^HPASSED                                                                                                                                                   [ 40%]
bgp/test_traffic_shift.py::test_TSA_B_C_with_no_neighbors[default]  ^HPASSED                                                                                                                             [ 60%]
bgp/test_traffic_shift.py::test_TSA_TSB_with_config_reload[default]  ^H ^HPASSED                                                                                                                            [ 80%]
bgp/test_traffic_shift.py::test_load_minigraph_with_traffic_shift_away[default] SKIPPED (Skip test on LT2/FT2 as BGP confederation configuration can only be loaded from golden config)               [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
