### PR TITLE
[NUT] Add v4 mgmt interface and forced route programming in deploy-cfg

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -126,6 +126,7 @@
       host: "{{ inventory_hostname }}"
       group: "{{ conn_graph_group if conn_graph_group is defined else omit }}"
       ignore_errors: true
+      forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
     delegate_to: localhost
     ignore_errors: true
 

--- a/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
+++ b/ansible/roles/testbed/nut/tasks/device_prepare_config.yml
@@ -10,8 +10,6 @@
   vars:
     tables_to_keep:
       - DEVICE_METADATA
-      - MGMT_INTERFACE
-      - MGMT_PORT
       - BANNER_MESSAGE
       - FEATURE
       - FLEX_COUNTER_TABLE

--- a/ansible/roles/testbed/nut/tasks/dut_create_config_patch.yml
+++ b/ansible/roles/testbed/nut/tasks/dut_create_config_patch.yml
@@ -11,26 +11,26 @@
   debug:
     var: device_info[inventory_hostname]
 
-- name: output device meta
-  debug:
-    var: device_meta[inventory_hostname]
-
-- name: output device conn
-  debug:
-    var: device_linked_ports[inventory_hostname]
-
-- name: output device port vlan
-  debug:
-    var: device_vlan_map_list[inventory_hostname]
-
-- name: output device bgp neighbor devices
-  debug:
-    var: device_bgp_neighbor_devices[inventory_hostname]
-
-- name: output device bgp neighbor ports
-  debug:
-    var: device_bgp_neighbor_ports[inventory_hostname]
-    #var: device_bgp_neighbors
+#- name: output device meta
+#  debug:
+#    var: device_meta[inventory_hostname]
+#
+#- name: output device conn
+#  debug:
+#    var: device_linked_ports[inventory_hostname]
+#
+#- name: output device port vlan
+#  debug:
+#    var: device_vlan_map_list[inventory_hostname]
+#
+#- name: output device bgp neighbor devices
+#  debug:
+#    var: device_bgp_neighbor_devices[inventory_hostname]
+#
+#- name: output device bgp neighbor ports
+#  debug:
+#    var: device_bgp_neighbor_ports[inventory_hostname]
+#    #var: device_bgp_neighbors
 
 - name: define features settings
   set_fact:

--- a/ansible/roles/testbed/nut/tasks/testbed_facts.yml
+++ b/ansible/roles/testbed/nut/tasks/testbed_facts.yml
@@ -20,4 +20,5 @@
 - name: get connection graph if defined for dut
   conn_graph_facts:
     hosts: "{{ testbed_facts['duts'] + testbed_facts['tgs'] + testbed_facts['l1s'] }}"
+    forced_mgmt_routes: "{{ forced_mgmt_routes | default([]) }}"
   delegate_to: localhost

--- a/ansible/roles/testbed/nut/templates/config_patch/common/mgmt_interface.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/common/mgmt_interface.json.j2
@@ -1,0 +1,30 @@
+{ "op": "add", "path": "/MGMT_PORT", "value": {} },
+{
+  "op": "add",
+  "path": "/MGMT_PORT/eth0",
+  "value": {
+      "admin_status": "up",
+      "alias": "eth0"
+  }
+},
+{ "op": "add", "path": "/MGMT_INTERFACE", "value": {} },
+{%- if info.ManagementIp %}
+{
+  "op": "add",
+  "path": "/MGMT_INTERFACE/eth0|{{ info.ManagementIp | replace("/","~1") }}",
+  "value": {
+      "gwaddr": "{{ info.ManagementGw }}",
+      "forced_mgmt_routes": {{ info.ManagementRoutes | tojson }}
+  }
+},
+{% endif %}
+{%- if 'ManagementIpV6' in info %}
+{
+  "op": "add",
+  "path": "/MGMT_INTERFACE/eth0|{{ info.ManagementIpV6 | replace("/","~1") }}",
+  "value": {
+      "gwaddr": "{{ info.ManagementGwV6 }}",
+      "forced_mgmt_routes": {{ info.ManagementRoutesV6 | tojson }}
+  }
+},
+{% endif %}

--- a/ansible/roles/testbed/nut/templates/config_patch/dut/all.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/dut/all.json.j2
@@ -9,6 +9,7 @@
   {%- include 'templates/config_patch/dut/vlan_members.json.j2' %}
   {%- include 'templates/config_patch/dut/bgp_neighbor_ports.json.j2' %}
   {%- include 'templates/config_patch/dut/bgp_neighbor_devices.json.j2' %}
+  {%- include 'templates/config_patch/common/mgmt_interface.json.j2' %}
   {%- include 'templates/config_patch/dut/device_metadata.json.j2' %}
   {%- endfilter %}
 

--- a/ansible/roles/testbed/nut/templates/config_patch/l1/all.json.j2
+++ b/ansible/roles/testbed/nut/templates/config_patch/l1/all.json.j2
@@ -2,6 +2,7 @@
   {% filter indent(width=2) %}
   {%- include 'templates/config_patch/l1/ocs_ports.json.j2' %}
   {%- include 'templates/config_patch/l1/ocs_xconnect.json.j2' %}
+  {%- include 'templates/config_patch/common/mgmt_interface.json.j2' %}
   {%- include 'templates/config_patch/l1/device_metadata.json.j2' %}
   {%- endfilter %}
 


### PR DESCRIPTION
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

When the forced mgmt route is updated, deploy-cfg will not follow and update the mgmt interface. This is because deploy-cfg only preserve the table but not generating a new one, which causes the issue.

#### How did you do it?

This change creates the mgmt interface table and mgmt port table to get this supported.

#### How did you verify/test it?

Run the deployment locally.

<img width="1062" height="195" alt="image" src="https://github.com/user-attachments/assets/72cd906d-c009-41a0-91a8-48547ea54531" />


#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
