### PR TITLE
[bgp] Relax update timer threshold on VS/KVM with fib suppress

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -181,13 +181,16 @@ def common_setup_teardown(
 
 
 @pytest.fixture
-def constants(is_quagga, setup_interfaces, has_suppress_feature, pytestconfig, tbinfo):
+def constants(is_quagga, setup_interfaces, has_suppress_feature, pytestconfig, tbinfo,
+              duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     class _C(object):
         """Dummy class to save test constants."""
 
         pass
 
     _constants = _C()
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    is_vs_platform = duthost.facts.get("asic_type") == "vs"
     if is_quagga:
         _constants.sleep_interval = 40
         _constants.update_interval_threshold = 20
@@ -195,6 +198,10 @@ def constants(is_quagga, setup_interfaces, has_suppress_feature, pytestconfig, t
         _constants.sleep_interval = 5
         if not has_suppress_feature:
             _constants.update_interval_threshold = 1
+        elif is_vs_platform:
+            # KVM/VS platforms have higher latency due to virtual
+            # switching; use a relaxed threshold to reduce flakiness
+            _constants.update_interval_threshold = 5
         else:
             _constants.update_interval_threshold = 2.5
 


### PR DESCRIPTION
### Description of PR
When `bgp suppress-fib-pending` is enabled, the BGP update timer test (`test_bgp_update_timer_single_route`) uses a 2.5s threshold for update propagation. On KVM/VS platforms, virtual switching latency makes this threshold too tight, causing intermittent failures in PR CI.

This PR increases the threshold to 5s specifically for VS/KVM platforms (`asic_type == 'vs'`) while keeping the original 2.5s for physical hardware.

### Motivation
This test is a known flaky test in KVM PR testing. The root cause is that fib suppress adds overhead to route propagation, and KVM's virtual switching adds further latency on top of that.

Fixes #11286

### How did you verify
- Code review of the threshold logic
- The fix is conservative: 5s is 2x the current threshold, matching the pattern used elsewhere in sonic-mgmt for KVM-specific relaxations