### PR TITLE
fix: flaky generic config updater test syslog

### DIFF
--- a/tests/generic_config_updater/test_syslog.py
+++ b/tests/generic_config_updater/test_syslog.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.gu_utils import apply_patch, expect_res_success, expect_op_failure, expect_op_success
@@ -305,4 +306,9 @@ def test_syslog_server_tc1_suite(rand_selected_dut, cfg_facts):
     syslog_server_tc1_add_duplicate(rand_selected_dut)
     syslog_server_tc1_xfail(rand_selected_dut)
     syslog_server_tc1_replace(rand_selected_dut)
+
+    # Adding a sleep of 5 seconds to avoid syslog_server_tc1_replace & syslog_server_tc1_remove triggering too close
+    # This would avoid systemd kill core_uploader.service since it was restarted more than 5 times within 10 second time
+    # window
+    time.sleep(5)
     syslog_server_tc1_remove(rand_selected_dut)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Currently this test we're running into this issue:
```
E               2026 Jan 31 04:37:53.222009 ERR systemd[1]: Failed to start core_uploader.service - Host core file uploader daemon.
```

This is because the core_uploader.service is restarted too quickly:

```
Feb 03 01:01:05 systemd[1]: core_uploader.service: Deactivated successfully.
Feb 03 01:01:05 systemd[1]: Stopped core_uploader.service - Host core file uploader daemon.
Feb 03 01:01:05 systemd[1]: Started core_uploader.service - Host core file uploader daemon.
Feb 03 01:01:06 systemd[1]: Stopping core_uploader.service - Host core file uploader daemon...
Feb 03 01:01:06 systemd[1]: core_uploader.service: Deactivated successfully.
Feb 03 01:01:06 systemd[1]: Stopped core_uploader.service - Host core file uploader daemon.
Feb 03 01:01:06 systemd[1]: core_uploader.service: Start request repeated too quickly.
Feb 03 01:01:06 systemd[1]: core_uploader.service: Failed with result 'start-limit-hit'.
Feb 03 01:01:06 systemd[1]: Failed to start core_uploader.service - Host core file uploader daemon.
```

During the step of 

```
    syslog_server_tc1_replace(rand_selected_dut) # 4 restart
    syslog_server_tc1_remove(rand_selected_dut) # 3 restart
```

If `syslog_server_tc1_remove` starts right after `syslog_server_tc1_replace`, we would reach a threshold of limit 5 restart per 10 seconds. Therefore, systemd will kill the core_uploader service

```
admin@sonic:~$ systemctl show core_uploader.service -p StartLimitBurst -p StartLimitIntervalSec
StartLimitBurst=5
```
We should add a small sleep window here to avoid 5 restart within the same time window. 

why `time.sleep(5)`? 4 restart would take 4 seconds, we sleep 5 to get to 9 seconds, reaching to `syslog_server_tc1_remove` would then take another few seconds until the restart kick in, we're safe for 10 second windows

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
