### PR TITLE
Update polling interval in trimming case

### DIFF
--- a/tests/packet_trimming/constants.py
+++ b/tests/packet_trimming/constants.py
@@ -147,14 +147,13 @@ SRV6_MY_SID_LIST = [
 SRV6_ROUTE_PREFIX = '2001::/16'
 
 # Drop counter
-SWITCH_INTERVAL = 1000
-PORT_INTERVAL = 100
-QUEUE_INTERVAL = 100
+# The polling interval should be no less than 2 seconds to avoid BGP routes large convergence time.
+TRIMMING_COUNTER_INTERVAL = 2000
 
 COUNTER_TYPE = [
-    ("switch", "SWITCH_STAT", SWITCH_INTERVAL),
-    ("port", "PORT_STAT", PORT_INTERVAL),
-    ("queue", "QUEUE_STAT", QUEUE_INTERVAL),
+    ("switch", "SWITCH_STAT", TRIMMING_COUNTER_INTERVAL),
+    ("port", "PORT_STAT", TRIMMING_COUNTER_INTERVAL),
+    ("queue", "QUEUE_STAT", TRIMMING_COUNTER_INTERVAL),
 ]
 
 # Mirror session configuration

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -28,7 +28,8 @@ from tests.packet_trimming.constants import (DEFAULT_SRC_PORT, DEFAULT_DST_PORT,
                                              SCHEDULER_TYPE, SCHEDULER_WEIGHT, SCHEDULER_PIR, MIRROR_SESSION_NAME,
                                              MIRROR_SESSION_SRC_IP, MIRROR_SESSION_DST_IP, MIRROR_SESSION_DSCP,
                                              MIRROR_SESSION_TTL, MIRROR_SESSION_GRE, MIRROR_SESSION_QUEUE,
-                                             SCHEDULER_CIR, SCHEDULER_METER_TYPE, PACKET_SIZE_MARGIN)
+                                             SCHEDULER_CIR, SCHEDULER_METER_TYPE, PACKET_SIZE_MARGIN,
+                                             TRIMMING_COUNTER_INTERVAL)
 from tests.packet_trimming.packet_trimming_config import PacketTrimmingConfig
 
 logger = logging.getLogger(__name__)
@@ -2889,6 +2890,10 @@ def verify_queue_and_port_trim_counter_consistency(duthost, port):
         AssertionError: If the trim counter on the queue is not equal to the trim counter on the port level
     """
     logger.info(f"Verify the consistency of the trim counter on the queue and the port level for port {port}")
+
+    sleep_time = TRIMMING_COUNTER_INTERVAL / 1000 + 1
+    logger.info(f"Waiting {sleep_time} seconds for the trim counter to be updated")
+    time.sleep(sleep_time)
 
     # Get the trim counter information on the queue level
     queue_counters = get_queue_trim_counters_json(duthost, port)


### PR DESCRIPTION
Summary: Update polling interval in trimming case
Fixes # The polling interval should be no less than 2 seconds to avoid BGP routes large convergence time

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run regression test, pass.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
