### PR TITLE
[ci] Fix semgrep issues with inline nosemgrep comments

### DIFF
--- a/ansible/dualtor/nic_simulator/nic_simulator.py
+++ b/ansible/dualtor/nic_simulator/nic_simulator.py
@@ -82,7 +82,7 @@ def run_command(cmd, check=True):
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        shell=True,
+        shell=True,  # nosemgrep: subprocess-shell-true
         check=check
     )
     result.stdout = result.stdout.decode()

--- a/ansible/library/configure_vms.py
+++ b/ansible/library/configure_vms.py
@@ -22,6 +22,7 @@ EXAMPLES = '''
 
 
 class ConfigureVMs(object):
+    # nosemgrep: hardcoded-password-default-argument
     def __init__(self, ip, cmds, module, login='admin', password='123456'):
         self.ip = ip
         self.cmds = cmds

--- a/ansible/library/exabgp.py
+++ b/ansible/library/exabgp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
-import jinja2
+import jinja2  # nosemgrep: direct-use-of-jinja2
 import sys
 import os
 import re

--- a/ansible/library/ptf_portchannel.py
+++ b/ansible/library/ptf_portchannel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
-import jinja2
+import jinja2  # nosemgrep: direct-use-of-jinja2
 import traceback
 import re
 import os

--- a/ansible/linkstate/scripts/fanout_listener.py
+++ b/ansible/linkstate/scripts/fanout_listener.py
@@ -67,13 +67,13 @@ class Conn(object):
 
     def read(self):
         fp = self.conn.makefile('rb', 1024)
-        data = pickle.load(fp)
+        data = pickle.load(fp)  # nosemgrep: avoid-pickle
         fp.close()
         return data
 
     def write(self, data):
         fp = self.conn.makefile('wb', 1024)
-        pickle.dump(data, fp, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(data, fp, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
         fp.close()
 
 

--- a/ansible/linkstate/scripts/mlnx/fanout_listener.py
+++ b/ansible/linkstate/scripts/mlnx/fanout_listener.py
@@ -40,13 +40,13 @@ class PtfHostConn(object):
 
     def read(self):
         fp = self.conn.makefile('rb', 1024)
-        data = pickle.load(fp)
+        data = pickle.load(fp)  # nosemgrep: avoid-pickle
         fp.close()
         return data
 
     def write(self, data):
         fp = self.conn.makefile('wb', 1024)
-        pickle.dump(data, fp, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(data, fp, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
         fp.close()
 
 

--- a/ansible/linkstate/scripts/ptf_proxy.py
+++ b/ansible/linkstate/scripts/ptf_proxy.py
@@ -23,7 +23,7 @@ def log(message, output_on_console=False):
 
 class TCPHandler(socketserver.StreamRequestHandler):
     def handle(self):
-        data = pickle.load(self.rfile)
+        data = pickle.load(self.rfile)  # nosemgrep: avoid-pickle
         log("Received request: %s" % str(data))
         key = self.client_address[0], data['intf']
         if key in self.server.x_table:
@@ -38,7 +38,7 @@ class TCPHandler(socketserver.StreamRequestHandler):
             data = {'status': 'OK'}
         data = {'status': 'OK'}
         log("Send reply %s" % str(data))
-        pickle.dump(data, self.wfile, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(data, self.wfile, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
 
 
 class Conn(object):
@@ -51,13 +51,13 @@ class Conn(object):
 
     def read(self):
         fp = self.conn.makefile('rb', 1024)
-        data = pickle.load(fp)
+        data = pickle.load(fp)  # nosemgrep: avoid-pickle
         fp.close()
         return data
 
     def write(self, data):
         fp = self.conn.makefile('wb', 1024)
-        pickle.dump(data, fp, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(data, fp, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
         fp.close()
 
 

--- a/ansible/linkstate/scripts/vm_state_changer.py
+++ b/ansible/linkstate/scripts/vm_state_changer.py
@@ -40,12 +40,12 @@ class FIFOServer(object):
 
     def serve_forever(self):
         while True:
-            data = pickle.load(self.fifor)
+            data = pickle.load(self.fifor)  # nosemgrep: avoid-pickle
             log("Received request %s" % str(data))
             self.intf_manager.linkChange(data['intf'], data['linkStatus'])
             data = {'status': 'OK'}
             log("Send reply %s" % str(data))
-            pickle.dump(data, self.fifow, pickle.HIGHEST_PROTOCOL)
+            pickle.dump(data, self.fifow, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
             self.fifow.flush()
 
 

--- a/ansible/linkstate/scripts/vm_tcp_listener.py
+++ b/ansible/linkstate/scripts/vm_tcp_listener.py
@@ -18,12 +18,12 @@ def log(message, output_on_console=False):
 
 class TCPHandler(socketserver.StreamRequestHandler):
     def handle(self):
-        data = pickle.load(self.rfile)
+        data = pickle.load(self.rfile)  # nosemgrep: avoid-pickle
         log("Received and send request %s" % str(data))
         self.server.fifo_client.write(data)
         data = self.server.fifo_client.read()
         log("Received and send reply %s" % str(data))
-        pickle.dump(data, self.wfile, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(data, self.wfile, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
 
 
 class FIFOClient(object):
@@ -35,11 +35,11 @@ class FIFOClient(object):
         self.fifor = open(self.FIFOr, 'w')
 
     def write(self, data):
-        pickle.dump(data, self.fifor, pickle.HIGHEST_PROTOCOL)
+        pickle.dump(data, self.fifor, pickle.HIGHEST_PROTOCOL)  # nosemgrep: avoid-pickle
         self.fifor.flush()
 
     def read(self):
-        return pickle.load(self.fifow)
+        return pickle.load(self.fifow)  # nosemgrep: avoid-pickle
 
 
 def main():

--- a/ansible/module_utils/serial_utils.py
+++ b/ansible/module_utils/serial_utils.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import logging
-from telnetlib import Telnet
+from telnetlib import Telnet  # nosemgrep: telnetlib
 from ansible.module_utils.debug_utils import config_module_logging
 
 config_module_logging('serial_utils')

--- a/ansible/roles/vm_set/library/kickstart.py
+++ b/ansible/roles/vm_set/library/kickstart.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
-from telnetlib import Telnet
+from telnetlib import Telnet  # nosemgrep: telnetlib
 import logging
 import sys
 from ansible.module_utils.debug_utils import config_module_logging

--- a/ansible/roles/vm_set/library/kvm_port.py
+++ b/ansible/roles/vm_set/library/kvm_port.py
@@ -36,7 +36,7 @@ def main():
         output = subprocess.check_output(
             "virsh domiflist %s" % vmname,
             env={"LIBVIRT_DEFAULT_URI": "qemu:///system"},
-            shell=True).decode('utf-8')
+            shell=True).decode('utf-8')  # nosemgrep: subprocess-shell-true
     except subprocess.CalledProcessError:
         module.fail_json(msg="failed to iflist dom %s" % vmname)
 

--- a/ansible/roles/vm_set/library/sonic_kickstart.py
+++ b/ansible/roles/vm_set/library/sonic_kickstart.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
-from telnetlib import Telnet
+from telnetlib import Telnet  # nosemgrep: telnetlib
 import logging
 from ansible.module_utils.debug_utils import config_module_logging
 

--- a/ansible/roles/vm_set/library/vlan_port.py
+++ b/ansible/roles/vm_set/library/vlan_port.py
@@ -138,8 +138,9 @@ class VlanPort(object):
     @staticmethod
     def cmd(cmdline, ignore_error=False):
         logging.debug("CMD: %s", cmdline)
-        process = subprocess.Popen(cmdline, stdout=subprocess.PIPE,
-                                   stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        process = subprocess.Popen(  # nosemgrep: subprocess-shell-true
+            cmdline, stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, stderr = process.communicate()
         ret_code = process.returncode
 

--- a/spytest/spytest/remote/port_breakout.py
+++ b/spytest/spytest/remote/port_breakout.py
@@ -83,7 +83,7 @@ if not SIM_HOST:
     def get_platform():
         cmd = "cat /host/machine.conf | grep onie_platform | cut -d '=' -f 2"
         pin = subprocess.Popen(cmd,
-                               shell=True,
+                               shell=True,  # nosemgrep: subprocess-shell-true
                                close_fds=True,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT)
@@ -100,9 +100,8 @@ if not SIM_HOST:
 
     def get_hwsku():
         dir = get_platform_path()
-        # nosemgrep-next-line
         pin = subprocess.Popen("cat " + dir + "/default_sku | cut -d ' ' -f 1",
-                               shell=True,
+                               shell=True,  # nosemgrep: subprocess-shell-true
                                close_fds=True,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT)
@@ -119,8 +118,7 @@ if not SIM_HOST:
         if display_cmd is True:
             print("Running command: " + command)
 
-        # nosemgrep-next-line
-        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)  # nosemgrep: subprocess-shell-true
         (out, err) = proc.communicate()
 
         if len(out) > 0 and print_to_console:


### PR DESCRIPTION
Replace .semgrepignore with targeted inline `# nosemgrep` comments for 28 legacy infrastructure files (ansible, spytest). This addresses the semgrep findings without blanket directory-level suppression.

Fixes line-length violations (E501) from nosemgrep comments by moving comments to preceding lines or reformatting.

Takes over from #22463 per team decision.

**Changes:**
- 15 files with inline `# nosemgrep: <rule-id>` comments
- No functional code changes
- All lines within 120-char limit