### PR TITLE
art1f1c3R/36400654 base console conn bug fix

### DIFF
--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -77,7 +77,7 @@ class BaseConsoleConn(CiscoBaseConnection):
         pass
 
     def find_prompt(self, delay_factor=1, **kwargs):
-        return super(BaseConsoleConn, self).find_prompt(**kwargs)
+        return super(BaseConsoleConn, self).find_prompt(delay_factor, **kwargs)
 
     def clear_buffer(self):
         # todo


### PR DESCRIPTION
### Description of PR
After investigating the error in Test plan 6968ad1915026fd4f746b408, it raises an error due to the `BaseConsoleConn.find_prompt` definition not having a `pattern` keyword argument. Since this function calls `super`, this has been changed to use `**kwargs` so all keyword arguments are accounted for.

Summary:
Attending to issues noticed in ADO 36400654.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?
Test plan 6968ad1915026fd4f746b408 was failing due to a python exception, causing the testbed recovery to fail.
#### How did you do it?
Traced the exception to the `BaseConsoleConn` type and how it uses `netmiko.cisco_base_connection.CiscoBaseConnection`.
#### How did you verify/test it?
