### PR TITLE
console port config fix if create_duthost_console

### DIFF
--- a/tests/common/helpers/dut_utils.py
+++ b/tests/common/helpers/dut_utils.py
@@ -436,7 +436,11 @@ def create_duthost_console(duthost, localhost, conn_graph_facts, creds):  # noqa
     console_device = conn_graph_facts['device_console_link'][dut_hostname]['ConsolePort']['peerdevice']
 
     console_type = f"console_{console_type}"
-    console_menu_type = f"{console_type}_{console_menu_type}"
+
+    if console_menu_type and console_menu_type.lower() != "n/a":
+        console_menu_type = f"{console_type}_{console_menu_type}"
+    else:
+        console_menu_type = console_type
 
     # console password and sonic_password are lists, which may contain more than one password
     sonicadmin_alt_password = localhost.host.options['variable_manager']._hostvars[dut_hostname].get(


### PR DESCRIPTION
### Description of PR
[component/folder touched] 

Fixes #22218
Fixes console_telnet
https://github.com/sonic-net/sonic-mgmt/issues/22218

**Info**
when calling create_duthost_console, the current logic wont be as CONSOLE_TELNET = "console_telnet"

https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/helpers/dut_utils.py#L438
current logic, CONSOLE_TELNET will be "console_telnet_telnet"
wont be CONSOLE_TELNET = "console_telnet"

https://github.com/sonic-net/sonic-mgmt/blob/master/tests/common/connections/base_console_conn.py#L22
CONSOLE_TELNET = "console_telnet"
CONSOLE_SSH = "console_ssh"

**Example:**
if configing on
sonic@sonic-ucs-m5-4:/data$ cat ./ansible/files/sonic_lab_console_links.csv

StartDevice,StartPort,EndDevice,Console_type,Console_menu_type,Proxy,BaudRate
console-1,10,sfd-t2-sup,ssh,ssh,,115200
....
console-vt2,2003,sfd-vt2-sup,telnet,telnet,,115200
=>
console-vt2,2003,sfd-vt2-sup,telnet,,,115200

**Summary**
Fixes # (issue)
adding auto-tech since option from 2 days ago(default) to 1hr


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [X] 202405
- [X] 202411
- [X] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
create a new testcase for mgmt port flap and need console port to send command
since ssh connection will be lost during the test.

#### How did you do it?

#### How did you verify/test it?
Yes

#### Any platform specific information?
reproduce rate 100%;  

#### Supported testbed topology if it's a new test case?
Generic issue

### Documentation
