### PR TITLE
Test changes (voq_intfs, voq_init, snmp_queue_counters) needed for single asic FS

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_voq.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_voq.yaml
@@ -47,6 +47,15 @@ voq/test_voq_init.py::test_voq_neighbor_create:
       - "is_chassis_config_absent==True"
 
 #################################################
+#####test_voq_intfs.py #####
+#################################################
+voq/test_voq_intfs.py:
+  skip:
+    reason: "Skipped as the test applies to chassis only"
+    conditions:
+      - "is_chassis_config_absent==True"
+
+#################################################
 #####test_voq_ipfwd.py #####
 #################################################
 voq/test_voq_ipfwd.py:

--- a/tests/snmp/test_snmp_queue_counters.py
+++ b/tests/snmp/test_snmp_queue_counters.py
@@ -201,7 +201,7 @@ def test_snmp_queue_counters(duthosts,
 
     # For broadcom-dnx voq chassis, number of voq are fixed (static), which cannot be modified dynamically
     # Hence, make sure the queue counters before deletion and after deletion are same for broadcom-dnx voq chassis
-    if duthost.facts.get("platform_asic") == "broadcom-dnx" and duthost.sonichost.is_multi_asic:
+    if duthost.facts.get("platform_asic") == "broadcom-dnx":
         pytest_assert((queue_counters_cnt_pre == queue_counters_cnt_post),
                       "Queue counters actual count {} differs from expected values {}".
                       format(queue_counters_cnt_post, queue_counters_cnt_pre))

--- a/tests/voq/test_voq_init.py
+++ b/tests/voq/test_voq_init.py
@@ -106,7 +106,7 @@ def test_voq_system_port_create(duthosts, enum_frontend_dut_hostname, enum_asic_
                     )
                 else:
                     host_name, asic_str, portname = cfg_port.split("|")
-                    asic_idx = int(asic_str.replace("asic", ""))
+                    asic_idx = int(asic_str.lower().replace("asic", ""))
 
                     if host_name == per_host.hostname and asic_idx == asic.asic_index:
                         port_table = all_cfg_facts[host_name][asic_idx]['ansible_facts']['PORT']


### PR DESCRIPTION
### Description of PR
1) VOQ test test_voq_init.py is failing for FS due to a asic name check.

This is a bug introduced as part of PR: https://github.com/nexthop-ai/private-sonic-mgmt/commit/bf415c64da05cffccb500202bdfea02d86707740

For single asic case, asic name is Asic0 (vs. asic0). "Asic0" is used in the codebase (below).
sonic-mgmt: ansible/library/port_alias.py
sonic-buildimage/src/sonic-config-engine/minigraph.py

2) test_snmp_queue_counters.py is failing as dnx has fixed voq set. But there is a multi asic check present for dnx causing failure for single asic fs case. Removed this check.

3) test_voq_intf.py: This test validates distributed database synchronization that only exists in multi-device VOQ chassis systems
There are existing tests to validate similar functionality on fixed systems

tests/platform_tests/test_interfaces.py
tests/common/test_config_reload.py

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Tests need update for single asic FS

#### How did you do it?
1) for voq, made the test check for asic name without case
2) for snmp, removed the multi asic check for dnx

#### How did you verify/test it?
Ran the test on single asic FS box.

#### Any platform specific information?
ran the tests on FS voq

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
