### PR TITLE
Fix python interpreter issue in advanced-reboot sad path

### DIFF
--- a/tests/common/fixtures/advanced_reboot.py
+++ b/tests/common/fixtures/advanced_reboot.py
@@ -662,6 +662,11 @@ class AdvancedReboot:
                     test_results[test_case_name].append("Failed to verify BGP router identifier is Loopback0 on %s" %
                                                         self.duthost.hostname)
             except Exception:
+                # The duthost may or may not have rebooted/upgraded at the time of exception, hence we may not
+                # have cleared the facts yet and still have a non-existant python interpreter in the cached facts.
+                # Therefore, clear the facts cached here as well to avoid any issues with running commands
+                # on the duthost after an exception is caught.
+                self.duthost.meta("clear_facts")
                 traceback_msg = traceback.format_exc()
                 err_msg = "Exception caught while running advanced-reboot test on ptf: \n{}".format(traceback_msg)
                 logger.error(err_msg)
@@ -761,6 +766,11 @@ class AdvancedReboot:
                 if self.consistency_checker_provider:
                     self.check_asic_and_db_consistency()
             except Exception:
+                # The duthost may or may not have rebooted/upgraded at the time of exception, hence we may not
+                # have cleared the facts yet and still have a non-existant python interpreter in the cached facts.
+                # Therefore, clear the facts cached here as well to avoid any issues with running commands
+                # on the duthost after an exception is caught.
+                self.duthost.meta("clear_facts")
                 traceback_msg = traceback.format_exc()
                 err_msg = "Exception caught while running advanced-reboot test on ptf during upgrade {}: \n{}".format(
                     upgrade_path_str, traceback_msg)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
MSFT ADO: 36810683

