### PR TITLE
sonic-mgmt: Fix test cleanup of intf config

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -222,13 +222,14 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
             time.sleep(1)
 
     duthost.shell('show ip bgp summary', module_ignore_errors=True)
-    # default keepalive is 60 seconds, timeout 180 seconds. Hence wait for 180 seconds before timeout.
-    pytest_assert(
-        wait_until(180, 10, 0, verify_bgp_session_down, duthost, neighbor),
-        "neighbor {} state is still established".format(neighbor)
-    )
 
     try:
+        # default keepalive is 60 seconds, timeout 180 seconds. Hence wait for 180 seconds before timeout.
+        pytest_assert(
+            wait_until(180, 10, 0, verify_bgp_session_down, duthost, neighbor),
+            "neighbor {} state is still established".format(neighbor)
+        )
+
         if test_type == "bgp_docker":
             duthost.shell("systemctl restart bgp")
         elif test_type == "swss_docker":


### PR DESCRIPTION
In bgp/test_bgp_session.py, move all assertions in verification of interface flap testing into the try/finally, so that config changes are undone after ALL failures and subsequent tests do not fail due to not all BGP sessions being established.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #22235

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fixing this issue allows subsequent tests run after a failing instance of bgp/test_bgp_session.py to run and potentially pass, instead of failing due to pretest errors caused by bad cleanup.

#### How did you do it?
Move all assertions which may result in test failure inside a try/catch/finally, which includes configuration cleanup as a part of the finally clause. 

#### How did you verify/test it?
Manual test run.