### PR TITLE
Fix typo: require -> required in AnsibleModule argument_spec

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -55,12 +55,12 @@ def is_full_lossy_hwsku(hwsku):
 class GenerateGoldenConfigDBModule(object):
     def __init__(self):
         self.module = AnsibleModule(argument_spec=dict(topo_name=dict(required=True, type='str'),
-                                    port_index_map=dict(require=False, type='dict', default=None),
-                                    macsec_profile=dict(require=False, type='str', default=None),
-                                    num_asics=dict(require=False, type='int', default=1),
-                                    hwsku=dict(require=False, type='str', default=None),
-                                    vm_configuration=dict(require=False, type='dict', default={}),
-                                    is_lit_mode=dict(require=False, type='bool', default=True)),
+                                    port_index_map=dict(required=False, type='dict', default=None),
+                                    macsec_profile=dict(required=False, type='str', default=None),
+                                    num_asics=dict(required=False, type='int', default=1),
+                                    hwsku=dict(required=False, type='str', default=None),
+                                    vm_configuration=dict(required=False, type='dict', default={}),
+                                    is_lit_mode=dict(required=False, type='bool', default=True)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']


### PR DESCRIPTION
### Description of PR

Summary:
Fix typo in `generate_golden_config_db.py` where `require=False` was used instead of the correct `required=False` in the AnsibleModule argument_spec. This typo would cause Ansible to not recognize the optional parameters correctly.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The AnsibleModule `argument_spec` uses `required` (not `require`) as the keyword to specify whether a parameter is mandatory. Using `require` is a typo that may cause unexpected behavior.

#### How did you do it?
Changed `require=False` to `required=False` for all 6 optional parameters in the `GenerateGoldenConfigDBModule` class:
- `port_index_map`
- `macsec_profile`
- `num_asics`
- `hwsku`
- `vm_configuration`
- `is_lit_mode`

#### How did you verify/test it?
Ran Microsoft pipeline to deploy topo with the changes

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A