### PR TITLE
fix the issue with skip_yang usage Issue 21923

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3791,7 +3791,7 @@ def yang_validation_check(request, duthosts):
 
     if skip_yang:
         logger.info("Skipping YANG validation check due to --skip_yang flag")
-        return
+        yield
 
     def run_yang_validation(stage):
         """Run YANG validation and return results"""


### PR DESCRIPTION
### Description of PR
Fixes the failure when skip_yang flag is used in test execution

Summary:
Fixes # 21923

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506
- [x] 202511

### Approach
#### What is the motivation for this PR?
Error when skip_yang is used
#### How did you do it?
Changed the return to yield in the yang validation function 

#### How did you verify/test it?
I run a test with skip_yang flag

#### Any platform specific information?
MtFuji
#### Supported testbed topology if it's a new test case?

### Documentation
N/A