### PR TITLE
[SRv6] Add srv6 dataplane tests stability by definition of weak server

### DIFF
--- a/tests/common/mellanox_data.py
+++ b/tests/common/mellanox_data.py
@@ -1210,6 +1210,11 @@ def is_mellanox_device(dut):
 
 
 @read_only_cache()
+def is_weak_server_testbed(dut):
+    return "simx" in dut.facts["platform"]
+
+
+@read_only_cache()
 def get_platform_data(dut):
     """
     Get the platform physical data for the given dut object

--- a/tests/srv6/test_srv6_dataplane.py
+++ b/tests/srv6/test_srv6_dataplane.py
@@ -18,7 +18,7 @@ from tests.common.helpers.assertions import pytest_assert
 from tests.common.portstat_utilities import parse_portstat
 from tests.common.utilities import wait_until
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
-from tests.common.mellanox_data import is_mellanox_device
+from tests.common.mellanox_data import is_mellanox_device, is_weak_server_testbed
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 from tests.common.helpers.srv6_helper import create_srv6_packet, send_verify_srv6_packet, \
     validate_srv6_in_appl_db, validate_srv6_in_asic_db, validate_srv6_route, is_bgp_route_synced
@@ -209,6 +209,10 @@ class SRv6Base():
         pytest_assert(wait_until(120, 5, 0, validate_srv6_route, duthost, ROUTE_BASE),
                       "SRv6 route in ASIC DB is not as expected")
 
+        delay_interval = 0
+        if is_weak_server_testbed(duthost):
+            delay_interval = 0.4
+            self.params['packet_num'] = 10
         ptf_src_mac = ptfadapter.dataplane.get_mac(0, self.params['ptf_downlink_port']).decode('utf-8')
         for srv6_packet in self.params['srv6_packets']:
             if duthost.facts["asic_type"] == "broadcom" and \
@@ -286,6 +290,7 @@ class SRv6Base():
             )
 
             srv6_pkt_list.append(srv6_pkt)
+            time.sleep(delay_interval)
 
         return srv6_pkt_list
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
SRv6 dataplane tests send ~13k packets in a short time(topo t0-isolated-d32u32s2).
On a weak server, not all packets from ptf are sent.
To add test stability also on this testbed, reduce the number of sent packets and add a delay between sends.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Test stability on a testbed with a weak server

#### How did you do it?
Defined weak server.

#### How did you verify/test it?
Test case executed in a loop on the testbed with a weak server.

