### PR TITLE
Skip test_sip_link_local/test_dip_link_local for v6 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_drop_packets.yaml
@@ -5,14 +5,14 @@
 #Hence, it is not dropped by default in Cisco-8000. For dropping link local address, it should be done through security/DATA ACL
 drop_packets/test_configurable_drop_counters.py::test_dip_link_local:
   skip:
-    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some mlx platforms does not drop DIP link local packets / KVM do not support drop reason in testcase / IPv6 DIP_LINK_LOCAL drop reason not supported on broadcom."
+    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some mlx platforms does not drop DIP link local packets / KVM do not support drop reason in testcase / DIP_LINK_LOCAL drop reason is for IPv4 only."
     conditions_logical_operator: or
     conditions:
       - "'Mellanox' in hwsku"
       - asic_type=='cisco-8000'
       - "topo_type in ['m0', 'mx']"
       - "asic_type in ['vs']"
-      - "asic_type in ['broadcom'] and '-v6-' in topo_name"
+      - "'-v6-' in topo_name"
 
 drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
   skip:
@@ -24,14 +24,14 @@ drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down:
 
 drop_packets/test_configurable_drop_counters.py::test_sip_link_local:
   skip:
-    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some MLX platforms does not drop SIP link local packets / KVM do not support drop reason in testcase / IPv6 DIP_LINK_LOCAL drop reason not supported on broadcom."
+    reason: "M0/Mx topos doesn't support drop packets / Cisco 8000 platform and some MLX platforms does not drop SIP link local packets / KVM do not support drop reason in testcase / SIP_LINK_LOCAL drop reason is for IPv4 only."
     conditions_logical_operator: or
     conditions:
       - asic_type=="cisco-8000"
       - "'Mellanox' in hwsku"
       - "topo_type in ['m0', 'mx']"
       - "asic_type in ['vs']"
-      - "asic_type in ['broadcom'] and '-v6-' in topo_name"
+      - "'-v6-' in topo_name"
 
 #######################################
 #####     test_drop_counters.py   #####

--- a/tests/drop_packets/test_configurable_drop_counters.py
+++ b/tests/drop_packets/test_configurable_drop_counters.py
@@ -45,8 +45,7 @@ VLAN_BASE_MAC_PATTERN = "72060001{:04}"
 
 MOCK_DEST_IP = "2.2.2.2"
 MOCK_DEST_IP_V6 = "2001:db8::2"
-LINK_LOCAL_IP = "169.254.0.1"  # 169.254.0.0/16
-LINK_LOCAL_IP_V6 = "fe81::1"  # fe80::/10
+LINK_LOCAL_IP = "169.254.0.1"
 
 
 # For dualtor
@@ -208,7 +207,7 @@ def test_neighbor_link_down(testbed_params, setup_counters, duthosts, rand_one_d
 
 
 @pytest.mark.parametrize("drop_reason", ["DIP_LINK_LOCAL"])
-def test_dip_link_local(testbed_params, setup_counters, duthosts, tbinfo, rand_one_dut_hostname,
+def test_dip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
                         toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa: F811
                         setup_standby_ports_on_rand_unselected_tor,                             # noqa: F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
@@ -224,13 +223,8 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, tbinfo, rand_o
     rx_port = random.choice(list(testbed_params["physical_port_map"].keys()))
     logging.info("Selected port %s to send traffic", rx_port)
 
-    if is_ipv6_only_topology(tbinfo):
-        src_ip = "2001:db8::10:10"
-        dst_ip = LINK_LOCAL_IP_V6
-    else:
-        src_ip = "10.10.10.10"
-        dst_ip = LINK_LOCAL_IP
-    pkt = generate_dropped_packet(rx_port, src_ip, dst_ip)
+    src_ip = "10.10.10.10"
+    pkt = generate_dropped_packet(rx_port, src_ip, LINK_LOCAL_IP)
 
     try:
         send_dropped_traffic(counter_type, pkt, rx_port)
@@ -240,7 +234,7 @@ def test_dip_link_local(testbed_params, setup_counters, duthosts, tbinfo, rand_o
 
 
 @pytest.mark.parametrize("drop_reason", ["SIP_LINK_LOCAL"])
-def test_sip_link_local(testbed_params, setup_counters, duthosts, tbinfo, rand_one_dut_hostname,
+def test_sip_link_local(testbed_params, setup_counters, duthosts, rand_one_dut_hostname,
                         toggle_all_simulator_ports_to_rand_selected_tor_m,                      # noqa: F811
                         setup_standby_ports_on_rand_unselected_tor,                             # noqa: F811
                         send_dropped_traffic, drop_reason, add_default_route_to_dut, generate_dropped_packet):
@@ -256,13 +250,8 @@ def test_sip_link_local(testbed_params, setup_counters, duthosts, tbinfo, rand_o
     rx_port = random.choice(list(testbed_params["physical_port_map"].keys()))
     logging.info("Selected port %s to send traffic", rx_port)
 
-    if is_ipv6_only_topology(tbinfo):
-        src_ip = LINK_LOCAL_IP_V6
-        dst_ip = "2001:db8::10:10"
-    else:
-        src_ip = LINK_LOCAL_IP
-        dst_ip = "10.10.10.10"
-    pkt = generate_dropped_packet(rx_port, src_ip, dst_ip)
+    dst_ip = "10.10.10.10"
+    pkt = generate_dropped_packet(rx_port, LINK_LOCAL_IP, dst_ip)
 
     try:
         send_dropped_traffic(counter_type, pkt, rx_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Originally these tests were skipped for only Broadcom ASICs on IPv6 topo.
But DIP_LINK_LOCAL/SIP_LINK_LOCAL drop reasons are for IPv4 packets only as per SAI spec:
https://github.com/opencomputeproject/SAI/blob/v1.17.4/inc/saidebugcounter.h#L228
So we need to skip it for every ASIC, also revert V6 topo changes to the test cases.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
SAI spec states that DIP_LINK_LOCAL/SIP_LINK_LOCAL drop reasons are only for IPv4, so we need to skip the tests for V6 topo

#### How did you do it?
Revert V6 topo changes and skip the test for everyone by removing Boradcom ASIC condition

#### How did you verify/test it?
Tests are skipped correctly on V6 topos now

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
