### PR TITLE
[test_cont_link_flap] ignore LOCAL interface routes in test_cont_link_flap case

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1495,12 +1495,12 @@ Totals               6450                 6449
         if skip_kernel_linkdown is True:
             output = self.shell("show ip route kernel")["stdout_lines"]
             ipv4_route_kernel_skip_count = 0
-            pattern = re.compile(r'^K\s+.*directly connected.*linkdown')
+            pattern = re.compile(r'^K\s+.*directly connected')
 
             for line in output:
                 if pattern.search(line):
                     ipv4_route_kernel_skip_count += 1
-                    logging.debug("skip IPv4 route kernel for linkdown: {}".format(line))
+                    logging.debug("skip IPv4 route kernel for directly connected: {}".format(line))
 
             if ipv4_route_kernel_skip_count > 0:
                 ipv4_summary['kernel']['routes'] -= ipv4_route_kernel_skip_count
@@ -1526,12 +1526,12 @@ Totals               6450                 6449
         if skip_kernel_linkdown is True:
             output = self.shell("show ipv6 route kernel")["stdout_lines"]
             ipv6_route_kernel_skip_count = 0
-            pattern = re.compile(r'^K\s+.*directly connected.*linkdown')
+            pattern = re.compile(r'^K\s+.*directly connected')
 
             for line in output:
                 if pattern.search(line):
                     ipv6_route_kernel_skip_count += 1
-                    logging.debug("skip IPv6 route kernel for linkdown: {}".format(line))
+                    logging.debug("skip IPv6 route kernel for directly connected: {}".format(line))
 
             if ipv6_route_kernel_skip_count > 0:
                 ipv6_summary['kernel']['routes'] -= ipv6_route_kernel_skip_count

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1500,7 +1500,7 @@ Totals               6450                 6449
             for line in output:
                 if pattern.search(line):
                     ipv4_route_kernel_skip_count += 1
-                    logging.debug("skip IPv4 route kernel for directly connected: {}".format(line))
+                    logging.debug("skip IPv4 route kernel for directly connected but not selected: {}".format(line))
 
             if ipv4_route_kernel_skip_count > 0:
                 ipv4_summary['kernel']['routes'] -= ipv4_route_kernel_skip_count
@@ -1531,7 +1531,7 @@ Totals               6450                 6449
             for line in output:
                 if pattern.search(line):
                     ipv6_route_kernel_skip_count += 1
-                    logging.debug("skip IPv6 route kernel for directly connected: {}".format(line))
+                    logging.debug("skip IPv6 route kernel for directly connected but not selected: {}".format(line))
 
             if ipv6_route_kernel_skip_count > 0:
                 ipv6_summary['kernel']['routes'] -= ipv6_route_kernel_skip_count


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
36045376

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The case is flaky

#### How did you do it?
Ignore the local interface routers in the case

#### How did you verify/test it?
PR test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
