### PR TITLE
Add test for sysready-status

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4914,22 +4914,6 @@ syslog/test_syslog_source_ip.py::TestSSIP::test_syslog_protocol_filter_severity:
       - "asic_type in ['vs']"
 
 #######################################
-#####         system_health       #####
-#######################################
-system_health/test_system_health.py:
-  skip:
-    reason: "There is no table SYSTEM_HEALTH_INFO in STATE_DB on kvm testbed, skip in PR testing"
-    conditions:
-      - "asic_type in ['vs']"
-
-system_health/test_system_health.py::test_service_checker_with_process_exit:
-  xfail:
-    strict: True
-    conditions:
-      - "branch in ['internal-202012']"
-      - "build_version.split('.')[1].isdigit() and int(build_version.split('.')[1]) <= 44"
-
-#######################################
 #####           tacacs          #####
 #######################################
 tacacs/test_accounting.py:

--- a/tests/system_health/test_system_status.py
+++ b/tests/system_health/test_system_status.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.common.utilities import wait_until
+from .test_system_health import wait_system_health_boot_up
 
 pytestmark = [
     pytest.mark.topology('any')
@@ -14,3 +15,25 @@ def test_system_is_running(duthost):
 
     if not wait_until(180, 10, 0, is_system_ready, duthost):
         pytest.fail('Failed to find routed interface in 180 s')
+
+
+def test_system_health_sysready_status(duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    wait_system_health_boot_up(duthost)
+
+    # This gives just one line, "System is ready" or "System is not ready - <reason>"
+    sysready_status_br = duthost.command("show system-health sysready-status brief")['stdout_lines']
+    assert "System is ready" in sysready_status_br[0]
+
+    # This gives a table with all the details, so we'll check the summary and that
+    # all the services are "OK"
+    sysready_status = duthost.command("show system-health sysready-status")['stdout_lines']
+    assert "System is ready" in sysready_status[0]
+
+    # Skip the 4 lines of summary + header
+    assert len(sysready_status) > 4
+    for line in sysready_status[4:]:
+        columns = line.split()
+
+        assert len(columns) == 4, f"Line {line} has {len(columns)} columns, expected 4"
+        assert columns[1] == "OK" and columns[2] == "OK", f"Service {columns[0]} is not OK, reason: {columns[3]}"


### PR DESCRIPTION
This is a basic test that waits for the system to be booted then ensures that "show system-health sysready-status" outputs "System is ready" and that the output on each line for each service says "OK"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
