### PR TITLE
test_ipv6_nlri_over_ipv4 single asic voq fixes

### DIFF
--- a/tests/bgp/test_ipv6_nlri_over_ipv4.py
+++ b/tests/bgp/test_ipv6_nlri_over_ipv4.py
@@ -103,18 +103,12 @@ def setup(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, request):
     dut_nlri_route = dut_nlri_routes[2]
     logger.debug("DUT NLRI route: {}".format(dut_nlri_route))
 
-    def neigh_routes_available(cmd):
-        neigh_nlri_routes = neigh_host.shell(cmd, module_ignore_errors=True)['stdout'].split('\n')
-        # Test validation can fail when it queries little earlier than the routes have reached
-        # the neighbor. Below is confirming neighbor has received enough routes
-        return len(neigh_nlri_routes) > 1000
-
     neigh_host = nbrhosts[neigh_name]["host"]
     if is_sonic_neigh:
         logger.debug(neigh_host.shell('vtysh -n {} vtysh -c "clear bgp * soft"'.format(neigh_namespace)))
         cmd = "show ipv6 bgp neighbor {} received-routes".format(dut_ip_v6)
-        wait_until(180, 10, 0, neigh_routes_available, cmd)
         neigh_nlri_routes = neigh_host.shell(cmd, module_ignore_errors=True)['stdout'].split('\n')
+        pytest_assert(len(neigh_nlri_routes) >= 3, "Neighbor didn't receive enough routes")
         logger.debug("neighbor routes: {}".format(neigh_nlri_routes[len(neigh_nlri_routes) - 3]))
         neigh_nlri_route = neigh_nlri_routes[len(neigh_nlri_routes) - 3].split()[1]
     else:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_ipv6_nlri_over_ipv4.py fails on single asic voq duthost

#### How did you do it?
The test needs to use the -n <namespace> in various commands only when its a multi-asic dut. 
Also the test required a wait_until to confirm the neighbor has received the routes before finding the neigh_nlri_route

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
