### PR TITLE
[BGP] fix test test_bgp_commands_with_like_bgp_container

### DIFF
--- a/tests/bgp/test_bgp_command.py
+++ b/tests/bgp/test_bgp_command.py
@@ -142,7 +142,7 @@ def test_bgp_commands_with_like_bgp_container(
     like_bgp_container_name = "database-like-bgp"
 
     create_result = duthost.shell(
-        'docker run --rm --detach --name={} docker-database:latest sleep infinity'.format(
+        'docker run --rm --detach --name={} -e DEV= docker-database:latest sleep infinity'.format(
             like_bgp_container_name
         ),
         module_ignore_errors=True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix test_bgp_commands_with_like_bgp_container tests.
During the test created container database-like-bgp by cli:
```docker run --rm --detach --name=database-like-bgp docker-database:latest sleep infinity```
But the container directly moved to status "Exited".
The root cause for it:
_DEV_ is undefined in _docker-database-init.sh_. Either the docker run command **must pass DEV as an environment** variable, **or /etc/sonic/database_config.json must already exist**.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix failed test

#### How did you do it?
Added "-e DEV= " to cli of container creation.

#### How did you verify/test it?
Executed test test_bgp_commands_with_like_bgp_container

