### PR TITLE
[Nvidia] Increase the memory threshold for SN4280 DPU

### DIFF
--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -40,7 +40,7 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0', 'x86_64-arista_7050_qx32s',
                                      'x86_64-cel_e1031-r0', 'x86_64-arista_7800r3a_36dm2_lc') or is_asan:
         memory_threshold = 90
-    if duthost.facts['platform'] in ('x86_64-mlnx_msn3800-r0',
+    if duthost.facts['platform'] in ('x86_64-mlnx_msn3800-r0', 'arm64-nvda_bf-bf3comdpu',
                                      'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-mlnx_msn3420-r0',
                                      'x86_64-arista_7060_cx32s'):
         memory_threshold = 70


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
More memory of the SN4280 DPU is reserved to support 64 ENIs: https://github.com/sonic-net/sonic-sairedis/pull/1696
Need increase the threshold for tests/platform_tests/test_cpu_memory_usage.py.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
tests/platform_tests/test_cpu_memory_usage.py::test_cpu_memory_usage is failing on the SN4280 DPU:
```
Failed: system cpu and memory usage check fails due to system memory usage is [63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 63.9%, 64.0%, 63.9%, 63.9%], threshold is 60%
```
The increment of memory usage is expected due to PR: https://github.com/sonic-net/sonic-sairedis/pull/1696.
#### How did you do it?
Increase the memory usage threshold to 70% for the DPU.
#### How did you verify/test it?
Run the test on SN4280 DPU.
#### Any platform specific information?
Only for SN4280 DPU.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
