### PR TITLE
Add test logic to account for multiple ports per PortChannel

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -52,10 +52,11 @@ def get_interfaces(duthost, tbinfo):
             return [interface], interface
         else:
             mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-            if interface not in mg_facts["minigraph_portchannels"].keys():
+            if interface not in mg_facts["minigraph_portchannels"].keys() or \
+               not mg_facts["minigraph_portchannels"][interface]['members']:
                 continue
             return mg_facts["minigraph_portchannels"][interface]['members'], interface
-    pytest.skip("No RIF interfaces nor Portchannels, skiping the test")
+    pytest.skip("No RIF interfaces nor PortChannels, skipping the test")
 
 
 def get_oid_for_interface(duthost, table_name, interface_name):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add test logic to account for port channel setups where there are multiple ports associated to the port channel.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test is failing on HwSKUs where there are multiple ports associated with a port channel.

#### How did you do it?
Add test logic to account for the possibility that there can be multiple ports associated with a port channel.

#### How did you verify/test it?
Test no longer fails on devices where there are multiple ports associated to a single port channel.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
