### PR TITLE
[snappi][master] Add test_cleanup code for tgen_port_info infra function

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2101,8 +2101,7 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
             duthosts, snappi_ports, snappi_api, setup=True)
         yield (testbed_config, port_config_list, snappi_ports)
         logger.info('Snappi cleanup after test')
-        setup = False
-        setup_dut_ports(setup, duthosts, testbed_config, port_config_list, snappi_ports)
+        setup_dut_ports(False, duthosts, testbed_config, port_config_list, snappi_ports)
     else:
         flatten_skeleton_parameter = request.param
         speed, category = flatten_skeleton_parameter.split("-")

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -2097,20 +2097,25 @@ def tgen_port_info(request: pytest.FixtureRequest, snappi_port_selection, get_sn
                 rx_port_count,
                 testbed
             )
+        testbed_config, port_config_list, snappi_ports = snappi_dut_base_config(
+            duthosts, snappi_ports, snappi_api, setup=True)
+        yield (testbed_config, port_config_list, snappi_ports)
+        logger.info('Snappi cleanup after test')
+        setup = False
+        setup_dut_ports(setup, duthosts, testbed_config, port_config_list, snappi_ports)
+    else:
+        flatten_skeleton_parameter = request.param
+        speed, category = flatten_skeleton_parameter.split("-")
+
+        if float(speed) not in snappi_port_selection or category not in snappi_port_selection[float(speed)]:
+            pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
+
+        snappi_ports = snappi_port_selection[float(speed)][category]
+
+        if not snappi_ports:
+            pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
+
         return snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True)
-
-    flatten_skeleton_parameter = request.param
-    speed, category = flatten_skeleton_parameter.split("-")
-
-    if float(speed) not in snappi_port_selection or category not in snappi_port_selection[float(speed)]:
-        pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
-
-    snappi_ports = snappi_port_selection[float(speed)][category]
-
-    if not snappi_ports:
-        pytest.skip(f"Unsupported combination for {flatten_skeleton_parameter}")
-
-    return snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True)
 
 
 def flatten_list(lst):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The tgen_port_info infra function in common/snappi_tests/snappi_fixtures.py is used to select port (dynamically or statically) for the test. During static port selection, the variables.override.yml file is used to select Rx and Tx port for the test.

However, after the test, there was no explicit test clean_up code. This PR addresses it.

Summary:
Fixes #20993 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The tgen_port_info is used to select the Rx and Tx port for the test.

In case of static port selection, the function returned snappi_dut_base_config(duthosts, snappi_ports, snappi_api, setup=True), and there was no explicit cleanup after the test.

#### How did you do it?
- If the 'is_override' flag is true, the static port selection code is used to select Rx and Tx ports from variables.override.yml file.
- Instead of returning with function 'snappi_dut_base_config', 'yield' is called to ensure that clean-up is called at the end of the test.
- Once yield returns back to the test, then 'setup_dut_ports' is called with setup=False to ensure that clean-up happens after the test.

#### How did you verify/test it?
For verification of this changes on 202511 branch, please refer to PR #22441 

