### PR TITLE
Split trimming counters into two tests and skip new test on th5

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3771,6 +3771,18 @@ packet_trimming:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+packet_trimming/test_packet_trimming_asymmetric.py::TestPacketTrimmingAsymmetric::test_trimming_counters_with_feature_toggle:
+  skip:
+    reason: "TH5 clears trim counters when packet trimming is turned off, skipping until trim counter persistance is supported."
+    conditions:
+      - "asic_gen in ['th5']"
+
+packet_trimming/test_packet_trimming_symmetric.py::TestPacketTrimmingSymmetric::test_trimming_counters_with_feature_toggle:
+  skip:
+    reason: "TH5 clears trim counters when packet trimming is turned off, skipping until trim counter persistance is supported."
+    conditions:
+      - "asic_gen in ['th5']"
+
 #######################################
 #####           pc               #####
 #######################################

--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -407,8 +407,27 @@ class BasePacketTrimming:
                         original_scheduler = original_schedulers.get(dut_member)
                         enable_egress_data_plane(duthost, dut_member, trim_queue, original_scheduler)
 
+    def test_trimming_counters_with_feature_toggle(self, duthost, ptfadapter, test_params, trim_counter_params):
+        """
+        Test Case: Verify PacketTrimming Counters After Feature Toggle
+        """
+        with allure.step(f"Configure packet trimming in global level for {self.trimming_mode} mode"):
+            self.configure_trimming_global_by_mode(duthost)
+
+        with allure.step("Enable trimming in buffer profile"):
+            for buffer_profile in test_params['trim_buffer_profiles']:
+                configure_trimming_action(duthost, test_params['trim_buffer_profiles'][buffer_profile], "on")
+            for buffer_profile in trim_counter_params['trim_buffer_profiles']:
+                configure_trimming_action(duthost, trim_counter_params['trim_buffer_profiles'][buffer_profile], "on")
+
+        # Packets are trimmed on two queues, verify trimming counters in queue and port level
+        with allure.step("Verify trimming counters on two queues"):
+            # Trigger trimmed packets on queue0
+            counter_kwargs = self.get_verify_trimmed_counter_packet_kwargs(duthost, ptfadapter, {**trim_counter_params})
+            verify_trimmed_packet(**counter_kwargs)
+
         with allure.step("Verify trimming counter when trimming feature toggles"):
-            trim_queue = 'UC'+str(trim_queue)
+            trim_queue = 'UC' + str(PacketTrimmingConfig.get_trim_queue(duthost))
 
             # Get queue level and port level counter when trimming is enabled
             port = test_params['egress_ports'][0]['dut_members'][0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
In the last portion of the trimming counters test, all buffer profiles have trimming turned off. The test expects the trimming counters to stay the same after this happens. This fails on th5 because the Broadcom SAI clears counters when the trimming feature has been turned off. Microsoft has requested that Broadcom change the SAI implementation, but until that happens we need to ensure this issue doesn't affect the pass rate.

#### How did you do it?
Split the problematic portion of the test into it's own testcase. We will be skipping this new testcase on th5 until the SAI implementation is changed to support the expected behavior.

#### How did you verify/test it?
Tested internally, verifying the new testcase was skipped and the existing testcase was not failing with the previously described issue.

#### Any platform specific information?
We are only skipping for th5, other vendors may need to add to the skip condition if they have the same issue.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
