### PR TITLE
Add timeout parameter for console_thread_res.get during reboot a dut

### DIFF
--- a/tests/db_migrator/test_migrate_dns.py
+++ b/tests/db_migrator/test_migrate_dns.py
@@ -65,7 +65,7 @@ def setup_env(duthost):
     restore_config(duthost, DNS_TEMPLATE, DNS_TEMPLATE_BACKUP)
 
     # Restore config
-    config_reload(duthost, safe_reload=True)
+    config_reload(duthost, safe_reload=True, wait_for_bgp=True)
 
 
 def get_nameserver_from_config_db(duthost):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: console_thread_res.get() may blocked and lead to total timeout. Then we need a timeout for the connection.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
