### PR TITLE
Fix incorrect service disablement; ensure sidecar processed first in ctnr upg test

### DIFF
--- a/tests/container_upgrade/container_upgrade_helper.py
+++ b/tests/container_upgrade/container_upgrade_helper.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import json
+import time
 
 from tests.common.utilities import wait_until, file_exists_on_dut
 from tests.common.helpers.assertions import pytest_assert as py_assert
@@ -10,6 +11,7 @@ from tests.common.utilities import cleanup_prev_images
 from tests.common.helpers.upgrade_helpers import install_sonic
 from tests.common.reboot import reboot
 from tests.common.helpers.custom_msg_utils import add_custom_msg
+from tests.common.helpers.dut_utils import is_container_running
 
 
 logger = logging.getLogger(__name__)
@@ -27,10 +29,6 @@ container_name_mapping = {
     "docker-sonic-bmp": "bmp",
     "docker-bmp-watchdog": "bmp_watchdog",
 }
-
-existing_service_list = [
-    "gnmi"
-]
 
 
 def parse_containers(container_string):
@@ -124,20 +122,28 @@ def os_upgrade(duthost, localhost, tbinfo, image_url):
               "All critical services should be fully started!")
 
 
-def disable_features(duthost):
-    for service in existing_service_list:
-        logger.info(f"Disabling {service} feature")
-        duthost.shell(f"config feature state {service} disabled", module_ignore_errors=True)
-    duthost.shell("config save -y", module_ignore_errors=True)
+def validate_is_v1_enabled(duthost, sidecar_container_name):
+    """
+    If sidecar container of existing service has IS_V1_ENABLED=false,
+    existing service container should not be running
+    """
+    container_name = sidecar_container_name.rsplit("_sidecar", 1)[0]
+    cmd = "docker exec %s env | grep IS_V1_ENABLED" % sidecar_container_name
+    output = duthost.shell(cmd, module_ignore_errors=True)['stdout']
+    if "IS_V1_ENABLED=false" in output:
+        time.sleep(5)
+        if is_container_running(duthost, container_name):
+            py_assert(False, f"{container_name} container should not be running")
 
 
 def pull_run_dockers(duthost, creds, env):
     logger.info("Pulling docker images")
-
-    # Disable features, and new container will be managed by kubernetes
-    disable_features(duthost)
     registry = load_docker_registry_info(duthost, creds)
-    for container, version, name in zip(env.containers, env.container_versions, env.container_names):
+    container_entries = list(zip(env.containers, env.container_versions, env.container_names))
+    # Ensure sidecars are processed first
+    container_entries.sort(key=lambda t: 0 if "sidecar" in t[2] else 1)
+
+    for container, version, name in container_entries:
         docker_image = f"{registry.host}/{container}:{version}"
         download_image(duthost, registry, container, version)
         parameters = env.parameters[container]
@@ -148,6 +154,9 @@ def pull_run_dockers(duthost, creds, env):
         if duthost.shell(f"docker run -d {parameters} {optional_parameters} --name {name} {docker_image}",
                          module_ignore_errors=True)['rc'] != 0:
             pytest.fail("Not able to run container using pulled image")
+
+        if "sidecar" in name:
+            validate_is_v1_enabled(duthost, name)
 
 
 def store_results(request, test_results, env):

--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -5,11 +5,11 @@
     "docker-sonic-gnmi": {
         "parameters": "--net=host -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /etc/fips/fips_enable:/etc/fips/fips_enable:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/dbus:/var/run/dbus:rw -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-chassis:/var/run/redis-chassis:ro --env RUNTIME_OWNER=local"
     },
-    "docker-sonic-bmp": {
-        "parameters": "--net=host -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-bmp:/var/run/redis-bmp:ro"
-    },
     "docker-gnmi-watchdog": {
         "parameters": "--pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"
+    },
+    "docker-sonic-bmp": {
+        "parameters": "--net=host -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-bmp:/var/run/redis-bmp:ro"
     },
     "docker-bmp-watchdog": {
         "parameters": "--pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: sync from internal
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
1) Some existing services (such as acms and gnmi) were being forcibly disabled even when they were not deployed in the pipeline test. For example, gnmi was not included in the test but was still forced to disable and exit.
- Removed disable_features related code
2) Make sure sidecar container is processed first, in order to verify existing service container if IS_V1_ENABLED=false

#### How did you do it?

#### How did you verify/test it?
Verified pipeline
https://elastictest.org/scheduler/testplan/6981068aaf04f23b91e4917a 
https://elastictest.org/scheduler/testplan/6981064dd7617b89998e18f0 
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
