### PR TITLE
Fix test_configurable_drop_counters.py for v6 topos

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -1044,13 +1044,6 @@ drop_packets:
     conditions:
       - "topo_type in ['m0', 'mx']"
 
-drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
-  xfail:
-    reason: "xfail for IPv6-only topologies, issue with python max size"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/19920 and '-v6-' in topo_name"
-
-
 drop_packets/test_drop_counters.py:
   xfail:
     reason: "xfail for scale topology, PTF is not stable at the scale testbed"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -5,13 +5,14 @@
 #Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
 drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
   skip:
-    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some mlx platforms does not drop DIP link local packets / KVM do not support drop reason in testcase."
+    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some mlx platforms does not drop DIP link local packets / KVM do not support drop reason in testcase / IPv6 DIP_LINK_LOCAL drop reason not supported on broadcom."
     conditions_logical_operator: or
     conditions:
       - "'Mellanox' in hwsku"
       - asic_type=='cisco-8000'
       - "topo_type in ['m0', 'mx']"
       - "asic_type in ['vs']"
+      - "asic_type in ['broadcom'] and '-v6-' in topo_name"
 
 drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
   skip:
@@ -23,13 +24,14 @@ drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
 
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:
-    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some MLX platforms does not drop SIP link local packets / KVM do not support drop reason in testcase."
+    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some MLX platforms does not drop SIP link local packets / KVM do not support drop reason in testcase / IPv6 DIP_LINK_LOCAL drop reason not supported on broadcom."
     conditions_logical_operator: or
     conditions:
       - asic_type=="cisco-8000"
       - "'Mellanox' in hwsku"
       - "topo_type in ['m0', 'mx']"
       - "asic_type in ['vs']"
+      - "asic_type in ['broadcom'] and '-v6-' in topo_name"
 
 #######################################
 #####     test_drop_counters.py   #####


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test_neighbor_link_down for v6 topo and remove xfail
Fix test_dip_link_local and test_sip_link_local for v6 topo, but skip them for Broadcom Asics because they don't support DIP_LINK_LOCAL/SIP_LINK_LOCAL drop reasons for IPv6 packets
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
test_configurable_drop_counters.py failed on v6 topos

#### How did you do it?
Fix test cases for V6 topos, and skip test_dip_link_local/test_sip_link_local for V6 topo with Broadcom Asics

#### How did you verify/test it?
test_neighbor_link_down passed on V6 topos and test_dip_link_local/test_sip_link_local are skipped on V6 topos with Broadcom Asics

#### Any platform specific information?
Broadcom Asics don't support DIP_LINK_LOCAL/SIP_LINK_LOCAL drop reasons for IPv6 packets

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
