### PR TITLE
[Nvidia] Increase the pre_reboot_timeout in fwutil ONIE/BIOS test for SN4280

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -102,6 +102,8 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
             else:
                 # For BIOS/ONIE, most time is spend after the reboot in ONIE
                 pre_reboot_timeout = 120
+                if duthost.facts["platform"] == "x86_64-nvidia_sn4280-r0":
+                    pre_reboot_timeout += 240
                 post_reboot_timeout = timeout
             localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=pre_reboot_timeout)
             # Wait for 30s in case there is ssh flap


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The switch shutdown time for SN4280 is longer due to PR:https://github.com/sonic-net/sonic-buildimage/pull/24165. 
We need increase the pre_reboot_timeout timeout.
Previously, we have already added this change but only in 202506 branch.
Now we decided add it also to master branch regardless of the status of sonic-buildimage PR#24165.
This is because the reboot time for SN4280 will be longer anyway due to the DPUs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Make sure the fwutil ONIE/BIOS is stable on SN4280 when the DPUs are online.
#### How did you do it?
Add a additional 240s in the pre_reboot_timeout.
#### How did you verify/test it?
Run the test on SN4280 light mode regression, it's passing consistently.
#### Any platform specific information?
Only for SN4280
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
