### PR TITLE
Revert "[action] [PR:21830] Fix TyperError in test_ecmp_balance.py due to function in utilities.py modified"

### DIFF
--- a/tests/ecmp/test_ecmp_balance.py
+++ b/tests/ecmp/test_ecmp_balance.py
@@ -102,7 +102,7 @@ def setup(duthosts, rand_selected_dut, tbinfo):
     )
 
     upstream_neigh_type = get_upstream_neigh_type(tbinfo)
-    downstream_neigh_type = get_downstream_neigh_type(tbinfo)
+    downstream_neigh_type = get_downstream_neigh_type(topo)
     pytest_require(
         upstream_neigh_type is not None and downstream_neigh_type is not None,
         "Cannot get neighbor type for unsupported topo: {}".format(topo),


### PR DESCRIPTION
Reverts sonic-net/sonic-mgmt#21853
https://github.com/sonic-net/sonic-mgmt/pull/20913 was not backported into 202511.