### PR TITLE
Fix test_add_rack.py for t1-f2-d10u8 topo

### DIFF
--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -188,15 +188,18 @@ def apply_clet(duthost, skip_test=False):
     # Apply delete
     duthost.shell("configlet -d -j {}".format(del_sonic_clet_file))
 
-    tor_ifname = tor_data["links"][0]["local"]["sonic_name"]
-    duthost.shell("config interface shutdown {}".format(tor_ifname))
-    do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown".format(tor_ifname))
+    for link in tor_data["links"]:
+        tor_ifname = link["local"]["sonic_name"]
+        duthost.shell("config interface shutdown {}".format(tor_ifname))
+        do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown".format(tor_ifname))
 
     duthost.shell("configlet -u -j {}".format(sonic_clet_file))
     do_pause(PAUSE_CLET_APPLY, "Pause after applying configlet")
 
-    duthost.shell("config interface startup {}".format(tor_ifname))
-    do_pause(PAUSE_INTF_UP, "pause upon i/f {} startup".format(tor_ifname))
+    for link in tor_data["links"]:
+        tor_ifname = link["local"]["sonic_name"]
+        duthost.shell("config interface startup {}".format(tor_ifname))
+        do_pause(PAUSE_INTF_UP, "pause upon i/f {} startup".format(tor_ifname))
 
     append_log_prefix_msg("checking_dump", pfx_lvl)
     assert wait_until(DB_COMP_WAIT_TIME, 20, 0, db_comp, duthost, clet_db_dir,

--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -140,10 +140,11 @@ def generic_patch_add_t0(duthost, skip_load=False, hack_apply=False):
         # Hack: TODO: Before adding port, patch updater need to ensure
         # the port is down. Until then bring it down explicitly.
         #
-        tor_ifname = tor_data["links"][0]["local"]["sonic_name"]
-        duthost.shell("config interface shutdown {}".format(tor_ifname))
-        do_pause(PAUSE_INTF_DOWN,
-                 "pause upon i/f {} shutdown before add patch".format(tor_ifname))
+        for link in tor_data["links"]:
+            tor_ifname = link["local"]["sonic_name"]
+            duthost.shell("config interface shutdown {}".format(tor_ifname))
+            do_pause(PAUSE_INTF_DOWN,
+                     "pause upon i/f {} shutdown before add patch".format(tor_ifname))
 
     patch_files = _list_patch_files(patch_add_t0_dir)
 
@@ -163,8 +164,10 @@ def generic_patch_add_t0(duthost, skip_load=False, hack_apply=False):
     do_pause(PAUSE_CLET_APPLY, "Pause after applying add patch")
 
     if hack_apply:
-        duthost.shell("config interface startup {}".format(tor_ifname))
-        do_pause(PAUSE_INTF_UP, "pause upon i/f {} startup after add patch".format(tor_ifname))
+        for link in tor_data["links"]:
+            tor_ifname = link["local"]["sonic_name"]
+            duthost.shell("config interface startup {}".format(tor_ifname))
+            do_pause(PAUSE_INTF_UP, "pause upon i/f {} startup after add patch".format(tor_ifname))
 
     assert wait_until(DB_COMP_WAIT_TIME, 20, 0, db_comp, duthost, patch_add_t0_dir,
                       orig_db_dir, "generic_patch_add_t0"), \
@@ -187,9 +190,10 @@ def generic_patch_rm_t0(duthost, skip_load=False, hack_apply=False):
         # Hack: TODO: Before removing port, patch updater need to ensure
         # the port is down. Until then bring it down explicitly.
         #
-        tor_ifname = tor_data["links"][0]["local"]["sonic_name"]
-        duthost.shell("config interface shutdown {}".format(tor_ifname))
-        do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown before add patch".format(tor_ifname))
+        for link in tor_data["links"]:
+            tor_ifname = link["local"]["sonic_name"]
+            duthost.shell("config interface shutdown {}".format(tor_ifname))
+            do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown before add patch".format(tor_ifname))
 
     patch_files = _list_patch_files(patch_rm_t0_dir)
 
@@ -208,9 +212,10 @@ def generic_patch_rm_t0(duthost, skip_load=False, hack_apply=False):
 
     # Manual shutdown needed because the removal of admin_status won't operate shutdown. It will
     # by default keep the previous admin_status state. Thus making app-db comparison fail.
-    tor_ifname = tor_data["links"][0]["local"]["sonic_name"]
-    duthost.shell("config interface shutdown {}".format(tor_ifname))
-    do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown before add patch".format(tor_ifname))
+    for link in tor_data["links"]:
+        tor_ifname = link["local"]["sonic_name"]
+        duthost.shell("config interface shutdown {}".format(tor_ifname))
+        do_pause(PAUSE_INTF_DOWN, "pause upon i/f {} shutdown before add patch".format(tor_ifname))
 
     assert wait_until(DB_COMP_WAIT_TIME, 20, 0, db_comp, duthost, patch_rm_t0_dir,
                       no_t0_db_dir, "generic_patch_rm_t0"), \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix multi-port portchannels to T0 VMs by shutdown/startup all LAG member ports one by one
We can't directly do it to the LAG interface because it is removed after applying T0 removal patch

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202503
- [x] 202511

### Tested branch
- [x] 202503
- [x] 202511

### Test result
202503: Kusto report GUID: 4155fe3b-12f5-4f43-9a37-568f9880d348
202511:  Kusto report GUID: 0b844847-c836-4978-ad6c-232d8532aaeb

### Approach
#### What is the motivation for this PR?
test_add_rack.py failed on t1-f2-d10u8 topo

#### How did you do it?
Fix multi-port portchannels to T0 VMs by shutdown/startup all LAG member ports one by one

#### How did you verify/test it?
test_add_rack.py passed on t1-f2-d10u8 topo

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
