### PR TITLE
Add gNOI File.TransferToRemote functional test (HTTP download via PTF server)

### DIFF
--- a/tests/gnmi/test_gnoi_file.py
+++ b/tests/gnmi/test_gnoi_file.py
@@ -47,7 +47,7 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
         # 3. Wait for HTTP server to start
         ptf_ip = ptfhost.mgmt_ip
         logger.info(f"Waiting for HTTP server to start at {ptf_ip}:{http_port}")
-        
+
         def server_ready():
             try:
                 result = ptfhost.command(f"curl -f --max-time 2 {ptf_ip}:{http_port}",
@@ -95,4 +95,3 @@ def test_file_transfer_to_remote(gnmi_tls, ptfhost, duthosts, rand_one_dut_hostn
             logger.info("Cleanup completed")
         except Exception as cleanup_e:
             logger.warning(f"Cleanup failed: {cleanup_e}")
-            


### PR DESCRIPTION
### Description of PR

Summary:
- Add a new gNOI file service test `test_file_transfer_to_remote` to validate `File.TransferToRemote` using an HTTP server hosted on the PTF.
- The test creates a temporary file on the PTF, serves it over HTTP, triggers TransferToRemote to download it onto the DUT, and verifies response hash, file existence, and content.
- Includes readiness wait for the HTTP server and cleanup of server/process and temporary files on both PTF and DUT.

Fixes # (issue)
- Fixes #<ADD_ISSUE_NUMBER_IF_APPLICABLE>

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Add coverage for gNOI `File.TransferToRemote` to confirm basic end-to-end behavior (remote HTTP fetch -> file on DUT) and provide a reproducible functional test using existing test infrastructure (PTF + DUT).

#### How did you do it?
- Implemented `test_file_transfer_to_remote` in `tests/gnmi/test_gnoi_file.py`.
- Start a simple HTTP server (`python -m http.server`) on the PTF host to serve a temporary test file.
- Use `wait_until` to confirm the server is reachable before issuing the RPC.
- Call `gnmi_tls.gnoi.file_transfer_to_remote()` to download to `/tmp/test.txt` on the DUT and validate:
  - RPC response contains `hash`
  - downloaded file exists on DUT
  - downloaded content matches expected
- Ensure cleanup: stop HTTP server on PTF and remove temporary files from both PTF and DUT.

#### How did you verify/test it?
- Ran the test on a setup with PTF + DUT available.
- Confirmed the HTTP server comes up and TransferToRemote downloads the file to the DUT with correct content.
- CI results: <ADD_LINK_OR_JOB_OUTPUT_IF_AVAILABLE>

#### Any platform specific information?
- Requires connectivity from DUT to the PTF management IP on TCP/8080 (or whatever port is used).
- If `File.TransferToRemote` is not implemented, the test logs a warning (current behavior).

#### Supported testbed topology if it's a new test case?
- Any topology with PTF host accessible from DUT mgmt network (HTTP reachability).

### Documentation
- N/A