### PR TITLE
Allow self-defined build reason for better filter

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -186,14 +186,13 @@ def get_trigger_type(tp_type: str, build_reason: str):
 
     # 2. PR type(pr test or baseline test)
     # check build reason
-    if build_reason.upper() == "BASELINETEST":
+    elif build_reason.upper() == "BASELINETEST":
         return "BaselineTest"
-
-    if build_reason.upper() == "PULLREQUEST":
+    elif build_reason.upper() == "PULLREQUEST":
         return "PRTest"
 
-    # Else, return None, no impact
-    return None
+    else:
+        return build_reason
 
 
 class TestPlanManager(object):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
In elastictest, trigger type filed would be written to Kusto, but in test_plan.py, trigger type field only works for nightly, PR and baseline test, but we need some self-defined trigger types for better data filter.
#### How did you do it?
Return self-defined trigger type if it's not in nightly, PR and baseline test.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
