### PR TITLE
change worker returncode to exitcode to get subprocess exit code

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -94,7 +94,7 @@ def parallel_run(
     # Callback API for wait_procs
     def on_terminate(worker):
         logger.info("process {} terminated with exit code {}".format(
-            worker.name, worker.returncode)
+            worker.name, worker.exitcode)
         )
 
     def force_terminate(workers, init_result):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: change worker returncode to exitcode to get subprocess exit code
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

This PR is to log the correct subprocess exit code in parallel_run. The worker parameter is an object of SonicProcess(a subclass of multiprocessing.Process), but as per below reference link, multiprocessing.Process does not have returncode attribute, it only has exitcode attribute

Reference: [multiprocessing.Process.exitcode](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.exitcode)


#### How did you do it?

change worker returncode(which is always None) to exitcode

e.g. below log entry
`process analyze_logs--<MultiAsicSonicHost hostname> terminated with exit code None`
will be changed to something like below
`process analyze_logs--<MultiAsicSonicHost hostname> terminated with exit code 252` or
`process analyze_logs--<MultiAsicSonicHost hostname> terminated with exit code 0`

#### How did you verify/test it?

ran a test with loganalyzer on physical setups

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
