### PR TITLE
Generate cert with 365 days valid period

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -179,6 +179,7 @@ def rotate_telemetry_certs(duthost, localhost):
               -x509 \
               -sha256 \
               -nodes \
+              -days 365 \
               -newkey rsa:2048 \
               -keyout streamingtelemetryserver.key \
               -subj '/CN=ndastreamingservertest' \
@@ -188,6 +189,7 @@ def rotate_telemetry_certs(duthost, localhost):
               -x509 \
               -sha256 \
               -nodes \
+              -days 365 \
               -newkey rsa:2048 \
               -keyout dsmsroot.key \
               -subj '/CN=ndastreamingclienttest' \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Generate cert with 365 days valid period
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Generate cert with 365 days valid period
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Telemetry test needs certificates to be installed on device for TLS authentication. Currently the cert rotation test will regenerate server certificate with life time to be 30 days. Issue of this is if we did not run telemetry test for more than a month or did not run cert rotation test for more than a month, new telemetry OC tests will fail as the certificates are expired. 

#### How did you do it?

Solution here is to create certificates with lifetime to be 365 days. This will greatly reduce the chance that telemetry OC tests fail because of expired certs. 

#### How did you verify/test it?

We experienced OC test fail because of cert expired. With the new fix the cert will be valid for 1 year and we are not seeing this kind of failure anymore. 

#### Any platform specific information?

No

#### Supported testbed topology if it's a new test case?

Not a new test case

### Documentation

No
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->