### PR TITLE
chore: skip GCU cacl test on Cisco 8800

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2567,6 +2567,13 @@ generic_config_updater/test_bgp_speaker.py::test_bgp_speaker_tc1_test_config:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20757 and '-v6-' in topo_name"
 
+generic_config_updater/test_cacl:
+  skip:
+    reason: "Skip on Cisco 8800 due to the known ACL_RULE path failed to be applied for multi-asic platform issue"
+    conditions:
+      - "asic_type in ['cisco-8000']"
+      - "https://github.com/sonic-net/sonic-buildimage/issues/20378"
+
 generic_config_updater/test_dhcp_relay.py:
   skip:
     reason: "Need to skip for Cisco backend platform/ generic_config_updater is not a supported feature for T2"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip the `generic_config_updater/test_cacl.py` test on Cisco 8800 due to a known issue: https://github.com/sonic-net/sonic-buildimage/issues/20378

Summary:
Fixes # (issue) Microsoft ADO 35815182

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Due to the known issue https://github.com/sonic-net/sonic-buildimage/issues/20378, plus this is not a production use case, we want to skip the `generic_config_updater/test_cacl.py` test when it's Cisco 8800 **and** the GitHub issue is active

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
