### PR TITLE
cherry-pick/merging two step process of verifying and storing the lldp content (#22269)

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -131,24 +131,58 @@ def _shutdown_startup_interface(duthost, interface, asic_str=""):
     duthost.shell("sudo config interface {} startup {}".format(asic_str, interface))
 
 
-def _verify_interface_lldp_recovery(db_instance, interfaces, lldpctl_interfaces, delay=0):
+def _build_lldpctl_lookup_map(lldpctl_interfaces):
+    """
+    Build a lookup map from lldpctl interfaces for O(1) access.
+    """
+    if isinstance(lldpctl_interfaces, dict):
+        return lldpctl_interfaces
+    lldpctl_map = {}
+    if isinstance(lldpctl_interfaces, list):
+        for iface in lldpctl_interfaces:
+            key = list(iface.keys())[0]
+            lldpctl_map[key.lower()] = iface.get(key)
+    return lldpctl_map
+
+
+def _verify_interface_lldp_recovery(db_instance, interfaces, lldpctl_lookup_map, timeout=60, interval=2, delay=0):
     """
     Verify LLDP entry recovers for interface(s) after flap.
     Supports both single interface (str) and multiple interfaces (list).
     """
     if isinstance(interfaces, str):
         interfaces = [interfaces]
+    pending_interfaces = set(interfaces)
+    entry_content_dict = {}
 
-    result = wait_until(60, 2, delay, verify_lldp_entry, db_instance, interfaces)
+    def _verify_lldp_entry_with_cache(db_instance, interfaces: list):
+        nonlocal entry_content_dict, pending_interfaces
+
+        for interface in interfaces:
+            # If content is populated for an interface, skip it in subsequent retries to save time.
+            if interface in entry_content_dict:
+                continue
+            entry_content = get_lldp_entry_content(db_instance, interface)
+            # Check if LLDP entry content is populated for an interface else return false to trigger wait_until retry
+            if len(entry_content) <= 1:
+                logger.debug("Interface {} LLDP entry not yet recovered".format(interface))
+                return False
+            # Store the content in dict and move to the next interface
+            entry_content_dict[interface] = entry_content
+            pending_interfaces.remove(interface)
+
+        return True
+
+    result = wait_until(timeout, interval, delay, _verify_lldp_entry_with_cache, db_instance, interfaces)
     pytest_assert(
         result,
         "After interface flap, LLDP_ENTRY_TABLE entries not recovered for: {}".format(
-            ", ".join(interfaces)
+            ", ".join(pending_interfaces)
         ),
     )
 
     for interface in interfaces:
-        verify_each_interface_lldp_content(db_instance, interface, lldpctl_interfaces)
+        assert_lldp_entry_content(interface, entry_content_dict[interface], lldpctl_lookup_map.get(interface.lower()))
 
 
 def assert_lldp_interfaces(
@@ -391,10 +425,11 @@ def test_lldp_entry_table_after_cont_flap(
         )
     logger.info("Using sequential flapping interfaces: {}".format(testable_interfaces))
     asic_interface_map = group_interfaces_by_asic(duthost, testable_interfaces)
+    lldpctl_lookup_map = _build_lldpctl_lookup_map(lldpctl_interfaces)
     for asic_str, asic_interfaces in asic_interface_map.items():
         for interface in asic_interfaces:
             _shutdown_startup_interface(duthost, interface, asic_str)
-            _verify_interface_lldp_recovery(db_instance, interface, lldpctl_interfaces, delay=10)
+            _verify_interface_lldp_recovery(db_instance, interface, lldpctl_lookup_map, delay=10)
 
 
 # Test case 4: Verify LLDP_ENTRY_TABLE after all batched interface flap
@@ -413,12 +448,13 @@ def test_lldp_entry_table_after_all_batched_flap(
     testable_interfaces = [iface for iface in lldp_entry_keys if iface != "eth0"]
     logger.info("Using bulk interface flap for {} interfaces".format(len(testable_interfaces)))
     asic_interface_map = group_interfaces_by_asic(duthost, testable_interfaces)
+    lldpctl_lookup_map = _build_lldpctl_lookup_map(lldpctl_interfaces)
     for asic_str, asic_interfaces in asic_interface_map.items():
         interface_list = ",".join(asic_interfaces)
         logger.info("Flapping interfaces: {}".format(interface_list))
         _shutdown_startup_interface(duthost, interface_list, asic_str)
     # Single wait_until call checking all interfaces together
-    _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_interfaces, delay=10)
+    _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_lookup_map, delay=10)
 
 
 # Test case 5: Verify LLDP_ENTRY_TABLE after system reboot


### PR DESCRIPTION

What is the motivation for this PR?
Initially, first we only verified the existence of the lldp entry without storing it. Then we again query the DB for each interface and then asserting the same content fetched previously. This is now combined with a single function call that verifies the lldp data is back and stores alongside that is now used for assertion.

How did you do it?
Refactored LLDP test logic in tests/lldp/test_lldp_syncd.py: Added _build_lldpctl_lookup_map() for faster lldpctl lookups. Added _verify_interface_lldp_recovery() that verifies recovery for one-or-many interfaces with caching to reduce repeated DB reads. How did you verify/test it?
Ran the LLDP test module and observed runtime improvement on large neighbor scale as compared to per-interface flap+wait loops (this PR is the “further optimization” referenced in bulk and 32 ports sequential cases in lldp test module #22145).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
