### PR TITLE
Add `wait_until` to `bgp_prefix_tc1_remove`

### DIFF
--- a/tests/generic_config_updater/test_bgp_prefix.py
+++ b/tests/generic_config_updater/test_bgp_prefix.py
@@ -228,6 +228,7 @@ def bgp_prefix_tc1_replace(duthost, community, community_table, cli_namespace_pr
     finally:
         delete_tmpfile(duthost, tmpfile)
 
+
 def check_bgp_prefix_config_remove(duthost, community, cli_namespace_prefix):
     """ Check bgp prefix config for remove op
     """
@@ -246,6 +247,7 @@ def check_bgp_prefix_config_remove(duthost, community, cli_namespace_prefix):
     except Exception as e:
         logger.error(f"Error checking bgp prefix configuration: {e}")
         return False
+
 
 def bgp_prefix_tc1_remove(duthost, community, cli_namespace_prefix, namespace=None):
     """ Test to remove prefix config


### PR DESCRIPTION
`bgp_prefix_tc1_remove` can fail because it asserts the gcu patch takes effect immediately but it can take a few seconds for it to take effect.
Convert the assert to a wait_until to fix this.
Details in: https://github.com/sonic-net/sonic-mgmt/issues/22239

The same solution was done for `bgp_prefix_tc1_replace` in https://github.com/sonic-net/sonic-mgmt/pull/19521

Summary:
Fixes #22239 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
