### PR TITLE
Add database container into critical monitor

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -323,6 +323,10 @@ def get_expected_alerting_messages_supervisor(duthost, containers_in_namespaces)
                 # TODO: Should remove the following two lines once the issue was solved in the image.
                 if "syncd" in container_name_in_namespace and critical_process == "dsserve":
                     continue
+
+                if "database" in container_name_in_namespace and "redis" in critical_process:
+                    continue
+
                 logger.info("Generating the regex of expected alerting message for process '{}' in container '{}'"
                             .format(critical_process, container_name_in_namespace))
                 expected_alerting_messages.append(".*Process '{}' is not running in namespace '{}'.*"
@@ -515,10 +519,6 @@ def ensure_all_critical_processes_running(duthost, containers_in_namespaces):
                 # Skip 'dsserve' process since it was not managed by supervisord
                 # TODO: Should remove the following two lines once the issue was solved in the image.
                 if "syncd" in container_name_in_namespace and critical_process == "dsserve":
-                    continue
-                
-                # skip 'redis' process in 'database' container since it is set to auto-restart if exited unexpectedly.
-                if "database" in container_name_in_namespace and "redis" in critical_process:
                     continue
 
                 ensure_process_is_running(duthost, container_name_in_namespace, critical_process)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

#### Summary:
Enhanced `test_monitoring_critical_processes` to include database container critical process monitoring and ensure proper recovery order to avoid dependency failures.

Fixes: Test Gap - database container processes were skipped from critical process monitoring tests

### Type of change
- [x] Test case improvement
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

---

## Approach

### What is the motivation for this PR?

**Test Gap Identified:** The database container was being skipped in `test_critical_process_monitoring`, leaving a gap in test coverage. Database container critical processes need to be monitored to ensure system reliability, as Redis is a critical dependency for many SONiC services.

When the database container was included in testing, a new issue emerged: after killing database processes, the recovery process would fail because other containers attempting to recover would fail to connect to Redis, which hadn't been restored yet.

### How did you do it?

1. **Removed database from skip list** - The database container is now included in critical process monitoring tests to ensure its processes generate expected syslog alerts when they fail.

### How did you verify/test it?

- Verified that database container critical processes are killed during test execution
- Confirmed expected syslog messages are generated for database container process failures

### Any platform specific information?


### Supported testbed topology if it's a new test case?

N/A - This is an improvement to existing test case `test_monitoring_critical_processes`, which supports:
- Topology: 'any', 't1-multi-asic'

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
