### PR TITLE
Update gNOI upgrade process to use reboot_and_check

### DIFF
--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -11,11 +11,19 @@ from tests.common import reboot
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
 from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
+from tests.common.platform.reboot_utils import reboot_and_check
 from tests.common.utilities import wait_until, setup_ferret
 from tests.common.platform.device_utils import check_neighbors
 from typing import Optional, Sequence, Tuple, Union, Dict
 SYSTEM_STABILIZE_MAX_TIME = 300
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def xcvr_skip_list(duthosts):
+    """Return empty transceiver skip list per DUT. Shared across upgrade-related test suites."""
+    return {dut.hostname: [] for dut in duthosts}
+
 
 TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
 TMP_VLAN_FILE = '/tmp/vlan_interfaces.json'
@@ -310,6 +318,10 @@ def perform_gnoi_upgrade(
     tbinfo,
     cfg: GnoiUpgradeConfig,
     cold_reboot_setup=None,
+    localhost=None,
+    conn_graph_facts=None,
+    xcvr_skip_list=None,
+    duthosts=None,
 ):
     """
     gNOI-based upgrade helper using PtfGnoi high-level APIs (no raw call_unary in tests).
@@ -341,7 +353,7 @@ def perform_gnoi_upgrade(
     gNOI_REBOOT_CAUSE_TIMEOUT = 5 * 60
     # Map upgrade_type ("warm"/"cold") to gNOI enum token ("WARM"/"COLD")
     # reboot_method = "WARM" if str(cfg.upgrade_type).lower() == "warm" else "COLD"
-    # ---- 1) reboot to base image ----
+    # ---- 1) pre-reboot setup ----
     if cfg.upgrade_type == REBOOT_TYPE_COLD:
         # advance-reboot test (on ptf) does not support cold reboot yet
         if cold_reboot_setup:
@@ -369,14 +381,22 @@ def perform_gnoi_upgrade(
     pytest_assert(isinstance(setpkg_resp, dict), "SetPackage did not return a JSON object")
 
     pytest_assert(cfg.to_version, "cfg.to_version must be provided for validation")
-    # ---- 4) Reboot (via wrapper) ----
-    try:
-        reboot_resp = ptf_gnoi.system_reboot(method=str(cfg.upgrade_type).upper())
-        logger.info("Reboot response: %s", reboot_resp)
-        pytest_assert(isinstance(reboot_resp, dict), "Reboot did not return a JSON object")
-    except Exception as e:
-        # Common/expected: connection drops during reboot
-        logger.info("Caught exception during gNOI Reboot call (often expected): %s", str(e))
+    # ---- 4) Reboot (via reboot_and_check) ----
+    pytest_assert(localhost is not None, "localhost must be provided for reboot_and_check")
+    pytest_assert(conn_graph_facts is not None, "conn_graph_facts must be provided for reboot_and_check")
+    pytest_assert(xcvr_skip_list is not None, "xcvr_skip_list must be provided for reboot_and_check")
+
+    interfaces = conn_graph_facts.get("device_conn", {}).get(duthost.hostname, {})
+    reboot_and_check(
+        localhost,
+        duthost,
+        interfaces,
+        xcvr_skip_list,
+        reboot_type=cfg.upgrade_type,
+        duthosts=duthosts,
+        invocation_type="gnoi_based",
+        ptf_gnoi=ptf_gnoi,
+    )
 
     if cfg.allow_fail:
         logger.warning("allow_fail=True: skipping reboot-cause/health/version validations")
@@ -395,7 +415,7 @@ def perform_gnoi_upgrade(
     check_neighbors(duthost, tbinfo)
     check_copp_config(duthost)
 
-    # ---- 7) Version validation) ----
+    # ---- 7) Version validation ----
     images = _get_images_from_sonic_installer_list(duthost)
     logger.info("sonic-installer list parsed: %s", images)
     pytest_assert(
@@ -403,7 +423,7 @@ def perform_gnoi_upgrade(
         f"Current image mismatch after reboot. current={images.get('current')} expected={cfg.to_version}. full={images}"
     )
 
-    return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": reboot_resp}
+    return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp}
 
 
 def _wait_gnoi_time_ready(ptf_gnoi, metadata, cfg: GnoiUpgradeConfig, timeout=None, interval: int = 10) -> bool:

--- a/tests/common/platform/reboot_utils.py
+++ b/tests/common/platform/reboot_utils.py
@@ -1,0 +1,48 @@
+import logging
+
+from tests.common.reboot import (
+    sync_reboot_history_queue_with_dut,
+    reboot,
+    REBOOT_TYPE_HISTOYR_QUEUE,
+    REBOOT_TYPE_COLD,
+    wait_for_startup,
+)
+
+
+def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
+                     reboot_type=REBOOT_TYPE_COLD, reboot_helper=None,
+                     reboot_kwargs=None, duthosts=None, invocation_type="cli_based", ptf_gnoi=None,
+                     interfaces_checker=None):
+    """
+    Perform the specified type of reboot and check platform status.
+    @param localhost: The Localhost object.
+    @param dut: The AnsibleHost object of DUT.
+    @param interfaces: DUT's interfaces defined by minigraph
+    @param xcvr_skip_list: list of DUT's interfaces for which transeiver checks are skipped
+    @param reboot_type: The reboot type, pre-defined const that has name convention of REBOOT_TYPE_XXX.
+    @param reboot_helper: The helper function used only by power off reboot
+    @param reboot_kwargs: The argument used by reboot_helper
+    @param interfaces_checker: Optional callable(dut, interfaces, xcvr_skip_list, reboot_type=None)
+                               that performs interface/service checks after reboot.
+                               When None, interface checks are skipped.
+    """
+
+    logging.info(
+        "Sync reboot cause history queue with DUT reboot cause history queue")
+    sync_reboot_history_queue_with_dut(dut)
+
+    logging.info("Run %s reboot on DUT" % reboot_type)
+    reboot(dut, localhost, reboot_type=reboot_type,
+           reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs, invocation_type=invocation_type,
+           ptf_gnoi=ptf_gnoi)
+
+    # Append the last reboot type to the queue
+    logging.info("Append the latest reboot type to the queue")
+    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
+
+    if interfaces_checker is not None:
+        interfaces_checker(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)
+        if dut.is_supervisor_node():
+            for lc in duthosts.frontend_nodes:
+                wait_for_startup(lc, localhost, delay=10, timeout=600)
+                interfaces_checker(lc, interfaces, xcvr_skip_list)

--- a/tests/platform_tests/test_reboot.py
+++ b/tests/platform_tests/test_reboot.py
@@ -13,7 +13,7 @@ import pytest
 from tests.common.fixtures.conn_graph_facts import conn_graph_facts     # noqa: F401
 from tests.common.fixtures.grpc_fixtures import gnmi_tls  # noqa: F401
 from tests.common.utilities import wait_until, get_plt_reboot_ctrl
-from tests.common.reboot import sync_reboot_history_queue_with_dut, reboot, check_reboot_cause,\
+from tests.common.reboot import check_reboot_cause,\
     check_reboot_cause_history, check_determine_reboot_cause_service, reboot_ctrl_dict,\
     wait_for_startup, REBOOT_TYPE_HISTOYR_QUEUE, REBOOT_TYPE_COLD,\
     REBOOT_TYPE_SOFT, REBOOT_TYPE_FAST, REBOOT_TYPE_WARM, REBOOT_TYPE_WATCHDOG
@@ -22,6 +22,7 @@ from tests.common.platform.interface_utils import check_all_interface_informatio
 from tests.common.platform.daemon_utils import check_pmon_daemon_status
 from tests.common.platform.processes_utils import wait_critical_processes, check_critical_processes
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.reboot_utils import reboot_and_check as _reboot_and_check
 
 pytestmark = [
     pytest.mark.disable_loganalyzer,
@@ -83,25 +84,13 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     @param reboot_helper: The helper function used only by power off reboot
     @param reboot_kwargs: The argument used by reboot_helper
     """
