### PR TITLE
[Otel] Enable OTEL feature when OTEL image exists

### DIFF
--- a/tests/container_hardening/test_container_hardening.py
+++ b/tests/container_hardening/test_container_hardening.py
@@ -20,7 +20,6 @@ PRIVILEGED_CONTAINERS = [
     # gnmi is temporarily in privileged mode, remove when
     # https://github.com/sonic-net/sonic-buildimage/issues/24542 is closed
     "gnmi",
-    "otel",
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Enable OTEL feature when OTEL image exists
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Enable OTEL feature when OTEL image exists
#### How did you do it?
Add a function to check if otel docker image exists, if yes, enable otel feature.
#### How did you verify/test it?
Verified it in internal setup.
#### Any platform specific information?
Nvidia SN5640
#### Supported testbed topology if it's a new test case?
to-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
