### PR TITLE
Fix race condition in tacacs_daily_daemon

### DIFF
--- a/ansible/scripts/start_tacacs.sh
+++ b/ansible/scripts/start_tacacs.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/root/tacacs_daily_daemon &
+/root/tacacs_daily_daemon > /var/log/tacacs_daily_daemon.log 2>&1 &

--- a/ansible/scripts/tacacs_daily_daemon
+++ b/ansible/scripts/tacacs_daily_daemon
@@ -2,6 +2,7 @@
 
 # This TACACS server need bind to port 49, because SONiC load_minigraph only support port 49
 TACPLUS_PORT=49
+LOCKFILE=/var/run/tacacs_daily_daemon.lock
 
 # Always kill running tac_plus process on port $TACPLUS_PORT to reload config
 # It will be start later by tacacs_daily_daemon
@@ -11,18 +12,10 @@ if [ $TACPLUS_PID ]; then
     kill -9 $TACPLUS_PID
 fi
 
-# Exit if tacacs_daily_daemon already running
-PROCESS_NUM=$(pgrep -l tacacs_daily_daemon | wc -l)
-if [ $PROCESS_NUM -ge 1 ]; then
-    echo "tacacs_daily_daemon already running"
-    exit 0
-fi
-
+exec 9>"$LOCKFILE"
 # Exit if tacacs_daily_daemon already running in background
-# need check -ge3, because every grep command will create a process with same name
-PROCESS_NUM=$(ps -ef | grep "/bin/sh .*tacacs_daily_daemon" | grep -v "grep" | wc -l)
-if [ $PROCESS_NUM -ge 3 ]; then
-    echo "tacacs_daily_daemon already running in background" $PROCESS_NUM
+if ! flock -n 9; then
+    echo "tacacs_daily_daemon already running in background"
     exit 0
 fi
 


### PR DESCRIPTION

### Description of PR

This addresses the issue in https://github.com/sonic-net/sonic-mgmt/issues/22517.

The change replaces the existing `ps` based check for whether the daemon is already running with a file lock using `flock`. Using a lock avoids parsing the process list and removes the race condition described in the issue.

Previously the script determined whether another instance was running with:

```
ps -ef | grep ... | grep ... | wc -l
```

When the shell runs this pipeline it forks several processes before the actual commands are fully loaded. There is a short window where those intermediate processes appears as the `tacacs_daily_daemon` and `ps -ef` can see them. If that happens, the count becomes >= 3 even though no other daemon instance is actually running. The issue link includes a detailed breakdown of this behavior.

Instead, the script now uses the following to guarantee that only one instance proceeds:
```
# Exit if tacacs_daily_daemon already running in background
LOCKFILE=/var/run/tacacs_daily_daemon.lock
exec 9>"$LOCKFILE"
if ! flock -n 9; then
    echo "tacacs_daily_daemon already running in background"
    exit 0
fi
```

Additionally, we redirect the daemon's stdout and stderr to `/var/log/tacacs_daily_daemon.log` file to prevent SIGPIPE signals when the parent SSH session terminates: When ansible executes `start_tacacs.sh` via ssh, the daemon inherits stdout/stderr descriptors pointing to the ssh session. When the ession closes (after ansible completes), these pipes are closed. Any subsequent write to stdout/stderr (e.g., echo statements in the while loop) causes the script to crash.

Summary:
Fixes #22517 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### How did you verify/test it?

Ran the ansible playbook:
`cd /data/ansible; ./testbed-cli.sh -k ceos add-topo ardut ~/.password -l server_1 -vvv`

And verified TACACS is running. Also manually killed TACACS and verified the daemon keeps running, as previously that would result in SIGPIPE.
