### PR TITLE
Fixes in test_add_cluster.py

### DIFF
--- a/tests/common/gu_utils.py
+++ b/tests/common/gu_utils.py
@@ -17,7 +17,8 @@ GCU_FIELD_OPERATION_CONF_FILE = "gcu_field_operation_validators.conf.json"
 GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
 GCUTIMEOUT_MAP = {
     'armhf-nokia_ixs7215_52x-r0': 1200,
-    'x86_64-nvidia_sn5640-r0': 3600  # Increase timeout due to issue #22370
+    'x86_64-nvidia_sn5640-r0': 3600,  # Increase timeout due to issue #22370
+    'x86_64-nokia_ixr7250e_36x400g-r0': 1600
 }
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # ([22274](https://github.com/sonic-net/sonic-mgmt/issues/22274))
Bug fix addressing issues in generic_config_updater/add_cluster/test_port_speed_change.py:

- Handle both base and IP prefix entries for PORTCHANNEL_INTERFACE.

- Update the GCUTIMEOUT_MAP configuration by adding a new timeout entry.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Related to ADO: [36655318](https://msazure.visualstudio.com/One/_workitems/edit/36655318).
Bug fix addressing issues in generic_config_updater/add_cluster/test_port_speed_change.py.

#### How did you do it?
- Fix a SyntaxError when retrieving PORTCHANNEL.
- Update the timeout configuration in the apply_patch function.
- Enhance the PORTCHANNEL_INTERFACE deletion logic to resolve the error: “Failed: Yang validation failed after config_reload”.


#### How did you verify/test it?
Tests passed: https://elastictest.org/scheduler/testplan/69844582efa0332370b983e6

#### Any platform specific information?


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
