### PR TITLE
Extend cacl/test_cacl_function.py test state duration

### DIFF
--- a/ansible/roles/test/files/helpers/config_service_acls.sh
+++ b/ansible/roles/test/files/helpers/config_service_acls.sh
@@ -105,7 +105,7 @@ logger -t cacltest "added cacl test rules"
 iptables -nL | logger -t cacltest
 
 # Sleep to allow Ansible playbook ample time to attempt to connect and timeout
-sleep 150
+sleep 250
 
 # Delete the test ACL config file
 rm -rf /tmp/testacl.json

--- a/tests/cacl/test_cacl_function.py
+++ b/tests/cacl/test_cacl_function.py
@@ -109,7 +109,7 @@ def test_cacl_function(duthosts, enum_rand_one_per_hwsku_hostname, localhost, cr
                                  state='started',
                                  search_regex=SONIC_SSH_REGEX,
                                  delay=0,
-                                 timeout=110,
+                                 timeout=210,
                                  module_ignore_errors=True)
 
         pytest_assert(not res.is_failed, "SSH did not start working when expected. {}".format(res.get('msg', '')))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Currently, `cacl/test_cacl_function.py` is flaky on large topos.
The cause is due to a hardcoded time used for determining when to revert the service acl changes on the DUT - the test state is reverted before the test is done running.

Fix by extending the duration where the DUT remains in the test state.

Fixes #22271
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
`cacl/test_cacl_function.py` is flaky on large topos.

#### How did you do it?
Extend the duration of the test state on the DUT.

#### How did you verify/test it?
Test is no longer flaky.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
