### PR TITLE
Fix stale COPP_TRAP entry left behind when OSPF BFD test is skipped

### DIFF
--- a/tests/ospf/conftest.py
+++ b/tests/ospf/conftest.py
@@ -39,7 +39,8 @@ EOF
     yield
 
     duthost.command(f"sudo rm {copp_trap_ospf_rule_json}")
-
+    config_reload(duthost, config_source='config_db', safe_reload=True)
+    time.sleep(10)
     return duthost
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes YANG validation failure during teardown of `ospf/test_ospf_bfd.py` when the test is skipped, by ensuring a stale `COPP_TRAP|ospf entry` is removed from the `CONFIG_DB`.

Fixes # (issue): 
https://github.com/sonic-net/sonic-mgmt/issues/22430
https://github.com/aristanetworks/sonic-qual.msft/issues/1106

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test `ospf/test_ospf_bfd.py` was failing during the teardown phase with a YANG validation error, specifically: 
```
Leafref "/sonic-copp/COPP_GROUP/COPP_GROUP_LIST/name" of value "queue4_group1" points to a non-existing leaf. 
```
This occurred when the test was skipped, which prevented the `ospf_Bfd_setup` fixture teardown (containing config_reload()) from running. Consequently, a stale `COPP_TRAP|ospf entry` was left in the `CONFIG_DB`, causing the re-enabled yang_validation_check to fail.

#### How did you do it?
`config_reload` was added to the teardown of the `trap_copp_ospf` fixture in `tests/ospf/conftest.py`. Since `trap_copp_ospf` always reaches its yield, its teardown consistently runs, regardless of whether downstream fixtures skip or fail. The addition of config_reload restores the entire `CONFIG_DB` from the clean `/etc/sonic/config_db.json`, ensuring the stale `COPP_TRAP|ospf` entry is removed.

#### How did you verify/test it?
The test execution confirmed that the test was skipped as expected (SKIPPED (Neighbor type must be sonic)), and the YANG validation failure was resolved.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
