### PR TITLE
Change qos_params.q3d.yaml topo to match topo_t2_single_node_min.yml

### DIFF
--- a/tests/qos/files/qos_params.q3d.yaml
+++ b/tests/qos/files/qos_params.q3d.yaml
@@ -1,6 +1,6 @@
 qos_params:
     q3d:
-        topo-t2-single-node-min:
+        topo-t2_single_node_min:
             400000_2000m:
                 hdrm_pool_size:
                     dscps:


### PR DESCRIPTION
Change the `t2 single node min topo` in `qos_params.q3d.yaml` to match the topology as it is found in `ansible/vars/topo_t2_single_node_max.yml`

The t2 single node topologies were created here https://github.com/sonic-net/sonic-mgmt/pull/17986 using underscores instead of dashes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511 (if https://github.com/sonic-net/sonic-mgmt/pull/22156 is backported) 

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
