### PR TITLE
Ignore syslog messages generated by orchagent during race-condition e…

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -297,6 +297,8 @@ r, ".* WARNING kernel:.*pcieport.*device.*error.*status/mask=.*"
 r, ".* ERR syncd\d*#syncd:.* -E-HLD-0- Trap.* is not supported.*"
 r, ".* ERR pmon#xcvrd:.*CMIS:.*no suitable app for the port appl.*"
 r, ".* ERR kernel:.*ltc2497.*i2c transfer failed: -EFAULT"
+r, ".* ERR swss#orchagent: :- removeVlan: Failed to remove non-empty VLAN*"
+r, ".* ERR swss#orchagent: :- removeVlan: Failed to remove ref count \d+ VLAN*"
 
 # Ignore ACL EGRESS feature unavailable error on fabric cards
 r, ".* ERR syncd\d*#syncd:.* SAI_API_SWITCH:brcm_sai_get_switch_attribute.* Get switch attrib 37 failed with error Feature unavailable.*"


### PR DESCRIPTION
LogAnalyzer analyzes if there are any errors in the syslog. LogAnalyzer to ignore selected logs due to race condition events of processing by orchagent.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Ignore syslog messages generated by orchagent during race-condition events.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Possible causes: router interface, ACL binding, buffer config, or other component still referencing the VLAN.

#### How did you do it?
Ignore the syslog for a Race-condition event logs that are still referencing to VLAN.

#### How did you verify/test it?
Executed testFdbFlush.py script on cmono-t0-2-dut

#### Any platform specific information?
cmono-t0-2-dut

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
