### PR TITLE
avoid GCU ECN test for currently unsupported Cisco platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2527,10 +2527,12 @@ generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_removal:
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:
-    reason: "This test is not run on this asic type, topology, or version currently"
+    # Cisco-8800-LC-48H-C48 (PAC ASIC) and Cisco-8122 (GR2 ASIC) platforms are skipped because
+    # dynamic WRED configuration updates are not yet implemented in the SAI layer for these ASICs.
+    reason: "WRED dynamic config updates not implemented in SAI for PAC/GR2 ASICs"
     conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Cisco-8800-LC-48H-C48']"
+      - "hwsku in ['Cisco-8800-LC-48H-C48', 'Cisco-8122-O128S2'] or hwsku.startswith('Cisco-8122-O64')"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
WRED configuration for certain Cisco platforms (GR2, PAC) are not yet propagated to hardware or
to ASIC_DB. So for the time being, we are skipping tests that will always fail.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Allowing GCU tests to pass for the time being

#### How did you do it?

Determined that GR2 platforms don't support propagation correctly, omitted them

#### How did you verify/test it?

It's difficult to test something that _doesn't_ happen.

#### Any platform specific information?

See the PR documentation and comments.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
