### PR TITLE
Add sleep rebooting cisco-8000 device

### DIFF
--- a/ansible/devutil/devices/sonic.py
+++ b/ansible/devutil/devices/sonic.py
@@ -47,6 +47,19 @@ def upgrade_by_sonic(sonichosts, localhost, image_url, disk_used_percent):
             time.sleep(900)
         else:
             sonichosts.shell("reboot", module_attrs={"become": True, "async": 300, "poll": 0})
+            is_cisco8000_platform = False
+            for hostname in target_hosts:
+                cfg_facts = sonichosts.config_facts(host=hostname, source='running')[hostname]
+                hwsku = cfg_facts.get('ansible_facts', {}) \
+                    .get('DEVICE_METADATA', {}) \
+                    .get('localhost', {}) \
+                    .get('hwsku', 'unknown')
+                logger.info("Host {} has hwsku {}".format(hostname, hwsku))
+                if 'Cisco' in hwsku:
+                    is_cisco8000_platform = True
+            if is_cisco8000_platform:
+                logger.info("Sleep 600s after rebooting cisco-8000 device...")
+                time.sleep(600)
 
         return True
     except RunAnsibleModuleFailed as e:

--- a/ansible/devutil/devices/sonic.py
+++ b/ansible/devutil/devices/sonic.py
@@ -31,6 +31,18 @@ class SonicHosts(AnsibleHosts):
 
 def upgrade_by_sonic(sonichosts, localhost, image_url, disk_used_percent):
     try:
+        # Skip upgrade image on DPU hosts
+        target_hosts = []
+        for hostname in sonichosts.hostnames:
+            if "dpu" in hostname.lower():
+                logger.info("Skip upgrade image on DPU hosts: {}".format(hostname))
+            else:
+                target_hosts.append(hostname)
+
+        if len(target_hosts) == 0:
+            logger.info("No hosts to upgrade")
+            return True
+        
         sonichosts.reduce_and_add_sonic_images(
             disk_used_pcent=disk_used_percent,
             new_image_url=image_url,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Image upgrade in nightly test may fail because we didn't wait enough time after rebooting Cisco devices.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Image upgrade in nightly test may fail because we didn't wait enough time after rebooting Cisco devices.

#### How did you do it?
Add sleep in Cisco devices.

#### How did you verify/test it?
On physical devices.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
