### PR TITLE
Revise Cisco-8000 VOQ hwskus

### DIFF
--- a/tests/qos/files/cisco/qos_param_generator.py
+++ b/tests/qos/files/cisco/qos_param_generator.py
@@ -12,8 +12,11 @@ class QosParamCisco(object):
                                                         "Cisco-8101-C64",
                                                         "Cisco-8101-O8C48",
                                                         "Cisco-8101-O8V48"],
-                              "x86_64-8101_32fh_o_c01-r0": ["Cisco-8101-O32",
-                                                            "Cisco-8101-V64"],
+                              "x86_64-8101_32fh_o_c01-r0": ["Cisco-8101C01-O8V48",
+                                                            "Cisco-8101C01-O32",
+                                                            "Cisco-8101C01-V64",
+                                                            "Cisco-8101C01-C28S4",
+                                                            "Cisco-8101C01-C32"],
                               "x86_64-8102_64h_o-r0": ["Cisco-8102-C64"]}
     VOQ_ASICS = ["gb", "gr"]
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update test case expectation for separate VOQ'ing paradigm for only platform `x86_64-8101_32fh_o_c01-r0`. 
Fixes LossyQueueVoq test for this platform to expect the correct VOQ style. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

- [x] On branch 202411, without change, verify LossyQueueVoq test fails     for HWSKU Cisco-8101C01-O32
Confirmed reproduced failure:
```
E           ======================================================================    
E           FAIL: sai_qos_tests.LossyQueueVoqTest                                     
E           ----------------------------------------------------------------------    
E           Traceback (most recent call last):                                        
E             File "saitests/py3/sai_qos_tests.py", line 4426, in runTest             
E               .format(self.flow_config)                                             
E           AssertionError: Identified a second flow despite being in mode 'shared'   
E                                                                                     
E           ----------------------------------------------------------------------    
E           Ran 1 test in 24.155s                                                     
E                                                                                     
E           FAILED (failures=1)                                                       
```
- [x] On branch 202411, with change,      verify LossyQueueVoq test passes for HWSKU Cisco-8101C01-O32

Validation notes:
- Validated on similar Cisco-8101C01-O32, not C32
- Validated on 202411 sonic-mgmt 3d1705e6d458f84d8826bfba91a71837956a1e9e  with patch here applied. 
- Validated only LossyQueueVoqTest

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
