### PR TITLE
Fix IndexError when parsing FIB route keys without colon

### DIFF
--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -213,8 +213,11 @@ def get_fib_info(duthost, dut_cfg_facts, duts_mg_facts, testname=None):
             fib = json.load(fp)
             for k, v in list(fib.items()):
                 skip = False
-
-                prefix = k.split(':', 1)[1]
+                if ":" in k:
+                    prefix = k.split(':', 1)[1]
+                else:
+                    # Handle keys without colon
+                    continue
                 ifnames = v['value']['ifname'].split(',')
                 nh = v['value']['nexthop']
 

--- a/tests/common/fixtures/fib_utils.py
+++ b/tests/common/fixtures/fib_utils.py
@@ -84,8 +84,11 @@ def get_t2_fib_info(duthosts, duts_cfg_facts, duts_mg_facts, testname=None):
                 fib = json.load(fp)
                 for k, v in list(fib.items()):
                     skip = False
-
-                    prefix = k.split(':', 1)[1]
+                    if ":" in k:
+                        prefix = k.split(':', 1)[1]
+                    else:
+                        # Handle keys without colon
+                        continue
                     ifnames = v['value']['ifname'].split(',')
                     nh = v['value']['nexthop']
                     nh_ips = nh.split(',')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The FIB parsing code assumed all route keys contain a colon (:) and
attempted to split on it unconditionally:
    prefix = k.split(':', 1)[1]

When a key like 'ROUTE_TABLE_DEL_SET' (without colon) is encountered,
split(':') returns a single-element list, causing IndexError when
accessing index [1].

Error:
    prefix = k.split(':', 1)[1]
    IndexError: list index out of range

Summary:
Added a safety check to verify colon exists before splitting:
    if ":" in k:
        prefix = k.split(':', 1)[1]
    else:
        continue

This ensures only properly formatted route keys (containing ':') are
processed, and malformed keys are skipped gracefully.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X ] 202505
- [ X] 202511

### Approach

#### What is the motivation for this PR?
Fix an IndexError crash in FIB (Forwarding Information Base) route parsing that occurs when processing route table
**Error:**
```
prefix = k.split(':', 1)[1]
IndexError: list index out of range
```
#### How did you do it?
Added a safety check to verify the presence of a colon before attempting to split route keys:

**Before:**
```python
prefix = k.split(':', 1)[1]  # Assumes colon always exists
```

**After:**
```python
if ":" in k:
    prefix = k.split(':', 1)[1]
else:
    continue  # Skip keys without proper format
```

This ensures only properly formatted route keys (e.g., `ROUTE_TABLE:192.168.0.0/24`) are processed, while malformed or special keys are gracefully skipped.

#### How did you verify/test it?
1. **Reproduced the issue**  with test_basic_fib
2. **Applied the fix** and confirmed test passes
3. **Verified** that normal route entries with colons still parse correctly
4. **Tested** with various key formats:
   - Standard routes: `ROUTE_TABLE:10.0.0.0/24` ✓
   - IPv6 routes: `ROUTE_TABLE:fc00::fc/126` ✓
   - Special keys: `ROUTE_TABLE_DEL_SET` ✓ (now skipped gracefully)
5. **Ran full test suite** to ensure no regressions
#### Any platform specific information?
**Platform dependency:** None - this is a generic parsing fix
#### Supported testbed topology if it's a new test case?
- **Existing topologies:** t0, t1, t1-lag
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
