### PR TITLE
Add GCU ACL test to confirm Active-Standby Dualtor devices do not duplicate traffic

### DIFF
--- a/tests/platform_tests/api/test_watchdog.py
+++ b/tests/platform_tests/api/test_watchdog.py
@@ -276,5 +276,5 @@ class TestWatchdogApi(PlatformApiTestBase):
         watchdog_timeout = -1
         actual_timeout = watchdog.arm(platform_api_conn, watchdog_timeout)
         self.expect(actual_timeout == -1, "{}: Watchdog should be disarmed, but returned timeout of {} seconds"
-                    .format(self.test_arm_too_big_timeout.__name__, watchdog_timeout))
+                    .format(self.test_arm_negative_timeout.__name__, watchdog_timeout))
         self.assert_expectations()


### PR DESCRIPTION
### Description of PR
Adds a new test case to confirm that traffic is still dropped on Standby ToR in Dualtor Active-Standby scenarios when FORWARD ACL rule is present on Standby TOR in a separate ACL table, but with lower priority than drop rule.


### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Some vendors have expressed concerns about whether ACL rules in different ACL tables will still follow expected priority guidelines.  This is a concern for active-standby scenarios where we rely on the standby TORs DROP rule working effectively so that traffic is not duplicated.  Test will confirm that when a TOR is set to standby, and traffic is forwarded from it with FORWARD rules in place with lower priority than the default Standby DROP rule, that the traffic is not sent

#### How did you do it?
Added test case to confirm that traffic is not forwarded on the standby TOR

#### How did you verify/test it?
Tested in starlab on Dualtor device

<img width="936" height="309" alt="image" src="https://github.com/user-attachments/assets/ec06c3f6-a674-452f-8266-c3a3b790ee3a" />

#### Supported testbed topology if it's a new test case?
DualTor Active-Standby
