### PR TITLE
[bgp] Suppress verbose logging in route_checker to prevent 10+ GB log files

### DIFF
--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -112,10 +112,10 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
             if multi_vrf_peer:
                 cmd_backup = "{} vrf {}".format(cmd_backup, hostname)
             cmd_backup = "{} | {}".format(cmd_backup, grepCmd)
-        res = host.eos_command(commands=[cmd], module_ignore_errors=True)
+        res = host.eos_command(commands=[cmd], module_ignore_errors=True, verbose=False)
         if res['failed'] and cmd_backup != "":
             res = host.eos_command(
-                commands=[cmd_backup], module_ignore_errors=True)
+                commands=[cmd_backup], module_ignore_errors=True, verbose=False)
         pytest_assert(
             not res['failed'], "Failed to retrieve routes from VM {}".format(hostname))
         routes = {}
@@ -195,7 +195,7 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
                 peer_ip_v6)
 
         host.shell(conf_cmd)
-        res = host.shell(bgp_nbr_cmd)
+        res = host.shell(bgp_nbr_cmd, verbose=False)
         routes_json = json.loads(res['stdout'])['receivedRoutes']
 
         routes = {}


### PR DESCRIPTION
**Summary:**
This PR fixes excessive debug logging in `route_checker.py` that produces 10+ GB log files on T2 topologies, filling disks and slowing down test infrastructure.

**Context:** The `parse_routes_process()` and `parse_routes_process_vsonic()` functions call `eos_command()` and `shell()` with the default `verbose=True`. The Ansible debug logger then dumps both the full command arguments AND the complete results (thousands of BGP routing table entries per neighbor) into the log file. On T2 topologies with many VMs and large routing tables, this produces individual log files exceeding 10 GB.

**Fix:** Pass `verbose=False` to the `eos_command()` and `shell()` calls in the route parsing functions. This follows the existing pattern used by `parse_rib()` in `bgp_helpers.py` which already uses `verbose=False` for the same reason. Route data is parsed programmatically — there is no diagnostic value in logging the raw output. Errors are still properly reported via `pytest_assert`.

Fixes #19165

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To prevent test log files from growing to 10+ GB, which fills disks and degrades test infrastructure on T2 topologies.

#### How did you do it?
Added `verbose=False` to three call sites in `tests/bgp/route_checker.py`:
1. `host.eos_command(commands=[cmd], module_ignore_errors=True, verbose=False)` — primary route query
2. `host.eos_command(commands=[cmd_backup], module_ignore_errors=True, verbose=False)` — fallback route query  
3. `host.shell(bgp_nbr_cmd, verbose=False)` — vsonic route query

This matches the existing pattern in `parse_rib()` (`bgp_helpers.py:183`) which already uses `verbose=False`.

#### How did you verify/test it?
- Code review confirmed that `verbose=False` suppresses the DEBUG-level logging of command arguments and results in `AnsibleHostBase._run()` (`tests/common/devices/base.py:73-89, 119-128`)
- The `verbose=False` parameter is an established pattern already used in `parse_rib()` for the same reason
- Error handling via `pytest_assert` and `res['failed']` checks remains unchanged

#### Any platform specific information?
Most impactful on T2 topologies with many BGP neighbors, but the fix is generic.

#### Supported testbed topology if it is a new test case?
N/A — existing infrastructure fix.

### Documentation
N/A