### PR TITLE
Tagging DPU steps in the ansible minigraph scenario.

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -40,13 +40,16 @@
       set_fact:
         testbed_file: testbed.yaml
       when: testbed_file is not defined
+      tags: always
 
     - name: Gathering testbed information
       test_facts: testbed_name="{{ testbed_name }}" testbed_file="{{ testbed_file }}"
       delegate_to: localhost
+      tags: always
 
     - fail: msg="The DUT you are trying to run test does not belongs to this testbed"
       when: inventory_hostname not in testbed_facts['duts']
+      tags: always
 
     - name: Set default num_asic
       set_fact:
@@ -60,11 +63,13 @@
     - name: set testbed_type
       set_fact:
         topo: "{{ testbed_facts['topo'] }}"
+      tags: always
 
     - name: set default light mode
       set_fact:
         is_light_mode: true
       when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"] and is_light_mode is not defined
+      tags: always
 
     - name: set ptf image name
       set_fact:
@@ -915,6 +920,7 @@
         become: true
         # t1-28-lag is smartswitch topo only
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"] and is_light_mode|bool == true
+        tags: [ dpu_config ]
 
       - name: Load DPU config in smartswitch
         load_extra_dpu_config:
@@ -924,6 +930,7 @@
         become: true
         # t1-28-lag is smartswitch topo only
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"] and is_light_mode|bool == true
+        tags: [ dpu_config ]
 
       - name: Configure TACACS
         become: true


### PR DESCRIPTION
### Description of PR
DPU config can be deployed after the switch configuration.

Minigraph deployment command has been extended:
Deploy minigraph for both Switch and DPU:
```
./testbed-cli.sh deploy-mg {{SWITCH}}-{{TOPO}} lab vault -vvvvv 
```
Deploy minigraph for Switch only:
```
./testbed-cli.sh deploy-mg {{SWITCH}}-{{TOPO}} lab vault -vvvvv --skip-tags "dpu_config" 
```
Deploy minigraph for DPU only:
```
./testbed-cli.sh deploy-mg {{SWITCH}}-{{TOPO}} lab vault -vvvvv --tags "dpu_config"
```

Summary:
Fixes the timing issues for the switch to be ready to lease the ips to DPUs and to DPUs to be ready to receive the configuration.

### Type of change

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Allow the DPU config separate from the switch

#### How did you do it?
Tag the DPU-related steps in ansible. Use tags
```
# Deploy minigraph for both Switch and DPU:
./testbed-cli.sh deploy-mg {{SWITCH}}-{{TOPO}} lab vault -vvvvv
# Deploy minigraph for Switch only:
./testbed-cli.sh deploy-mg {{SWITCH}}-{{TOPO}} lab vault -vvvvv --skip-tags "dpu_config"
# Deploy minigraph for DPU only:
./testbed-cli.sh deploy-mg {{SWITCH}}-{{TOPO}} lab vault -vvvvv --tags "dpu_config"
```

#### How did you verify/test it?
Deployed on the smartswitch

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
