### PR TITLE
[ARP][test_arp_update] Verify MAC relearning after fdbclear

### DIFF
--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -73,17 +73,29 @@ def fdb_cleanup(duthost):
         pytest_assert(wait_until(200, 2, 0, lambda: fdb_table_has_no_dynamic_macs(duthost) is True),
                       "FDB Table Cleanup failed")
 
+
 def get_dut_mac(duthost, config_facts, tbinfo):
+    """
+    Get DUT MAC address
+    """
     if 'dualtor' in tbinfo['topo']['name']:
         for vlan_details in list(config_facts['VLAN'].values()):
             return vlan_details['mac'].lower()
     return duthost.shell("sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'")["stdout_lines"][0]
 
+
 def fdb_has_mac(duthost, mac):
+    """
+    Check if FDB has specific MAC address
+    """
     mac = mac.lower()
     return any(mac in line.lower() for line in duthost.command("show mac")["stdout_lines"])
 
+
 def get_first_vlan_ipv4(config_facts):
+    """
+    Get first VLAN interface and its IPv4 address
+    """
     vlan_intfs = config_facts.get("VLAN_INTERFACE", {})
     for intf, addrs in vlan_intfs.items():
         for addr in addrs:

--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -89,6 +89,9 @@ def fdb_has_mac(duthost, mac):
     Check if FDB has specific MAC address
     """
     mac = mac.lower()
+    logger.info(f"Checking if FDB has MAC address {mac}")
+    mac_lines = [line for line in duthost.command("show mac")["stdout_lines"] if mac in line.lower()]
+    logger.info("Matched MAC entries:\n{}".format("\n".join(mac_lines) if mac_lines else "<none>"))
     return any(mac in line.lower() for line in duthost.command("show mac")["stdout_lines"])
 
 

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -214,7 +214,7 @@ def test_dut_ping_learns_mac(
 ):
     """
     After fdbclear on DUT,
-    PTF sends an ARP request to DUT, 
+    PTF sends an ARP request to DUT,
     DUT replies to ARP request,
     PTF then sends ICMP echo request to DUT,
     Verify DUT learns PTF MAC in FDB.

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -1,12 +1,16 @@
 # Test cases to validate functionality of the arp_update script
 
 import logging
+import ptf.testutils as testutils
 import pytest
 import random
+from ipaddress import ip_interface
 
+from tests.arp.arp_utils import clear_dut_arp_cache, fdb_cleanup, get_dut_mac, fdb_has_mac, get_first_vlan_ipv4
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert as pt_assert
+from tests.common.helpers.constants import PTF_TIMEOUT
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_utils import mux_cable_server_ip
 
