### PR TITLE
`acl_test.py` Increase the timeout of `check_rule_counters`

### DIFF
--- a/tests/acl/test_acl.py
+++ b/tests/acl/test_acl.py
@@ -1057,7 +1057,7 @@ class BaseAclTest(six.with_metaclass(ABCMeta, object)):
             return True
 
         logger.info('Wait all rule counters are ready')
-        return wait_until(60, 2, 0, self.check_rule_counters_internal, duthost)
+        return wait_until(120, 2, 0, self.check_rule_counters_internal, duthost)
 
     def check_rule_counters_internal(self, duthost):
         for asic_id in duthost.get_frontend_asic_ids():


### PR DESCRIPTION
`check_rule_counters` waits for 60s for all ACL rules to be installed from the first ACL rule creation to the last.
We've seen that occasionally the amount of time from the first rule creation to the last rule creation is greater than 60s.
Hence increasing the timeout from 60s to 120s.

More details in https://github.com/sonic-net/sonic-mgmt/issues/21988

Summary:
Fixes #21988 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

