### PR TITLE
Use systemctl restart instead of docker restart in bgp session test

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -230,9 +230,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     try:
         if test_type == "bgp_docker":
-            duthost.shell("docker restart bgp")
+            duthost.shell("systemctl restart bgp")
         elif test_type == "swss_docker":
-            duthost.shell("docker restart swss")
+            duthost.shell("systemctl restart swss")
         elif test_type == "reboot":
             # Use warm reboot for t0, cold reboot for others
             topo_name = tbinfo["topo"]["name"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Regarding image issue https://github.com/sonic-net/sonic-buildimage/issues/24669, docker restart swss has a chance to cause interface and bgp couldn't come up in 30 mins, and it's causing high failure rate in PR testing, we need to unblock it ASAP
#### How did you do it?
Use systemctl restart instead of docker restart
#### How did you verify/test it?
Tested in KVM and physical testbed
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
