### PR TITLE
[platform] Add test for safe grep in pmon container (issue #18394)

### DIFF
--- a/tests/platform_tests/test_pmon_grep_safe.py
+++ b/tests/platform_tests/test_pmon_grep_safe.py
@@ -167,6 +167,8 @@ def test_pmon_grep_no_kernel_panic(duthosts, rand_one_dut_hostname):
         r"BUG:",
         r"Oops:",
         r"general protection fault",
+        r"Unable to handle kernel",
+        r"RIP:",
     ]
     panic_found = []
     for line in new_lines:


### PR DESCRIPTION
## Description of PR
Adds a test that runs grep inside the pmon container to verify it does not trigger kernel panics.

Fixes #18394

## Type of change
- [x] New Test case

## Approach

### What is the motivation for this PR?
Issue #18394 reports that running `grep -r` inside the pmon container over `/sys/kernel/debug` can trigger kernel panics on some platforms due to unsafe debugfs mounts.

### How did you do it?
1. Verify pmon container is running
2. Run basic grep inside pmon as sanity check
3. If `/sys/kernel/debug` exists, run `grep -r` over it with a 120s timeout
4. Check dmesg for kernel panic/BUG/Oops messages after the grep

### How did you verify/test it?
- Tested on KVM T0 (vms-kvm-t0, vlab-01) — passed
- Test correctly handles missing `timeout` command in container
- Uses timestamp-based dmesg baseline to avoid ring buffer wrap issues

### Supported testbed topology if it's a new test case?
`any` topology — pmon container exists on all SONiC devices

Signed-off-by: Ying Xie <ying.xie@microsoft.com>