Verification of the PR on master with multi-dut setup:
```
azureuser@7e081020c2c7:/data/tests$ date;python3 -m pytest --inventory ../ansible/ixia-sonic --host-pattern ixre-egl-board73,ixre-egl-board74 --testbed ixre-chassis17-t2 --testbed_file ../ansible/testbed.csv --show-capture=stdout --log-cli-level info --showlocals -ra --allow_recover --junit-xml=/tmp/y.xml --skip_sanity --log-file=/tmp/y.log --topology multidut-tgen -cache-clear --disable_loganalyzer snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py -k test_pfc_pause_multi_lossless_prio --pdb
Fri Feb 20 14:26:57 UTC 2026
================================================================================================= test session starts =================================================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.5.0
----------- curtailed output ----------
INFO     tests.conftest:conftest.py:691 Randomly select dut ixre-egl-board73 for testing
INFO     root:__init__.py:81 -------------------- fixture enable_packet_aging_after_test setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture enable_packet_aging_after_test setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture rand_lossless_prio setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture rand_lossless_prio setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture rand_lossy_prio setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture rand_lossy_prio setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture start_pfcwd_after_test setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture start_pfcwd_after_test setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture disable_voq_watchdog setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture disable_voq_watchdog setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture number_of_tx_rx_ports setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture number_of_tx_rx_ports setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture snappi_api_serv_ip setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture snappi_api_serv_ip setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture snappi_api_serv_port setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture snappi_api_serv_port setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture snappi_api setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture snappi_api setup ends --------------------
INFO     tests.conftest:conftest.py:727 Randomly select dut ixre-egl-board74 for testing
INFO     root:__init__.py:69 -------------------- fixture prio_dscp_map setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture prio_dscp_map setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture all_prio_list setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture all_prio_list setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture lossless_prio_list setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture lossless_prio_list setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture lossy_prio_list setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture lossy_prio_list setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture get_snappi_ports setup starts --------------------
INFO     root:__init__.py:69 -------------------- fixture get_snappi_ports_multi_dut setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture get_snappi_ports_multi_dut setup ends --------------------
INFO     root:__init__.py:76 -------------------- fixture get_snappi_ports setup ends --------------------
INFO     root:__init__.py:69 -------------------- fixture snappi_port_selection setup starts --------------------
INFO     root:__init__.py:76 -------------------- fixture snappi_port_selection setup ends --------------------
INFO     root:__init__.py:77 Log analyzer is disabled
INFO     root:__init__.py:81 -------------------- fixture disable_pfcwd setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture disable_pfcwd setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture tgen_port_info setup starts --------------------
----------- curtailed output ----------
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1419 Start interfaces 0.164s
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:906 Found relevant portchannel interfaces
INFO     root:__init__.py:85 -------------------- fixture tgen_port_info setup ends --------------------
INFO     root:conftest.py:3819 skip setup dualtor mux cables on non-dualtor testbed
INFO     tests.common.plugins.memory_utilization:__init__.py:64 Before test: collected memory_values {'before_test': {}, 'after_test': {}}
----------- curtailed output ----------
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:784 Polling DUT for traffic statistics for 23 seconds ...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:803 Polling TGEN for in-flight traffic statistics...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:824 In-flight traffic statistics for flows: ['Test Flow Prio 3', 'Test Flow Prio 4', 'Background Flow Prio 1', 'Background Flow Prio 5', 'Background Flow Prio 6', 'Background Flow Prio 2', 'Background Flow Prio 0']
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:825 In-flight TX frames: [68216, 68215, 81896551, 81896551, 81896551, 81896551, 81896551]
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:826 In-flight RX frames: [0, 0, 81896551, 81896551, 81896551, 81896551, 81896551]
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:832 In-flight traffic statistics for flows:
----------- curtailed output ----------
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:837 DUT polling complete
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:850 Checking if all flows have stopped. Attempt #1
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:856 All test and background traffic flows stopped
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:894 Dumping per-flow statistics
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:899 Stopping transmit on all remaining flows
INFO     snappi_ixnetwork.snappi_api:snappi_api.py:1419 Flows stop 6.608s
PASSED                                                                                                                                                                                                          [ 50%]
----------- curtailed output ----------
INFO     root:__init__.py:81 -------------------- fixture disable_pfcwd setup starts --------------------
INFO     root:__init__.py:85 -------------------- fixture disable_pfcwd setup ends --------------------
INFO     root:__init__.py:81 -------------------- fixture tgen_port_info setup starts --------------------
INFO     tests.common.snappi_tests.snappi_fixtures:snappi_fixtures.py:906 Found relevant portchannel interfaces
INFO     root:__init__.py:85 -------------------- fixture tgen_port_info setup ends --------------------
INFO     root:conftest.py:3819 skip setup dualtor mux cables on non-dualtor testbed
----------- curtailed output ----------
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:784 Polling DUT for traffic statistics for 27 seconds ...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:803 Polling TGEN for in-flight traffic statistics...
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:824 In-flight traffic statistics for flows: ['Test Flow Prio 3', 'Test Flow Prio 4', 'Background Flow Prio 1', 'Background Flow Prio 5', 'Background Flow Prio 6', 'Background Flow Prio 2', 'Background Flow Prio 0']
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:825 In-flight TX frames: [68221, 68222, 99137931, 99137931, 99137931, 99137931, 99137931]
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:826 In-flight RX frames: [0, 0, 99137931, 99137931, 99137931, 99137931, 99137931]
INFO     tests.common.snappi_tests.traffic_generation:traffic_generation.py:832 In-flight traffic statistics for flows:
----------- curtailed output ----------
INFO     tests.conftest:conftest.py:3097 Dumping Disk and Memory Space information after test on ixre-egl-board73
INFO     tests.conftest:conftest.py:3097 Dumping Disk and Memory Space information after test on ixre-egl-board74
INFO     tests.conftest:conftest.py:3101 Collecting core dumps after test on ixre-egl-board74
INFO     tests.conftest:conftest.py:3101 Collecting core dumps after test on ixre-egl-board73
INFO     tests.conftest:conftest.py:3112 Collecting running config after test on ixre-egl-board74
INFO     tests.conftest:conftest.py:3112 Collecting running config after test on ixre-egl-board73
INFO     tests.conftest:conftest.py:3259 Core dump and config check passed for test_pfc_pause_lossless_with_snappi.py
----------- curtailed output ----------
----------------------------------------------------------------------------------------------- live log sessionfinish ------------------------------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
============================================================================== 2 passed, 14 deselected, 10 warnings in 808.66s (0:13:28) ==============================================================================
INFO:root:Can not get Allure report URL. Please check logs

```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
