### PR TITLE
Add Non-Lag v6 Topologies to GCU Dynamic ACL Non-Lag List

### DIFF
--- a/tests/generic_config_updater/test_dynamic_acl.py
+++ b/tests/generic_config_updater/test_dynamic_acl.py
@@ -168,6 +168,16 @@ def setup(rand_selected_dut, rand_unselected_dut, tbinfo, vlan_name, topo_scenar
         't1-isolated-d28u1',
         't1-isolated-d28',
         't0-d18u8s4',
+        't0-isolated-v6-d256u256s2',
+        't0-isolated-v6-d128u128s2',
+        't0-isolated-v6-d96u32s2',
+        't0-isolated-v6-d32u32s2',
+        't0-isolated-v6-d16u16s1',
+        't0-isolated-v6-d16u16s2',
+        't1-isolated-v6-d224u8',
+        't1-isolated-v6-d128',
+        't1-isolated-v6-d56u2',
+        't1-isolated-v6-d28u1',
     )
 
     if topo == "m0_l3" or tbinfo['topo']['name'] in topos_no_portchannels:


### PR DESCRIPTION
### Description of PR
Summary: The non-lag list of topologies in the GCU test_dynamic_acl test is missing the v6 topologies, resulting in improper accounting of the upstream ports on those tests, yielding the following error when trying to reference an index of the upstream ports (upstream_ports[0]): IndexError: list index out of range

This change adds those missing v6 topologies to the appropriate list in the test file so that the upstream ports are accounted for properly for those topologies.

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix an IndexError encountered when running generic_config_updater/test_dynamic_acl.py against non-lag v6 topologies.

#### How did you do it?
Added missing v6 topologies to the topos_no_portchannels list in generic_config_updater/test_dynamic_acl.py.

#### How did you verify/test it?
Ran the tests in generic_config_updater/test_dynamic_acl.py and confirmed that they now pass.

#### Any platform specific information?
This affects non-lag v6 topologies.