### PR TITLE
Fix reboot detection for non-default SSH ports and always-up port setups

### DIFF
--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -1175,12 +1175,17 @@ def add_platform_api_server_port_nat_for_dpu(
                 {SERVER_PORT} -j DNAT --to-destination {dpu_ip}:{SERVER_PORT}')
 
 
-def get_ansible_ssh_port(duthost, ansible_adhoc):  # noqa: F811
-    host = ansible_adhoc(become=True, args=[], kwargs={})[duthost.hostname]
-    vm = host.options["inventory_manager"].get_host(duthost.hostname).vars
-    ansible_ssh_port = vm.get("ansible_ssh_port", None)
-    logger.info(f'ansible_ssh_port for {duthost.hostname} is {ansible_ssh_port}')
-    return ansible_ssh_port
+def get_ssh_port_from_duthost(duthost):
+    """
+    Get SSH port from duthost's Ansible inventory variables.
+    Returns: SSH port number (int)
+    """
+    if getattr(duthost, 'host', None):
+        dut_vars = duthost.host.options["inventory_manager"].get_host(duthost.hostname).vars
+        ansible_ssh_port = dut_vars.get("ansible_port", 22)
+    else:
+        ansible_ssh_port = 22
+    return int(ansible_ssh_port)
 
 
 def create_npu_host_based_on_dpu_info(ansible_adhoc, tbinfo, request, duthost):  # noqa: F811

--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -7,7 +7,7 @@ import pytest
 from tests.common.helpers.platform_api import watchdog
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service, \
-      add_platform_api_server_port_nat_for_dpu, get_ansible_ssh_port    # noqa: F401
+      add_platform_api_server_port_nat_for_dpu, get_ssh_port_from_duthost    # noqa: F401
 from .platform_api_test_base import PlatformApiTestBase
 from tests.common.plugins.ansible_fixtures import ansible_adhoc  # noqa: F401
 
@@ -139,7 +139,7 @@ class TestWatchdogApi(PlatformApiTestBase):
                         "Watchdog remaining_time {} seconds is wrong for disarmed state".format(remaining_time))
 
         is_dpu = duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")
-        ansible_ssh_port = get_ansible_ssh_port(duthost, ansible_adhoc) if is_dpu else 22
+        ansible_ssh_port = get_ssh_port_from_duthost(duthost, ansible_adhoc) if is_dpu else 22
         res = localhost.wait_for(host=duthost.mgmt_ip, port=ansible_ssh_port, state="stopped", delay=5,
                                  timeout=watchdog_timeout + TIMEOUT_DEVIATION, module_ignore_errors=True)
 


### PR DESCRIPTION
Details:
Previous check reboot method relied on SSH port to be constant 22, and for SSH port to shut down and start up after reboot. There are setups in which the SSH port is not default 22, and the SSH port stays up after reboot, requiring to read the SSH banner to verify reboot was done and no information was transferred.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some setups are not with default SSH port of 22 but have different SSH ports. In addition, not all setups have the SSH port shut down after reboot and then starts up, but the SSH port always stays up, and other method is required to verify that reboot was done.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Different ssh port numeration, and different ssh port functionality require to check differently if reboot was executed successfully.

#### How did you do it?
Added function that reads ansible port from inventory files with fallback method to SSH port 22. 
Modified the wait_for_shutdown function to check if SSH banner is available (instead of just port status), which correctly detects reboot even on setups where the SSH port remains up during reboot.
Changed use of get_ansible_ssh_port to get_ssh_port_from_duthost in test_watchdog usecase.
#### How did you verify/test it?
This change was tested with both setups that have SSH port 22 and port shutdown after reboot, and setups that have different ssh port that remains up even during reboot.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
