### PR TITLE
Fix test_stress_acl.py for t1-f2-d10u8 topo

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -210,7 +210,7 @@ def prepare_test_port(rand_selected_dut, tbinfo):
 
     dst_ip_addr = None
     if tbinfo["topo"]['name'] in ["t1-isolated-d28u1", "t1-isolated-d56u2", "t1-isolated-d448u15-lag",
-                                  "t1-isolated-d56u1-lag"] or topo == "m1":
+                                  "t1-isolated-d56u1-lag", "t1-f2-d10u8"] or topo == "m1":
         dst_ip_addr = random.choices(list(upstream_port_neighbor_ips.values()))
     return ptf_src_port, upstream_port_ids, dut_port, dst_ip_addr
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
t1-f2-d10u8 topo has a downstream T0 neighbor with IP 10.0.0.1, which conflicts with default dst_ip_addr in this test.
We should randomly choose an upstream VM IP instead, like t1-isolated-* topos.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202503
- [x] 202511

### Tested branch
- [x] 202503
- [x] 202511

### Test result
202503: Kusto report GUID: 4155fe3b-12f5-4f43-9a37-568f9880d348
202511:  Kusto report GUID: 0b844847-c836-4978-ad6c-232d8532aaeb

### Approach
#### What is the motivation for this PR?
test_stress_acl.py failed on t1-f2-d10u8 topo

#### How did you do it?
Randomly choose an upstream VM IP instead, like t1-isolated-* topos

#### How did you verify/test it?
test_stress_acl.py passed on t1-f2-d10u8 topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
