### PR TITLE
[Ondatra] testhelper: Added support to save data to artifacts.

### DIFF
--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/config_convergence.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/config_convergence.go
@@ -23,11 +23,8 @@ import (
 )
 
 const (
-	configConvergenceTimeout      = 2 * time.Minute
 	configConvergencePollInterval = 30 * time.Second
-	switchStateTimeout            = 2 * time.Minute
 	switchStatePollInterval       = 10 * time.Second
-	portsUpTimeout                = 2 * time.Minute
 )
 
 // configStateDiffReporter is a custom diff reporter for comparing
@@ -184,8 +181,6 @@ func WaitForConfigConvergence(ctx context.Context, t *testing.T, dut *ondatra.DU
 	if config == nil {
 		return errors.New("nil config passed to WaitForConfigConvergence()")
 	}
-	ctx, cancel := context.WithTimeout(ctx, configConvergenceTimeout)
-	defer cancel()
 	dutName := dut.Name()
 	// Poll until the config and state are similar.
 	return poll(ctx, configConvergencePollInterval, func() pollStatus {
@@ -254,9 +249,6 @@ func WaitForAllPortsUp(ctx context.Context, t *testing.T, dut *ondatra.DUTDevice
 	if err != nil {
 		return fmt.Errorf("unable to get ygNMI client, err: %v", err)
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, portsUpTimeout)
-	defer cancel()
 
 	allInterfaces, err := ygnmi.GetAll(ctx, yc, gnmi.OC().InterfaceAny().Name().Config())
 	if err != nil {
@@ -345,8 +337,6 @@ func WaitForSwitchState(ctx context.Context, t *testing.T, dut *ondatra.DUTDevic
 	dutName := dut.Name()
 	log.InfoContextf(ctx, "Polling for switch state to be ready for dut: %v", dutName)
 	switchState := down
-	ctx, cancel := context.WithTimeout(ctx, switchStateTimeout)
-	defer cancel()
 
 	// Poll until the switch is ready or the context is done.
 	err := poll(ctx, switchStatePollInterval, func() pollStatus {

--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/platform_components.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/platform_components.go
@@ -453,6 +453,7 @@ func (p PCIeInfo) GetName() string {
 
 // PcieInfoForDevice returns information about all PCIe devices.
 func PcieInfoForDevice(t *testing.T, d *ondatra.DUTDevice) ([]PCIeInfo, error) {
+
 	info, err := platformInfoForDevice(t, d)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch platform specific information")

--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/results.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/results.go
@@ -1,8 +1,56 @@
 package testhelper
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
 	"testing"
+
+	log "github.com/golang/glog"
 )
+
+var (
+	writeToFile = func(filePath string, result string) error {
+		return os.WriteFile(filePath, []byte(result), 0644)
+	}
+	getFromEnv = func(varName string) string {
+		return os.Getenv(varName)
+	}
+)
+
+// ArtifactAbsPath returns the absolute path for a file in the artifact directory.
+func ArtifactAbsPath(fileName string) (string, error) {
+	outputDirPath := "TEST_UNDECLARED_OUTPUTS_DIR"
+	outputDir := getFromEnv(outputDirPath)
+	if outputDir == "" {
+		return "", fmt.Errorf("undeclared TEST_UNDECLARED_OUTPUTS_DIR in env, expected to be set")
+	}
+	return path.Join(outputDir, fileName), nil
+}
+
+// SaveToArtifact saves the given data to the artifact directory.
+func SaveToArtifact(data, fp string) error {
+	if fp == "" {
+		return fmt.Errorf("file path is empty")
+	}
+	baseDir, err := ArtifactAbsPath("")
+	if err != nil {
+		return err
+	}
+	a := path.Join(baseDir, fp)
+	if !strings.HasPrefix(a, baseDir) {
+		return fmt.Errorf("file path %v is not inside artifact directory %v", fp, baseDir)
+	}
+	if err := os.MkdirAll(path.Dir(a), 0755); err != nil {
+		return err
+	}
+	log.Infof("Saving to path: %s", a)
+	if err := writeToFile(a, data); err != nil {
+		return err
+	}
+	return nil
+}
 
 // Teardown performs the teardown routine after the test completion.
 func (o TearDownOptions) Teardown(t *testing.T) {

--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/testhelper.go
@@ -20,8 +20,6 @@ import (
 
 var pph portPmdHandler
 
-var dutModelName string
-
 // Function pointers that interact with the switch. They enable unit testing
 // of methods that interact with the switch.
 var (

--- a/sdn_tests/pins_ondatra/tests/thinkit/arriba_test.cc
+++ b/sdn_tests/pins_ondatra/tests/thinkit/arriba_test.cc
@@ -1,6 +1,7 @@
 #include "tests/forwarding/arriba_test.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -19,6 +20,39 @@ ABSL_FLAG(std::vector<std::string>, arriba_test_vector_files, {},
 
 namespace pins_test {
 namespace {
+
+// Unsolicited packets that, for the time being, are acceptable in a PINS
+// testbeds.
+inline bool AlpineIsExpectedUnsolicitedPacket(const packetlib::Packet& packet) {
+  if (packet.headers().size() == 3 &&
+      packet.headers(2).icmp_header().type() == "0x85") {
+    return true;
+  }
+  // TODO Switch generates IPV6 hop_by_hop packets.
+  if (packet.headers().size() == 2 &&
+      packet.headers(1).ipv6_header().next_header() == "0x00") {
+    return true;
+  }
+  // Switch generates LACP packets if LAGs are present.
+  if (packet.headers().size() == 1 &&
+      packet.headers(0).ethernet_header().ethertype() == "0x8809") {
+    return true;
+  }
+  // Alpine's deployment environment sends ARP packets.
+  if (!packet.headers().empty() &&
+      packet.headers(0).ethernet_header().ethertype() == "0x0806") {
+    LOG(INFO) << "ALPINE: ARP packet";
+    return true;
+  }
+  // Extension to VLAN tagged ARP packets.
+  if (packet.headers().size() > 1 &&
+      packet.headers(0).ethernet_header().ethertype() == "0x8100" &&
+      packet.headers(1).vlan_header().ethertype() == "0x0806") {
+    LOG(INFO) << "ALPINE: VLAN tagged ARP packet";
+    return true;
+  }
+  return false;
+}
 
 // Returns one test instance per test vector textproto file provided through the
 // `--arriba_test_vector_files` flag.


### PR DESCRIPTION
Keyword_check:
sonic-mgmt/sdn_tests/pins_ondatra$ ~/tools/keyword_checks.sh .
Keyword check Passed.


Build Result:
~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build ...
INFO: Analyzed 44 targets (0 packages loaded, 0 targets configured).
INFO: Found 44 targets...
INFO: Elapsed time: 8.429s, Critical Path: 8.18s
INFO: 26 processes: 1 internal, 25 linux-sandbox.
INFO: Build completed successfully, 26 total actions

/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:cthinkit
INFO: Analyzed target //infrastructure/thinkit:cthinkit (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:cthinkit up-to-date:
  bazel-bin/infrastructure/thinkit/libcthinkit.a
  bazel-bin/infrastructure/thinkit/libcthinkit.so
INFO: Elapsed time: 0.258s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_generic_testbed
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed up-to-date (nothing to build)
INFO: Elapsed time: 0.254s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_generic_testbed_fixture
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture up-to-date:
  bazel-bin/infrastructure/thinkit/libondatra_generic_testbed_fixture.a
  bazel-bin/infrastructure/thinkit/libondatra_generic_testbed_fixture.so
INFO: Elapsed time: 0.226s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_generic_testbed_fixture_test
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test up-to-date:
  bazel-bin/infrastructure/thinkit/ondatra_generic_testbed_fixture_test
INFO: Elapsed time: 0.227s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_mirror_testbed
INFO: Analyzed target //infrastructure/thinkit:ondatra_mirror_testbed (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_mirror_testbed up-to-date (nothing to build)
INFO: Elapsed time: 0.229s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_mirror_testbed_fixture
INFO: Analyzed target //infrastructure/thinkit:ondatra_mirror_testbed_fixture (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_mirror_testbed_fixture up-to-date:
  bazel-bin/infrastructure/thinkit/libondatra_mirror_testbed_fixture.a
  bazel-bin/infrastructure/thinkit/libondatra_mirror_testbed_fixture.so
INFO: Elapsed time: 0.255s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_params
INFO: Analyzed target //infrastructure/thinkit:ondatra_params (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_params up-to-date:
  bazel-bin/infrastructure/thinkit/libondatra_params.a
  bazel-bin/infrastructure/thinkit/libondatra_params.so
INFO: Elapsed time: 0.240s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //infrastructure/thinkit:ondatra_params_test 
INFO: Analyzed target //infrastructure/thinkit:ondatra_params_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_params_test up-to-date:
  bazel-bin/infrastructure/thinkit/ondatra_params_test
INFO: Elapsed time: 0.226s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:random_blackbox_events_test
INFO: Analyzed target //tests/thinkit:random_blackbox_events_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:random_blackbox_events_test up-to-date:
  bazel-bin/tests/thinkit/random_blackbox_events_test
INFO: Elapsed time: 3.947s, Critical Path: 3.62s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:arbitration_test
INFO: Analyzed target //tests/thinkit:arbitration_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:arbitration_test up-to-date:
  bazel-bin/tests/thinkit/arbitration_test
INFO: Elapsed time: 3.846s, Critical Path: 3.52s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:configure_mirror_testbed_test
INFO: Analyzed target //tests/thinkit:configure_mirror_testbed_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:configure_mirror_testbed_test up-to-date:
  bazel-bin/tests/thinkit/configure_mirror_testbed_test
INFO: Elapsed time: 3.670s, Critical Path: 3.37s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:arriba_test
INFO: Analyzed target //tests/thinkit:arriba_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:arriba_test up-to-date:
  bazel-bin/tests/thinkit/arriba_test
INFO: Elapsed time: 17.218s, Critical Path: 16.90s
INFO: 5 processes: 3 internal, 2 linux-sandbox.
INFO: Build completed successfully, 5 total actions

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:l3_admit_test
INFO: Analyzed target //tests/thinkit:l3_admit_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:l3_admit_test up-to-date:
  bazel-bin/tests/thinkit/l3_admit_test
INFO: Elapsed time: 2.547s, Critical Path: 2.22s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build //tests/thinkit:smoke_test 
INFO: Analyzed target //tests/thinkit:smoke_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:smoke_test up-to-date:
  bazel-bin/tests/thinkit/smoke_test
INFO: Elapsed time: 2.490s, Critical Path: 2.17s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions

~/mgmt/sonic-mgmt/sdn_tests/pins_ondatra$ ~/tools/sdn_build.sh .
==========[Building test: ethcounter_sw_dual_switch_test]==========
INFO: Analyzed target //tests:ethcounter_sw_dual_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:ethcounter_sw_dual_switch_test up-to-date:
  bazel-bin/tests/ethcounter_sw_dual_switch_test_/ethcounter_sw_dual_switch_test
INFO: Elapsed time: 0.284s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: ethcounter_sw_dual_switch_test]==========
==========[Building test: gnmi_long_stress_test]==========
INFO: Analyzed target //tests:gnmi_long_stress_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_long_stress_test up-to-date:
  bazel-bin/tests/gnmi_long_stress_test_/gnmi_long_stress_test
INFO: Elapsed time: 0.290s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_long_stress_test]==========
==========[Building test: gnmi_stress_helper]==========
INFO: Analyzed target //tests:gnmi_stress_helper (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_stress_helper up-to-date:
  bazel-bin/tests/gnmi_stress_helper.a
INFO: Elapsed time: 0.266s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_stress_helper]==========
==========[Building test: gnoi_file_test]==========
INFO: Analyzed target //tests:gnoi_file_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_file_test up-to-date:
  bazel-bin/tests/gnoi_file_test_/gnoi_file_test
INFO: Elapsed time: 0.263s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnoi_file_test]==========
==========[Building test: gnoi_factory_reset_test]==========
INFO: Analyzed target //tests:gnoi_factory_reset_test (0 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //tests:gnoi_factory_reset_test up-to-date:
  bazel-bin/tests/gnoi_factory_reset_test_/gnoi_factory_reset_test
INFO: Elapsed time: 3.357s, Critical Path: 3.08s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnoi_factory_reset_test]==========
==========[Building test: lacp_timeout_test]==========
INFO: Analyzed target //tests:lacp_timeout_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:lacp_timeout_test up-to-date:
  bazel-bin/tests/lacp_timeout_test_/lacp_timeout_test
INFO: Elapsed time: 0.267s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: lacp_timeout_test]==========
==========[Building test: link_event_damping_test]==========
INFO: Analyzed target //tests:link_event_damping_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:link_event_damping_test up-to-date:
  bazel-bin/tests/link_event_damping_test_/link_event_damping_test
INFO: Elapsed time: 0.267s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: link_event_damping_test]==========
==========[Building test: port_debug_data_test]==========
INFO: Analyzed target //tests:port_debug_data_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:port_debug_data_test up-to-date:
  bazel-bin/tests/port_debug_data_test_/port_debug_data_test
INFO: Elapsed time: 0.263s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: port_debug_data_test]==========
==========[Building test: platforms_hardware_component_test]==========
INFO: Analyzed target //tests:platforms_hardware_component_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:platforms_hardware_component_test up-to-date:
  bazel-bin/tests/platforms_hardware_component_test_/platforms_hardware_component_test
INFO: Elapsed time: 0.312s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: platforms_hardware_component_test]==========
==========[Building test: module_reset_test]==========
INFO: Analyzed target //tests:module_reset_test_dualnode (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:module_reset_test_dualnode up-to-date:
  bazel-bin/tests/module_reset_test_dualnode_/module_reset_test_dualnode
INFO: Elapsed time: 0.250s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: module_reset_test]==========
==========[Building test: installation_test]==========
INFO: Analyzed target //tests:installation_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:installation_test up-to-date:
  bazel-bin/tests/installation_test_/installation_test
INFO: Elapsed time: 0.264s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: installation_test]==========
==========[Building test: inband_sw_interface_dual_switch_test]==========
INFO: Analyzed target //tests:inband_sw_interface_dual_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:inband_sw_interface_dual_switch_test up-to-date:
  bazel-bin/tests/inband_sw_interface_dual_switch_test_/inband_sw_interface_dual_switch_test
INFO: Elapsed time: 0.271s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: inband_sw_interface_dual_switch_test]==========
==========[Building test: gnmi_get_modes_test]==========
INFO: Analyzed target //tests:gnmi_get_modes_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_get_modes_test up-to-date:
  bazel-bin/tests/gnmi_get_modes_test_/gnmi_get_modes_test
INFO: Elapsed time: 0.256s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_get_modes_test]==========
==========[Building test: transceiver_test]==========
INFO: Analyzed target //tests:transceiver_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:transceiver_test up-to-date:
  bazel-bin/tests/transceiver_test_/transceiver_test
INFO: Elapsed time: 0.264s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: transceiver_test]==========
==========[Building test: inband_sw_interface_test]==========
INFO: Analyzed target //tests:inband_sw_interface_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:inband_sw_interface_test up-to-date:
  bazel-bin/tests/inband_sw_interface_test_/inband_sw_interface_test
