### PR TITLE
feat: allow previous connection for deploy-l1

### DIFF
--- a/ansible/roles/testbed/nut/tasks/l1_create_config_patch.yml
+++ b/ansible/roles/testbed/nut/tasks/l1_create_config_patch.yml
@@ -49,3 +49,4 @@
     l1_links: "{{ device_from_l1_links[inventory_hostname] }}"
     l1_cross_connects: "{{ device_l1_cross_connects[inventory_hostname] }}"
     l1_existing_cross_connects: "{{ device_l1_existing_cross_connects }}"
+    reset_previous_connection: "{{ reset_previous_connection | default(true) | bool }}"

--- a/ansible/roles/testbed/nut/templates/config_patch/l1/ocs_xconnect.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/l1/ocs_xconnect.json.j2
@@ -1,6 +1,13 @@
 {%- for port_a, port_b in l1_existing_cross_connects.items() %}
-{ "op": "remove", "path": "/OCS_CROSS_CONNECT/{{ port_a }}-{{ port_b }}" },
+    {%- if reset_previous_connection | bool %}
+        { "op": "remove", "path": "/OCS_CROSS_CONNECT/{{ port_a }}-{{ port_b }}" },
+    {%- else %}
+        {%- if port_a in l1_cross_connects or port_b in l1_cross_connects %}
+            { "op": "remove", "path": "/OCS_CROSS_CONNECT/{{ port_a }}-{{ port_b }}" },
+        {%- endif %}
+    {%- endif %}
 {% endfor %}
+
 {%- for port_a, port_b in l1_cross_connects.items() %}
 { "op": "add", "path": "/OCS_CROSS_CONNECT/{{ port_a }}A-{{ port_b }}B", "value": {} },
 { "op": "add", "path": "/OCS_CROSS_CONNECT/{{ port_a }}A-{{ port_b }}B/a_side", "value": "{{ port_a }}A" },

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -700,7 +700,7 @@ function deploy_l1
   echo "Devices to generate config for: $devices"
   echo ""
 
-  ansible-playbook -i "$inventory" deploy_config_on_testbed.yml --vault-password-file="$passfile" -l "$devices" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e deploy=true -e save=true -e config_duts=false$@
+  ansible-playbook -i "$inventory" deploy_config_on_testbed.yml --vault-password-file="$passfile" -l "$devices" -e testbed_name="$testbed_name" -e testbed_file=$tbfile -e deploy=true -e save=true -e config_duts=false -e reset_previous_connection=false$@
 
   echo Done
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) Currently, deploy-l1 is using overwrite mode. Which replace all the previous connection and add a new one on top.

However, this will also not allow us to re-use l1.

New changes add a parameter `allow_previous_connection` which helps to allow existing connections.

It only remove if the connection is overlap with the second connection

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
