### PR TITLE
Reduce log print in test_ipv6_bgp_scale.py

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -170,13 +170,15 @@ def announce_routes(localhost, tbinfo, ptf_ip, dut_interfaces):
         log_path="/tmp",
         dut_interfaces=dut_interfaces,
         upstream_neighbor_groups=tbinfo['upstream_neighbor_groups'] if 'upstream_neighbor_groups' in tbinfo else 0,
-        downstream_neighbor_groups=tbinfo['downstream_neighbor_groups'] if 'downstream_neighbor_groups' in tbinfo else 0
+        downstream_neighbor_groups=tbinfo['downstream_neighbor_groups'] if 'downstream_neighbor_groups' in tbinfo
+        else 0,
+        verbose=False
     )
 
 
 def get_all_bgp_ipv6_routes(duthost, save_snapshot=False):
     logger.info("Getting ipv6 routes")
-    routes_str = duthost.shell("docker exec bgp vtysh -c 'show ipv6 route bgp json'")['stdout']
+    routes_str = duthost.shell("docker exec bgp vtysh -c 'show ipv6 route bgp json'", verbose=False)['stdout']
     if save_snapshot:
         with open("/tmp/bgp_ipv6_routes_" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + '.json', "w") as f:
             f.write(routes_str)
@@ -208,7 +210,8 @@ def change_routes_on_peers(localhost, ptf_ip, topo_name, peers_routes_to_change,
         peers_routes_to_change=peers_routes_to_change,
         path="../ansible/",
         log_path="/tmp",
-        dut_interfaces=dut_interfaces
+        dut_interfaces=dut_interfaces,
+        verbose=False
     )
 
 
@@ -393,6 +396,7 @@ def check_bgp_routes_converged(duthost, expected_routes, shutdown_connections=No
         interval=interval,
         log_path=log_path,
         compressed=compressed,
+        verbose=False,
         action=action
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1188,6 +1188,7 @@ def topo_bgp_routes(localhost, ptfhosts, tbinfo):
             path="../ansible/",
             log_path=log_path,
             dut_interfaces=servers_dut_interfaces.get(ptf_ip) if servers_dut_interfaces else None,
+            verbose=False
         )
         if 'topo_routes' not in res:
             logger.warning("No routes generated.")


### PR DESCRIPTION
Summary: Reduce log print in test_ipv6_bgp_scale.py
Fixes # 
Command `show ipv6 route bgp json` and announce_routes print large scale logs (more than 300M for one case and 2G for test session), which cause cannot analysis failure log
Fix: Reduce route log print

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
