### PR TITLE
Fix test_config_clock_timezone flaky issue

### DIFF
--- a/tests/clock/test_clock.py
+++ b/tests/clock/test_clock.py
@@ -346,12 +346,8 @@ def test_config_clock_timezone(duthosts, init_timezone):
             condition=lambda: ClockUtils.verify_timezone_value(
                 duthosts,
                 expected_tz_name=new_timezone
-            ),
-            reason=f'Timezone did not change to "{new_timezone}" within timeout'
+            )
         )
-
-    with allure.step(f'Verify timezone changed to "{new_timezone}"'):
-        ClockUtils.verify_timezone_value(duthosts, expected_tz_name=new_timezone)
 
     with allure.step('Select a random string as invalid timezone'):
         invalid_timezone = ''.join(random.choice(string.ascii_lowercase) for _ in range(random.randint(1, 10)))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Sometime the test case fails due to: AssertionError: Expected: Asia/Jerusalem == Universal
KVM will fail more frequently.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Sometime the test case fails due to: AssertionError: Expected: Asia/Jerusalem == Universal

#### How did you do it?
Wait 5 seconds for the timezone to be applied

#### How did you verify/test it?
Physical testbed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
