### PR TITLE
[202511] Ignore "zmq send failed" in test_bgp_suppress_fib.py loganal…

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -129,7 +129,8 @@ def ignore_expected_loganalyzer_errors(duthosts, rand_one_dut_hostname, loganaly
             "\\(.* minutes\\).*",
             r".* ERR memory_checker: \[memory_checker\] Failed to get container ID of.*",
             r".* ERR memory_checker: \[memory_checker\] cgroup memory usage file.*",
-            r".*ERR teamd#teamsyncd: :- readData: netlink reports an error=.*"
+            r".*ERR teamd#teamsyncd: :- readData: netlink reports an error=.*",
+            r".*ERR bgp#fpmsyncd: .*zmq send failed.*zmqerrno: 11:Resource temporarily unavailable.*"
         ]
         loganalyzer[duthost.hostname].ignore_regex.extend(ignoreRegex)
 
@@ -959,7 +960,8 @@ def test_bgp_route_without_suppress(duthost, tbinfo, nbrhosts, ptfadapter, prepa
 
 
 def test_bgp_route_with_suppress_negative_operation(duthost, tbinfo, nbrhosts, ptfadapter, localhost, prepare_param,
-                                                    restore_bgp_suppress_fib, generate_route_and_traffic_data):
+                                                    restore_bgp_suppress_fib, generate_route_and_traffic_data,
+                                                    loganalyzer):
     try:
         with allure.step("Prepare needed parameters"):
             router_mac, mg_facts, ptf_ip, exabgp_port_list, exabgp_port_list_v6, recv_port_list = prepare_param


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
orch_northbond_route_zmq_enabled was enabled in:
https://github.com/sonic-net/sonic-mgmt/pull/20441 which enables fpmsyncd to send route events to orchagent via a ZMQ channel instead of Redis.
test_bgp_route_with_suppress_negative_operation kills orchagent and restarts BGP sessions. After restart, fpmsyncd tries to send all updates to orchagent via ZMQ, but orchagent is still down. Eventually, ZMQ buffer is filled up and causes the error.
Ignore this error log as it is expected.
Other test cases without explicit BGP sessions restart are also affected by this loganalyzer failure. It is caused by https://github.com/sonic-net/sonic-buildimage/pull/23187, which resets BGP sessions when "suppress-fib-pending" config changes. But it was approved to be reverted in https://github.com/sonic-net/sonic-buildimage/pull/24883, so only test_bgp_route_with_suppress_negative_operation needs to add loganalyzer ignoreRegex.
Manual cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/22201

Fixes #22200

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Loganalyzer failure in test_bgp_suppress_fib.py

#### How did you do it?
Ignore this error as it is expected

#### How did you verify/test it?
test_bgp_suppress_fib.py passed

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
