### PR TITLE
[infra] Run duthosts in parallel fixture manager

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -505,7 +505,7 @@ def pytest_sessionfinish(session, exitstatus):
 
 
 @pytest.fixture(name="duthosts", scope="session")
-def fixture_duthosts(enhance_inventory, ansible_adhoc, tbinfo, request):
+def fixture_duthosts(enhance_inventory, ansible_adhoc, tbinfo, request, parallel_manager):
     """
     @summary: fixture to get DUT hosts defined in testbed.
     @param enhance_inventory: fixture to enhance the capability of parsing the value of pytest cli argument
@@ -516,8 +516,8 @@ def fixture_duthosts(enhance_inventory, ansible_adhoc, tbinfo, request):
     @param request: pytest request object
     """
     try:
-        host = DutHosts(ansible_adhoc, tbinfo, request, get_specified_duts(request),
-                        target_hostname=get_target_hostname(request), is_parallel_leader=is_parallel_leader(request))
+        host = DutHosts(ansible_adhoc, tbinfo, request, get_specified_duts(request), target_hostname=get_target_hostname(request),
+                        is_parallel_leader=is_parallel_leader(request), parallel_manager=parallel_manager)
         return host
     except BaseException as e:
         logger.error("Failed to initialize duthosts.")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Run the fixture duthosts in the parallel fixture manager to reduce runtime.
This depends on https://github.com/sonic-net/sonic-mgmt/pull/21949.

Signed-off-by: Longxiang Lyu [lolv@microsoft.com](mailto:lolv@microsoft.com)

#### How did you do it?
As the motivation.

#### How did you verify/test it?
On kvm dualtor testbed:
before, `fixture_duthosts` takes 12.5s.
after, `fixture_duthosts` takes 6.57s.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
