### PR TITLE
Stabilize the advanced reboot test and small bug fixes

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
+++ b/ansible/roles/test/files/ptftests/py3/advanced-reboot.py
@@ -295,7 +295,7 @@ class ReloadTest(BaseTest):
 
         self.sender_thr = threading.Thread(target=self.send_in_background)
         self.sniff_thr = threading.Thread(target=self.sniff_in_background)
-        self.start_sender_delay = 30
+        self.start_sender_delay = 60
 
         # Check if platform type is kvm
         stdout, stderr, return_code = self.dut_connection.execCommand(
@@ -1905,7 +1905,7 @@ class ReloadTest(BaseTest):
             # So now:
             # 1. sniffer max timeout is increased (to prevent sniffer finish before sender)
             # 2. and sender can signal sniffer to end after all packets are sent.
-            time.sleep(1)
+            time.sleep(15)
             self.kill_sniffer = True
 
     def sniff_in_background(self, wait=None):
@@ -1917,7 +1917,7 @@ class ReloadTest(BaseTest):
         if not wait:
             wait = self.time_to_listen + self.test_params['sniff_time_incr']
         sniffer_start = datetime.datetime.now()
-        self.log("Sniffer started at %s" % str(sniffer_start))
+        self.log("Starting sniffer thread at %s" % str(sniffer_start))
         sniff_filter = "tcp and tcp dst port 5000 and tcp src port 1234 and not icmp"
         sniffer = threading.Thread(target=self.tcpdump_sniff, kwargs={
                                    'wait': wait, 'sniff_filter': sniff_filter})
@@ -1959,17 +1959,18 @@ class ReloadTest(BaseTest):
         interface = self.test_params['vmhost_external_port']
         cmd = f"sudo nohup tcpdump -i {interface} {tcpdump_filter} -w {pcap_path}"
         self.vmhost_connection.execCommand(cmd + " > /dev/null 2>&1 &")
-        self.log(f'Tcpdump sniffer starting on vmhost interface: {interface}')
+        self.log(f'Tcpdump sniffer started on vmhost interface: {interface}')
         base_tcpdump_delay = 2
         if self.test_params['packet_capture_location'] == PHYSICAL_PORT:
             elapsed_time = 0
+            start_time = time.time()
             while elapsed_time < self.start_sender_delay - base_tcpdump_delay:
-                elapsed_time += 1
                 time.sleep(1)
                 stdout_lines, stderr_lines, _ = self.vmhost_connection.execCommand(f"ls {self.remote_capture_pcap}")
                 if (self.remote_capture_pcap + '\n') in stdout_lines and len(stderr_lines) == 0:
                     self.log(f"The pcap file on the vmhost is created: {self.remote_capture_pcap}")
                     break
+                elapsed_time = int(time.time() - start_time)
             else:
                 self.log(f"Error: the pcap file on the vmhost is not created in {self.start_sender_delay}s.")
                 raise Exception("Tcpdump on the vmhost failed to start, test is aborted.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This is only for the flow that running tcpdump on the vmhost(server)
1. Wait 15 seconds before killing the sniffer after the sender stops in case it needs more
   time to flush the buffer on weak servers.

2. Increase the start_sender_delay
We have observed a big delay in starting the sniffer probably cause by
the time spent to login the test server. Need increase the delay to make
sure the sender is started after the sniffer.

2026-02-07 22:00:11 : Sniffer started at 2026-02-07 22:00:11.750715
2026-02-07 22:00:33 : IO sender and sniffer threads have started, wait until completion
**2026-02-07 22:00:41 : Sender started at 2026-02-07 22:00:41.762531 --> sender was started before the sniffer**
**2026-02-07 22:00:44 : Tcpdump sniffer starting on vmhost interface: p1p1 --> the log indicates the sniffer is really started**
2026-02-07 22:00:46 : The pcap file on the vmhost is created: /tmp/capture.pcapng_10.210.24.183
2026-02-07 22:03:06 : Sender has been running for 0:02:24.745037
2026-02-07 22:03:33 : Sniffer has been running for 0:03:21.598008

3. Fix another bug in checking the pcap file existing. The vmhost_connection takes time so the timing was not correct.

4. Fix some logs.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Stabilize the advanced reboot test and small bug fixes
#### How did you do it?
See the summary
#### How did you verify/test it?
Run the test on multiple Nvidia platforms, the issue didn't reproduce.
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
