### PR TITLE
[snappi] Add test_cleanup code for tgen_port_info infra function

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1779,8 +1779,7 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
             duthosts, snappi_ports, snappi_api, setup=True)
         yield (testbed_config, port_config_list, snappi_ports)
         logger.info('Snappi cleanup after test')
-        setup = False
-        setup_dut_ports(setup, duthosts, testbed_config, port_config_list, snappi_ports)
+        setup_dut_ports(False, duthosts, testbed_config, port_config_list, snappi_ports)
     else:
         flatten_skeleton_parameter = request.param
         speed, category = flatten_skeleton_parameter.split("-")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The tgen_port_info infra function in common/snappi_tests/snappi_fixtures.py is used to select port (dynamically or statically) for the test. During static port selection, the variables.override.yml file is used to select Rx and Tx port for the test.

However, after the test, there was no explicit test clean_up code. This PR addresses it.

Summary:
Fixes #

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The tgen_port_info is used to select the Rx and Tx port for the test.

In case of static port selection, the function returned snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True), and there was no explicit cleanup after the test.

#### How did you do it?
- If the 'is_override' flag is true, the static port selection code is used to select Rx and Tx ports from variables.override.yml file.
- Instead of returning with function 'snappi_dut_base_config', 'yield' is called to ensure that clean-up is called at the end of the test.
- Once yield returns back to the test, then 'setup_dut_ports' is called with setup=False to ensure that clean-up happens after the test.

#### How did you verify/test it?
- Modified the code in setup_dut_ports to use the p2p IP-addresses for the test.
- When the test is 'yielded' back to the function, the setup_dut_port is called for cleanup. Checked if the log is printed to ensure that clean-up is indeed called.
- There is an 'else' statement added to ensure that dynamic port selection is NOT called after the yield returns back the test to tgen_port_info function.
- Tested on 202511 local branch.

Option#1 - One port is Router port and other is port-channel.
```
--- curtailed output ----
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1994 Running test for test-subtype:single-line-long-to-short-400Gbps
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1577 rx_port:[{'ip': '100.117.59.187', 'port_id': '5', 'peer_port': 'Ethernet56', 'peer_device': 'ixre-egl-board74', 'speed': '400000', 'location': '100.117.59.187/12', 'intf_config_changed': False, 'api_server_ip': '10.251.30.3', 'asic_type': 'broadcom', 'duthost': <MultiAsicSonicHost ixre-egl-board74>, 'snappi_speed_type': 'speed_400_gbps', 'asic_value': 'asic0'}]
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1578 tx_port:[{'ip': '100.117.59.187', 'port_id': '2', 'peer_port': 'Ethernet40', 'peer_device': 'ixre-egl-board73', 'speed': '400000', 'location': '100.117.59.187/2', 'intf_config_changed': False, 'api_server_ip': '10.251.30.3', 'asic_type': 'broadcom', 'duthost': <MultiAsicSonicHost ixre-egl-board73>, 'snappi_speed_type': 'speed_400_gbps', 'asic_value': 'asic0'}]
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:358 Using system_id:00:00:00:00:00:01 for portchannel:PortChannel111
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:890 Configuring p2p IPs on the interface
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1218 Configuring Dut: ixre-egl-board74 with port Ethernet56 with IP 20.1.1.0/31
--- curtailed output ----
----------------------------------------------------------------------------------------------------------------------- live log teardown ------------------------------------------------------------------------------------------------------------------------
INFO     tests.common.plugins.memory_utilization:__init__.py:124 After test: collected memory_values {'before_test': {}, 'after_test': {}}
INFO     root:__init__.py:93 -------------------- fixture disable_pfcwd teardown starts --------------------
INFO     root:__init__.py:102 -------------------- fixture disable_pfcwd teardown ends --------------------
INFO     root:__init__.py:93 -------------------- fixture tgen_port_info teardown starts --------------------
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:2026 Should come back here after finishing the test else useless
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:890 Configuring p2p IPs on the interface
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1218 Configuring Dut: ixre-egl-board74 with port Ethernet56 with IP 20.1.1.0/31
INFO     root:__init__.py:102 -------------------- fixture tgen_port_info teardown ends --------------------
 snappi_tests/pfc/test_global_pause_with_snappi_new.py::test_global_pause[tgen_port_info0] âœ“                                                                                                                                                        50% â–ˆâ–ˆâ–ˆâ–ˆâ–ˆ  
```

Option#2: when both the ports are port-channels:
```
--- curtailed output ----
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1994 Running test for test-subtype:single-line-long-to-long-400Gbps
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1577 rx_port:[{'ip': '100.117.59.187', 'port_id': '2', 'peer_port': 'Ethernet40', 'peer_device': 'ixre-egl-board73', 'speed': '400000', 'location': '100.117.59.187/2', 'intf_config_changed': False, 'api_server_ip': '10.251.30.3', 'asic_type': 'broadcom', 'duthost': <MultiAsicSonicHost ixre-egl-board73>, 'snappi_speed_type': 'speed_400_gbps', 'asic_value': 'asic0'}]
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:1578 tx_port:[{'ip': '100.117.59.187', 'port_id': '3', 'peer_port': 'Ethernet152', 'peer_device': 'ixre-egl-board73', 'speed': '400000', 'location': '100.117.59.187/5', 'intf_config_changed': False, 'api_server_ip': '10.251.30.3', 'asic_type': 'broadcom', 'duthost': <MultiAsicSonicHost ixre-egl-board73>, 'snappi_speed_type': 'speed_400_gbps', 'asic_value': 'asic1'}]
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:358 Using system_id:00:00:00:00:00:02 for portchannel:PortChannel111
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:358 Using system_id:00:00:00:00:00:03 for portchannel:PortChannel112
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:904 Found relevant portchannel interfaces
INFO     root:__init__.py:85 -------------------- fixture tgen_port_info setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture disable_pfcwd setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture disable_pfcwd setup ends --------------------
--- curtailed output ----
----------------------------------------------------------------------------------------------------------------------- live log teardown ------------------------------------------------------------------------------------------------------------------------
INFO     tests.common.plugins.memory_utilization:__init__.py:124 After test: collected memory_values {'before_test': {}, 'after_test': {}}
INFO     root:__init__.py:93 -------------------- fixture disable_pfcwd teardown starts --------------------
INFO     root:__init__.py:102 -------------------- fixture disable_pfcwd teardown ends --------------------
INFO     root:__init__.py:93 -------------------- fixture tgen_port_info teardown starts --------------------
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:2026 Should come back here after finishing the test else useless
--- curtailed output ----
INFO     tests.conftest:conftest.py:3114 Core dump and config check passed for test_global_pause_with_snappi_new.py
 snappi_tests/pfc/test_global_pause_with_snappi_new.py::test_global_pause[tgen_port_info1] âœ“                                                                                                                                                       100% â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ
--- curtailed output ----
--------------------------------------------------------------------------------------------------------------------- live log sessionfinish ---------------------------------------------------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs

Results (704.84s (0:11:44)):
       2 passed
INFO:root:Can not get Allure report URL. Please check logs
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
