### PR TITLE
Remove test_gnmi_configdb_full_01 that misused gnoi_reboot

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2661,14 +2661,6 @@ gnmi/test_gnmi_configdb.py:
       - "is_multi_asic==True"
       - "release in ['202412']"
 
-gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
-  skip:
-    reason: "The test refers to a stale implementation of GNOI.System.Reboot."
-    conditions_logical_operator: or
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/17436"
-      - "release in ['202412']"
-
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_replace_01:
   skip:
     reason: "dut ipv6 mgmt ip not supported"

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -543,14 +543,6 @@ gnmi/test_gnmi_appldb.py::test_gnmi_appldb_01:
 #######################################
 #####          GNMI               #####
 #######################################
-gnmi/test_gnmi_configdb.py::test_gnmi_configdb_full_01:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 gnmi/test_gnmi_configdb.py::test_gnmi_configdb_incremental_01:
   skip:
     reason: >


### PR DESCRIPTION
### Description of PR

Summary:
Remove `test_gnmi_configdb_full_01` which incorrectly used `gnoi_reboot` as a config reload mechanism. The test was pushing config via GNMI, then calling `gnoi_reboot` expecting the config to be applied after reboot - this conflates reboot with config reload, which are fundamentally different operations.

Fixes #17436

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The test `test_gnmi_configdb_full_01` was using `gnoi_reboot` incorrectly - treating it as a config reload mechanism rather than an actual device reboot. This represents a flawed test design that tests incorrect behavior.

#### How did you do it?

- Removed the faulty test `test_gnmi_configdb_full_01` from `tests/gnmi/test_gnmi_configdb.py`
- Removed associated skip entries from `tests_mark_conditions.yaml` and `tests_mark_conditions_sonic_vpp.yaml`
- Cleaned up unused imports (`gnoi_reboot`, `wait_critical_processes`, `check_interface_status_of_up_ports`)

#### How did you verify/test it?

- Pre-commit hooks pass
- This is a test removal, no new functionality to verify

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A - this removes a test

### Documentation

N/A