-
-    logging.info(
-        "Sync reboot cause history queue with DUT reboot cause history queue")
-    sync_reboot_history_queue_with_dut(dut)
-
-    logging.info("Run %s reboot on DUT" % reboot_type)
-    reboot(dut, localhost, reboot_type=reboot_type,
-           reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs, invocation_type=invocation_type,
-           ptf_gnoi=ptf_gnoi)
-
-    # Append the last reboot type to the queue
-    logging.info("Append the latest reboot type to the queue")
-    REBOOT_TYPE_HISTOYR_QUEUE.append(reboot_type)
-
-    check_interfaces_and_services(dut, interfaces, xcvr_skip_list, reboot_type=reboot_type)
-    if dut.is_supervisor_node():
-        for lc in duthosts.frontend_nodes:
-            wait_for_startup(lc, localhost, delay=10, timeout=600)
-            check_interfaces_and_services(lc, interfaces, xcvr_skip_list)
+    _reboot_and_check(
+        localhost, dut, interfaces, xcvr_skip_list,
+        reboot_type=reboot_type, reboot_helper=reboot_helper,
+        reboot_kwargs=reboot_kwargs, duthosts=duthosts,
+        invocation_type=invocation_type, ptf_gnoi=ptf_gnoi,
+        interfaces_checker=check_interfaces_and_services,
+    )
 
 
 def check_interfaces_and_services(dut, interfaces, xcvr_skip_list,

--- a/tests/upgrade_path/conftest.py
+++ b/tests/upgrade_path/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.common.helpers.upgrade_helpers import xcvr_skip_list  # noqa: F401
+
 
 def pytest_runtest_setup(item):
     from_list = item.config.getoption('base_image_list')

--- a/tests/upgrade_path/test_upgrade_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_gnoi.py
@@ -29,7 +29,8 @@ def gnoi_upgrade_path_lists(request):
 def test_upgrade_via_gnoi(
     localhost, duthosts, ptfhost, rand_one_dut_hostname,
     nbrhosts, fanouthosts, tbinfo, request,
-    gnoi_upgrade_path_lists, gnmi_tls  # noqa: F811
+    gnoi_upgrade_path_lists, gnmi_tls,  # noqa: F811
+    conn_graph_facts, xcvr_skip_list
 ):
     duthost = duthosts[rand_one_dut_hostname]
 
@@ -63,4 +64,8 @@ def test_upgrade_via_gnoi(
         tbinfo=tbinfo,
         cfg=cfg,
         cold_reboot_setup=upgrade_path_preboot_setup,
+        localhost=localhost,
+        conn_graph_facts=conn_graph_facts,
+        xcvr_skip_list=xcvr_skip_list,
+        duthosts=duthosts,
     )


### PR DESCRIPTION
- Updated `perform_gnoi_upgrade` to call `ensure_gnoi_tls_server` post-reboot for enhanced reboot check

This improves the reliability of gNOI-based upgrades and ensures proper device checks are  handled during test execution.

To test:
./run_tests.sh -n vms20-t0-7060 -i ../ansible/str2,../ansible/veos -u -m individual -c upgrade_path/test_upgrade_gnoi.py::test_upgrade_via_gnoi -e "--upgrade_type=cold --base_image_list=http://10.201.148.43/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202505/tagged/sonic-aboot-broadcom-20250510.30.swi --target_image_list=http://10.201.148.43/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202505/tagged/sonic-aboot-broadcom-20250510.30.swi --target_version=SONiC.20250510.30" -l info

WARNING  tests.common.reboot:reboot.py:731 Fail to create dut console. Please check console config or if console works ro not. 'device_console_info' WARNING  tests.common.reboot:reboot.py:746 dut console is not ready, we cannot get log by console

------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------ WARNING  tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:64 Skipping memory check for monit-memory_usage due to zero value
 tests/upgrade_path/test_upgrade_gnoi.py::test_upgrade_via_gnoi ✓                                                                                                           100% ██████████
==================================================================================== warnings summary =====================================================================================

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
This improves the reliability of gNOI-based upgrades and ensures proper device checks are  handled during test execution.

#### How did you do it?
- Updated `perform_gnoi_upgrade` to call `ensure_gnoi_tls_server` post-reboot for enhanced reboot check

#### How did you verify/test it?
./run_tests.sh -n vms20-t0-7060 -i ../ansible/str2,../ansible/veos -u -m individual -c upgrade_path/test_upgrade_gnoi.py::test_upgrade_via_gnoi -e "--upgrade_type=cold --base_image_list=http://10.201.148.43/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202505/tagged/sonic-aboot-broadcom-20250510.30.swi --target_image_list=http://10.201.148.43/pipelines/Networking-acs-buildimage-Official/broadcom/internal-202505/tagged/sonic-aboot-broadcom-20250510.30.swi --target_version=SONiC.20250510.30" -l info

WARNING  tests.common.reboot:reboot.py:731 Fail to create dut console. Please check console config or if console works ro not. 'device_console_info' WARNING  tests.common.reboot:reboot.py:746 dut console is not ready, we cannot get log by console

------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------ WARNING  tests.common.plugins.memory_utilization.memory_utilization:memory_utilization.py:64 Skipping memory check for monit-memory_usage due to zero value
 tests/upgrade_path/test_upgrade_gnoi.py::test_upgrade_via_gnoi ✓                                                                                                           100% ██████████
==================================================================================== warnings summary =====================================================================================

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
