### PR TITLE
[AI - Snappi]: Adding FEC Error Insertion Test Script

### DIFF
--- a/tests/snappi_tests/layer1/test_fec_error_insertion.py
+++ b/tests/snappi_tests/layer1/test_fec_error_insertion.py
@@ -1,7 +1,7 @@
-from tests.snappi_tests.dataplane.imports import *   # noqa F403
+from tests.snappi_tests.dataplane.imports import pytest, SnappiTestParams, wait_for_arp, wait, pytest_assert
 from snappi_tests.dataplane.files.helper import get_duthost_bgp_details, create_snappi_config, \
     get_fanout_port_groups, set_primary_chassis, create_traffic_items, start_stop, get_stats    # noqa: F401, F405
-
+import logging
 pytestmark = [pytest.mark.topology("nut")]
 logger = logging.getLogger(__name__)  # noqa: F405
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding FEC Error Insertion Test Script
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
 The test aims at injecting different fec error codeword types and monitors the traffic and link state
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
### Output

03:54:56 test_fec_error.test_fec_error_injection L0146 INFO | |----------------------------------------|
03:54:56 test_fec_error.test_fec_error_injection L0147 INFO | Iteration: 1 | Using Fanout Ports :-

03:54:56 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet32 : 10.36.84.31/5.1 : speed_400_gbps
03:54:56 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet40 : 10.36.84.31/6.1 : speed_400_gbps
03:54:56 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet48 : 10.36.84.31/7.1 : speed_400_gbps
03:54:56 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet56 : 10.36.84.31/8.1 : speed_400_gbps
03:54:56 test_fec_error.test_fec_error_injection L0150 INFO | |----------------------------------------|

03:54:56 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet32 with IP 20.1.1.0/31
03:54:57 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet40 with IP 20.1.1.2/31
03:54:58 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet48 with IP 20.1.1.4/31
03:54:59 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet56 with IP 20.1.1.6/31
03:55:00 connection._warn L0332 WARNING| Verification of certificates is disabled
03:55:00 connection._info L0329 INFO | Determining the platform and rest_port using the 10.36.84.31 address...
03:55:00 connection._warn L0332 WARNING| Unable to connect to http://10.36.84.31:443/.
03:55:00 connection._info L0329 INFO | Connection established to https://10.36.84.31:443 on linux
03:55:26 connection._info L0329 INFO | Using IxNetwork api server version 10.80.2411.101
03:55:26 connection._info L0329 INFO | User info IxNetwork/ixnetworkweb/admin-16-13240
03:55:27 snappi_api.info L1252 INFO | snappi-1.17.1
03:55:27 snappi_api.info L1252 INFO | snappi_ixnetwork-1.17.0
03:55:27 snappi_api.info L1252 INFO | ixnetwork_restpy-1.5.0
03:55:28 snappi_api.info L1252 INFO | Config validation 0.006s
03:55:34 snappi_api.info L1252 INFO | Ports configuration 5.580s
03:55:35 snappi_api.info L1252 INFO | Captures configuration 0.146s
03:55:47 snappi_api.info L1252 INFO | Add location hosts [10.36.84.31] 12.233s
03:55:49 snappi_api.info L1252 INFO | Location hosts ready [10.36.84.31] 2.181s
03:55:50 snappi_api.info L1252 INFO | Speed conversion is not require for (port.name, speed) : [('Tx_0', 'aresOne-M-TwoByFourHundredGigPAM4-106G'), ('Tx_1', 'aresOne-M-TwoByFourHundredGigPAM4-106G'), ('Rx_0', 'aresOne-M-TwoByFourHundredGigPAM4-106G'), ('Rx_1', 'aresOne-M-TwoByFourHundredGigPAM4-106G')]
03:55:50 snappi_api.info L1252 INFO | Aggregation mode speed change 0.803s
03:55:51 snappi_api.info L1252 INFO | Location preemption [10.36.84.31/5.1, 10.36.84.31/6.1, 10.36.84.31/7.1, 10.36.84.31/8.1] 0.117s
03:56:33 snappi_api.info L1252 INFO | Location connect [Tx_0, Tx_1, Rx_0, Rx_1] 41.992s
03:56:33 snappi_api.info L1252 INFO | Location state check [Tx_0, Tx_1, Rx_0, Rx_1] 0.415s
03:56:33 snappi_api.info L1252 INFO | Location configuration 58.847s
03:56:34 snappi_api.info L1252 INFO | Layer1 configuration 0.619s
03:56:34 snappi_api.info L1252 INFO | Lag Configuration 0.073s
03:56:34 snappi_api.info L1252 INFO | Convert device config : 0.208s
03:56:34 snappi_api.info L1252 INFO | Create IxNetwork device config : 0.000s
03:56:36 snappi_api.info L1252 INFO | Push IxNetwork device config : 1.136s
03:56:36 snappi_api.info L1252 INFO | Devices configuration 1.403s
03:56:38 snappi_api.info L1252 INFO | Flows configuration 2.410s
03:56:48 snappi_api.info L1252 INFO | Start interfaces 9.361s
03:56:48 snappi_api.info L1252 INFO | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
03:56:48 snappi_api.info L1252 INFO | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
03:56:48 test_fec_error.test_fec_error_injection L0156 INFO | Wait for Arp to Resolve ...
03:58:30 test_fec_error.test_fec_error_injection L0165 INFO |

