### PR TITLE
[SmartSwitch] Add DPU extra config for hostname and disabled features

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -1039,6 +1039,7 @@
       - name: Load DPU config in smartswitch
         load_extra_dpu_config:
           hwsku: "{{ hwsku }}"
+          hostname: "{{ inventory_hostname }}"
           host_username: "{{ sonic_login }}"
           host_passwords: "{{ sonic_default_passwords }}"
         become: true

--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -2,9 +2,24 @@
     "DEVICE_METADATA": {
         "localhost": {
             "bgp_asn": "65100",
+            "hostname": "DPU_HOSTNAME_PLACEHOLDER",
             "subtype": "SmartSwitch",
             "switch_type": "dpu",
             "type": "SmartSwitchDPU"
+        }
+    },
+    "FEATURE": {
+        "acms": {
+            "state": "disabled"
+        },
+        "lldp": {
+            "state": "disabled"
+        },
+        "restapi": {
+            "state": "disabled"
+        },
+        "snmp": {
+            "state": "disabled"
         }
     },
     "GNMI": {


### PR DESCRIPTION
### Description of PR

This PR adds DPU extra configuration for SmartSwitch testbeds to properly configure hostname and disable unnecessary features on DPUs.

Summary:
- Add hostname configuration for DPUs in format `<switch_hostname>-dpu-<index>` (e.g., `str3-msn4280-02-dpu-0`)
- Disable features not needed on DPU: lldp, snmp, restapi, acms
- Fix template copy logic to ensure each DPU gets unique hostname

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
DPUs on SmartSwitch were not getting proper hostnames and had unnecessary features (lldp, snmp, restapi, acms) enabled that are not needed for DPU operation.

#### How did you do it?
1. Added `hostname` field with placeholder to `smartswitch_dpu_extra.json`
2. Added FEATURE table entries to disable lldp, snmp, restapi, acms
3. Modified `load_extra_dpu_config.py` to:
   - Accept hostname parameter from ansible
   - Copy fresh template for each DPU iteration (fix for all DPUs getting same name)
   - Replace hostname placeholder with `<switch_hostname>-dpu-<index>`
4. Updated `config_sonic_basedon_testbed.yml` to pass `inventory_hostname`

#### How did you verify/test it?
Tested on Mellanox 4280 SmartSwitch testbed. Verified each DPU gets unique hostname and disabled features are applied.
Ran the Deploy-mg pipeline successfully https://dev.azure.com/mssonic/internal/_build/results?buildId=1045955&view=results

#### Any platform specific information?
Applies to SmartSwitch platforms with DPUs

#### Supported testbed topology if it's a new test case?
N/A - This is a testbed configuration improvement for SmartSwitch topologies (t1-smartswitch-ha, t1-28-lag, smartswitch-t1, t1-48-lag)

### Documentation
N/A - Configuration change, no new documentation required.