### PR TITLE
Reset the teamd failed state counter in case test_encap_with_mirror_s…

### DIFF
--- a/tests/dualtor/test_ipinip.py
+++ b/tests/dualtor/test_ipinip.py
@@ -234,6 +234,8 @@ def setup_uplink(rand_selected_dut, tbinfo, enable_feature_autorestart):
         time.sleep(5)
         # Unmask the service
         rand_selected_dut.shell_cmds(cmds="systemctl unmask teamd")
+        # Reset failed state counter to avoid start-limit-hit issue
+        rand_selected_dut.shell_cmds(cmds="systemctl reset-failed teamd.service")
         # Restart teamd
         rand_selected_dut.shell_cmds(cmds="systemctl restart teamd")
         _wait_portchannel_up(rand_selected_dut, up_portchannel)


### PR DESCRIPTION
Summary: Reset the teamd failed state counter in case test_encap_with_mirror_session
Fixes #
teamd service has start limit with value of `StartLimitBurst=3` and `StartLimitIntervalUSec=20min`, which means teamd service cannot start if it restarts more than 3 times within 20 minutes.
To avoid this issue, we reset the systemd failed state counter before service restart.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