03:58:30 test_fec_error.test_fec_error_injection L0166 INFO | Setting FEC Error Type to : codeWords on Snappi ports :-
03:58:37 test_fec_error.test_fec_error_injection L0169 INFO | Tx_0
03:58:57 test_fec_error.test_fec_error_injection L0169 INFO | Tx_1
03:59:11 test_fec_error.test_fec_error_injection L0173 INFO | |----------------------------------------|
03:59:11 test_fec_error.test_fec_error_injection L0174 INFO | Starting Traffic ...
03:59:17 snappi_api.info L1252 INFO | Flows generate/apply 5.166s
03:59:29 snappi_api.info L1252 INFO | Flows clear statistics 12.218s
03:59:29 snappi_api.info L1252 INFO | Captures start 0.000s
03:59:32 snappi_api.info L1252 INFO | Flows start 3.071s
03:59:32 utilities.wait L0117 INFO | Pause 10 seconds, reason: For traffic to start
03:59:42 test_fec_error.test_fec_error_injection L0180 INFO | Starting FEC Error Insertion
03:59:43 utilities.wait L0117 INFO | Pause 15 seconds, reason: For error insertion to start
03:59:59 test_fec_error.test_fec_error_injection L0183 INFO | Dumping Traffic Item statistics :
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
| | Tx Frames | Rx Frames | Frames Delta | Loss % | Tx Frame Rate | Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
| 0 | 4113608300 | 2381117369 | 1732490931 | 42.116 | 1.8797e+08 | 0 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
04:00:01 sonic.links_status_down L2542 INFO | Interface Ethernet32 is down on sonic-s6100-dut1
04:00:01 test_fec_error.test_fec_error_injection L0191 INFO | PASS: Ethernet32 Went down after injecting FEC Error: codeWords
04:00:03 sonic.links_status_down L2542 INFO | Interface Ethernet40 is down on sonic-s6100-dut1
04:00:03 test_fec_error.test_fec_error_injection L0191 INFO | PASS: Ethernet40 Went down after injecting FEC Error: codeWords
04:00:06 test_fec_error.test_fec_error_injection L0199 INFO | PASS : Snappi Rx Port observed packet drop after starting FEC Error Insertion
04:00:06 test_fec_error.test_fec_error_injection L0200 INFO | Stopping FEC Error Insertion
04:00:06 utilities.wait L0117 INFO | Pause 20 seconds, reason: For error insertion to stop
04:00:28 sonic.links_status_down L2545 INFO | Interface Ethernet32 is up on sonic-s6100-dut1
04:00:28 test_fec_error.test_fec_error_injection L0209 INFO | PASS: Ethernet32 is up after stopping FEC Error injection: codeWords
04:00:29 sonic.links_status_down L2545 INFO | Interface Ethernet40 is up on sonic-s6100-dut1
04:00:29 test_fec_error.test_fec_error_injection L0209 INFO | PASS: Ethernet40 is up after stopping FEC Error injection: codeWords
04:00:31 utilities.wait L0117 INFO | Pause 10 seconds, reason: For clear stats operation to complete
04:00:41 test_fec_error.test_fec_error_injection L0212 INFO | Dumping Traffic Item statistics :
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
| | Tx Frames | Rx Frames | Frames Delta | Loss % | Tx Frame Rate | Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
| 0 | 1544566178 | 1544565613 | 565 | 0 | 1.8797e+08 | 1.8797e+08 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
04:00:43 test_fec_error.test_fec_error_injection L0217 INFO | PASS : Rx Port resumed receiving packets after stopping FEC Error Insertion
04:00:43 test_fec_error.test_fec_error_injection L0218 INFO | Stopping Traffic ...
04:00:48 snappi_api.info L1252 INFO | Flows stop 5.606s
04:00:49 utilities.wait L0117 INFO | Pause 10 seconds, reason: For traffic to stop
04:00:59 test_fec_error.test_fec_error_injection L0224 INFO | ....Finally Block
04:00:59 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.0/31 from port Ethernet32
04:01:00 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.2/31 from port Ethernet40
04:01:01 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.4/31 from port Ethernet48
04:01:02 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.6/31 from port Ethernet56
04:01:04 test_fec_error.test_fec_error_injection L0146 INFO | |----------------------------------------|
04:01:04 test_fec_error.test_fec_error_injection L0147 INFO | Iteration: 2 | Using Fanout Ports :-

