### PR TITLE
fix default route for t0-isolated topo

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -569,8 +569,11 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
     last_suffix = 0
     for index, vm_name in enumerate(sorted(vms.keys())):
         router_type = "leaf"
+        tor_default_route = False
         if 'tor' in topo['configuration'][vm_name]['properties']:
             router_type = 'tor'
+            if "PT" in vm_name:
+                tor_default_route = True
         port, port6 = get_change_routes_ports(vm_name, topo)
         aggregate_prefixes = topo['configuration'][vm_name].get("aggregate_routes", AGGREGATE_ROUTES_DEFAULT_VALUE)
         aggregate_routes = [(prefix, nhipv4 if "." in prefix else nhipv6, "") for prefix in aggregate_prefixes]
@@ -583,7 +586,8 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
                                                      spine_asn, leaf_asn_start, tor_asn_start,
                                                      nhipv4, nhipv4, tor_subnet_size, max_tor_subnet_number, "t0",
                                                      router_type=router_type,
-                                                     no_default_route=no_default_route, offset=current_routes_offset)
+                                                     no_default_route=no_default_route, offset=current_routes_offset,
+                                                     tor_default_route=tor_default_route)
             if aggregate_routes_v4:
                 filterout_subnet_ipv4(aggregate_routes, routes_v4)
                 routes_v4.extend(aggregate_routes_v4)
@@ -597,7 +601,8 @@ def fib_t0(topo, ptf_ip, no_default_route=False, action="announce", upstream_nei
                                                      router_type=router_type,
                                                      no_default_route=no_default_route,
                                                      ipv6_address_pattern=ipv6_address_pattern,
-                                                     offset=current_routes_offset)
+                                                     offset=current_routes_offset,
+                                                     tor_default_route=tor_default_route)
             if aggregate_routes_v6:
                 filterout_subnet_ipv6(aggregate_routes, routes_v6)
                 routes_v6.extend(aggregate_routes_v6)

--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -79,7 +79,9 @@ def get_upstream_neigh(tb, device_neigh_metadata, af, nexthops):
     for neigh_name, neigh_cfg in list(topo_cfg_facts.items()):
         if not is_in_neighbor(neigh_types, neigh_name):
             continue
-        if "PT0" in neigh_name and "tor" in neigh_cfg.get('properties', []):
+        if 't0-isolated' in tb['topo']['name'] and "PT" not in neigh_name:
+            # For t0-isolated topology, PT0 default routes will be preferred over T1 neighbors,
+            # so only consider PT neighbors for default route verification
             continue
         interfaces = neigh_cfg.get('interfaces', {})
         ipv4_addr = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
In t0-isolated topo, the default route may come from PT0 or T1, and PT0 is preferred due to shorter AS path. Update the test case to suit it.

Fixes default route for t0-isolated topo.

```
route/test_default_route.py::test_default_route_with_bgp_flap FAILED     [ 75%]
......
        logging.info("peer intf ip from tb {}".format(upstream_neigh_ip))
>       pytest_assert(len(nexthops) == len(upstream_neigh_ip),
                      "Default route nexthops doesn't match the testbed topology")
E       Failed: Default route nexthops doesn't match the testbed topology

```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix default route announcement from PT0 in t0-isolated topo

#### How did you do it?
- advertise default for PT0 neighbor.
- update test_default_route.py test case to use PT0 only as upstream neighbor.

#### How did you verify/test it?
local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
