### PR TITLE
Fix test_vrf1_neigh_after_restore

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1655,6 +1655,18 @@ class TestVrfDeletion:
                 for ip in ips:
                     duthost.shell("config interface ip add {} {}".format(intf, ip))
 
+        time.sleep(5)
+
+        for intf, ip_facts in list(g_vars["vrf_intfs"]["Vrf1"].items()):
+            if 'Vlan' not in intf:
+                continue
+            for ver, ips in list(ip_facts.items()):
+                for ip in ips:
+                    neigh_ip = ip.ip + 1
+                    ping_cmd = 'ping' if ip.version == 4 else 'ping6'
+                    duthost.shell("{} -I Vrf1 {} -c 1 -f -W1".format(ping_cmd,
+                                  neigh_ip), module_ignore_errors=True)
+
     @pytest.fixture(scope="class", autouse=True)
     def setup_vrf_deletion(self, duthosts, rand_one_dut_hostname, ptfhost, tbinfo, cfg_facts):
         duthost = duthosts[rand_one_dut_hostname]


### PR DESCRIPTION
### Summary:
Fixed test_vrf1_neigh_after_restore failure by adding neighbor pre-resolution to restore_vrf(). After VRF deletion, the neighbor cache is flushed. Restoring only the configuration (VRF, interfaces, IPs) leaves neighbors unresolved, causing PTF test timeouts. Added ping-based neighbor discovery (mirroring setup_vlan_peer() lines 338-340) to pre-resolve VLAN neighbors before tests run.





### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach

#### What is the motivation for this PR?

The test case `test_vrf1_neigh_after_restore` in `TestVrfDeletion` class was consistently failing because:

1. **Root Cause**: 
After VRF deletion (`config vrf del Vrf1`), all neighbor entries (ARP/NDP) are flushed from the neighbor cache.

2. **The Problem**: 
When VRF is restored via `restore_vrf()`, only the configuration is restored (VRF creation, interface binding, IP address assignment). The neighbor cache remains empty.

VLAN neighbor not restored after VRF restoration :
```
root@sup-t0-dut:/home/admin# ip -6 neigh show vrf Vrf1
fc00::2 dev PortChannel101 lladdr 06:65:18:d6:60:fc router REACHABLE 
fc00::a dev PortChannel102 lladdr 3e:9f:7b:02:f1:85 router REACHABLE 
```

4. **Why Initial Setup Works**: 
The `setup_vlan_peer()` function explicitly pings VLAN neighbors to pre-populate the neighbor cache before tests run, ensuring neighbors are in REACHABLE state.


5. **The Gap**: 
The `restore_vrf()` method was missing this critical neighbor pre-resolution step, creating an inconsistency between initial setup and restoration behavior.


#### How did you do it?

Added neighbor pre-resolution logic to the `restore_vrf()` method in the `TestVrfDeletion` class (lines 1666-1671) that exactly mirrors the approach used in `setup_vlan_peer()` (lines 338-340):


### With the fix VLAN neighbor restored after VRF restoration :
```
admin@sup-t0-dut:~$ ip -6 neigh show vrf Vrf1
fe80::3c9f:7bff:fe02:f185 dev PortChannel102 FAILED 
fc00:168::2 dev Vlan1000 lladdr 0a:b5:ef:f2:f0:59 REACHABLE 
fc00::2 dev PortChannel101 lladdr 06:65:18:d6:60:fc router REACHABLE 
fc00::a dev PortChannel102 lladdr 3e:9f:7b:02:f1:85 router REACHABLE 

```


