### PR TITLE
Add proper cleanup in setup_bgp_peers in test_bgp_update_replication test.

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -202,7 +202,7 @@ def setup_bgp_peers(
             peer.start_session()
         yield bgp_peers
     finally:
-    # Always cleanup, even on setup failure
+        # Always cleanup, even on setup failure
         for peer in started_peers:
             peer.stop_session()
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
In some instances, there was a failure during peer.start_session() that left residual bgp_session running that lead to subsequent tests failure.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/sonic-net/sonic-mgmt/issues/22183)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Failure in other tests under `tests/bgp` due to failure in `tests/bgp/test_bgp_update_replication.py` at `start_session()`

#### How did you do it?
Add proper cleanup mechanism

#### How did you verify/test it?
Ran the tests

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