INFO: Elapsed time: 0.256s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: inband_sw_interface_test]==========
==========[Building test: platforms_software_component_test]==========
INFO: Analyzed target //tests:platforms_software_component_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:platforms_software_component_test up-to-date:
  bazel-bin/tests/platforms_software_component_test_/platforms_software_component_test
INFO: Elapsed time: 0.268s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: platforms_software_component_test]==========
==========[Building test: gnoi_reboot_test]==========
INFO: Analyzed target //tests:gnoi_reboot_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_reboot_test up-to-date:
  bazel-bin/tests/gnoi_reboot_test_/gnoi_reboot_test
INFO: Elapsed time: 0.273s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnoi_reboot_test]==========
==========[Building test: cpu_sw_single_switch_test]==========
INFO: Analyzed target //tests:cpu_sw_single_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:cpu_sw_single_switch_test up-to-date:
  bazel-bin/tests/cpu_sw_single_switch_test_/cpu_sw_single_switch_test
INFO: Elapsed time: 0.259s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: cpu_sw_single_switch_test]==========
==========[Building test: ethcounter_sw_single_switch_test]==========
INFO: Analyzed target //tests:ethcounter_sw_single_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:ethcounter_sw_single_switch_test up-to-date:
  bazel-bin/tests/ethcounter_sw_single_switch_test_/ethcounter_sw_single_switch_test
