### PR TITLE
Remove comment stub from auto-assign.py

### DIFF
--- a/.github/.code-reviewers/auto-assign.py
+++ b/.github/.code-reviewers/auto-assign.py
@@ -104,7 +104,7 @@ if reviewer_candidates:
 
     try:
         # Request reviews
-        # pr.create_review_request(reviewers=reviewers_to_add)
+        pr.create_review_request(reviewers=reviewers_to_add)
         print(
             f"Successfully requested reviews for PR #{pr.number} from users: {reviewers_to_add}"
         )


### PR DESCRIPTION
### Description of PR
A quick follow-up to remove the comment stub used for testing 

Summary:
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
