### PR TITLE
Fix test_switchover_faulty_ycable find flakiness

### DIFF
--- a/tests/dualtor/test_switchover_faulty_ycable.py
+++ b/tests/dualtor/test_switchover_faulty_ycable.py
@@ -57,7 +57,7 @@ def setup_faulted_y_cable_driver(duthost, simulate_probe_unknown=False, simulate
             force=True
         )
         find_path_res = duthost.shell(
-            "docker exec pmon find / -name y_cable_simulated.py")["stdout"]
+            "docker exec pmon find / -name y_cable_simulated.py 2>/dev/null", module_ignore_errors=True)["stdout"]
         # Let's check the file exist before patching
         duthost.shell("docker exec pmon stat %s" % find_path_res)
         y_cable_simulated_path = os.path.dirname(find_path_res)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

### Description of PR

The test uses the `docker exec pmon find /` command, which can exit with rc=1 due to transient `/proc` entries disappearing during the search — even when `y_cable_simulated.py` is found and printed to stdout.  
This causes `RunAnsibleModuleFail` before the path is assigned, leading to `UnboundLocalError: local variable 'y_cable_simulated_path' referenced before assignment` in the `finally` block during cleanup.

**Fix**:  
- Suppress stderr warnings with `2>/dev/null`  
- Ignore non-zero exit codes via `module_ignore_errors=True` to make the lookup reliable

Fixes https://github.com/sonic-net/sonic-mgmt/issues/21946

### Type of change

- [x] Bug fix  
- [ ] Testbed and Framework (new/improvement)  
- [ ] New Test case  
- [ ] Skipped for non-supported platforms  
- [ ] Test case improvement  

### Back port request

- [ ] 202205  
- [ ] 202305  
- [ ] 202311  
- [ ] 202405  
- [ ] 202411  
- [ ] 202505  
- [x] 202511  

### Approach

#### What is the motivation for this PR?

This change eliminates a flaky failure in `test_switchover_faulty_ycable.py` observed on dual-TOR testbeds.  
The failure is intermittent (~10–30% rate depending on system load) because the `find /` command traverses `/` and encounters transient `/proc/<pid>` directories that disappear mid-execution. This causes `find` to exit with rc=1 even when the target file path is correctly printed to stdout.  
The test code does not tolerate this non-zero return code → `RunAnsibleModuleFail` is raised before path assignment → `UnboundLocalError` during teardown/cleanup.

#### How did you do it?

- Added `2>/dev/null` to the `find` command to suppress the noisy `/proc/... No such file or directory` warnings on stderr  
- Added `module_ignore_errors=True` to the `duthost.shell()` call so that a non-zero return code does not raise `RunAnsibleModuleFail` when stdout still contains the expected path  

#### How did you verify/test it?

- Ran test_switchover_faulty_ycable.py  in a loop (20+ consecutive runs) on a  dual-TOR testbed  
- Verified in test logs that `/proc` warnings no longer appear and cleanup executes cleanly without exceptions

#### Any platform specific information?

Primarily reproducible on multi-ASIC SONiC platforms using the `pmon` container

#### Supported testbed topology if it's a new test case?

N/A (robustness improvement to existing dual-TOR test)

### Documentation

N/A – no new feature or new test case. This is a targeted fix for test reliability.
