### PR TITLE
[arp] Fix test_arp_no_reply_other_intf using wrong PTF test class

### DIFF
--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -74,8 +74,8 @@ def test_arp_no_reply_other_intf(common_setup_teardown, intfs_for_test, enum_fro
         'port': intf2_indice,
         'kvm_support': True
     }
-    log_file = "/tmp/arptest.SrcOutRangeNoReply.{0}.log".format(datetime.now().strftime("%Y-%m-%d-%H:%M:%S"))
-    ptf_runner(ptfhost, 'ptftests', "arptest.SrcOutRangeNoReply", '/root/ptftests',
+    log_file = "/tmp/arptest.WrongIntNoReply.{0}.log".format(datetime.now().strftime("%Y-%m-%d-%H:%M:%S"))
+    ptf_runner(ptfhost, 'ptftests', "arptest.WrongIntNoReply", '/root/ptftests',
                params=intf2_params, log_file=log_file, is_python3=True)
 
     switch_arptable = asichost.switch_arptable()['ansible_facts']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix `test_arp_no_reply_other_intf` in `tests/arp/test_arpall.py` to use the correct PTF test class `arptest.WrongIntNoReply` instead of `arptest.SrcOutRangeNoReply`.

Fixes #20519

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The test function `test_arp_no_reply_other_intf` is supposed to verify that ARP requests arriving on the wrong interface receive no reply. However, due to a copy-paste error
  introduced during the original ansible-to-pytest conversion (PR #1752), it incorrectly invokes `arptest.SrcOutRangeNoReply` (which tests out-of-subnet source IP) instead of
  `arptest.WrongIntNoReply` (which tests ARP from the wrong interface).

   This means the "wrong interface" scenario was never actually being tested — it was a duplicate of `test_arp_no_reply_src_out_range`.

#### How did you do it?

 Changed the PTF test class from `arptest.SrcOutRangeNoReply` to `arptest.WrongIntNoReply` and updated the log file name accordingly. This matches the original Ansible
  playbook (`ansible/roles/test/tasks/arpall.yml` lines 136-147) which correctly uses `arptest.WrongIntNoReply` with `intf2` params.

#### How did you verify/test it?

Verified the fix aligns with the original Ansible test and the PTF test classes:
   - `arptest.WrongIntNoReply`: Sends ARP from wrong interface (intf2), expects no reply, checks IP 10.10.1.4 not in ARP table.
   - `arptest.SrcOutRangeNoReply`: Sends ARP with out-of-range src IP from intf1, expects no reply, checks IP 10.10.1.22 not in ARP table.

   The existing params (`intf2_params` with `intf2_indice`) and assertion (checking `10.10.1.4`) already match what `WrongIntNoReply` expects.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
