### PR TITLE
Modifying raise exception logic

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -237,9 +237,9 @@ def gnmi_set(duthost, ptfhost, delete_list, update_list, replace_list, cert=None
 
     output = ptfhost.shell(cmd, module_ignore_errors=True)
 
-    stdout = output.get("stdout", "") or ""
-    stderr = output.get("stderr", "") or ""
-    rc = output.get("rc", 0)
+    stdout = output.get("stdout") or ""
+    stderr = output.get("stderr") or ""
+    rc = output.get("rc", 1)
     combined = f"{stdout}\n{stderr}"
 
     if rc != 0 or "GRPC error" in combined or "rpc error" in combined:


### PR DESCRIPTION
### Description of PR

Summary: Fix flakiness in `tests/gnmi/test_gnmi.py::test_gnmi_authorize_failed_with_revoked_cert` where the gNMI CLI failure could be missed (e.g., non-zero rc or stderr-only gRPC error), resulting in an empty captured message and an assertion failure.

Fixes: N/A (internal PROD ADO:36433384 for flaky test; no public issue linked)

### Type of change

* [x] Bug fix
* [ ] Testbed and Framework(new/improvement)
* [ ] New Test case

  * [ ] Skipped for non-supported platforms
* [ ] Test case improvement

### Back port request

* [ ] 202205
* [ ] 202305
* [ ] 202311
* [ ] 202405
* [ ] 202411
* [x] 202505
* [ ] 202511

### Approach

#### What is the motivation for this PR?

`test_gnmi_authorize_failed_with_revoked_cert` intermittently failed because the gNMI client command could fail without matching the existing `"GRPC error\n"` stdout check, leaving the test’s captured error message empty.

#### How did you do it?

Updated `gnmi_set()` error handling to reliably detect failures by checking command return code and gRPC error markers across stdout/stderr, and raise a detailed exception so the caller consistently captures the real failure reason.

#### How did you verify/test it?

Validated on a 202505 image using a 7050CX3 DUT (T0) by running:

* `tests/gnmi/test_gnmi.py::test_gnmi_capabilities`
* `tests/gnmi/test_gnmi.py::test_gnmi_capabilities_authenticate`
* `tests/gnmi/test_gnmi.py::test_gnmi_authorize_failed_with_invalid_cname`
* `tests/gnmi/test_gnmi.py::test_gnmi_authorize_failed_with_revoked_cert`

Result: **4 passed**.

#### Any platform specific information?

Observed previously on 7050CX3/vms testbeds; change is generic to gNMI CLI error capture.

#### Supported testbed topology if it's a new test case?

N/A.

### Documentation

N/A.
