### PR TITLE
Temporarily pause watchdog punching during test case for nexthop devices

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -50,9 +50,14 @@ class TestWatchdogApi(PlatformApiTestBase):
         and disables it after the test ends'''
 
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-        if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
-                duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0' or \
-                duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
+        if (
+            duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0'
+            or duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0'
+            or duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu")
+        ):
+            duthost.shell("watchdogutil disarm")
+        elif duthost.facts["platform"].startswith("x86_64-nexthop_"):
+            duthost.shell("systemctl disable watchdog.timer --now")
             duthost.shell("watchdogutil disarm")
 
         assert not watchdog.is_armed(platform_api_conn)
@@ -65,6 +70,9 @@ class TestWatchdogApi(PlatformApiTestBase):
             if duthost.facts['platform'] == 'armhf-nokia_ixs7215_52x-r0' or \
                     duthost.facts['platform'] == 'arm64-nokia_ixs7215_52xb-r0':
                 duthost.shell("systemctl start cpu_wdt.service")
+            elif duthost.facts["platform"].startswith("x86_64-nexthop_"):
+                duthost.shell("systemctl enable watchdog.timer --now")
+
             if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
                 duthost.shell("watchdogutil arm")
 


### PR DESCRIPTION
### Description of PR
Summary:

Temporarily pause watchdog punching during test case for Nexthop devices

Fixes https://github.com/sonic-net/sonic-mgmt/issues/21886

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

To satisfy the pytest fixture [condition](https://github.com/sonic-net/sonic-mgmt/blob/005e4c81cfc8bed6e8c3a6d195569a53300e194b/tests/platform_tests/api/test_watchdog.py#L47C9-L47C29) and avoid race conditions due to watchdog puncher.

#### How did you do it?

In the pytest fixture (that runs setup and for each test case), disable watchdog punching and then disarm watchdog for Nexthop devices. 

#### How did you verify/test it?

Run the test cases in `test_watchdog.py` on Nexthop and non-Nexthop devices.

#### Any platform specific information?

This PR makes the `test_watchdog.py` compatible with Nexthop devices that have watchdog enabled all the time.

