### PR TITLE
HA privatelink support

### DIFF
--- a/tests/common/snappi_tests/ixload/snappi_fixtures.py
+++ b/tests/common/snappi_tests/ixload/snappi_fixtures.py
@@ -3,8 +3,7 @@ This module contains the snappi fixture in the snappi_tests directory.
 """
 from tests.common.snappi_tests.ixload.snappi_helper import (l47_trafficgen_main, duthost_ha_config,
                                                             npu_startup, dpu_startup, set_static_routes, set_ha_roles,
-                                                            set_ha_admin_up, set_ha_activate_role, duthost_port_config,
-                                                            delete_staticarp_files)
+                                                            set_ha_admin_up, set_ha_activate_role, duthost_port_config)
 from tests.common.snappi_tests.uhd.uhd_helpers import NetworkConfigSettings  # noqa: F403, F401
 import pytest
 import threading
@@ -79,13 +78,9 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
     if l47_trafficgen_enabled:
         logger.info(f"Configuring L47 parameters for test case: {ha_test_case}")
 
-        ixos_version = tbinfo['ixos_version']
         l47_version = tbinfo['l47_version']
         service_type = tbinfo['service_type']
         chassis_ip = tbinfo['chassis_ip']
-        chassis_user_login = tbinfo['chassis_user_login']
-        chassis_user_passwd = tbinfo['chassis_user_passwd']
-        clean_l47trafficgen_staticarps = tbinfo['clean_l47trafficgen_staticarps']
         gw_ip = tbinfo['l47_gateway']
 
         ports_list = tbinfo['ports_list']
@@ -105,24 +100,16 @@ def setup_config_snappi_l47(request, duthosts, tbinfo, ha_test_case=None):
 
         connection_dict = {
             'chassis_ip': chassis_ip,
-            'chassis_user_login': chassis_user_login,
-            'chassis_user_passwd': chassis_user_passwd,
             'gw_ip': gw_ip,
             'port': '8080',
-            'ixos_version': ixos_version,
             'version': l47_version,
         }
-
-        logger.info("Cleaning old static ARP files from the l47traifficgen server")
-        if clean_l47trafficgen_staticarps:
-            delete_staticarp_files(chassis_ip, chassis_user_login, chassis_user_passwd, ixos_version)
 
         nw_config = NetworkConfigSettings()
         if ha_test_case != "cps":
             nw_config.ENI_COUNT = 32  # Set to 32 ENIs for HA test cases to test 1 Active/Standby DPU
         api, config, initial_cps_value = l47_trafficgen_main(ports_list, connection_dict, nw_config, service_type,
-                                                             test_type_dict['all'], test_filename,
-                                                             test_type_dict['initial_cps_obj'])
+                                                             test_type_dict['all'], test_type_dict['initial_cps_obj'])
 
         if l47_trafficgen_save:
             snappi_l47_params['save'] = True

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1723,8 +1723,8 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
         num_cps_cards = tbinfo['num_cps_cards']
         num_tcpbg_cards = tbinfo['num_tcpbg_cards']
         num_udpbg_cards = tbinfo['num_udpbg_cards']
-        vxlan_port = tbinfo.get('vxlan_port', 0)
-        vxlan_src_port = tbinfo.get('vxlan_src_port', 0)
+        vxlan_port = tbinfo['vxlan_port']
+        vxlan_src_port = tbinfo['vxlan_src_port']
         num_dpu_ports = len(dpu_ports)
 
         cards_dict = {
@@ -1758,7 +1758,7 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
             file_name = "tempUhdConfig_pl.json"
             arp_bypass_list = create_arp_bypass_pl(fp_ports_list, ip_list, uhdSettings, cards_dict, subnet_mask)
             connections_list = create_connections_pl(fp_ports_list, ip_list, subnet_mask, uhdSettings, cards_dict,
-                                                     arp_bypass_list, vxlan_port, vxlan_src_port)
+                                                     arp_bypass_list)
 
         config = {
             "profiles": create_profiles(uhdSettings),  # noqa: F405
@@ -1778,10 +1778,7 @@ def setup_config_uhd_connect(request, tbinfo, ha_test_case=None):
         logger.info(f"Pushing created UHD configuration file {file_name} to UHD Connect")
         uhdConf_cmd = ('curl -k -X POST -H \"Content-Type: application/json\" -d @\"{}/{}\"   '
                        '{}').format(file_location, file_name, url)
-        try:
-            res = subprocess.run(uhdConf_cmd, shell=True, capture_output=True, text=True)  # noqa: F841
-        except Exception as e:
-            logger.error(f"UHD config upload failed: {e}")
+        subprocess.run(uhdConf_cmd, shell=True, capture_output=True, text=True)
 
         if not save_uhd_config:
             logger.info("Removing UHD config file")

--- a/tests/common/snappi_tests/uhd/uhd_helpers.py
+++ b/tests/common/snappi_tests/uhd/uhd_helpers.py
@@ -16,7 +16,6 @@ class NetworkConfigSettings:
         self.ENI_MAC_STEP = '00:00:00:18:00:00'
         self.ENI_STEP = 1
         self.ENI_L2R_STEP = 1000
-        self.ENI_PER_PORT = 64
 
         self.VTEP_IP = self.ipp("221.0.0.1")
         self.PAL = self.ipp("221.1.0.1")
@@ -340,7 +339,6 @@ def create_front_panel_ports(count, config, cards_dict):
 def create_arp_bypass_pl(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
 
     connections_list = []
-    ethpass_ports = cards_dict['ethpass_ports']
     num_cps_cards = cards_dict['num_cps_cards']
     first_cps_card, first_tcpbg_card = set_first_stateful_cards(cards_dict)
     vrange_count = config.ENI_COUNT//num_cps_cards
@@ -354,8 +352,6 @@ def create_arp_bypass_pl(fp_ports_list, ip_list, config, cards_dict, subnet_mask
         else:
             first_tcpbg_card = 0
     """
