### PR TITLE
Adapt the fixture duthost_mgmt_ip on dual tor setup

### DIFF
--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -883,11 +883,12 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
 
 
 @pytest.fixture(scope="module")
-def duthost_mgmt_ip(duthost):
+def duthost_mgmt_ip(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     Gets the management IP address (v4 or v6) on eth0.
     Defaults to IPv4 on a dual stack configuration.
     """
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
     ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The fixture duthost_mgmt_ip introduced in PR https://github.com/sonic-net/sonic-mgmt/pull/20942 does not support on dual tor setup
Enhance it to support it on dual tor setup

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The fixture duthost_mgmt_ip introduced in PR https://github.com/sonic-net/sonic-mgmt/pull/20942 does not support on dual tor setup
#### How did you do it?
Enhance it to support it on dual tor setup
#### How did you verify/test it?
Run pass on local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
