### PR TITLE
Add EXPECTED_RESULT to GLOBAL_PARAMS in PR test template

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -27,6 +27,7 @@ parameters:
     MAX_RUN_TEST_MINUTES: 240
     MGMT_COMMIT_HASH: ""
     PTF_MODIFIED: "False"
+    EXPECTED_RESULT: ""
 
 - name: OVERRIDE_PARAMS
   type: object


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
In internal PR testing, we set STOP_ON_FAILURE to false and EXPECTED_RESULT to SUCCESS to let PR test expose all issues. To make it possible for internal PR testing using public PR test template, we need to add the param in public PR test template.
#### How did you do it?
Add EXPECTED_RESULT to GLOBAL_PARAMS and default value ""
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
