### PR TITLE
Fix decap/test_decap.py for cisco-8000: force dscp uniform mode

### DIFF
--- a/tests/decap/conftest.py
+++ b/tests/decap/conftest.py
@@ -16,12 +16,17 @@ def _read_appl_db_field(duthost, key, field):
 
 
 def _should_use_pipe_for_dscp(duthost):
+    asic_type = (duthost.facts.get('asic_type') or '').lower()
+
+    # cisco-8000 uses dscp uniform mode for IP-in-IP decap.
+    if asic_type == 'cisco-8000':
+        return False
+
     # Prefer the live default from APP_DB if present
     dscp_mode = _read_appl_db_field(duthost, 'TUNNEL_DECAP_TABLE:IPINIP_TUNNEL', 'dscp_mode')
     if dscp_mode in ('pipe', 'uniform'):
         return dscp_mode == 'pipe'
 
-    asic_type = (duthost.facts.get('asic_type') or '').lower()
     os_version = duthost.os_version if hasattr(duthost, 'os_version') else ''
 
     if asic_type in ('mellanox', 'innovium'):


### PR DESCRIPTION
Summary: decap/test_decap.py failed for IPv4inIPv6 and IPv6inIPv6 encapsulation combinations for cisco-8000.

ip-in-ip decap with dscp=pipe is not supported for Cisco G200 and was blocked via

[sonic-mgmt/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml at 7dabd9182208e5d32e6c658633522625a3b8aada · sonic-net/sonic-mgmt](https://github.com/sonic-net/sonic-mgmt/blob/7dabd9182208e5d32e6c658633522625a3b8aada/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml#L838C1-L838C68)

The blocking stopped working after

[[test-decap] Fix test decap for pipe mode by developfast · Pull Request #20304 · sonic-net/sonic-mgmt](https://github.com/sonic-net/sonic-mgmt/pull/20304/changes/6f5735a8b10096a8df4ed3c18952a2541dd271fb)

that removed test parametrization from conftest.py, 
the skip conditions in tests_mark_conditions.yaml for test_decap[ttl=pipe, dscp=pipe, vxlan=disable] no longer match the test name.

This causes test_decap to run with dscp=pipe mode on cisco-8000 as the [ipinip.json.j2](https://github.com/sonic-net/sonic-buildimage/blob/5eb8184b4dd29612488e989a8db1560bb293aaf2/dockers/docker-orchagent/ipinip.json.j2#L124) has dscp_mode=pipe configured.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
