### PR TITLE
[memory_utilization] Fix memory check issue for container_autorestart and logrotate

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -16,7 +16,8 @@ from tests.common.helpers.dut_utils import get_disabled_container_list
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('any')
+    pytest.mark.topology('any'),
+    pytest.mark.disable_memory_utilization
 ]
 
 CONTAINER_CHECK_INTERVAL_SECS = 1

--- a/tests/syslog/test_logrotate.py
+++ b/tests/syslog/test_logrotate.py
@@ -60,7 +60,7 @@ def simulate_small_var_log_partition(rand_selected_dut, localhost):
         duthost.shell('sudo mkfs.ext4 /dev/loop2')
         duthost.shell('sudo mount /dev/loop2 /var/log')
 
-        config_reload(duthost, safe_reload=True)
+        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)
 
         logger.info('Start logrotate-config service')
         duthost.shell('sudo service logrotate-config restart')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
36843474

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
autorestart/test_container_autorestart.py::test_containers_autorestart, this is a case related to the container restart, need to skip the memory checker during the test

simulate_small_var_log_partition memory checker collects memory before and after the case, so we need to make sure the test environment is stable before the case, it’s better to add the check for interface up and wait for bgp up in the fixture simulate_small_var_log_partition, config reload.
        config_reload(duthost, safe_reload=True)
        config_reload(duthost, safe_reload=True, check_intf_up_ports=True, wait_for_bgp=True)

#### How did you do it?
Skip the checker in autorestart/test_container_autorestart.py
Waiting device stable before testing

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
