### PR TITLE
Fix TyperError in test_ecmp_balance.py due to function in utilities.py modified

### DIFF
--- a/tests/ecmp/test_ecmp_balance.py
+++ b/tests/ecmp/test_ecmp_balance.py
@@ -102,7 +102,7 @@ def setup(duthosts, rand_selected_dut, tbinfo):
     )
 
     upstream_neigh_type = get_upstream_neigh_type(tbinfo)
-    downstream_neigh_type = get_downstream_neigh_type(topo)
+    downstream_neigh_type = get_downstream_neigh_type(tbinfo)
     pytest_require(
         upstream_neigh_type is not None and downstream_neigh_type is not None,
         "Cannot get neighbor type for unsupported topo: {}".format(topo),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Those
Due to https://github.com/sonic-net/sonic-mgmt/pull/20620/, the `get_upstream_neigh_type` in `utilities.py` was modified.
I fixed it in https://github.com/sonic-net/sonic-mgmt/pull/21488
Then `get_downstream_neigh_type` was modified again in https://github.com/sonic-net/sonic-mgmt/pull/20913
I have to modify the parameter again.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Update the `get_downstream_neigh_type` function parameter which was modified by other PR.

#### How did you do it?
Use tbinfo instead of topy_type

#### How did you verify/test it?
Run `test_ecmp_balance.py`

test evidence:
https://elastictest.org/scheduler/testplan/695c7df5ed78cb175048b503?testcase=ecmp%2Ftest_ecmp_balance.py&type=console
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
ansible: 2.18.12
rootdir: /var/src/sonic-mgmt_vms64-t1-7260-14/tests
configfile: pytest.ini
plugins: cov-7.0.0, stress-1.0.1, sugar-1.1.1, xdist-3.8.0, plus-0.8.1, allure-pytest-2.15.2, html-4.1.1, repeat-0.9.4, metadata-3.1.1, ansible-25.12.0
collected 4 items

ecmp/test_ecmp_balance.py::test_udp_packets[ipv4] PASSED                 [ 25%]
ecmp/test_ecmp_balance.py::test_udp_packets_ecmp[ipv4] PASSED            [ 50%]
ecmp/test_ecmp_balance.py::test_udp_packets[ipv6] PASSED                 [ 75%]
ecmp/test_ecmp_balance.py::test_udp_packets_ecmp[ipv6] PASSED            [100%]DEBUG:tests.conftest:[log_custom_msg] item: <Function test_udp_packets_ecmp[ipv6]>
INFO:root:Can not get Allure report URL. Please check logs

```


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
