### PR TITLE
bulk and 32 ports sequential cases in lldp test module

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1687,3 +1687,22 @@ def get_day_of_week_distributed_ports_from_buckets(ports: list, num_buckets: int
     logger.info("Selected {} ports from {} buckets using DoW-based selection: {}".format(
         len(selected_ports), num_buckets, selected_ports))
     return selected_ports
+
+
+def group_interfaces_by_asic(duthost, interfaces: list) -> dict:
+    """
+    Group interfaces by their ASIC namespace.
+    Args:
+        duthost: DUT host object
+        interfaces: List of interface names
+    Returns:
+        dict: Mapping of ASIC namespace string to list of interfaces
+              e.g., {"": ["Eth1", "Eth2"], "-n asic0": ["Eth3"]}
+    """
+    if not duthost.is_multi_asic:
+        return {"": list(interfaces)}
+    asic_interface_map = collections.defaultdict(list)
+    for interface in interfaces:
+        namespace = duthost.get_port_asic_instance(interface).get_asic_namespace()
+        asic_interface_map["-n {}".format(namespace)].append(interface)
+    return dict(asic_interface_map)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR refactors the existing code for interface operations and introduces a bulk operation mode based on the number of interfaces. The motivation is to improve efficiency and scalability when handling multiple interfaces, particularly in environments where batch processing can lead to noticeable performance improvements. When the number of interfaces is more than the set limit, we will shutdown and startup the interfaces with single command and check for lldp entries with a single 10 seconds wait, further giving each entry to be included in the table within 60 seconds, polling each 2 seconds.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The motivation for this PR is to improve the test runtime performance, specifically by introducing a bulk operation mode to optimize processing when the number of interfaces exceeds a certain threshold. This aims to reduce execution time and resource consumption during large-scale network tests or deployments.

#### How did you do it?
- Refactored the related codebase to modularize and streamline logic around interface operations.
- Added checks to determine when to switch to bulk mode based on the number of interfaces.
- Implemented efficient bulk processing techniques, minimizing the number of individual execution steps.

#### How did you verify/test it?
- Ran existing interface-related test cases to ensure backward compatibility.
- Created test scenarios with varying numbers of interfaces to confirm that bulk operation improves performance where intended.
- The test runtime for 420 neighbors dropped from 2 hours 18 mins to 20 mins. Further optimization led to drop to 12 mins for which PR: https://github.com/sonic-net/sonic-mgmt/pull/22269

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
