### PR TITLE
chore: fix l1 group does not rotate via passwords

### DIFF
--- a/ansible/group_vars/l1_switch/secrets.yml
+++ b/ansible/group_vars/l1_switch/secrets.yml
@@ -1,3 +1,4 @@
+ansible_connection: multi_passwd_ssh
 ansible_ssh_user: admin
 ansible_ssh_pass: password_placeholder
 ansible_altpasswords: password_placeholder


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add support to rotate password for L1
Fixes # (issue) 36400745

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Now, L1 testbed doesn't have support to authenticate with multi-password. This PR will enable it
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
