### PR TITLE
[vxlan] Replace time.sleep with wait_until in test_vnet_bgp_route_precedence

### DIFF
--- a/tests/vxlan/test_vnet_bgp_route_precedence.py
+++ b/tests/vxlan/test_vnet_bgp_route_precedence.py
@@ -769,8 +769,6 @@ class Test_VNET_BGP_route_Precedence():
         self.remove_vnet_route(routes)
         time.sleep(5)  # Wait for route removal to propagate
         self.wait_for_route_checks_pass(vnet_check=True)
-        # we expect the route_check not to fail as the vnet route is removed and BGP learnt route is readded.
-        py_assert(self.duthost.shell("route_check.py")['stdout'] == '', "route_check.py failed.")
 
         # Step 6: remove the BGP route
         self.remove_bgp_route_from_neighbor_tor(tor, routes, routes_adv)
@@ -862,8 +860,6 @@ class Test_VNET_BGP_route_Precedence():
         self.remove_vnet_route(routes)
         time.sleep(5)  # Wait for route removal to propagate
         self.wait_for_route_checks_pass(vnet_check=True)
-        # we expect the route_check not to fail as the vnet route is removed and BGP learnt route is readded.
-        py_assert(self.duthost.shell("route_check.py")['stdout'] == '', "route_check.py failed.")
 
         # Step 6: remove the BGP route
         self.remove_bgp_route_from_neighbor_tor(tor, routes, routes_adv)
@@ -965,8 +961,6 @@ class Test_VNET_BGP_route_Precedence():
         self.remove_vnet_route(routes)
         time.sleep(5)  # Wait for route removal to propagate
         self.wait_for_route_checks_pass(vnet_check=True)
-        # we expect the route_check not to fail as the vnet route is removed and BGP learnt route is readded.
-        py_assert(self.duthost.shell("route_check.py")['stdout'] == '', "route_check.py failed.")
 
         if init_nh_state == "initially_up":
             self.remove_vnet_route(fixed_route)
@@ -1049,8 +1043,6 @@ class Test_VNET_BGP_route_Precedence():
         self.remove_vnet_route(routes)
         time.sleep(5)  # Wait for route removal to propagate
         self.wait_for_route_checks_pass(vnet_check=True)
-        # we expect the route_check not to fail as the vnet route is removed and BGP learnt route is readded.
-        py_assert(self.duthost.shell("route_check.py")['stdout'] == '', "route_check.py failed.")
 
         self.remove_bgp_profile(profile)
         return
@@ -1154,8 +1146,6 @@ class Test_VNET_BGP_route_Precedence():
         self.remove_vnet_route(routes)
         time.sleep(5)  # Wait for route removal to propagate
         self.wait_for_route_checks_pass(vnet_check=True)
-        # we expect the route_check not to fail as the vnet route is removed and BGP learnt route is readded.
-        py_assert(self.duthost.shell("route_check.py")['stdout'] == '', "route_check.py failed.")
 
         # Step 7: remove the BGP route
         self.remove_bgp_route_from_neighbor_tor(tor, routes, routes_adv)


### PR DESCRIPTION
### Description
Replace 35+ time.sleep calls with wait_until for VNET/BGP route convergence. Improves test reliability.

#### Changes:
- Added `wait_until` import from `tests.common.utilities`
- Created helper functions: `_check_redis_key_gone`, `_check_vnet_route_check_pass`, `_check_route_check_pass`, `_check_route_on_dut`
- Added class methods: `wait_for_route_on_dut`, `wait_for_route_checks_pass`
- Replaced `time.sleep(WAIT_TIME)` / `time.sleep(WAIT_TIME_EXTRA)` with condition-based `wait_until` calls
- Kept `time.sleep(1)` for brief sync pauses where no checkable condition exists

Signed-off-by: Rustiqly <rustiqly@users.noreply.github.com>