### PR TITLE
Fix `Ethernet-Rec0` counter expectation in Everflow Test

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1090,7 +1090,7 @@ class BaseEverflowTest(object):
 
                 if isinstance(result, bool):
                     logging.info("Using dummy testutils to skip traffic test, skip following checks")
-                    return
+                    return num_pkts_sent
 
                 _, received_packet = result
                 logging.info("Received packet: %s", packet.Ether(received_packet).summary())


### PR DESCRIPTION
Update 'send_and_check_mirror_packets' to return the number of packets sent, in turn update 'test_everflow_fwd_recircle_port_queue_check' to expect the Ethernet-Rec0 VOQ counters to increment the same number of packets sent by the test.

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/21941

Summary:
Fixes #21941 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