04:01:04 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet36 : 10.36.84.31/5.2 : speed_400_gbps
04:01:04 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet44 : 10.36.84.31/6.2 : speed_400_gbps
04:01:04 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet52 : 10.36.84.31/7.2 : speed_400_gbps
04:01:04 test_fec_error.test_fec_error_injection L0149 INFO | Ethernet60 : 10.36.84.31/8.2 : speed_400_gbps
04:01:04 test_fec_error.test_fec_error_injection L0150 INFO | |----------------------------------------|

04:01:04 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet36 with IP 20.1.1.0/31
04:01:05 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet44 with IP 20.1.1.2/31
04:01:05 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet52 with IP 20.1.1.4/31
04:01:06 test_fec_error.configure_dut_interface L0046 INFO | Configuring port Ethernet60 with IP 20.1.1.6/31
04:01:07 snappi_api.info L1252 INFO | Config validation 0.006s
04:01:09 snappi_api.info L1252 INFO | Ports configuration 0.684s
04:01:10 snappi_api.info L1252 INFO | Captures configuration 0.491s
04:01:11 snappi_api.info L1252 INFO | Location hosts ready [10.36.84.31] 0.137s
04:01:11 snappi_api.info L1252 INFO | Speed change not require due to redundant Layer1 config
04:01:11 snappi_api.info L1252 INFO | Aggregation mode speed change 0.009s
04:01:13 snappi_api.info L1252 INFO | Location preemption [10.36.84.31/5.2, 10.36.84.31/6.2, 10.36.84.31/7.2, 10.36.84.31/8.2] 0.125s
04:01:49 snappi_api.info L1252 INFO | Location connect [Tx_0, Tx_1, Rx_0, Rx_1] 36.820s
04:01:52 snappi_api.info L1252 INFO | Location state check [Tx_0, Tx_1, Rx_0, Rx_1] 2.209s
04:01:52 snappi_api.info L1252 INFO | Location configuration 42.035s
04:01:52 snappi_api.info L1252 INFO | Layer1 configuration 0.469s
04:01:52 snappi_api.info L1252 INFO | Lag Configuration 0.057s
04:01:53 snappi_api.info L1252 INFO | Convert device config : 0.924s
04:01:53 snappi_api.info L1252 INFO | Create IxNetwork device config : 0.000s
04:01:54 snappi_api.info L1252 INFO | Push IxNetwork device config : 1.085s
04:01:54 snappi_api.info L1252 INFO | Devices configuration 2.067s
04:01:58 snappi_api.info L1252 INFO | Flows configuration 3.432s
04:02:06 snappi_api.info L1252 INFO | Start interfaces 8.231s
04:02:07 snappi_api.info L1252 INFO | IxNet - One or more destination MACs or VPNs are invalid or unreachable and the packets configured to be sent to them were not created
04:02:07 snappi_api.info L1252 INFO | IxNet - The Traffic Item was modified. Please perform a Traffic Generate to update the associated traffic Flow Groups
04:02:07 test_fec_error.test_fec_error_injection L0156 INFO | Wait for Arp to Resolve ...
04:02:11 test_fec_error.test_fec_error_injection L0165 INFO |

