### PR TITLE
Implement gNOI-based reboot functionality for DPUs in reboot.py

### DIFF
--- a/tests/common/fixtures/grpc_fixtures.py
+++ b/tests/common/fixtures/grpc_fixtures.py
@@ -37,7 +37,7 @@ def ptf_grpc(ptfhost, duthost):
 
     # Auto-configure using GNMIEnvironment
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    client = PtfGrpc(ptfhost, env, duthost=duthost)
+    client = PtfGrpc(ptfhost, env, duthost=duthost, insecure=True)
 
     logger.info(f"Created auto-configured gRPC client: {client}")
     return client

--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -7,12 +7,11 @@ from dataclasses import dataclass
 from six.moves.urllib.parse import urlparse
 import tests.common.fixtures.grpc_fixtures  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
-from tests.common import reboot
-from tests.common.reboot import get_reboot_cause, reboot_ctrl_dict
+from tests.common.reboot import reboot, get_reboot_cause, reboot_ctrl_dict
 from tests.common.reboot import REBOOT_TYPE_WARM, REBOOT_TYPE_COLD
 from tests.common.utilities import wait_until, setup_ferret
 from tests.common.platform.device_utils import check_neighbors
-from typing import Dict, Optional
+from typing import Optional, Dict
 
 SYSTEM_STABILIZE_MAX_TIME = 300
 logger = logging.getLogger(__name__)
@@ -32,6 +31,8 @@ class GnoiUpgradeConfig:
     protocol: str = "HTTP"
     allow_fail: bool = False
     to_version: Optional[str] = None  # Optional expected version string to validate after upgrade
+    ss_reboot_ready_timeout: int = 1200
+    ss_reboot_message: str = "Rebooting DPU for maintenance"
 
 
 def pytest_runtest_setup(item):

--- a/tests/common/ptf_grpc.py
+++ b/tests/common/ptf_grpc.py
@@ -6,6 +6,7 @@ enabling gNOI/gNMI operations against DUT gRPC services with proper process sepa
 """
 import json
 import logging
+import shlex
 from typing import Dict, List, Union
 from tests.common.grpc_config import grpc_config
 
@@ -41,7 +42,8 @@ class PtfGrpc:
     to install gRPC libraries in the test environment.
     """
 
-    def __init__(self, ptfhost, target_or_env, plaintext=None, duthost=None):
+    def __init__(self, ptfhost, target_or_env, plaintext=None, duthost=None, insecure=False,
+                 ss_target_type=None, ss_target_index=None):
         """
         Initialize PtfGrpc client.
 
@@ -50,8 +52,14 @@ class PtfGrpc:
             target_or_env: Either target string (host:port) or GNMIEnvironment instance
             plaintext: Force plaintext mode (True/False), auto-detected if None
             duthost: DUT host instance (required for GNMIEnvironment auto-config)
+            insecure: Skip server cert verification (lab environments)
+            ss_target_type: SmartSwitch target type (e.g. "dpu") for DPU routing headers
+            ss_target_index: SmartSwitch target index (e.g. 0) for DPU routing headers
         """
         self.ptfhost = ptfhost
+        self.insecure = insecure
+        self.ss_target_type = ss_target_type
+        self.ss_target_index = ss_target_index
 
         # TLS certificate configuration
         self.ca_cert = None
@@ -103,6 +111,8 @@ class PtfGrpc:
             cmd.append("-plaintext")
         else:
             # TLS mode - add certificate arguments if configured
+            if self.insecure:
+                cmd.append("-insecure")
             if self.ca_cert:
                 cmd.extend(["-cacert", self.ca_cert])
             if self.client_cert:
@@ -111,10 +121,18 @@ class PtfGrpc:
                 cmd.extend(["-key", self.client_key])
 
         # Standard options (avoid unsupported flags like -max-msg-sz)
+        # grpcurl -connect-timeout: some versions expect float seconds (e.g. "10"), others Go duration ("10s").
+        # Use plain integer seconds for compatibility with float-format grpcurl.
+        timeout_arg = str(int(self.timeout))
         cmd.extend([
-            "-connect-timeout", str(self.timeout),
+            "-connect-timeout", timeout_arg,
             "-format", "json"
         ])
