### PR TITLE
[Mellanox] Skip warm-reboot test for two cases when issu is disabled

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -20,6 +20,8 @@ from tests.common.connections.base_console_conn import (
     CONSOLE_SSH_SONIC_CONFIG
 )
 import time
+from tests.common.mellanox_data import is_mellanox_device, is_issu_enabled
+import random
 
 CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
@@ -877,6 +879,21 @@ def enable_nat_for_dpus(duthost, dpu_name_ssh_port_dict, request):
     ]
     duthost.shell_cmds(cmds=enable_nat_cmds)
     check_nat_is_enabled_and_set_cache(duthost, request)
+
+
+def get_random_reload_type(duthost):
+    """
+    Get a random reload type from the list of reload types
+    :param duthost: duthost object
+    :return: a random reload type
+    """
+    reload_types = ["reload", "cold", "fast", "warm"]
+    if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
+        logger.info("ISSU is not enabled on the Mellanox device, remove warm reboot from the list")
+        reload_types.remove("warm")
+    reboot_type = random.choice(reload_types)
+    logger.info(f"Selected reload type: {reboot_type}")
+    return reboot_type
 
 
 def migrate_container_systemd(duthost, service, parameters):

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1,4 +1,8 @@
 import functools
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 SPC1_HWSKUS = ["ACS-MSN2700", "Mellanox-SN2700", "Mellanox-SN2700-D48C8", "ACS-MSN2740", "ACS-MSN2100", "ACS-MSN2410",
@@ -1378,3 +1382,20 @@ def get_hardware_version(duthost, platform):
 def get_hw_management_version(duthost):
     full_version = duthost.shell('dpkg-query --showformat=\'${Version}\' --show hw-management')['stdout']
     return full_version[len('1.mlnx.'):]
+
+
+def is_issu_enabled(duthost):
+    logger.info("Check if ISSU is enabled on the device")
+    dut_platform = duthost.facts["platform"]
+    dut_hwsku = duthost.facts["hwsku"]
+
+    sai_profile = f"/usr/share/sonic/device/{dut_platform}/{dut_hwsku}/sai.profile"
+    cmd_get_sai_xml_filename = f"basename $(cat {sai_profile} | grep SAI_INIT_CONFIG_FILE | cut -d'=' -f2)"
+    sai_xml_filename = duthost.shell(cmd_get_sai_xml_filename)["stdout"].strip()
+    sai_xml_path = f"/usr/share/sonic/device/{dut_platform}/{dut_hwsku}/{sai_xml_filename}"
+
+    pattern = "<issu-enabled>*1*<\/issu-enabled>"
+    output = duthost.shell(f'egrep "{pattern}" {sai_xml_path} | wc -l')['stdout'].strip()
+    logger.info(f"ISSU is enabled: {output == '1'}")
+
+    return True if output == "1" else False

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1399,12 +1399,3 @@ def is_issu_enabled(duthost):
     logger.info(f"ISSU is enabled: {output == '1'}")
 
     return True if output == "1" else False
-
-
-def get_reload_type_list(duthost):
-    reload_types = ["reload", "cold", "fast", "warm"]
-    if not is_issu_enabled(duthost):
-        logger.info("ISSU is not enabled on the Mellanox device, remove warm reboot from the list")
-        reload_types.remove("warm")
-    logger.info(f"Reload types: {reload_types}")
-    return reload_types

--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1394,8 +1394,17 @@ def is_issu_enabled(duthost):
     sai_xml_filename = duthost.shell(cmd_get_sai_xml_filename)["stdout"].strip()
     sai_xml_path = f"/usr/share/sonic/device/{dut_platform}/{dut_hwsku}/{sai_xml_filename}"
 
-    pattern = "<issu-enabled>*1*<\/issu-enabled>"
+    pattern = r"<issu-enabled>*1*<\/issu-enabled>"
     output = duthost.shell(f'egrep "{pattern}" {sai_xml_path} | wc -l')['stdout'].strip()
     logger.info(f"ISSU is enabled: {output == '1'}")
 
     return True if output == "1" else False
+
+
+def get_reload_type_list(duthost):
+    reload_types = ["reload", "cold", "fast", "warm"]
+    if not is_issu_enabled(duthost):
+        logger.info("ISSU is not enabled on the Mellanox device, remove warm reboot from the list")
+        reload_types.remove("warm")
+    logger.info(f"Reload types: {reload_types}")
+    return reload_types

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -13,6 +13,7 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 from .static_dns_util import RESOLV_CONF_FILE, verify_nameserver_in_config_db, verify_nameserver_in_conf_file, \
     get_nameserver_from_resolvconf, config_mgmt_ip, add_dns_nameserver, del_dns_nameserver, get_mgmt_port_ip_info, \
     get_nameserver_from_config_db, clear_nameserver_from_resolvconf
+from tests.common.mellanox_data import is_mellanox_device, is_issu_enabled
 
 
 pytestmark = [
@@ -85,6 +86,9 @@ def test_static_dns_basic(request, duthost, localhost, backup_and_restore_config
     reboot_type = request.config.getoption("--static_dns_reboot_type")
     if reboot_type == "random":
         reload_types = ["reload", "cold", "fast", "warm"]
+        if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
+            logger.info("ISSU is not enabled on the device, remove warm reboot from the list")
+            reload_types.remove("warm")
         reboot_type = random.choice(reload_types)
     with allure.step(f"Reload the system with command {reboot_type}"):
         if reboot_type == "reload":

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -1,6 +1,5 @@
 import pytest
 import logging
-import random
 import re
 
 from tests.common.reboot import reboot
@@ -13,7 +12,7 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 from .static_dns_util import RESOLV_CONF_FILE, verify_nameserver_in_config_db, verify_nameserver_in_conf_file, \
     get_nameserver_from_resolvconf, config_mgmt_ip, add_dns_nameserver, del_dns_nameserver, get_mgmt_port_ip_info, \
     get_nameserver_from_config_db, clear_nameserver_from_resolvconf
-from tests.common.mellanox_data import is_mellanox_device, get_reload_type_list
+from tests.common.helpers.dut_utils import get_random_reload_type
 
 
 pytestmark = [
@@ -85,9 +84,7 @@ def test_static_dns_basic(request, duthost, localhost, backup_and_restore_config
     duthost.shell("config save -y")
     reboot_type = request.config.getoption("--static_dns_reboot_type")
     if reboot_type == "random":
-        reload_types = get_reload_type_list(duthost) if is_mellanox_device(duthost) \
-            else ["reload", "cold", "fast", "warm"]
-        reboot_type = random.choice(reload_types)
+        reboot_type = get_random_reload_type(duthost)
     with allure.step(f"Reload the system with command {reboot_type}"):
         if reboot_type == "reload":
             config_reload(duthost, safe_reload=True, check_intf_up_ports=True)

--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -13,7 +13,7 @@ from tests.common.platform.interface_utils import check_interface_status_of_up_p
 from .static_dns_util import RESOLV_CONF_FILE, verify_nameserver_in_config_db, verify_nameserver_in_conf_file, \
     get_nameserver_from_resolvconf, config_mgmt_ip, add_dns_nameserver, del_dns_nameserver, get_mgmt_port_ip_info, \
     get_nameserver_from_config_db, clear_nameserver_from_resolvconf
-from tests.common.mellanox_data import is_mellanox_device, is_issu_enabled
+from tests.common.mellanox_data import is_mellanox_device, get_reload_type_list
 
 
 pytestmark = [
@@ -85,10 +85,8 @@ def test_static_dns_basic(request, duthost, localhost, backup_and_restore_config
     duthost.shell("config save -y")
     reboot_type = request.config.getoption("--static_dns_reboot_type")
     if reboot_type == "random":
-        reload_types = ["reload", "cold", "fast", "warm"]
-        if is_mellanox_device(duthost) and not is_issu_enabled(duthost):
-            logger.info("ISSU is not enabled on the device, remove warm reboot from the list")
-            reload_types.remove("warm")
+        reload_types = get_reload_type_list(duthost) if is_mellanox_device(duthost) \
+            else ["reload", "cold", "fast", "warm"]
         reboot_type = random.choice(reload_types)
     with allure.step(f"Reload the system with command {reboot_type}"):
         if reboot_type == "reload":

--- a/tests/iface_loopback_action/test_iface_loopback_action.py
+++ b/tests/iface_loopback_action/test_iface_loopback_action.py
@@ -14,6 +14,7 @@ from .iface_loopback_action_helper import verify_interface_loopback_action
 from .iface_loopback_action_helper import verify_rif_tx_err_count, is_rif_counters_ready, check_ip_interface_up
 from .iface_loopback_action_helper import shutdown_rif_interfaces, startup_rif_interfaces
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.mellanox_data import is_mellanox_device, get_reload_type_list
 
 
 pytestmark = [
@@ -107,7 +108,8 @@ def test_loopback_action_reload(request, duthost, localhost, ptfadapter, ports_c
 
         reboot_type = request.config.getoption("--rif_loopback_reboot_type")
         if reboot_type == "random":
-            reload_types = ["reload", "cold", "fast", "warm"]
+            reload_types = get_reload_type_list(duthost) if is_mellanox_device(duthost) \
+                else ["reload", "cold", "fast", "warm"]
             reboot_type = random.choice(reload_types)
         if reboot_type == "reload":
             config_reload(duthost, safe_reload=True)

--- a/tests/iface_loopback_action/test_iface_loopback_action.py
+++ b/tests/iface_loopback_action/test_iface_loopback_action.py
@@ -14,7 +14,7 @@ from .iface_loopback_action_helper import verify_interface_loopback_action
 from .iface_loopback_action_helper import verify_rif_tx_err_count, is_rif_counters_ready, check_ip_interface_up
 from .iface_loopback_action_helper import shutdown_rif_interfaces, startup_rif_interfaces
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
-from tests.common.mellanox_data import is_mellanox_device, get_reload_type_list
+from tests.common.helpers.dut_utils import get_random_reload_type
 
 
 pytestmark = [
@@ -108,9 +108,7 @@ def test_loopback_action_reload(request, duthost, localhost, ptfadapter, ports_c
 
         reboot_type = request.config.getoption("--rif_loopback_reboot_type")
         if reboot_type == "random":
-            reload_types = get_reload_type_list(duthost) if is_mellanox_device(duthost) \
-                else ["reload", "cold", "fast", "warm"]
-            reboot_type = random.choice(reload_types)
+            reboot_type = get_random_reload_type(duthost)
         if reboot_type == "reload":
             config_reload(duthost, safe_reload=True)
         else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
skip warm-reboot for test_loopback_action_reload and test_static_dns_basic when issu is disabled on mellanox device

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
skip warm-reboot for test_loopback_action_reload and test_static_dns_basic when issu is disabled on mellanox device

#### How did you do it?
skip warm-reboot when issu is disabled

#### How did you verify/test it?
run the two cases on mellanox device

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?
Any

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
