### PR TITLE
Add route configuration to private link tests for NASA 25.10

### DIFF
--- a/tests/dash/test_dash_eni_counter.py
+++ b/tests/dash/test_dash_eni_counter.py
@@ -71,6 +71,12 @@ def common_setup_teardown(localhost, duthost, ptfhost, dpu_index, dpuhosts, skip
         **pl.PE_SUBNET_ROUTE_CONFIG,
         **pl.VM_SUBNET_ROUTE_CONFIG
     }
+
+    if 'bluefield' in dpuhost.facts['asic_type']:
+        route_and_mapping_messages.update({
+            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG
+        })
+
     logger.info(route_and_mapping_messages)
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -56,6 +56,12 @@ def common_setup_teardown(
         **pl.PE_SUBNET_ROUTE_CONFIG,
         **pl.VM_SUBNET_ROUTE_CONFIG
     }
+
+    if 'bluefield' in dpuhost.facts['asic_type']:
+        route_and_mapping_messages.update({
+            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG
+        })
+
     logger.info(route_and_mapping_messages)
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The INBOUND_VNI_ROUTE_RULE_CONFIG is required for the private link scenario on Nvidia smartswitch starting from NASA ver 25.10.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
There is a behavior change in NASA 25.10, we need INBOUND_VNI_ROUTE_RULE_CONFIG to make sure the PL traffic can be forwarded by the DPU correctly.
#### How did you do it?
Modified tests:
tests/dash/test_dash_privatelink.py
tests/dash/test_dash_eni_counter.py

The other dash tests like fnic and plnsg already have this config.
#### How did you verify/test it?
Run the test on SN4280.
#### Any platform specific information?
Change is only for Nvidia smartswitch
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
