### PR TITLE
Skip test_monitor_config on VS T1 multi-ASIC

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml
@@ -183,6 +183,11 @@ generic_config_updater/test_mmu_dynamic_threshold_config_update.py:
     conditions:
     - asic_type in ['vs'] and 't1-8-lag' in topo_name
     reason: This test case either cannot pass or should be skipped on virtual chassis
+generic_config_updater/test_monitor_config.py:
+  skip:
+    conditions:
+    - asic_type in ['vs'] and 't1-8-lag' in topo_name
+    reason: This test case either cannot pass or should be skipped on virtual chassis
 generic_config_updater/test_packet_trimming_config_asymmetric.py:
   skip:
     conditions:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip `generic_config_updater/test_monitor_config.py` on VS T1 multi-ASIC topologies.
Reason: This test either cannot pass or should be skipped on virtual chassis.

Fixes issue: N/A (or reference internal tracking if applicable)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework (improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Some test cases fail or are not relevant on virtual chassis with VS T1 multi-ASIC topology. Skipping them avoids false negatives in automated test runs.

#### How did you do it?
Added a skip condition in `tests/common/plugins/conditional_mark/tests_mark_conditions_vs_t1_multiasic.yaml`:

```yaml
generic_config_updater/test_monitor_config.py:
  skip:
    conditions:
    - asic_type in ['vs'] and 't1-8-lag' in topo_name
    reason: This test case either cannot pass or should be skipped on virtual chassis
