### PR TITLE
Add skip for test_everflow_per_interface.py unsupported platforms

### DIFF
--- a/tests/everflow/test_everflow_per_interface.py
+++ b/tests/everflow/test_everflow_per_interface.py
@@ -111,6 +111,10 @@ def setup_mirror_session_dest_ip_route(tbinfo, setup_info, apply_mirror_session,
     Setup the route for mirror session destination ip and update monitor port list.
     Remove the route as part of cleanup.
     """
+    duthost_set = BaseEverflowTest.get_duthost_set(setup_info)
+    for duthost in duthost_set:
+        if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s') and erspan_ip_ver == 6: # noqa E501
+            pytest.skip("Skip IPv6 mirror session on unsupported platforms")
     ip = "ipv4" if erspan_ip_ver == 4 else "ipv6"
     namespace = setup_info[UP_STREAM]['remote_namespace']
     tx_port = setup_info[UP_STREAM]["dest_port"][0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
We noticed that some `test_everflow_per_interface.py` testcases were failing on certain platforms. It turns out these testcases were being skipped before due to the chips on these platforms not supporting IPv6 erspan mirroring. The skip was unintentionally removed in https://github.com/sonic-net/sonic-mgmt/pull/22242. This is because the skip logic was moved from conditional mark into a fixture that `test_everflow_per_interface.py` doesn't use.

#### How did you do it?
This change adds the skip logic for these platforms into the fixture used by `test_everflow_per_interface.py`.

#### How did you verify/test it?
Verified the skip is working on both platforms.

#### Any platform specific information?
The hardware not being supported is being tracked in https://github.com/sonic-net/sonic-mgmt/issues/19096 and CSP CS00012414171

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
