### PR TITLE
Upload testbed lock timing metrics for KVM PR tests  

### DIFF
--- a/.azure-pipelines/add_lock_timing_info.py
+++ b/.azure-pipelines/add_lock_timing_info.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+"""
+    Script for adding lock timing information
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def add_lock_timing_info(input_file, min_worker, max_worker, platform, topology):
+    if not os.path.exists(input_file):
+        print(f"Error: Input file '{input_file}' not found")
+        return False
+    
+    try:
+        with open(input_file, 'r') as f:
+            data = json.load(f)
+        
+        data['min_worker'] = min_worker
+        data['max_worker'] = max_worker
+        data['platform'] = platform
+        data['topology'] = topology
+
+        with open(input_file, 'w') as f:
+            json.dump(data, f, indent=2)
+
+        print(f"Successfully uploaded {input_file} with testbed configuration.")
+        return True
+    except json.JSONDecodeError as e:
+        print(f"WARNING: Failed to parse JSON from '{input_file}': {e}")
+        return False
+    except IOError as e:
+        print(f"WARNING: Failed to read '{input_file}': {e}")
+        return False
+    except Exception as e:
+        print(f"WARNING: Unexpected error reading '{input_file}': {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--input-file",
+        type=str,
+        default="lock_timing.json",
+        help="Path to the lock timing JSON file (default: lock_timing.json)"
+    )
+    parser.add_argument(
+        "--min-worker",
+        type=int,
+        help="Minimum worker count"
+    )
+    parser.add_argument(
+        "--max-worker",
+        type=int,
+        help="Maximum worker count"
+    )
+    parser.add_argument(
+        "--platform",
+        type=str,
+        default="",
+        help="Platform type (e.g., 'kvm')"
+    )
+    parser.add_argument(
+        "--topology",
+        type=str,
+        default="",
+        help="Topology type (e.g., 't0', 't1')"
+    )
+    
+    args = parser.parse_args()
+    
+    success = add_lock_timing_info(
+        args.input_file,
+        args.min_worker,
+        args.max_worker,
+        args.platform,
+        args.topology
+    )
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.azure-pipelines/run-test-elastictest-template.yml
+++ b/.azure-pipelines/run-test-elastictest-template.yml
@@ -264,6 +264,16 @@ steps:
       else
         echo "Azure CLI is already installed"
       fi
+      
+      # Install python requirements for test reporting
+      if pip install -r ./test_reporting/requirements.txt; then
+        echo "##vso[task.setvariable variable=TEST_REPORTING_REQUIREMENTS_INSTALLED]true"
+        echo "Successfully installed test_reporting requirements"
+      else
+        echo "##vso[task.setvariable variable=TEST_REPORTING_REQUIREMENTS_INSTALLED]false"
+        echo "WARNING: Failed to install test_reporting requirements. Lock timing upload will be skipped."
+      fi
+
     displayName: "Install Azure-CLI"
 
   - script: |
@@ -375,6 +385,65 @@ steps:
           echo "All testplan failed, cancel following steps"
           exit 3
       fi
+
+      # Check if test_reporting requirements were installed successfully
+      if [ "$TEST_REPORTING_REQUIREMENTS_INSTALLED" != "true" ]; then
+          echo "Skipping lock timing upload, test_reporting requirements not installed"
+      elif [ "${{ parameters.PLATFORM }}" == "kvm" ] && [ -f "lock_timing.json" ]; then
+          echo "Attempting to upload lock timing data to Kusto..."
+          
+          LOCK_TIMING_UPLOAD_SUCCESS=true
+          
+          # Add testbed configuration to lock timing data before upload
+          python ./.azure-pipelines/add_lock_timing_info.py \
+            --input-file lock_timing.json \
+            --min-worker "${{ parameters.MIN_WORKER }}" \
+            --max-worker "${{ parameters.MAX_WORKER }}" \
+            --platform "${{ parameters.PLATFORM }}" \
+            --topology "${{ parameters.TOPOLOGY }}" || {
+              echo "WARNING: Failed to get lock timing data. Continuing without upload."
+              LOCK_TIMING_UPLOAD_SUCCESS=false
+          }
+          
+          if [ "$LOCK_TIMING_UPLOAD_SUCCESS" = true ]; then
+              az login --identity --client-id $(SONIC_AUTOMATION_UMI) || {
+                  echo "WARNING: Azure login failed. Continuing without lock timing upload."
+                  LOCK_TIMING_UPLOAD_SUCCESS=false
+              }
+          fi
+          
+          if [ "$LOCK_TIMING_UPLOAD_SUCCESS" = true ]; then
+              accessToken=$(az account get-access-token --resource https://api.kusto.windows.net --query accessToken -o tsv) || {
+                  echo "WARNING: Failed to get Kusto access token. Continuing without lock timing upload."
+                  LOCK_TIMING_UPLOAD_SUCCESS=false
+              }
+              
+              if [ -n "$accessToken" ]; then
+                  export ACCESS_TOKEN=$accessToken
+                  export TEST_REPORT_INGEST_KUSTO_CLUSTER=$(TEST_REPORT_INGEST_KUSTO_CLUSTER)
+                  
+                  python ./test_reporting/report_uploader.py -c "lock_timing" lock_timing.json SonicTestData || {
+                      echo "WARNING: Failed to upload lock timing data to Kusto."
+                      LOCK_TIMING_UPLOAD_SUCCESS=false
+                  }
+              else
+                  echo "WARNING: Access token is empty. Continuing without lock timing upload."
+                  LOCK_TIMING_UPLOAD_SUCCESS=false
+              fi
+          fi
+          
+          if [ "$LOCK_TIMING_UPLOAD_SUCCESS" = true ]; then
+              echo "Lock timing data successfully uploaded to Kusto"
+          else
+              echo "Lock timing upload skipped or failed (non-critical)"
+          fi
+          
+      elif [ "${{ parameters.PLATFORM }}" != "kvm" ]; then
+          echo "Skipping lock timing upload - only enabled for KVM platform (current: ${{ parameters.PLATFORM }})"
+      else
+          echo "INFO: lock_timing.json not found."
+      fi
+
 
       echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
 

--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -447,6 +447,7 @@ class TestPlanManager(object):
         print(f"Result of cancelling test plan at {tp_url}:")
         print(str(resp["data"]))
 
+
     def poll(self, test_plan_id, interval=60, timeout=-1, expected_state="", expected_result=None):
         print(f"Polling progress and status of test plan at {self.frontend_url}/scheduler/testplan/{test_plan_id}")
         print(f"Polling interval: {interval} seconds")
@@ -494,6 +495,7 @@ class TestPlanManager(object):
             current_tp_status = resp_data.get("status", None)
             current_tp_result = resp_data.get("result", None)
 
+            
             if expected_state:
                 current_status = test_plan_status_factory(current_tp_status)
                 expected_status = test_plan_status_factory(expected_state)
@@ -553,16 +555,61 @@ class TestPlanManager(object):
                                 f"Check {self.frontend_url}/scheduler/testplan/{test_plan_id} for test plan status"
                             )
 
+                    # Extract lock timing data when LOCK_TESTBED step completes successfully
+                    if expected_state == "LOCK_TESTBED" and step_status == "SUCCEEDED":
+                        try:
+                            self._extract_and_save_lock_timing(test_plan_id, start_time)
+                        except Exception as timing_err:
+                            print(f"WARNING: Failed to extract lock timing data: {timing_err}")
+
                     print(f"Current step status is {step_status}.")
                     return
 
                 time.sleep(interval)
 
         else:
+            # Record lock timing data on timeout as well
+            if expected_state == "LOCK_TESTBED":
+                try:
+                    self._extract_and_save_lock_timing(test_plan_id, start_time)
+                except Exception as timing_err:
+                    print(f"WARNING: Failed to extract lock timing data on timeout: {timing_err}")
+
             raise PollTimeoutException(
                 f"Max polling time reached, test plan at {poll_url} is not successfully finished or cancelled"
             )
 
+    def _extract_and_save_lock_timing(self, test_plan_id, poll_start_time):
+        try:
+            lock_end_time = time.time()
+            lock_duration = lock_end_time - poll_start_time
+            
+            lock_timing_data = {
+                "test_plan_id": test_plan_id,
+                "start_time": datetime.fromtimestamp(poll_start_time, tz=timezone.utc).isoformat(),
+                "end_time": datetime.fromtimestamp(lock_end_time, tz=timezone.utc).isoformat(),
+                "duration_seconds": round(lock_duration, 2),
+                "build_id": os.environ.get("BUILD_BUILDID", ""),
+            }        
+
+            output_file = "lock_timing.json"
+            try:
+                with open(output_file, "w") as f:
+                    json.dump(lock_timing_data, f, indent=2)
+                print(f"Lock timing data saved to {output_file}")
+            except IOError as e:
+                print(f"WARNING: Failed to write lock timing file '{output_file}': {e}")
+                return None
+            except Exception as e:
+                print(f"WARNING: Unexpected error writing lock timing file: {e}")
+                return None
+            
+            return lock_timing_data
+            
+        except Exception as e:
+            print(f"WARNING: Failed to extract lock timing data: {e}")
+            return None
+    
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,7 @@ stages:
   condition: and(succeeded(), in(dependencies.Pre_test.result, 'Succeeded'))
   variables:
   - group: SONiC-Elastictest
+  - group: KUSTO_SECRETS
   - name: BUILD_BRANCH
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       value: $(System.PullRequest.TargetBranch)

--- a/test_reporting/report_data_storage.py
+++ b/test_reporting/report_data_storage.py
@@ -89,6 +89,14 @@ class ReportDBConnector(ABC):
         Args:
             expected_runs: A list of expected runs.
         """
