### PR TITLE
Always check and pull latest base image when setup mgmt container

### DIFF
--- a/setup-container.sh
+++ b/setup-container.sh
@@ -161,8 +161,6 @@ function pull_sonic_mgmt_docker_image() {
 
         if eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_SONIC_MGMT}$"; then
             IMAGE_ID="${DOCKER_SONIC_MGMT}"
-        elif eval "${DOCKER_IMAGES_CMD}" | grep -q "^${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}$"; then
-            IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
         elif log_info "pulling docker image from a registry ..." && eval "${DOCKER_PULL_CMD}"; then
             IMAGE_ID="${DOCKER_REGISTRY}/${DOCKER_SONIC_MGMT}"
         else


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Always check and pull latest base image when setup mgmt container

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Always check and pull latest base image when setup mgmt container

#### How did you do it?
Remove the check before pull image. The `docker pull` command could check and skip download when the image is already up to date.

#### How did you verify/test it?
Verified by setup sonic-mgmt container.

In first setup, it pull the latest base image:
```
$ ./setup-container.sh -n sonic-mgmt-zhijianli -d /home/zhijianli/mgmt -v
INFO: pulling docker image from a registry ...
latest: Pulling from docker-sonic-mgmt
02de03a7213b: Already exists 
d82fe5b37fbf: Pull complete 
c41cc3212d30: Pull complete 
5fa4ee8d7aff: Pull complete 
630edb528e57: Pull complete 
c3b073777cd8: Pull complete 
b9f8df40b670: Pull complete 
d9085e0f6870: Pull complete 
f1426d6e0d5a: Pull complete 
d54db61fc326: Pull complete 
7d9ea9b05825: Pull complete 
03a95e603690: Pull complete 
130e37af438c: Pull complete 
708f4649a7cb: Pull complete 
6962626ba4cc: Pull complete 
f476b4fbda68: Pull complete 
6bfac7b8c7c2: Pull complete 
4aa0ed787028: Pull complete 
1b66c10f398d: Pull complete 
4f4fb700ef54: Pull complete 
14988c7542e9: Pull complete 
ecb4847d1793: Pull complete 
a63f313df15a: Pull complete 
594cc6e1c0cc: Pull complete 
Digest: sha256:478d7fc357dd75ebc902669697dbd601e322c63ecc4e7930eeab27ac7ec36ac7
Status: Downloaded newer image for sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
...
```

In second try, the image on server is already up to date, so the download is skipped autometically:

```
$ ./setup-container.sh -n sonic-mgmt-zhijianli -d /home/zhijianli/mgmt -v
INFO: pulling docker image from a registry ...
latest: Pulling from docker-sonic-mgmt
Digest: sha256:478d7fc357dd75ebc902669697dbd601e322c63ecc4e7930eeab27ac7ec36ac7
Status: Image is up to date for sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest
...
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
