### PR TITLE
ignore SCD kernel warning about I2C communication ack errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -440,3 +440,6 @@ r, ".*ERR sfputil: Failed to read from file /sys/module/sx_core/asic\d+/module\d
 
 # This is a deprecation warning not a functional error, which matches the regex "kernel:.*allocation", not an err.
 r, ".*kernel.*gpio.*Static allocation of GPIO base is deprecated.*"
+
+# Ignore SCD kernel warning about I2C communication ack errors on Arista platforms
+r, ".*WARNING kernel:.*scd.*rsp.*ack_error=1.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
36327584

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
In the new testbed, the kernel outputs warning messages containing the word “error,” which causes LogAnalyzer to treat them as errors.

#### How did you do it?
It's a warning message, should not be failed in loganalyzer, ignore these messages.

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/696d71df4bbe3bd7ad16cdf3
https://elastictest.org/scheduler/testplan/696d71dd4b8aa910b618436d
https://elastictest.org/scheduler/testplan/696d71dd4b8aa910b618436b
https://elastictest.org/scheduler/testplan/696d71dc15026fd4f746b8f0
https://elastictest.org/scheduler/testplan/696d71db4bbe3bd7ad16cdf1
https://elastictest.org/scheduler/testplan/696d71da5e4aaa3c28ac7499

#### Any platform specific information?
Arista 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