04:02:11 test_fec_error.test_fec_error_injection L0166 INFO | Setting FEC Error Type to : codeWords on Snappi ports :-
04:02:20 test_fec_error.test_fec_error_injection L0169 INFO | Tx_0
04:02:27 test_fec_error.test_fec_error_injection L0169 INFO | Tx_1
04:02:28 test_fec_error.test_fec_error_injection L0173 INFO | |----------------------------------------|
04:02:28 test_fec_error.test_fec_error_injection L0174 INFO | Starting Traffic ...
04:02:36 snappi_api.info L1252 INFO | Flows generate/apply 7.149s
04:02:48 snappi_api.info L1252 INFO | Flows clear statistics 12.561s
04:02:48 snappi_api.info L1252 INFO | Captures start 0.000s
04:02:51 snappi_api.info L1252 INFO | Flows start 2.208s
04:02:51 utilities.wait L0117 INFO | Pause 10 seconds, reason: For traffic to start
04:03:01 test_fec_error.test_fec_error_injection L0180 INFO | Starting FEC Error Insertion
04:03:02 utilities.wait L0117 INFO | Pause 15 seconds, reason: For error insertion to start
04:03:18 test_fec_error.test_fec_error_injection L0183 INFO | Dumping Traffic Item statistics :
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
| | Tx Frames | Rx Frames | Frames Delta | Loss % | Tx Frame Rate | Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
| 0 | 4476336300 | 2233211203 | 2243125097 | 50.111 | 1.8797e+08 | 0 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
04:03:20 sonic.links_status_down L2542 INFO | Interface Ethernet36 is down on sonic-s6100-dut1
04:03:20 test_fec_error.test_fec_error_injection L0191 INFO | PASS: Ethernet36 Went down after injecting FEC Error: codeWords
04:03:21 sonic.links_status_down L2542 INFO | Interface Ethernet44 is down on sonic-s6100-dut1
04:03:21 test_fec_error.test_fec_error_injection L0191 INFO | PASS: Ethernet44 Went down after injecting FEC Error: codeWords
04:03:23 test_fec_error.test_fec_error_injection L0199 INFO | PASS : Snappi Rx Port observed packet drop after starting FEC Error Insertion
04:03:23 test_fec_error.test_fec_error_injection L0200 INFO | Stopping FEC Error Insertion
04:03:23 utilities.wait L0117 INFO | Pause 20 seconds, reason: For error insertion to stop
04:03:44 sonic.links_status_down L2545 INFO | Interface Ethernet36 is up on sonic-s6100-dut1
04:03:44 test_fec_error.test_fec_error_injection L0209 INFO | PASS: Ethernet36 is up after stopping FEC Error injection: codeWords
04:03:46 sonic.links_status_down L2545 INFO | Interface Ethernet44 is up on sonic-s6100-dut1
04:03:46 test_fec_error.test_fec_error_injection L0209 INFO | PASS: Ethernet44 is up after stopping FEC Error injection: codeWords
04:03:48 utilities.wait L0117 INFO | Pause 10 seconds, reason: For clear stats operation to complete
04:03:59 test_fec_error.test_fec_error_injection L0212 INFO | Dumping Traffic Item statistics :
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
| | Tx Frames | Rx Frames | Frames Delta | Loss % | Tx Frame Rate | Rx Frame Rate |
|----+-------------+-------------+----------------+----------+-----------------+-----------------|
| 0 | 1310220255 | 1310219684 | 571 | 0 | 1.8797e+08 | 1.8797e+08 |
+----+-------------+-------------+----------------+----------+-----------------+-----------------+
04:04:00 test_fec_error.test_fec_error_injection L0217 INFO | PASS : Rx Port resumed receiving packets after stopping FEC Error Insertion
04:04:00 test_fec_error.test_fec_error_injection L0218 INFO | Stopping Traffic ...
04:04:07 snappi_api.info L1252 INFO | Flows stop 6.409s
04:04:07 utilities.wait L0117 INFO | Pause 10 seconds, reason: For traffic to stop
04:04:17 test_fec_error.test_fec_error_injection L0224 INFO | ....Finally Block
04:04:17 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.0/31 from port Ethernet36
04:04:18 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.2/31 from port Ethernet44
04:04:19 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.4/31 from port Ethernet52
04:04:20 test_fec_error.cleanup_dut_interface L0057 INFO | Removing 20.1.1.6/31 from port Ethernet60
PASSED [100%]