INFO: Elapsed time: 0.264s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: ethcounter_sw_single_switch_test]==========
==========[Building test: gnmi_set_get_test]==========
INFO: Analyzed target //tests:gnmi_set_get_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_set_get_test up-to-date:
  bazel-bin/tests/gnmi_set_get_test_/gnmi_set_get_test
INFO: Elapsed time: 0.268s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_set_get_test]==========
==========[Building test: lacp_test]==========
INFO: Analyzed target //tests:lacp_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:lacp_test up-to-date:
  bazel-bin/tests/lacp_test_/lacp_test
INFO: Elapsed time: 0.251s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: lacp_test]==========
==========[Building test: z_gnmi_stress_test]==========
INFO: Analyzed target //tests:z_gnmi_stress_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:z_gnmi_stress_test up-to-date:
  bazel-bin/tests/z_gnmi_stress_test_/z_gnmi_stress_test
INFO: Elapsed time: 0.267s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: z_gnmi_stress_test]==========
==========[Building test: system_paths_test]==========
INFO: Analyzed target //tests:system_paths_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:system_paths_test up-to-date:
  bazel-bin/tests/system_paths_test_/system_paths_test
INFO: Elapsed time: 0.263s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: system_paths_test]==========
==========[Building test: gnmi_wildcard_subscription_test]==========
INFO: Analyzed target //tests:gnmi_wildcard_subscription_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_wildcard_subscription_test up-to-date:
  bazel-bin/tests/gnmi_wildcard_subscription_test_/gnmi_wildcard_subscription_test
INFO: Elapsed time: 0.256s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_wildcard_subscription_test]==========
==========[Building test: mgmt_interface_test]==========
INFO: Analyzed target //tests:mgmt_interface_test (0 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //tests:mgmt_interface_test up-to-date:
  bazel-bin/tests/mgmt_interface_test_/mgmt_interface_test
INFO: Elapsed time: 7.544s, Critical Path: 7.27s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: mgmt_interface_test]==========
==========[Building test: gnmi_subscribe_modes_test]==========
INFO: Analyzed target //tests:gnmi_subscribe_modes_test (0 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //tests:gnmi_subscribe_modes_test up-to-date:
  bazel-bin/tests/gnmi_subscribe_modes_test_/gnmi_subscribe_modes_test
INFO: Elapsed time: 7.556s, Critical Path: 7.27s
INFO: 5 processes: 1 internal, 4 linux-sandbox.
INFO: Build completed successfully, 5 total actions
==========[Build Complete: gnmi_subscribe_modes_test]==========
==========[Building test: all_tests]==========
INFO: Analyzed 22 targets (0 packages loaded, 0 targets configured).
INFO: Found 22 targets...
INFO: Elapsed time: 0.257s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: all_tests]==========
