### PR TITLE
Make ceos_topo_converger idempotent for already-converged topologies

### DIFF
--- a/ansible/ceos_topo_converger.py
+++ b/ansible/ceos_topo_converger.py
@@ -265,6 +265,9 @@ class SonicTopoConverger:
 def converge_testbed(input_file: str, output_file: str) -> None:
     with open(input_file, "r", encoding="utf-8") as in_file:
         topo = yaml.safe_load(in_file)
+    if topo.get("topo_is_multi_vrf", False):
+        print("Topology already converged, skipping convergence.")
+        return
     converger = SonicTopoConverger(topo, output_file)
     converger.run()
 


### PR DESCRIPTION
## Description

Make the ceos topology converger idempotent so it can safely be invoked on an already-converged topology file.

### What is the motivation for this PR?

When using `use_converged_peers: true`, `testbed-cli.sh add-topo` runs the converger which overwrites the topo file with the converged version. A subsequent `testbed-cli.sh deploy-mg` also invokes the converger (via `TestbedProcessing.py`), but it fails because the input file is already converged.

This forces users to manually restore the original topo file (`git checkout vars/topo_*.yml`) between `add-topo` and `deploy-mg`, which also wipes the `topo_is_multi_vrf` and `convergence_data` metadata that the test framework needs for the `nbrhosts` fixture to correctly map VRF peers to physical containers (see #22524).

### How did you do it?

Added an early-out check in `converge_testbed()`: if the topology already has `topo_is_multi_vrf` set, skip convergence and preserve the file as-is.

### How did you verify/test it?

Validated on a KVM testbed with t1-lag topology and `use_converged_peers: true`:
- `add-topo` converges the topo file (sets `topo_is_multi_vrf: True`)
- `deploy-mg` now skips re-convergence, preserving the converged metadata
- Tests can read `topo_is_multi_vrf` and `convergence_data` from the topo file

Fixes #22526
Related: #22524, #22525