### PR TITLE
Adding a step to test_interfaces.py to verify pmon contains all interfaces data for the test

### DIFF
--- a/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
+++ b/tests/platform_tests/mellanox/test_check_sfp_eeprom.py
@@ -6,7 +6,7 @@ from .util import check_sfp_eeprom_info, is_support_dom, get_pci_cr0_path, get_p
 from tests.common.platform.transceiver_utils import parse_sfp_eeprom_infos
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.platform_tests.conftest import check_pmon_uptime_minutes
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes
 
 pytestmark = [
     pytest.mark.asic('mellanox', 'nvidia-bluefield'),

--- a/tests/platform_tests/test_xcvr_info_in_db.py
+++ b/tests/platform_tests/test_xcvr_info_in_db.py
@@ -11,7 +11,7 @@ from tests.common.platform.interface_utils import get_port_map, get_lport_to_fir
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa F401
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
-from tests.platform_tests.conftest import check_pmon_uptime_minutes
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes
 
 pytestmark = [
     pytest.mark.topology('any')

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,7 +1,9 @@
 from netaddr import IPAddress
 import pytest
 
+from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import check_pmon_uptime_minutes
 
 pytestmark = [
     pytest.mark.topology('any', 't1-multi-asic'),
@@ -13,6 +15,10 @@ def test_interfaces(duthosts, enum_frontend_dut_hostname, tbinfo, enum_asic_inde
     """compare the interfaces between observed states and target state"""
 
     duthost = duthosts[enum_frontend_dut_hostname]
+
+    pytest_assert(wait_until(360, 10, 0, check_pmon_uptime_minutes, duthost),
+                  "Pmon docker is not ready for test")
+
     asic_host = duthost.asic_instance(enum_asic_index)
     host_facts = asic_host.interface_facts()['ansible_facts']['ansible_interface_facts']
     mg_facts = asic_host.get_extended_minigraph_facts(tbinfo)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For making sure we have all the transceiver information available, we need to verify that the pmon docker is up enough time.
this PR adds a step that verify that the pmon docker is up  at least 6 minutes to make sure all the transceivers data is available. 
 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Adding a step to /test_interfaces.py  that the pmon docker is running at least 6 minutes, and if not, it waits until it does- to make sure it contains all interfaces

depends on PR : https://github.com/sonic-net/sonic-mgmt/pull/20658

#### How did you verify/test it?
ran the test during the pmon restart
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
