### PR TITLE
[Ansible] Use ansible_playbook_python instead of hardcoded 'python'

### DIFF
--- a/ansible/dualtor/config_simulated_y_cable.yml
+++ b/ansible/dualtor/config_simulated_y_cable.yml
@@ -16,7 +16,7 @@
 - name: Get host server address
   script: scripts/vmhost_server_address.py --inv-file {{ vm_file }} --server-name {{ testbed_facts['server'] }}
   args:
-    executable: python
+    executable: "{{ ansible_playbook_python }}"
   delegate_to: localhost
   register: vmhost_server_address
 


### PR DESCRIPTION
### Description of PR

On Ubuntu 24, `vmhost_server_address.py` fails with `ModuleNotFoundError: No module named 'ansible'` because `executable: python` uses system Python which lacks ansible.

This PR changes `executable: python` to `executable: "{{ ansible_playbook_python }}"` to use the same Python interpreter that runs ansible-playbook (which has ansible installed).

Summary:
Fix #22616

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
On Ubuntu 24, `/usr/bin/python` does not have ansible installed.

#### How did you do it?
Changed `executable: python` to `executable: "{{ ansible_playbook_python }}"`, which resolves to the Python interpreter running ansible-playbook, which has ansible in its environment.

#### How did you verify/test it?
Verified running Python file can import ansible correctly.

#### Any platform specific information?
Affects Ubuntu 24 based sonic-mgmt environments. No impact on Ubuntu 20/22 since they have ansible available to system Python.

#### Supported testbed topology if it's a new test case?
N/A — bug fix only.

### Documentation

N/A — bug fix only.