### PR TITLE
Ignore error message due to missing feature

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -446,6 +446,12 @@ r, ".*kernel.*gpio.*Static allocation of GPIO base is deprecated.*"
 # Ignore SCD kernel warning about I2C communication ack errors on Arista platforms
 r, ".*WARNING kernel:.*scd.*rsp.*ack_error=1.*"
 
+# Ignore error log due to missing feature
+r, ".*CMD-IFC timeout for device.*"
+r, ".*Register access failed.*"
+r, ".*Failed to access PMAOS.*"
+r, ".*Failed in sx_netdev_module_get_present.*"
+
 # CHASSIS_STATE_DB only exists on chassis platforms; gnmi processes log an ERR on non-chassis systems at startup
 r, ".*ERR gnmi#.*getDbInfo: Failed to find CHASSIS_STATE_DB.*"
 


### PR DESCRIPTION
Summary: Ignore non-functional error message generated by race condition
Fixes #
These error messages are caused by a race condition between internal modules during system startup: some sysfs entries are not yet ready when other modules attempt to access them, which results in the errors observed in the log.

These errors are non-functional — they do not impact any feature or traffic behavior, and the system continues to operate normally.

A proper fix will be delivered in a future release. In the meantime, this PR adds the corresponding entries to the log analyzer ignore list to prevent false test failures.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
These error messages are caused by a race condition between internal modules during system startup: some sysfs entries are not yet ready when other modules attempt to access them, which results in the errors observed in the log.

#### How did you do it?
These errors are non-functional — they do not impact any feature or traffic behavior, and the system continues to operate normally.
A proper fix will be delivered in a future release. In the meantime, this PR adds the corresponding entries to the log analyzer ignore list to prevent false test failures.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
