### PR TITLE
Skip IPv6 mirror session on unsupported platforms in everflow_per_interface test

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -87,6 +87,12 @@ def build_acl_rule_vars(candidate_ports, ip_ver, erspan_ip_ver):  # noqa F811
 
 @pytest.fixture(scope='module')
 def apply_mirror_session(setup_info, erspan_ip_ver):  # noqa F811
+    duthost_set = BaseEverflowTest.get_duthost_set(setup_info)
+    for duthost in duthost_set:
+        # Skip IPv6 mirror session due to issue #19096
+        if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s') and erspan_ip_ver == 6: # noqa E501
+            pytest.skip("Skip IPv6 mirror session on unsupported platforms")
+
     mirror_session_info = BaseEverflowTest.mirror_session_info(
         EVERFLOW_SESSION_NAME, setup_info[UP_STREAM]['everflow_dut'].facts["asic_type"])
     logger.info("Applying mirror session to DUT")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR is to skip IPv6 mirror session on unsupported platforms in everflow_per_interface test.
Similar change is done in PR https://github.com/sonic-net/sonic-mgmt/pull/22242
We can't call fixture `setup_mirror_session` in [‎tests/everflow/everflow_test_utilities.py](https://github.com/sonic-net/sonic-mgmt/pull/22242/changes#diff-9995c7b21f8c4bdfbce3afa16caea4605f218416c27cccb61a2c217efe259107) due to different signature.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR is to skip IPv6 mirror session on unsupported platforms in everflow_per_interface test.

#### How did you do it?
Check platform name and `erspan_ip_ver` in `apply_mirror_session` and skip the test if it's not supported.

#### How did you verify/test it?
The change is verified on a physical testbed.
```
collected 8 items                                                                                                                                                                                                                                              

everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv4-default] PASSED                                                                                                                                                    [ 12%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv4-default] PASSED                                                                                                                                                    [ 25%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv4-default] PASSED                                                                                                                                                    [ 37%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv4-default] PASSED                                                                                                                                                    [ 50%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv6-erspan_ipv6-default] SKIPPED (Skip IPv6 mirror session on unsupported platforms)                                                                                               [ 62%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv6-erspan_ipv6-default] SKIPPED (Skip IPv6 mirror session on unsupported platforms)                                                                                               [ 75%]
everflow/test_everflow_per_interface.py::test_everflow_per_interface[ipv4-erspan_ipv6-default] SKIPPED (Skip IPv6 mirror session on unsupported platforms)                                                                                               [ 87%]
everflow/test_everflow_per_interface.py::test_everflow_packet_format[ipv4-erspan_ipv6-default] SKIPPED (Skip IPv6 mirror session on unsupported platforms)                                                                                               [100%] 
```
#### Any platform specific information?
Arista platform specific change.

#### Supported testbed topology if it's a new test case?
Not a new test.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
