### PR TITLE
test_psud: Add PSU status and LED validation tests

### DIFF
--- a/tests/platform_tests/daemon/test_psud.py
+++ b/tests/platform_tests/daemon/test_psud.py
@@ -198,15 +198,18 @@ def test_pmon_psud_psu_status_and_led(duthosts, enum_supervisor_dut_hostname, da
         present_psu_count += 1
 
         # Check PSU operational status
-        status = psu_data.get("status", "false")
-        if status.lower() != "true":
-            psu_status_failures.append("{} status is '{}', expected 'true'".format(psu_name, status))
+        if "status" not in psu_data:
+            psu_status_failures.append("{} missing 'status' field in STATE_DB".format(psu_name))
+        elif psu_data["status"].lower() != "true":
+            psu_status_failures.append("{} status is '{}', expected 'true'".format(psu_name, psu_data["status"]))
 
         # Check PSU LED is green when a real color value is reported.
         # Some platforms report 'N/A' when PSU LED status is not supported; accept that as well.
-        led_status = psu_data.get("led_status", "unknown")
-        if led_status.lower() not in ("green", "n/a"):
-            psu_led_failures.append("{} led_status is '{}', expected 'green' or 'N/A'".format(psu_name, led_status))
+        if "led_status" not in psu_data:
+            psu_led_failures.append("{} missing 'led_status' field in STATE_DB".format(psu_name))
+        elif psu_data["led_status"].lower() not in ("green", "n/a"):
+            psu_led_failures.append("{} led_status is '{}', expected 'green' or 'N/A'".format(
+                psu_name, psu_data["led_status"]))
 
     pytest_assert(present_psu_count > 0, "No present PSUs found in STATE_DB")
     logger.info("Validated {} present PSU(s) for status and LED".format(present_psu_count))


### PR DESCRIPTION
Add new test case test_pmon_psud_psu_status_and_led to validate that:
1. Each present PSU reports status as OK (status='true')
2. Each present PSU has its LED set to green (led_status='green')

This addresses the test gap described in issue #22143 where the psud tests only checked for PSU presence but did not validate the actual PSU operational status and LED color.

Fixes: #22143

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Add new test case test_pmon_psud_psu_status_and_led to validate that:
1. Each present PSU reports status as OK (status='true')
2. Each present PSU has its LED set to green (led_status='green')

This addresses the test gap described in issue #22143 where the psud tests only checked for PSU presence but did not validate the actual PSU operational status and LED color.

Fixes: #22143

#### How did you do it?
This code is fully generated by AI.

#### How did you verify/test it?
Tested on hardware platform where PSU LED color is red and the test failed accordingly.
Tested on hardware platform where PSU LED color is green and the test passed accordingly.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
