### PR TITLE
Fix the nnpy installation failure for test_copp

### DIFF
--- a/tests/copp/copp_utils.py
+++ b/tests/copp/copp_utils.py
@@ -215,12 +215,14 @@ def _install_nano_bookworm(dut, creds, syncd_docker_name):
         https_proxy = creds.get('proxy_env', {}).get('https_proxy', '')
         # Change the permission of /tmp to 1777 to workaround issue sonic-net/sonic-buildimage#16034
         cmd = '''docker exec -e http_proxy={} -e https_proxy={} {} bash -c " \
-                chmod 1777 /tmp \
+                mkdir -p /var/tmp_build \
                 && rm -rf /var/lib/apt/lists/* \
                 && apt-get update \
                 && apt-get install -y python3-pip build-essential libssl-dev libffi-dev \
                 python3-dev python3-setuptools wget libnanomsg-dev python-is-python3 \
-                && pip3 install cffi==1.16.0 && pip3 install nnpy \
+                && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi==1.16.0 \
+                && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy \
+                && rm -rf /var/tmp_build \
                 && mkdir -p /opt && cd /opt && wget \
                 https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
                 && mkdir ptf && cd ptf && wget \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

nnpy package installation failed in test_copp on master image.

```
Collecting nnpy
  Using cached nnpy-1.4.2.tar.gz (6.4 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [45 lines of output]
      Traceback (most recent call last):
        File "/usr/local/lib/python3.11/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/usr/local/lib/python3.11/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.11/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 175, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/build_meta.py", line 374, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 3, in <module>
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/__init__.py", line 115, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/_distutils/core.py", line 148, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/dist.py", line 321, in __init__
          _Distribution.__init__(self, dist_attrs)
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/_distutils/dist.py", line 309, in __init__
          self.finalize_options()
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/dist.py", line 784, in finalize_options
          ep(self)
        File "/tmp/pip-build-env-p05ghanq/overlay/local/lib/python3.11/dist-packages/setuptools/dist.py", line 804, in _finalize_setup_keywords
          ep.load()(self, ep.name, value)
        File "/tmp/pip-build-env-p05ghanq/normal/local/lib/python3.11/dist-packages/cffi/setuptools_ext.py", line 229, in cffi_modules
          add_cffi_module(dist, cffi_module)
        File "/tmp/pip-build-env-p05ghanq/normal/local/lib/python3.11/dist-packages/cffi/setuptools_ext.py", line 50, in add_cffi_module
          execfile(build_file_name, mod_vars)
        File "/tmp/pip-build-env-p05ghanq/normal/local/lib/python3.11/dist-packages/cffi/setuptools_ext.py", line 26, in execfile
          exec(code, glob, glob)
        File "generate.py", line 120, in <module>
          ffi = create_module()
                ^^^^^^^^^^^^^^^
        File "generate.py", line 109, in create_module
          ffi = FFI()
                ^^^^^
        File "/tmp/pip-build-env-p05ghanq/normal/local/lib/python3.11/dist-packages/cffi/api.py", line 48, in __init__
          import _cffi_backend as backend
      ImportError: /tmp/pip-build-env-p05ghanq/normal/local/lib/python3.11/dist-packages/_cffi_backend.cpython-311-x86_64-linux-gnu.so: failed to map segment from shared object
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> nnpy

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To fix the failure of nnpy package installation, the root cause is 

This error—failed to map segment from shared object—is almost always caused by the /tmp partition being mounted with the noexec flag.

In many security-hardened Linux environments (like those used for SONiC), the system prevents files in /tmp from being executed. Since pip creates a temporary build environment in /tmp to compile nnpy and cffi, the installation crashes when it tries to load the newly built library.

The Fix: Change the Temporary Directory
You can tell pip to use a different directory for building that has execution permissions (like your home directory or /var/tmp).

Why nnpy specifically is failing?

1. Unlike many other packages, nnpy is a "thick" wrapper around the C-library nanomsg. It uses a tool called CFFI (C Foreign Function Interface).
2. pip downloads the nnpy source.
3. It creates a "virtual" build environment in /tmp.
4. It compiles a C-extension (_cffi_backend.so).
5. It tries to "import" that C-extension to finish the metadata generation.

The Linux kernel sees the file is in a noexec zone and kills the process, resulting in the error you saw.
#### How did you do it?
change to use `/var/tmp-build` as `TMPDIR `for `cffi` and `nnpy` installation.

#### How did you verify/test it?

```
admin@bjw2-can-7260-12:~$ docker exec \
>   -e http_proxy="http://10.150.22.222:8080" \
>   -e https_proxy="http://10.150.22.222:8080" \
>   syncd \
>   bash -lc 'mkdir -p /var/tmp_build \
>     && rm -rf /var/lib/apt/lists/* \
>     && apt-get update \
>     && apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python3-setuptools wget libnanomsg-dev python-is-python3 \
>     && TMPDIR=/var/tmp_build pip3 install --no-cache-dir cffi==1.16.0 \
>     && TMPDIR=/var/tmp_build pip3 install --no-cache-dir nnpy \
>     && rm -rf /var/tmp_build \
>     && mkdir -p /opt \
>     && cd /opt \
>     && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
>     && mkdir -p ptf \
>     && cd ptf \
>     && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py \
>     && touch __init__.py \
>     && apt-get -y purge build-essential libssl-dev libffi-dev python3-dev python3-setuptools wget'
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
Get:3 http://deb.debian.org/debian bookworm-backports InRelease [59.4 kB]
Get:4 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:5 http://deb.debian.org/debian bookworm/contrib Sources [51.1 kB]
Get:6 http://deb.debian.org/debian bookworm/non-free-firmware Sources [7152 B]
Get:7 http://deb.debian.org/debian bookworm/main Sources [9495 kB]
Get:8 http://deb.debian.org/debian bookworm/contrib amd64 Packages [53.5 kB]
Get:9 http://deb.debian.org/debian bookworm/non-free-firmware amd64 Packages [6368 B]
Get:10 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]
Get:11 http://deb.debian.org/debian bookworm-updates/main Sources [3288 B]
Get:12 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6924 B]
Get:13 http://deb.debian.org/debian bookworm-backports/non-free-firmware amd64 Packages [3828 B]
Get:14 http://deb.debian.org/debian bookworm-backports/main amd64 Packages [300 kB]
Get:15 http://deb.debian.org/debian bookworm-backports/contrib amd64 Packages [5856 B]
Get:16 http://deb.debian.org/debian-security bookworm-security/contrib Sources [856 B]
Get:17 http://deb.debian.org/debian-security bookworm-security/non-free-firmware Sources [796 B]
Get:18 http://deb.debian.org/debian-security bookworm-security/main Sources [197 kB]
Get:19 http://deb.debian.org/debian-security bookworm-security/non-free-firmware amd64 Packages [688 B]
Get:20 http://deb.debian.org/debian-security bookworm-security/contrib amd64 Packages [896 B]
Get:21 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [291 kB]
Fetched 19.5 MB in 4s (4620 kB/s)
Reading package lists...
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
Reading package lists...
Building dependency tree...
Reading state information...
python3-setuptools is already the newest version (66.1.1-1+deb12u2).
python-is-python3 is already the newest version (3.11.2-1+deb12u1).
The following additional packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu bzip2 cpp cpp-12 dpkg-dev
  g++ g++-12 gcc gcc-12 libasan8 libbinutils libc-dev-bin libc6-dev libcc1-0
  libcrypt-dev libctf-nobfd0 libctf0 libdpkg-perl libexpat1-dev libgcc-12-dev
  libgomp1 libgprofng0 libisl23 libitm1 libjs-jquery libjs-sphinxdoc
  libjs-underscore liblsan0 libmpc3 libmpfr6 libnanomsg5 libnsl-dev
  libpython3-dev libpython3.11-dev libquadmath0 libssl3 libstdc++-12-dev
  libtirpc-dev libtsan2 libubsan1 linux-libc-dev make openssl patch
  python3.11-dev rpcsvc-proto xz-utils zlib1g-dev
Suggested packages:
  binutils-doc bzip2-doc cpp-doc gcc-12-locales cpp-12-doc debian-keyring
  g++-multilib g++-12-multilib gcc-12-doc gcc-multilib manpages-dev autoconf
  automake libtool flex bison gdb gcc-doc gcc-12-multilib glibc-doc gnupg | sq
  | sqop | pgpainless-cli sensible-utils git bzr libssl-doc libstdc++-12-doc
  make-doc ed diffutils-doc
Recommended packages:
  fakeroot gnupg | sq | sqop | pgpainless-cli libalgorithm-merge-perl manpages
  manpages-dev libc-devtools libfile-fcntllock-perl liblocale-gettext-perl
  javascript-common
The following NEW packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu build-essential bzip2 cpp
  cpp-12 dpkg-dev g++ g++-12 gcc gcc-12 libasan8 libbinutils libc-dev-bin
  libc6-dev libcc1-0 libcrypt-dev libctf-nobfd0 libctf0 libdpkg-perl
  libexpat1-dev libffi-dev libgcc-12-dev libgomp1 libgprofng0 libisl23 libitm1
  libjs-jquery libjs-sphinxdoc libjs-underscore liblsan0 libmpc3 libmpfr6
  libnanomsg-dev libnanomsg5 libnsl-dev libpython3-dev libpython3.11-dev
  libquadmath0 libstdc++-12-dev libtirpc-dev libtsan2 libubsan1 linux-libc-dev
  make patch python3-dev python3-pip python3.11-dev rpcsvc-proto wget xz-utils
  zlib1g-dev
The following packages will be upgraded:
  libssl-dev libssl3 openssl
3 upgraded, 54 newly installed, 0 to remove and 10 not upgraded.
Need to get 81.7 MB of archives.
After this operation, 308 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian bookworm/main amd64 bzip2 amd64 1.0.8-5+b1 [49.8 kB]
Get:2 http://deb.debian.org/debian bookworm/main amd64 wget amd64 1.21.3-1+deb12u1 [937 kB]
Get:3 http://deb.debian.org/debian bookworm/main amd64 xz-utils amd64 5.4.1-1 [471 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 binutils-common amd64 2.40-2 [2487 kB]
Get:5 http://deb.debian.org/debian bookworm/main amd64 libbinutils amd64 2.40-2 [572 kB]
Get:6 http://deb.debian.org/debian bookworm/main amd64 libctf-nobfd0 amd64 2.40-2 [153 kB]
Get:7 http://deb.debian.org/debian bookworm/main amd64 libctf0 amd64 2.40-2 [89.8 kB]
Get:8 http://deb.debian.org/debian bookworm/main amd64 libgprofng0 amd64 2.40-2 [812 kB]
Get:9 http://deb.debian.org/debian bookworm/main amd64 binutils-x86-64-linux-gnu amd64 2.40-2 [2246 kB]
Get:10 http://deb.debian.org/debian bookworm/main amd64 binutils amd64 2.40-2 [65.0 kB]
Get:11 http://deb.debian.org/debian bookworm/main amd64 libc-dev-bin amd64 2.36-9+deb12u13 [47.4 kB]
Get:12 http://deb.debian.org/debian bookworm/main amd64 linux-libc-dev amd64 6.1.159-1 [2215 kB]
Get:13 http://deb.debian.org/debian bookworm/main amd64 libcrypt-dev amd64 1:4.4.33-2 [118 kB]
Get:14 http://deb.debian.org/debian bookworm/main amd64 libtirpc-dev amd64 1.3.3+ds-1 [191 kB]
Get:15 http://deb.debian.org/debian bookworm/main amd64 libnsl-dev amd64 1.3.0-2 [66.4 kB]
Get:16 http://deb.debian.org/debian bookworm/main amd64 rpcsvc-proto amd64 1.4.3-1 [63.3 kB]
Get:17 http://deb.debian.org/debian bookworm/main amd64 libc6-dev amd64 2.36-9+deb12u13 [1904 kB]
Get:18 http://deb.debian.org/debian bookworm/main amd64 libisl23 amd64 0.25-1.1 [683 kB]
Get:19 http://deb.debian.org/debian bookworm/main amd64 libmpfr6 amd64 4.2.0-1 [701 kB]
Get:20 http://deb.debian.org/debian bookworm/main amd64 libmpc3 amd64 1.3.1-1 [51.5 kB]
Get:21 http://deb.debian.org/debian bookworm/main amd64 cpp-12 amd64 12.2.0-14+deb12u1 [9768 kB]
Get:22 http://deb.debian.org/debian bookworm/main amd64 cpp amd64 4:12.2.0-3 [6836 B]
Get:23 http://deb.debian.org/debian bookworm/main amd64 libcc1-0 amd64 12.2.0-14+deb12u1 [41.7 kB]
Get:24 http://deb.debian.org/debian bookworm/main amd64 libgomp1 amd64 12.2.0-14+deb12u1 [116 kB]
Get:25 http://deb.debian.org/debian bookworm/main amd64 libitm1 amd64 12.2.0-14+deb12u1 [26.1 kB]
Get:26 http://deb.debian.org/debian bookworm/main amd64 libasan8 amd64 12.2.0-14+deb12u1 [2193 kB]
Get:27 http://deb.debian.org/debian bookworm/main amd64 liblsan0 amd64 12.2.0-14+deb12u1 [969 kB]
Get:28 http://deb.debian.org/debian bookworm/main amd64 libtsan2 amd64 12.2.0-14+deb12u1 [2197 kB]
Get:29 http://deb.debian.org/debian bookworm/main amd64 libubsan1 amd64 12.2.0-14+deb12u1 [883 kB]
Get:30 http://deb.debian.org/debian bookworm/main amd64 libquadmath0 amd64 12.2.0-14+deb12u1 [145 kB]
Get:31 http://deb.debian.org/debian bookworm/main amd64 libgcc-12-dev amd64 12.2.0-14+deb12u1 [2437 kB]
Get:32 http://deb.debian.org/debian bookworm/main amd64 gcc-12 amd64 12.2.0-14+deb12u1 [19.3 MB]
Get:33 http://deb.debian.org/debian bookworm/main amd64 gcc amd64 4:12.2.0-3 [5216 B]
Get:34 http://deb.debian.org/debian bookworm/main amd64 libstdc++-12-dev amd64 12.2.0-14+deb12u1 [2047 kB]
Get:35 http://deb.debian.org/debian bookworm/main amd64 g++-12 amd64 12.2.0-14+deb12u1 [10.7 MB]
Get:36 http://deb.debian.org/debian bookworm/main amd64 g++ amd64 4:12.2.0-3 [1356 B]
Get:37 http://deb.debian.org/debian bookworm/main amd64 make amd64 4.3-4.1 [396 kB]
Get:38 http://deb.debian.org/debian bookworm/main amd64 libdpkg-perl all 1.21.22 [603 kB]
Get:39 http://deb.debian.org/debian bookworm/main amd64 patch amd64 2.7.6-7 [128 kB]
Get:40 http://deb.debian.org/debian bookworm/main amd64 dpkg-dev all 1.21.22 [1353 kB]
Get:41 http://deb.debian.org/debian bookworm/main amd64 build-essential amd64 12.9 [7704 B]
Get:42 http://deb.debian.org/debian bookworm/main amd64 libexpat1-dev amd64 2.5.0-1+deb12u2 [151 kB]
Get:43 http://deb.debian.org/debian bookworm/main amd64 libffi-dev amd64 3.4.4-1 [59.4 kB]
Get:44 http://deb.debian.org/debian bookworm/main amd64 libjs-jquery all 3.6.1+dfsg+~3.5.14-1 [326 kB]
Get:45 http://deb.debian.org/debian bookworm/main amd64 libjs-underscore all 1.13.4~dfsg+~1.11.4-3 [116 kB]
Get:46 http://deb.debian.org/debian bookworm/main amd64 libjs-sphinxdoc all 5.3.0-4 [130 kB]
Get:47 http://deb.debian.org/debian bookworm/main amd64 libnanomsg5 amd64 1.1.5+dfsg-1.1+b1 [96.6 kB]
Get:48 http://deb.debian.org/debian bookworm/main amd64 libnanomsg-dev amd64 1.1.5+dfsg-1.1+b1 [41.0 kB]
Get:49 http://deb.debian.org/debian bookworm/main amd64 zlib1g-dev amd64 1:1.2.13.dfsg-1 [916 kB]
Get:50 http://deb.debian.org/debian bookworm/main amd64 libpython3.11-dev amd64 3.11.2-6+deb12u6 [4742 kB]
Get:51 http://deb.debian.org/debian bookworm/main amd64 libpython3-dev amd64 3.11.2-1+b1 [9572 B]
Get:52 http://deb.debian.org/debian bookworm/main amd64 libssl-dev amd64 3.0.18-1~deb12u1 [2443 kB]
Get:53 http://deb.debian.org/debian bookworm/main amd64 libssl3 amd64 3.0.18-1~deb12u1 [2029 kB]
Get:54 http://deb.debian.org/debian bookworm/main amd64 openssl amd64 3.0.18-1~deb12u1 [1432 kB]
Get:55 http://deb.debian.org/debian bookworm/main amd64 python3.11-dev amd64 3.11.2-6+deb12u6 [615 kB]
Get:56 http://deb.debian.org/debian bookworm/main amd64 python3-dev amd64 3.11.2-1+b1 [26.2 kB]
Get:57 http://deb.debian.org/debian bookworm/main amd64 python3-pip all 23.0.1+dfsg-1 [1325 kB]
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
Fetched 81.7 MB in 5s (17.5 MB/s)
Selecting previously unselected package bzip2.
(Reading database ... 11645 files and directories currently installed.)
Preparing to unpack .../00-bzip2_1.0.8-5+b1_amd64.deb ...
Unpacking bzip2 (1.0.8-5+b1) ...
Selecting previously unselected package wget.
Preparing to unpack .../01-wget_1.21.3-1+deb12u1_amd64.deb ...
Unpacking wget (1.21.3-1+deb12u1) ...
Selecting previously unselected package xz-utils.
Preparing to unpack .../02-xz-utils_5.4.1-1_amd64.deb ...
Unpacking xz-utils (5.4.1-1) ...
Selecting previously unselected package binutils-common:amd64.
Preparing to unpack .../03-binutils-common_2.40-2_amd64.deb ...
Unpacking binutils-common:amd64 (2.40-2) ...
Selecting previously unselected package libbinutils:amd64.
Preparing to unpack .../04-libbinutils_2.40-2_amd64.deb ...
Unpacking libbinutils:amd64 (2.40-2) ...
Selecting previously unselected package libctf-nobfd0:amd64.
Preparing to unpack .../05-libctf-nobfd0_2.40-2_amd64.deb ...
Unpacking libctf-nobfd0:amd64 (2.40-2) ...
Selecting previously unselected package libctf0:amd64.
Preparing to unpack .../06-libctf0_2.40-2_amd64.deb ...
Unpacking libctf0:amd64 (2.40-2) ...
Selecting previously unselected package libgprofng0:amd64.
Preparing to unpack .../07-libgprofng0_2.40-2_amd64.deb ...
Unpacking libgprofng0:amd64 (2.40-2) ...
Selecting previously unselected package binutils-x86-64-linux-gnu.
Preparing to unpack .../08-binutils-x86-64-linux-gnu_2.40-2_amd64.deb ...
Unpacking binutils-x86-64-linux-gnu (2.40-2) ...
Selecting previously unselected package binutils.
Preparing to unpack .../09-binutils_2.40-2_amd64.deb ...
Unpacking binutils (2.40-2) ...
Selecting previously unselected package libc-dev-bin.
Preparing to unpack .../10-libc-dev-bin_2.36-9+deb12u13_amd64.deb ...
Unpacking libc-dev-bin (2.36-9+deb12u13) ...
Selecting previously unselected package linux-libc-dev:amd64.
Preparing to unpack .../11-linux-libc-dev_6.1.159-1_amd64.deb ...
Unpacking linux-libc-dev:amd64 (6.1.159-1) ...
Selecting previously unselected package libcrypt-dev:amd64.
Preparing to unpack .../12-libcrypt-dev_1%3a4.4.33-2_amd64.deb ...
Unpacking libcrypt-dev:amd64 (1:4.4.33-2) ...
Selecting previously unselected package libtirpc-dev:amd64.
Preparing to unpack .../13-libtirpc-dev_1.3.3+ds-1_amd64.deb ...
Unpacking libtirpc-dev:amd64 (1.3.3+ds-1) ...
Selecting previously unselected package libnsl-dev:amd64.
Preparing to unpack .../14-libnsl-dev_1.3.0-2_amd64.deb ...
Unpacking libnsl-dev:amd64 (1.3.0-2) ...
Selecting previously unselected package rpcsvc-proto.
Preparing to unpack .../15-rpcsvc-proto_1.4.3-1_amd64.deb ...
Unpacking rpcsvc-proto (1.4.3-1) ...
Selecting previously unselected package libc6-dev:amd64.
Preparing to unpack .../16-libc6-dev_2.36-9+deb12u13_amd64.deb ...
Unpacking libc6-dev:amd64 (2.36-9+deb12u13) ...
Selecting previously unselected package libisl23:amd64.
Preparing to unpack .../17-libisl23_0.25-1.1_amd64.deb ...
Unpacking libisl23:amd64 (0.25-1.1) ...
Selecting previously unselected package libmpfr6:amd64.
Preparing to unpack .../18-libmpfr6_4.2.0-1_amd64.deb ...
Unpacking libmpfr6:amd64 (4.2.0-1) ...
Selecting previously unselected package libmpc3:amd64.
Preparing to unpack .../19-libmpc3_1.3.1-1_amd64.deb ...
Unpacking libmpc3:amd64 (1.3.1-1) ...
Selecting previously unselected package cpp-12.
Preparing to unpack .../20-cpp-12_12.2.0-14+deb12u1_amd64.deb ...
Unpacking cpp-12 (12.2.0-14+deb12u1) ...
Selecting previously unselected package cpp.
Preparing to unpack .../21-cpp_4%3a12.2.0-3_amd64.deb ...
Unpacking cpp (4:12.2.0-3) ...
Selecting previously unselected package libcc1-0:amd64.
Preparing to unpack .../22-libcc1-0_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libcc1-0:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libgomp1:amd64.
Preparing to unpack .../23-libgomp1_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libgomp1:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libitm1:amd64.
Preparing to unpack .../24-libitm1_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libitm1:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libasan8:amd64.
Preparing to unpack .../25-libasan8_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libasan8:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package liblsan0:amd64.
Preparing to unpack .../26-liblsan0_12.2.0-14+deb12u1_amd64.deb ...
Unpacking liblsan0:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libtsan2:amd64.
Preparing to unpack .../27-libtsan2_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libtsan2:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libubsan1:amd64.
Preparing to unpack .../28-libubsan1_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libubsan1:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libquadmath0:amd64.
Preparing to unpack .../29-libquadmath0_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libquadmath0:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package libgcc-12-dev:amd64.
Preparing to unpack .../30-libgcc-12-dev_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libgcc-12-dev:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package gcc-12.
Preparing to unpack .../31-gcc-12_12.2.0-14+deb12u1_amd64.deb ...
Unpacking gcc-12 (12.2.0-14+deb12u1) ...
Selecting previously unselected package gcc.
Preparing to unpack .../32-gcc_4%3a12.2.0-3_amd64.deb ...
Unpacking gcc (4:12.2.0-3) ...
Selecting previously unselected package libstdc++-12-dev:amd64.
Preparing to unpack .../33-libstdc++-12-dev_12.2.0-14+deb12u1_amd64.deb ...
Unpacking libstdc++-12-dev:amd64 (12.2.0-14+deb12u1) ...
Selecting previously unselected package g++-12.
Preparing to unpack .../34-g++-12_12.2.0-14+deb12u1_amd64.deb ...
Unpacking g++-12 (12.2.0-14+deb12u1) ...
Selecting previously unselected package g++.
Preparing to unpack .../35-g++_4%3a12.2.0-3_amd64.deb ...
Unpacking g++ (4:12.2.0-3) ...
Selecting previously unselected package make.
Preparing to unpack .../36-make_4.3-4.1_amd64.deb ...
Unpacking make (4.3-4.1) ...
Selecting previously unselected package libdpkg-perl.
Preparing to unpack .../37-libdpkg-perl_1.21.22_all.deb ...
Unpacking libdpkg-perl (1.21.22) ...
Selecting previously unselected package patch.
Preparing to unpack .../38-patch_2.7.6-7_amd64.deb ...
Unpacking patch (2.7.6-7) ...
Selecting previously unselected package dpkg-dev.
Preparing to unpack .../39-dpkg-dev_1.21.22_all.deb ...
Unpacking dpkg-dev (1.21.22) ...
Selecting previously unselected package build-essential.
Preparing to unpack .../40-build-essential_12.9_amd64.deb ...
Unpacking build-essential (12.9) ...
Selecting previously unselected package libexpat1-dev:amd64.
Preparing to unpack .../41-libexpat1-dev_2.5.0-1+deb12u2_amd64.deb ...
Unpacking libexpat1-dev:amd64 (2.5.0-1+deb12u2) ...
Selecting previously unselected package libffi-dev:amd64.
Preparing to unpack .../42-libffi-dev_3.4.4-1_amd64.deb ...
Unpacking libffi-dev:amd64 (3.4.4-1) ...
Selecting previously unselected package libjs-jquery.
Preparing to unpack .../43-libjs-jquery_3.6.1+dfsg+~3.5.14-1_all.deb ...
Unpacking libjs-jquery (3.6.1+dfsg+~3.5.14-1) ...
Selecting previously unselected package libjs-underscore.
Preparing to unpack .../44-libjs-underscore_1.13.4~dfsg+~1.11.4-3_all.deb ...
Unpacking libjs-underscore (1.13.4~dfsg+~1.11.4-3) ...
Selecting previously unselected package libjs-sphinxdoc.
Preparing to unpack .../45-libjs-sphinxdoc_5.3.0-4_all.deb ...
Unpacking libjs-sphinxdoc (5.3.0-4) ...
Selecting previously unselected package libnanomsg5.
Preparing to unpack .../46-libnanomsg5_1.1.5+dfsg-1.1+b1_amd64.deb ...
Unpacking libnanomsg5 (1.1.5+dfsg-1.1+b1) ...
Selecting previously unselected package libnanomsg-dev.
Preparing to unpack .../47-libnanomsg-dev_1.1.5+dfsg-1.1+b1_amd64.deb ...
Unpacking libnanomsg-dev (1.1.5+dfsg-1.1+b1) ...
Selecting previously unselected package zlib1g-dev:amd64.
Preparing to unpack .../48-zlib1g-dev_1%3a1.2.13.dfsg-1_amd64.deb ...
Unpacking zlib1g-dev:amd64 (1:1.2.13.dfsg-1) ...
Selecting previously unselected package libpython3.11-dev:amd64.
Preparing to unpack .../49-libpython3.11-dev_3.11.2-6+deb12u6_amd64.deb ...
Unpacking libpython3.11-dev:amd64 (3.11.2-6+deb12u6) ...
Selecting previously unselected package libpython3-dev:amd64.
Preparing to unpack .../50-libpython3-dev_3.11.2-1+b1_amd64.deb ...
Unpacking libpython3-dev:amd64 (3.11.2-1+b1) ...
Preparing to unpack .../51-libssl-dev_3.0.18-1~deb12u1_amd64.deb ...
Unpacking libssl-dev:amd64 (3.0.18-1~deb12u1) over (3.0.11-1~deb12u2+fips) ...
Preparing to unpack .../52-libssl3_3.0.18-1~deb12u1_amd64.deb ...
Unpacking libssl3:amd64 (3.0.18-1~deb12u1) over (3.0.11-1~deb12u2+fips) ...
Preparing to unpack .../53-openssl_3.0.18-1~deb12u1_amd64.deb ...
Unpacking openssl (3.0.18-1~deb12u1) over (3.0.11-1~deb12u2+fips) ...
Selecting previously unselected package python3.11-dev.
Preparing to unpack .../54-python3.11-dev_3.11.2-6+deb12u6_amd64.deb ...
Unpacking python3.11-dev (3.11.2-6+deb12u6) ...
Selecting previously unselected package python3-dev.
Preparing to unpack .../55-python3-dev_3.11.2-1+b1_amd64.deb ...
Unpacking python3-dev (3.11.2-1+b1) ...
Selecting previously unselected package python3-pip.
Preparing to unpack .../56-python3-pip_23.0.1+dfsg-1_all.deb ...
Unpacking python3-pip (23.0.1+dfsg-1) ...
Setting up wget (1.21.3-1+deb12u1) ...

Configuration file '/etc/wgetrc', does not exist on system.
Installing new config file as you requested.
Setting up libnanomsg5 (1.1.5+dfsg-1.1+b1) ...
Setting up binutils-common:amd64 (2.40-2) ...

Configuration file '/etc/gprofng.rc', does not exist on system.
Installing new config file as you requested.
Setting up libssl3:amd64 (3.0.18-1~deb12u1) ...
Setting up linux-libc-dev:amd64 (6.1.159-1) ...
Setting up libctf-nobfd0:amd64 (2.40-2) ...
Setting up libgomp1:amd64 (12.2.0-14+deb12u1) ...
Setting up bzip2 (1.0.8-5+b1) ...
Setting up libffi-dev:amd64 (3.4.4-1) ...
Setting up libtirpc-dev:amd64 (1.3.3+ds-1) ...
Setting up rpcsvc-proto (1.4.3-1) ...
Setting up make (4.3-4.1) ...
Setting up libmpfr6:amd64 (4.2.0-1) ...
Setting up xz-utils (5.4.1-1) ...
update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/lzma.1.gz because associated file /usr/share/man/man1/xz.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/unlzma.1.gz because associated file /usr/share/man/man1/unxz.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzcat.1.gz because associated file /usr/share/man/man1/xzcat.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzmore.1.gz because associated file /usr/share/man/man1/xzmore.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzless.1.gz because associated file /usr/share/man/man1/xzless.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzdiff.1.gz because associated file /usr/share/man/man1/xzdiff.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzcmp.1.gz because associated file /usr/share/man/man1/xzcmp.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzgrep.1.gz because associated file /usr/share/man/man1/xzgrep.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzegrep.1.gz because associated file /usr/share/man/man1/xzegrep.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzfgrep.1.gz because associated file /usr/share/man/man1/xzfgrep.1.gz (of link group lzma) doesn't exist
Setting up libquadmath0:amd64 (12.2.0-14+deb12u1) ...
Setting up libssl-dev:amd64 (3.0.18-1~deb12u1) ...
Setting up libmpc3:amd64 (1.3.1-1) ...
Setting up patch (2.7.6-7) ...
Setting up python3-pip (23.0.1+dfsg-1) ...
Setting up libdpkg-perl (1.21.22) ...
Setting up libubsan1:amd64 (12.2.0-14+deb12u1) ...
Setting up libnsl-dev:amd64 (1.3.0-2) ...
Setting up libcrypt-dev:amd64 (1:4.4.33-2) ...
Setting up libasan8:amd64 (12.2.0-14+deb12u1) ...
Setting up libnanomsg-dev (1.1.5+dfsg-1.1+b1) ...
Setting up libtsan2:amd64 (12.2.0-14+deb12u1) ...
Setting up libjs-jquery (3.6.1+dfsg+~3.5.14-1) ...
Setting up libbinutils:amd64 (2.40-2) ...
Setting up libisl23:amd64 (0.25-1.1) ...
Setting up libc-dev-bin (2.36-9+deb12u13) ...
Setting up openssl (3.0.18-1~deb12u1) ...
Setting up libcc1-0:amd64 (12.2.0-14+deb12u1) ...
Setting up liblsan0:amd64 (12.2.0-14+deb12u1) ...
Setting up libitm1:amd64 (12.2.0-14+deb12u1) ...
Setting up libjs-underscore (1.13.4~dfsg+~1.11.4-3) ...
Setting up libctf0:amd64 (2.40-2) ...
Setting up cpp-12 (12.2.0-14+deb12u1) ...
Setting up libgprofng0:amd64 (2.40-2) ...
Setting up libgcc-12-dev:amd64 (12.2.0-14+deb12u1) ...
Setting up libjs-sphinxdoc (5.3.0-4) ...
Setting up cpp (4:12.2.0-3) ...
Setting up libc6-dev:amd64 (2.36-9+deb12u13) ...
Setting up binutils-x86-64-linux-gnu (2.40-2) ...
Setting up libstdc++-12-dev:amd64 (12.2.0-14+deb12u1) ...
Setting up binutils (2.40-2) ...
Setting up dpkg-dev (1.21.22) ...

Configuration file '/etc/dpkg/shlibs.default', does not exist on system.
Installing new config file as you requested.

Configuration file '/etc/dpkg/shlibs.override', does not exist on system.
Installing new config file as you requested.
Setting up libexpat1-dev:amd64 (2.5.0-1+deb12u2) ...
Setting up gcc-12 (12.2.0-14+deb12u1) ...
Setting up zlib1g-dev:amd64 (1:1.2.13.dfsg-1) ...
Setting up g++-12 (12.2.0-14+deb12u1) ...
Setting up gcc (4:12.2.0-3) ...
Setting up libpython3.11-dev:amd64 (3.11.2-6+deb12u6) ...
Setting up g++ (4:12.2.0-3) ...
update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
Setting up build-essential (12.9) ...
Setting up libpython3-dev:amd64 (3.11.2-1+b1) ...
Setting up python3.11-dev (3.11.2-6+deb12u6) ...
Setting up python3-dev (3.11.2-1+b1) ...
Processing triggers for libc-bin (2.36-9+deb12u13) ...
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
Collecting cffi==1.16.0
  Downloading cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
Collecting pycparser (from cffi==1.16.0)
  Downloading pycparser-2.23-py3-none-any.whl.metadata (993 bytes)
Downloading cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (464 kB)
Downloading pycparser-2.23-py3-none-any.whl (118 kB)
Installing collected packages: pycparser, cffi

Successfully installed cffi-1.16.0 pycparser-2.23
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
Collecting nnpy
  Downloading nnpy-1.4.2.tar.gz (6.4 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: cffi in /usr/local/lib/python3.11/dist-packages (from nnpy) (1.16.0)
Requirement already satisfied: pycparser in /usr/local/lib/python3.11/dist-packages (from cffi->nnpy) (2.23)
Building wheels for collected packages: nnpy
  Building wheel for nnpy (pyproject.toml): started
  Building wheel for nnpy (pyproject.toml): finished with status 'done'
  Created wheel for nnpy: filename=nnpy-1.4.2-cp311-cp311-linux_x86_64.whl size=30507 sha256=e3d7f22611b5196a77d8bf982d50f0dc5b84983b228d9cef79030d3895fe6383
  Stored in directory: /var/tmp_build/pip-ephem-wheel-cache-yr_q97ww/wheels/e8/bc/c7/7801c0a739d3aec50a4a2e5247374af323759cef8217dc1d12
Successfully built nnpy
Installing collected packages: nnpy
Successfully installed nnpy-1.4.2
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
--2026-01-21 06:41:21--  https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py
Connecting to 10.150.22.222:8080... connected.
Proxy request sent, awaiting response... 200 OK
Length: 15297 (15K) [text/plain]
Saving to: 'ptf_nn_agent.py'

     0K .......... ....                                       100% 37.7M=0s

2026-01-21 06:41:22 (37.7 MB/s) - 'ptf_nn_agent.py' saved [15297/15297]

--2026-01-21 06:41:22--  https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py
Connecting to 10.150.22.222:8080... connected.
Proxy request sent, awaiting response... 200 OK
Length: 3492 (3.4K) [text/plain]
Saving to: 'afpacket.py'

     0K ...                                                   100% 27.3M=0s

2026-01-21 06:41:22 (27.3 MB/s) - 'afpacket.py' saved [3492/3492]

Reading package lists...
Building dependency tree...
Reading state information...
The following packages were automatically installed and are no longer required:
  binutils binutils-common binutils-x86-64-linux-gnu bzip2 cpp cpp-12 dpkg-dev
  g++ g++-12 gcc gcc-12 libasan8 libbinutils libc-dev-bin libc6-dev libcc1-0
  libcrypt-dev libctf-nobfd0 libctf0 libdpkg-perl libexpat1-dev libgcc-12-dev
  libgomp1 libgprofng0 libisl23 libitm1 libjs-jquery libjs-sphinxdoc
  libjs-underscore liblsan0 libmpc3 libmpfr6 libnsl-dev libpython3-dev
  libpython3.11-dev libquadmath0 libstdc++-12-dev libtirpc-dev libtsan2
  libubsan1 linux-libc-dev make patch python3-pkg-resources python3.11-dev
  rpcsvc-proto xz-utils zlib1g-dev
Use 'apt autoremove' to remove them.
The following packages will be REMOVED:
  build-essential* libffi-dev* libssl-dev* python3-dev* python3-pip*
  python3-setuptools* wget*
0 upgraded, 0 newly installed, 7 to remove and 10 not upgraded.
After this operation, 26.2 MB disk space will be freed.
(Reading database ... 16874 files and directories currently installed.)
Removing build-essential (12.9) ...
Removing libffi-dev:amd64 (3.4.4-1) ...
Removing libssl-dev:amd64 (3.0.18-1~deb12u1) ...
Removing python3-dev (3.11.2-1+b1) ...
Removing python3-pip (23.0.1+dfsg-1) ...
Removing python3-setuptools (66.1.1-1+deb12u2) ...
Removing wget (1.21.3-1+deb12u1) ...
(Reading database ... 15678 files and directories currently installed.)
Purging configuration files for wget (1.21.3-1+deb12u1) ...
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:4 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:6 and /etc/apt/sources.list.d/debian.sources:1
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:16 and /etc/apt/sources.list.d/debian.sources:2
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
