### PR TITLE
Skip Update of Switch level DSCP->TC map

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -86,6 +86,15 @@ def dscp_config(dscp_mode, duthost, loganalyzer):
         request: pytest request
         duthost (AnsibleHost): The DUT host
     """
+    asic_type = duthost.facts['asic_type']
+
+    # global DSCP_TO_TC_MAP update is not supported on Broadcom platforms
+    if asic_type == 'broadcom':
+        apply_dscp_cfg_setup(duthost, dscp_mode, loganalyzer)
+        yield
+        apply_dscp_cfg_teardown(duthost, loganalyzer)
+        return
+
     is_global_map_key_exist = duthost.shell('redis-cli -n 4 -c KEYS "PORT_QOS_MAP|global"')["stdout"]
     if is_global_map_key_exist:
         origin_dscp_to_tc_map = duthost.shell('redis-cli -n 4 -c HGET "PORT_QOS_MAP|global" "dscp_to_tc_map"')["stdout"]


### PR DESCRIPTION

### Description of PR
Update of global DSCP_TO_TC mapping is not supported on Broadcom asics.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/21985

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR https://github.com/sonic-net/sonic-mgmt/pull/20429 has redesigned the test "qos/test_qos_dscp_mapping.py" recently in 202511 to enforce "AZURE" DSCP_TO_TC mapping.
But this is not supported in broadcom and fails everytime.

#### How did you do it?
By skipping the config for broadcom asics.

#### How did you verify/test it?
Ran the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
