### PR TITLE
[test_auto_techsupport] test_max_limit testcase fix on container unexpected dump size

### DIFF
--- a/tests/show_techsupport/test_auto_techsupport.py
+++ b/tests/show_techsupport/test_auto_techsupport.py
@@ -440,40 +440,53 @@ class TestAutoTechSupport:
             for stub_file in range(num_of_dummy_files):
                 dummy_files_list.append(dummy_file_generator(self.duthost, size_in_mb=expected_file_size_in_mb))
 
-        with allure.step('Validate: {} limit(disabled): {}'.format(test_mode, max_limit)):
+        try:
+            # Test techsupport command with --since option to limit the dump size
+            if test_mode == 'techsupport':
+                self.duthost.shell("config auto-techsupport global since \"1h\"")
 
-            with allure.step('Create .core file in test docker and check techsupport generated'):
-                available_tech_support_files = get_available_tech_support_files(self.duthost)
-                expected_core_file = trigger_auto_techsupport(self.duthost, self.test_docker)
-                validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
-                                                expected_core_file=expected_core_file,
-                                                available_tech_support_files=available_tech_support_files)
+            with allure.step('Validate: {} limit(disabled): {}'.format(test_mode, max_limit)):
 
-            with allure.step('Check that all stub files exist'):
-                validate_expected_stub_files(self.duthost, validation_folder, dummy_files_list,
-                                             expected_number_of_additional_files=1)
+                with allure.step('Create .core file in test docker and check techsupport generated'):
+                    available_tech_support_files = get_available_tech_support_files(self.duthost)
+                    expected_core_file = trigger_auto_techsupport(self.duthost, self.test_docker)
+                    validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
+                                                    expected_core_file=expected_core_file,
+                                                    available_tech_support_files=available_tech_support_files)
 
-        max_limit = 3 if one_percent_in_mb > 300 and test_mode == 'core' else 14
+                with allure.step('Check that all stub files exist'):
+                    validate_expected_stub_files(self.duthost, validation_folder, dummy_files_list,
+                                                 expected_number_of_additional_files=1)
 
-        with allure.step('Validate: {} limit: {}'.format(test_mode, max_limit)):
-            with allure.step('Set {} limit to: {}'.format(test_mode, max_limit)):
-                set_limit(self.duthost, test_mode, max_limit, cleanup_list=None)
+            max_limit = 3 if one_percent_in_mb > 300 and test_mode == 'core' else 14
 
-            with allure.step('Create .core file in test docker and check techsupport generated'):
-                available_tech_support_files = get_available_tech_support_files(self.duthost)
-                expected_core_file = trigger_auto_techsupport(self.duthost, self.test_docker)
-                validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
-                                                expected_core_file=expected_core_file,
-                                                available_tech_support_files=available_tech_support_files)
+            with allure.step('Validate: {} limit: {}'.format(test_mode, max_limit)):
+                with allure.step('Set {} limit to: {}'.format(test_mode, max_limit)):
+                    set_limit(self.duthost, test_mode, max_limit, cleanup_list=None)
 
-            with allure.step('Check that all expected stub files exist and unexpected does not exist'):
-                expected_max_usage = one_percent_in_mb * max_limit
-                expected_stub_files = dummy_files_list[2:]
-                not_expected_stub_files = dummy_files_list[:2]
-                validate_expected_stub_files(self.duthost, validation_folder, expected_stub_files,
-                                             expected_number_of_additional_files=2,
-                                             not_expected_stub_files_list=not_expected_stub_files,
-                                             expected_max_folder_size=expected_max_usage)
+                with allure.step('Create .core file in test docker and check techsupport generated'):
+                    available_tech_support_files = get_available_tech_support_files(self.duthost)
+                    expected_core_file = trigger_auto_techsupport(self.duthost, self.test_docker)
+                    validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
+                                                    expected_core_file=expected_core_file,
+                                                    available_tech_support_files=available_tech_support_files)
+
+                with allure.step('Check that all expected stub files exist and unexpected does not exist'):
+                    expected_max_usage = one_percent_in_mb * max_limit
+                    expected_stub_files = dummy_files_list[2:]
+                    not_expected_stub_files = dummy_files_list[:2]
+                    validate_expected_stub_files(self.duthost, validation_folder, expected_stub_files,
+                                                 expected_number_of_additional_files=2,
+                                                 not_expected_stub_files_list=not_expected_stub_files,
+                                                 expected_max_folder_size=expected_max_usage)
+        except Exception as e:
+            self.duthost.shell("show auto-techsupport global")
+            logger.warning('Error occurred during test execution: {}'.format(str(e)))
+            raise
+        finally:
+            # Always restore default "since" value at the end
+            if test_mode == 'techsupport':
+                self.duthost.shell("config auto-techsupport global since \"2 days ago\"")
 
     @pytest.mark.disable_loganalyzer
     def test_sai_sdk_dump(self, tbinfo, global_rate_limit_zero, cleanup_list):


### PR DESCRIPTION
**Description of PR**
[component/folder touched] 

