### PR TITLE
[infra][PR2] Fix parallel_run fork deadlock

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -1,3 +1,4 @@
+import ansible
 import datetime
 import logging
 import math
@@ -39,6 +40,10 @@ _forked_handlers_lock = threading.Lock()
 os.register_at_fork(before=logging._acquireLock,
                     after_in_parent=logging._releaseLock,
                     after_in_child=logging._releaseLock)
+display = ansible.utils.display.Display()
+os.register_at_fork(before=display._lock.acquire,
+                    after_in_parent=display._lock.release,
+                    after_in_child=display._lock.release)
 
 
 def fix_logging_handler_fork_lock():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The ansible `Display` lock can also be an orphaned lock in the child processes.
Let's do the same way as logging related locks (PR: https://github.com/sonic-net/sonic-mgmt/pull/22211) to prevent deadlock.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