-    # eth_bypass set here
-    connections_list.append(_get_eth_bypass_dict(config, ethpass_ports))
 
     vlan_start_tmp = vlan_start
     for port in range(num_cps_cards):
@@ -368,15 +364,14 @@ def create_arp_bypass_pl(fp_ports_list, ip_list, config, cards_dict, subnet_mask
         }
 
         # Test role will all use client instead of one client and one server
-        server_role = 's'
+        client_role = 'c'
+
         arp_bypass_dict['endpoints'].append(
-            {'choice': 'front_panel', 'front_panel': {'port_name': 'l47_port_{}{}'.format(port+1, server_role),
+            {'choice': 'front_panel', 'front_panel': {'port_name': 'l47_port_{}{}'.format(9, client_role),
                                                       'vlan': {'choice': 'vlan_range', 'vlan_range':
                                                           {'start': vlan_start_tmp, 'count': vrange_count,  # noqa: E128
                                                            'step': 1}}}}
         )
-
-        client_role = 'c'
         arp_bypass_dict['endpoints'].append(
             {'choice': 'front_panel', 'front_panel': {'port_name': 'l47_port_{}{}'.format(port+1, client_role),
                                                       'vlan': {'choice': 'vlan_range', 'vlan_range':
@@ -447,6 +442,7 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
 
         # TODO needed when there are multiple DPU Ports
         # dpu_port = 1 if server_vlan <= 128 else 2
+        dpu_port = 1
 
         # Server side
         """
@@ -504,15 +500,16 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
                 "vlan": {"choice": "vlan_range", "vlan_range": {"start": nvgre_eni_temp, "count": 32, "step": 1}}},
              "tags": ["vlan"]},
         )
+        dpu_port = 2
         server_dict_temp['endpoints'].append(
-            {"choice": "front_panel", "front_panel": {"port_name": "l47_dpuPort_{}".format(1)},
+            {"choice": "front_panel", "front_panel": {"port_name": "dpu_port_{}".format(dpu_port)},
              "tags": ["nvgre"]}
         )
 
         # Client Side
         # TODO vni_index
-        client_start = config.IP_L_START
-        ip_tmp = client_start + (int(ipaddress.ip_address('8.0.0.0')) * port)
+        # client_start = config.IP_L_START
+        # ip_tmp = client_start + (int(ipaddress.ip_address('8.0.0.0')) * port)
         vlanEP_ip_tmp = vlan_endpoint_ip + (nvgre_count * port)
         vxlan_vni_tmp = vxlan_vni_start + (nvgre_count * port)
 
@@ -530,7 +527,7 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
                                         'count': nvgre_count, 'step': 1}}, "protocols": {"accept": ["tcp"]},
                                         "routing_method": "ip_routing", "ip_routing": {"destination_ips":
                                         {"choice": "ipv4_range", "ipv4_range": {  # noqa: E128
-                                        "start": "{}".format(ip_tmp),  # noqa: E122
+                                        # "start": "{}".format(ip_tmp),  # noqa: E122
                                         "count": config.NVGRE_COUNT, "step": "0.64.0.0"}}},  # noqa: E122
                                         "udp_src_port": vxlan_port, "udp_dst_port": vxlan_src_port}
         }}
@@ -544,8 +541,9 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
                                                                 'step': 1}}}, "tags": ["vlan"]},
         )
 
+        dpu_port = 1
         client_dict_temp['endpoints'].append(
-            {"choice": "front_panel", "front_panel": {"port_name": "l47_dpuPort_{}".format(1)},
+            {"choice": "front_panel", "front_panel": {"port_name": "dpu_port_{}".format(dpu_port)},
              "tags": ["vxlan"]}
         )
 
@@ -554,21 +552,6 @@ def create_connections_pl(fp_ports_list, ip_list, subnet_mask, config, cards_dic
         connections_list.append(client_dict_temp)
 
     return connections_list
-
-
-def _get_eth_bypass_dict(config, ethpass_ports):
-    eth_bypass_dict = {
-        'name': "Eth Bypass",
-        'functions': [{"choice": "connect_ethernet", "connect_ethernet": {}}],
-        'endpoints': []
-    }
-    for port in ethpass_ports:
-        eth_bypass_dict['endpoints'].append(
-            {'choice': 'front_panel', 'front_panel': {'port_name': 'l47_port_11{}'.format(port['FrontPanel']),
-                                                      'vlan': {'choice': 'non_vlan'}}}
-        )
-
-    return eth_bypass_dict
 
 
 def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
@@ -586,8 +569,6 @@ def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
         else:
             first_tcpbg_card = 0
     """
-
-    """
     eth_bypass_dict = {
         'name': "Eth Bypass",
         'functions': [{"choice": "connect_ethernet", "connect_ethernet": {}}],
@@ -601,9 +582,6 @@ def create_arp_bypass(fp_ports_list, ip_list, config, cards_dict, subnet_mask):
                     {'port_name': 'l47_port_11{}'.format(port['FrontPanel']), 'vlan': {'choice': 'non_vlan'}}}
             )
         connections_list.append(eth_bypass_dict)
-    """
-    # eth_bypass set here
-    connections_list.append(_get_eth_bypass_dict(config, ethpass_ports))
 
     for eni, ip in enumerate(ip_list):
 

--- a/tests/snappi_tests/dash/sample_testbed.yaml
+++ b/tests/snappi_tests/dash/sample_testbed.yaml
@@ -14,12 +14,8 @@
   l47_tg_servermac: 140776176680961
   l47_tg_clientmac: 140776176680962
   dut_mac: 40501075136016
-  ixos_version: 26.0.2600.14
-  l47_version: 26.0.0.94
+  l47_version: 11.00.0.292
   chassis_ip: 10.1.1.4
-  chassis_user_login: root
-  chassis_user_passwd: peanutbutter123
-  clean_l47trafficgen_staticarps: True
   uhd_ip: 10.1.1.5
   dpu_active_ip: 172.35.1.1
   dpu_standby_ip: 172.35.1.2


### PR DESCRIPTION
HA privatelink support for testcases.

testbed-cli:
python3 -m pytest --inventory ../ansible/snappi-sonic --host-pattern all --testbed vms-snappi-sonic --testbed_file ../ansible/testbed_HA.yaml --show-capture=stdout --log-cli-level info -ra --allow_recover --skip_sanity --disable_loganalyzer --uhd_config ../ansible/files/sonic_lab_links_uhd.csv --save_uhd_config --npu_dpu_startup --l47_trafficgen --save_l47_trafficgen snappi_tests/dash/test_dpuloss.py

Example of output after test completes:
| Peak Performance | Stable Performance | Failure Detected |
+=======================+======================+==============================+
| 2404650 CPS @ 56000ms | 1609831.91 CPS | No mid-test failure detected |
+-----------------------+----------------------+------------------------------+

### Description of PR

Summary:
Add support for service_type = privatelink.  
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [X] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Add support for service_type = privatelink 

#### How did you do it?

Created in local sonic-mgmt container.

#### How did you verify/test it?

Using a local sonic-mgmt container

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

t1-smartswitch

### Documentation implementation?
Link to the wiki page?
-->
