### PR TITLE
Reset the systemd failed state counter in case test_bgp_session_interface_down

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -318,6 +318,15 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
         "neighbor {} state is still established".format(neighbor)
     )
 
+    # BGP service has start limit with value of StartLimitBurst=3 and StartLimitIntervalUSec=20min,
+    # which means bgp service cannot start if it restarts more than 3 times within 20 minutes.
+    # This case tests bgp and swss service restart. Restarting swss service also triggers bgp service restart.
+    # - In Debian 11, the bgp restart triggered by swss restart was not counted.
+    # - In Debian 13, this is correctly counted, causing the start limit to be reached and bgp service cannot start.
+    # To avoid this issue, reset the systemd failed state counter before service restart.
+    if test_type in ("bgp_docker", "swss_docker"):
+        duthost.shell("sudo systemctl reset-failed bgp.service")
+
     if test_type == "bgp_docker":
         duthost.shell("systemctl restart bgp")
     elif test_type == "swss_docker":


### PR DESCRIPTION

Summary: Reset the systemd failed state counter in case `test_bgp_session_interface_down`
Fixes #
BGP service has start limit with value of `StartLimitBurst=3` and `StartLimitIntervalUSec=20min`, which means bgp service cannot start if it restarts more than 3 times within 20 minutes. Case `test_bgp_session_interface_down` tests bgp and swss service restart. Restarting swss service also triggers bgp service restart.
- In Debian 11, the bgp restart triggered by swss restart was not counted.
- In Debian 13, this is correctly counted, causing the start limit to be reached and bgp service cannot start. 
To avoid this issue, reset the systemd failed state counter before service restart.


```
admin@router:~$ systemctl show bgp.service | grep -E "StartLimit|Restart"
Restart=no
RestartMode=normal
RestartUSec=30s
RestartSteps=0
RestartMaxDelayUSec=infinity
RestartUSecNext=30s
NRestarts=0
RestartKillSignal=15
StartLimitIntervalUSec=20min          <<<
StartLimitBurst=3                              <<<
StartLimitAction=none

```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
