### PR TITLE
Add cleanup to dns/static_dns_test_static_dns.py

### DIFF
--- a/tests/dns/static_dns/test_static_dns.py
+++ b/tests/dns/static_dns/test_static_dns.py
@@ -5,6 +5,7 @@ import re
 
 from tests.common.reboot import reboot
 from tests.common.config_reload import config_reload
+from tests.common.fixtures.duthost_utils import backup_and_restore_config_db  # noqa F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
@@ -58,7 +59,7 @@ def stop_dhclient(duthost):
 
 
 @pytest.mark.disable_loganalyzer
-def test_static_dns_basic(request, duthost, localhost, mgmt_interfaces):
+def test_static_dns_basic(request, duthost, localhost, backup_and_restore_config_db, mgmt_interfaces): # noqa F811
     """
     Basic test for the Static DNS
     :param duthost: DUT host object


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix `dns/static_dns/test_static_dns.py` not fully cleaning up the DUT state after tests.

There are 2 places where permanent change to the DUT state is done:
1. When `config save -y` is run in `test_static_dns_basic` without backing up the original `/etc/sonic/config_db.json`.
- This is fixed by adding the fixture to backup and restore config_db

2. When an instance of `dhclient` is started in `test_dynamic_dns_not_working_when_static_ip_configured`, which permanently changes the mgmt ip address.
- This is fixed by running `config_reload` after the test. Note: simply changing via `iptable` commands do not work - a `config_reload` is needed to restore the DUT properly.

Fixes #22270

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202412
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Some tests are failing (`test_configurable_drop_counters.py`) when run after `dns/static_dns/test_static_dns.py`.

#### How did you do it?
Add clean up steps to ensure the DUT is recovered to the state before `dns/static_dns/test_static_dns.py` is run.

#### How did you verify/test it?
`test_configurable_drop_counters.py` no longer fails when run after `dns/static_dns/test_static_dns.py`.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
