### PR TITLE
inclusion of Route Programming sairedis events in test bgp scale from rotated logs

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -451,7 +451,9 @@ def get_route_programming_metrics_from_sairedis_replay(duthost, start_time, sair
         try:
             return duthost.shell(f"sudo grep -e '{nhg_pattern}' -e '{route_pattern}' {path}")['stdout'].splitlines()
         except Exception as e:
-            logger.info("Failed to read %s: %s", path, e)
+            is_rotated_log = path.endswith('.rec.1')
+            log_level = logging.INFO if is_rotated_log else logging.WARNING
+            logger.log(log_level, "Failed to read %s: %s", path, e)
             return []
     lines = read_lines(sairedislog)
     log_rotated_lines = read_lines(sairedislog + ".1")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update IPv6 BGP scale test log parsing to also include relevant events from rotated `sairedis` logs (`sairedislog.1`). Instead of only falling back to the rotated log when the current log has no matches, this change always reads both files and combines the results so RP/NHG events aren’t missed due to log rotation. Also downgrade a “failed to read” message from warning to info to reduce noise when a file isn’t present.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
During the IPv6 BGP scale tests, relevant RP/NHG events can be split across `sairedis` logs due to log rotation. The previous implementation only checked the rotated log as a fallback when the active log had no matches, which could miss events when both logs contain matches (or when some events are only in `.1` while others are in the active file).

#### How did you do it?
In `tests/bgp/test_ipv6_bgp_scale.py`:
- Read matching lines from both `sairedislog` and `sairedislog.1`.
- Combine results as `lines = log_rotated_lines + lines` so rotated log events are included.
- Change the “Failed to read …” message from `warning` to `info` since the rotated log file may not exist and that’s not necessarily an error condition.

#### How did you verify/test it?
Ran the tests on Arista 7060X6 and Mellanox SN5640

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
