### PR TITLE
Fix invalid method call in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -787,7 +787,7 @@ def ptfhosts(enhance_inventory, ansible_adhoc, tbinfo, duthost, request):
         # try to parse it from inventory
         ptf_host = duthost.host.options["inventory_manager"].get_host(duthost.hostname).get_vars()["ptf_host"]
         _hosts.append(PTFHost(ansible_adhoc, ptf_host, duthost, tbinfo,
-                             macsec_enabled=request.config.option.enable_macsec))
+                              macsec_enabled=request.config.option.enable_macsec))
     return _hosts
 
 


### PR DESCRIPTION
Summary:
In the ptfhosts pytest fixture in conftest.py, a method `_hosts.apend` appears, which is a typo corrected by this change to `_hosts.append`.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/22157

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix an invalid method call in conftest.py.

#### How did you do it?
Corrected the call from  `_hosts.apend` to `_hosts.append`.

#### How did you verify/test it?
Ran pylint against conftest.py and confirmed the error message no longer occurs.