### PR TITLE
Fix-test_psu-for-device-with-no-psu-temperature: update test_psu.py::test_temperature to handle invalid temperatures appropriately

### DIFF
--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -292,14 +292,23 @@ class TestPsuApi(PlatformApiTestBase):
                     continue
 
                 temperature = psu.get_temperature(platform_api_conn, psu_id)
-                if self.expect(temperature is not None, "Failed to retrieve temperature of PSU {}".format(psu_id)):
-                    self.expect(isinstance(temperature, float), "PSU {} temperature appears incorrect".format(psu_id))
+                if not self.expect(temperature is not None and temperature != "N/A",
+                                   "Failed to retrieve temperature of PSU {}".format(psu_id)):
+                    continue
+
+                if not self.expect(isinstance(temperature, float),
+                                   "PSU {} temperature validation failed: "
+                                   "expected float, got: {} (type: {})"
+                                   .format(psu_id, temperature, type(temperature).__name__)):
+                    continue
 
                 temp_threshold = psu.get_temperature_high_threshold(platform_api_conn, psu_id)
-                if self.expect(temp_threshold is not None,
+                if self.expect(temp_threshold is not None and temp_threshold != "N/A",
                                "Failed to retrieve temperature threshold of PSU {}".format(psu_id)):
                     if self.expect(isinstance(temp_threshold, float),
-                                   "PSU {} temperature high threshold appears incorrect".format(psu_id)):
+                                   "PSU {} temperature high threshold validation failed: "
+                                   "expected float, got: {} (type: {})"
+                                   .format(psu_id, temp_threshold, type(temp_threshold).__name__)):
                         self.expect(temperature < temp_threshold,
                                     "Temperature {} of PSU {} is over the threshold {}"
                                     .format(temperature, psu_id, temp_threshold))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: This PR improves the robustness of PSU temperature testing in the Platform API test suite.
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/21825

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Prevent a string and float comparison from causing the test to fail.

#### How did you do it?
Adding type checking and error messages.

#### How did you verify/test it?
Ran tests/platform_tests/api/test_psu.py on a nominal platform, ensure it passes.

Log:
[psu.test.log](https://github.com/user-attachments/files/24457979/psu.test.log)


Ran modified test where the second PSU would always report "N/A" and verified the test correctly identifies the issue and skips the remainder of the test.

Log:
[psu0na.test.log](https://github.com/user-attachments/files/24458214/psu0na.test.log)

Console Output
```
platform_tests/api/test_psu.py::TestPsuApi::test_temperature[DUT_NAME] FAILED [ 78%]

...

E           Failed: Failed to retrieve temperature of PSU 0

err_msg    = 'Failed to retrieve temperature of PSU 0'
self       = <tests.platform_tests.api.test_psu.TestPsuApi object at 0x7f8a12bb8130>

platform_tests/api/platform_api_test_base.py:32: Failed
```


#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Not applicable (Test case improvement).

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
