### PR TITLE
Add CLI and gNOI-based reboot validation to test_reboot

### DIFF
--- a/tests/common/ptf_grpc.py
+++ b/tests/common/ptf_grpc.py
@@ -382,13 +382,13 @@ class PtfGrpc:
 
         # Prepare request data
         request_data = "{}"  # Default empty JSON
-        extra_args = ["-d", "@"]
         if request:
             if isinstance(request, dict):
                 request_data = json.dumps(request)
             else:
                 request_data = str(request)
-        cmd = self._build_grpcurl_cmd(extra_args=extra_args, service_method=service_method)
+        # grpcurl does not read stdin unless -d @ is used
+        cmd = self._build_grpcurl_cmd(extra_args=["-d", "@"], service_method=service_method)
         result = self._execute_grpcurl(cmd, request_data)
 
         try:
@@ -416,7 +416,8 @@ class PtfGrpc:
             GrpcTimeoutError: If call times out
         """
         service_method = f"{service}/{method}"
-        cmd = self._build_grpcurl_cmd(service_method=service_method)
+        # grpcurl does not read stdin unless -d @ is used
+        cmd = self._build_grpcurl_cmd(extra_args=["-d", "@"], service_method=service_method)
 
         # Prepare request data
         request_data = "{}"  # Default empty JSON
@@ -520,7 +521,8 @@ class PtfGrpc:
             GrpcTimeoutError: If call times out
         """
         service_method = f"{service}/{method}"
-        cmd = self._build_grpcurl_cmd(service_method=service_method)
+        # grpcurl does not read stdin unless -d @ is used
+        cmd = self._build_grpcurl_cmd(extra_args=["-d", "@"], service_method=service_method)
 
         # Prepare multiple requests as newline-delimited JSON
         if not requests:


### PR DESCRIPTION
Extended the reboot test to support validation using both CLI-based and gNOI-based methods, providing more comprehensive coverage of different reboot mechanisms.

To run the tests:

./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c platform_tests/test_reboot.py::test_cold_reboot -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity" -l info

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To add test case for gNOI based cold reboot validation

#### How did you do it?
Extended the existing CLI-based reboot test to also test gNOI base by
adding fixtures.

#### How did you verify/test it?
v-cshekar@sonic-mgmt-chandra:/var/src/sonic-mgmt-int/tests$ ./run_tests.sh -n testbed-bjw3-can-t0-7060-7 -i ../ansible/veos,../ansible/bjw3 -u -m individual -c platform_tests/test_reboot.py::test_cold_reboot -e "--skip_sanity" -l info pkill: pattern that searches for process name longer than 15 characters will result in zero matches Try pkill -f' option to match against the complete command line.

INFO tests.common.plugins.memory_utilization:init.py:124 After test: collected memory_values {'before_test': {'bjw3-can-7060-7': {'monit': {'memory_usage': 52.5}, 'top': {'zebra': 39.0, 'bgpd': 72.7}, 'free': {'used': 4097}, 'docker': {'snmp': 0.8, 'pmon': 3.4, 'lldp': 0.8, 'gnmi': 0.8, 'radv': 0.4, 'syncd': 8.2, 'bgp': 2.5, 'teamd': 0.5, 'swss': 2.8, 'database': 0.8}, 'frr_bgp': {'used': 64.0}, 'frr_zebra': {'used': 46.0}}}, 'after_test': {'bjw3-can-7060-7': {'monit': {}, 'top': {'zebra': 23.2, 'bgpd': 63.3}, 'free': {'used': 3927}, 'docker': {'snmp': 0.8, 'pmon': 3.4, 'lldp': 0.8, 'gnmi': 0.8, 'radv': 0.4, 'syncd': 7.7, 'teamd': 0.5, 'bgp': 2.1, 'swss': 3.0, 'database': 0.8}, 'frr_bgp': {'used': 64.0}, 'frr_zebra': {'used': 47.0}}}}
tests/platform_tests/test_reboot.py::test_cold_reboot[gnoi_based-bjw3-can-7060-7] ✓ 50% █████
-------------------------------------------------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------------------------------------------------
INFO root:init.py:53 Completeness level not set during test execution. Setting to default level: 1
INFO root:init.py:151 Test has no defined levels. Continue without test completeness checks

INFO tests.conftest:conftest.py:2945 Dumping Disk and Memory Space information after test on bjw3-can-7060-7
INFO tests.conftest:conftest.py:2949 Collecting core dumps after test on bjw3-can-7060-7
INFO tests.conftest:conftest.py:2960 Collecting running config after test on bjw3-can-7060-7
INFO tests.conftest:conftest.py:3106 Core dump and config check passed for test_reboot.py
tests/platform_tests/test_reboot.py::test_cold_reboot[cli_based-bjw3-can-7060-7] ✓ 100% ██████████
=================================================================================================================== warnings summary ====================================================================================================================

Using KVM switch:
./run_tests.sh -n vms-kvm-t0 -d vlab-01 -c platform_tests/test_reboot.py::test_cold_reboot -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_sanity" -l info


#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
