### PR TITLE
Xfail test_config_clock_timezone due to github issue https://github.com/sonic-net/sonic-buildimage/issues/24562

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -634,6 +634,15 @@ cacl/test_ebtables_application.py:
       - "asic_type in ['vs']"
 
 #######################################
+#####             clock           #####
+#######################################
+clock/test_clock.py::test_config_clock_timezone:
+  xfail:
+    reason: "xfail due to github issue https://github.com/sonic-net/sonic-buildimage/issues/24562"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/24562 and asic_type in ['mellanox', 'nvidia', 'vs']"
+
+#######################################
 #####           configlet         #####
 #######################################
 configlet:


### PR DESCRIPTION

Summary: Xfail test_config_clock_timezone due to github issue https://github.com/sonic-net/sonic-buildimage/issues/24562
Fixes # 
1. tests/clock/test_clock.py:ClockUtils.get_valid_timezones:
show clock timezones
2. src/sonic-utilities/show/main.py:timezones:
timedatectl list-timezones
3. This will list all timezones, including legacy entries like PST8PDT.
4. tests/clock/test_clock.py:test_config_clock_timezone:
config clock timezone PST8PDT
5. src/sonic-host-services/scripts/hostcfgd:DeviceMetaCfg:timezone_update:
timedatectl set-timezone PST8PDT
6. Error: Invalid or not installed time zone 'PST8PDT'


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
