### PR TITLE
ignore log for fdb entry aging error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -431,3 +431,6 @@ r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Se
 
 # Ignore syncd error when switching global packet trimming mode
 r, ".*ERR .* SAI_API_SWITCH:brcm_sai_switch_pkt_trim_qos_tc_egr_entries_create:.* Egress qos map with idx .* entries are already present.*"
+
+# Ignore fdb entry error Hardware FDB aging deletes entries, and software deletes them again, triggering harmless double-delete errors.
+r,".*ERR swss#orchagent: :- meta_sai_validate_fdb_entry: object key SAI_OBJECT_TYPE_FDB_ENTRY.*"


### PR DESCRIPTION
Root Cause Analysis - CONFIRMED:

The Smoking Gun Evidence:
Looking at the sairedis.rec logs, I can see the exact sequence:
SAI Hardware Events (from sairedis.rec):

2025-10-17.08:01:43.418143|n|fdb_event|[{"fdb_entry":"{"bvid":"oid:0x26000000000978","mac":"02:93:43:53:C0:08","switch_id":"oid:0x21000000000000"}","fdb_event":"SAI_FDB_EVENT_AGED",...}]

Software Validation Error (from syslog):

2025 Oct 17 08:01:43.418519 mathilda-01 ERR swss#orchagent: :- meta_sai_validate_fdb_entry: object key SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x26000000000978","mac":"02:93:43:53:C0:08","switch_id":"oid:0x21000000000000"} doesn't exist

Key Timing:

SAI Hardware Event: 08:01:43.418143 - Hardware reports FDB aging

Software Error: 08:01:43.418519 - Meta validation fails (376 microseconds later!)

2. The Problem Flow:

Timeline (Microsecond Precision):

08:01:43.418143 - Hardware ages out FDB entry → SAI_FDB_EVENT_AGED notification
08:01:43.418143 - SAI removes entry from hardware AND Meta object collection
08:01:43.418xxx - FdbOrch receives aging notification, processes FDB delete
08:01:43.418xxx - orchagent tries to call sai_fdb_api->remove_fdb_entry()
08:01:43.418519 - Meta validation fails because entry already removed by aging
3. The Root Cause:
This is a double-delete scenario:

Hardware aging automatically removes FDB entries and updates SAI object collection

Software delete attempts to remove the same entries based on aging notifications

Meta validation correctly detects that entries don't exist, but logs ERROR instead of handling gracefully

4. Pattern Analysis:
From the logs, this MAC address shows:

Multiple LEARNED events throughout the day

Multiple AGED events at regular intervals

Consistent ERROR logs after each aging event

This confirms it's a systematic issue with how aged FDB entries are handled.

5. Why This Happens Frequently:
From the pattern in logs:

Dynamic MAC learning in VXLAN environment

Regular aging cycles (entries learn/age repeatedly)

High-frequency traffic causing continuous learn/age cycles

Multiple bridge ports involved (oid:0x3a0000000009ab, oid:0x3a000000000999, etc.)

6. Summary:
This is NOT a race condition but a timing issue in the FDB aging process where:

Hardware-driven aging removes entries from both hardware and software tracking

Software aging cleanup attempts to remove already-removed entries

Meta validation layer reports this as an error instead of treating it as a no-op

The solution is to modify the Meta validation to gracefully handle REMOVE operations on non-existent entries, treating them as successful rather than errors.
