### PR TITLE
Allow non-zero exit code when enabling a systemd service

### DIFF
--- a/tests/minigraph/test_masked_services.py
+++ b/tests/minigraph/test_masked_services.py
@@ -19,24 +19,15 @@ def is_service_loaded(duthost, service):
 
 
 def change_service_state(duthost, service, enable):
-    outputs = []
     if enable:
-        outputs = [
-            duthost.shell("systemctl unmask {}.service".format(service)),
-            duthost.shell("systemctl enable {}.service".format(service),
-                          module_ignore_errors=True),
-            duthost.shell("systemctl start {}.service".format(service))
-        ]
+        duthost.command("systemctl unmask {}.service".format(service)),
+        duthost.command("systemctl enable {}.service".format(service),
+                        module_ignore_errors=True),
+        duthost.command("systemctl start {}.service".format(service))
     else:
-        outputs = [
-            duthost.shell("systemctl stop {}.service".format(service)),
-            duthost.shell("systemctl disable {}.service".format(service)),
-            duthost.shell("systemctl mask {}.service".format(service))
-        ]
-    for output in outputs:
-        if output["failed"]:
-            pytest.fail("Error starting or stopping service")
-            return
+        duthost.command("systemctl stop {}.service".format(service)),
+        duthost.command("systemctl disable {}.service".format(service)),
+        duthost.command("systemctl mask {}.service".format(service))
 
 
 @pytest.mark.disable_loganalyzer


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

With Trixie, service files for SONiC containers are runtime-generated files (because of how systemd-sonic-generator now has to work). This means that enabling such a service will result in an error being returned from systemd saying that the service is a generated service and cannot be explicitly enabled.

#### How did you do it?

Allow such errors for this command; functionally, things still work.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
