### PR TITLE
Fix LACP channel-group assignment in ceos_topo_converger for converged peers

### DIFF
--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -163,6 +163,9 @@ class SonicTopoConverger:
                         continue
                     eth_intf = f"Ethernet{eth_intf_index}"
                     vrf[eth_intf] = deepcopy(peer_intfs[intf])
+                    # Update lacp channel-group to match the new Port-Channel index
+                    if "lacp" in vrf[eth_intf] and "Port-Channel1" in peer_intfs:
+                        vrf[eth_intf]["lacp"] = intf_index
                     orig_intf_map[intf] = eth_intf
                     eth_intf_index += 1
 


### PR DESCRIPTION
## Description

Fix a bug in `ceos_topo_converger.py` where the LACP channel-group number is not updated when remapping Ethernet interfaces for converged peers on LAG topologies.

### What is the motivation for this PR?

When using `use_converged_peers: true` on LAG topologies (e.g., t1-lag), the converger copies interface configs via `deepcopy` but retains the original `lacp` value (always `1`). This causes all Ethernet interfaces in the converged cEOS container to join `channel-group 1` instead of being distributed across separate Port-Channels.

**Before fix (t1-lag, 8 spines converged into 1 cEOS):**
- All 16 Ethernet interfaces → `channel-group 1` (Po1)
- Po1 has 16 members (only 2 can LACP bundle), Po2-Po8 have zero members
- Only 1 of 8 PortChannels comes up on the DUT

**After fix:**
- Et1,Et2 → channel-group 1; Et3,Et4 → channel-group 2; ... Et15,Et16 → channel-group 8
- All 8 PortChannels come up with correct 2-member distribution
- All 24 BGP sessions establish

### How did you do it?

After the `deepcopy` of the peer interface config, update the `lacp` field to match the new Port-Channel index (`intf_index`):

```python
vrf[eth_intf] = deepcopy(peer_intfs[intf])
if "lacp" in vrf[eth_intf] and "Port-Channel1" in peer_intfs:
    vrf[eth_intf]["lacp"] = intf_index
```

### How did you verify/test it?

Validated on a KVM testbed with t1-lag topology and `use_converged_peers: true`:
- Verified `show running-config | section channel-group` on spine cEOS shows correct distribution
- All 8 PortChannels up with 2 members each on DUT
- All 24/24 BGP sessions established (8 T2 spines + 16 T0 ToRs)

Fixes #22525