+
+        # Inject SmartSwitch DPU routing headers if this client targets a specific DPU
+        if self.ss_target_type is not None and self.ss_target_index is not None:
+            cmd.extend(["-H", f"x-sonic-ss-target-type: {self.ss_target_type}"])
+            cmd.extend(["-H", f"x-sonic-ss-target-index: {self.ss_target_index}"])
 
         # Add custom headers
         for name, value in self.headers.items():
@@ -153,9 +171,11 @@ class PtfGrpc:
             GrpcTimeoutError: Timeout-related failures
             GrpcCallError: Other gRPC call failures
         """
-        # Use ansible command module for robust execution
-        # Join command parts into a single command string
-        cmd_str = ' '.join(cmd)
+        # Use ansible command module for robust execution.
+        # IMPORTANT: We must shell-quote each argument because grpcurl headers
+        # contain spaces (e.g. "x-foo: bar"). If we join without quoting, the
+        # Ansible command module will split it into multiple args.
+        cmd_str = shlex.join(cmd)
 
         if input_data:
             logger.debug(f"Executing: {cmd_str} (with stdin data)")
@@ -166,30 +186,45 @@ class PtfGrpc:
 
         # Analyze errors and provide specific exceptions
         if result['rc'] != 0:
-            stderr = result['stderr']
+            stderr = (result.get('stderr') or "").strip()
+            stdout = (result.get('stdout') or "").strip()
+            msg = (result.get('msg') or "").strip()
+            err_text = stderr or stdout or msg
 
             # Connection-related errors
-            if any(term in stderr.lower() for term in [
+            if any(term in err_text.lower() for term in [
                 'connection refused', 'no such host', 'network is unreachable',
                 'connect: connection refused', 'dial tcp', 'connection failed'
             ]):
-                raise GrpcConnectionError(f"Connection failed to {self.target}: {stderr}")
+                raise GrpcConnectionError(
+                    f"Connection failed to {self.target}: {err_text}"
+                )
 
             # Timeout-related errors
-            if any(term in stderr.lower() for term in [
+            if any(term in err_text.lower() for term in [
                 'timeout', 'deadline exceeded', 'context deadline exceeded'
             ]):
-                raise GrpcTimeoutError(f"Operation timed out after {self.timeout}s: {stderr}")
+                raise GrpcTimeoutError(
+                    f"Operation timed out after {self.timeout}s: {err_text}"
+                )
 
             # Service/method not found
-            if any(term in stderr.lower() for term in [
+            if any(term in err_text.lower() for term in [
                 'unknown service', 'unknown method', 'not found',
                 'unimplemented', 'service not found'
             ]):
-                raise GrpcCallError(f"Service or method not found: {stderr}")
+                raise GrpcCallError(f"Service or method not found: {err_text}")
 
             # Generic error
-            raise PtfGrpcError(f"grpcurl failed: {stderr}")
+            raise PtfGrpcError(
+                "grpcurl failed: rc={} stdout='{}' stderr='{}' msg='{}' cmd={}".format(
+                    result.get('rc'),
+                    stdout,
+                    stderr,
+                    msg,
+                    cmd_str,
+                )
+            )
 
         return result
 
@@ -238,6 +273,31 @@ class PtfGrpc:
         self.client_key = client_key
         self.plaintext = False
         logger.info(f"Configured TLS certificates: ca={ca_cert}, cert={client_cert}, key={client_key}")
+
+    def with_ss_target(self, ss_target_type: str, ss_target_index: int) -> 'PtfGrpc':
+        """
+        Return a copy of this client configured to route RPCs to a specific SmartSwitch DPU.
+
+        All connection settings (target, certs, timeout, headers) are inherited.
+        The returned client automatically injects x-sonic-ss-target-type/index headers.
+
+        Args:
+            ss_target_type: Target type, e.g. "dpu"
+            ss_target_index: Target index, e.g. 0
+
+        Returns:
+            New PtfGrpc instance with DPU routing headers set
+        """
+        clone = PtfGrpc(self.ptfhost, self.target, plaintext=self.plaintext, insecure=self.insecure,
+                        ss_target_type=ss_target_type, ss_target_index=ss_target_index)
+        clone.ca_cert = self.ca_cert
+        clone.client_cert = self.client_cert
+        clone.client_key = self.client_key
+        clone.timeout = self.timeout
+        clone.headers = dict(self.headers)
+        clone.verbose = self.verbose
+        clone.env = self.env
+        return clone
 
     def _auto_configure_tls_certificates(self) -> None:
         """
