### PR TITLE
GARP for ptf mgmt after creating container

### DIFF
--- a/ansible/roles/vm_set/tasks/ptf_change_mac.yml
+++ b/ansible/roles/vm_set/tasks/ptf_change_mac.yml
@@ -10,6 +10,11 @@
     groups:
       - ptf
 
+- name: Send GARP to update neighbor's the ARP table for reachability
+  command: docker exec -i ptf_{{ vm_set_name }} arping -c 2 -A {{ ptf_host_ip }}
+  become: yes
+  ignore_errors: yes
+
 - name: wait until ptf is reachable
   wait_for:
     port: 22


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix the issue where PTF container is not reachable if MAC address was changed after rebuilding container.

There will be a timeout for task "wait until ptf is reachable". When it happens, the gateway still uses the old MAC for the ptf container, which needs to be updated before initiating reachability test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
PTF timeout after rebuilding PTF container.

#### How did you do it?
trigger GARP before PTF reachability test.

#### How did you verify/test it?
On local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
