### PR TITLE
[Mellanox] Skip warm-reboot for test_static_dns_basic when issu is disabled

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1,4 +1,8 @@
 import functools
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 SPC1_HWSKUS = ["ACS-MSN2700", "Mellanox-SN2700", "Mellanox-SN2700-D48C8", "ACS-MSN2740", "ACS-MSN2100", "ACS-MSN2410",
@@ -1257,3 +1261,20 @@ def get_hardware_version(duthost, platform):
 def get_hw_management_version(duthost):
     full_version = duthost.shell('dpkg-query --showformat=\'${Version}\' --show hw-management')['stdout']
     return full_version[len('1.mlnx.'):]
+
+
+def is_issu_enabled(duthost):
+    logger.info("Check if ISSU is enabled on the device")
+    dut_platform = duthost.facts["platform"]
+    dut_hwsku = duthost.facts["hwsku"]
+
+    sai_profile = f"/usr/share/sonic/device/{dut_platform}/{dut_hwsku}/sai.profile"
+    cmd_get_sai_xml_filename = f"basename $(cat {sai_profile} | grep SAI_INIT_CONFIG_FILE | cut -d'=' -f2)"
+    sai_xml_filename = duthost.shell(cmd_get_sai_xml_filename)["stdout"].strip()
+    sai_xml_path = f"/usr/share/sonic/device/{dut_platform}/{dut_hwsku}/{sai_xml_filename}"
+
+    pattern = r"<issu-enabled>*1*<\/issu-enabled>"
+    output = duthost.shell(f'egrep "{pattern}" {sai_xml_path} | wc -l')['stdout'].strip()
+    logger.info(f"ISSU is enabled: {output == '1'}")
+
+    return True if output == "1" else False

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -12,6 +12,7 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 from .static_dns_util import RESOLV_CONF_FILE, verify_nameserver_in_config_db, verify_nameserver_in_conf_file, \
     get_nameserver_from_resolvconf, config_mgmt_ip, add_dns_nameserver, del_dns_nameserver, get_mgmt_port_ip_info, \
     get_nameserver_from_config_db, clear_nameserver_from_resolvconf
+from tests.common.mellanox_data import is_mellanox_device, is_issu_enabled
 
 
 pytestmark = [
@@ -84,6 +85,9 @@ def test_static_dns_basic(request, duthost, localhost, mgmt_interfaces):
     reboot_type = request.config.getoption("--static_dns_reboot_type")
     if reboot_type == "random":
         reload_types = ["reload", "cold", "fast", "warm"]
+        if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
+            logger.info("ISSU is not enabled on the device, remove warm reboot from the list")
+            reload_types.remove("warm")
         reboot_type = random.choice(reload_types)
     with allure.step(f"Reload the system with command {reboot_type}"):
         if reboot_type == "reload":


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip warm-reboot for test_static_dns_basic when issu is disabled on mellanox device

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Skip warm-reboot for test_static_dns_basic when issu is disabled on mellanox device

#### How did you do it?
when issu is disabled on mellanox device, remove 'warm' from reload_types list

#### How did you verify/test it?
Run the tests on Mellanox device

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
