### PR TITLE
Xfail test_ecn_config_updates due to GCU changes for 202511 and master

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2472,8 +2472,6 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
       - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/22295 and platform in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0']"
-
-generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   xfail:
     reason: "This test will be reworked following changes to GCU validators"
     conditions_logical_operator: "OR"


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Following changes done to the GCU validator code in sonic-net/sonic-utilities#4219, `test_ecn_config_updates` now fails with an error saying that the config it is trying to apply should've been rejected, but is actually applied. According to the author of the change, the test code will be modified based on this change.

For the purposes of unblocking submodule updates of sonic-utilities on master and 202511, xfail this test case on those two branches.

#### How did you do it?

Add `generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates` to the `test_mark_conditionals.yaml` file.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
