### PR TITLE
[Mellanox] fix test_restart_swss issue

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -37,7 +37,7 @@ def skip_ignored_broken_symbolinks(broken_symbolinks):
     return broken_symbolinks_updated
 
 
-def check_sysfs(dut):
+def check_sysfs(dut, expected_module_temp_fault_value=['0']):
     """
     @summary: Check various hw-management related sysfs under /var/run/hw-management
     """
@@ -167,7 +167,7 @@ def check_sysfs(dut):
         if not sfp_info["temp_fault"]:
             continue
 
-        assert sfp_info["temp_fault"] == '0', "SFP%d temp fault" % int(sfp_id)
+        assert sfp_info["temp_fault"] in expected_module_temp_fault_value, "SFP%d temp fault" % int(sfp_id)
         sfp_temp = float(sfp_info['temp']) if sfp_info['temp'] != '0' else 0
         sfp_temp_crit = float(
             sfp_info['crit_temp']) if sfp_info['crit_temp'] != '0' else 0

--- a/tests/platform_tests/test_sequential_restart.py
+++ b/tests/platform_tests/test_sequential_restart.py
@@ -50,7 +50,8 @@ def is_service_hiting_start_limit(duthost, container_name):
     return False
 
 
-def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service, interfaces, xcvr_skip_list):
+def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service, interfaces, xcvr_skip_list,
+                              expected_module_temp_fault_value=['0']):
     """
     Restart specified service and check platform status
     """
@@ -92,7 +93,7 @@ def restart_service_and_check(localhost, dut, enum_frontend_asic_index, service,
         check_hw_management_service(dut)
 
         logging.info("Check sysfs")
-        check_sysfs(dut)
+        check_sysfs(dut, expected_module_temp_fault_value)
 
     logging.info("Check that critical processes are healthy for 60 seconds")
     check_critical_processes(dut, 60)
@@ -115,7 +116,13 @@ def test_restart_swss(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_
         all_interfaces = new_intf_dict
         logging.info("ASIC {} interface_list {}".format(enum_frontend_asic_index, all_interfaces))
 
-    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "swss", all_interfaces, xcvr_skip_list)
+    if duthost.facts["asic_type"] in ["mellanox"]:
+        expected_module_temp_fault_value = ['0', '254000']
+    else:
+        expected_module_temp_fault_value = ['0']
+
+    restart_service_and_check(localhost, duthost, enum_frontend_asic_index, "swss", all_interfaces, xcvr_skip_list,
+                              expected_module_temp_fault_value=expected_module_temp_fault_value)
 
 
 def test_restart_syncd(duthosts, enum_rand_one_per_hwsku_hostname, enum_frontend_asic_index,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
After supporting multi asic, with the new init flow, pmon is running while swss/syncd are stopped. The thermal_updater service attempts to read the module temperature but fails (since sysfs is not available while syncd is down). To report the failure, thermal_updater writes the ERROR_READ_THERMAL_DATA (254000) value into the /var/run/hw-management/thermal/moduleX. So, the expected module temp fault value might be 0 or 254000.
The relevant PR: https://github.com/sonic-net/sonic-buildimage/pull/25064

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
fix test_restart_swss issue for mellanox device

#### How did you do it?
Add 254000 expected_module_temp_fault_value 

#### How did you verify/test it?
Run the test on mellanox device

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
