### PR TITLE
Fix conftest typing for older Python Version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Optional
 import enum
 import os
 import json
@@ -922,7 +923,7 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
     """
 
     # Internal helper functions
-    def create_or_get_fanout(fanout_hosts, fanout_name, dut_host) -> FanoutHost | None:
+    def create_or_get_fanout(fanout_hosts, fanout_name, dut_host) -> Optional[FanoutHost]:
         """
         Create FanoutHost if not exists, or return existing one.
         Fanout creation logic for both Ethernet and Serial connections.


### PR DESCRIPTION
### Description of PR

Summary:

Fix python compatibility issue in this [PR](https://github.com/sonic-net/sonic-mgmt/pull/21729)

Make `tests/conftest.py` compatible with Python 3.7–3.9 by replacing PEP 604 union syntax with `typing.Optional`.  
Fixes # (not applicable)

Note: There was a known issue that setup-container.sh will not pull the latest base image so that it still using old python version. It is fixed in ths [PR](https://github.com/sonic-net/sonic-mgmt/pull/21833)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`FanoutHost | None` is Python 3.10+ syntax; importing `tests/conftest.py` raises a `SyntaxError` on Python 3.7–3.9. This change restores compatibility.

#### How did you do it?
Replaced the union annotation with `Optional[FanoutHost]` and added the `typing.Optional` import.

#### How did you verify/test it?
Not run (syntax-only change).

#### Any platform specific information?
None.

#### Supported testbed topology if it's a new test case?
N/A.

### Documentation
Not applicable.
