### PR TITLE
[SmartSwitch]Enhance testbed_health_check.py to enable NAT for DPU hosts

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -27,7 +27,7 @@ ansible_path = os.path.realpath(os.path.join(_self_dir, "../ansible"))
 if ansible_path not in sys.path:
     sys.path.append(ansible_path)
 
-from devutil.devices.factory import init_host, init_localhost, init_testbed_sonichosts, init_sonichosts  # noqa: E402
+from devutil.devices.factory import init_host, init_localhost, init_sonichosts  # noqa: E402
 from devutil.devices.ansible_hosts import HostsUnreachable, RunAnsibleModuleFailed  # noqa: E402
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Description of PR

Summary:
Enhance `testbed_health_check.py` to support SmartSwitch testbeds with DPU (Data Processing Unit) hosts. This enables the testbed health check to automatically configure NAT on NPU hosts, allowing SSH connectivity to DPU hosts for health verification.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
SmartSwitch testbeds contain DPU hosts that require NAT port forwarding through their associated NPU hosts for SSH access. Without this configuration, the testbed health checker cannot reach DPU hosts to verify their status.

#### How did you do it?
- Added `_get_testbed_dut_names()` to read DUT hostnames from testbed file (no SSH required)
- Refactored `init_hosts()` to:
  1. Separate NPU and DPU hostnames based on 'dpu' in name
  2. Initialize NPU hosts first (directly reachable)
  3. Enable NAT on NPU hosts using `sonic-dpu-mgmt-traffic.sh`
  4. Then initialize DPU hosts (now reachable via NAT)
- Updated `_get_dpu_name_ssh_port_dict()` to accept `dpu_hostnames` parameter
- Updated `enable_nat_for_dpuhosts()` to accept optional `dpu_hostnames` parameter
- 
#### How did you verify/test it?
Tested on SmartSwitch testbed with DPU hosts - verified NAT configuration is applied and health checks complete successfully on both NPU and DPU hosts.

#### Any platform specific information?
Specific to SmartSwitch platforms with DPU hosts.

#### Supported testbed topology if it's a new test case?
N/A - This is a testbed infrastructure improvement.

### Documentation
N/A