### PR TITLE
Keep One Port Up in BGP Scale Test to Preserve PTF Reachability and Accurate Downtime

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -485,9 +485,10 @@ def _select_targets_to_flap(bgp_peers_info, all_flap, flapping_count):
     bgp_neighbors = list(bgp_peers_info.keys())
     pytest_assert(len(bgp_neighbors) >= 2, "At least two BGP neighbors required for flap test")
     if all_flap:
-        flapping_neighbors = bgp_neighbors
+        flapping_neighbors = list(bgp_neighbors)
         injection_neighbor = random.choice(bgp_neighbors)
-        logger.info(f"[FLAP TEST] All neighbors are flapping: {len(flapping_neighbors)}")
+        flapping_neighbors.remove(injection_neighbor)
+        logger.info(f"[FLAP TEST] All - 1 neighbors are flapping: {len(flapping_neighbors)}")
     else:
         flapping_neighbors = random.sample(bgp_neighbors, flapping_count)
         injection_candidates = [n for n in bgp_neighbors if n not in flapping_neighbors]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In IPv6 BGP scale flap testing, when `all_flap` is enabled we must keep one neighbor stable avoid dataplane downtime miscalculation. This PR updates the target selection logic to flap “all minus one” neighbors by removing the randomly chosen injection neighbor from the flapping neighbor list, and updates the log message accordingly.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The flap test requires a dedicated “injection neighbor” to remain up for route injection/verification. Previously, with `all_flap=True`, the injection neighbor could also be included in the flapping set, causing inconsistent/incorrect behavior.

#### How did you do it?
In `tests/bgp/test_ipv6_bgp_scale.py` (`_select_targets_to_flap`), when `all_flap` is enabled:
- Copy the neighbor list (`list(bgp_neighbors)`) to avoid aliasing.
- Randomly pick the injection neighbor.
- Remove the injection neighbor from `flapping_neighbors` so we flap all other neighbors.
- Update the log message to reflect “All - 1 neighbors”.

#### How did you verify/test it?
Ran the tests on Arista 7060X6 and Mellanox SN5640
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
