### PR TITLE
[memory_checker] Always test gnmi container instead of deprecated telemetry

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -244,7 +244,7 @@ def test_setup_and_cleanup(memory_checker_dut_and_container, request):
 
 @pytest.fixture
 def remove_and_restart_container(memory_checker_dut_and_container):
-    """Removes and restarts 'telemetry' container from DuT.
+    """Removes and restarts 'gnmi' container from DuT.
 
     Args:
         memory_checker_dut_and_container: Fixture providing the duthost and container to test
@@ -263,11 +263,14 @@ def remove_and_restart_container(memory_checker_dut_and_container):
 
 
 def get_test_container(duthost):
-    test_container = "gnmi"
-    cmd = "docker images | grep -w sonic-telemetry"
-    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-        test_container = "telemetry"
-    return test_container
+    """Return the container name for memory checker tests.
+
+    Always use 'gnmi' — the telemetry container is deprecated and may be
+    masked via systemd even when its Docker image is present.  Testing
+    telemetry when it exists but is masked causes spurious failures.
+    See: https://github.com/sonic-net/sonic-mgmt/issues/22349
+    """
+    return "gnmi"
 
 
 @pytest.fixture


### PR DESCRIPTION
#### Why I did it

Fixes #22349.

`test_memory_checker` previously checked for the `sonic-telemetry` Docker image and tested the telemetry container if present. Since the telemetry container is now deprecated and may be masked via systemd even when its image exists in the build, this causes spurious test failures.

#### How I did it

Changed `get_test_container()` to always return `"gnmi"` instead of conditionally selecting `"telemetry"` when its Docker image is present. Updated the fixture docstring accordingly.

#### How to verify it

1. Build a SONiC image that includes `sonic-telemetry` but has the telemetry service masked
2. Run `test_memory_checker` — it should now always test the `gnmi` container and pass
3. On images without telemetry, behavior is unchanged (was already falling back to gnmi)