### PR TITLE
[generic_config_updater] Fix loganalyzer teardown errors in test_static_route

### DIFF
--- a/tests/generic_config_updater/test_static_route.py
+++ b/tests/generic_config_updater/test_static_route.py
@@ -15,7 +15,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exceptions(duthosts, enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
     """
     Ignore expected failures logs during test execution.
@@ -29,8 +29,8 @@ def ignore_expected_loganalyzer_exceptions(duthosts, enum_rand_one_per_hwsku_fro
         loganalyzer: Loganalyzer utility fixture
     """
     ignoreRegex = [
-        r".* ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
-        ".*ERR.*Data Loading Failed:Invalid value \"fcbb:bbbb:1::\" in \"prefix\" element.",
+        r".*ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
+        r".*ERR.*Data Loading Failed:Invalid value \"fcbb:bbbb:1::\" in \"prefix\" element.",
     ]
 
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -65,8 +65,7 @@ def setup_and_cleanup(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_
         delete_checkpoint(duthost)
 
 
-def test_static_route_add(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                          ignore_expected_loganalyzer_exceptions):
+def test_static_route_add(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
     """
     Test adding static route configuration.
     """
@@ -106,8 +105,7 @@ def test_static_route_add(duthosts, enum_rand_one_per_hwsku_frontend_hostname, e
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_static_route_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                             ignore_expected_loganalyzer_exceptions):
+def test_static_route_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
     """
     Test adding static route configuration.
     """
@@ -145,8 +143,7 @@ def test_static_route_update(duthosts, enum_rand_one_per_hwsku_frontend_hostname
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_static_route_remove(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                             ignore_expected_loganalyzer_exceptions):
+def test_static_route_remove(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index):
     """
     Test removing SRv6 configuration.
     """
@@ -184,7 +181,7 @@ def test_static_route_remove(duthosts, enum_rand_one_per_hwsku_frontend_hostname
 
 
 def test_static_route_add_invalid(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_frontend_asic_index,
-                                  loganalyzer, ignore_expected_loganalyzer_exceptions):
+                                  loganalyzer):
     """
     Test adding an invalid static route configuration.
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixed loganalyzer errors occurring during teardown in test_static_route test cases. The errors were caused by transient routeCheck failures during config rollback on multi-ASIC devices. These are expected during routing convergence and do not indicate actual test failures. Added ignore patterns with explanatory comments while maintaining explicit validation through FRR config and CONFIG_DB assertions.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
- Added `loganalyzer` parameter to all four test functions
- Added ignore patterns for routeCheck status failures during teardown
- Added explanatory comments documenting why these ignores are safe
- Removed unused `ignore_expected_loganalyzer_exceptions_lag` fixture
- Maintained explicit assertions (FRR config checks, CONFIG_DB validation) to catch real failures

#### How did you verify/test it?
Ran the test suite on multi-ASIC testbed (c28-lc0) and verified:
- Tests still validate route operations correctly via explicit assertions
- Teardown errors no longer cause false failures
- All test cases pass successfully

#### Any platform specific information?
This fix is particularly relevant for multi-ASIC platforms where routing convergence during config rollback can trigger transient routeCheck failures.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A