### PR TITLE
[Marvell-Teralynx] enable arp unknown_mac test case

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -186,9 +186,9 @@ arp/test_stress_arp.py::test_ipv4_arp:
 
 arp/test_unknown_mac.py:
   skip:
-    reason: "Behavior on cisco-8000 & (Marvell) platform for unknown MAC is flooding rather than DROP, hence skipping."
+    reason: "Behavior on cisco-8000 platform for unknown MAC is flooding rather than DROP, hence skipping."
     conditions:
-      - "asic_type in ['cisco-8000','marvell-teralynx']"
+      - "asic_type in ['cisco-8000']"
 
 arp/test_unknown_mac.py::TestUnknownMac::test_unknown_mac:
   xfail:


### PR DESCRIPTION
[Cherry pick of #19810 ]

### Description of PR
Enable arp_unknown_mac test case for Marvell-Teralynx platform

Summary:
This change helps enable arp_unknown_mac test cases for Marvell-Teralynx platform

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement
- [x] Enable test case for new platform

### Approach
#### What is the motivation for this PR?
Test was being skipped till now for the platform. Enabling it for PTF execution

#### How did you do it?
Removed the platform check for the mentioned test case.

#### How did you verify/test it?
Executed the test case.

#### Any platform specific information?
NA

