### PR TITLE
Fix TLS certificate clock skew issue in gNOI tests

### DIFF
--- a/tests/common/cert_utils.py
+++ b/tests/common/cert_utils.py
@@ -1,0 +1,389 @@
+"""
+Certificate generation utilities for TLS testing.
+
+This module provides Python-native certificate generation using the cryptography
+library, replacing shell-based openssl commands for better control and reliability.
+
+Can be used for any TLS-based service testing: gNOI, gNMI, REST API, etc.
+"""
+import os
+import ipaddress
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple, List
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+class TlsCertificateGenerator:
+    """
+    Generate TLS certificates for testing.
+
+    This class generates a complete certificate chain (CA, server, client) with
+    configurable validity periods and Subject Alternative Names. By default,
+    certificates are backdated by 1 day to handle clock skew between test hosts.
+
+    Can be used for any TLS-based service: gNOI, gNMI, REST API, etc.
+
+    Attributes:
+        server_ip: IP address to include in server certificate SAN
+        validity_days: Number of days certificates are valid (default: 825)
+        backdate_days: Days to backdate not_valid_before (default: 1)
+
+    Example:
+        generator = TlsCertificateGenerator(server_ip="10.0.0.1")
+        generator.write_all("/tmp/certs")
+        # Creates: ca.crt, ca.key, server.crt, server.key, client.crt, client.key
+    """
+
+    # Default certificate file names
+    DEFAULT_CA_CERT = "ca.crt"
+    DEFAULT_CA_KEY = "ca.key"
+    DEFAULT_SERVER_CERT = "server.crt"
+    DEFAULT_SERVER_KEY = "server.key"
+    DEFAULT_CLIENT_CERT = "client.crt"
+    DEFAULT_CLIENT_KEY = "client.key"
+
+    # Default certificate subjects
+    DEFAULT_CA_CN = "test.ca.sonic"
+    DEFAULT_SERVER_CN = "test.server.sonic"
+    DEFAULT_CLIENT_CN = "test.client.sonic"
+
+    def __init__(
+        self,
+        server_ip: str,
+        validity_days: int = 825,
+        backdate_days: int = 1,
+        dns_names: Optional[List[str]] = None,
+        key_size: int = 2048,
+        ca_cn: Optional[str] = None,
+        server_cn: Optional[str] = None,
+        client_cn: Optional[str] = None,
+        ca_cert_name: Optional[str] = None,
+        ca_key_name: Optional[str] = None,
+        server_cert_name: Optional[str] = None,
+        server_key_name: Optional[str] = None,
+        client_cert_name: Optional[str] = None,
+        client_key_name: Optional[str] = None,
+    ):
+        """
+        Initialize the certificate generator.
+
+        Args:
+            server_ip: IP address to include in server certificate SAN
+            validity_days: Certificate validity period in days
+            backdate_days: Days to backdate not_valid_before to handle clock skew
+            dns_names: List of DNS names to include in server certificate SAN
+            key_size: RSA key size in bits
+            ca_cn: Common Name for CA certificate
+            server_cn: Common Name for server certificate
+            client_cn: Common Name for client certificate
+            ca_cert_name: Filename for CA certificate
+            ca_key_name: Filename for CA private key
+            server_cert_name: Filename for server certificate
+            server_key_name: Filename for server private key
+            client_cert_name: Filename for client certificate
+            client_key_name: Filename for client private key
+        """
+        self.server_ip = server_ip
+        self.validity_days = validity_days
+        self.backdate_days = backdate_days
+        self.dns_names = dns_names or ["localhost"]
+        self.key_size = key_size
+
+        # Certificate subject names (configurable)
+        self.ca_cn = ca_cn or self.DEFAULT_CA_CN
+        self.server_cn = server_cn or self.DEFAULT_SERVER_CN
+        self.client_cn = client_cn or self.DEFAULT_CLIENT_CN
+
+        # Certificate file names (configurable)
+        self.ca_cert_name = ca_cert_name or self.DEFAULT_CA_CERT
+        self.ca_key_name = ca_key_name or self.DEFAULT_CA_KEY
+        self.server_cert_name = server_cert_name or self.DEFAULT_SERVER_CERT
+        self.server_key_name = server_key_name or self.DEFAULT_SERVER_KEY
+        self.client_cert_name = client_cert_name or self.DEFAULT_CLIENT_CERT
+        self.client_key_name = client_key_name or self.DEFAULT_CLIENT_KEY
+
+        # Generated keys and certificates (populated by generate_all)
+        self._ca_key: Optional[rsa.RSAPrivateKey] = None
+        self._ca_cert: Optional[x509.Certificate] = None
+        self._server_key: Optional[rsa.RSAPrivateKey] = None
+        self._server_cert: Optional[x509.Certificate] = None
+        self._client_key: Optional[rsa.RSAPrivateKey] = None
+        self._client_cert: Optional[x509.Certificate] = None
+
+    def _generate_key(self) -> rsa.RSAPrivateKey:
+        """Generate an RSA private key."""
+        return rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=self.key_size,
+        )
+
+    def _get_validity_period(self) -> Tuple[datetime, datetime]:
+        """Get certificate validity period with backdating for clock skew tolerance."""
+        now = datetime.now(timezone.utc)
+        not_valid_before = now - timedelta(days=self.backdate_days)
+        not_valid_after = now + timedelta(days=self.validity_days)
+        return not_valid_before, not_valid_after
+
+    def _generate_ca(self) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+        """Generate CA certificate and key."""
+        key = self._generate_key()
+        not_valid_before, not_valid_after = self._get_validity_period()
+
+        subject = issuer = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, self.ca_cn),
+        ])
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    key_encipherment=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .sign(key, hashes.SHA256())
+        )
+
+        return key, cert
+
+    def _generate_server(
+        self, ca_key: rsa.RSAPrivateKey, ca_cert: x509.Certificate
+    ) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+        """Generate server certificate signed by CA."""
+        key = self._generate_key()
+        not_valid_before, not_valid_after = self._get_validity_period()
+
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, self.server_cn),
+        ])
+
+        # Build SAN with DNS names and server IP address
+        san_entries = [x509.DNSName(name) for name in self.dns_names]
+        san_entries.append(x509.IPAddress(ipaddress.ip_address(self.server_ip)))
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(ca_cert.subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+            .add_extension(
+                x509.SubjectAlternativeName(san_entries),
+                critical=False,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_encipherment=True,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False,
+            )
+            .sign(ca_key, hashes.SHA256())
+        )
+
+        return key, cert
+
+    def _generate_client(
+        self, ca_key: rsa.RSAPrivateKey, ca_cert: x509.Certificate
+    ) -> Tuple[rsa.RSAPrivateKey, x509.Certificate]:
+        """Generate client certificate signed by CA."""
+        key = self._generate_key()
+        not_valid_before, not_valid_after = self._get_validity_period()
+
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, self.client_cn),
+        ])
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(ca_cert.subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(not_valid_before)
+            .not_valid_after(not_valid_after)
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    key_encipherment=True,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    content_commitment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH]),
+                critical=False,
+            )
+            .sign(ca_key, hashes.SHA256())
+        )
+
+        return key, cert
+
+    def generate_all(self) -> None:
+        """Generate complete certificate chain (CA, server, client)."""
+        self._ca_key, self._ca_cert = self._generate_ca()
+        self._server_key, self._server_cert = self._generate_server(
+            self._ca_key, self._ca_cert
+        )
+        self._client_key, self._client_cert = self._generate_client(
+            self._ca_key, self._ca_cert
+        )
+
+    def _serialize_cert(self, cert: x509.Certificate) -> bytes:
+        """Serialize certificate to PEM format."""
+        return cert.public_bytes(serialization.Encoding.PEM)
+
+    def _serialize_key(self, key: rsa.RSAPrivateKey) -> bytes:
+        """Serialize private key to PEM format (unencrypted)."""
+        return key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    def write_all(self, output_dir: str) -> None:
+        """
+        Generate and write all certificates to the specified directory.
+
+        Args:
+            output_dir: Directory to write certificate files
+
+        Creates files based on configured names (defaults shown):
+            - ca.crt, ca.key (CA certificate and key)
+            - server.crt, server.key (Server certificate and key)
+            - client.crt, client.key (Client certificate and key)
+        """
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Generate all certificates
+        self.generate_all()
+
+        # Write CA files
+        with open(os.path.join(output_dir, self.ca_cert_name), "wb") as f:
+            f.write(self._serialize_cert(self._ca_cert))
+        with open(os.path.join(output_dir, self.ca_key_name), "wb") as f:
+            f.write(self._serialize_key(self._ca_key))
+
+        # Write server files
+        with open(os.path.join(output_dir, self.server_cert_name), "wb") as f:
+            f.write(self._serialize_cert(self._server_cert))
+        with open(os.path.join(output_dir, self.server_key_name), "wb") as f:
+            f.write(self._serialize_key(self._server_key))
+
+        # Write client files
+        with open(os.path.join(output_dir, self.client_cert_name), "wb") as f:
+            f.write(self._serialize_cert(self._client_cert))
+        with open(os.path.join(output_dir, self.client_key_name), "wb") as f:
+            f.write(self._serialize_key(self._client_key))
+
+    def get_client_cn(self) -> str:
+        """Return the client certificate Common Name (e.g., for GNMI_CLIENT_CERT config)."""
+        return self.client_cn
+
+    def get_cert_bytes(self) -> dict:
+        """
+        Get all certificates and keys as bytes (for in-memory usage).
+
+        Returns:
+            Dict with keys: ca_cert, ca_key, server_cert, server_key,
+                           client_cert, client_key
+        """
+        if self._ca_cert is None:
+            self.generate_all()
+
+        return {
+            "ca_cert": self._serialize_cert(self._ca_cert),
+            "ca_key": self._serialize_key(self._ca_key),
+            "server_cert": self._serialize_cert(self._server_cert),
+            "server_key": self._serialize_key(self._server_key),
+            "client_cert": self._serialize_cert(self._client_cert),
+            "client_key": self._serialize_key(self._client_key),
+        }
+
+
+def create_gnmi_cert_generator(server_ip: str, **kwargs) -> TlsCertificateGenerator:
+    """
+    Factory function to create a certificate generator with gNMI/gNOI naming conventions.
+
+    This preserves backward compatibility with existing file naming (gnmiCA.cer,
+    gnmiserver.cer, etc.) while using the generic TlsCertificateGenerator.
+
+    Args:
+        server_ip: IP address of the server (DUT) to include in server cert SAN
+        **kwargs: Additional arguments passed to TlsCertificateGenerator
+
+    Returns:
+        TlsCertificateGenerator configured with gNMI naming conventions
+
+    Example:
+        generator = create_gnmi_cert_generator(server_ip="10.0.0.1")
+        generator.write_all("/tmp/gnoi_certs")
+        # Creates: gnmiCA.cer, gnmiCA.key, gnmiserver.cer, gnmiserver.key,
+        #          gnmiclient.cer, gnmiclient.key
+    """
+    gnmi_defaults = {
+        "ca_cn": "test.gnmi.sonic",
+        "server_cn": "test.server.gnmi.sonic",
+        "client_cn": "test.client.gnmi.sonic",
+        "ca_cert_name": "gnmiCA.cer",
+        "ca_key_name": "gnmiCA.key",
+        "server_cert_name": "gnmiserver.cer",
+        "server_key_name": "gnmiserver.key",
+        "client_cert_name": "gnmiclient.cer",
+        "client_key_name": "gnmiclient.key",
+        "dns_names": ["hostname.com"],
+    }
+
+    # User-provided kwargs override defaults
+    gnmi_defaults.update(kwargs)
+
+    return TlsCertificateGenerator(server_ip=server_ip, **gnmi_defaults)

