### PR TITLE
Fix pytest import failure caused by optional OTLP type annotations

### DIFF
--- a/tests/common/telemetry/reporters/ts_reporter.py
+++ b/tests/common/telemetry/reporters/ts_reporter.py
@@ -111,7 +111,7 @@ class TSReporter(Reporter):
         else:
             self._export_metrics(metrics_data)
 
-    def _create_metrics_data(self, timestamp: float) -> Optional[MetricsData]:
+    def _create_metrics_data(self, timestamp: float) -> Optional["MetricsData"]:
         """
         Create MetricsData using SDK objects from current measurements.
 
@@ -168,7 +168,7 @@ class TSReporter(Reporter):
 
         return MetricsData(resource_metrics=[resource_metrics])
 
-    def _create_resource(self) -> Resource:
+    def _create_resource(self) -> "Resource":
         """
         Create SDK Resource with attributes.
         """
@@ -182,7 +182,7 @@ class TSReporter(Reporter):
         return Resource.create(all_attrs)
 
     def _create_sdk_metric(self, metric, records: List[MetricRecord],
-                           timestamp: float) -> Optional[Metric]:
+                           timestamp: float) -> Optional["Metric"]:
         """
         Create SDK Metric from metric records.
 
@@ -246,7 +246,7 @@ class TSReporter(Reporter):
         else:
             return None
 
-    def _export_metrics(self, metrics_data: MetricsData):
+    def _export_metrics(self, metrics_data: "MetricsData"):
         """
         Export MetricsData using the configured OTLP exporter.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Pytest collection fails with a NameError when importing TSReporter in environments where OpenTelemetry is not installed.
This happens because MetricsData is imported conditionally but referenced directly in function type annotations, which are evaluated at import time. As a result, tests cannot be collected even though OTLP is meant to be optional.
<img width="906" height="222" alt="image" src="https://github.com/user-attachments/assets/d2514093-694f-4ef4-9c4a-9d6f5489c998" />
#### How did you do it?
Replaced direct references to optional OpenTelemetry types in function annotations with forward-referenced (string-based) annotations, preventing runtime evaluation during module import while preserving existing behavior.
#### How did you verify/test it?
Verified in PR test and nightly test
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
