### PR TITLE
Fix scapy's max_list_count for test_bgp_suppress_fib.py

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -9,6 +9,7 @@ import time
 
 from scapy.all import sniff, IP, IPv6
 from scapy.contrib import bgp
+from scapy.config import conf
 import ptf.testutils as testutils
 import ptf.packet as scapy
 from copy import deepcopy
@@ -66,6 +67,18 @@ TRAFFIC_WAIT_TIME = 0.1
 BULK_TRAFFIC_WAIT_TIME = 0.01
 BGP_ROUTE_FLAP_TIMES = 5
 UPDATE_WITHDRAW_THRESHOLD = 5  # consider the switch with low power cpu and a lot of bgp neighbors
+
+
+@pytest.fixture(autouse=True, scope="module")
+def scapy_max_list_count():
+    """
+    New Python version 3.12.3 honors scapy's max_list_count (default 100) config option.
+    This fixture increases the max_list_count to handle BGP UPDATEs with many withdrawn routes.
+    """
+    original = conf.max_list_count
+    conf.max_list_count = 500
+    yield
+    conf.max_list_count = original
 
 
 # Returns True if the topology has a spine layer, else returns False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
New Python version 3.12.3 is used after Ubuntu 24.04 upgrade. Scapy is still 2.7.0, but new Python version honors its max_list_count (default 100) config option. This limits the number of PacketListField it can parse, which fails to count BGP update packets with many withdrawn routes as bgp.BGPUpdate.
Increase max_list_count to 500 and restore it in the module scope.

Fixes #22522

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
