### PR TITLE
[Snappi] Fix issue to additionally use peer duthost-name to select right snappi_port

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -341,7 +341,7 @@ def __portchannel_intf_config(config, port_config_list, duthost, snappi_ports):
         v4_entry = next((e for e in entries if __valid_ipv4_addr(e['addr'])), None)
         v6_entry = next((e for e in entries if not __valid_ipv4_addr(e['addr'])), None)
 
-        # Added fix to select member_port_id based on peer_port and peer_dut
+        # Added fix to select member_port_id based on peer_port and peer_dut.
         member_port_ids = [
             int(sp['port_id'])
             for sp in (snappi_ports)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Snappi has infra file snappi_fixtures.py and function setup_dut_ports to populate port_config_list for selecting right Rx and Tx ports for the test.

It iterates through the VLAN interfaces, Portchannels, L3 interfaces in that order to select the ports. However, in port-channel and l3_interfaces, it goes through the snappi_ports only based on the names (say Ethernet144) to select the ports.

This is an issue if test has two or more LCs with same port names in the test. Example - LC1 has Ethernet144 and so does LC2.

In this case, a code like this, will cause same port to be selected:
 member_port_ids = [i for i, sp in enumerate(snappi_ports) for m in members if sp['peer_port'] == m]

The snappi_ports will have LC1-Ethernet144 and LC2-Ethernet144, causing member_port_ids to match ONLY the first port-name Ethernet144 of LC1 everytime. 

This PR addresses the issue by checking dut-hostname as well, thus ensuring that same port does not get selected twice.

Fixes are present in function - __portchannel_intf_config and __l3_intf_config.

Summary:
Fixes #21734 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The selection of same port on two different LCs will cause same snappi_port to be selected every time as Rx and Tx. 

#### How did you do it?
Included duthost.hostname + peer_port to be used as key instead of just peer_port.

In this case, the right port from different DUT will be selected, even though port-names are same.

#### How did you verify/test it?
Ran the test locally to determine the fix.

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