--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -4,6 +4,7 @@ Pytest fixtures for gRPC clients (gNOI, gNMI, etc.)
 This module provides pytest fixtures for easy access to gRPC clients with
 automatic configuration discovery, making it simple to write gRPC-based tests.
 """
+import os
 import pytest
 import logging
 from tests.common.grpc_config import grpc_config
@@ -176,7 +177,7 @@ def ptf_gnmi(ptf_grpc):
 
 
 @pytest.fixture(scope="module")
-def setup_gnoi_tls_server(duthost, localhost, ptfhost):
+def setup_gnoi_tls_server(duthost, ptfhost):
     """
     Set up gNOI server with TLS certificates and configuration.
 
@@ -185,7 +186,7 @@ def setup_gnoi_tls_server(duthost, localhost, ptfhost):
 
     The fixture:
     1. Creates a configuration checkpoint for rollback
-    2. Generates TLS certificates with proper SAN for DUT IP
+    2. Generates TLS certificates with proper SAN for DUT IP (backdated to handle clock skew)
     3. Distributes certificates to DUT and PTF container
     4. Configures CONFIG_DB for TLS mode (port 50052)
     5. Restarts the gNOI server process
@@ -194,7 +195,6 @@ def setup_gnoi_tls_server(duthost, localhost, ptfhost):
 
     Args:
         duthost: DUT host instance to configure
