### PR TITLE
Fix test_bgp_bounce.py for v6 topos

### DIFF
--- a/tests/bgp/templates/bgp_no_export.j2
+++ b/tests/bgp/templates/bgp_no_export.j2
@@ -23,6 +23,9 @@ enable password zebra
 route-map TO_TIER0_V4 permit 50
  set community no-export additive
 !
+route-map TO_TIER0_V6 permit 50
+ set community no-export additive
+!
 {% endif %}
 route-map FROM_BGP_SPEAKER_V4 permit 10
 !
@@ -92,6 +95,13 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   address-family ipv6
     neighbor {{ neighbor_addr }} activate
     maximum-paths 64
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
+ {%- if 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] %}
+    neighbor {{ neighbor_addr }} route-map TO_TIER0_V6 out
+    neighbor {{ neighbor_addr }} send-community
+    neighbor {{ neighbor_addr }} allowas-in 1
+ {% endif %}
+{% endif %}
   exit-address-family
 {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Check IPv6 no-export community with IPv6 VM commands for v6 topos
Add IPv6 route-map to bgp_no_export.j2 template
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_bgp_bounce.py failed on v6 topos

#### How did you do it?
Modify the test to do IPv6 version checks for v6 topos 

#### How did you verify/test it?
The test passed on v6 topos

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
