### PR TITLE
Add Cisco-8122-O128S2 to ansible variable cisco-8000_gr2_hwskus

### DIFF
--- a/ansible/group_vars/sonic/variables
+++ b/ansible/group_vars/sonic/variables
@@ -40,10 +40,10 @@ marvell_hwskus: [ "et6448m", "Nokia-7215" ]
 marvell-teralynx_tl7_hwskus: ["Wistron_sw_to3200k_32x100" , "Wistron_sw_to3200k"]
 marvell-teralynx_tl10_hwskus: ["dbmvtx9180_64osfp_128x400G_lab"]
 
-cisco_hwskus: ["Cisco-8102-C64", "Cisco-8101-T32", "Cisco-8111-O32", "Cisco-8101-C64", "Cisco-8101-V64", "Cisco-8101-C48T8", "Cisco-8101-O8V48", "Cisco-8101-O8C48", "Cisco-8101C01-C32", "Cisco-8101C01-C28S4", "Cisco-8111-C32", "Cisco-8111-O32", "Cisco-8111-O64", "Cisco-8122-O64", "Cisco-8122-O64S2", "Cisco-8122-O128", "Cisco-8800-LC-48H-C48", "Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36", "cisco-8101-p4-32x100-vs", "Cisco-8102-28FH-DPU-O"]
+cisco_hwskus: ["Cisco-8102-C64", "Cisco-8101-T32", "Cisco-8111-O32", "Cisco-8101-C64", "Cisco-8101-V64", "Cisco-8101-C48T8", "Cisco-8101-O8V48", "Cisco-8101-O8C48", "Cisco-8101C01-C32", "Cisco-8101C01-C28S4", "Cisco-8111-C32", "Cisco-8111-O32", "Cisco-8111-O64", "Cisco-8122-O64", "Cisco-8122-O64S2", "Cisco-8122-O128", "Cisco-8122-O128S2", "Cisco-8800-LC-48H-C48", "Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36", "cisco-8101-p4-32x100-vs", "Cisco-8102-28FH-DPU-O"]
 cisco-8000_gb_hwskus: ["Cisco-8102-C64", "Cisco-8101-T32", "Cisco-8101-O32", "Cisco-8101-C64", "Cisco-8101-V64", "Cisco-8101-C48T8", "Cisco-8101-O8V48", "Cisco-8101-O8C48", "Cisco-8101C01-C32", "Cisco-8101C01-C28S4", "Cisco-8111-C32", "Cisco-88-LC0-36FH-M-O36", "Cisco-88-LC0-36FH-O36", "Cisco-8102-28FH-DPU-O", "Cisco-8102-28FH-DPU-O8C40", "Cisco-8102-28FH-DPU-C28", "Cisco-8102-28FH-DPU-O8V40", "Cisco-8102-28FH-DPU-O8C20", "Cisco-8102-28FH-DPU-O12C16"]
 cisco-8000_gr_hwskus: ["Cisco-8111-O32", "Cisco-8111-O64"]
-cisco-8000_gr2_hwskus: ["Cisco-8122-O64", "Cisco-8122-O64S2", "Cisco-8122-O128"]
+cisco-8000_gr2_hwskus: ["Cisco-8122-O64", "Cisco-8122-O64S2", "Cisco-8122-O128", "Cisco-8122-O128S2"]
 cisco-8000_pac_hwskus: ["Cisco-8800-LC-48H-C48"]
 
 ## Note:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Adds new gr2 hwsku Cisco-8122-O128S2 to ansible variable cisco-8000_gr2_hwskus.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix the failure that fixture dutConfig couldn't get dutAsic.

#### How did you do it?
Add Cisco-8122-O128S2 to ansible variable cisco-8000_gr2_hwskus.

#### How did you verify/test it?
Run test_qos_sai.py.

#### Any platform specific information?
hwsku Cisco-8122-O128S2.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
