### PR TITLE
[202511] Update for dhcp and lag tests

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -424,4 +424,4 @@ r, ".*ERR pmon.*Failed to unfreeze VDM stats in contextmanager for port.*"
 r, ".*ERR bgp\#bgpmon:\s+\*ERROR\*\s+Failed\s+with\s+rc:\d+\s+when\s+execute:\s+.*vtysh.*-c.*show\s+bgp\s+summary\s+json.*"
 
 # Ignore systemd-networkd.socket not being able to be started. This is expected on non-DPU platforms.
-r, ".*ERR systemd[1]: Failed to listen on systemd-networkd.socket - Network Service Netlink Socket.*"
+r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Service Netlink Socket.*"

--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -78,7 +78,14 @@ def ignore_expected_loganalyzer_exceptions(duthosts, selected_dut_hostname, loga
     if loganalyzer:
         ignoreRegex = [
             ".*ERR sonic_yang.*",
-            ".*ERR.*Failed to start dhcp_relay.service - dhcp_relay container.*",  # Valid test_dhcp_relay for Bookworm
+
+            # Valid test_dhcp_relay for Bookworm and newer
+            ".*ERR.*Failed to start dhcp_relay.service - dhcp_relay container.*",
+            ".*ERR GenericConfigUpdater:.*Command failed: 'nsenter --target 1"
+            ".*systemctl restart dhcp_relay', returncode: 1",
+            ".*ERR GenericConfigUpdater:.*stderr: Job for dhcp_relay.service "
+            "failed because start of the service was attempted too often.",
+
             ".*ERR.*Failed to start dhcp_relay container.*",  # Valid test_dhcp_relay
             # Valid test_dhcp_relay test_syslog
             ".*ERR GenericConfigUpdater: Service Validator: Service has been reset.*",


### PR DESCRIPTION
Cherry-pick of #21499

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Update the loganalyzer ignore list to fix a regex issue, and update the GCU test to ignore new error syslogs.

The regex for ignoring systemd-networkd.socket failing to start included [1], which has a special meaning when interpreted as regex (match one character that has 1 in it; in other words, match a 1). Escape the brackets so that they get treated literally.

sonic-net/sonic-utilities#4105 started logging errors when a GCU command fails with a non-zero exit status. However, there is one case of a (known) failure where dhcp_relay fails to restart because it hit the start limit. These error logs need to be ignored.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