https://github.com/sonic-net/sonic-mgmt/issues/21059

show_techsupport/test_auto_techsupport.py on test_max_limit
with failing result of below

TestAutoTechSupport test_max_limit AssertionError with
Expected file: ...tar.gz not found in available files list

reason: DUT will remove more than 2 files (=3 or =4  with total size *5% for each) 
             but testcase expects to remove 2 only.
             DUT filesystem could have more logs before tests. 
             we should keep recent logs only.
 
**info**
the reason is that below is the testcase flow:
Test logic is as follows:

Set core/techsupport max limit to 0
Create 4 core/techsupport dummy files(each file 5%) which will use 20% of space in test folder
Trigger techsupport and check that dummy files + new created core/techsupport files available
Set core/techsupport max limit to 14
Trigger techsupport and check that 2 oldest dummy files removed, all other + new created core/techsupport
from 20% to 14%, it means the testcase expected to remove original 2 files at least.
however, except for 4 x5% dumpfiles, testcase also triggers 2 coredumps from random containers which can not expect these new core dump size always below than 5%.
this is the reason DUT removes all 3 or 4 files (3 or 4 *5%) to keep below than 14%.

**example:**
2025 May 15 05:02:16.156977 mth-t0-64 INFO python[403820]: ansible-ansible.legacy.command Invoked with _raw_params=sudo dd if=/dev/zero of=/var/dump/sonic_dump_mth-t0-64_20250515_050215.tar.gz bs=1M count=1642
2025 May 15 05:02:18.653583 mth-t0-64 INFO python[403842]: ansible-ansible.legacy.command Invoked with _raw_params=sudo dd if=/dev/zero of=/var/dump/sonic_dump_mth-t0-64_20250515_050218.tar.gz bs=1M count=1642 
2025 May 15 05:02:23.706056 mth-t0-64 INFO python[403868]: ansible-ansible.legacy.command Invoked with _raw_params=sudo dd if=/dev/zero of=/var/dump/sonic_dump_mth-t0-64_20250515_050223.tar.gz bs=1M count=1642
2025 May 15 05:02:29.118887 mth-t0-64 INFO python[403893]: ansible-ansible.legacy.command Invoked with _raw_params=sudo dd if=/dev/zero of=/var/dump/sonic_dump_mth-t0-64_20250515_050228.tar.gz bs=1M count=1642 

2025 May 15 05:02:34.613223 mth-t0-64 INFO python[403919]: ansible-ansible.legacy.command Invoked with _raw_params=docker exec radv bash /etc/sonic/core_file_generator.sh
2025 May 15 05:05:52.383694 mth-t0-64 INFO coredump_gen_handler.py[403985]: show techsupport --silent --global-timeout 60 --since 2 days ago is successful, sonic_dump_mth-t0-64_20250515_050236.tar.gz is created

"total 8.0G", "-rw-r--r-- 1
root root 1.7G May 15 05:02 sonic_dump_mth-t0-64_20250515_050215.tar.gz", 5%
root root 1.7G May 15 05:02 sonic_dump_mth-t0-64_20250515_050218.tar.gz", 5%
root root 1.7G May 15 05:02 sonic_dump_mth-t0-64_20250515_050223.tar.gz", 5%
root root 1.7G May 15 05:02 sonic_dump_mth-t0-64_20250515_050228.tar.gz", 5%
**root root 1.6G May 15 05:05 sonic_dump_mth-t0-64_20250515_050236.tar.gz.  5%**

05/05/2025 05:06:21 base._run                                L0071 DEBUG  | /data/tests/common/devices/multi_asic.py::_run_on_asics#135: [mth-t0-64] AnsibleModule::shell, args=["**sudo config auto-techsupport global  max-techsupport-limit 14**"

2025 May 15 05:06:24.939665 mth-t0-64 INFO python[426833]: ansible-ansible.legacy.command Invoked with _raw_params=docker exec radv bash /etc/sonic/core_file_generator.sh
2025 May 15 05:09:40.924952 mth-t0-64 INFO coredump_gen_handler.py[426899]: show techsupport --silent --global-timeout 60 --since 2 days ago is successful, sonic_dump_mth-t0-64_20250515_050626.tar.gz is created

2025 May 15 05:09:41.130114 mth-t0-64 INFO techsupport_cleanup.py[449103]: 6 GB deleted from /var/dump
05/05/2025 05:09:46
total 3.1G
**--> issue here: expected to remove 2 dump files only but more....**
root root 1.6G May 15 05:05 sonic_dump_mth-t0-64_20250515_050236.tar.gz  5%
root root 1.6G May 15 05:09 sonic_dump_mth-t0-64_20250515_050626.tar.gz" 5%


Summary:
Fixes # (issue)
adding auto-tech since option from 2 days ago(default) to 1hr


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [X] 202405
- [X] 202411
- [X] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
testcase failing
#### How did you do it?

#### How did you verify/test it?
Yes
#### Any platform specific information?
reproduce rate < 10%; sometimes removing 3 files, sometimes removing 4 files 
#### Supported testbed topology if it's a new test case?
Generic issue
### Documentation
