### PR TITLE
[sonic-mgmt][dualtor] Fix "sflow/test_sflow.py" reboot testcase failures

### DIFF
--- a/tests/sflow/test_sflow.py
+++ b/tests/sflow/test_sflow.py
@@ -608,7 +608,7 @@ class TestAgentId():
 class TestReboot():
 
     def testRebootSflowEnable(self, sflowbase_config, config_sflow_agent,
-                              duthosts, rand_one_dut_hostname,
+                              duthosts, rand_one_dut_hostname, force_active_tor,
                               localhost, partial_ptf_runner, ptfhost):
         duthost = duthosts[rand_one_dut_hostname]
         duthost.command("config sflow polling-interval 80")
@@ -617,6 +617,7 @@ class TestReboot():
         reboot(duthost, localhost)
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        force_active_tor(duthost, "all")
         assert wait_until(60, 5, 0, verify_sflow_config_apply, duthost)
         verify_show_sflow(duthost, status='up', collector=[
                           'collector0', 'collector1'], polling_int=80)
@@ -636,7 +637,7 @@ class TestReboot():
             active_collectors="['collector0','collector1']")
 
     def testRebootSflowDisable(self, sflowbase_config, duthosts, rand_one_dut_hostname,
-                               localhost, partial_ptf_runner, ptfhost):
+                               force_active_tor, localhost, partial_ptf_runner, ptfhost):
         duthost = duthosts[rand_one_dut_hostname]
         config_sflow(duthost, sflow_status='disable')
         verify_show_sflow(duthost, status='down')
@@ -647,6 +648,7 @@ class TestReboot():
         reboot(duthost, localhost)
         assert wait_until(
             300, 20, 0, duthost.critical_services_fully_started), "Not all critical services are fully started"
+        force_active_tor(duthost, "all")
         verify_show_sflow(duthost, status='down')
         for intf in var['sflow_ports']:
             var['sflow_ports'][intf]['ifindex'] = get_ifindex(duthost, intf)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: [sonic-mgmt][dualtor] Fix `sflow/test_sflow.py` reboot testcase failures
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/22502

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Current usage of fixture `rand_one_dut_hostname` in the test does toggle all ports to the selected duthost before running the test, by using http post request (thus MUX_CABLE state will still be "auto" in config_db). But, the duthost reboot can trigger muxcable switchover (as the config_db state is "auto"), thus previously active ports can become standby (and viceversa).

This is causing, sflow packets destined to collector interface (setup in ptfhost and directly connected to now standby port) get dropped by mux. And thus test is failing with `AssertionError: False is not true : ....Flow packets are not received in active collector ,collector1`

#### How did you do it?
Post reboot of the selected duthost, configure muxcable back to "active" mode by using `force_active_tor` fixture.

#### How did you verify/test it?
Ran the test with the fix on dualtor topologies, and the test is passing fine.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
