### PR TITLE
Reduce traffic retry time in trimming case

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -380,7 +380,7 @@ class BasePacketTrimming:
 
         trim_queue = PacketTrimmingConfig.get_trim_queue(duthost)
 
-        with allure.step("Verify TrimDrop counters on switch level"):
+        with allure.step("Verify TrimDrop counters on port level"):
             original_schedulers = {}
             try:
                 # Block the trimmed queue
@@ -395,10 +395,13 @@ class BasePacketTrimming:
                 counter_kwargs.update({'expect_packets': False})
                 verify_trimmed_packet(**counter_kwargs)
 
-                # Get the TrimDrop counters on switch level
-                switch_trim_drop_value = get_switch_trim_counters_json(duthost)['trim_drop']
-                logger.info(f"switch_trim_drop_value: {switch_trim_drop_value}")
-                pytest_assert(switch_trim_drop_value > 0, "Trim drop counter on switch level is not greater than 0")
+                # Get the TrimDrop counters on port level
+                for egress_port in trim_counter_params['egress_ports']:
+                    for port in egress_port['dut_members']:
+                        port_trim_drop_value = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+                        logger.info(f"port: {port}, port_trim_drop_value: {port_trim_drop_value}")
+                        pytest_assert(port_trim_drop_value > 0,
+                                      f"Trim drop counter on port {port} is not greater than 0")
 
             finally:
                 # Enable the trimmed queue with original scheduler

--- a/tests/packet_trimming/constants.py
+++ b/tests/packet_trimming/constants.py
@@ -140,6 +140,9 @@ SRV6_MY_SID_LIST = [
     [SRV6_MY_LOCATOR_LIST[9][0], SRV6_MY_LOCATOR_LIST[9][1], SRV6_UN, 'default']
 ]
 
+# Static route prefix for SRv6 packets
+SRV6_ROUTE_PREFIX = '2001::/16'
+
 # Drop counter
 SWITCH_INTERVAL = 1000
 PORT_INTERVAL = 100

--- a/tests/packet_trimming/packet_trimming_config.py
+++ b/tests/packet_trimming/packet_trimming_config.py
@@ -1,5 +1,6 @@
 class PacketTrimmingConfig:
     DSCP = 48
+    COUNTER_DSCP = 3   # Map to queue2
 
     @staticmethod
     def get_trim_size(duthost):
@@ -99,4 +100,4 @@ class PacketTrimmingConfig:
             }
             return th5_queue.get(duthost.facts['hwsku'], 0)
 
-        return 0
+        return PacketTrimmingConfig.COUNTER_DSCP

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -760,7 +760,7 @@ def fill_egress_buffer(duthost, ptfadapter, port_id, buffer_size, target_queue, 
     remaining_packets = fill_packet_count % BATCH_PACKET_COUNT
 
     total_sent_packets = 0
-    max_retries = 10  # Maximum number of retries per batch
+    max_retries = 3  # Maximum number of retries per batch
 
     # Send packets in batches
     logger.info(f"Sending packets in batches of {BATCH_PACKET_COUNT} packets each")


### PR DESCRIPTION
Summary: Reduce packet trimming case run time
Fixes # 
1. Reduce the retry time from 10 to 3
2. Update test_trimming_counters to use queue2 as the test queue, which only need 1.6K packets to fill full the queue, instead of 100K packets in queue0.
3. Update test_trimming_with_srv6, add static route to make sure the srv6 traffic send out from the expected port instead of shutdown other ports.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
