### PR TITLE
Fix serial device prefix fallback value

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -3009,10 +3009,10 @@ Totals               6450                 6449
         Get the serial device prefix for the platform.
 
         Returns:
-            str: The device prefix (e.g., "/dev/C0-", "/dev/ttyUSB-")
+            str: The device prefix (e.g., "/dev/C0-", "/dev/ttyUSB")
         """
         # Reads udevprefix.conf from the platform directory to determine the correct device prefix
-        # Falls back to /dev/ttyUSB- if the config file doesn't exist
+        # Falls back to /dev/ttyUSB if the config file doesn't exist
         script = '''
 from sonic_py_common import device_info
 import os
@@ -3032,8 +3032,8 @@ print(device_prefix)
         res: ShellResult = self.shell(cmd, module_ignore_errors=True)
 
         if res['rc'] != 0 or not res['stdout'].strip():
-            logging.warning("Failed to get serial device prefix, using default /dev/ttyUSB-")
-            device_prefix = "/dev/ttyUSB-"
+            logging.warning("Failed to get serial device prefix, using default /dev/ttyUSB")
+            device_prefix = "/dev/ttyUSB"
         else:
             device_prefix = res['stdout'].strip()
 
@@ -3047,7 +3047,7 @@ print(device_prefix)
             port: Port number (e.g., 1, 2)
 
         Returns:
-            str: The full device path (e.g., "/dev/C0-1", "/dev/ttyUSB-1")
+            str: The full device path (e.g., "/dev/C0-1", "/dev/ttyUSB1")
         """
         device_prefix = self._get_serial_device_prefix()
         return f"{device_prefix}{port}"


### PR DESCRIPTION
### Description of PR

Summary:
Fix incorrect fallback value for serial device prefix in `_get_serial_device_prefix()`. Changed from `/dev/ttyUSB-` to `/dev/ttyUSB` to generate correct device paths (e.g., `/dev/ttyUSB1` instead of `/dev/ttyUSB-1`).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
When `udevprefix.conf` cannot be read, the fallback value `/dev/ttyUSB-` generates invalid device paths.

#### How did you do it?
Changed fallback from `/dev/ttyUSB-` to `/dev/ttyUSB` and updated related docstrings/comments.

#### How did you verify/test it?
Code review.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A