### PR TITLE
[bgp scale] : Use a cyclic ICMP type within a safe range 

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -3,6 +3,7 @@ Test plan PR: https://github.com/sonic-net/sonic-mgmt/pull/15702
 '''
 
 import datetime
+import itertools
 import pytest
 import logging
 import json
@@ -47,8 +48,8 @@ STATIC_ROUTES = ['0.0.0.0/0', '::/0']
 WITHDRAW_ROUTE_NUMBER = 1
 PACKET_QUEUE_LENGTH = 1000000
 ICMP_TYPE_MIN = 5
-ICMP_TYPE_MAX = 99
-_global_icmp_type = ICMP_TYPE_MIN - 1
+ICMP_TYPE_MAX = 125
+_icmp_type_generator = itertools.cycle(range(ICMP_TYPE_MIN, ICMP_TYPE_MAX + 1))
 test_results = {}
 current_test = ""
 
@@ -60,11 +61,7 @@ def log_test_results():
 
 
 def _get_icmp_type():
-    global _global_icmp_type
-    _global_icmp_type += 1
-    if _global_icmp_type > ICMP_TYPE_MAX:
-        _global_icmp_type = ICMP_TYPE_MIN
-    return _global_icmp_type
+    return next(_icmp_type_generator)
 
 
 def setup_packet_mask_counters(ptf_dataplane, icmp_type):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update the IPv6 BGP scale PTF traffic generation to use a *cyclic* ICMPv6 type chosen from a safe, non-reserved range, instead of incrementing a global ICMP type value. This avoids eventually drifting into reserved/invalid ICMP type values across repeated test phases/runs in future when new test cases maybe added and keeps packet-mask counters stable.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ X ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The bgp scale test previously used a global ICMP type that was incremented on each phase. Over time when new test cases kept adding, this can move into reserved/unsafe ICMP type values, which may cause unexpected behavior and flaky results. We want each phase to use a distinct ICMP type for mask counters, while guaranteeing the type stays within a safe range.

#### How did you do it?
- Added an `itertools.cycle()` generator over a bounded ICMP type range (currently `5..125`).
- Replaced the global incrementing variable with `_get_icmp_type()` to fetch the next type for each test phase.
- This global variable can only be accessed through this function.
- Updated `generate_packets()` to accept `icmp_type` as an explicit parameter and plumbed it through call sites (flapper + withdraw/announce phases).

#### How did you verify/test it?
- Verified the test module imports and packet generation uses the provided `icmp_type`.
- Confirmed all previous call sites were updated to pass `icmp_type`, and packet-mask setup uses the same value for each phase.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