+    
+    @abstractmethod
+    def upload_lock_timing_data(self, lock_timing_data: Dict) -> None:
+        """Upload lock timing data to the back-end data store.
+
+        Args:
+            lock_timing_data: A dictionary containing lock timing metrics.
+        """
 
 
 class KustoConnector(ReportDBConnector):
@@ -109,6 +117,7 @@ class KustoConnector(ReportDBConnector):
     PIPELINE_TABLE = "TestReportPipeline"
     CASE_INVOC_TABLE = "CaseInvocationCoverage"
     SAI_HEADER_INVOC_TABLE = "SAIHeaderDefinition"
+    LOCK_TIMING_TABLE = "LockTimingData"
 
     TABLE_FORMAT_LOOKUP = {
         METADATA_TABLE: DataFormat.JSON,
@@ -126,6 +135,7 @@ class KustoConnector(ReportDBConnector):
         PIPELINE_TABLE: DataFormat.JSON,
         CASE_INVOC_TABLE: DataFormat.MULTIJSON,
         SAI_HEADER_INVOC_TABLE: DataFormat.MULTIJSON,
+        LOCK_TIMING_TABLE: DataFormat.JSON,
     }
 
     TABLE_MAPPING_LOOKUP = {
@@ -144,6 +154,7 @@ class KustoConnector(ReportDBConnector):
         PIPELINE_TABLE: "FlatPipelineMappingV1",
         CASE_INVOC_TABLE: "CaseInvocationCoverageMapping",
         SAI_HEADER_INVOC_TABLE: "SAIHeaderDefinitionMapping",
+        LOCK_TIMING_TABLE: "LockTimingDataMapping",
     }
 
     def __init__(self, db_name: str, auth_method: str = "appKey"):
