### PR TITLE
[dhcp_relay] change ptfutils to tcpdump for better result

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcp_relay_stress_test.py
@@ -1,8 +1,10 @@
 import time
 import logging
+import subprocess
+import signal
+import os
 import ptf.testutils as testutils
 import ptf.packet as scapy
-from ptf.mask import Mask
 from dhcp_relay_test import DHCPTest
 
 logger = logging.getLogger(__name__)
@@ -44,263 +46,85 @@ class DHCPContinuousStressTest(DHCPTest):
                 self.send_packet_with_interval(dhcp_ack, server_port)
 
 
-class DHCPStressDiscoverTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressTest(DHCPTest):
     def setUp(self):
         DHCPTest.setUp(self)
         self.packets_send_duration = self.test_params["packets_send_duration"]
         self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
 
     # Simulate client coming on VLAN and broadcasting a DHCPDISCOVER message
-    def client_send_discover_stress(self, dst_mac, src_port):
-        # Form and send DHCPDISCOVER packet
-        dhcp_discover = self.create_dhcp_discover_packet(dst_mac, src_port)
+    def client_send_packet_stress(self):
+        server_ports = "|".join(["eth{}".format(idx) for idx in self.receive_port_indices])
+        tcpdump_cmd = (
+            "tcpdump -i any -n -q -l 'inbound and udp and (port 67 or port 68) and (udp[249:2] = 0x01{})' "
+            "| grep -w -E '{}' > /tmp/dhcp_stress_test_{}.log"
+        ).format(self.packet_type_hex, server_ports, self.packet_type)
+        tcpdump_proc = subprocess.Popen(tcpdump_cmd, shell=True)
+        if self.packet_type == "discover" or self.packet_type == "request":
+            dhcp_packet = self.create_packet(self.dest_mac_address, self.client_udp_src_port)
+        else:
+            dhcp_packet = self.create_packet()
         end_time = time.time() + self.packets_send_duration
         xid = 0
         while time.time() < end_time:
             # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
-            dhcp_discover[scapy.BOOTP].xid = xid
+            dhcp_packet[scapy.BOOTP].xid = xid
             xid += 1
-            testutils.send_packet(self, self.client_port_index, dhcp_discover)
+            testutils.send_packet(self, self.send_port_indices[0], dhcp_packet)
             time.sleep(1/self.client_packets_per_sec)
 
-    def count_relayed_discover(self):
-        # Create a packet resembling a relayed DCHPDISCOVER packet
-        dhcp_discover_relayed = self.create_dhcp_discover_relayed_packet()
+        time.sleep(15)
 
-        # Mask off fields we don't care about matching
-        masked_discover = Mask(dhcp_discover_relayed)
-        masked_discover.set_do_not_care_scapy(scapy.Ether, "dst")
+        pids = subprocess.check_output("pgrep tcpdump", shell=True).split()
+        for pid in pids:
+            os.kill(int(pid), signal.SIGINT)
+        tcpdump_proc.wait()
 
-        masked_discover.set_do_not_care_scapy(scapy.IP, "version")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "len")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "id")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "src")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "dst")
-        masked_discover.set_do_not_care_scapy(scapy.IP, "options")
-
-        masked_discover.set_do_not_care_scapy(scapy.UDP, "chksum")
-        masked_discover.set_do_not_care_scapy(scapy.UDP, "len")
-
-        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_discover.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        discover_count = testutils.count_matched_packets_all_ports(
-            self, masked_discover, self.server_port_indices)
-        return discover_count
+        wc_cmd = f"wc -l /tmp/dhcp_stress_test_{self.packet_type}.log"
+        wc_output = subprocess.check_output(wc_cmd, shell=True)
+        line_cnt = wc_output.decode().split()[0]
+        os.remove("/tmp/dhcp_stress_test_{}.log".format(self.packet_type))
+        subprocess.check_output("echo {} > /tmp/dhcp_stress_test_{}".format(line_cnt, self.packet_type), shell=True)
 
     def runTest(self):
