### PR TITLE
Restore ansible/group_vars/vm_host/creds.yml and remove from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ sonic-dump/
 **/common/sai_validation/github.com/
 tests/pfc_headroom_test_params/*.json
 tests/priority/*.json
-ansible/group_vars/vm_host/creds.yml

--- a/ansible/group_vars/vm_host/creds.yml
+++ b/ansible/group_vars/vm_host/creds.yml
@@ -1,0 +1,10 @@
+---
+ansible_user: use_own_value
+ansible_password: use_own_value
+ansible_become_password: use_own_value
+
+# Use the following username/password variables to login to vm hosts
+# instead of the default variables (defined above).
+vm_host_user: use_own_value
+vm_host_password: use_own_value
+vm_host_become_password: use_own_value


### PR DESCRIPTION
The file was incorrectly deleted and added to .gitignore in commit 23b6935ef. This commit restores the file with placeholder values and removes it from .gitignore so it can be properly tracked in the repository.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