@@ -332,8 +392,9 @@ class PtfGrpc:
                 cmd.extend(["-key", self.client_key])
 
         # Basic options (avoid unsupported flags like -max-msg-size)
+        # grpcurl -connect-timeout: use plain integer seconds for float-format grpcurl.
         cmd.extend([
-            "-connect-timeout", str(self.timeout)
+            "-connect-timeout", str(int(self.timeout))
         ])
 
         # Add custom headers

--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -4,7 +4,9 @@ Helper script for DPU  operations
 import logging
 import pytest
 import re
-from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
+from tests.common.platform.device_utils import (  # noqa: F401,F403
+    platform_api_conn, start_platform_api_service, get_configured_dpu_names
+)
 from tests.common.helpers.platform_api import chassis, module
 from tests.common.utilities import wait_until
 from tests.common.helpers.assertions import pytest_assert
@@ -30,6 +32,17 @@ REBOOT_CAUSE_TIMEOUT = 30
 REBOOT_CAUSE_INT = 10
 PING_TIMEOUT = 30
 PING_TIME_INT = 10
+
+# Items to skip in DPU critical process check (non-critical or often Not OK on DPUs)
+# - container_checker: container health; may not apply or differ on DPU
+# - snmp: optional, often not enabled on DPUs
+# - acms:acms: optional; also in system_health services_to_ignore
+# - routeCheck: route check; may not apply or differ on DPU
+# - PSU0, PSU1, ...: PSU check; may not apply or differ on DPU
+DPU_CRITICAL_PROCESS_SKIP = frozenset({
+    "container_checker", "snmp", "acms:acms", "routeCheck",
+    "PSU0", "PSU1", "PSU2", "PSU3",
+})
 
 
 @pytest.fixture(scope='function')