-        self.client_send_discover_stress(self.dest_mac_address, self.client_udp_src_port)
-        discover_cnt = self.count_relayed_discover()
-
-        # At the end of the test, overwrite the file with discover count.
-        try:
-            with open('/tmp/dhcp_stress_test_discover.json', 'w') as result_file:
-                result_file.write(str(discover_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the discover file: %s", repr(e))
+        self.client_send_packet_stress()
 
 
-class DHCPStressOfferTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressDiscoverTest(DHCPStressTest):
     def setUp(self):
-        DHCPTest.setUp(self)
-        self.packets_send_duration = self.test_params["packets_send_duration"]
-        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
-
-    # Simulate client coming on VLAN and broadcasting a DHCPOFFER message
-    def client_send_offer_stress(self):
-        dhcp_offer = self.create_dhcp_offer_packet()
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPOFFER packet for making sure no packet miss
-            dhcp_offer[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.server_port_indices[0], dhcp_offer)
-            time.sleep(1/self.client_packets_per_sec)
-
-    def count_relayed_offer(self):
-        # Create a packet resembling a relayed DCHPOFFER packet
-        dhcp_offer_relayed = self.create_dhcp_offer_relayed_packet()
-
-        # Mask off fields we don't care about matching
-        masked_offer = Mask(dhcp_offer_relayed)
-
-        masked_offer.set_do_not_care_scapy(scapy.IP, "version")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "len")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "id")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "options")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "src")
-        masked_offer.set_do_not_care_scapy(scapy.IP, "dst")
-
-        masked_offer.set_do_not_care_scapy(scapy.UDP, "len")
-        masked_offer.set_do_not_care_scapy(scapy.UDP, "chksum")
-
-        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_offer.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        offer_count = testutils.count_matched_packets(self, masked_offer, self.client_port_index)
-        return offer_count
-
-    def runTest(self):
-        self.client_send_offer_stress()
-        offer_cnt = self.count_relayed_offer()
-
-        # At the end of the test, overwrite the file with offer count.
-        try:
-            with open('/tmp/dhcp_stress_test_offer.json', 'w') as result_file:
-                result_file.write(str(offer_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the offer file: %s", repr(e))
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = self.server_port_indices
+        self.send_port_indices = [self.client_port_index]
+        self.create_packet = self.create_dhcp_discover_packet
+        self.packet_type = "discover"
+        self.packet_type_hex = "01"
 
 
-class DHCPStressRequestTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressOfferTest(DHCPStressTest):
     def setUp(self):
-        DHCPTest.setUp(self)
-        self.packets_send_duration = self.test_params["packets_send_duration"]
-        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
-
-    # Simulate client coming on VLAN and broadcasting a DHCPREQUEST message
-    def client_send_request_stress(self, dst_mac, src_port):
-        # Form and send DHCPREQUEST packet
-        dhcp_request = self.create_dhcp_request_packet(dst_mac, src_port)
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPACK packet for making sure no packet miss
-            dhcp_request[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.client_port_index, dhcp_request)
-            time.sleep(1/self.client_packets_per_sec)
-
-    def count_relayed_request(self):
-        # Create a packet resembling a relayed DCHPREQUEST packet
-        dhcp_request_relayed = self.create_dhcp_request_relayed_packet()
-
-        # Mask off fields we don't care about matching
-        masked_request = Mask(dhcp_request_relayed)
-        masked_request.set_do_not_care_scapy(scapy.Ether, "dst")
-
-        masked_request.set_do_not_care_scapy(scapy.IP, "version")
-        masked_request.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_request.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_request.set_do_not_care_scapy(scapy.IP, "len")
-        masked_request.set_do_not_care_scapy(scapy.IP, "id")
-        masked_request.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_request.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_request.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_request.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_request.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_request.set_do_not_care_scapy(scapy.IP, "src")
-        masked_request.set_do_not_care_scapy(scapy.IP, "dst")
-        masked_request.set_do_not_care_scapy(scapy.IP, "options")
-
-        masked_request.set_do_not_care_scapy(scapy.UDP, "chksum")
-        masked_request.set_do_not_care_scapy(scapy.UDP, "len")
-
-        masked_request.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_request.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_request.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        request_count = testutils.count_matched_packets_all_ports(
-            self, masked_request, self.server_port_indices)
-        return request_count
-
-    def runTest(self):
-        self.client_send_request_stress(self.dest_mac_address, self.client_udp_src_port)
-        request_cnt = self.count_relayed_request()
-
-        # At the end of the test, overwrite the file with request count.
-        try:
-            with open('/tmp/dhcp_stress_test_request.json', 'w') as result_file:
-                result_file.write(str(request_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the request file: %s", repr(e))
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = [self.client_port_index]
+        self.send_port_indices = self.server_port_indices
+        self.create_packet = self.create_dhcp_offer_packet
+        self.packet_type = "offer"
+        self.packet_type_hex = "02"
 
 
-class DHCPStressAckTest(DHCPTest):
-    def __init__(self):
-        DHCPTest.__init__(self)
-
+class DHCPStressRequestTest(DHCPStressTest):
     def setUp(self):
-        DHCPTest.setUp(self)
-        self.packets_send_duration = self.test_params["packets_send_duration"]
-        self.client_packets_per_sec = self.test_params["client_packets_per_sec"]
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = self.server_port_indices
+        self.send_port_indices = [self.client_port_index]
+        self.create_packet = self.create_dhcp_request_packet
+        self.packet_type = "request"
+        self.packet_type_hex = "03"
 
-    # Simulate client coming on VLAN and broadcasting a DHCPACK message
-    def client_send_ack_stress(self):
-        dhcp_ack = self.create_dhcp_ack_packet()
-        end_time = time.time() + self.packets_send_duration
-        xid = 0
-        while time.time() < end_time:
-            # Set a unique transaction ID for each DHCPACK packet for making sure no packet miss
-            dhcp_ack[scapy.BOOTP].xid = xid
-            xid += 1
-            testutils.send_packet(self, self.server_port_indices[0], dhcp_ack)
-            time.sleep(1/self.client_packets_per_sec)
 
-    def count_relayed_ack(self):
-        # Create a packet resembling a relayed DCHPACK packet
-        dhcp_ack_relayed = self.create_dhcp_ack_relayed_packet()
-
-        # Mask off fields we don't care about matching
-        masked_ack = Mask(dhcp_ack_relayed)
-
-        masked_ack.set_do_not_care_scapy(scapy.IP, "version")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "ihl")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "tos")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "len")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "id")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "flags")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "frag")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "ttl")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "proto")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "chksum")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "options")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "src")
-        masked_ack.set_do_not_care_scapy(scapy.IP, "dst")
-
-        masked_ack.set_do_not_care_scapy(scapy.UDP, "len")
-        masked_ack.set_do_not_care_scapy(scapy.UDP, "chksum")
-
-        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "sname")
-        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "file")
-        masked_ack.set_do_not_care_scapy(scapy.BOOTP, "xid")
-
-        ack_count = testutils.count_matched_packets(self, masked_ack, self.client_port_index)
-        return ack_count
-
-    def runTest(self):
-        self.client_send_ack_stress()
-        ack_cnt = self.count_relayed_ack()
-
-        # At the end of the test, overwrite the file with ack count.
-        try:
-            with open('/tmp/dhcp_stress_test_ack.json', 'w') as result_file:
-                result_file.write(str(ack_cnt))
-        except Exception as e:
-            logger.error("Failed to write to the ack file: %s", repr(e))
+class DHCPStressAckTest(DHCPStressTest):
+    def setUp(self):
+        DHCPStressTest.setUp(self)
+        self.receive_port_indices = [self.client_port_index]
+        self.send_port_indices = self.server_port_indices
+        self.create_packet = self.create_dhcp_ack_packet
+        self.packet_type = "ack"
+        self.packet_type_hex = "05"

--- a/tests/dhcp_relay/test_dhcp_relay_stress.py
+++ b/tests/dhcp_relay/test_dhcp_relay_stress.py
@@ -140,7 +140,7 @@ def test_dhcp_relay_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_du
             "testing_mode": testing_mode,
             "kvm_support": True
         }
-        count_file = '/tmp/dhcp_stress_test_{}.json'.format(dhcp_type)
+        count_file = '/tmp/dhcp_stress_test_{}'.format(dhcp_type)
 
         def _check_count_file_exists():
             command = 'ls {} > /dev/null 2>&1 && echo exists || echo missing'.format(count_file)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

On some testbeds, we have observed around 25% packet loss with dhcp relay stress test. We have confirmed that packets were sent out of dut intf fine, but packets were dropped at 1. before reaching server and 2. after reaching server and during ptf packet capture. For large packet amounts ptfutils tends to drop packets and the amount goes up as packet amount increase. By switching using tcpdump directly, 25% packet loss can be reduced to around 10%.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This pr reduces packet loss during ptf packet capture and makes result better

#### How did you do it?
Replace ptfutils packet capture with tcpdump capture

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
