### PR TITLE
[gcu/test_ntp.py] Don't use T2 sup for running GCU NTP test

### DIFF
--- a/tests/generic_config_updater/test_ntp.py
+++ b/tests/generic_config_updater/test_ntp.py
@@ -340,10 +340,11 @@ def ntp_server_set_intf(duthost, ntp_service, src_intf):
         delete_tmpfile(duthost, tmpfile)
 
 
-def test_ntp_server_change_source_intf(rand_selected_dut):
+# For T2 devices, don't run this on the sup, since Loopback0 doesn't exist.
+def test_ntp_server_change_source_intf(rand_selected_front_end_dut):
     """ Test changing the source interface via GCU
     """
-    ntp_service = get_ntp_service_name(rand_selected_dut)
+    ntp_service = get_ntp_service_name(rand_selected_front_end_dut)
 
-    ntp_server_set_intf(rand_selected_dut, ntp_service, "Loopback0")
-    ntp_server_set_intf(rand_selected_dut, ntp_service, "eth0")
+    ntp_server_set_intf(rand_selected_front_end_dut, ntp_service, "Loopback0")
+    ntp_server_set_intf(rand_selected_front_end_dut, ntp_service, "eth0")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

On T2, the supervisor card doesn't have a Loopback0 interface. Because Loopback0 is hardcoded in the GCU NTP test, this test case will fail there.

#### How did you do it?

Avoid that failure by making sure a LC is chosen.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
