### PR TITLE
[Smartswitch] Remove the lldp from the critical service for DPU

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -104,8 +104,8 @@ class MultiAsicSonicHost(object):
 
         # Update the asic service based on feature table state and asic flag
         for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
-            if service == 'teamd' and is_dpu:
-                logger.info("Removing teamd from default services for switch_type DPU")
+            if (service == 'teamd' or service == 'lldp') and is_dpu:
+                logger.info(f"Removing {service} from default services for DPU")
                 self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                 continue
             if service not in config_facts['FEATURE']:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is to align with PR: https://github.com/sonic-net/sonic-buildimage/pull/25032.
LLDP is disabled from the DPU image.
The safe config reload fails on checking the lldp docker status in the dash PL test.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Remove the lldp from the DPU critical services.
#### How did you verify/test it?
Run the dash PL test.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
