### PR TITLE
Skip 'pcied' daemon status check for amd elba dpus

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1038,6 +1038,12 @@ platform_tests/daemon/test_ledd.py::test_pmon_ledd_kill_and_start_status:
       - "release in ['201911']"
       - "asic_type in ['vs']"
 
+platform_tests/daemon/test_pcied.py:
+  skip:
+    reason: "Not supported, AMD DPU Pcie link bringup sequence is handled differently"
+    conditions:
+      - "platform in ['arm64-elba-asic-flash128-r0']"
+
 #######################################
 #####    fwutil/test_fwutil.py    #####
 #######################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

This PR is to fix sonic-mgmt show platform test cases which runs on amd specific dpus with sonic
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

Listing down the test cases and what changed in each.

1.platform_tests/daemon/test_pcied.py
- above TCs  AMD DPU Pcie link bringup sequence is handled differently
- Hence skip'test_pcied' 

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request

- [x] 202511