### PR TITLE
Update ptf_nn_agent port range

### DIFF
--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -10,7 +10,7 @@ from tests.common import constants
 import random
 
 
-DEFAULT_PTF_NN_PORT_RANGE = [10900, 11000]
+DEFAULT_PTF_NN_PORT_RANGE = [10900, 10999]
 DEFAULT_DEVICE_NUM = 0
 ETH_PFX = 'eth'
 ETHERNET_PFX = "Ethernet"


### PR DESCRIPTION

Summary: Update ptf_nn_agent port range
Fixes # 
Port 11000 is used in `test_bgp_update_timer.py` and `test_bgp_peer_shutdown.py`.
The **ptf_nn_agent** port is generated randomly from the range **10900-11000**. If it select port 11000, it will conflict with the tests using port 11000 and the case will fail
Update ptf_nn_agent port range to 10900-10999 to avoid the conflict

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run regression test pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
