### PR TITLE
[memory_checker] Always test gnmi container instead of deprecated telemetry

### DIFF
--- a/tests/memory_checker/test_memory_checker.py
+++ b/tests/memory_checker/test_memory_checker.py
@@ -244,7 +244,7 @@ def test_setup_and_cleanup(memory_checker_dut_and_container, request):
 
 @pytest.fixture
 def remove_and_restart_container(memory_checker_dut_and_container):
-    """Removes and restarts 'telemetry' container from DuT.
+    """Removes and restarts 'gnmi' container from DuT.
 
     Args:
         memory_checker_dut_and_container: Fixture providing the duthost and container to test
@@ -262,14 +262,6 @@ def remove_and_restart_container(memory_checker_dut_and_container):
     container.post_check()
 
 
-def get_test_container(duthost):
-    test_container = "gnmi"
-    cmd = "docker images | grep -w sonic-telemetry"
-    if duthost.shell(cmd, module_ignore_errors=True)['rc'] == 0:
-        test_container = "telemetry"
-    return test_container
-
-
 @pytest.fixture
 def memory_checker_dut_and_container(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """Perform some checks and return applicable duthost and container name
@@ -284,7 +276,10 @@ def memory_checker_dut_and_container(duthosts, enum_rand_one_per_hwsku_frontend_
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
 
-    container_name = get_test_container(duthost)
+    # Always test gnmi — telemetry is deprecated and may be masked via
+    # systemd even when its Docker image is present.
+    # See: https://github.com/sonic-net/sonic-mgmt/issues/22349
+    container_name = "gnmi"
     container = MemoryCheckerContainer(container_name, duthost)
 
     pytest_require("Celestica-E1031" not in duthost.facts["hwsku"]


### PR DESCRIPTION
Fixes #22349.

test_memory_checker previously checked for the sonic-telemetry Docker image
and tested the telemetry container if present. Since the telemetry container
is now deprecated and may be masked via systemd even when its image exists,
this causes test failures.

Always use the 'gnmi' container for memory checker tests, which is the
current active replacement for telemetry.

Signed-off-by: Rustiqly <rustiqly@users.noreply.github.com>
Signed-off-by: Sonicly1G <sonicly1g@users.noreply.github.com>

Re-submitted from rustiqly (closes #22427). Fixes #22349.