### PR TITLE
Enhance test_verify_fec_histogram logic to handle a stable link with stale transient FEC symbol errors

### DIFF
--- a/tests/platform_tests/test_intf_fec.py
+++ b/tests/platform_tests/test_intf_fec.py
@@ -219,10 +219,13 @@ def get_fec_histogram(duthost, intf_name):
     return fec_hist
 
 
-def validate_fec_histogram(duthost, intf_name):
+def validate_fec_histogram(duthost, intf_name, init, prev=None):
     """
     @Summary: Validate FEC histogram critical bins for any errors. Fail the test if bin value > 0
+    for a stable link over last two snapshots.
     """
+    if not init and not prev:
+        pytest.fail("FEC histogram from previous snapshot is not provided")
 
     fec_hist = get_fec_histogram(duthost, intf_name)
     if not fec_hist:
@@ -232,16 +235,25 @@ def validate_fec_histogram(duthost, intf_name):
     error_bins = []
     for bin_index in critical_bins:
         bin_value = int(fec_hist[bin_index].get('codewords', 0))
-        if bin_value > 0:
-            error_bins.append((bin_index, bin_value))
+        if init:
+            if bin_value > 0:
+                error_bins.append((bin_index, bin_value))
+        else:
+            prev_bin_value = int(prev[bin_index].get('codewords', 0))
+            if bin_value - prev_bin_value > 0:
+                error_bins.append((bin_index, bin_value))
 
     if error_bins:
-        error_messages = ["FEC histogram bin {} has errors for interface {}: {}".format(bin_index, intf_name, bin_value)
+        error_messages = ["FEC histogram bin {} has errors for interface {}: {} (init: {})".format(
+                              bin_index, intf_name, bin_value, init)
                           for bin_index, bin_value in error_bins]
-        logging.error("\n".join(error_messages))
-        return False
+        if init:
+            logging.info("\n".join(error_messages))
+        else:
+            logging.error("\n".join(error_messages))
+        return False, fec_hist
 
-    return True
+    return True, fec_hist
 
 
 def test_verify_fec_histogram(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
@@ -260,8 +272,26 @@ def test_verify_fec_histogram(duthosts, enum_rand_one_per_hwsku_frontend_hostnam
     if not interfaces:
         pytest.skip("Skipping this test as there is no fec eligible interface")
 
+    # It's possible there are some transient FEC symbol errors on interface
+    # state transition. Hence, this test uses the first check to read the current
+    # FEC histogram counters to see whether there are stale errors. If so,
+    # it will increase the waiting time for the next read and compare any
+    # changes in the critical bins between 2 snapshots. For a stable link, no
+    # increments in these critical bins are expected.
+    snapshots = {}
+    sleep_time = 10
     for intf_name in interfaces:
-        for _ in range(3):
-            if not validate_fec_histogram(duthost, intf_name):
+        valid, fec_hist = validate_fec_histogram(duthost, intf_name, True)
+        if not valid:
+            logging.info("Update test sleep time to 10 min due to bin errors in the initial snapshot")
+            sleep_time = 10 * 60
+        snapshots[intf_name] = fec_hist
+
+    for _ in range(2):
+        time.sleep(sleep_time)
+        for intf_name in interfaces:
+            prev_fec_hist = snapshots[intf_name]
+            valid, fec_hist = validate_fec_histogram(duthost, intf_name, False, prev_fec_hist)
+            if not valid:
                 pytest.fail("FEC histogram validation failed for interface {}".format(intf_name))
-            time.sleep(10)
+            snapshots[intf_name] = fec_hist


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

`platform_tests/test_intf_fec.py` `test_verify_fec_histogram` checks no critical FEC bins for a link and may fail the test if there are some errors with the link. However, this test doesn't consider the transient symbol errors accumulated during interface state transition (or other transient state) and thus it can also fail for a stable link with stale errors during the testing time.

For example, it may fail with following BIN output:
```
(Pdb) intf_name
'Ethernet280'
(Pdb) fec_hist
[{'symbol errors per codeword': 'BIN0', 'codewords': '99235826365'},
{'symbol errors per codeword': 'BIN1', 'codewords': '406154'}, {'symbol
errors per codeword': 'BIN2', 'codewords': '1781'}, {'symbol errors per
codeword': 'BIN3', 'codewords': '0'}, {'symbol errors per codeword':
'BIN4', 'codewords': '0'}, {'symbol errors per codeword': 'BIN5',
'codewords': '0'}, {'symbol errors per codeword': 'BIN6', 'codewords':
'0'}, {'symbol errors per codeword': 'BIN7', 'codewords': '0'}, {'symbol
errors per codeword': 'BIN8', 'codewords': '0'}, {'symbol errors per
codeword': 'BIN9', 'codewords': '0'}, {'symbol errors per codeword':
'BIN10', 'codewords': '0'}, {'symbol errors per codeword': 'BIN11',
'codewords': '0'}, {'symbol errors per codeword': 'BIN12', 'codewords':
'0'}, {'symbol errors per codeword': 'BIN13', 'codewords': '0'},
{'symbol errors per codeword': 'BIN14', 'codewords': '0'}, {'symbol
errors per codeword': 'BIN15', 'codewords': '1'}]
```

Note that there's only 1 BIN15 symbol error and it's not incrementing for a long time, so this link is stable. However, the test can still fail in this case.

This change is trying to enhance the test case to handle these stale errors by checking whether a test interface is susceptible to this issue with the 1st snapshot of fec histogram. If so, it will extend waiting time to 10 minutes for each loop and that's 20 minutes in total and make sure no critical BINs will ever increment during this 20 min period. The rational is that it's very likely to see the changes in these BINs in this long window if the link is not stable. Usually we can see the changes in every seconds for a marginal link.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] msft-202412
- [x] msft-202503

### Approach
#### What is the motivation for this PR?
Improve the pass rate by handling these corner cases

#### How did you do it?
Wait for enough long time to make sure the links are actually stable

#### How did you verify/test it?
Confirmed the test now can pass with a stable link but transient FEC symbol errors

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
