### PR TITLE
[Arista] Update LT2,FT2 testcase skip for reboot, iface_namingmode

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1330,7 +1330,7 @@ platform_tests/test_reboot.py::test_fast_reboot:
     reason: "Skip test_fast_reboot for M*/t1/t2 / Fast reboot is broken on dualtor topology. Skipping for now. / Skip for smartswitch topology."
     conditions_logical_operator: or
     conditions:
-      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2']"
+      - "topo_type in ['m0', 'mx', 'm1', 't1', 't2', 'lt2', 'ft2']"
       - "'dualtor' in topo_name and https://github.com/sonic-net/sonic-buildimage/issues/16502"
       - "'isolated' in topo_name"
       - "is_smartswitch==True"

--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -1216,8 +1216,6 @@ class TestConfigInterface():
         # Set speed to configure
         configure_speed = supported_speeds[0] if supported_speeds else native_speed
 
-        ignore_host_lane_count_loganalyzer(ignore_condition=duthost.facts['hwsku'] in ["Arista-7060X6-64PE-P32O64",
-                                                                                       "Arista-7060X6-64PE-P64"])
 
         if not self.check_speed_change(duthost, asic_index, interface, configure_speed):
             pytest.skip(


### PR DESCRIPTION
The fast reboot testcase fails consistently and is skipped for t1,t2. Adding lt2,ft2 topos to skip condition.

Also, removing log ignore for lt2,ft2 in iface_namingmode because the testcase is not supported due to ASIC limitations. The test will pass because the speed is changed but the interface will stay down causing issues in following iface_naming mode tests.

The skip is present in master but is missing a backport to msft-202503: https://github.com/sonic-net/sonic-mgmt/pull/19074

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] msft-202503

### Approach
#### What is the motivation for this PR?
```2026 Jan  6 00:56:30.285352 qspf305 NOTICE swss#orchagent: :- doPortTask: Set port Ethernet0 speed to 400000
2026 Jan  6 00:56:30.286401 qspf305 NOTICE swss#orchagent: :- handleNotification: Get port state change notification id:1000000000003 status:2 oper_error_status:0x0                                                                 
2026 Jan  6 00:56:30.286416 qspf305 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet0 oper state set from up to down                        
2026 Jan  6 00:56:30.286815 qspf305 WARNING pmon#DomInfoUpdateTask[34]: *** ('Ethernet0', 'APPL_DB', 'PORT_TABLE') handle_port_update_event() fvp {'index': '1', 'flap_count': '4', 'port_name': 'Ethernet0', 'asic_id': 0, 'op': 'SET'}                                                                          
2026 Jan  6 00:56:30.288624 qspf305 NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status DOWN to host interface Ethernet0
```
#### How did you do it?

#### How did you verify/test it?
Skipping the test_config_interface_speed test resolved all other test failures. 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
