### PR TITLE
Fix interfaces stuck up on lt2-isolated after testbed setup

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -719,6 +719,14 @@
         rescue:
           - debug: msg="SOC properties may not be defined in the device config file. Skipping adjustment of SOC properties."
 
+      # golden config for lt2/ft2 modifies the PORT table. To support lt2-isolated
+      # which have some interfaces disabled, apply the minigraph config first so that
+      # golden config inherits the same admin_status settings
+      - name: Apply minigraph prior to generating golden_config_db.json
+        become: true
+        shell: config load_minigraph -y
+        when: "'lt2' in topo or 'ft2' in topo"
+
       - name: Generate golden_config_db.json
         generate_golden_config_db:
           topo_name: "{{ topo }}"


### PR DESCRIPTION
### Description of PR

On lt2/ft2 topologies, generate_golden_config_db copies and modifies the PORT table from the DUT's base config, where all interfaces are up. In lt2-isolated topologies, we want some interfaces to be disabled. This change happens inside the same PORT table, so loading the minigraph config with --override-config causes changes made by the topology to be overwritten by the Golden Config DB.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Extra interfaces have admin_status=up on lt2-isolated topologies after testbed setup, when they should have admin_status=down

#### How did you do it?

Special case lt2/ft2 to apply the topology's minigraph config before generating & applying the Golden Config DB.

#### How did you verify/test it?

Verified that lt2-isolated topology comes up with expected interface status.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
