### PR TITLE
[bgp] change docker restart to systemctl restart

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -230,9 +230,9 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
 
     try:
         if test_type == "bgp_docker":
-            duthost.shell("docker restart bgp")
+            duthost.shell("systemctl restart bgp")
         elif test_type == "swss_docker":
-            duthost.shell("docker restart swss")
+            duthost.shell("systemctl restart swss")
         elif test_type == "reboot":
             # Use warm reboot for t0, cold reboot for others
             topo_name = tbinfo["topo"]["name"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Replace the docker restart command with the systemctl restart command as it is better supported, faster and more stable. Also in other places when there is comment saying docker restart it almost always mean systemctl restart.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
docker restart bgp/swss has shown to fail sometimes on some platforms

#### How did you do it?
Replace the command

#### How did you verify/test it?
Run the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
