### PR TITLE
[Smartswitch] Stabilize test cases in test_reload_dpu.py

### DIFF
--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -736,7 +736,8 @@ def ssh_connection_with_retry(localhost, host_ip, port, delay, timeout):
         'search_regex': SONIC_SSH_REGEX
     }
     short_timeout = 40
-    params_to_update_list = [{}, {'search_regex': None, 'timeout': short_timeout}]
+    short_delay = 10
+    params_to_update_list = [{}, {'search_regex': None, 'timeout': short_timeout, 'delay': short_delay}]
     for num_try, params_to_update in enumerate(params_to_update_list):
         iter_connection_params = default_connection_params.copy()
         iter_connection_params.update(params_to_update)

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -24,7 +24,7 @@ pytestmark = [
 kernel_panic_cmd = "sudo nohup bash -c 'sleep 5 && echo c > /proc/sysrq-trigger' &"
 memory_exhaustion_cmd = "sudo nohup bash -c 'sleep 5 && tail /dev/zero' &"
 DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
-DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 100
+DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
 MAX_COOL_OFF_TIME = 300
 
 
@@ -121,8 +121,7 @@ def test_dpu_status_post_switch_mem_exhaustion(duthosts, dpuhosts,
                        state='absent',
                        search_regex=SONIC_SSH_REGEX,
                        delay=10,
-                       timeout=DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION,
-                       module_ignore_errors=True)
+                       timeout=DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION)
 
     logging.info("Executing post test check")
     post_test_switch_check(duthost, localhost,
@@ -164,8 +163,7 @@ def test_dpu_status_post_switch_kernel_panic(duthosts, dpuhosts,
                        state='absent',
                        search_regex=SONIC_SSH_REGEX,
                        delay=10,
-                       timeout=DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC,
-                       module_ignore_errors=True)
+                       timeout=DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC)
 
     logging.info("Executing post test check")
     post_test_switch_check(duthost, localhost,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Enhancement is for the switch memory exhaustion and kernel panic test cases.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Stabilize test cases as they sometimes fails due to test issue:
test_dpu_status_post_switch_mem_exhaustion
test_dpu_status_post_switch_kernel_panic
 
#### How did you do it?
1. Increase DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION as it takes time to exhaust the memory.
2. Fail the test if the wait_for ssh shutdown fails.
3. Use a shorter retry delay in the common method ssh_connection_with_retry. The check happens after the delay, if the delay is bigger than the timeout, this wait_for always fails. See ansible document:
https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/wait_for_module.html.

#### How did you verify/test it?
Run the tests on SN4280 testbed, all passed.
#### Any platform specific information?
Only for smartswitch
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
