### PR TITLE
[gcu/test_dns_nameserver] Fix flaky CI failures caused by not waiting long enough

### DIFF
--- a/tests/generic_config_updater/test_dns_nameserver.py
+++ b/tests/generic_config_updater/test_dns_nameserver.py
@@ -134,8 +134,11 @@ def remove_dns_nameserver(duthost, dns_nameserver):
         expect_op_success(duthost, output)
 
         pytest_assert(
-            not server_exist_in_conf(duthost, DNS_SERVER_RE.format(dns_nameserver)),
-            "Failed to remove {} from /etc/resolv.conf".format(dns_nameserver)
+            wait_until(10, 2, 0,
+                       lambda host, ns: not server_exist_in_conf(host, ns),
+                       duthost,
+                       DNS_SERVER_RE.format(dns_nameserver)),
+            f"Failed to remove {dns_nameserver} from /etc/resolv.conf"
         )
 
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Fix flaky failures in `test_dns_nameserver.py` caused by not waiting long enough for the resolv-config service on the DUT to update `/etc/resolv.conf`. Based on logs, just waiting one second might be sufficient, but allow up to 10 seconds, checking every 2 seconds.

#### How did you do it?

Use `wait_until` to repeatedly check `/etc/resolv.conf` on the DUT to see if it has (or does not have) the expected entries.

#### How did you verify/test it?

Ran the test a few times locally on a T1 KVM setup, but note that I wasn't able to locally repro the flaky failures, so this just verifies basic functionality.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
