### PR TITLE
[snappi] Fixed typo in variable hostname in variables.override.yml file to resolve key-error

### DIFF
--- a/tests/snappi_tests/variables.override.yml
+++ b/tests/snappi_tests/variables.override.yml
@@ -4,7 +4,7 @@ vms-snappi-sonic-multidut:
         rx_ports:
           - hostname: sonic-s6100-dut1
             port_name: Ethernet72
-          - host_name: sonic-s6100-dut2
+          - hostname: sonic-s6100-dut2
             port_name: Ethernet76
         tx_ports:
           - hostname: sonic-s6100-dut2


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The parameter "hostname" in variables.override.yml is defined as "host_name". This causes key-error in function get_snappi_ports_for_rdma present in snappi_fixtures.py in the following code:
```
    for port in snappi_port_list:
        for var_rx_port in var_rx_ports:
            if port['peer_port'] == var_rx_port['port_name'] and port['peer_device'] == var_rx_port['hostname']:
                rx_snappi_ports.append(port)
        for var_tx_port in var_tx_ports:
            if port['peer_port'] == var_tx_port['port_name'] and port['peer_device'] == var_tx_port['hostname']:
                tx_snappi_ports.append(port)
```

Summary:
Fixes #22360 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fixed a minor typo error.

#### How did you do it?
Fixed a minor typo error. Corrected the variable 'host_name" to "hostname" in the yml file.

#### How did you verify/test it?
Ran it on local branch with fixed parameter.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
