### PR TITLE
Skip swss events in telemetry/test_events.py for Nokia-7215, Nokia-7215A1 and Arista-720DT-MGX

### DIFF
--- a/tests/common/broadcom_data.py
+++ b/tests/common/broadcom_data.py
@@ -6,4 +6,4 @@ LOSSY_ONLY_HWSKUS = ['Arista-7060X6-64PE-C256S2', 'Arista-7060X6-64PE-C224O8',
                      'Arista-7060X6-64PE-B-C512S2', 'Arista-7060X6-64PE-B-C448O16']
 NO_QOS_HWSKUS = ['Arista-7050CX3-32C-C28S16', 'Arista-7050CX3-32C-S128',
                  'Arista-7050CX3-32C-C6S104', 'Arista-720DT-G48S4',
-                 'Arista-720DT-48S']
+                 'Arista-720DT-48S', 'Arista-720DT-MGX-G48S4']

--- a/tests/common/marvell_prestera_data.py
+++ b/tests/common/marvell_prestera_data.py
@@ -1,2 +1,6 @@
 def is_marvell_prestera_device(dut):
     return dut.facts["asic_type"] == "marvell-prestera"
+
+
+NO_QOS_HWSKUS = ['Nokia-7215', 'Nokia-M0-7215',
+                 'Nokia-7215-A1-G48S4', 'Nokia-7215-A1-MGX-G48S4']

--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -10,6 +10,7 @@ from tests.common.mellanox_data import LOSSY_ONLY_HWSKUS as MELLANOX_LOSSY_ONLY_
 from tests.common.broadcom_data import LOSSY_ONLY_HWSKUS as BROADCOM_LOSSY_ONLY_HWSKUS
 from tests.common.mellanox_data import NO_QOS_HWSKUS as MELLANOX_NO_QOS_HWSKUS
 from tests.common.broadcom_data import NO_QOS_HWSKUS as BROADCOM_NO_QOS_HWSKUS
+from tests.common.marvell_prestera_data import NO_QOS_HWSKUS as MARVELL_PRESTERA_NO_QOS_HWSKUS
 from tests.common.utilities import wait_until
 
 random.seed(10)
@@ -42,6 +43,8 @@ def test_event(duthost, gnxi_path, ptfhost, ptfadapter, data_dir, validate_yang)
         skip_pfc_hwskus = [*MELLANOX_LOSSY_ONLY_HWSKUS, *MELLANOX_NO_QOS_HWSKUS]
     elif asic_type == "broadcom":
         skip_pfc_hwskus = [*BROADCOM_LOSSY_ONLY_HWSKUS, *BROADCOM_NO_QOS_HWSKUS]
+    elif asic_type == "marvell-prestera":
+        skip_pfc_hwskus = MARVELL_PRESTERA_NO_QOS_HWSKUS
     else:
         skip_pfc_hwskus = []
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
PR #19872 broke the test skip on Nokia (Marvell) M0/Mx platforms. In this PR, I add them back.
In addition, I add Arista-720DT-MGX for skip.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Skip swss events in telemetry/test_events.py for Nokia-7215, Nokia-7215A1 and Arista-720DT-MGX

#### How did you do it?

#### How did you verify/test it?
Verified on Nokia-7215 Mx testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
