### PR TITLE
check detect time samples before accessing list by index in test_pfcw…

### DIFF
--- a/tests/pfcwd/test_pfcwd_timer_accuracy.py
+++ b/tests/pfcwd/test_pfcwd_timer_accuracy.py
@@ -271,6 +271,22 @@ class TestPfcwdAllTimer(object):
                     )
                     break
 
+        # Validate that we have enough samples before accessing list by index
+        # If more than half of iterations failed to collect timestamps, fail with a clear message
+        required_samples = check_point + 1
+        detect_count = len(self.all_detect_time)
+        restore_count = len(self.all_restore_time)
+        if detect_count < required_samples or restore_count < required_samples:
+            detect_failures = ITERATION_NUM - detect_count
+            restore_failures = ITERATION_NUM - restore_count
+            pytest.fail(
+                "Too many iterations failed to collect PFCWD timestamps. "
+                "Detect time samples: {}/{} (failures: {}), Restore time samples: {}/{} (failures: {}). "
+                "Required at least {} samples. This may indicate environment or timing issues.".format(
+                    detect_count, ITERATION_NUM, detect_failures,
+                    restore_count, ITERATION_NUM, restore_failures,
+                    required_samples))
+
         err_msg = ("Real detection time is greater than configured: Real detect time: {} "
                    "Expected: {} (wd_detect_time + wd_poll_time)".format(self.all_detect_time[check_point],
                                                                          config_detect_time))


### PR DESCRIPTION
…d_timer_accuracy

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
36117223
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The error message “IndexError: list index out of range” is unclear and potentially misleading.

#### How did you do it?
Modify the output error message, check the timestamp sample before accessing the list

#### How did you verify/test it?
run elastic test
202505
https://elastictest.org/scheduler/testplan/69841fb948d58f009f2c7154

202511
https://elastictest.org/scheduler/testplan/69842120bb7d1dad4c803d16

inject failure
https://elastictest.org/scheduler/testplan/698482c1bb7d1dad4c803dc8
```
>           pytest.fail(
                "Too many iterations failed to collect PFCWD timestamps. "
                "Detect time samples: {}/{} (failures: {}), Restore time samples: {}/{} (failures: {}). "
                "Required at least {} samples. This may indicate environment or timing issues.".format(
                    detect_count, ITERATION_NUM, detect_failures,
                    restore_count, ITERATION_NUM, restore_failures,
                    required_samples))
E           Failed: Too many iterations failed to collect PFCWD timestamps. Detect time samples: 0/20 (failures: 20), Restore time samples: 0/20 (failures: 20). Required at least 10 samples. This may indicate environment or timing issues.
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
