### PR TITLE
xfail test_vlan_ports_down for v6 only topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5045,6 +5045,12 @@ vlan/test_vlan_ping.py:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/15061 and 'dualtor-aa' in topo_name"
 
+vlan/test_vlan_ports_down.py::test_vlan_ports_down:
+  xfail:
+    reason: "Test xfail due to issue https://github.com/sonic-net/sonic-mgmt/issues/21798"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/21798 and '-v6-' in topo_name"
+
 #######################################
 #####             voq             #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Xfail test_vlan_ports_down for v6 only topo due to the issue of https://github.com/sonic-net/sonic-mgmt/issues/21798

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
xfail test_vlan_ports_down for v6 only topo due to the issue of https://github.com/sonic-net/sonic-mgmt/issues/21798

#### How did you do it?
xfail test_vlan_ports_down for v6 only topo 

#### How did you verify/test it?
Run the test on v6 only topo

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
