### PR TITLE
fix the failure in the gnmi_set during health check - Issue 21907

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -230,7 +230,7 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
         ptfhost.shell(f"ping {ip} -c 3", module_ignore_errors=True)
 
     # Health check to make sure the gnmi server is listening on port
-    health_check_cmd = f"sudo ss -ltnp | grep {env.gnmi_port} | grep {env.gnmi_program}"
+    health_check_cmd = f"sudo ss -ltnp | grep {env.gnmi_port} | grep {env.gnmi_process}"
 
     wait_until(120, 1, 5,
                lambda: len(duthost.shell(health_check_cmd, module_ignore_errors=True)['stdout_lines']) > 0)


### PR DESCRIPTION

### Description of PR
Fix the failure in gnmi_set when doing health check

Summary:
Fixes # 21907

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix issue 21907
#### How did you do it?
Changed the grep command 
#### How did you verify/test it?
Manually run the test that was showing errors before:
"gnmi/test_gnmi_appldb.py

#### Any platform specific information?
MtFuji

#### Supported testbed topology if it's a new test case?

### Documentation
N/A
