### PR TITLE
Fix router_type for C0 VMs in m1-108 topo file

### DIFF
--- a/ansible/vars/topo_m1-108.yml
+++ b/ansible/vars/topo_m1-108.yml
@@ -462,7 +462,7 @@ configuration:
   ARISTA01C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -483,7 +483,7 @@ configuration:
   ARISTA02C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -504,7 +504,7 @@ configuration:
   ARISTA03C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -525,7 +525,7 @@ configuration:
   ARISTA04C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -546,7 +546,7 @@ configuration:
   ARISTA05C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -567,7 +567,7 @@ configuration:
   ARISTA06C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -588,7 +588,7 @@ configuration:
   ARISTA07C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:
@@ -609,7 +609,7 @@ configuration:
   ARISTA08C0:
     properties:
     - common
-    - m0
+    - c0
     bgp:
       asn: 64900
       peers:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
C0 router_type was M0, which caused announce_routes.py to announce downstream routes to C0 VMs.
Hardcoded DOWNSTREAM_DST_IP in test_acl.py was covered by it, so test packets were forwarded to C0 instead of M0 and failed the test.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Wrong router_type for C0 VMs in m1-108 topo file, and it caused test_acl.py to fail

#### How did you do it?
Correct the router_type

#### How did you verify/test it?
test_acl.py passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
