### PR TITLE
Add Makefile for testbed management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,46 @@ INVENTORY   ?= veos_vtb
 PASSFILE    ?= password.txt
 DUT         ?= vlab-01
 
+# Neighbor VM type (veos|ceos|vsonic) - simulated neighboring devices
+NEIGHBOR    ?= ceos
+
 # Test config
 T           ?=
 EXTRA       ?=
 
-# Base exec
-EXEC_ANSIBLE := docker exec -t -w $(ANSIBLE_DIR) $(CONTAINER)
-EXEC_TESTS   := docker exec -t -w $(TESTS_DIR) $(CONTAINER)
+# TTY handling: use -t only if terminal is available (for CI compatibility)
+TTY         := $(shell test -t 0 && echo "-t")
 
-.PHONY: check-container shell add-topo remove-topo deploy-mg test
+# Base exec
+EXEC_ANSIBLE := docker exec $(TTY) -w $(ANSIBLE_DIR) $(CONTAINER)
+EXEC_TESTS   := docker exec $(TTY) -w $(TESTS_DIR) $(CONTAINER)
+
+.PHONY: help check-container shell add-topo remove-topo deploy-mg test
+
+help:
+	@echo "Usage: make <target> [VARIABLE=value ...]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  shell       - Enter sonic-mgmt container"
+	@echo "  add-topo    - Deploy topology"
+	@echo "  remove-topo - Remove topology"
+	@echo "  deploy-mg   - Deploy minigraph to DUT"
+	@echo "  test        - Run tests (requires T=<test_path>)"
+	@echo ""
+	@echo "Variables:"
+	@echo "  TOPO        - Topology name (default: vms-kvm-t0)"
+	@echo "  TESTBED     - Testbed file (default: vtestbed.yaml)"
+	@echo "  INVENTORY   - Inventory file (default: veos_vtb)"
+	@echo "  DUT         - DUT name (default: vlab-01)"
+	@echo "  NEIGHBOR    - Neighbor VM type: ceos|veos|vsonic (default: ceos)"
+	@echo "  T           - Test path for 'test' target"
+	@echo "  EXTRA       - Extra arguments for test"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make add-topo"
+	@echo "  make add-topo TOPO=vms-kvm-t1"
+	@echo "  make test T=bgp/test_bgp_fact.py"
+	@echo "  make test T=bgp/test_bgp_fact.py EXTRA='-e \"--neighbor_type=sonic\"'"
 
 check-container:
 	@docker ps --format '{{.Names}}' | grep -q '^$(CONTAINER)$$' || \
@@ -29,10 +60,10 @@ shell: check-container
 	docker exec -it $(CONTAINER) bash
 
 add-topo: check-container
-	$(EXEC_ANSIBLE) ./testbed-cli.sh -t $(TESTBED) -m $(INVENTORY) add-topo $(TOPO) $(PASSFILE)
+	$(EXEC_ANSIBLE) ./testbed-cli.sh -t $(TESTBED) -m $(INVENTORY) -k $(NEIGHBOR) add-topo $(TOPO) $(PASSFILE)
 
 remove-topo: check-container
-	$(EXEC_ANSIBLE) ./testbed-cli.sh -t $(TESTBED) -m $(INVENTORY) -k ceos remove-topo $(TOPO) $(PASSFILE)
+	$(EXEC_ANSIBLE) ./testbed-cli.sh -t $(TESTBED) -m $(INVENTORY) -k $(NEIGHBOR) remove-topo $(TOPO) $(PASSFILE)
 
 deploy-mg: check-container
 	$(EXEC_ANSIBLE) ./testbed-cli.sh -t $(TESTBED) -m $(INVENTORY) deploy-mg $(TOPO) $(INVENTORY) $(PASSFILE)


### PR DESCRIPTION
### Description of PR

Adds a Makefile to simplify running testbed commands from outside the sonic-mgmt container.

Summary:
- Eliminates need to manually `docker exec` into the container for common operations
- All variables (topology, testbed file, inventory, etc.) are configurable
- Includes safety check to ensure container is running before executing commands

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Running testbed commands requires bashing into the sonic-mgmt container and navigating to the correct directory. This adds friction for developers who want to quickly run tests or manage topologies.

#### How did you do it?
Created a Makefile with targets that wrap `docker exec -w <dir>` to run commands in the container from outside. Uses configurable variables with sensible defaults for cEOS-based virtual testbeds.

#### How did you verify/test it?
Tested `make shell`, `make add-topo`, `make test T=...` against a local KVM testbed.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A - not a test case

### Documentation
Usage examples:
```bash
make shell                              # Enter container
make add-topo                           # Deploy vms-kvm-t0 topology
make add-topo TOPO=vms-kvm-t1           # Deploy different topology
make deploy-mg                          # Deploy minigraph
make test T=bgp/test_bgp_fact.py        # Run a test
make test T=bgp/test_bgp_fact.py EXTRA='-e "--neighbor_type=sonic"'
```
