### PR TITLE
[HA] [smartswitch] Ha flow validation for AMD DPU

### DIFF
--- a/tests/ha/ha_dash_flow_utils.py
+++ b/tests/ha/ha_dash_flow_utils.py
@@ -31,6 +31,9 @@ def parse_pdsctl_show_flow_output(output):
             current_table_data = []
         elif re.match(r'^\d+', line):
             elements = list(filter(None, line.split()))
+            if len(elements) != len(keys):
+                logger.warning("Column lenght mismatch")
+                continue
             entry = dict(zip(keys, elements))
             current_table_data.append(entry)
 
@@ -46,7 +49,7 @@ def parse_pdsctl_show_flow_output(output):
 def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
     if 'pensando' not in dpuhost1.facts['asic_type'] or 'pensando' not in dpuhost2.facts['asic_type']:
         logger.warning("Only Pensando is supported for this function")
-        return None
+        return False
 
     output1 = dpuhost1.shell("pdsctl show flow")["stdout"]
     output2 = dpuhost2.shell("pdsctl show flow")["stdout"]


### PR DESCRIPTION
### Description of PR
Added utility to compare flows from primary and secondary DPUS on a HA configuration 
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506
- [x] 202511

### Approach
#### What is the motivation for this PR?
Needed for HA testing

#### How did you do it?
Added a utility function.

#### How did you verify/test it?
Tested in PDB:
DUT1:
Flow-table-10
27955202   1         H    10.0.0.11                                10.2.0.100                               UDP       6789      4567        I     A       NA      NA        
27955202   1         U    2603:10e1:100:2::3401:203                fd41:108:20:d107:64:ff71:a00:b           UDP       4567      6789        R     A       NA      NA        
No. of flows: 2 



(Pdb) p flow_tables
{'Flow-table-10': [
{'Session': '27955202', 'LookupId': '1', 'Dir': 'H', 'SIP': '10.0.0.11', 'DIP': '10.2.0.100', 'Proto': 'UDP', 'Sport': '6789', 'Dport': '4567', 'Role': 'I', 'Action': 'A'},
{'Session': '27955202', 'LookupId': '1', 'Dir': 'U', 'SIP': '2603:10e1:100:2::3401:203', 'DIP': 'fd41:108:20:d107:64:ff71:a00:b', 'Proto': 'UDP', 'Sport': '4567', 'Dport': '6789', 'Role': 'R', 'Action': 'A'}]}

DUT2
Flow-table-10
27955202   1         H    10.0.0.11                                10.2.0.100                               UDP       6789      4567        I     A       NA      NA        
27955202   1         U    2603:10e1:100:2::3401:203                fd41:108:20:d107:64:ff71:a00:b           UDP       4567      6789        R     A       NA      NA        
No. of flows: 2 


(Pdb) p flow_table2
{'Flow-table-10': [
{'Session': '27955202', 'LookupId': '1', 'Dir': 'H', 'SIP': '10.0.0.11', 'DIP': '10.2.0.100', 'Proto': 'UDP', 'Sport': '6789', 'Dport': '4567', 'Role': 'I', 'Action': 'A'},
{'Session': '27955202', 'LookupId': '1', 'Dir': 'U', 'SIP': '2603:10e1:100:2::3401:203', 'DIP': 'fd41:108:20:d107:64:ff71:a00:b', 'Proto': 'UDP', 'Sport': '4567', 'Dport': '6789', 'Role': 'R', 'Action': 'A'}]}



#### Any platform specific information?
MtFuji and AMD DPU

#### Supported testbed topology if it's a new test case?
HA topology

### Documentation
N/A