### PR TITLE
Remove packets_for_test fixture dependency for proxy arp enabled

### DIFF
--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -303,7 +303,6 @@ def proxy_arp_enabled(request, rand_selected_dut, config_facts):
     vlan_ids = [vlans[vlan]['vlanid'] for vlan in list(vlans.keys())]
     old_proxy_arp_vals = {}
     new_proxy_arp_vals = []
-    ip_version, _, _ = packets_for_test
 
     # Enable proxy ARP/NDP for the VLANs on the DUT
     for vid in vlan_ids:

--- a/tests/arp/conftest.py
+++ b/tests/arp/conftest.py
@@ -282,7 +282,7 @@ def ip_and_intf_info(config_facts, intfs_for_test, ptfhost, ptfadapter):
 
 
 @pytest.fixture
-def proxy_arp_enabled(packets_for_test, rand_selected_dut, config_facts):
+def proxy_arp_enabled(request, rand_selected_dut, config_facts):
     """
     Tries to enable proxy ARP for each VLAN on the ToR
 
@@ -316,7 +316,7 @@ def proxy_arp_enabled(packets_for_test, rand_selected_dut, config_facts):
         new_proxy_arp_res = duthost.shell(proxy_arp_check_cmd.format(vid))
         new_proxy_arp_vals.append(new_proxy_arp_res['stdout'])
 
-    if ip_version == 'v6':
+    if 'ipv6' in request.node.name:
         # Allow time for ndppd to reset and startup
         time.sleep(30)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Use test name to determine test ip version instead of using a test fixture intended for other purposes.

Fixes #21801 21801

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Unintended test cases were created and extra logic was ran.

#### How did you do it?
Use the test name to determine the ip version of the test case instead.

#### How did you verify/test it?
Unintended test cases are no longer called and the test passes on both v6-only t0 topologies and standard t0 topologies.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
