### PR TITLE
Update PR test template to allow longer lock testbed time and execution time

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -6,7 +6,7 @@ parameters:
 
 - name: TIMEOUT_IN_MINUTES_PR_TEST
   type: number
-  default: 480
+  default: 640
 
 - name: CHECKOUT_SONIC_MGMT
   type: boolean
@@ -29,7 +29,7 @@ parameters:
     RETRY_TIMES: "2"
     STOP_ON_FAILURE: "True"
     TEST_PLAN_NUM: "1"
-    MAX_RUN_TEST_MINUTES: 240
+    MAX_RUN_TEST_MINUTES: 480
     MGMT_COMMIT_HASH: ""
     PTF_MODIFIED: "False"
     EXPECTED_RESULT: ""


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Currently we are facing some timeout issue in PR testing, need to update PR test template to fix timeout issues.
#### How did you do it?
1. In pipeline level, increase TIMEOUT_IN_MINUTES_PR_TEST to 8 hours in case some azure build-in steps may take a long time.
2. In elastictest level, increase MAX_RUN_TEST_MINUTES to 6 hours since lock testbed would take longer than before, we need to make sure elastictest has enough time to run test cases.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
