### PR TITLE
Fix scapy's max_list_count for test_bgp_suppress_fib.py

### DIFF
--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -9,6 +9,7 @@ import time
 
 from scapy.all import sniff, IP, IPv6
 from scapy.contrib import bgp
+from scapy.config import conf
 import ptf.testutils as testutils
 import ptf.packet as scapy
 from copy import deepcopy
@@ -66,6 +67,19 @@ TRAFFIC_WAIT_TIME = 0.1
 BULK_TRAFFIC_WAIT_TIME = 0.01
 BGP_ROUTE_FLAP_TIMES = 5
 UPDATE_WITHDRAW_THRESHOLD = 5  # consider the switch with low power cpu and a lot of bgp neighbors
+
+
+@pytest.fixture(autouse=True, scope="module")
+def scapy_max_list_count():
+    """
+    Scapy 2.6.0+ uses conf.max_list_count (default 100) as global size limit for PacketListField/FieldListField
+    scapy.contrib.bgp overrides it with max_count=20000 for nlri, but not for withdrawn_routes
+    Set conf.max_list_count to 20000 to parse BGP update packets with 100+ withdrawn routes
+    """
+    original = conf.max_list_count
+    conf.max_list_count = 20000
+    yield
+    conf.max_list_count = original
 
 
 # Returns True if the topology has a spine layer, else returns False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
New Ubuntu 24.04 base image upgrades Scapy from 2.5.0 to 2.7.0.
Scapy 2.6.0+ uses conf.max_list_count (default 100) as global size limit for PacketListField/FieldListField. scapy.contrib.bgp overrides it with max_count=20000 for nlri, but not for withdrawn_routes.
This causes failures when parsing BGP udpate packets with more than 100 withdrawn routes.
Increase conf.max_list_count to 20000 and restore it in the module fixture.
Fixes #22522

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
