### PR TITLE
Improve BGP test to support BGP confederation

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -944,3 +944,21 @@ class MultiAsicSonicHost(object):
     @lru_cache
     def containers(self):
         return SonicDockerManager(self)
+
+    def get_bgp_confed_asn(self):
+        """
+        Get BGP confederation ASN from running config
+        Return None if not configured
+        """
+        if self.sonichost.is_multi_asic:
+            asic = self.frontend_asics[0]
+            config_facts = asic.config_facts(
+                host=self.hostname, source="running", namespace=asic.namespace
+            )['ansible_facts']
+        else:
+            config_facts = self.sonichost.config_facts(
+                host=self.hostname, source="running"
+            )['ansible_facts']
+
+        bgp_confed_asn = config_facts.get('BGP_DEVICE_GLOBAL', {}).get('CONFED', {}).get('asn', None)
+        return bgp_confed_asn

--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -21,6 +21,45 @@ def _write_variable_from_j2_to_configdb(duthost, template_file, **kwargs):
         duthost.file(path=save_dest_path, state="absent")
 
 
+def _config_bgp_neighbor_with_vtysh(duthost, peer_addr, peer_asn, dut_addr, dut_asn):
+    """Configure BGP neighbor using vtysh command"""
+    cmd = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {dut_asn}' "
+        "-c 'neighbor {peer_addr} remote-as {peer_asn}' "
+        "-c 'neighbor {peer_addr} activate' "
+    )
+    duthost.shell(cmd.format(peer_addr=peer_addr,
+                             peer_asn=peer_asn,
+                             dut_addr=dut_addr,
+                             dut_asn=dut_asn))
+
+
+def _remove_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+    """Remove BGP neighbor using vtysh command"""
+    cmd = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {dut_asn}' "
+        "-c 'no neighbor {peer_addr}' "
+    )
+    duthost.shell(cmd.format(peer_addr=peer_addr,
+                             dut_asn=dut_asn))
+
+
+def _shutdown_bgp_neighbor_with_vtysh(duthost, peer_addr, dut_asn):
+    """Shutdown BGP neighbor using vtysh command"""
+    cmd = (
+        "vtysh "
+        "-c 'configure terminal' "
+        "-c 'router bgp {dut_asn}' "
+        "-c 'neighbor {peer_addr} shutdown' "
+    )
+    duthost.shell(cmd.format(peer_addr=peer_addr,
+                             dut_asn=dut_asn))
+
+
 def run_bgp_facts(duthost, enum_asic_index):
     """compare the bgp facts between observed states and target state"""
 
@@ -90,7 +129,8 @@ class BGPNeighbor(object):
     def __init__(self, duthost, ptfhost, name,
                  neighbor_ip, neighbor_asn,
                  dut_ip, dut_asn, port, neigh_type=None,
-                 namespace=None, is_multihop=False, is_passive=False, debug=False):
+                 namespace=None, is_multihop=False, is_passive=False, debug=False,
+                 confed_asn=None, use_vtysh=False):
         self.duthost = duthost
         self.ptfhost = ptfhost
         self.ptfip = ptfhost.mgmt_ip
@@ -105,12 +145,22 @@ class BGPNeighbor(object):
         self.is_passive = is_passive
         self.is_multihop = not is_passive and is_multihop
         self.debug = debug
+        self.use_vtysh = use_vtysh
+        self.confed_asn = confed_asn
 
     def start_session(self):
         """Start the BGP session."""
         logging.debug("start bgp session %s", self.name)
 
-        if not self.is_passive:
+        if self.use_vtysh:
+            _config_bgp_neighbor_with_vtysh(
+                self.duthost,
+                peer_addr=self.ip,
+                peer_asn=self.asn,
+                dut_addr=self.peer_ip,
+                dut_asn=self.peer_asn
+            )
+        elif not self.is_passive:
             _write_variable_from_j2_to_configdb(
                 self.duthost,
                 "bgp/templates/neighbor_metadata_template.j2",
@@ -150,7 +200,7 @@ class BGPNeighbor(object):
             router_id=router_id,
             peer_ip=self.peer_ip,
             local_asn=self.asn,
-            peer_asn=self.peer_asn,
+            peer_asn=self.confed_asn if self.confed_asn is not None else self.peer_asn,
             port=self.port,
             debug=self.debug
         )
@@ -170,10 +220,18 @@ class BGPNeighbor(object):
     def stop_session(self):
         """Stop the BGP session."""
         logging.debug("stop bgp session %s", self.name)
-        if not self.is_passive:
+
+        if self.use_vtysh:
+            _remove_bgp_neighbor_with_vtysh(
+                self.duthost,
+                peer_addr=self.ip,
+                dut_asn=self.peer_asn
+            )
+        elif not self.is_passive:
             for asichost in self.duthost.asics:
                 asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'BGP_NEIGHBOR|{}'".format(self.ip))
                 asichost.run_sonic_db_cli_cmd("CONFIG_DB del 'DEVICE_NEIGHBOR_METADATA|{}'".format(self.name))
+
         self.ptfhost.exabgp(name=self.name, state="absent")
 
     def teardown_session(self):
@@ -191,7 +249,14 @@ class BGPNeighbor(object):
         )
 
         self.ptfhost.exabgp(name=self.name, state="stopped")
-        if not self.is_passive:
+
+        if self.use_vtysh:
+            _shutdown_bgp_neighbor_with_vtysh(
+                self.duthost,
+                peer_addr=self.ip,
+                dut_asn=self.peer_asn
+            )
+        elif not self.is_passive:
             for asichost in self.duthost.asics:
                 if asichost.namespace == self.namespace:
                     logging.debug("update CONFIG_DB admin_status to down on {}".format(asichost.namespace))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to improve existing BGP tests to support BGP confederation.
Below two tests are improved
-  [test_bgp_peer_shutdown.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-9d72d8d9e2fcf1b7573aadae84686354be322286dfce64199d0b158d8002cda0)
- [test_bgp_update_timer.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-85d6c9d73bdee5ce2f7bca42ac67428028046115c26e6223a0df78e8706e3bd6)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR is to improve existing BGP tests to support BGP confederation.

#### How did you do it?
1. Improve [bgp.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-a6848e9239af6d197528a7960ad94553f237dc318bd195837d5a31a210ff879c) to support using `vtysh` to configure BGP neighbors
2. Improve [multi_asic.py](https://github.com/sonic-net/sonic-mgmt/compare/fix_bgp_confed_test?expand=1#diff-9b70276a3c2fb324d2737f57ab8ae139d7eb30cc886d3717f185088a9f8f241a) to add a helper function to retrieve BGP confederation ASN.

#### How did you verify/test it?
Both tests are verified on LT2/FT2 testbeds.
```
collected 2 items                                                                                                                                                                                                                                              

bgp/test_bgp_update_timer.py::test_bgp_update_timer_single_route[default]  ^HPASSED                                                                                                                                                       [ 50%]
bgp/test_bgp_update_timer.py::test_bgp_update_timer_session_down[default] PASSED                                                                                                                                                       [100%]

collected 1 item                                                                                                                                                                                                                                               

bgp/test_bgp_peer_shutdown.py::test_bgp_peer_shutdown[default]  ^HPASSED                                                                                                                                                                  [100%]
```
#### Any platform specific information?
No.

#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
