### PR TITLE
Backport [202511] [generic_config_updater] Fix ethernet test port availability and error handling 

### DIFF
--- a/tests/generic_config_updater/conftest.py
+++ b/tests/generic_config_updater/conftest.py
@@ -95,6 +95,7 @@ def ignore_expected_loganalyzer_exceptions(duthosts, selected_dut_hostname, loga
             ".*ERR kernel.*Reset adapter.*",  # Valid test_portchannel_interface replace mtu
             ".*ERR swss[0-9]*#orchagent: :- getPortOperSpeed.*",  # Valid test_portchannel_interface replace mtu
             ".*ERR systemd.*Failed to start Host core file uploader daemon.*",  # Valid test_syslog
+            r".*ERR monit\[\d+\]: 'routeCheck' status failed \(255\) -- Failure results:.*",
 
             # sonic-swss/orchagent/crmorch.cpp
             ".*ERR swss[0-9]*#orchagent.*getResAvailableCounters.*",  # test_monitor_config

--- a/tests/generic_config_updater/test_eth_interface.py
+++ b/tests/generic_config_updater/test_eth_interface.py
@@ -20,17 +20,17 @@ SHOW_FEC_OPER_CMD_TEMPLATE = "show interfaces fec status {}"
 
 
 @pytest.fixture(autouse=True)
-def ensure_dut_readiness(duthosts, rand_one_dut_hostname):
+def ensure_dut_readiness(duthosts, rand_one_dut_front_end_hostname):
     """
     Setup/teardown fixture for each ethernet test
     rollback to check if it goes back to starting config
 
     Args:
         duthosts: list of DUTs
-        rand_one_dut_hostname: The fixture returns a randomly selected DUT hostname
+        rand_one_dut_front_end_hostname: The fixture returns a randomly selected frontend DUT hostname
     """
 
-    duthost = duthosts[rand_one_dut_hostname]
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     create_checkpoint(duthost)
 
     yield
@@ -112,6 +112,27 @@ def check_interface_status(duthost, field, interface='Ethernet0'):
     return status
 
 
+def remove_port_from_portchannel(duthost, port, portchannel, namespace=None):
+    """
+        Removes a port from its PortChannel membership
+
+        Args:
+            duthost: DUT host object under test
+            port: Port name to remove
+            portchannel: PortChannel name
+            namespace: DUT asic namespace
+    """
+    namespace_prefix = '' if namespace is None else '-n ' + namespace
+    cmd = 'config portchannel {} member del {} {}'.format(namespace_prefix, portchannel, port)
+    logger.info("Removing {} from {} in namespace {}".format(
+        port, portchannel, namespace or 'default'))
+    output = duthost.shell(cmd)
+    pytest_assert(
+        output['rc'] == 0,
+        "Failed to remove {} from {}: {}".format(port, portchannel, output.get('stderr', '')))
+    return True
+
+
 def get_ethernet_port_not_in_portchannel(duthost, namespace=None):
     """
         Returns the name of an ethernet port which is not a member of a port channel
@@ -145,6 +166,62 @@ def get_ethernet_port_not_in_portchannel(duthost, namespace=None):
             port_name = port
             break
     return port_name
+
+
+def get_test_port(duthost, namespace=None, remove_from_portchannel=True):
+    """
+        Returns an available ethernet port for testing.
+        If no free ports exist and remove_from_portchannel=True, removes a port from a PortChannel.
+        The port will be restored by the ensure_dut_readiness fixture's rollback mechanism.
+
+        Args:
+            duthost: DUT host object under test
+            namespace: DUT asic namespace
+            remove_from_portchannel: If True, remove a port from PortChannel if no free ports available
+
+        Returns:
+            Port name string, or empty string if no suitable port found
+    """
+    # First try to get a port not in a PortChannel
+    port = get_ethernet_port_not_in_portchannel(duthost, namespace=namespace)
+    if port:
+        logger.info("Found available port: {}".format(port))
+        return port
+
+    if not remove_from_portchannel:
+        logger.warning("No available ports and remove_from_portchannel=False")
+        return ""
+
+    # If no free port, find one in a PortChannel and remove it
+    logger.info("No free ports available, attempting to remove a port from PortChannel")
+    config_facts = duthost.config_facts(
+        host=duthost.hostname,
+        source="running",
+        verbose=False,
+        namespace=namespace
+    )['ansible_facts']
+
+    if 'PORTCHANNEL_MEMBER' not in config_facts or 'PORT' not in config_facts:
+        logger.warning("No PortChannel members or ports found")
+        return ""
+
+    port_channel_member_facts = config_facts['PORTCHANNEL_MEMBER']
+
+    # Find a suitable port to remove (prefer Ext role ports)
+    for portchannel in list(port_channel_member_facts.keys()):
+        for member in list(port_channel_member_facts[portchannel].keys()):
+            port_role = config_facts['PORT'].get(member, {}).get('role')
+            if port_role and port_role != 'Ext':
+                continue  # Skip internal/fabric ports
+
+            # Found a candidate - remove it from the PortChannel
+            logger.info("Removing {} from {} for testing (will be restored by rollback)".format(
+                member, portchannel))
+            remove_port_from_portchannel(duthost, member, portchannel, namespace=namespace)
+            return member
+
+    logger.warning("No suitable ports found even in PortChannels")
+    return ""
 
 
 def get_port_speeds_for_test(duthost, port):
@@ -195,7 +272,8 @@ def test_remove_lanes(duthosts, rand_one_dut_front_end_hostname,
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     json_patch = [
         {
             "op": "remove",
@@ -221,7 +299,8 @@ def test_replace_lanes(duthosts, rand_one_dut_front_end_hostname, ensure_dut_rea
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     cur_lanes = check_interface_status(duthost, "Lanes", port)
     cur_lanes = cur_lanes.split(",")
     cur_lanes.sort()
@@ -253,10 +332,14 @@ def test_replace_mtu(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    # Can't directly change mtu of the port channel member
-    # So find a ethernet port that are not in a port channel
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
-    pytest_assert(port, "No available ethernet ports, all ports are in port channels.")
+
+    # Get a test port - check without removing from PortChannel to avoid routing issues
+    port = get_test_port(duthost, namespace=asic_namespace, remove_from_portchannel=False)
+
+    if not port:
+        # MTU changes on ports removed from PortChannel can cause routing convergence issues
+        # Skip this test to avoid teardown failures
+        pytest.skip("No free ports available. Skipping MTU test to avoid routing issues from PortChannel changes.")
     target_mtu = "1514"
     json_patch = [
         {
@@ -287,7 +370,8 @@ def test_toggle_pfc_asym(duthosts, rand_one_dut_front_end_hostname, ensure_dut_r
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     json_patch = [
         {
             "op": "replace",
@@ -320,7 +404,8 @@ def test_replace_fec(duthosts, rand_one_dut_front_end_hostname, ensure_dut_readi
         'asic{}'.format(enum_rand_one_frontend_asic_index)
     namespace_prefix = '' if asic_namespace is None else '-n ' + asic_namespace
     intf_init_status = duthost.get_interfaces_status()
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     intf_init_fec_oper = get_fec_oper(duthost, port)
     json_patch = [
         {
@@ -363,7 +448,8 @@ def test_update_invalid_index(duthosts, rand_one_dut_front_end_hostname, ensure_
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     json_patch = [
         {
             "op": "replace",
@@ -433,7 +519,8 @@ def test_update_speed(duthosts, rand_one_dut_front_end_hostname, ensure_dut_read
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     speed_params = get_port_speeds_for_test(duthost, port)
     for speed, is_valid in speed_params:
         json_patch = [
@@ -468,7 +555,8 @@ def test_update_description(duthosts, rand_one_dut_front_end_hostname, ensure_du
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     json_patch = [
         {
             "op": "replace",
@@ -495,7 +583,8 @@ def test_eth_interface_admin_change(duthosts, rand_one_dut_front_end_hostname, a
     duthost = duthosts[rand_one_dut_front_end_hostname]
     asic_namespace = None if enum_rand_one_frontend_asic_index is None else \
         'asic{}'.format(enum_rand_one_frontend_asic_index)
-    port = get_ethernet_port_not_in_portchannel(duthost, namespace=asic_namespace)
+    port = get_test_port(duthost, namespace=asic_namespace)
+    pytest_assert(port, "No available ethernet ports on this ASIC")
     json_patch = [
         {
             "op": "add",


### PR DESCRIPTION
Backport of [PR #22082](https://github.com/sonic-net/sonic-mgmt/pull/22082) and [PR #21026](https://github.com/sonic-net/sonic-mgmt/pull/21026) for 202511

