### PR TITLE
add one errmsg to be ignored in duplicate routes test case

### DIFF
--- a/tests/route/test_duplicate_route.py
+++ b/tests/route/test_duplicate_route.py
@@ -104,6 +104,7 @@ def verify_expected_loganalyzer_logs(
         ".*ERR.* mlnx_create_route_async.* Entry Already Exists.",
         ".*ERR.* object key SAI_OBJECT_TYPE_ROUTE_ENTRY:.* already exists.*",  # TODO move to expectRegex
         ".*ERR.* addRoutePost: Failed to create route.*",  # TODO move to expectRegex
+        ".*ERR.* ipv4_route_bulk_updates API returned.*Key already exists in table.*",
     ]
     if loganalyzer:
         # Skip if loganalyzer is disabled


### PR DESCRIPTION

### Description of PR
There is a new error message that gets generated when test_duplicate_routes.py is run, i.e. when a duplicate route entry is trying to be downloaded, which is an error condition.  This new error message is not recognized by the existed "ignore list" and it should be added to it to avoid flagging a known condition as an unknown error.

Summary:
Simply add the new error message to the ignore list.

### Type of change
script change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
Let the test run smoothly for code base with new error message

#### How did you do it?
just add it to the list

#### How did you verify/test it?
tested the script

#### Any platform specific information?
worked on sim

#### Supported testbed topology if it's a new test case?
n/a

### Documentation
n/a
