### PR TITLE
Update ignore error list because some logs add some string like client_pid

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -229,12 +229,12 @@ r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] mlnx_sai_utils.c\[\d+\]- sai_get_attribu
 r, ".* ERR syncd#SDK: \[SAI_BRIDGE.ERR\].*mlnx_sai_bridge.c\[\d+\]- mlnx_bridge_port_isolation_group_get: Isolation group is only supported for bridge port type port"
 r, ".* ERR syncd#SDK: \[SAI_BRIDGE.ERR\].*mlnx_sai_bridge.c\[\d+\]- mlnx_bridge_1d_oid_to_data: Unexpected bridge type 0 is not 1D"
 r, ".* ERR syncd#SDK: \[SAI_BRIDGE.ERR\].*mlnx_sai_bridge.c\[\d+\]- mlnx_bridge_port_lag_or_port_get: Invalid port type - 2"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- sai_get_attributes: Failed to get attribute*."
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, PORT_ID, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, ISOLATION_GROUP, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_UNICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*\] \[Type:.* sx_bridge_id.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_MULTICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
-r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\] .\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, BROADCAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- sai_get_attributes: Failed to get attribute*."
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, PORT_ID, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, ISOLATION_GROUP, key:BRIDGE_PORT \[OID:.*\] \[bridge_ports_db.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_UNICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*\] \[Type:.* sx_bridge_id.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, UNKNOWN_MULTICAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
+r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*.\/src\/mlnx_sai_utils.c.*- get_dispatch_attribs_handler: Failed Get #\d+, BROADCAST_FLOOD_GROUP, key:BRIDGE \[OID:.*Type:.*sx_bridge_id.*"
 r, ".* ERR syncd#SDK: \[SAI_UTILS.ERR\].*get_dispatch_attribs_handler:.*(INGRESS_SAMPLE_MIRROR_SESSION|EGRESS_SAMPLE_MIRROR_SESSION).*"
 
 # https://github.com/sonic-net/sonic-mgmt/issues/10384


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Update ignore error list because the log add some string like client_pid.

For example:
```
2025 Dec 25 04:05:54.897872 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2418]- sai_get_attributes: Failed to get attribute
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2233]- get_dispatch_attribs_handler: Failed Get #0, PORT_ID, key:BRIDGE_PORT [OID:0x4080000003A] [bridge_ports_db[1032]]
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2418]- sai_get_attributes: Failed to get attribute
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2233]- get_dispatch_attribs_handler: Failed Get #0, ISOLATION_GROUP, key:BRIDGE_PORT [OID:0x4080000003A] [bridge_ports_db[1032]]
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2418]- sai_get_attributes: Failed to get attribute
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2233]- get_dispatch_attribs_handler: Failed Get #0, UNKNOWN_UNICAST_FLOOD_GROUP, key:BRIDGE [OID:0x10010039] [Type:.1Q, ID:0, sx_bridge_id:4097]
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2418]- sai_get_attributes: Failed to get attribute
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2233]- get_dispatch_attribs_handler: Failed Get #0, UNKNOWN_MULTICAST_FLOOD_GROUP, key:BRIDGE [OID:0x10010039] [Type:.1Q, ID:0, sx_bridge_id:4097]
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2418]- sai_get_attributes: Failed to get attribute
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2233]- get_dispatch_attribs_handler: Failed Get #0, BROADCAST_FLOOD_GROUP, key:BRIDGE [OID:0x10010039] [Type:.1Q, ID:0, sx_bridge_id:4097]
2025 Dec 25 04:05:54.898671 sonic ERR syncd#SDK: [SAI_UTILS.ERR] client_pid=21, ./src/mlnx_sai_utils.c[2418]- sai_get_attributes: Failed to get attribute
```

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Update ignore error list because some logs add some strings like client_pid. To enhance the robustness of the regex, replace specific strings with '.*'.

#### How did you do it?
update the ignore error list

#### How did you verify/test it?
run the community test

#### Any platform specific information?
any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
