### PR TITLE
Increase timeout for `check_rule_active` from 60s to 120s

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1017,7 +1017,7 @@ class BaseEverflowTest(object):
         duthost.shell("config load -y {}".format(dest_path))
 
         if duthost.facts['asic_type'] != 'vs':
-            pytest_assert(wait_until(120, 2, 0, self.check_rule_active, duthost, table_name),
+            pytest_assert(wait_until(150, 2, 0, self.check_rule_active, duthost, table_name),
                           "Acl rule counters are not ready")
 
     def apply_ip_type_rule(self, duthost, ip_version):

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -1017,7 +1017,7 @@ class BaseEverflowTest(object):
         duthost.shell("config load -y {}".format(dest_path))
 
         if duthost.facts['asic_type'] != 'vs':
-            pytest_assert(wait_until(60, 2, 0, self.check_rule_active, duthost, table_name),
+            pytest_assert(wait_until(120, 2, 0, self.check_rule_active, duthost, table_name),
                           "Acl rule counters are not ready")
 
     def apply_ip_type_rule(self, duthost, ip_version):


### PR DESCRIPTION
We've seen that acl rule installation can take a while as discussed in https://github.com/sonic-net/sonic-mgmt/issues/21988

This `check_rule_active/check_rule_counters` code was added in https://github.com/sonic-net/sonic-mgmt/pull/21384
but it never worked on DNX due to unsupported SAI calls: https://github.com/sonic-net/sonic-buildimage/issues/24665

Now that we're working around this issue with:
https://github.com/sonic-net/sonic-mgmt/pull/22237
We're starting to run into timeouts waiting for ACL rules: `Failed: Acl rule counters are not ready`

Here are the logs from a failing run where you can see the time it takes for the last ACL rule to be installed takes more than 60s:
```
2026 Feb  5 03:44:23.106324 ctn101 INFO python[509061]: ansible-ansible.legacy.command Invoked with _raw_params=acl-loader update full /tmp/everflow/acl-erspan.json --table_name EVERFLOW_EGRESSV6 --session_name test_session_1 --mirror_stage egress
2026 Feb  5 03:44:27.267227 ctn101 INFO python[509601]: ansible-ansible.legacy.command Invoked with _raw_params=config load -y /tmp/everflow/acl_config.json

...

2026 Feb  5 03:46:22.380011 ctn101 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_9 in table EVERFLOW_EGRESSV6
```

We're also increasing the timeout from 60s to 120s for the acl rules in the acl/ package tests here:
https://github.com/sonic-net/sonic-mgmt/pull/21760

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
