### PR TITLE
[dhcp_relay] replace typo dhcpcom with dhcpmon

### DIFF
--- a/docs/testplan/dhcp_relay/DHCPv4-Relay-Test-Plan.md
+++ b/docs/testplan/dhcp_relay/DHCPv4-Relay-Test-Plan.md
@@ -265,10 +265,10 @@ This test plan covers comprehensive testing of DHCPv4 relay functionality in SON
 
 ### Key Helper Functions
 - `check_interface_status()`: Verify relay agent socket binding
-- `query_dhcpcom_relay_counter_result()`: Retrieve DHCP counters
-- `validate_dhcpcom_relay_counters()`: Validate counter accuracy
-- `start_dhcp_monitor_debug_counter()`: Enable debug counter mode
-- `init_dhcpcom_relay_counters()`: Reset counter values
+- `query_dhcpmon_counter_result()`: Retrieve DHCP counters from dhcpmon
+- `validate_dhcpmon_counters()`: Validate counter accuracy from dhcpmon
+- `restart_dhcpmon_in_debug()`: Enable dhcpmon debug mode
+- `init_dhcpmon_counters()`: Reset counter values from dhcpmon
 
 ### Fixtures
 - `ignore_expected_loganalyzer_exceptions`: Filter expected errors

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -863,20 +863,20 @@ dhcp_relay:
     conditions:
       - "release in ['202412']"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress:
   xfail:
     reason: "7215 has low performance, and can only take low stress (about 5 pps)"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[discover]:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover]:
   xfail:
     reason: "Need to skip for discover test cases on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       - "https://github.com/sonic-net/sonic-mgmt/issues/19230"
 
-dhcp_relay/test_dhcp_counter_stress.py::test_dhcpcom_relay_counters_stress[request]:
+dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[request]:
   xfail:
     reason: "Need to skip for request test cases on dualtor"
     conditions:

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -5,7 +5,7 @@ import re
 
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
-from tests.common.dhcp_relay_utils import init_dhcpcom_relay_counters, validate_dhcpcom_relay_counters, \
+from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, \
                                           validate_counters_and_pkts_consistency
 from tests.common.utilities import wait_until, capture_and_check_packet_on_dut
 from tests.dhcp_relay.dhcp_relay_utils import check_dhcp_stress_status
@@ -42,7 +42,7 @@ def ignore_expected_loganalyzer_exceptions(rand_one_dut_hostname, loganalyzer):
 
 
 @pytest.mark.parametrize('dhcp_type', ['discover', 'offer', 'request', 'ack'])
-def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
+def test_dhcpmon_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data, validate_dut_routes_exist,
                                        testing_config, setup_standby_ports_on_rand_unselected_tor,
                                        toggle_all_simulator_ports_to_rand_selected_tor_m,     # noqa F811
                                        dhcp_type, clean_processes_after_stress_test,
@@ -61,10 +61,10 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
     for dhcp_relay in dut_dhcp_relay_data:
         client_port_id = dhcp_relay['client_iface']['port_idx']
 
-        init_dhcpcom_relay_counters(duthost)
+        init_dhcpmon_counters(duthost)
         if testing_mode == DUAL_TOR_MODE:
             standby_duthost = rand_unselected_dut
-            init_dhcpcom_relay_counters(standby_duthost)
+            init_dhcpmon_counters(standby_duthost)
 
         params = {
             "hostname": duthost.hostname,
@@ -99,8 +99,8 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
             validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_dict,
                                                    error_in_percentage=error_margin)
             if testing_mode == DUAL_TOR_MODE:
-                validate_dhcpcom_relay_counters(dhcp_relay, standby_duthost,
-                                                {}, {}, 0)
+                validate_dhcpmon_counters(dhcp_relay, standby_duthost,
+                                          {}, {}, 0)
 
         def get_ip_link_result(duthost):
             # Get the output of 'ip link' command and parse it to a dictionary of index: name
@@ -129,7 +129,7 @@ def test_dhcpcom_relay_counters_stress(ptfhost, ptfadapter, dut_dhcp_relay_data,
         ):
             ptf_runner(ptfhost, "ptftests", "dhcp_relay_stress_test.DHCPStress{}Test".format(dhcp_type.capitalize()),
                        platform_dir="ptftests", params=params,
-                       log_file="/tmp/test_dhcpcom_relay_counters_stress.DHCPStressTest.log",
+                       log_file="/tmp/test_dhcpmon_relay_counters_stress.DHCPStressTest.log",
                        qlen=100000, is_python3=True, async_mode=True)
             check_dhcp_stress_status(duthost, packets_send_duration)
             pytest_assert(wait_until(600, 2, 0, _check_count_file_exists), "{} is missing".format(count_file))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The word dhcpcom has been in the mgmt repo since the dhcp_relay test hld. It is not an abbreviation of counter or monitor. All the dhcpcom functions are used to query to validate dhcpmon data, so it was probably meant to be dhcpmon when the hld was first drafted. Correct all of them.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Correct typo

#### How did you do it?
Search and replace

#### How did you verify/test it?
Run the original tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
