### PR TITLE
Fix match packet payload method for Marvell platforms in everflow_policer_test.py

### DIFF
--- a/ansible/roles/test/files/acstests/everflow_policer_test.py
+++ b/ansible/roles/test/files/acstests/everflow_policer_test.py
@@ -289,8 +289,8 @@ class EverflowPolicerTest(BaseTest):
             elif self.asic_type in ["marvell-teralynx"] or \
                     self.hwsku in ["rd98DX35xx_cn9131", "rd98DX35xx"] or \
                     self.hwsku.startswith("Nokia-7215-A1"):
-                pkt = scapy.Ether(pkt)[scapy.GRE].payload
-                pkt = scapy.Ether(pkt[8:])
+                pkt = bytes(scapy.Ether(pkt)[scapy.GRE].payload)  # Get the scapy packet GRE payload and convert to bytes for slicing operation
+                pkt = scapy.Ether(pkt[8:])  # Mask the ERSPAN II header (8 bytes)
             elif self.asic_type == "barefoot":
                 pkt = scapy.Ether(pkt).load
             elif self.asic_type == "cisco-8000":


### PR DESCRIPTION
### Description of PR

Fixed IndexError in `everflow_policer_test.py` when parsing GRE payload for Marvell and Nokia platforms. The `match_payload()` function was failing because it attempted to slice a Scapy layer object instead of raw bytes.

Scapy automatically parsed the GRE payload as an ERSPAN_II layer object, not raw bytes. When you do pkt[8:] on a Scapy layer object, it doesn't slice bytes—it returns the 8th layer (which doesn't exist), hence we get IndexError on Layer number 8.

Summary:
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The Everflow policer test fails on Marvell and Nokia platforms with the following error:
```
ERROR: everflow_policer_test.EverflowPolicerTest
@summary: Run EVERFLOW Policer Test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/acstests/everflow_policer_test.py", line 339, in runTest
    rx_pkts, tx_pps, rx_pps = self.checkMirroredFlow()
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/acstests/everflow_policer_test.py", line 300, in checkMirroredFlow
    if rcv_pkt is not None and match_payload(rcv_pkt):
                               ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/acstests/everflow_policer_test.py", line 279, in match_payload
    pkt = scapy.Ether(pkt[8:])
                      ~~~^^^^
  File "/root/env-python3/lib/python3.11/site-packages/scapy/packet.py", line 1327, in __getitem__
    raise IndexError("Layer [%s] not found" % name)
IndexError: Layer [8] not found
```

#### How did you do it?

Convert the GRE payload to bytes before slicing by wrapping it with `bytes()`:

```
pkt = bytes(scapy.Ether(pkt)[scapy.GRE].payload)
pkt = scapy.Ether(pkt[8:])
```

#### How did you verify/test it?
1. Ran the Everflow policer test on the affected platform
2. Added debug logging to capture and analyze packets using base64 encoding
3. Verified that:
   - GRE payload type was `<class 'scapy.contrib.erspan.ERSPAN_II'>` (layer object, not bytes)
   - After the fix, the inner Ethernet frame is correctly extracted
   - The `match_payload()` function returns successfully
   - The Everflow policer test passes

Debug prints:

```
exp_pkt base64: AAECAwQF4MsZdEtwCABFIACIAAAAAAQvsCIBAQEBAgICAgAAiL4AAAAAAAAAAAAAAADgyxl0S3C4yjrsoAAIAEUkAFYAAQAAQAZIfBQAAAEeAAABEjQAUAAAAAAAAAAAUAIgAE8cAAAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywt
masked_exp_pkt base64: AAECAwQF4MsZdEtwCABFIACIAAAAAAQvsCIBAQEBAgICAgAAiL4AAAAAAAAAAAAAAADgyxl0S3C4yjrsoAAIAEUkAFYAAQAAQAZIfBQAAAEeAAABEjQAUAAAAAAAAAAAUAIgAE8cAAAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywt
rcv_pkt base64: KhjFFpnW4MsZdEtwCABFIACIAAAAAAQvsCIBAQEBAgICAhAAiL4AAAQ+EAAYAAAAADHgyxl0S3C4yjrsoAAIAEUkAFYAAQAAQAZIfBQAAAEeAAABEjQAUAAAAAAAAAAAUAIgAE8cAAAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywt
GRE payload type: <class 'scapy.contrib.erspan.ERSPAN_II'>
GRE payload: ERSPAN_II / Ether / IP / TCP 20.0.0.1:4660 > 30.0.0.1:http S / Raw
GRE payload bytes: b'\x10\x00\x18\x00\x00\x00\x001\xe0\xcb\x19tKp\xb8\xca:\xec\xa0\x00\x08\x00E$\x00V\x00\x01\x00\x00@\x06H|\x14\x00\x00\x01\x1e\x00\x00\x01\x124\x00P\x00\x00\x00\x00'
```

Observing the GRE payload bytes (mask ERSPAN II 8 bytes):

```
b'\x10\x00\x18\x00\x00\x00\x001\xe0\xcb\x19tKp...'
     ↑________________________↑  ↑_______________
         ERSPAN_II header        Inner Ethernet
            (8 bytes)              starts here
```


#### Any platform specific information?

This fix applies to the following platforms:
- `marvell-teralynx` 
- `rd98DX35xx_cn9131`
- `rd98DX35xx` 
- Nokia-7215-A1 series (HWSKUs starting with `Nokia-7215-A1`)

#### Supported testbed topology if it's a new test case?
N/A - This is a bug fix for an existing test.

### Documentation
N/A - Bug fix only, no new features or test cases.