### PR TITLE
[sonic-mgmt] Fix "sflow/test_sflow.py" to use consistent fixtures

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -188,7 +188,8 @@ def config_sflow(duthost, sflow_status='enable'):
 
 
 @pytest.fixture(scope='module')
-def config_sflow_feature(request, duthost):
+def config_sflow_feature(request, duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
     feature_status, _ = duthost.get_feature_status()
 
     if 'sflow' not in feature_status:
@@ -317,7 +318,8 @@ def sflowbase_config(duthosts, rand_one_dut_hostname):
 # ----------------------------------------------------------------------------------
 
 @pytest.fixture
-def selected_portchannel_members(duthost, tbinfo):
+def selected_portchannel_members(duthosts, rand_one_dut_hostname, tbinfo):
+    duthost = duthosts[rand_one_dut_hostname]
     """
     Get the sflow interface
 
@@ -345,7 +347,8 @@ def selected_portchannel_members(duthost, tbinfo):
 
 
 @pytest.fixture
-def restore_sflow_interface_status_and_rate(duthost, selected_portchannel_members):
+def restore_sflow_interface_status_and_rate(duthosts, rand_one_dut_hostname, selected_portchannel_members):
+    duthost = duthosts[rand_one_dut_hostname]
 
     yield
 
@@ -452,14 +455,16 @@ class TestSflowPolling():
     Disable polling and check the dut doesn't send counter samples .
     """
 
-    def testPolling(self, duthost, partial_ptf_runner):
+    def testPolling(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 20")
         verify_show_sflow(duthost, status='up', polling_int=20)
         partial_ptf_runner(
             polling_int=20,
             active_collectors="['collector0','collector1']")
 
-    def testDisablePolling(self, duthost, partial_ptf_runner):
+    def testDisablePolling(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 0")
 
         verify_show_sflow(duthost, status='up', polling_int=0)
@@ -467,7 +472,8 @@ class TestSflowPolling():
             polling_int=0,
             active_collectors="['collector0','collector1']")
 
-    def testDifferentPollingInt(self, duthost, partial_ptf_runner):
+    def testDifferentPollingInt(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell("config sflow polling-interval 60")
 
         verify_show_sflow(duthost, status='up', polling_int=60)
@@ -484,8 +490,10 @@ class TestSflowInterface():
     Test interfaces with different sampling rates
     """
 
-    def testIntfRemoval(self, sflowbase_config, duthost, partial_ptf_runner, selected_portchannel_members,
+    def testIntfRemoval(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                        partial_ptf_runner, selected_portchannel_members,
                         restore_sflow_interface_status_and_rate):
+        duthost = duthosts[rand_one_dut_hostname]
         disabled_sflow_intf_list = selected_portchannel_members[0]
         enabled_sflow_intf_list = [intf for intf_list in selected_portchannel_members[1:] for intf in intf_list]
 
@@ -503,8 +511,10 @@ class TestSflowInterface():
             enabled_sflow_interfaces=enabled_sflow_intf_list,
             active_collectors="['collector0','collector1']")
 
-    def testIntfSamplingRate(self, sflowbase_config, duthost, ptfhost, partial_ptf_runner, selected_portchannel_members,
+    def testIntfSamplingRate(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                             ptfhost, partial_ptf_runner, selected_portchannel_members,
                              restore_sflow_interface_status_and_rate):
+        duthost = duthosts[rand_one_dut_hostname]
         first_portchannel_members = selected_portchannel_members[0]
         second_portchannel_members = selected_portchannel_members[1]
 
@@ -558,7 +568,8 @@ class TestAgentId():
     Add eth0 ip as the agent ip and check the samples are received with intended agent-id.
     """
 
-    def testNonDefaultAgent(self, duthost, partial_ptf_runner):
+    def testNonDefaultAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         agent_ip = var['lo_ip']
         duthost.shell(" config sflow agent-id del")
         duthost.shell(" config sflow agent-id  add Loopback0")
@@ -568,7 +579,8 @@ class TestAgentId():
             agent_id=agent_ip,
             active_collectors="['collector0','collector1']")
 
-    def testDelAgent(self, duthost, partial_ptf_runner):
+    def testDelAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.shell(" config sflow agent-id del")
         verify_show_sflow(duthost, status='up', agent_id='default')
         time.sleep(5)
@@ -579,7 +591,8 @@ class TestAgentId():
             agent_id=agent_ip,
             active_collectors="['collector0','collector1']")
 
-    def testAddAgent(self, duthost, partial_ptf_runner):
+    def testAddAgent(self, duthosts, rand_one_dut_hostname, partial_ptf_runner):
+        duthost = duthosts[rand_one_dut_hostname]
         agent_ip = var['mgmt_ip']
         duthost.shell(" config sflow agent-id  add  eth0")
         verify_show_sflow(duthost, status='up', agent_id='eth0')
@@ -594,8 +607,10 @@ class TestAgentId():
 @pytest.mark.disable_loganalyzer
 class TestReboot():
 
-    def testRebootSflowEnable(self, sflowbase_config, config_sflow_agent, duthost,
+    def testRebootSflowEnable(self, sflowbase_config, config_sflow_agent,
+                              duthosts, rand_one_dut_hostname,
                               localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
         duthost.command("config sflow polling-interval 80")
         verify_show_sflow(duthost, status='up', polling_int=80)
         duthost.command('sudo config save -y')
@@ -620,7 +635,9 @@ class TestReboot():
             polling_int=80,
             active_collectors="['collector0','collector1']")
 
-    def testRebootSflowDisable(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testRebootSflowDisable(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                               localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
         config_sflow(duthost, sflow_status='disable')
         verify_show_sflow(duthost, status='down')
         partial_ptf_runner(
@@ -641,7 +658,9 @@ class TestReboot():
             enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
             active_collectors="[]")
 
-    def testFastreboot(self, sflowbase_config, config_sflow_agent, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testFastreboot(self, sflowbase_config, config_sflow_agent, duthosts,
+                       rand_one_dut_hostname, localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
 
         config_sflow(duthost, sflow_status='enable')
         verify_show_sflow(duthost, status='up', collector=[
@@ -663,7 +682,9 @@ class TestReboot():
             enabled_sflow_interfaces=list(var['sflow_ports'].keys()),
             active_collectors="['collector0','collector1']")
 
-    def testWarmreboot(self, sflowbase_config, duthost, localhost, partial_ptf_runner, ptfhost):
+    def testWarmreboot(self, sflowbase_config, duthosts, rand_one_dut_hostname,
+                       localhost, partial_ptf_runner, ptfhost):
+        duthost = duthosts[rand_one_dut_hostname]
 
         config_sflow(duthost, sflow_status='enable')
         verify_show_sflow(duthost, status='up', collector=[


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [sonic-mgmt] Fix "sflow/test_sflow.py" to use consistent fixtures
Fixes # https://github.com/aristanetworks/sonic-qual.msft/issues/1021

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
In `sflow/test_sflow.py`, Setup/Config fixtures like `setup`, `config_sflow_agent`, `sflowbase_config` are using `rand_one_dut_hostname` fixture to select a single dut from duthosts. But some test cases and fixtures that are relying on above mentioned fixtures are using `duthost` fixture to select a dut. And dut selected by these two fixtures can be different and lead to unexpected behaviours.

**For example:**
`config_sflow_feature` fixture is using `duthost` fixture to enable sflow feature status by running command `sudo config feature state sflow enabled` on duthost.

But `setup` fixture is using `rand_one_dut_hostname` fixture for dut selection (can be different from one selected by duthost fixture), and can cause all test cases to get skipped with message `sflow feature is not enabled` (though feature is supposed to be enabled by `config_sflow_feature` fixture).


#### How did you do it?

Fix is to use same fixture `rand_one_dut_hostname` through out the test for dut selection.


#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
