### PR TITLE
Fix test_watchdog on multi-asic

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -35,12 +35,6 @@
           't1-isolated-v6-d56u1-lag', 't1-isolated-v6-d448u15-lag',
           't1-isolated-v6-d128' ]
 
-test_pretest.py::test_disable_rsyslog_rate_limit:
-  skip:
-    reason: "We don't need to disable the rate limit on vs testbed"
-    conditions:
-      - "asic_type in ['vs']"
-
 #######################################
 #####          custom_acl         #####
 #######################################
@@ -5087,6 +5081,15 @@ test_pktgen.py:
     reason: "No need in M0/Mx/M1"
     conditions:
       - "topo_type in ['m0', 'mx', 'm1']"
+
+#######################################
+#####         pretest             #####
+#######################################
+test_pretest.py::test_disable_rsyslog_rate_limit:
+  skip:
+    reason: "We don't need to disable the rate limit on vs testbed"
+    conditions:
+      - "asic_type in ['vs']"
 
 #######################################
 #####         vs_chassis          #####


### PR DESCRIPTION
### Description of PR
Skip recover the rate limit on vs testbed. Otherwise it will prevent swssN container sending rsyslog to host

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
