### PR TITLE
Update SDK dump file path in dut_utils.py to use a shared log directory

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -371,12 +371,14 @@ def ignore_t2_syslog_msgs(duthost):
 
 
 def get_sai_sdk_dump_file(duthost, dump_file_name):
-    full_path_dump_file = f"/tmp/{dump_file_name}"
+    # a folder mounted from the host to the syncd container
+    # visible as /var/log/sdk_dbg for both the host and the syncd container
+    # and this won't cause syncd container memory usage to grow
+    dump_folder = "/var/log/sdk_dbg"
+    full_path_dump_file = f"{dump_folder}/{dump_file_name}"
+    logger.info(f"Generating SDK dump file: {full_path_dump_file}")
     cmd_gen_sdk_dump = f"docker exec syncd bash -c 'saisdkdump -f {full_path_dump_file}' "
     duthost.shell(cmd_gen_sdk_dump)
-
-    cmd_copy_dmp_from_syncd_to_host = f"docker cp syncd:{full_path_dump_file}  {full_path_dump_file}"  # noqa E231
-    duthost.shell(cmd_copy_dmp_from_syncd_to_host)
 
     compressed_dump_file = f"/tmp/{dump_file_name}.tar.gz"
     duthost.archive(path=full_path_dump_file, dest=compressed_dump_file, format='gz')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Change sdk dump generation folder from `/tmp` to `/var/log/sdk_dbg`
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Previously for mellanox devices, we will generate sai sdk dump in folder `/tmp` inside syncd container, as `/tmp` folder is tmpfs, saving dumps in this folder will cause the syncd container memory usage to increase
#### How did you do it?
Changed the dump file path from `/tmp` to `/var/log/sdk_dbg`. Removed the unnecessary copy command from syncd to host because folder `/var/log/sdk_dbg` is mounted from host
#### How did you verify/test it?
Run crm test on physical setups and verified syncd container memory usage will NOT increase anymore, and the expected sai sdk dump will still be generated and attached to help debugging
#### Any platform specific information?
Mellanox devices
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
