### PR TITLE
Modifying the is_snappi_multidut fixture for single line card on modular chassis

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1644,11 +1644,13 @@ def get_snappi_ports_multi_dut(duthosts,  # noqa: F811
 
 
 def is_snappi_multidut(duthosts):
-    if not duthosts[-1].get_facts().get("modular_chassis") and len(duthosts) == 1:
+    if duthosts is None or len(duthosts) == 0:
         return False
-    if not duthosts[-1].get_facts().get("modular_chassis") and len(duthosts) > 1:
+    if not duthosts[0].get_facts().get("modular_chassis") and len(duthosts) == 1:
+        return False
+    if not duthosts[0].get_facts().get("modular_chassis") and len(duthosts) > 1:
         return True
-    return duthosts[-1].get_facts().get("modular_chassis")
+    return duthosts[0].get_facts().get("modular_chassis")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
… chassis

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Modifying the is_snappi_multidut fixture for single line card on modular chassis
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
If the duthost contains a single Line card of a modular chassis the function will return false, instead it has to be returned True
#### How did you do it?
Modified the if else logic
#### How did you verify/test it?
Tested on non modular single line card chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
