### PR TITLE
Enable test_bgp_bounce with ipv6-only topo

### DIFF
--- a/tests/bgp/templates/bgp_no_export.j2
+++ b/tests/bgp/templates/bgp_no_export.j2
@@ -23,6 +23,9 @@ enable password zebra
 route-map TO_TIER0_V4 permit 50
  set community no-export additive
 !
+route-map TO_TIER0_V6 permit 50
+ set community no-export additive
+!
 {% endif %}
 route-map FROM_BGP_SPEAKER_V4 permit 10
 !
@@ -79,19 +82,22 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   address-family ipv4
     neighbor {{ neighbor_addr }} activate
     maximum-paths 64
-{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
- {%- if 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] %}
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] %}
     neighbor {{ neighbor_addr }} route-map TO_TIER0_V4 out
     neighbor {{ neighbor_addr }} send-community
     neighbor {{ neighbor_addr }} allowas-in 1
- {% endif %}
-  exit-address-family
 {% endif %}
+  exit-address-family
 {% endif %}
 {% if neighbor_addr | ipv6 %}
   address-family ipv6
     neighbor {{ neighbor_addr }} activate
     maximum-paths 64
+{% if 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[bgp_session['name']]['type'] %}
+    neighbor {{ neighbor_addr }} route-map TO_TIER0_V6 out
+    neighbor {{ neighbor_addr }} send-community
+    neighbor {{ neighbor_addr }} allowas-in 1
+{% endif %}
   exit-address-family
 {% endif %}
 {% endif %}

--- a/tests/bgp/test_bgp_bounce.py
+++ b/tests/bgp/test_bgp_bounce.py
@@ -7,6 +7,7 @@ import pytest
 import time
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import is_ipv6_only_topology
 from bgp_helpers import apply_bgp_config
 from bgp_helpers import get_no_export_output
 from bgp_helpers import BGP_ANNOUNCE_TIME
@@ -16,7 +17,7 @@ pytestmark = [
 ]
 
 
-def test_bgp_bounce(duthost, nbrhosts, deploy_plain_bgp_config, deploy_no_export_bgp_config, backup_bgp_config):
+def test_bgp_bounce(duthost, nbrhosts, tbinfo, deploy_plain_bgp_config, deploy_no_export_bgp_config, backup_bgp_config):
     """
     Verify bgp community no export functionality
 
@@ -33,6 +34,7 @@ def test_bgp_bounce(duthost, nbrhosts, deploy_plain_bgp_config, deploy_no_export
     """
     bgp_plain_config = deploy_plain_bgp_config
     bgp_no_export_config = deploy_no_export_bgp_config
+    ipv6_only = is_ipv6_only_topology(tbinfo)
 
     # Get random ToR VM
     vm_name = random.choice([vm_name for vm_name in list(nbrhosts.keys()) if vm_name.endswith('T0')])
@@ -48,7 +50,7 @@ def test_bgp_bounce(duthost, nbrhosts, deploy_plain_bgp_config, deploy_no_export
     time.sleep(BGP_ANNOUNCE_TIME)
 
     # Take action on one of the ToR VM
-    no_export_route_num = get_no_export_output(vm_host)
+    no_export_route_num = get_no_export_output(vm_host, ipv6=ipv6_only)
     pytest_assert(not no_export_route_num, "Routes has no_export attribute")
 
     # Apply bgp no export config
@@ -58,5 +60,5 @@ def test_bgp_bounce(duthost, nbrhosts, deploy_plain_bgp_config, deploy_no_export
     time.sleep(BGP_ANNOUNCE_TIME)
 
     # Take action on one of the ToR VM
-    no_export_route_num = get_no_export_output(vm_host)
+    no_export_route_num = get_no_export_output(vm_host, ipv6=ipv6_only)
     pytest_assert(no_export_route_num, "Routes received on T1 are no-export")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #21906 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Enable test_bgp_bounce with ipv6-only testbed

#### How did you do it?
Added ipv6-only check, and enable function to check for ipv6

#### How did you verify/test it?
Ran on ipv6-only testbed 
<img width="2982" height="110" alt="image" src="https://github.com/user-attachments/assets/39076d57-f9a6-4154-9a1f-ba8e2dfee8e1" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
