### PR TITLE
Updated test_pfc_pause.py to exhaust egress buffer during congestion

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/pfc_pause_test.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_pause_test.py
@@ -78,6 +78,7 @@ class PfcPauseTest(BaseTest):
         tos_bg = self.dscp_bg << 2
 
         pkt_args = {
+            'pktlen' : 1500,
             'eth_dst': self.mac_dst,
             'eth_src': self.mac_src,
             'ip_src': self.ip_src,
@@ -94,6 +95,7 @@ class PfcPauseTest(BaseTest):
         pkt = simple_udp_packet(**pkt_args)
 
         pkt_bg_args = {
+            'pktlen' : 1500,
             'eth_dst': self.mac_dst,
             'eth_src': self.mac_src,
             'ip_src': self.ip_src,
@@ -110,6 +112,7 @@ class PfcPauseTest(BaseTest):
         pkt_bg = simple_udp_packet(**pkt_bg_args)
 
         exp_pkt_args = {
+            'pktlen' : 1500,
             'ip_src': self.ip_src,
             'ip_dst': self.ip_dst,
             'ip_tos': tos_bg,

--- a/tests/qos/test_pfc_pause.py
+++ b/tests/qos/test_pfc_pause.py
@@ -36,8 +36,8 @@ PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 PFC_PKT_COUNT = 1000000000
 
 PTF_FILE_REMOTE_PATH = '~/ptftests/py3/pfc_pause_test.py'
-PTF_PKT_COUNT = 20
-PTF_PKT_INTVL_SEC = 0.1
+PTF_PKT_COUNT = 5000
+PTF_PKT_INTVL_SEC = 0.01
 PTF_PASS_RATIO_THRESH = 0.6
 
 """ Maximum number of interfaces to test on a DUT """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This test change is to simulate egress buffer exhaustion for a {port, priority} to see if it impacts other priorities.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
