### PR TITLE
[sonic-mgmt] Fix sflow/test_sflow.py failures with `AttributeError: 'SflowTest' object has no attribute 'collector0_samples'`

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -99,7 +99,7 @@ class SflowTest(BaseTest):
         with open(outfile, 'w') as f:
             process = subprocess.Popen(['/usr/local/bin/sflowtool', '-j', '-p'] + sflow_port,
                                        stdout=f,
-                                       stderr=subprocess.STDOUT,
+                                       stderr=subprocess.DEVNULL,
                                        shell=False
                                        )
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Fix sflow/test_sflow.py failures with `AttributeError: 'SflowTest' object has no attribute 'collector0_samples'`
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/22181

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
All of the `sflow/test_sflow.py` testcases are failing with `AttributeError: 'SflowTest' object has no attribute 'collector0_samples'`

https://github.com/sonic-net/sonic-buildimage/pull/24691 have upgraded `sflowtool` version last week. This recent version of sflowtool has https://github.com/sflow/sflowtool/commit/68058170a58a7290322876b14487c992e8a71074 changes, which is setting socket buffer size (in case default is too low).

Above change is causing `sflowtool` to print informational messages like `requestSocketBuffer(sflow/v6 in): already have 31457280` to stderr, but currently the PTF test is redirecting stderr to stdout (`stderr=subprocess.STDOUT`). These non-JSON lines/messages get mixed into the output file that expects only JSON, and causes parser to crash when trying to parse the message as Python literal.

#### How did you do it?

**Fix:** Redirect stderr to /dev/null instead of stdout (as these are informational messages, and not critical errors)

#### How did you verify/test it?
All the sflow test cases are passing now.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
