### PR TITLE
Skip ip-proto in fib test on FT2

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -374,7 +374,7 @@ def get_vlan_untag_ports(duthosts, duts_running_config_facts):
 
 
 @pytest.fixture(scope="module")
-def hash_keys(duthost):
+def hash_keys(duthost, tbinfo):
     # Copy from global var to avoid side effects of multiple iterations
     hash_keys = HASH_KEYS[:]
     if 'dst-mac' in hash_keys:
@@ -407,6 +407,11 @@ def hash_keys(duthost):
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
     if duthost.facts['asic_type'] in ["marvell-teralynx", "cisco-8000"]:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+    if 'ft2' in tbinfo['topo']['name']:
+        #  Remove ip-proto from hash_keys for FT2 as there is not enough entropy in ip-proto
+        #  to ensure packets are evenly distributed to all 64 egress ports
         if 'ip-proto' in hash_keys:
             hash_keys.remove('ip-proto')
     # remove the ingress port from multi asic platform


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_hash is flaky on FT2 testbed because there is not enough entropy in hash key `ip-proto` to ensure traffic is balanced evenly among all 64 nexthops.
This PR fixed the issue by removing `ip-proto` from hash_keys.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202503

### Approach
#### What is the motivation for this PR?
This PR fixed the `test_hash` on FT2 topo by removing `ip-proto` from hash_keys.

#### How did you do it?
Check if the topo type is `ft2` and remove `ip-proto` from `hash_keys`.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 15 items                                                                                                                                                                                                            

fib/test_fib.py::test_basic_fib[True-True-1514] PASSED                                                                                                                                                                  [  6%]
fib/test_fib.py::test_hash[ipv4]  ^H ^H ^H ^H ^H ^HPASSED                                                                                                                                                                                 [ 13%]
fib/test_fib.py::test_hash[ipv6]  ^H ^H ^H ^H ^H ^HPASSED                                                                                                                                                                                 [ 20%]
fib/test_fib.py::test_ipinip_hash[ipv4] SKIPPED (The test case runs on T1 topology)                                                                                                                                     [ 26%]
fib/test_fib.py::test_ipinip_hash[ipv6] SKIPPED (The test case runs on T1 topology)                                                                                                                                     [ 33%]
fib/test_fib.py::test_ipinip_hash_negative[ipv4]  ^HPASSED                                                                                                                                                                 [ 40%]
fib/test_fib.py::test_ipinip_hash_negative[ipv6]  ^H ^HPASSED                                                                                                                                                                 [ 46%]
fib/test_fib.py::test_vxlan_hash[ipv4-ipv4]  ^H ^HPASSED                                                                                                                                                                      [ 53%]
fib/test_fib.py::test_vxlan_hash[ipv4-ipv6]  ^H ^HPASSED                                                                                                                                                                      [ 60%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv6]  ^HPASSED                                                                                                                                                                      [ 66%]
fib/test_fib.py::test_vxlan_hash[ipv6-ipv4]  ^H ^HPASSED                                                                                                                                                                      [ 73%]
fib/test_fib.py::test_nvgre_hash[ipv4-ipv4] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*. Skip on t1-isolated-d32/128 topos)                                        [ 80%]
fib/test_fib.py::test_nvgre_hash[ipv4-ipv6] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*. Skip on t1-isolated-d32/128 topos)                                        [ 86%]
fib/test_fib.py::test_nvgre_hash[ipv6-ipv6] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*. Skip on t1-isolated-d32/128 topos)                                        [ 93%]
fib/test_fib.py::test_nvgre_hash[ipv6-ipv4] SKIPPED (Nvgre hash test is not fully supported on VS and Broadcom platform; Not supported on M*. Skip on t1-isolated-d32/128 topos)                                        [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
