### PR TITLE
[Chassis] Added multi Asics support to everflow Ipv6

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -992,8 +992,15 @@ class BaseEverflowTest(object):
         for line in res[2:]:
             if len(line) < status_index:
                 continue
-            if line[status_index:] != 'Active':
-                return False
+            if duthost.is_multi_asic:
+                st = eval(line[status_index:])
+                namespace_list = duthost.get_asic_namespace_list()
+                for namespace in namespace_list:
+                    if st[namespace] != 'Active':
+                        return False
+            else:
+                if line[status_index:] != 'Active':
+                    return False
         return True
 
     def apply_non_openconfig_acl_rule(self, duthost, extra_vars, rule_file, table_name):
@@ -1010,7 +1017,12 @@ class BaseEverflowTest(object):
         duthost.host.options['variable_manager'].extra_vars.update(extra_vars)
         duthost.file(path=dest_path, state='absent')
         duthost.template(src=os.path.join(FILE_DIR, rule_file), dest=dest_path)
-        duthost.shell("config load -y {}".format(dest_path))
+        dest_paths = dest_path
+        if duthost.is_multi_asic:
+            num_asics = duthost.facts['num_asic']
+            for num_asic in range(num_asics):
+                dest_paths = dest_paths + "," + dest_path
+        duthost.shell("config load -y {}".format(dest_paths))
 
         if duthost.facts['asic_type'] != 'vs':
             pytest_assert(wait_until(60, 2, 0, self.check_rule_active, duthost, table_name),

--- a/tests/everflow/files/test_rules_ip_type_v6.json
+++ b/tests/everflow/files/test_rules_ip_type_v6.json
@@ -2,7 +2,7 @@
     "ACL_RULE": {
         "{{ table_name }}|rule_999": {
             "PRIORITY": "999",
-            "IP_TYPE": "IPV6ANY",
+            "IP_TYPE": "ANY",
             "{{ action }}": "test_session_1",
             "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0011"
         },

--- a/tests/everflow/files/test_rules_ip_type_v6.json
+++ b/tests/everflow/files/test_rules_ip_type_v6.json
@@ -2,7 +2,7 @@
     "ACL_RULE": {
         "{{ table_name }}|rule_999": {
             "PRIORITY": "999",
-            "IP_TYPE": "ANY",
+            "IP_TYPE": "IPV6ANY",
             "{{ action }}": "test_session_1",
             "DST_IPV6": "2002:0225:7c6b:a982:d48b:230e:f271:0011"
         },

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -103,7 +103,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dut = setup_info[UP_STREAM]['everflow_dut']
         else:
             dut = setup_info[DOWN_STREAM]['everflow_dut']
-            
+
         yield dut
 
     @pytest.fixture(scope='class')

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -103,7 +103,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
             dut = setup_info[UP_STREAM]['everflow_dut']
         else:
             dut = setup_info[DOWN_STREAM]['everflow_dut']
-
+            
         yield dut
 
     @pytest.fixture(scope='class')
@@ -201,7 +201,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
             everflow_dut = setup_info[DOWN_STREAM]['everflow_dut']
             remote_dut = setup_info[DOWN_STREAM]['remote_dut']
 
-        table_name = self._get_table_name(everflow_dut)
+        table_name = self._get_table_name(everflow_dut, self.acl_stage())
         temporary_table = False
 
         duthost_set = set()
@@ -214,7 +214,10 @@ class EverflowIPv6Tests(BaseEverflowTest):
 
         for duthost in duthost_set:
             if temporary_table:
-                self.apply_acl_table_config(duthost, table_name, "MIRRORV6", config_method)
+                inst_list = duthost.get_sonic_host_and_frontend_asic_instance()
+                for inst in inst_list:
+                    self.apply_acl_table_config(duthost, table_name, "MIRRORV6", config_method,
+                                                bind_namespace=getattr(inst, 'namespace', None))
 
             self.apply_acl_rule_config(duthost, table_name, setup_mirror_session["session_name"],
                                        config_method, rules=EVERFLOW_V6_RULES)
@@ -229,16 +232,17 @@ class EverflowIPv6Tests(BaseEverflowTest):
                 self.remove_acl_table_config(duthost, table_name, config_method)
 
     # TODO: This can probably be refactored into a common utility method later.
-    def _get_table_name(self, duthost):
+    def _get_table_name(self, duthost, acl_stage="ingress"):
         show_output = duthost.command("show acl table")
 
         table_name = None
         for line in show_output["stdout_lines"]:
             if "MIRRORV6" in line:
-                # NOTE: Once we branch out the sonic-mgmt repo we can skip the version check.
-                if "201811" in duthost.os_version or self.acl_stage() in line:
-                    table_name = line.split()[0]
-                    break
+                if acl_stage in line:
+                    # NOTE: Once we branch out the sonic-mgmt repo we can skip the version check.
+                    if "201811" in duthost.os_version or self.acl_stage() in line:
+                        table_name = line.split()[0]
+                        break
 
         return table_name
 


### PR DESCRIPTION
### Description of PR
This is a fix for sonic-mgmt issue #21702 (All everflow/test_everflow_ipv6.py are erroring out)
This was caused by PR 21384 (Add Support for Egress V6 Testing)

Everflow issues:
1. Added multiAsics support - All everflow/test_everflow_ipv6.py are erroring (sonic-mgmt issue #21702)
2. IP_TYPE "ANY" is not supported in SAI for DNX. Nokia created CS00012446025
3. IP_TYPE "IP" is installed but not hit in SAI causing traffic failure (sonic-buildimage issue #25281). Nokia created CS00012446460  - Nokia has suggested a fix to Broadcom.

Summary:
Fixes # (issue)
sonic-mgmt issue #21702

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x ] 202511

### Approach
#### What is the motivation for this PR?
To Fix 
#### How did you do it?
Added multi Asics support

#### How did you verify/test it?
Ran the entire everflow suites on multi Asics chassis

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
