### PR TITLE
test gNMI instead of telemetry in minigraph test

### DIFF
--- a/tests/minigraph/test_masked_services.py
+++ b/tests/minigraph/test_masked_services.py
@@ -33,26 +33,18 @@ def change_service_state(duthost, service, enable):
 @pytest.mark.disable_loganalyzer
 def test_masked_services(duthosts, rand_one_dut_hostname):
     """
-    @summary: This test case will mask telemetry/gnmi service, then test load_minigraph and check its success
+    @summary: This test case will mask gnmi service, then test load_minigraph and check its success
     """
     duthost = duthosts[rand_one_dut_hostname]
-    cmd = "docker images | grep -w sonic-telemetry"
+    cmd = "docker images | grep -w sonic-gnmi"
     if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-        cmd = "docker ps | grep -w telemetry"
+        cmd = "docker ps | grep -w gnmi"
         if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-            test_service = "telemetry"
+            test_service = "gnmi"
         else:
-            pytest.fail("Telemetry is not running")
+            pytest.fail("GNMI is not running")
     else:
-        cmd = "docker images | grep -w sonic-gnmi"
-        if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-            cmd = "docker ps | grep -w gnmi"
-            if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-                test_service = "gnmi"
-            else:
-                pytest.fail("GNMI is not running")
-        else:
-            pytest.fail("Can't find telemetry and gnmi image")
+        pytest.fail("Can't find gnmi image")
     logging.info("Bringing down {} service".format(test_service))
     service_status = duthost.critical_process_status(test_service)
 


### PR DESCRIPTION
The test looks for the presense of the telemetry image, and if found tries to start the container. A change in sonic-buildiamge resulted in the telemetry container no longer being started by default, so the presense of the image does not imply the container is running.

We could change this test to manually start telemetry, but I think a better solution is to move to gNMI, whose image is always present and should always be started.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Manually ran the test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
