### PR TITLE
[Smartswitch] Use VM_VNI as the outer VNI for PL outbound packet

### DIFF
--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -170,7 +170,7 @@ def inbound_pl_packets(
         ip_id=0,
         udp_dport=vxlan_udp_dport,
         udp_sport=vxlan_udp_base_src_port,
-        vxlan_vni=pl.ENCAP_VNI if floating_nic else int(pl.VNET1_VNI),
+        vxlan_vni=pl.ENCAP_VNI if floating_nic else int(pl.VM_VNI),
         inner_frame=exp_inner_packet,
     )
 
@@ -261,7 +261,7 @@ def outbound_pl_packets(
             ip_src=pl.VM1_PA,
             ip_dst=pl.APPLIANCE_VIP,
             gre_key_present=True,
-            gre_key=(outer_vni << 8) if floating_nic else (int(pl.VNET1_VNI) << 8),
+            gre_key=(outer_vni << 8) if floating_nic else (int(pl.VM_VNI) << 8),
             inner_frame=inner_packet,
         )
     else:
@@ -427,7 +427,7 @@ def verify_each_packet_on_each_port(exp_pkts, received_pkts_res, ports):
     """
     Verify each packet can be received on the corresponding port
     """
-    logger.info(f"Checking pkts on ports :{ports}")
+    logger.info(f"Checking pkts on ports: {ports}")
     for port, exp_pkt in zip(ports, exp_pkts):
         if port in received_pkts_res:
             find_matched_ptk = False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The outer VNI for PL outbound packet should be the VM_VNI when it's the VM scenario(not floating NIC).

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Run the dash PL test on SN4280 light mode testbed, passed.
#### Any platform specific information?
Only for smartswitch.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