This is a follow on to https://github.com/sonic-net/sonic-mgmt/pull/22123 where that PR only handled the python interpreter issues for a happy path through the tests. For a sad path, we can still hit the issue. For example:
```
2026-02-17T12:56:22.2143706Z INFO     tests.ptf_runner:ptf_runner.py:220 ptf command: /root/env-python3/bin/ptf --test-dir ptftests/py3 advanced-reboot.ReloadTest ...
2026-02-17T13:08:17.1325646Z ERROR    tests.ptf_runner:ptf_runner.py:239 Exception caught while executing case: advanced-reboot.ReloadTest. Error message: Traceback (most recent call last):
2026-02-17T13:08:17.1334910Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/ptf_runner.py", line 221, in ptf_runner
2026-02-17T13:08:17.1342877Z     result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors, module_async=async_mode)
2026-02-17T13:08:17.1351045Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:17.1358277Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/devices/base.py", line 143, in _run
2026-02-17T13:08:17.1365966Z     raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), hostname_res)
2026-02-17T13:08:17.1373797Z tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
2026-02-17T13:08:17.1380703Z failed = True
2026-02-17T13:08:17.1386857Z changed = True
2026-02-17T13:08:17.1394367Z rc = 1
2026-02-17T13:08:17.1412188Z cmd = /root/env-python3/bin/ptf --test-dir ptftests/py3 advanced-reboot.ReloadTest --platform-dir ptftests --qlen=1000 --platform remote -t ...
2026-02-17T13:08:17.1487036Z start = 2026-02-17 12:54:41.290655
...
2026-02-17T13:08:18.3232333Z 2026-02-17 13:06:29 : --------------------------------------------------
2026-02-17T13:08:18.3234767Z 2026-02-17 13:06:29 : Fails:
2026-02-17T13:08:18.3237261Z 2026-02-17 13:06:29 : --------------------------------------------------
2026-02-17T13:08:18.3240059Z 2026-02-17 13:06:29 : FAILED:dut:Total downtime period must be less then 0:00:00.050000 seconds. It was 0.39939379692077637
2026-02-17T13:08:18.3242913Z 2026-02-17 13:06:29 : FAILED:172.16.145.137:BGP v4 routes must be up when the test starts
2026-02-17T13:08:18.3245637Z 2026-02-17 13:06:29 : FAILED:172.16.145.137:BGP v6 routes must be up when the test starts
2026-02-17T13:08:18.3248247Z 2026-02-17 13:06:29 : ==================================================
2026-02-17T13:08:18.3250776Z 2026-02-17 13:06:29 : Disabling arp_responder
2026-02-17T13:08:18.3251704Z 
2026-02-17T13:08:18.3253937Z ******************************************
2026-02-17T13:08:18.3256276Z ATTENTION: SOME TESTS DID NOT PASS!!!
2026-02-17T13:08:18.3257151Z 
2026-02-17T13:08:18.3259293Z The following tests failed:
2026-02-17T13:08:18.3261548Z ReloadTest
2026-02-17T13:08:18.3262305Z 
2026-02-17T13:08:18.3264514Z ******************************************stderr =
2026-02-17T13:08:18.3267611Z /root/env-python3/lib/python3.11/site-packages/scapy/layers/ipsec.py:512: CryptographyDeprecat...
2026-02-17T13:08:18.3270601Z   cipher=algorithms.TripleDES,
2026-02-17T13:08:18.3273627Z /root/env-python3/lib/python3.11/site-packages/scapy/layers/ipsec.py:516: CryptographyDeprecati...
2026-02-17T13:08:18.3276595Z   cipher=algorithms.TripleDES,
2026-02-17T13:08:18.3279277Z advanced-reboot.ReloadTest ... 12:56:37.071  device_connection: ERROR   : Caught exception socket.timeout: TimeoutError(), , <class 'TimeoutError'>
2026-02-17T13:08:18.3281963Z FAIL
2026-02-17T13:08:18.3282707Z 
2026-02-17T13:08:18.3284982Z ======================================================================
2026-02-17T13:08:18.3287395Z FAIL: advanced-reboot.ReloadTest
2026-02-17T13:08:18.3289815Z ----------------------------------------------------------------------
2026-02-17T13:08:18.3292296Z Traceback (most recent call last):
2026-02-17T13:08:18.3294673Z   File "/root/ptftests/py3/advanced-reboot.py", line 1470, in runTest
2026-02-17T13:08:18.3297081Z     self.handle_post_reboot_test_reports()
2026-02-17T13:08:18.3299607Z   File "/root/ptftests/py3/advanced-reboot.py", line 1406, in handle_post_reboot_test_reports
2026-02-17T13:08:18.3302073Z     self.assertTrue(is_good, errors)
2026-02-17T13:08:18.3304378Z AssertionError: False is not true : 
2026-02-17T13:08:18.3305248Z 
2026-02-17T13:08:18.3307451Z Something went wrong. Please check output below:
2026-02-17T13:08:18.3308362Z 
2026-02-17T13:08:18.3310799Z FAILED:dut:Total downtime period must be less then 0:00:00.050000 seconds. It was 0.39939379692077637
2026-02-17T13:08:18.3313444Z FAILED:172.16.145.137:BGP v4 routes must be up when the test starts
2026-02-17T13:08:18.3315947Z FAILED:172.16.145.137:BGP v6 routes must be up when the test starts
2026-02-17T13:08:18.3317000Z 
2026-02-17T13:08:18.3317744Z 
2026-02-17T13:08:18.3320020Z ----------------------------------------------------------------------
2026-02-17T13:08:18.3322417Z Ran 1 test in 704.594s
2026-02-17T13:08:18.3323298Z 
2026-02-17T13:08:18.3325420Z FAILED (failures=1)
2026-02-17T13:08:18.3326203Z 
2026-02-17T13:08:18.3330201Z ERROR    tests.common.fixtures.advanced_reboot:advanced_reboot.py:659 Exception caught while running advanced-reboot test on ptf: 
2026-02-17T13:08:18.3332829Z Traceback (most recent call last):
2026-02-17T13:08:18.3335380Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/fixtures/advanced_reboot.py", line 644, in runRebootTest
2026-02-17T13:08:18.3337849Z     thread.join(timeout=10)
2026-02-17T13:08:18.3340363Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/utilities.py", line 292, in join
2026-02-17T13:08:18.3342755Z     six.reraise(*self._e)
2026-02-17T13:08:18.3345126Z   File "/usr/lib/python3/dist-packages/six.py", line 719, in reraise
2026-02-17T13:08:18.3347448Z     raise value
2026-02-17T13:08:18.3349838Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/utilities.py", line 270, in run
2026-02-17T13:08:18.3352237Z     threading.Thread.run(self)
2026-02-17T13:08:18.3354580Z   File "/usr/lib/python3.12/threading.py", line 1010, in run
2026-02-17T13:08:18.3356967Z     self._target(*self._args, **self._kwargs)
2026-02-17T13:08:18.3359526Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/fixtures/advanced_reboot.py", line 966, in __runPtfRunner
2026-02-17T13:08:18.3361975Z     result = ptf_runner(
2026-02-17T13:08:18.3364180Z              ^^^^^^^^^^^
2026-02-17T13:08:18.3366619Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/ptf_runner.py", line 221, in ptf_runner
2026-02-17T13:08:18.3369288Z     result = host.shell(cmd, chdir="/root", module_ignore_errors=module_ignore_errors, module_async=async_mode)
2026-02-17T13:08:18.3371833Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:18.3374286Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/devices/base.py", line 143, in _run
2026-02-17T13:08:18.3376912Z     raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), hostname_res)
2026-02-17T13:08:18.3379582Z tests.common.errors.RunAnsibleModuleFail: run module shell failed, Ansible Results =>
2026-02-17T13:08:18.3381965Z failed = True
...
2026-02-17T13:08:19.4678655Z 
2026-02-17T13:08:19.4680796Z FAILED (failures=1)
2026-02-17T13:08:19.4681578Z 
2026-02-17T13:08:19.4684016Z INFO     postupgrade_helper:postupgrade_helper.py:26 Skipping postupgrade_actions
2026-02-17T13:08:19.4686776Z ERROR    root:__init__.py:40 Traceback (most recent call last):
2026-02-17T13:08:19.4689375Z   File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 1720, in runtest
2026-02-17T13:08:19.4691923Z     self.ihook.pytest_pyfunc_call(pyfuncitem=self)
2026-02-17T13:08:19.4694468Z   File "/opt/venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
2026-02-17T13:08:19.4697220Z     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
2026-02-17T13:08:19.4699655Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:19.4702108Z   File "/opt/venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
2026-02-17T13:08:19.4704656Z     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2026-02-17T13:08:19.4707018Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:19.4709458Z   File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
2026-02-17T13:08:19.4711862Z     raise exception
2026-02-17T13:08:19.4714273Z   File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
2026-02-17T13:08:19.4716694Z     res = hook_impl.function(*args)
2026-02-17T13:08:19.4718942Z           ^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:19.4721379Z   File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
2026-02-17T13:08:19.4723870Z     result = testfunction(**testargs)
2026-02-17T13:08:19.4726103Z              ^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:19.4728606Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/metadata-scripts/test_metadata_upgrade_path.py", line 194, in test_upgrade_path
2026-02-17T13:08:19.4731364Z     upgrade_test_helper(duthost, localhost, ptfhost, from_image,
2026-02-17T13:08:19.4733989Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/helpers/upgrade_helpers.py", line 291, in upgrade_test_helper
2026-02-17T13:08:19.4736752Z     advancedReboot.runRebootTestcase(prebootList=sad_preboot_list, inbootList=sad_inboot_list,
2026-02-17T13:08:19.4739503Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/fixtures/advanced_reboot.py", line 699, in runRebootTestcase
2026-02-17T13:08:19.4741997Z     return self.runRebootTest()
2026-02-17T13:08:19.4744222Z            ^^^^^^^^^^^^^^^^^^^^
2026-02-17T13:08:19.4746702Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/fixtures/advanced_reboot.py", line 663, in runRebootTest
2026-02-17T13:08:19.4749178Z     self.postboot_setup()
2026-02-17T13:08:19.4751808Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/metadata-scripts/test_metadata_upgrade_path.py", line 192, in upgrade_path_postboot_setup
2026-02-17T13:08:19.4754349Z     patch_rsyslog(duthost)
2026-02-17T13:08:19.4756888Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/helpers/dut_utils.py", line 354, in patch_rsyslog
2026-02-17T13:08:19.4759327Z     duthost.lineinfile(
2026-02-17T13:08:19.4761835Z   File "/azp/_work/1/s/sonic-mgmt-int/tests/common/devices/base.py", line 143, in _run
2026-02-17T13:08:19.4764457Z     raise RunAnsibleModuleFail("run module {} failed".format(self.module_name), hostname_res)
2026-02-17T13:08:19.4767128Z tests.common.errors.RunAnsibleModuleFail: run module lineinfile failed, Ansible Results =>
2026-02-17T13:08:19.4769535Z failed = True
2026-02-17T13:08:19.4771768Z module_stdout = 
2026-02-17T13:08:19.4774176Z module_stderr = Warning: Permanently added '10.3.146.165' (RSA) to the list of known hosts.
2026-02-17T13:08:19.4776612Z Debian GNU/Linux 13 \n \l
2026-02-17T13:08:19.4777473Z 
2026-02-17T13:08:19.4779663Z /bin/sh: 1: /usr/bin/python3.11: not found
2026-02-17T13:08:19.4780550Z 
2026-02-17T13:08:19.4782893Z msg = The module failed to execute correctly, you probably need to set the interpreter.
2026-02-17T13:08:19.4785331Z See stdout/stderr for the exact error
2026-02-17T13:08:19.4787563Z rc = 127
2026-02-17T13:08:19.4789713Z _ansible_no_log = False
2026-02-17T13:08:19.4791972Z changed = False
2026-02-17T13:08:19.4794098Z stdout =
2026-02-17T13:08:19.4796208Z stderr =

```
This is an example where the ptf ReloadTest failed and on the next command on the device it hit the python interepreter issue.

This PR fixes it by clearing the cache in the sad exit path of advanced reboot test too.



### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix a bug

#### How did you do it?
Cleared the cached python interpreter so that it would be rediscovered before the next command is run on the host.

#### How did you verify/test it?
Ran the test again that failed in the ReloadTest and this time the python interpreter issue wasn't seen

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
