### PR TITLE
Do not check crm route usage in VS testbed in stress route test

### DIFF
--- a/tests/stress/test_stress_routes.py
+++ b/tests/stress/test_stress_routes.py
@@ -46,6 +46,7 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     topo_name = tbinfo["topo"]["name"]
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    asic_type = duthost.facts["asic_type"]
     namespace = asichost.namespace
 
     ignoreRegex = [
@@ -87,11 +88,12 @@ def test_announce_withdraw_route(duthosts, localhost, tbinfo, get_function_compl
     ipv4_route_used_after = get_crm_resource_status(duthost, "ipv4_route", "used", namespace)
     ipv6_route_used_after = get_crm_resource_status(duthost, "ipv6_route", "used", namespace)
 
-    pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                  "ipv4 route used after is not equal to it used before")
-    pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
-                  "ipv6 route used after is not equal to it used before")
-
+    # Do not check route used for vs tests because vs testbed do not have real asic
+    if asic_type != "vs":
+        pytest_assert(abs(ipv4_route_used_after - ipv4_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+                      "ipv4 route used after is not equal to it used before")
+        pytest_assert(abs(ipv6_route_used_after - ipv6_route_used_before) < ALLOW_ROUTES_CHANGE_NUMS,
+                      "ipv6 route used after is not equal to it used before")
     end_time_frr_daemon_memory = get_frr_daemon_memory_usage(duthost, frr_demons_to_check, namespace)
     logging.info(f"memory usage at end: {end_time_frr_daemon_memory}")
     check_memory_usage_is_expected(duthost, frr_demons_to_check, start_time_frr_daemon_memory,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
In stress route test, will check route usage after announce withdraw routes. The way checking route usage is reading crm resource from counters db, and the data source of counters db is asic. But vs testbeds do not have real asic, so the data is not accurate, we shouldn't verify crm usage after announce withdraw routes.
#### How did you do it?
Do not verify crm usage after announce withdraw routes.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
