### PR TITLE
[test_switchover_impact] enable active-active topo for switchover tests

### DIFF
--- a/tests/dualtor_io/test_switchover_impact.py
+++ b/tests/dualtor_io/test_switchover_impact.py
@@ -22,6 +22,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.enable_active_active
 @pytest.mark.parametrize("switchover", ["planned"])
 def test_tor_switchover_impact(request,                                                    # noqa: F811
                                upper_tor_host, lower_tor_host,                             # noqa: F811


### PR DESCRIPTION
test was missing pytest marker to enable active-active testing.

### Description of PR
enables test_switchover_impact to run on active-active

Summary:

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
test_switchover_impact was skipped on active-active test runs and needed pytest marker to be enabled

#### How did you do it?
added pytest marker to enable active-active

#### How did you verify/test it?
ran on active-active testbed

#### Any platform specific information?
n/a

#### Supported testbed topology if it's a new test case?
n/a

### Documentation
n/a
