### PR TITLE
[fdb] Apply CRM polling interval to all DUTs

### DIFF
--- a/tests/fdb/conftest.py
+++ b/tests/fdb/conftest.py
@@ -24,14 +24,14 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def set_polling_interval(duthost):
+def set_polling_interval(duthosts):
     wait_time = 2
-    duthost.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))
+    duthosts.command("crm config polling interval {}".format(CRM_POLLING_INTERVAL))
     wait(wait_time, "Waiting {} sec for CRM counters to become updated".format(wait_time))
 
     yield
 
-    duthost.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
+    duthosts.command("crm config polling interval {}".format(CRM_DEFAULT_POLL_INTERVAL))
     wait(wait_time, "Waiting {} sec for CRM counters to become updated".format(wait_time))
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR fixes CRM polling interval configuration in FDB tests
  for multi-DUT testbeds.

  The `set_polling_interval` fixture only configured polling on
  first DUT, causing test failures when FDB entries weren't
  reflected in CRM resources quickly enough.

Summary:
Fixes #22453 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Test `test_fdb_mac_move` failed in multi-DUT testbeds:

Failed: fdb_entry not populated in CRM resources

The fixture only set CRM polling on one DUT. Other DUTs kept
the default 300s interval, causing slow counter updates.

#### How did you do it?
Changed `set_polling_interval` in `tests/fdb/conftest.py`:
  - Parameter: `duthost` → `duthosts`
  - Use duthosts.command() to set polling interval
  - Apply same fix to cleanup code
  
#### How did you verify/test it?
- Tested on multi-DUT testbed with original failure
- Verified polling set on all DUTs
- Confirmed `test_fdb_mac_move` passes consistently without this error
- Verified CRM counters update correctly

#### Any platform specific information?
No. Applies to all platforms in multi-DUT testbeds.

#### Supported testbed topology if it's a new test case?
N/A - Bug fix for existing test.

### Documentation
No documentation needed. Internal test fixture fix only.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
