### PR TITLE
Fix value handling in telemetry reporting

### DIFF
--- a/tests/common/telemetry/__init__.py
+++ b/tests/common/telemetry/__init__.py
@@ -4,7 +4,7 @@ SONiC Mgmt Test Telemetry Framework
 """
 
 # Base classes
-from .base import Reporter, Metric, MetricCollection, MetricDefinition
+from .base import Reporter, Metric, MetricCollection, MetricDefinition, default_value_convertor
 
 # Metric types
 from .metrics import GaugeMetric, HistogramMetric
@@ -46,7 +46,7 @@ __version__ = "1.0.0"
 # Public API - define what gets imported with "from common.telemetry import *"
 __all__ = [
     # Base classes
-    'Reporter', 'Metric', 'MetricCollection', 'MetricDefinition',
+    'Reporter', 'Metric', 'MetricCollection', 'MetricDefinition', 'default_value_convertor',
 
     # Metric types
     'GaugeMetric', 'HistogramMetric',

--- a/tests/common/telemetry/metrics/gauge.py
+++ b/tests/common/telemetry/metrics/gauge.py
@@ -5,7 +5,7 @@ Gauge metrics represent a value that can go up or down over time,
 such as temperature, utilization percentages, or current measurements.
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Callable
 from ..base import Metric, Reporter, MetricDataEntry
 from ..constants import METRIC_TYPE_GAUGE
 
@@ -19,6 +19,7 @@ class GaugeMetric(Metric):
     """
 
     def __init__(self, name: str, description: str, unit: str, reporter: Reporter,
+                 value_convertor: Callable[[str], float] = None,
                  common_labels: Optional[Dict[str, str]] = None):
         """
         Initialize gauge metric.
@@ -30,7 +31,7 @@ class GaugeMetric(Metric):
             reporter: Reporter instance to send measurements to
             common_labels: Common labels to apply to all measurements of this metric
         """
-        super().__init__(METRIC_TYPE_GAUGE, name, description, unit, reporter, common_labels)
+        super().__init__(METRIC_TYPE_GAUGE, name, description, unit, reporter, value_convertor, common_labels)
 
     def record(self, value: float, additional_labels: Optional[Dict[str, str]] = None):
         """
@@ -44,4 +45,5 @@ class GaugeMetric(Metric):
         labels_key = self._labels_to_key(additional_labels)
 
         # Store the value with labels (gauge always overwrites previous value for same labels)
-        self._data[labels_key] = MetricDataEntry(data=value, labels=additional_labels or {})
+        normalized_value = self._value_convertor(value) if self._value_convertor else value
+        self._data[labels_key] = MetricDataEntry(data=normalized_value, labels=additional_labels or {})

--- a/tests/common/telemetry/metrics/histogram.py
+++ b/tests/common/telemetry/metrics/histogram.py
@@ -31,7 +31,7 @@ class HistogramMetric(Metric):
             buckets: Optional bucket boundaries for histogram distribution
             common_labels: Common labels to apply to all measurements of this metric
         """
-        super().__init__(METRIC_TYPE_HISTOGRAM, name, description, unit, reporter, common_labels)
+        super().__init__(METRIC_TYPE_HISTOGRAM, name, description, unit, reporter, None, common_labels)
         self.buckets = buckets
 
     def record(self, value: float, additional_labels: Optional[Dict[str, str]] = None):


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The current stats output by CLI can be invalid values, such as N/A, False, True and etc. This fails the data reporting, because these values are not numeric. 

#### How did you do it?

This change allows these values to be converted properly into a numeric value for data reporting.

#### How did you verify/test it?

Run locally with existing ixia tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
