### PR TITLE
[acl] Replace time.sleep with wait_until in test_src_mac_rewrite

### DIFF
--- a/tests/acl/test_src_mac_rewrite.py
+++ b/tests/acl/test_src_mac_rewrite.py
@@ -574,7 +574,8 @@ def create_vxlan_vnet_config(duthost, tunnel_name, src_ip, portchannel_name="Por
         result = duthost.shell('redis-cli -n 0 KEYS "SWITCH_TABLE:switch"', module_ignore_errors=True)
         return "SWITCH_TABLE:switch" in result.get("stdout", "")
 
-    wait_until(10, 2, 2, _check_vxlan_switch_config, duthost)
+    pytest_assert(wait_until(10, 2, 2, _check_vxlan_switch_config, duthost),
+                  "SWITCH_TABLE:switch not found in APP_DB after configure_vxlan_switch")
 
 
 def backup_config(duthost):


### PR DESCRIPTION
### Description
Replace time.sleep with wait_until for ACL config convergence and counter checks. Improves test reliability on KVM/VS platforms by polling for expected state instead of using fixed delays.

#### Changes
- Replace 10 `time.sleep()` calls with `wait_until()` polling for actual config/state convergence
- Add helper functions for checking ACL table/rule/counter state
- Remove unused `import time`

Signed-off-by: Rustiqly <rustiqly@users.noreply.github.com>