### PR TITLE
Fix intermittent 'KeyError' failures in test_snmp_interfaces

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -25,6 +25,54 @@ COUNTERS_RIF_NAME_MAP = 'COUNTERS_RIF_NAME_MAP'
 COUNTER_VALUE = 5000
 
 
+def check_snmp_interfaces(duthost, localhost, hostip, creds_all_duts, validate_all_fields=False):
+    """
+    Get SNMP facts and validate that all interfaces have the required 'name' field and other MIBs are fully populated
+    :param validate_all_fields: If True, also validate MIB-specific fields
+    """
+    snmp_facts = get_snmp_facts(
+        duthost, localhost, host=hostip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+
+    if 'snmp_interfaces' not in snmp_facts:
+        logger.info("'snmp_interfaces' not in snmp_facts")
+        return False
+
+    for idx, interface in snmp_facts['snmp_interfaces'].items():
+        if 'name' not in interface:
+            logger.info("'name' not in snmp_facts['snmp_interfaces'][{}]. Available fields: {}".format(
+                idx, list(interface.keys())))
+            return False
+
+    if validate_all_fields:
+        required_fields = ['operstatus', 'adminstatus', 'mtu', 'description', 'type', 'ifindex',
+                           'ifInDiscards', 'ifOutDiscards', 'ifInErrors', 'ifOutErrors', 'speed', 'ifHighSpeed']
+        for idx, interface in snmp_facts['snmp_interfaces'].items():
+            for field in required_fields:
+                if field not in interface:
+                    logger.info("'{}' not in snmp_facts['snmp_interfaces'][{}]. Available fields: {}".format(
+                        field, idx, list(interface.keys())))
+                    return False
+
+    logger.info("SNMP interfaces validated successfully")
+    return True
+
+
+def get_snmp_facts_with_validation(duthost, localhost, hostip, creds_all_duts, validate_all_fields=False):
+    """
+    Get SNMP facts with check to ensure MIBs are fully populated.
+    Uses wait_until to retry if check fails.
+    :return: checked SNMP facts
+    """
+    assert wait_until(60, 3, 0, check_snmp_interfaces, duthost, localhost, hostip,
+                      creds_all_duts, validate_all_fields), \
+        "SNMP get facts check failed - MIBs may not be fully populated"
+
+    return get_snmp_facts(
+        duthost, localhost, host=hostip, version="v2c",
+        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+
+
 @pytest.fixture()
 def disable_conterpoll(duthost):
     """
@@ -245,9 +293,7 @@ def verify_snmp_counter(duthost, localhost, creds_all_duts, hostip, mg_facts, ri
     """
     Verify correct correctness of snmp counter
     """
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts_with_validation(duthost, localhost, hostip, creds_all_duts, validate_all_fields=True)
 
     minigraph_port_name_to_alias_map = mg_facts['minigraph_port_name_to_alias_map']
     snmp_port_map = {snmp_facts['snmp_interfaces'][idx]['name']: idx for idx in snmp_facts['snmp_interfaces']}
@@ -281,9 +327,7 @@ def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts_with_validation(duthost, localhost, hostip, creds_all_duts)
 
     snmp_ifnames = [v['name']
                     for k, v in list(snmp_facts['snmp_interfaces'].items())]
@@ -310,9 +354,7 @@ def test_snmp_mgmt_interface(localhost, creds_all_duts, duthosts, enum_rand_one_
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
 
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts_with_validation(duthost, localhost, hostip, creds_all_duts, validate_all_fields=True)
     config_facts = duthost.config_facts(
         host=duthost.hostname, source="persistent")['ansible_facts']
 
@@ -343,9 +385,7 @@ def test_snmp_interfaces_mibs(duthosts, enum_rand_one_per_hwsku_hostname, localh
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     hostip = duthost.host.options['inventory_manager'].get_host(
         duthost.hostname).vars['ansible_host']
-    snmp_facts = get_snmp_facts(
-        duthost, localhost, host=hostip, version="v2c",
-        community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
+    snmp_facts = get_snmp_facts_with_validation(duthost, localhost, hostip, creds_all_duts, validate_all_fields=True)
 
     for asic in duthost.asics:
         config_facts = duthost.config_facts(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

This PR fixes an intermittent error in `test_snmp_interfaces.py` where get_snmp_facts will return snmp facts without all MIB fields being populated. 

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

**Summary:**

This PR fixes an intermittent `KeyError` failure in `test_snmp_interfaces.py` caused by `get_snmp_facts` returning SNMP facts before all MIB fields are fully populated.

**Changes:**
- Add helper functions: `check_snmp_interfaces` and `get_snmp_facts_with_validation`
- Replace `get_snmp_facts` with `get_snmp_facts_with_validation` in test methods
- Validated on 202505 and master branches using T0 topology

Fixes #21792

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

When running the test, there was an intermittent failure raising`KeyError: 'name'`. 
```
localhost = <tests.common.devices.local.Localhost object at 0x7f765d034760>
creds_all_duts = {'upscaleai-t0': {'7nodes_cisco_P1': 'vars/configdb_jsons/7nodes_cisco/P1.json', '7nodes_cisco_P2': 'vars/config...o_P3': 'vars/configdb_jsons/7nodes_cisco/P3.json', '7nodes_cisco_P4': 'vars/configdb_jsons/7nodes_cisco/P4.json', ...}}
duthosts = [<MultiAsicSonicHost upscaleai-t0>]
enum_rand_one_per_hwsku_hostname = 'upscaleai-t0'

    @pytest.mark.bsl
    def test_snmp_interfaces(localhost, creds_all_duts, duthosts, enum_rand_one_per_hwsku_hostname):
        """compare the snmp facts between observed states and target state"""
        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
        hostip = duthost.host.options['inventory_manager'].get_host(
            duthost.hostname).vars['ansible_host']
    
        snmp_facts = get_snmp_facts(
            duthost, localhost, host=hostip, version="v2c",
            community=creds_all_duts[duthost.hostname]["snmp_rocommunity"], wait=True)['ansible_facts']
    
>       snmp_ifnames = [v['name']
                        for k, v in list(snmp_facts['snmp_interfaces'].items())]

creds_all_duts = {'t0': {'7nodes_cisco_P1': 'vars/configdb_jsons/7nodes_cisco/P1.json', '7nodes_cisco_P2': 'vars/config...o_P3': 'vars/configdb_jsons/7nodes_cisco/P3.json', '7nodes_cisco_P4': 'vars/configdb_jsons/7nodes_cisco/P4.json', ...}}
duthost    = <MultiAsicSonicHost upscaleai-t0>
duthosts   = [<MultiAsicSonicHost upscaleai-t0>]
enum_rand_one_per_hwsku_hostname = 'upscaleai-t0'
hostip     = '192.168.121.10'
localhost  = <tests.common.devices.local.Localhost object at 0x7f765d034760>
snmp_facts = {'ansible_all_ipv4_addresses': [], 'ansible_sysCachedMemory': 12235164, 'ansible_sysTotalBuffMemory': 99132, 'ansible_sysTotalFreeMemory': 14617100, ...}

snmp/test_snmp_interfaces.py:171: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <list_iterator object at 0x7f764fb56d60>

>   snmp_ifnames = [v['name']
                    for k, v in list(snmp_facts['snmp_interfaces'].items())]
E   KeyError: 'name'

.0         = <list_iterator object at 0x7f764fb56d60>
k          = '3000'
v          = {'description': '', 'ifHighSpeed': '40000'}

snmp/test_snmp_interfaces.py:171: KeyError
```

#### How did you do it?

Introduced new helper functions `check_snmp_interfaces` and `get_snmp_facts_with_validation` to verify that the MIB data is fully populated before continuing.

- Replace `get_snmp_facts` with `get_snmp_facts_with_validation` in test methods

#### How did you verify/test it?

I ran this test on the **202505** and **master** branches.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
