### PR TITLE
Adjust tests_mark_conditions file for SPC6

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3416,10 +3416,11 @@ high_frequency_telemetry:
     reason: "High frequency telemetry isn't supported in this platform or on T2 topology"
     conditions_logical_operator: or
     conditions:
-      - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe_b']"
       - "'bmc' in topo_type"
       - "'t2' in topo_type"
       - "topo_type in ['lrh', 'urh']"
+      - "asic_type not in ['mellanox'] and platform not in ['x86_64-arista_7060x6_64pe_b']"
+      - "asic_type in ['mellanox'] and ('sn2' in platform or 'sn3' in platform or 'sn4' in platform)"
 
 high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
HFT and srv6 are supported on SPC6, removed the following to enable the tests to run

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511

### Approach
#### What is the motivation for this PR?
run htf on spc6 platforms
enable srv6 tests to run of 202412 or 202511+ images

#### How did you do it?
deleted the condition that skips if release is not 202412, and added spc6 platform to hft conditions


#### How did you verify/test it?
internal runs


#### Any platform specific information?
SPC6 nvidia platform


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
