### PR TITLE
[sonic-mgmt/tests/dut_console folder]: base_console_conn updates to n…

### DIFF
--- a/tests/common/connections/base_console_conn.py
+++ b/tests/common/connections/base_console_conn.py
@@ -76,8 +76,8 @@ class BaseConsoleConn(CiscoBaseConnection):
         # not supported
         pass
 
-    def find_prompt(self, delay_factor=1):
-        return super(BaseConsoleConn, self).find_prompt(delay_factor)
+    def find_prompt(self, delay_factor=1, pattern=None):
+        return super(BaseConsoleConn, self).find_prompt(delay_factor=delay_factor, pattern=pattern)
 
     def clear_buffer(self):
         # todo


### PR DESCRIPTION
Due to python upgrade to 3.12 the paramiko library is update to 4.x version .
This (paramiko) is where base_connection is defined.

 Correcting the signature of find_prompt() on child
    base_console_conn so as to agree with the paramiko (updated to 4.0.0) parent base_connection.
That way, super() is actually taken into account.
We expect now that find_prompt is working better but as 4.x paramiko make telnet negotiation more strict
    there is a chance that failures seen sporadically.

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Correcting some dut_console tests that suffer on telnet login process.

Fixes: correcting the signature of find_prompt on child base_console_conn so as to agree with parent base_connection (defined on netmiko) in order super call to be successful.
In that way prompt can be found correctly now and the login procedure works better.
netmiko can be found inside sonic-mgmt container under /opt/venv/lib/python3.12/site-packages/netmiko

Actual problem seen: dut_console testcases suffered due to telnet login failures.

### Type of change
 [x] Bug fix


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x ] 202511
i plan to send another PR for 202511.
### Approach
fixing the signatures and call the super with the correct argument so as parent method to be usable.

#### What is the motivation for this PR?
making telnet login operates normally again.

#### How did you do it?
fixing the signatures and super call
#### How did you verify/test it?
running the dut_console folder and ssh folder.

#### Any platform specific information?
it is seen on nokia platforms at least.

#### Supported testbed topology if it's a new test case?
on T0 it failed and it has been seen on M0/Mx as well.

### Documentation
