### PR TITLE
Adjust test_buffer.py for SN6600

### DIFF
--- a/tests/qos/files/dynamic_buffer_param.json
+++ b/tests/qos/files/dynamic_buffer_param.json
@@ -27,7 +27,8 @@
 	},
 	"extra_overhead": {
 	    "8": "95232",
-	    "default": "58368"
+	    "default": "58368",
+		"x86_64-nvidia_sn6600_simx-r0": "96256"
 	},
 	"shared-headroom-pool": {
 	    "size": "1024000",
@@ -38,10 +39,16 @@
 		"0": "[BUFFER_PROFILE_TABLE:ingress_lossy_pg_zero_profile]"
 	    },
 	    "BUFFER_QUEUE_TABLE": {
-		"0-2": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
-		"3-4": "[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]",
-		"5-6": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
-		"7-15": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"
+		"default":
+			{"0-2": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"3-4": "[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]",
+			"5-6": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"7-15": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"},
+		"x86_64-nvidia_sn6600_simx-r0":
+			{"0-2": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"3-4": "[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]",
+			"5-6": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"7-11": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"}
 	    },
 	    "BUFFER_PORT_INGRESS_PROFILE_LIST_TABLE": ["[BUFFER_PROFILE_TABLE:ingress_lossless_zero_profile]"],
 	    "BUFFER_PORT_EGRESS_PROFILE_LIST_TABLE": ["[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]", "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"]
@@ -56,7 +63,12 @@
 		"x86_64-nvidia_sn4800_simx-r0": "400000",
 		"x86_64-nvidia_sn5600-r0": "800000",
 		"x86_64-nvidia_sn5640-r0": "800000",
-		"x86_64-nvidia_sn5600_simx-r0": "800000"
+		"x86_64-nvidia_sn5600_simx-r0": "800000",
+		"x86_64-nvidia_sn6600_simx-r0": "800000"
+	},
+	"supported_speeds_to_test": {
+		"default": ["10000", "50000"],
+		"x86_64-nvidia_sn6600_simx-r0": ["100000"]
 	}
     }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Adjusting test_buffer for sn6600 platform -
SPC6 require different constants for test buffer.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
SPC6 require different constants for test buffer, so it needed to be updated

#### How did you do it?
add default values and platform specific values

#### How did you verify/test it?
internal regression

#### Any platform specific information?
Nvidia SPC6 platforms


#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
