### PR TITLE
[ptf] Set dataplane logger level to ERROR to reduce log volume

### DIFF
--- a/tests/common/plugins/ptfadapter/ptfadapter.py
+++ b/tests/common/plugins/ptfadapter/ptfadapter.py
@@ -102,6 +102,9 @@ class PtfTestAdapter(BaseTest):
         nn.platform_config_update(ptf.config)
         ptf.dataplane_instance = DataPlane(config=ptf.config)
 
+        # set ptf logger level to ERROR to reduce log volume
+        ptf.dataplane_instance.logger.setLevel(logging.ERROR)
+
         # TODO: in case of multi PTF hosts topologies we'll have to provide custom platform that supports that
         # and initialize port_map specifying mapping between tcp://<host>:<port> and port tuple (device_id, port_id)
         for id, ifname in list(ptf.config['port_map'].items()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The ptf dataplane worker is too chatty:
```
$ cat 697c48e0d7617b89998e12c8_dualtor_io_test_heartbeat_failure.log| grep dataplane | wc -l
275387
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Set dataplane logger level to `ERROR` to reduce log volume.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
