### PR TITLE
Netmask MIB Enhancement Sonic-mgmt test

### DIFF
--- a/tests/snmp/test_rfc1213_netmask.py
+++ b/tests/snmp/test_rfc1213_netmask.py
@@ -3,18 +3,44 @@ import ipaddress
 import re
 
 pytestmark = [
-    pytest.mark.topology('any'),
-    pytest.mark.device_type('vs'),
+    pytest.mark.topology("any"),
+    pytest.mark.device_type("vs"),
 ]
 
+# Requirement example:
+# snmpwalk -v2c -c public 192.168.1.1 1.3.6.1.2.1.4.34.1.5.1
 IP_NET_TO_NETMASK_OID = "1.3.6.1.2.1.4.34.1.5.1"
+
+# Left-hand side example:
+# iso.3.6.1.2.1.4.34.1.5.1.4.<ip> = OID: iso.3.6.1.2.1.4.32.1.5.<ifIndex>.1.4.<netip>.<prefix>
+LHS_PREFIX = "iso.3.6.1.2.1.4.34.1.5.1.4."
+
+
+def _get_dut_mgmt_ip(duthost):
+    """
+    Best-effort way to get DUT management IP from pytest-ansible host vars.
+    (Matches the user's manual command which walks against the DUT mgmt IP, not localhost.)
+    """
+    host = duthost.host.options["inventory_manager"].get_host(duthost.hostname)
+    mgmt_ip = host.vars.get("ansible_host")
+    assert mgmt_ip, f"Unable to determine DUT mgmt IP for {duthost.hostname} (ansible_host is empty)"
+    return mgmt_ip
 
 
 def snmpwalk(duthost, community, oid):
-    return duthost.shell(
-        f"snmpwalk -v2c -c {community} localhost {oid}",
-        module_ignore_errors=True
-    )["stdout_lines"]
+    """
+    Run snmpwalk against the DUT mgmt IP (not localhost) so it matches the requirement/result.
+    Also assert on return code so we don't silently convert failures into empty output.
+    """
+    dut_ip = _get_dut_mgmt_ip(duthost)
+    cmd = f"snmpwalk -v2c -c {community} {dut_ip} {oid}"
+    res = duthost.shell(cmd, module_ignore_errors=True)
+
+    assert res["rc"] == 0, (
+        f"snmpwalk failed rc={res['rc']} cmd={cmd} "
+        f"stdout={res.get('stdout', '')} stderr={res.get('stderr', '')}"
+    )
+    return res["stdout_lines"]
 
 
 def test_ipNetToNetMask_exists(duthost, creds):
@@ -25,44 +51,55 @@ def test_ipNetToNetMask_exists(duthost, creds):
 
     assert output, "ipNetToNetMask SNMP walk returned no output"
 
+    # In the requirement/result, each line contains "= OID:"
     for line in output:
-        assert "OBJECT IDENTIFIER" in line, \
-            f"Unexpected value type: {line}"
+        assert "= OID:" in line, f"Unexpected snmpwalk line (expected OID value): {line}"
 
 
 def test_ipNetToNetMask_oid_format(duthost, creds):
     """
-    Validate returned OID format:
-    ipNetToNetMask.<addrType>.<ip> = OID ...<ifIndex>.<1>.<4>.<netip>.<mask>
+    Validate returned OID format (based on actual output):
+
+    LHS:
+      iso.3.6.1.2.1.4.34.1.5.1.4.<ip> = OID: ...
+
+    RHS:
+      OID: iso.3.6.1.2.1.4.32.1.5.<ifIndex>.1.4.<netip>.<prefix>
+
+    We validate:
+      - LHS IP is valid IPv4
+      - RHS ends with a prefix length between 0..32
     """
     output = snmpwalk(duthost, creds["snmp_rocommunity"], IP_NET_TO_NETMASK_OID)
 
     oid_regex = re.compile(
-        r"::ipNetToNetMask\.4\.(\d+\.\d+\.\d+\.\d+)\s+=\s+OID:\s+([\d\.]+)"
+        r"^iso\.3\.6\.1\.2\.1\.4\.34\.1\.5\.1\.4\.(\d+\.\d+\.\d+\.\d+)\s+=\s+OID:\s+iso\.(.+)$"
     )
 
     for line in output:
-        match = oid_regex.search(line)
-        assert match, f"OID format mismatch: {line}"
+        m = oid_regex.match(line.strip())
+        assert m, f"OID format mismatch: {line}"
 
-        ip = match.group(1)
-        returned_oid = match.group(2)
+        ip = m.group(1)
+        returned_oid_tail = m.group(2)  # everything after "iso."
+        returned_oid = "iso." + returned_oid_tail
 
         # Basic sanity: IP must be valid
         ipaddress.ip_address(ip)
 
         # Returned OID must include prefix length at the end
         prefix = int(returned_oid.split(".")[-1])
-        assert 0 <= prefix <= 32, f"Invalid prefix length {prefix}"
+        assert 0 <= prefix <= 32, f"Invalid prefix length {prefix} in returned OID: {returned_oid}"
 
 
 def test_ipNetToNetMask_matches_interface_config(duthost, creds):
     """
-    Cross-check SNMP netmask prefix with 'ip addr show'
+    Cross-check SNMP netmask prefix with 'ip addr show' output.
+
+    We only assert for IPs that appear in 'ip -o -4 addr show' to avoid failing on
+    extra SNMP rows (e.g., broadcast-like entries) that may not be listed by `ip addr`.
     """
-    ip_addr_output = duthost.shell(
-        "ip -o -4 addr show | awk '{print $4}'"
-    )["stdout_lines"]
+    ip_addr_output = duthost.shell("ip -o -4 addr show | awk '{print $4}'")["stdout_lines"]
 
     expected_prefixes = {}
     for entry in ip_addr_output:
@@ -72,12 +109,24 @@ def test_ipNetToNetMask_matches_interface_config(duthost, creds):
     snmp_output = snmpwalk(duthost, creds["snmp_rocommunity"], IP_NET_TO_NETMASK_OID)
 
     for line in snmp_output:
-        if "ipNetToNetMask.4." not in line:
+        line = line.strip()
+        if "= OID:" not in line:
             continue
 
-        ip = line.split("ipNetToNetMask.4.")[1].split(" ")[0]
-        prefix = int(line.split(".")[-1])
+        # Parse LHS IP reliably:
+        # iso.3.6.1.2.1.4.34.1.5.1.4.<ip> = OID: ...
+        lhs = line.split(" = ")[0]
+        if not lhs.startswith(LHS_PREFIX):
+            continue
+        ip = lhs[len(LHS_PREFIX):]
+
+        # Parse prefix reliably from RHS:
+        # ... = OID: iso.<...>.<prefix>
+        rhs = line.split("OID:")[1].strip()
+        prefix = int(rhs.split(".")[-1])
 
         if ip in expected_prefixes:
-            assert prefix == expected_prefixes[ip], \
-                f"Prefix mismatch for {ip}: expected {expected_prefixes[ip]}, got {prefix}"
+            assert prefix == expected_prefixes[ip], (
+                f"Prefix mismatch for {ip}: expected {expected_prefixes[ip]}, got {prefix}. "
+                f"Line: {line}"
+            )

--- a/tests/snmp/test_rfc1213_netmask.py
+++ b/tests/snmp/test_rfc1213_netmask.py
@@ -33,7 +33,7 @@ def snmpwalk(duthost, community, oid):
     Also assert on return code so we don't silently convert failures into empty output.
     """
     dut_ip = _get_dut_mgmt_ip(duthost)
-    cmd = f"snmpwalk -v2c -c {community} {dut_ip} {oid}"
+    cmd = f"docker exec snmp snmpwalk -v2c -c {community} {dut_ip} {oid}"
     res = duthost.shell(cmd, module_ignore_errors=True)
 
     assert res["rc"] == 0, (

--- a/tests/snmp/test_rfc1213_netmask.py
+++ b/tests/snmp/test_rfc1213_netmask.py
@@ -1,0 +1,83 @@
+import pytest
+import ipaddress
+import re
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs'),
+]
+
+IP_NET_TO_NETMASK_OID = "1.3.6.1.2.1.4.34.1.5.1"
+
+
+def snmpwalk(duthost, community, oid):
+    return duthost.shell(
+        f"snmpwalk -v2c -c {community} localhost {oid}",
+        module_ignore_errors=True
+    )["stdout_lines"]
+
+
+def test_ipNetToNetMask_exists(duthost, creds):
+    """
+    Verify ipNetToNetMask MIB is present and walkable
+    """
+    output = snmpwalk(duthost, creds["snmp_rocommunity"], IP_NET_TO_NETMASK_OID)
+
+    assert output, "ipNetToNetMask SNMP walk returned no output"
+
+    for line in output:
+        assert "OBJECT IDENTIFIER" in line, \
+            f"Unexpected value type: {line}"
+
+
+def test_ipNetToNetMask_oid_format(duthost, creds):
+    """
+    Validate returned OID format:
+    ipNetToNetMask.<addrType>.<ip> = OID ...<ifIndex>.<1>.<4>.<netip>.<mask>
+    """
+    output = snmpwalk(duthost, creds["snmp_rocommunity"], IP_NET_TO_NETMASK_OID)
+
+    oid_regex = re.compile(
+        r"::ipNetToNetMask\.4\.(\d+\.\d+\.\d+\.\d+)\s+=\s+OID:\s+([\d\.]+)"
+    )
+
+    for line in output:
+        match = oid_regex.search(line)
+        assert match, f"OID format mismatch: {line}"
+
+        ip = match.group(1)
+        returned_oid = match.group(2)
+
+        # Basic sanity: IP must be valid
+        ipaddress.ip_address(ip)
+
+        # Returned OID must include prefix length at the end
+        prefix = int(returned_oid.split(".")[-1])
+        assert 0 <= prefix <= 32, f"Invalid prefix length {prefix}"
+
+
+def test_ipNetToNetMask_matches_interface_config(duthost, creds):
+    """
+    Cross-check SNMP netmask prefix with 'ip addr show'
+    """
+    ip_addr_output = duthost.shell(
+        "ip -o -4 addr show | awk '{print $4}'"
+    )["stdout_lines"]
+
+    expected_prefixes = {}
+    for entry in ip_addr_output:
+        ip, prefix = entry.split("/")
+        expected_prefixes[ip] = int(prefix)
+
+    snmp_output = snmpwalk(duthost, creds["snmp_rocommunity"], IP_NET_TO_NETMASK_OID)
+
+    for line in snmp_output:
+        if "ipNetToNetMask.4." not in line:
+            continue
+
+        ip = line.split("ipNetToNetMask.4.")[1].split(" ")[0]
+        prefix = int(line.split(".")[-1])
+
+        if ip in expected_prefixes:
+            assert prefix == expected_prefixes[ip], \
+                f"Prefix mismatch for {ip}: expected {expected_prefixes[ip]}, got {prefix}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding support of NETMASK MIB [ OID: 1.3.6.1.2.1.4.34.1.5.1] in snmp-subagent. This MIB returns the mapping between the assigned IP address and its network IP along with the netmask and IfIndex.Updated rfc1213.py from snmp-subagent to accomodate NETMASK MIB implementation.

Fixes # (issue)
https://github.com/sonic-net/sonic-snmpagent/pull/355

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
