### PR TITLE
[ptfadapter] Fix ptf_nn_agent startup failure due to port contention

### DIFF
--- a/tests/common/plugins/ptfadapter/__init__.py
+++ b/tests/common/plugins/ptfadapter/__init__.py
@@ -20,6 +20,7 @@ MAX_RETRY_TIME = 3
 
 logger = logging.getLogger(__name__)
 
+
 def pytest_addoption(parser):
     parser.addoption("--keep_payload", action="store_true", default=False,
                      help="Keep the original packet payload, do not update payload to default pattern")
@@ -138,12 +139,12 @@ def ptfadapter(ptfhosts, tbinfo, request, duthost):
 
             # If stdout has content, it means grep found a listener -> PORT IS BUSY
             if res['stdout'].strip():
-               logger.warning(
-                   "Setup Conflict: Port %s is ALREADY IN USE on PTF host.",
-                   ptf_nn_port
-               )
-               logger.debug("Process details: %s",res['stdout'])
-               continue
+                logger.warning(
+                    "Setup Conflict: Port %s is ALREADY IN USE on PTF host.",
+                    ptf_nn_port
+                )
+                logger.debug("Process details: %s", res['stdout'])
+                continue
 
             # generate supervisor configuration for ptf_nn_agent
             ptfhost.host.options['variable_manager'].extra_vars.update({


### PR DESCRIPTION
**Summary**:
This PR fixes intermittent `PtfAdapterNNConnectionError` failures in the `ptfadapter` fixture by implementing a robust "Check-Before-Use" mechanism for the `ptf_nn_agent` port selection. We have also reduced the range to `[10900, 10999]`.

Context: The `ptfadapter` fixture randomly selects a port in the range `[10900, 11000]` to start the `ptf_nn_agent`. However, on BGP-enabled testbeds (e.g., t0, t1), the ExaBGP HTTP API service is persistently configured to listen on port 11000 (managed by Supervisor).
When the randomizer selects port `11000`, the `ptf_nn_agent` fails to bind correctly. This results in a handshake timeout `(Current Connections = 0) `and causes the test to flake.

**Fix**: This patch modifies the valid port range to `[10900, 10999]` and `start_ptf_nn_agent` to actively check if the selected port is free on the PTF host before attempting to configure Supervisor.

Fixes #22192 
Fixes [sonic-qual.msft](https://github.com/aristanetworks/sonic-qual.msft/issues/1068)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To eliminate "**flaky**" infrastructure failures caused by port contention. Specifically, to prevent the `ptfadapter` from colliding with persistent background services like ExaBGP on port 11000.
#### How did you do it?
I updated the `start_ptf_nn_agent` function in `tests/common/plugins/ptfadapter/__init__.py`.

1. Reduced the valid port range to `[10900, 10999]`.
2. Added a shell command execution step to run `ss -tulpn | grep ':<port>\b'` on the PTF host.
3. Added a strict loop control: continue to the next iteration if the port is busy, preventing the code from proceeding to `supervisorctl` update

#### How did you verify/test it?
**Reproduction**: Manually forced the `ptfadapter` to use port `11000` on a `t0` topology where ExaBGP was running. Confirmed the test failed as expected.
**Verification**: Applied the patch and ran the same forced-collision scenario. `Setup Conflict: Port 11000 is ALREADY IN USE... Picking a different port`.
#### Any platform specific information?
N/A - This is a generic test framework fix.
#### Supported testbed topology if it's a new test case?
N?A
### Documentation
N?A