@@ -355,6 +366,9 @@ class KustoConnector(ReportDBConnector):
 
     def upload_case_numbers(self, case_numbers: List) -> None:
         self._ingest_data(self.TEST_CASE_NUMBERS_TABLE, case_numbers)
+    
+    def upload_lock_timing_data(self, lock_timing_data: Dict) -> None:
+        self._ingest_data(self.LOCK_TIMING_TABLE, lock_timing_data)
 
     def _upload_swss_log_file(self, swss_file: str) -> None:
         self._ingest_data_file(self.SWSSDATA_TABLE, swss_file)

--- a/test_reporting/report_uploader.py
+++ b/test_reporting/report_uploader.py
@@ -161,6 +161,15 @@ python3 report_uploader.py tests/files/sample_tr.xml -e TRACKING_ID#22
                 kusto_db.upload_sai_header_def_report_file(path_name)
             except Exception as e:
                 print("Failed to ingest file '{}', exception: {}".format(path_name, repr(e)))
+    elif args.category == "lock_timing":
+        for path_name in args.path_list:
+            try:
+                with open(path_name) as f:
+                    lock_timing_data = json.load(f)
+                kusto_db.upload_lock_timing_data(lock_timing_data)
+                print(f"Successfully uploaded lock timing data from {path_name}")
+            except Exception as e:
+                print("Failed to upload lock timing data '{}', exception: {}".format(path_name, repr(e)))
 
     else:
         print('Unknown category "{}"'.format(args.category))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #36255060 (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Tests are taking quite long to run which may be caused by a large lock testbed time. This PR captures the time it takes for a testbed to lock and uploads it to the SonicTestData Kusto database. This will then be used to make a Grafana dashboard for further analysis.

#### How did you do it?
In test_plan.py, I added a method that records some lock timing data when the LOCK_TESTBED step completes, both on success and timeout. The rest of the lock timing data is filled in by the add_lock_timing_info.py script. In the run-test-elastictest-templete.yml pipeline, the file with the data is uploaded using report_uploader.py.

#### How did you verify/test it?
I created a manually triggered pipeline that mirrors the current automated pipeline. Upon running the pipeline, I would observe all logs and ensure that no issues occured. I further verified its success by ensuring that the data was logged into the database. Additionally, if for some reason some parts of the code fails, I have implemented graceful exits so it doesn't affect the main pipeline.

#### Any platform specific information?
This feature works only for kvm platforms as lock testbeds usually took longer on kvms rather than physical.

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