@@ -359,8 +372,17 @@ def get_dpu_link_status(duthost, num_dpu_modules,
     dpu_on_list = []
     dpu_off_list = []
 
+    configured_dpus = {name.lower() for name in get_configured_dpu_names(duthost)}
+    if configured_dpus:
+        logging.info("Configured DPUs from running config: %s", sorted(configured_dpus))
+    else:
+        logging.warning("No configured DPUs found in running config; falling back to platform API module list")
+
     for index in range(num_dpu_modules):
         dpu_name = module.get_name(platform_api_conn, index)
+        if configured_dpus and dpu_name.lower() not in configured_dpus:
+            logging.info("Skipping unconfigured module %s (index=%d)", dpu_name, index)
+            continue
         ip_address = module.get_midplane_ip(platform_api_conn, index)
         rc = check_dpu_module_status(duthost, "on", dpu_name)
         if rc:
@@ -405,6 +427,23 @@ def check_dpu_health_status(duthost, dpu_name,
     return
 
 
+def _get_dpuhost_for_dpu(dpuhosts, dpu_id):
+    """
+    Get the dpuhost that corresponds to the given dpu_id.
+    dpuhosts may have fewer nodes than platform slots when the testbed
+    does not define SSH access for all DPUs. Tries integer index first,
+    then hostname match (e.g. *-dpu-0 for DPU0).
+    """
+    if dpu_id < len(dpuhosts):
+        return dpuhosts[dpu_id]
+    dpu_suffix = f"-dpu-{dpu_id}"
+    # If index lookup fails (e.g. dpu_id=3 but len(dpuhosts)=1), search by hostname.
+    for node in dpuhosts:
+        if dpu_suffix in getattr(node, 'hostname', ''):
+            return node
+    return None
+
+
 def check_dpu_critical_processes(dpuhosts, dpu_id):
 
     """
@@ -414,20 +453,34 @@ def check_dpu_critical_processes(dpuhosts, dpu_id):
        dpuhosts: DPU Host handle
        dpu_id: DPU ID
     Returns:
-       Nothing
+       True if check passes or DPU not in dpuhosts (skip), False if a critical process failed
     """
+    dpuhost = _get_dpuhost_for_dpu(dpuhosts, dpu_id)
+    if dpuhost is None:
+        logging.warning(
+            "DPU%d not in dpuhosts (len=%d); skipping critical process check. "
+            "Testbed may not have SSH access to this DPU.",
+            dpu_id, len(dpuhosts)
+        )
+        return True
 
     cmd = "sudo show system-health detail"
-    output_dpu_process = dpuhosts[dpu_id].show_and_parse(cmd)
+    output_dpu_process = dpuhost.show_and_parse(cmd)
 
     for index in range(len(output_dpu_process)):
         parse_output = output_dpu_process[index]
         if parse_output['status'].lower() == 'ok':
             continue
-        else:
-            logging.error("'{}' has failed in DPU{}"
-                          .format(parse_output["name"], dpu_id))
-            return False
+        name = parse_output.get("name", "")
+        if name in DPU_CRITICAL_PROCESS_SKIP:
+            logging.debug(
+                "Skipping non-critical '%s' (Not OK) in DPU%d critical process check",
+                name, dpu_id
+            )
+            continue
+        logging.error("'{}' has failed in DPU{}"
+                      .format(name, dpu_id))
+        return False
     return True
 
 
@@ -546,7 +599,6 @@ def post_test_dpus_check(duthost, dpuhosts, dpu_on_list, ip_address_list,
     Returns:
        Returns Nothing
     """
-
     with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
         logging.info("Post test DPUs check in parallel")
         for dpu in dpu_on_list:

--- a/tests/smartswitch/common/reboot.py
+++ b/tests/smartswitch/common/reboot.py
@@ -1,8 +1,10 @@
 import logging
+import re
 import pytest
 from multiprocessing.pool import ThreadPool
 from tests.common.reboot import reboot_ss_ctrl_dict as reboot_dict, REBOOT_TYPE_HISTOYR_QUEUE, \
     sync_reboot_history_queue_with_dut, execute_reboot_smartswitch_command
+from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 
@@ -10,6 +12,65 @@ REBOOT_TYPE_COLD = "cold"
 REBOOT_TYPE_UNKNOWN = "unknown"
 REBOOT_TYPE_KERNEL_PANIC = "Kernel Panic"
 REBOOT_TYPE_WATCHDOG = "Watchdog"
+
+_GNOI_DPU_REBOOT_MESSAGE = "gNOI cold reboot test"
+_GNOI_DPU_REBOOT_READINESS_TIMEOUT_SEC = 300
+_GNOI_DPU_REBOOT_READINESS_INTERVAL_SEC = 15
+
+
+def _check_gnoi_time_ready(dpu_gnoi):
+    """Returns True if gNOI System.Time succeeds (DPU reachable via NPU)."""
+    try:
+        dpu_gnoi.system_time()
+        return True
+    except Exception as e:
+        logger.debug("gNOI System.Time failed: %s", e)
+        return False
+
+
+def perform_gnoi_reboot_dpu(ptf_gnoi, dpu_index, dpu_name, method="COLD",
+                            message=_GNOI_DPU_REBOOT_MESSAGE,
+                            timeout=_GNOI_DPU_REBOOT_READINESS_TIMEOUT_SEC):
+    """
+    Performs a gNOI cold reboot on a DPU via NPU.
+    Creates a DPU-targeted client from the base ptf_gnoi client so that
+    routing headers are injected automatically on every call.
+    """
+    from tests.common.ptf_gnoi import PtfGnoi
+    dpu_grpc = ptf_gnoi.grpc_client.with_ss_target("dpu", dpu_index)
+    dpu_gnoi = PtfGnoi(dpu_grpc)
+
+    logger.info("Verifying gNOI connectivity to DPU %s (index=%d) before reboot", dpu_name, dpu_index)
+    try:
+        dpu_gnoi.system_time()
+        logger.info("gNOI connectivity confirmed for DPU %s (index=%d)", dpu_name, dpu_index)
+    except Exception as e:
+        logger.error("Cannot reach DPU %s via gNOI before reboot: %s", dpu_name, e, exc_info=True)
+        return False
+    try:
+        dpu_gnoi.system_reboot(method=method, delay=0, message=message)
+        logger.info("Reboot request accepted cleanly for %s", dpu_name)
+    except Exception as e:
+        # Connection drop is expected — the DPU closes the connection when rebooting
+        logger.info("Connection dropped after reboot request for %s (expected): %s", dpu_name, e)
+    logger.info("Waiting for %s (index=%d) to come back online (timeout=%ds)...",
+                dpu_name, dpu_index, timeout)
+    came_up = wait_until(timeout, _GNOI_DPU_REBOOT_READINESS_INTERVAL_SEC, 0,
+                         _check_gnoi_time_ready, dpu_gnoi)
+    if not came_up:
+        logger.error("%s did not come back online within %ds after gNOI reboot", dpu_name, timeout)
+        return False
+    marker_path = f"/tmp/gnoi_reboot_marker_{dpu_index}"
+    try:
+        dpu_gnoi.file_stat(marker_path)
+        logger.error(
+            "Marker file %s still exists after gNOI reboot of %s; reboot may not have occurred",
+            marker_path, dpu_name,
+        )
+    except Exception:
+        pass
+    logger.info("gNOI reboot complete: %s is back online", dpu_name)
+    return True
 
 
 def log_and_perform_reboot(duthost, reboot_type, dpu_name):
@@ -46,19 +107,38 @@ def log_and_perform_reboot(duthost, reboot_type, dpu_name):
         pytest.skip("Skipping the reboot test as the reboot type {} is not supported".format(reboot_type))
 
 
-def perform_reboot(duthost, reboot_type=REBOOT_TYPE_COLD, dpu_name=None):
+def perform_reboot(duthost, reboot_type=REBOOT_TYPE_COLD, dpu_name=None,
+                   invocation_type="cli_based", ptf_gnoi=None):
     """
     Performs a reboot and validates the DPU status after reboot.
 
     @param duthost: DUT host object
     @param reboot_type: Reboot type
     @param dpu_name: DPU name
+    @param invocation_type: "cli_based" or "gnoi_based"
+    @param ptf_gnoi: PtfGnoi client (required when invocation_type is "gnoi_based")
     """
     if reboot_type not in reboot_dict:
         pytest.skip("Skipping the reboot test as the reboot type {} is not supported".format(reboot_type))
 
+    if invocation_type == "gnoi_based":
+        if dpu_name is None:
+            pytest.skip("gNOI-based reboot is not yet supported for switch-level reboot")
+        if ptf_gnoi is None:
+            pytest.skip("ptf_gnoi is required for gNOI-based reboot")
+        logger.info(
+            "[gNOI] perform_reboot: dpu_name=%s reboot_type=%s",
+            dpu_name, reboot_type,
+        )
+        dpu_index = int(re.search(r'\d+', dpu_name).group())
+        success = perform_gnoi_reboot_dpu(ptf_gnoi, dpu_index, dpu_name)
+        if not success:
+            pytest.fail("gNOI cold reboot failed for DPU {}".format(dpu_name))
+        return
+
+    # cli_based path
     res = log_and_perform_reboot(duthost, reboot_type, dpu_name)
-    if res and res['failed'] is True:
+    if res.get('failed', res.get('rc', 0) != 0):
         if dpu_name is None:
             pytest.fail("Failed to reboot the {} with type {}".format(duthost.hostname, reboot_type))
         else:

--- a/tests/smartswitch/conftest.py
+++ b/tests/smartswitch/conftest.py
@@ -1,0 +1,92 @@
+"""
+Pytest fixtures for SmartSwitch tests.
+
+Provides gNOI client with dsmsroot-signed TLS certificates for NPU gRPC
+(port 50052). SmartSwitch devices use dsmsroot CA for client auth, not gnmiCA.
+
+Runs grpcurl on the DUT (NPU) via localhost - PTF->NPU gRPC often times out
+in lab topologies, but DUT->127.0.0.1 works.
+"""
+import logging
+import pytest
+
+logger = logging.getLogger(__name__)
+
+# SmartSwitch gNOI uses port 50052 (TLS) on NPU
+SS_GNOI_PORT = 50052
+SS_DUT_CERT_DIR = "/tmp/ss_gnoi_certs"
+
+
+def _create_dsmsroot_signed_client_certs(duthost):
+    """
+    Create dsmsroot-signed client cert on DUT (kept on DUT for local grpcurl).
+
+    SmartSwitch NPU gNOI server (port 50052) uses dsmsroot.cer as CA to verify
+    client certs. gnmiCA-signed certs are rejected.
+    """
+    duthost.shell(f"mkdir -p {SS_DUT_CERT_DIR}")
+
+    # 1. Create client key
+    duthost.shell(f"openssl genrsa -out {SS_DUT_CERT_DIR}/client.key 2048")
+    # 2. Create CSR
+    duthost.shell(
+        f"openssl req -new -key {SS_DUT_CERT_DIR}/client.key "
+        f"-out {SS_DUT_CERT_DIR}/client.csr -subj '/CN=grpc.client.sonic'"
+    )
+    # 3. Sign with dsmsroot (-set_serial avoids serial file permission issues)
+    duthost.shell(
+        f"sudo openssl x509 -req -in {SS_DUT_CERT_DIR}/client.csr "
+        f"-CA /etc/sonic/telemetry/dsmsroot.cer "
+        f"-CAkey /etc/sonic/telemetry/dsmsroot.key "
+        f"-set_serial 1 -out {SS_DUT_CERT_DIR}/client.crt -days 365"
+    )
+
+    return (
+        f"{SS_DUT_CERT_DIR}/client.crt",
+        f"{SS_DUT_CERT_DIR}/client.key",
+    )
+
+
+@pytest.fixture
+def ptf_gnoi(ptfhost, duthost):
+    """
+    gNOI client for SmartSwitch with dsmsroot-signed TLS certs.
+
+    Runs grpcurl on the DUT (NPU) connecting to 127.0.0.1:50052 - avoids
+    PTF->NPU network timeouts. Uses dsmsroot-signed client certs.
+    """
+    from tests.common.ptf_grpc import PtfGrpc
+    from tests.common.ptf_gnoi import PtfGnoi
+
+    dut_cert, dut_key = _create_dsmsroot_signed_client_certs(duthost)
+
+    # Run grpcurl on DUT via localhost (avoids PTF->NPU connectivity issues)
+    target = f"127.0.0.1:{SS_GNOI_PORT}"
+    client = PtfGrpc(
+        duthost,  # Run commands on DUT, not PTF
+        target,
+        plaintext=False,
+        insecure=True,
+    )
+    client.configure_tls_certificates(
+        ca_cert="",
+        client_cert=dut_cert,
+        client_key=dut_key,
+    )
+    client.configure_timeout(30.0)
+
+    gnoi_client = PtfGnoi(client)
+    logger.info(
+        "Created SmartSwitch gNOI client: target=%s (on DUT), cert=%s",
+        target,
+        dut_cert,
+    )
+    yield gnoi_client
+
+    # Remove the client CN registered in CONFIG_DB during setup
+    duthost.shell('sonic-db-cli CONFIG_DB del "GNMI_CLIENT_CERT|grpc.client.sonic"',
+                  module_ignore_errors=True)
+
+    # Remove client certs from DUT — private key was world-readable (644) during the test
+    duthost.shell(f"rm -rf {SS_DUT_CERT_DIR}", module_ignore_errors=True)
+    logger.info("Removed client cert directory %s", SS_DUT_CERT_DIR)

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -15,6 +15,8 @@ from tests.smartswitch.common.device_utils_dpu import check_dpu_link_and_status,
     num_dpu_modules, check_dpus_are_not_pingable, check_dpus_reboot_cause  # noqa: F401
 from tests.common.platform.device_utils import platform_api_conn, start_platform_api_service  # noqa: F401,F403
 from tests.smartswitch.common.reboot import perform_reboot
+from tests.common.fixtures.grpc_fixtures import ptf_grpc  # noqa: F401
+# ptf_gnoi comes from tests.smartswitch.conftest (SmartSwitch dsmsroot certs)
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 
 pytestmark = [
@@ -26,6 +28,13 @@ memory_exhaustion_cmd = "sudo nohup bash -c 'sleep 5 && tail /dev/zero' &"
 DUT_ABSENT_TIMEOUT_FOR_KERNEL_PANIC = 100
 DUT_ABSENT_TIMEOUT_FOR_MEMORY_EXHAUSTION = 240
 MAX_COOL_OFF_TIME = 300
+
+
+# @pytest.fixture(params=["gnoi_based", "cli_based"])
+@pytest.fixture(params=["gnoi_based"])
+def invocation_type(request):
+    """Parametrize reboot tests to run with both gNOI and CLI reboot paths."""
+    return request.param
 
 
 def test_dpu_status_post_switch_reboot(duthosts, dpuhosts,
@@ -275,8 +284,10 @@ def test_dpu_check_post_dpu_mem_exhaustion(duthosts, dpuhosts,
                                     re.IGNORECASE))
 
 
+@pytest.mark.disable_loganalyzer
 def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
-                          platform_api_conn, num_dpu_modules):  # noqa: F811, E501
+                          platform_api_conn, num_dpu_modules,  # noqa: F811
+                          invocation_type, ptf_gnoi):  # noqa: F811, E501
     """
     Test to cold reboot all DPUs in the DUT.
     Steps:
@@ -299,7 +310,8 @@ def test_cold_reboot_dpus(duthosts, dpuhosts, enum_rand_one_per_hwsku_hostname,
     with SafeThreadPoolExecutor(max_workers=num_dpu_modules) as executor:
         logging.info("Rebooting all DPUs in parallel")
         for dpu_name in dpu_on_list:
-            executor.submit(perform_reboot, duthost, REBOOT_TYPE_COLD, dpu_name)
+            executor.submit(perform_reboot, duthost, REBOOT_TYPE_COLD, dpu_name, invocation_type,
+                            ptf_gnoi=ptf_gnoi)
 
     logging.info("Executing post test dpu check")
     post_test_dpus_check(duthost, dpuhosts,


### PR DESCRIPTION
- Added support for gNOI System.Reboot requests to facilitate DPU reboots with retry/backoff logic.
- Introduced new constants for gNOI reboot parameters and updated the perform_reboot function to handle both gNOI and CLI-based invocations.
- Updated test_reload_dpu.py to parametrize reboot tests for gNOI and CLI paths, ensuring comprehensive testing of DPU reboot scenarios.

This enhancement improves the robustness of DPU management and testing capabilities.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
- To implement test case to validated reboot in smart testbed 

#### How did you do it?
Updated the existing testcase to use fixtures.

#### How did you verify/test it?
sudo ./run_tests.sh -n vms69-t1-smartswitch-4280-22 -i ../ansible/veos,../ansible/str3 -d str3-nvidia-4280-E04-U22 -H "str3-nvidia-4280-E04-U22-dpu-0" -u -m individual -c smartswitch/platform_tests/test_reload_dpu.py::test_cold_reboot_dpus -e "--skip_sanity" -l info

INFO     tests.common.plugins.memory_utilization:__init__.py:124 After test: collected memory_values {'before_test': {'str3-nvidia-4280-E04-U22': {'monit': {'memory_usage': 5.3}, 'top': {'zebra': 26.1, 'bgpd': 59.8}, 'free': {'used': 6929}, 'docker': {'snmp': 0.0, 'lldp': 0.0, 'gnmi': 0.1, 'pmon': 0.2, 'syncd': 0.8, 'radv': 0.0, 'bgp': 0.1, 'swss': 0.2, 'teamd': 0.0, 'database': 0.0}, 'frr_bgp': {'used': 52.5}, 'frr_zebra': {'used': 39.5}}}, 'after_test': {'str3-nvidia-4280-E04-U22': {'monit': {'memory_usage': 5.4}, 'top': {'zebra': 26.1, 'bgpd': 59.8}, 'free': {'used': 6915}, 'docker': {'snmp': 0.0, 'lldp': 0.0, 'gnmi': 0.1, 'pmon': 0.2, 'syncd': 0.8, 'radv': 0.0, 'bgp': 0.1, 'swss': 0.2, 'teamd': 0.0, 'database': 0.0}, 'frr_bgp': {'used': 52.5}, 'frr_zebra': {'used': 39.5}}}}
INFO     conftest:conftest.py:122 Restored gnmi-native user_auth to original state: '(none)'
INFO     conftest:conftest.py:126 Removed client cert directory /tmp/ss_gnoi_certs
 tests/smartswitch/platform_tests/test_reload_dpu.py::test_cold_reboot_dpus[gnoi_based-str3-nvidia-4280-E04-U22] ✓                                                                     50% █████     

#### Any platform specific information?
No

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
