### PR TITLE
Update gnmi container parameters and add gnxi tests for container upg…

### DIFF
--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -3,7 +3,7 @@
         "parameters": ""
     },
     "docker-sonic-gnmi": {
-        "parameters": "--net=host -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /etc/fips/fips_enable:/etc/fips/fips_enable:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/dbus:/var/run/dbus:rw -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-chassis:/var/run/redis-chassis:ro --env RUNTIME_OWNER=local"
+        "parameters": "--net=host --pid=host --userns=host --uts=host --cap-add=SYS_ADMIN --cap-add=SYS_BOOT --cap-add=SYS_PTRACE --cap-add=NET_ADMIN --cap-add=DAC_OVERRIDE --security-opt apparmor=unconfined --security-opt seccomp=unconfined -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /etc/fips/fips_enable:/etc/fips/fips_enable:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/dbus:/var/run/dbus:rw -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-chassis:/var/run/redis-chassis:ro --env RUNTIME_OWNER=local"
     },
     "docker-gnmi-watchdog": {
         "parameters": "--pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"

--- a/tests/container_upgrade/testcases.json
+++ b/tests/container_upgrade/testcases.json
@@ -6,6 +6,8 @@
     "gnmi/test_gnmi.py": 0,
     "gnmi/test_gnmi_configdb.py": 0,
     "gnmi/test_gnmi_appldb.py": 0,
+    "gnxi/test_gnoi_system.py": 0,
+    "gnxi/test_gnoi_file.py": 0,
     "telemetry/test_telemetry.py::test_config_db_parameters": 0,
     "tacacs/test_accounting.py": 3
 }


### PR DESCRIPTION
### Description of PR

Update the container_upgrade test infrastructure to support testing the GNMI container with hardening flags and expand test coverage with gnxi tests.

**Summary:**
- Update `docker-sonic-gnmi` parameters in `parameters.json` with container hardening flags from [sonic-buildimage PR #25089](https://github.com/sonic-net/sonic-buildimage/pull/25089)
- Add `gnxi/test_gnoi_system.py` and `gnxi/test_gnoi_file.py` to `testcases.json`

**Related PR:** sonic-net/sonic-buildimage#25089

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

The GNMI container is being hardened in sonic-buildimage PR #25089, which replaces `--privileged` with specific Linux capabilities. The container_upgrade test suite needs to be updated to:
1. Use the correct docker run parameters that match the hardened container configuration
2. Include gnxi tests (gNOI system and file operations) to verify gNOI functionality works correctly with the new container configuration

#### How did you do it?

1. Updated `parameters.json` to add the following flags for `docker-sonic-gnmi`:
   - `--pid=host` - Required for nsenter to access host processes
   - `--userns=host` - Required for namespace operations
   - `--uts=host` - Required for hostname operations
   - `--cap-add=SYS_ADMIN` - For `setns()` syscall used by nsenter
   - `--cap-add=SYS_BOOT` - For reboot operations via gNOI
   - `--cap-add=SYS_PTRACE` - For reading `/proc/1/ns/*` files (kernel requires PTRACE_MODE_READ)
   - `--cap-add=NET_ADMIN` - For network administration operations
   - `--cap-add=DAC_OVERRIDE` - To bypass file permission checks
   - `--security-opt apparmor=unconfined` - Required for nsenter
   - `--security-opt seccomp=unconfined` - Required for nsenter

2. Added gnxi tests to `testcases.json`:
   - `gnxi/test_gnoi_system.py` - Tests gNOI System operations
   - `gnxi/test_gnoi_file.py` - Tests gNOI File operations

#### How did you verify/test it?

These changes align with the tested configuration in sonic-buildimage PR #25089, which was verified on vlab-01 with:
- `docker exec gnmi nsenter -t 1 -m -n -p -u -i sonic-installer list`
- `docker exec gnmi nsenter -t 1 -m -n -p -u -i reboot`

#### Any platform specific information?

N/A - These are generic container parameters applicable to all platforms.

#### Supported testbed topology if it's a new test case?

Existing topology support - `any` (as defined by container_upgrade test marks)

### Documentation

N/A