### PR TITLE
test_prefix_list.py fix for single asic voq

### DIFF
--- a/tests/bgp/test_prefix_list.py
+++ b/tests/bgp/test_prefix_list.py
@@ -60,7 +60,8 @@ def verify_prefix_list_in_db(duthost, prefix_type, prefix):
 def verify_prefix_in_bgp_table(duthost, ip_version, prefix):
     # Check whether prefix in BGP table
     for asic_index in duthost.get_frontend_asic_ids():
-        cmd = "vtysh -n {} -c 'show bgp {} {}'".format(asic_index, ip_version, prefix)
+        asic_ns = f"-n {asic_index}" if duthost.is_multi_asic else ""
+        cmd = f"vtysh {asic_ns} -c 'show bgp {ip_version} {prefix}'"
         outputs = duthost.shell(cmd)["stdout"]
         if "Network not in table" in outputs:
             logger.info("Expected prefix {} to be in the BGP table, but it was not found".format(prefix))
@@ -71,7 +72,8 @@ def verify_prefix_in_bgp_table(duthost, ip_version, prefix):
 def verify_prefix_in_fib_table(duthost, prefix):
     # Check whether prefix in FIB table
     for asic_index in duthost.get_frontend_asic_ids():
-        cmd = "sonic-db-cli -n asic{} APPL_DB hgetall \"ROUTE_TABLE:{}\"".format(asic_index, prefix)
+        asic_ns = f"-n asic{asic_index}" if duthost.is_multi_asic else ""
+        cmd = f"sonic-db-cli {asic_ns} APPL_DB hgetall \"ROUTE_TABLE:{prefix}\""
         output = duthost.shell(cmd)["stdout"].strip().replace("'", "\"")
         route_info = json.loads(output) if output else {}
         if route_info == {} or ("blackhole" in route_info and route_info["blackhole"] == "true"):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_prefix_list.py fails on single asic voq duthost

#### How did you do it?
This test needs to use the -n <namespace> in various commands only when its a multi-asic dut.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
