### PR TITLE
change test_memory_checker to always test gnmi container instead of telemetry

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -262,14 +262,6 @@ def remove_and_restart_container(memory_checker_dut_and_container):
     container.post_check()
 
 
-def get_test_container(duthost):
-    test_container = "gnmi"
-    cmd = "docker images | grep -w sonic-telemetry"
-    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-        test_container = "telemetry"
-    return test_container
-
-
 @pytest.fixture
 def memory_checker_dut_and_container(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Perform some checks and return applicable duthost and container name
@@ -283,9 +275,7 @@ def memory_checker_dut_and_container(duthosts, enum_rand_one_per_hwsku_frontend_
         (duthost, container)
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-
-    container_name = get_test_container(duthost)
-    container = MemoryCheckerContainer(container_name, duthost)
+    container = MemoryCheckerContainer("gnmi", duthost)
 
     pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]
                    and (("20191130" in duthost.os_version and


### PR DESCRIPTION
### Description of PR
test_memory_checker runs memory checks on telemetry container, which is now soft deprecated. test_memory_checker should instead test gnmi container. This causes test failure when telemetry container is included in a build, but not enabled.

fixes https://github.com/sonic-net/sonic-mgmt/issues/22349

Summary:
Fixes test_memory_checker failure when telemetry container is included in build

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_memory_checker failures seen in nexthop master and 202511 branches

#### How did you do it?
Swap the test to run on gnmi container instead of telemetry, even if telemetry container exists in the image.

#### How did you verify/test it?
Tested on humm208 DUT
```
+---------------------------------------------+-------------------------------------+--------+----------+-------+
| Test                                        | Description                         | Result | Duration | Error |
+---------------------------------------------+-------------------------------------+--------+----------+-------+
| tests/memory_checker/test_memory_checker.py | skipped 0 errors 0 failed 0 total 4 | PASS   | 1761.12  |       |
+---------------------------------------------+-------------------------------------+--------+----------+-------+
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