-        localhost: Localhost instance for certificate generation
         ptfhost: PTF host instance for client certificates
 
     Usage:
@@ -207,10 +207,14 @@ def setup_gnoi_tls_server(duthost, localhost, ptfhost):
     Note:
         Client fixtures (ptf_grpc, ptf_gnoi) automatically adapt to TLS mode
         when this fixture is active through GNMIEnvironment detection.
+
+        Certificates are backdated by 1 day to handle clock skew between
+        the test host, DUT, and PTF container.
     """
     from tests.common.gu_utils import create_checkpoint, rollback
 
     checkpoint_name = "gnoi_tls_setup"
+    cert_dir = "/tmp/gnoi_certs"
 
     logger.info("Setting up gNOI TLS server environment")
 
@@ -218,8 +222,8 @@ def setup_gnoi_tls_server(duthost, localhost, ptfhost):
     create_checkpoint(duthost, checkpoint_name)
 
     try:
-        # 2. Generate certificates
-        _create_gnoi_certs(duthost, localhost, ptfhost)
+        # 2. Generate and distribute certificates
+        _create_gnoi_certs(duthost, ptfhost, cert_dir)
 
         # 3. Configure server for TLS mode
         _configure_gnoi_tls_server(duthost)
@@ -243,59 +247,32 @@ def setup_gnoi_tls_server(duthost, localhost, ptfhost):
             logger.error(f"Failed to rollback configuration: {e}")
 
         try:
-            _delete_gnoi_certs(localhost)
+            _delete_gnoi_certs(cert_dir)
             logger.info("Certificate cleanup completed")
         except Exception as e:
             logger.error(f"Failed to cleanup certificates: {e}")
 
 
-def _create_gnoi_certs(duthost, localhost, ptfhost):
-    """Generate gNOI TLS certificates with proper SAN for DUT IP."""
+def _create_gnoi_certs(duthost, ptfhost, cert_dir):
+    """
+    Generate and distribute gNOI TLS certificates.
+
+    Certificates are backdated by 1 day to handle clock skew between hosts.
+
+    Args:
+        duthost: DUT host instance (for IP and copying server certs)
+        ptfhost: PTF host instance (for copying client certs)
+        cert_dir: Local directory to store generated certificates
+    """
+    from tests.common.cert_utils import create_gnmi_cert_generator
+
     logger.info("Generating gNOI TLS certificates")
 
-    # Create all certificate files in /tmp to avoid polluting working directory
-    cert_dir = "/tmp/gnoi_certs"
-    localhost.shell(f"mkdir -p {cert_dir}")
-    localhost.shell(f"cd {cert_dir}")
+    # Generate certificates with 1-day backdating to handle clock skew
+    generator = create_gnmi_cert_generator(server_ip=duthost.mgmt_ip)
+    generator.write_all(cert_dir)
 
-    # Create Root key
-    localhost.shell(f"cd {cert_dir} && openssl genrsa -out gnmiCA.key 2048")
-
-    # Create Root cert
-    localhost.shell(f"""cd {cert_dir} && openssl req -x509 -new -nodes -key gnmiCA.key -sha256 -days 1825 \
-                       -subj '/CN=test.gnmi.sonic' -out gnmiCA.cer""")
-
-    # Create server key
-    localhost.shell(f"cd {cert_dir} && openssl genrsa -out gnmiserver.key 2048")
-
-    # Create server CSR
-    localhost.shell(f"""cd {cert_dir} && openssl req -new -key gnmiserver.key \
-                       -subj '/CN=test.server.gnmi.sonic' -out gnmiserver.csr""")
-
-    # Create extension file with DUT IP SAN
-    ext_conf_content = f"""[ req_ext ]
-subjectAltName = @alt_names
-[alt_names]
-DNS.1   = hostname.com
-IP      = {duthost.mgmt_ip}"""
-
-    localhost.shell(f"cd {cert_dir} && echo '{ext_conf_content}' > extfile.cnf")
-
-    # Sign server certificate with SAN extension
-    localhost.shell(f"""cd {cert_dir} && openssl x509 -req -in gnmiserver.csr -CA gnmiCA.cer -CAkey gnmiCA.key \
-                       -CAcreateserial -out gnmiserver.cer -days 825 -sha256 \
-                       -extensions req_ext -extfile extfile.cnf""")
-
-    # Create client key
-    localhost.shell(f"cd {cert_dir} && openssl genrsa -out gnmiclient.key 2048")
-
-    # Create client CSR
-    localhost.shell(f"""cd {cert_dir} && openssl req -new -key gnmiclient.key \
-                       -subj '/CN=test.client.gnmi.sonic' -out gnmiclient.csr""")
-
-    # Sign client certificate
-    localhost.shell(f"""cd {cert_dir} && openssl x509 -req -in gnmiclient.csr -CA gnmiCA.cer -CAkey gnmiCA.key \
-                       -CAcreateserial -out gnmiclient.cer -days 825 -sha256""")
+    logger.info(f"Certificates generated in {cert_dir}")
 
     # Get certificate copy destinations from centralized config
     copy_destinations = grpc_config.get_cert_copy_destinations()
@@ -397,10 +374,12 @@ def _verify_gnoi_tls_connectivity(duthost, ptfhost):
     logger.info("TLS connectivity verification completed successfully")
 
 
-def _delete_gnoi_certs(localhost):
+def _delete_gnoi_certs(cert_dir):
     """Clean up generated certificate files."""
+    import shutil
+
     logger.info("Cleaning up certificate files")
 
-    # Remove the entire certificate directory in /tmp
-    cert_dir = "/tmp/gnoi_certs"
-    localhost.shell(f"rm -rf {cert_dir}", module_ignore_errors=True)
+    # Remove the entire certificate directory
+    if os.path.exists(cert_dir):
+        shutil.rmtree(cert_dir, ignore_errors=True)


### PR DESCRIPTION
### Description of PR

Replace shell-based openssl certificate generation with Python cryptography library. Certificates are now backdated by 1 day to handle clock skew between test host, DUT, and PTF container.

This fixes the TLS verification error:
```
tls: failed to verify certificate: x509: certificate has expired or is not yet valid: 
current time 2026-02-04T19:53:53Z is before 2026-02-04T19:54:02Z
```

**Summary:**
- Add `tests/common/cert_utils.py` with generic `TlsCertificateGenerator` class
- Add `create_gnmi_cert_generator()` factory for gNMI/gNOI naming conventions
- Update `grpc_fixtures.py` to use Python-based cert generation
- Remove `localhost` fixture dependency from `setup_gnoi_tls_server`

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

When the clocks between the sonic-mgmt container (where certificates are generated), DUT, and PTF container are not perfectly synchronized, TLS certificate verification fails with "certificate has expired or is not yet valid" errors. This happens because `openssl` sets the certificate's `notBefore` timestamp to the current time, and if any host's clock is slightly behind, the certificate appears "not yet valid."

#### How did you do it?

1. Created a new `TlsCertificateGenerator` class using Python's `cryptography` library that:
   - Generates CA, server, and client certificates programmatically
   - Backdates the `not_valid_before` field by 1 day (configurable) to tolerate clock skew
   - Is generic and reusable for any TLS service (gNOI, gNMI, REST API, etc.)

2. Added `create_gnmi_cert_generator()` factory function that configures the generator with existing gNMI/gNOI naming conventions (gnmiCA.cer, gnmiserver.cer, etc.)

3. Updated `_create_gnoi_certs()` in `grpc_fixtures.py` to use the new Python-based generator instead of shell `openssl` commands

4. Removed the `localhost` fixture dependency since certificate generation now happens directly in Python

#### How did you verify/test it?

- Verified the `cryptography` library is available in the sonic-mgmt container (v41.0.7)
- Tested certificate generation in the container, confirming certificates are backdated by 1 day
- Verified generated certificates have correct PEM format and expected CN/SAN values

#### Any platform specific information?

N/A - This is a test framework change that works across all platforms.

#### Supported testbed topology if it's a new test case?

N/A - This is a fix to existing test infrastructure.

### Documentation

N/A