### PR TITLE
Cherry-pick/bgp sessions admin flap test (#21520)

### DIFF
--- a/ansible/library/check_bgp_ipv6_routes_converged.py
+++ b/ansible/library/check_bgp_ipv6_routes_converged.py
@@ -11,7 +11,8 @@ import base64
 
 
 # Constants
-INTERFACE_COMMAND_TEMPLATE = "sudo config interface {action} {target}"
+CONFIG_INTERFACE_COMMAND_TEMPLATE = "sudo config interface {action} {target}"
+CONFIG_BGP_SESSIONS_COMMAND_TEMPLATE = "sudo config bgp {action} {target}"
 
 
 def get_bgp_ipv6_routes(module):
@@ -26,11 +27,21 @@ def _perform_action_on_connections(module, action, connection_type, targets, all
     """
     Perform actions (shutdown/startup) on BGP sessions or interfaces.
     """
-
+    # Action on BGP sessions
+    if connection_type == "bgp_sessions":
+        if all_neighbors:
+            cmd = CONFIG_BGP_SESSIONS_COMMAND_TEMPLATE.format(action=action, target="all")
+            _execute_command_on_dut(module, cmd)
+        else:
+            for session in targets:
+                target_session = "neighbor " + session
+                cmd = CONFIG_BGP_SESSIONS_COMMAND_TEMPLATE.format(action=action, target=target_session)
+                _execute_command_on_dut(module, cmd)
+        logging.info(f"BGP sessions {action} completed.")
     # Action on Interfaces
-    if connection_type == "ports":
+    elif connection_type == "ports":
         ports_str = ",".join(targets)
-        cmd = INTERFACE_COMMAND_TEMPLATE.format(action=action, target=ports_str)
+        cmd = CONFIG_INTERFACE_COMMAND_TEMPLATE.format(action=action, target=ports_str)
         _execute_command_on_dut(module, cmd)
         logging.info(f"Interfaces {action} completed.")
     else:
@@ -102,7 +113,7 @@ def main():
         expected_routes = json.loads(module.params['expected_routes'])
 
     shutdown_connections = module.params.get('shutdown_connections', [])
-    connection_type = module.params['connection_type']
+    connection_type = module.params.get('connection_type', 'none')
     shutdown_all_connections = module.params['shutdown_all_connections']
     timeout = module.params['timeout']
     interval = module.params['interval']

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -367,6 +367,14 @@ def _restore(duthost, connection_type, shutdown_connections, shutdown_all_connec
     if connection_type == 'ports':
         logger.info(f"Recover interfaces {shutdown_connections} after failure")
         duthost.no_shutdown_multiple(shutdown_connections)
+    elif connection_type == 'bgp_sessions':
+        if shutdown_all_connections:
+            logger.info("Recover all BGP sessions after failure")
+            duthost.shell("sudo config bgp startup all")
+        else:
+            for session in shutdown_connections:
+                logger.info(f"Recover BGP session {session} after failure")
+                duthost.shell(f"sudo config bgp startup neighbor {session}")
 
 
 def check_bgp_routes_converged(duthost, expected_routes, shutdown_connections=None, connection_type='none',
@@ -520,7 +528,7 @@ def flapper(duthost, pdp, bgp_peers_info, transient_setup, flapping_count, conne
     exp_mask = setup_packet_mask_counters(pdp, global_icmp_type)
     all_flap = (flapping_count == 'all')
 
-    # We are currently treating the shutdown action as a setup mechanism for a startup action to follow.
+    # Currently treating the shutdown action as a setup mechanism for a startup action to follow.
     # So we only do the selection of flapping and injection neighbors when action is shutdown
     # And we reuse the same selection for startup action
     if action == 'shutdown':
@@ -532,7 +540,7 @@ def flapper(duthost, pdp, bgp_peers_info, transient_setup, flapping_count, conne
             bgp_peers_info, all_flap, flapping_count
         )
 
-        flapping_connections = {'ports': flapping_ports}.get(connection_type, [])
+        flapping_connections = {'ports': flapping_ports, 'bgp_sessions': flapping_neighbors}.get(connection_type, [])
         # Build expected routes after shutdown
         startup_routes = get_all_bgp_ipv6_routes(duthost, save_snapshot=False)
         neighbor_ecmp_routes = get_ecmp_routes(startup_routes, bgp_peers_info)
@@ -769,6 +777,33 @@ def test_nexthop_group_member_scale(
         pytest.fail(f"Dataplane downtime is too high, threshold is {_get_max_time('dataplane_downtime', 1)} seconds")
     if not result.get("converged"):
         pytest.fail("BGP routes are not stable in long time")
+
+
+@pytest.mark.parametrize("flapping_neighbor_count", [1, 10])
+def test_bgp_admin_flap(
+    request,
+    duthost,
+    ptfadapter,
+    bgp_peers_info,
+    flapping_neighbor_count
+):
+    """
+    Validates that both control plane and data plane remain functional with acceptable downtime when BGP sessions are
+    flapped (brought down and back up), simulating various failure or maintenance scenarios.
+
+    Uses the flapper function to orchestrate the flapping of BGP sessions and measure convergence times.
+
+    Parameters range from flapping a single session to all sessions.
+
+    Expected result:
+        Dataplane downtime is less than MAX_BGP_SESSION_DOWNTIME or MAX_DOWNTIME_UNISOLATION for all ports.
+    """
+    pdp = ptfadapter.dataplane
+    pdp.set_qlen(PACKET_QUEUE_LENGTH)
+    # Measure shutdown convergence
+    transient_setup = flapper(duthost, pdp, bgp_peers_info, None, flapping_neighbor_count, 'bgp_sessions', 'shutdown')
+    # Measure startup convergence
+    flapper(duthost, pdp, None, transient_setup, flapping_neighbor_count, 'bgp_sessions', 'startup')
 
 
 @pytest.mark.parametrize("flapping_port_count", [1, 10, 20, 'all'])


### PR DESCRIPTION
Manual Cherry Pick to 202511: This PR adds the high‑scale BGP admin flap tests that build on top of the refactoring done in PR #21335. It introduces new test cases and utilities to exercise BGP IPv6 convergence and scale behavior under repeated admin shutdown/startup (“flap”) scenarios for BGP sessions and interfaces.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