@@ -90,3 +94,54 @@ def test_kernel_asic_mac_mismatch(
     rand_selected_dut.shell("docker exec swss supervisorctl start arp_update")
 
     wait_until(10, 1, 0, lambda dut, ip: not neighbor_learned(dut, ip), rand_selected_dut, target_ip)
+
+
+def test_fdbclear_ptf_arp_learns_mac(
+    rand_selected_dut,
+    ptfadapter,
+    config_facts,
+    ip_and_intf_info,
+    tbinfo
+):
+    ptf_intf_ipv4_addr, _, _, _, ptf_intf_index = ip_and_intf_info
+    ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
+    if isinstance(ptf_intf_mac, (bytes, bytearray)):
+        ptf_intf_mac = ptf_intf_mac.decode()
+
+    duthost = rand_selected_dut
+    dut_mac = get_dut_mac(duthost, config_facts, tbinfo)
+    vlan_name, dut_ipv4 = get_first_vlan_ipv4(config_facts)
+    logger.info("DUT VLAN IPv4: {}".format(dut_ipv4))
+
+    fdb_cleanup(duthost)
+    clear_dut_arp_cache(duthost)
+    ptfadapter.dataplane.flush()
+
+    arp_req = testutils.simple_arp_packet(pktlen=60,
+                                        eth_dst='ff:ff:ff:ff:ff:ff',
+                                        eth_src=ptf_intf_mac,
+                                        vlan_pcp=0,
+                                        arp_op=1,
+                                        ip_snd=str(ptf_intf_ipv4_addr),
+                                        ip_tgt=str(dut_ipv4),
+                                        hw_snd=ptf_intf_mac,
+                                        hw_tgt='ff:ff:ff:ff:ff:ff'
+    )
+    
+    arp_reply = testutils.simple_arp_packet(eth_dst=ptf_intf_mac,
+                                        eth_src=dut_mac,
+                                        arp_op=2,
+                                        ip_snd=str(dut_ipv4),
+                                        ip_tgt=str(ptf_intf_ipv4_addr),
+                                        hw_snd=dut_mac,
+                                        hw_tgt=ptf_intf_mac
+    )
+
+    logger.info("Sending ARP request for target {} from PTF interface {}".format(dut_ipv4, ptf_intf_index))
+    testutils.send_packet(ptfadapter, ptf_intf_index, arp_req)
+    testutils.verify_packet(ptfadapter, arp_reply, ptf_intf_index, timeout=PTF_TIMEOUT)
+
+    pt_assert(
+        wait_until(10, 1, 0, fdb_has_mac, duthost, ptf_intf_mac),
+        "FDB did not learn PTF MAC after ARP request"
+    )

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -41,10 +41,10 @@ def ptf_interface_info(ip_and_intf_info, ptfadapter):
     ptf_intf_mac = ptfadapter.dataplane.get_mac(0, ptf_intf_index)
     if isinstance(ptf_intf_mac, (bytes, bytearray)):
         ptf_intf_mac = ptf_intf_mac.decode()
-    
+
     ptf_iface = f"eth{ptf_intf_index}"
     ptf_ip = str(ptf_intf_ipv4_addr)
-    
+
     return {
         'ip': ptf_ip,
         'ipv4_addr': ptf_intf_ipv4_addr,
@@ -54,7 +54,7 @@ def ptf_interface_info(ip_and_intf_info, ptfadapter):
     }
 
 
-@pytest.fixture  
+@pytest.fixture
 def dut_interface_info(rand_selected_dut, config_facts, tbinfo):
     """
     Get DUT interface information
@@ -62,11 +62,11 @@ def dut_interface_info(rand_selected_dut, config_facts, tbinfo):
     duthost = rand_selected_dut
     dut_mac = get_dut_mac(duthost, config_facts, tbinfo)
     vlan_name, dut_ipv4 = get_first_vlan_ipv4(config_facts)
-    
+
     return {
         'host': duthost,
         'mac': dut_mac,
-        'vlan_name': vlan_name, 
+        'vlan_name': vlan_name,
         'ipv4': dut_ipv4
     }
 
@@ -77,14 +77,14 @@ def clean_environment(rand_selected_dut, ptfadapter):
     Cleanup FDB and DUT ARP cache before and after test run
     """
     duthost = rand_selected_dut
-    
+
     logger.info("Setting up clean environment: clearing FDB and ARP cache")
     fdb_cleanup(duthost)
     clear_dut_arp_cache(duthost)
     ptfadapter.dataplane.flush()
-    
+
     yield
-    
+
     logger.info("Test completed, environment cleanup done")
 
 
@@ -94,16 +94,16 @@ def ptf_with_ip_config(ptf_interface_info, ptfhost):
     Configure IP on PTF interface and cleanup afterwards
     """
     ptf_info = ptf_interface_info
-    
+
     # Configure IP on PTF interface
     ptfhost.shell(f"ip addr add {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
-    
+
     yield ptf_info
-    
+
     # Cleanup: remove IP from PTF interface
     ptfhost.shell(f"ip addr del {ptf_info['ip']}/21 dev {ptf_info['interface']}", module_ignore_errors=True)
-    
-    
+
+
 def neighbor_learned(dut, target_ip):
     neigh_output = dut.shell(f"ip neigh show {target_ip}")['stdout'].strip()
     logger.info(f"DUT neighbor entry: {neigh_output}")
@@ -169,7 +169,7 @@ def test_kernel_asic_mac_mismatch(
 
 def test_ptf_arp_learns_mac(
     ptf_interface_info,
-    dut_interface_info, 
+    dut_interface_info,
     clean_environment,
     ptfadapter,
     tbinfo
@@ -182,7 +182,7 @@ def test_ptf_arp_learns_mac(
     # Setup PTF and DUT info
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info
-    
+
     logger.info("DUT VLAN IPv4: {}".format(dut_info['ipv4']))
 
     # Simulate ARP request from PTF to DUT
@@ -211,7 +211,7 @@ def test_ptf_arp_learns_mac(
 
     logger.info("Sending ARP request for target {} from PTF interface {}".format(
         dut_info['ipv4'], ptf_info['index']))
-    
+
     # Send ARP request and verify ARP reply
     testutils.send_packet(ptfadapter, ptf_info['index'], arp_req)
     testutils.verify_packet(ptfadapter, arp_reply, ptf_info['index'], timeout=PTF_TIMEOUT)
@@ -225,7 +225,7 @@ def test_ptf_arp_learns_mac(
 
 def test_dut_arping_learns_mac(
     ptf_interface_info,
-    dut_interface_info, 
+    dut_interface_info,
     clean_environment,
     setup_vlan_arp_responder  # noqa: F811
 ):
@@ -238,7 +238,7 @@ def test_dut_arping_learns_mac(
     # Setup PTF and DUT info
     ptf_info = ptf_interface_info
     dut_info = dut_interface_info
-    
+
     # Setup PTF responder info
     vlan_name, ipv4_base, _, ip_offset = setup_vlan_arp_responder
     ptf_responder_ip = str(ipv4_base.ip + ip_offset)
@@ -262,7 +262,7 @@ def test_dut_ping_learns_mac(
     ptfhost
 ):
     """
-    Configure IP on PTF interface, 
+    Configure IP on PTF interface,
     ping DUT from PTF,
     then verify both sides learned MAC address
     """

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -183,7 +183,7 @@ arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
     reason: "skip for IPv6-only topologies"
     conditions:
       - "'-v6-' in topo_name"
-      
+
 arp/test_arp_update.py::test_ptf_arp_learns_mac:
   skip:
     reason: "Skip test_ptf_arp_learns_mac on dualtor"
@@ -5593,3 +5593,4 @@ zmq/test_gnmi_zmq.py::test_gnmi_zmq:
     conditions:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
+

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -177,19 +177,19 @@ arp/test_arp_update.py::test_dut_ping_learns_mac:
     conditions:
       - "'dualtor' in topo_name"
       
-arp/test_arp_update.py::test_ptf_arp_learns_mac:
-  skip:
-    reason: "Skip test_ptf_arp_learns_mac on dualtor"
-    conditions:
-      - "'dualtor' in topo_name"
-      
 arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
   regex: true
   skip:
     reason: "skip for IPv6-only topologies"
     conditions:
       - "'-v6-' in topo_name"
-
+      
+arp/test_arp_update.py::test_ptf_arp_learns_mac:
+  skip:
+    reason: "Skip test_ptf_arp_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+      
 arp/test_neighbor_mac_noptf.py:
   skip:
     reason: "Not supported in standalone topologies."

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -165,6 +165,24 @@ arp/test_arp_extended.py::test_proxy_arp[v4-:
     conditions:
       - "'-v6-' in topo_name"
 
+arp/test_arp_update.py::test_ptf_arp_learns_mac:
+  skip:
+    reason: "Skip test_ptf_arp_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+
+arp/test_arp_update.py::test_dut_arping_learns_mac:
+  skip:
+    reason: "Skip test_dut_arping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+      
+arp/test_arp_update.py::test_dut_ping_learns_mac:
+  skip:
+    reason: "Skip test_dut_ping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+      
 arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
   regex: true
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -176,7 +176,7 @@ arp/test_arp_update.py::test_dut_ping_learns_mac:
     reason: "Skip test_dut_ping_learns_mac on dualtor"
     conditions:
       - "'dualtor' in topo_name"
-      
+
 arp/test_arp_update.py::test_kernel_asic_mac_mismatch\[.*ipv4.*\]:
   regex: true
   skip:
@@ -189,7 +189,7 @@ arp/test_arp_update.py::test_ptf_arp_learns_mac:
     reason: "Skip test_ptf_arp_learns_mac on dualtor"
     conditions:
       - "'dualtor' in topo_name"
-      
+
 arp/test_neighbor_mac_noptf.py:
   skip:
     reason: "Not supported in standalone topologies."
@@ -5593,4 +5593,3 @@ zmq/test_gnmi_zmq.py::test_gnmi_zmq:
     conditions:
       - "is_mgmt_ipv6_only==True"
       - "https://github.com/sonic-net/sonic-mgmt/issues/20395"
-

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -170,16 +170,16 @@ arp/test_arp_update.py::test_dut_arping_learns_mac:
     reason: "Skip test_dut_arping_learns_mac on dualtor"
     conditions:
       - "'dualtor' in topo_name"
+
+arp/test_arp_update.py::test_dut_ping_learns_mac:
+  skip:
+    reason: "Skip test_dut_ping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
       
 arp/test_arp_update.py::test_ptf_arp_learns_mac:
   skip:
     reason: "Skip test_ptf_arp_learns_mac on dualtor"
-    conditions:
-      - "'dualtor' in topo_name"
-      
-arp/test_arp_update.py::test_dut_ping_learns_mac:
-  skip:
-    reason: "Skip test_dut_ping_learns_mac on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -165,15 +165,15 @@ arp/test_arp_extended.py::test_proxy_arp[v4-:
     conditions:
       - "'-v6-' in topo_name"
 
-arp/test_arp_update.py::test_ptf_arp_learns_mac:
-  skip:
-    reason: "Skip test_ptf_arp_learns_mac on dualtor"
-    conditions:
-      - "'dualtor' in topo_name"
-
 arp/test_arp_update.py::test_dut_arping_learns_mac:
   skip:
     reason: "Skip test_dut_arping_learns_mac on dualtor"
+    conditions:
+      - "'dualtor' in topo_name"
+      
+arp/test_arp_update.py::test_ptf_arp_learns_mac:
+  skip:
+    reason: "Skip test_ptf_arp_learns_mac on dualtor"
     conditions:
       - "'dualtor' in topo_name"
       


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Add tests to validate that DUT can relearn MAC addresses after fdbclear via ARP request/response, arping, and ICMP ping traffic.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
After ‘fdbclear’ on DUT
- Testcase `test_ptf_arp_learns_mac`: Simulate arp request/response from PTF and confirm Mac is learnt on DUT
- Testcase `test_dut_arping_learns_mac` Simulate arping from DUT and enable PTF to respond, confirm MAC is learnt on DUT
- Testcase `test_dut_ping_learns_mac` PTF sends an ARP request to DUT, DUT replies to ARP request, PTF then sends ICMP echo request to DUT, verify DUT learns PTF MAC in FDB.
#### How did you verify/test it?
```
---------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/arp/test_arp_update.xml -----------------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
01:36:45 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 5 passed, 1 warning in 211.93s (0:03:31) ==================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_dut_ping_learns_mac[str4-sn5640-2-None]>
```
```
---------------------------------------------------------------- generated xml file: /data/sonic-mgmt-int/tests/logs/arp/test_arp_update.xml -----------------------------------------------------------------
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
02:00:00 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 5 passed, 1 warning in 193.20s (0:03:13) ==================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_dut_ping_learns_mac[str4-7060x6-512-1-None]>
```
#### Any platform specific information?
Nvidia SN5640, Arista 7060x6
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
