### PR TITLE
add optional_parameter for container upgrade test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,6 +295,8 @@ def pytest_addoption(parser):
                      help="File that containers parameters for each container")
     parser.addoption("--testcase_file", action="store", default=None, type=str,
                      help="File that contains testcases to execute per iteration")
+    parser.addoption("--optional_parameters", action="store", default="", type=str,
+                     help="Extra args appended to docker run, e.g. '-e IS_V1_ENABLED=true'")
 
     #################################
     #   Stress test options         #

--- a/tests/container_upgrade/conftest.py
+++ b/tests/container_upgrade/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def build_required_container_upgrade_params(containers, os_versions, image_url_template,
-                                            parameters_file, testcase_file):
+                                            parameters_file, testcase_file, optional_parameters):
     if any(var == "" or var is None for var in [containers, os_versions, image_url_template,
                                                 parameters_file, testcase_file]):
         return None
@@ -12,6 +12,7 @@ def build_required_container_upgrade_params(containers, os_versions, image_url_t
     params["image_url_template"] = image_url_template
     params["parameters_file"] = parameters_file
     params["testcase_file"] = testcase_file
+    params["optional_parameters"] = optional_parameters or ""
     return params
 
 
@@ -21,11 +22,13 @@ def pytest_generate_tests(metafunc):
     image_url_template = metafunc.config.getoption("image_url_template")
     parameters_file = metafunc.config.getoption("parameters_file")
     testcase_file = metafunc.config.getoption("testcase_file")
+    optional_parameters = metafunc.config.getoption("optional_parameters")
     if "required_container_upgrade_params" in metafunc.fixturenames:
         params = build_required_container_upgrade_params(containers, os_versions,
                                                          image_url_template,
                                                          parameters_file,
-                                                         testcase_file)
+                                                         testcase_file,
+                                                         optional_parameters)
 
         skip_condition = False
         if params is None:

--- a/tests/container_upgrade/container_upgrade_helper.py
+++ b/tests/container_upgrade/container_upgrade_helper.py
@@ -143,10 +143,11 @@ def pull_run_dockers(duthost, creds, env):
         docker_image = f"{registry.host}/{container}:{version}"
         download_image(duthost, registry, container, version)
         parameters = env.parameters[container]
+        optional_parameters = env.optional_parameters
         # Stop and remove existing container
         duthost.shell(f"docker stop {name}", module_ignore_errors=True)
         duthost.shell(f"docker rm {name}", module_ignore_errors=True)
-        if duthost.shell(f"docker run -d {parameters} --name {name} {docker_image}",
+        if duthost.shell(f"docker run -d {parameters} {optional_parameters} --name {name} {docker_image}",
                          module_ignore_errors=True)['rc'] != 0:
             pytest.fail("Not able to run container using pulled image")
 

--- a/tests/container_upgrade/test_container_upgrade.py
+++ b/tests/container_upgrade/test_container_upgrade.py
@@ -33,6 +33,8 @@ class ContainerUpgradeTestEnvironment(object):
         parameters_file = required_container_upgrade_params["parameters_file"]
         self.parameters = create_parameters_mapping(containers, parameters_file)
 
+        self.optional_parameters = required_container_upgrade_params.get("optional_parameters", "") or ""
+
         self.version_pointer = 0
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add optional_parameters as extra args appended to docker run, e.g. `-e IS_V1_ENABLED=true`, it will be helpful for sidecar containers, use either `-e IS_V1_ENABLED=true` or `-e IS_V1_ENABLED=false`
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
