### PR TITLE
[BGP][test_bgp_session.py::test_bgp_session_interface_down] - Increase BGP Session State Timeout Window when restarting SWSS Container

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -265,9 +265,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
     pytest_assert(wait_until(120, 10, 30, duthost.critical_services_fully_started),
                   "Not all critical services are fully started")
 
-    bgp_session_wait_timeout = 120
+    timeout = 120
     if test_type == "swss_docker":
         # It may take up to 6 minutes after restarting swss for BGP sessions to be up
-        bgp_session_wait_timeout = 360
-    pytest_assert(wait_until(bgp_session_wait_timeout, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
+        timeout = 360
+    pytest_assert(wait_until(timeout, 10, 0, duthost.check_bgp_session_state, list(setup['neighhosts'].keys())),
                   "Not all BGP sessions are established on DUT")


### PR DESCRIPTION
### Description of PR
On platforms with a large number of interfaces, the time taken for SWSS and related services to come up can cause the swss_docker subset of the bgp_session tests to fail on timeout.

Increase the timeout window for checking the BGP Session state after restarting the SWSS container.

Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test_bgp_session_interface_down swss_docker tests were timing out waiting for BGP sessions to be established on the Arista-7060X6-64PE-B-C512S2 platform in the t0-isolated-d32u32s2 topology.

#### How did you do it?
Increased timeout window for the swss_docker case.

#### How did you verify/test it?
Ran test_bgp_session_interface_down tests on Arista-7060X6-64PE-B-C512S2 t0-isolated-d32u32s2 topology and confirmed all passed.

#### Any platform specific information?
Issue originally observed on Arista-7060X6-64PE-B-C512S2.