### PR TITLE
Modify ntpd conf to prevent socket exhaustion

### DIFF
--- a/tests/common/helpers/ntp_helper.py
+++ b/tests/common/helpers/ntp_helper.py
@@ -27,6 +27,8 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
     elif ntp_daemon_type == NtpDaemon.NTP:
         ntp_conf_path = '/etc/ntp.conf'
         ntp_service_name = 'ntp'
+
+    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         # Limit listening to the mgmt interface, to prevent socket allocation
         # exhaustion
         ptfhost.lineinfile(path=ntp_conf_path, line="interface ignore wildcard")
@@ -98,7 +100,7 @@ def setup_ntp_context(ptfhost, duthost, ptf_use_ipv6):
 
     ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^server.*127.127.1.0.*prefer")
 
-    if ntp_daemon_type == NtpDaemon.NTP:
+    if ntp_daemon_type in (NtpDaemon.NTPSEC, NtpDaemon.NTP):
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.ignore.wildcard")
         ptfhost.lineinfile(path=ntp_conf_path, line="", regexp="^interface.listen.mgmt")
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When running ntpd on the ptf_ardut container as a part of ntp testing, modify the config to ignore all interfaces except mgmt.

It was found while developing multi-vrf that it is possible at scale to run out of sockets for ntp, which prevents the service from starting correctly.  Listening on the mgmt interface only allows the test to run ntp from the ptf_ardut container to the dut correctly, and ntp tests pass.

Summary:
Fixes #21748

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The original issue leading to this change was found as part of development of cEOSLab peer container convergence (multi-vrf), and was preventing any ntp tests from fully running on a testbed with multi-vrf enabled.

#### How did you do it?
We identified ntp as running to the dut from the ptf_ardut container over the mgmt interface of the container, and changed config to restrict ntp to listen only on this interface.

#### How did you verify/test it?
All ntp tests were run on a t1 testbed: on a run including the multi-vrf feature the fix allowed ntpd to start and all tests to pass.  All tests passed when run on the same testbed without the multi-vrf feature as well.

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A
