### PR TITLE
Fix test_fib.py test_hash failed with AssertionError 'Did not receive…

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -503,7 +503,7 @@ class HashTest(BaseTest):
         logs = self.create_packets_logs(
             src_port=src_port,
             pkt=pkt,
-            ipinip_pkt=inner_pkt,
+            ipinip_pkt=pkt,
             vxlan_pkt=pkt,
             nvgre_pkt=pkt,
             inner_pkt=inner_pkt,
@@ -736,7 +736,7 @@ class IPinIPHashTest(HashTest):
                 inner_frame=pkt[version])
             exp_pkt = ipinip_pkt.copy()
             exp_pkt['IP'].ttl -= 1
-        return pkt, exp_pkt, ipinip_pkt
+        return ipinip_pkt, exp_pkt, pkt
 
     def apply_mask_to_exp_pkt(self, masked_exp_pkt, version='IP'):
         masked_exp_pkt.set_do_not_care_scapy(scapy.Ether, "src")


### PR DESCRIPTION
… expected packet on any of ports'

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511

### Approach
#### What is the motivation for this PR?
To Fix test_fib.py test_hash failed with AssertionError 'Did not receive expected packet on any of ports'. This issue was due to packets not being properly formed by the PTF

#### How did you do it?
changes were made in ansible/roles/test/files/ptftests/py3/hash_test.py 
Modified  check_ipv4_route() where the parameters returned was of the wrong order(pkt, exp_pkt, ipinip_pkt) than expected (ip_inip_pkt, exp_pkt, pkt). 

Modified The check_ipv6_route() where it was calling create_packets_logs() and sending ipinip_pkt=inner_pkt instead of  ipinip_pkt=pkt  as the parameter

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
