### PR TITLE
Fix test_dscp_to_queue_mapping_uniform_mode for t1-isolated-d128

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -239,8 +239,8 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
 
         asic_type = duthost.facts['asic_type']
         dst_mac = test_params['dst_mac']
-        ptf_src_port_id = test_params['ptf_downlink_port']
-        ptf_dst_port_ids = test_params['ptf_uplink_ports']
+        ptf_src_port_id = test_params['ptf_src_port_id']
+        ptf_dst_port_ids = test_params['ptf_dst_port_ids']
         outer_dst_pkt_ip = test_params['outer_dst_ip']
         outer_src_pkt_ip = DUMMY_OUTER_SRC_IP
         inner_dst_pkt_ip = DUMMY_INNER_DST_IP


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This test selects a downlink as a source port and an uplink as a dest port, but the t1-isolated-d128 has no uplinks. This change merges the list of down/uplink ports and selects one at random as the source port, and cleans up some incorrect assertions and unused arguments.

This is a manual backport of https://github.com/sonic-net/sonic-mgmt/pull/21662

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Manually verified

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
