### PR TITLE
[202511] Ignore mgmt_ds_lock error in loganalyzer due to expected behavior

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -423,5 +423,8 @@ r, ".*ERR pmon.*Failed to unfreeze VDM stats in contextmanager for port.*"
 # https://github.com/sonic-net/sonic-buildimage/issues/21186
 r, ".*ERR bgp\#bgpmon:\s+\*ERROR\*\s+Failed\s+with\s+rc:\d+\s+when\s+execute:\s+.*vtysh.*-c.*show\s+bgp\s+summary\s+json.*"
 
+# https://github.com/sonic-net/sonic-buildimage/issues/24966
+r, ".* ERR bgp#mgmtd.*mgmt_ds_lock: ERROR: lock already taken on DS:running by session-id.*"
+
 # Ignore systemd-networkd.socket not being able to be started. This is expected on non-DPU platforms.
 r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Service Netlink Socket.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Ignore expected FRR backend datastore lock contention during initialization - backends retry indefinitely until successful
Backend daemons like zebra and staticd both try to acquire the lock during initialization, and zebra starts first, then staticd retries every 50ms until zebra finishes initialization and release the lock.
Zebra takes time to initialize on some SKUs, and causes the staticd to retry. However, lock contention and retry mechanism is by design. This log is expected and it only triggers loganalyzer error because its log level is ERR.
sonic-buildimage issue: https://github.com/sonic-net/sonic-buildimage/issues/24966

Manually cherry pick of #21856

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_bgp_router_id.py failed due to loganalyzer during bgp service restart

#### How did you do it?
Ignore the expected log

#### How did you verify/test it?
test_bgp_router_id.py passed

#### Any platform specific information?
We only saw the problem on Arista 7050CX3-32c because zebra takes a little bit longer time to initialize on it. Could happen to other SKUs.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
