### PR TITLE
[infra] Fix ansible dead worker issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import threading
 import pathlib
 import importlib
 import inspect
+import concurrent.futures.thread as cft
 
 from datetime import datetime
 from ipaddress import ip_interface, IPv4Interface
@@ -116,6 +117,11 @@ pytest_plugins = ('tests.common.plugins.ptfadapter',
                   'tests.common.plugins.random_seed',
                   'tests.common.plugins.memory_utilization',
                   'tests.common.fixtures.duthost_utils')
+
+
+# NOTE: This is to backport fix https://github.com/python/cpython/pull/126098
+if sys.version_info < (3, 12, 8):
+    os.register_at_fork(after_in_child=cft._threads_queues.clear)
 
 
 patch_ansible_worker_process()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To fix the ansible worker dead issue observed in sonic-mgmt test.
This issue is that the ansible worker is detected dead when calling ansible from thread worker in thread pool.
This is same as https://github.com/python/cpython/issues/88110.

The root cause is that, `concurrent.futures.thread` thread pool registers a callback to poll the threads when python interpreter exits, and those thread workers are stored in the dictionary `concurrent.futures.thread._threads_queues`. The ansible forked child worker process will inherit this dictionary, which contains those orphaned threads. And when the ansible child worker process tries to exit, the callback polls those orphaned threads, causing the worker process returns `1` and ansible complains the worker dead.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Backport the cpython fix https://github.com/python/cpython/pull/126098 if the sonic-mgmt python version is < 3.12.8.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
