### PR TITLE
[qos] Add test case for default strict priority scheduling validation

### DIFF
--- a/tests/qos/test_qos_strict_priority.py
+++ b/tests/qos/test_qos_strict_priority.py
@@ -1,0 +1,138 @@
+"""Test case for default strict priority scheduling validation.
+
+Covers test gap issue #22405:
+https://github.com/sonic-net/sonic-mgmt/issues/22405
+
+In default strict priority scheduling, traffic classes (TCs) are served in
+descending order of priority (TC7 > TC6 > ... > TC0). Existing tests only
+validate PIR/CIR in strict priority schedulers but do not verify the actual
+priority ordering across TCs.
+
+This test validates that under congestion, higher priority TCs are served
+before lower priority TCs.
+"""
+
+import logging
+import pytest
+
+from tests.common.fixtures.conn_graph_facts import fanout_graph_facts, conn_graph_facts     # noqa: F401
+from tests.common.fixtures.duthost_utils import dut_qos_maps                                # noqa: F401
+from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                      # noqa: F401
+from tests.common.fixtures.ptfhost_utils import copy_saitests_directory                      # noqa: F401
+from tests.common.fixtures.ptfhost_utils import change_mac_addresses                         # noqa: F401
+from tests.common.fixtures.ptfhost_utils import ptf_portmap_file                             # noqa: F401
+from tests.common.dualtor.dual_tor_utils import dualtor_ports, is_tunnel_qos_remap_enabled   # noqa: F401
+from tests.common.helpers.assertions import pytest_assert
+from .qos_sai_base import QosSaiBase
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+
+class TestQosSaiStrictPriority(QosSaiBase):
+    """Test class for validating default strict priority scheduling behavior.
+
+    Under default strict priority, the scheduler should serve traffic classes
+    in descending priority order. This means TC7 has the highest priority and
+    TC0 has the lowest. When all TCs compete for bandwidth on the same egress
+    port, the higher priority TC should be fully served before any lower
+    priority TC receives bandwidth.
+
+    This test complements the existing DWRR/WRR tests by specifically
+    validating priority ordering rather than rate limiting (PIR/CIR).
+    """
+
+    def testQosSaiStrictPriorityScheduling(
+        self, ptfhost, duthosts, get_src_dst_asic_and_duts, dutTestParams,
+        dutConfig, dutQosConfig, skip_src_dst_different_asic,
+        change_lag_lacp_timer
+    ):
+        """
+        Test QoS SAI Default Strict Priority Scheduling.
+
+        Validates that under congestion, traffic classes are served in
+        descending priority order (TC7 > TC6 > ... > TC0).
+
+        Test Steps:
+            1. Send equal amounts of traffic for multiple TCs simultaneously
+               to the same egress port, creating congestion.
+            2. Read egress queue counters to determine how many packets each
+               TC forwarded.
+            3. Verify that higher priority TCs forwarded at least as many
+               packets as lower priority TCs.
+            4. Verify that the highest priority TC achieves near line-rate
+               throughput.
+
+        Args:
+            ptfhost (AnsibleHost): Packet Test Framework (PTF)
+            dutTestParams (Fixture, dict): DUT host test params
+            dutConfig (Fixture, dict): Map of DUT config containing dut
+                interfaces, test port IDs, test port IPs, and test ports
+            dutQosConfig (Fixture, dict): Map containing DUT host QoS
+                configuration
+
+        Returns:
+            None
+
+        Raises:
+            RunAnsibleModuleFail if ptf test fails
+        """
+        portSpeedCableLength = dutQosConfig["portSpeedCableLength"]
+        qosConfig = dutQosConfig["param"]
+
+        if "strict_priority" in qosConfig.get(portSpeedCableLength, {}):
+            qosConfigSp = qosConfig[portSpeedCableLength]["strict_priority"]
+        elif "strict_priority" in qosConfig:
+            qosConfigSp = qosConfig["strict_priority"]
+        else:
+            pytest.skip(
+                "strict_priority test parameters not defined in QoS config"
+            )
+
+        self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts)
+
+        testParams = dict()
+        testParams.update(dutTestParams["basicParams"])
+        testParams.update(qosConfigSp)
+        testParams.update({
+            "dst_port_id": dutConfig["testPorts"]["dst_port_id"],
+            "dst_port_ip": dutConfig["testPorts"]["dst_port_ip"],
+            "src_port_id": dutConfig["testPorts"]["src_port_id"],
+            "src_port_ip": dutConfig["testPorts"]["src_port_ip"],
+            "src_port_vlan": dutConfig["testPorts"]["src_port_vlan"],
+            "pkts_num_leak_out":
+                qosConfig[portSpeedCableLength]["pkts_num_leak_out"],
+            "hwsku": dutTestParams["hwsku"],
+            "topo": dutTestParams["topo"],
+        })
+
+        if "platform_asic" in dutTestParams["basicParams"]:
+            testParams["platform_asic"] = \
+                dutTestParams["basicParams"]["platform_asic"]
+        else:
+            testParams["platform_asic"] = None
+
+        if "pkts_num_egr_mem" in list(
+            qosConfig[portSpeedCableLength].keys()
+        ):
+            testParams["pkts_num_egr_mem"] = \
+                qosConfig[portSpeedCableLength]["pkts_num_egr_mem"]
+
+        # Dry run first to normalize queue scheduling state,
+        # following the same pattern as testQosSaiDwrr.
+        testParams["dry_run"] = True
+        self.runPtfTest(
+            ptfhost,
+            testCase="sai_qos_tests.StrictPriorityTest",
+            testParams=testParams,
+        )
+
+        testParams["dry_run"] = False
+        self.runPtfTest(
+            ptfhost,
+            testCase="sai_qos_tests.StrictPriorityTest",
+            testParams=testParams,
+        )

--- a/tests/saitests/sai_strict_priority_test.py
+++ b/tests/saitests/sai_strict_priority_test.py
@@ -1,0 +1,157 @@
+"""PTF dataplane test for strict priority scheduling validation.
+
+This test class is invoked by the pytest test in test_qos_strict_priority.py.
+It sends traffic across multiple traffic classes to the same egress port and
+verifies that strict priority ordering is maintained.
+
+Covers issue #22405:
+https://github.com/sonic-net/sonic-mgmt/issues/22405
+"""
+
+import logging
+import time
+import json
+
+from ptf.testutils import send_packet, simple_tcp_packet
+import ptf.testutils as testutils
+from sai_qos_tests import QosTestBase
+
+
+class StrictPriorityTest(QosTestBase):
+    """Verify default strict priority scheduling across traffic classes.
+
+    Sends equal traffic volumes for each TC to the same egress port under
+    congestion and verifies that higher priority TCs are served first.
+
+    Required test parameters:
+        dst_port_id (int): Destination port ID
+        dst_port_ip (str): Destination port IP
+        src_port_id (int): Source port ID
+        src_port_ip (str): Source port IP
+        src_port_vlan (str/None): Source port VLAN
+        pkts_num_leak_out (int): Number of leak out packets
+        pkt_count (int): Number of test packets per TC (default: 10000)
+        packet_size (int): Packet size in bytes (default: 64)
+        test_queues (list): Queue indices to test in descending priority
+            order (default: [7, 6, 5, 4, 3, 2, 1, 0])
+        dscp_list (list): DSCP values corresponding to each queue in
+            test_queues (default: [56, 48, 40, 32, 24, 16, 8, 0])
+        tolerance (int): Tolerance percentage for throughput comparison
+            (default: 10)
+        dry_run (bool): If True, skip validation (used to warm up queues)
+    """
+
+    def setUp(self):
+        QosTestBase.setUp(self)
+
+        self.dst_port_id = int(self.test_params['dst_port_id'])
+        self.dst_port_ip = self.test_params['dst_port_ip']
+        self.src_port_id = int(self.test_params['src_port_id'])
+        self.src_port_ip = self.test_params['src_port_ip']
+        self.src_port_vlan = self.test_params.get('src_port_vlan')
+        self.pkts_num_leak_out = int(self.test_params['pkts_num_leak_out'])
+        self.pkt_count = int(self.test_params.get('pkt_count', 10000))
+        self.packet_size = int(self.test_params.get('packet_size', 64))
+        self.dry_run = self.test_params.get('dry_run', False)
+
+        # Queue indices to test, in descending priority order
+        default_queues = [7, 6, 5, 4, 3, 2, 1, 0]
+        self.test_queues = self.test_params.get('test_queues', default_queues)
+        if isinstance(self.test_queues, str):
+            self.test_queues = json.loads(self.test_queues)
+        self.test_queues = [int(q) for q in self.test_queues]
+
+        # DSCP values corresponding to each queue
+        default_dscps = [56, 48, 40, 32, 24, 16, 8, 0]
+        self.dscp_list = self.test_params.get('dscp_list', default_dscps)
+        if isinstance(self.dscp_list, str):
+            self.dscp_list = json.loads(self.dscp_list)
+        self.dscp_list = [int(d) for d in self.dscp_list]
+
+        assert len(self.test_queues) == len(self.dscp_list), \
+            "test_queues and dscp_list must have the same length"
+
+        self.tolerance = int(self.test_params.get('tolerance', 10))
+
+    def runTest(self):
+        """
+        Test Procedure:
+        1. Clear queue counters on the egress port.
+        2. For each TC (from highest to lowest priority), send pkt_count
+           packets with the corresponding DSCP value to the same egress port.
+           All packets use the same src/dst port to create congestion.
+        3. Wait for all packets to be processed.
+        4. Read queue counters from the egress port.
+        5. Verify strict priority ordering:
+           - packets_forwarded[TC_high] >= packets_forwarded[TC_low]
+             for all adjacent TC pairs.
+           - The highest priority TC achieves near line-rate throughput.
+        """
+        # Step 1: Clear queue counters
+        self.sai_thrift_clear_queue_counters(self.dst_port_id)
+
+        # Step 2: Send traffic for each TC
+        for i, queue_idx in enumerate(self.test_queues):
+            dscp = self.dscp_list[i]
+            pkt = self.construct_tcp_pkt(
+                src_port=self.src_port_id,
+                dst_port_ip=self.dst_port_ip,
+                src_port_ip=self.src_port_ip,
+                dscp=dscp,
+                pkt_size=self.packet_size,
+                vlan=self.src_port_vlan
+            )
+            logging.info(
+                "Sending %d packets for queue %d (DSCP %d)",
+                self.pkt_count, queue_idx, dscp
+            )
+            # Send leak out packets first, then test packets
+            total_pkts = self.pkts_num_leak_out + self.pkt_count
+            send_packet(self, self.src_port_id, pkt, total_pkts)
+
+        # Step 3: Wait for processing
+        time.sleep(8)
+
+        # Step 4: Read queue counters
+        queue_counters = self.sai_thrift_read_queue_counters(self.dst_port_id)
+
+        logging.info("Queue counters after strict priority test:")
+        for i, queue_idx in enumerate(self.test_queues):
+            count = queue_counters.get(queue_idx, 0)
+            logging.info("  Queue %d (TC%d): %d packets", queue_idx, queue_idx, count)
+
+        if self.dry_run:
+            logging.info("Dry run complete - skipping validation")
+            return
+
+        # Step 5: Validate strict priority ordering
+        for i in range(len(self.test_queues) - 1):
+            high_q = self.test_queues[i]
+            low_q = self.test_queues[i + 1]
+            high_count = queue_counters.get(high_q, 0)
+            low_count = queue_counters.get(low_q, 0)
+
+            logging.info(
+                "Comparing Queue %d (%d pkts) >= Queue %d (%d pkts)",
+                high_q, high_count, low_q, low_count
+            )
+            assert high_count >= low_count, \
+                "Strict priority violation: Queue {} ({} pkts) should have " \
+                ">= throughput than Queue {} ({} pkts)".format(
+                    high_q, high_count, low_q, low_count
+                )
+
+        # Verify highest priority queue gets near line-rate
+        highest_q = self.test_queues[0]
+        highest_count = queue_counters.get(highest_q, 0)
+        expected_min = self.pkt_count * (100 - self.tolerance) / 100
+        assert highest_count >= expected_min, \
+            "Highest priority Queue {} should receive near line-rate. " \
+            "Expected >= {} packets, got {}".format(
+                highest_q, int(expected_min), highest_count
+            )
+
+        logging.info(
+            "Strict priority test PASSED: all queues served in correct "
+            "descending priority order"
+        )


### PR DESCRIPTION
## What is the motivation for this PR?

This PR addresses test gap issue #22405.

**Problem:** The existing QoS test suite validates PIR/CIR rate limiting for strict priority schedulers but does **not** verify the actual priority ordering across Traffic Classes (TCs). In default strict priority scheduling, TCs should be served in descending priority order (TC7 > TC6 > ... > TC0). Without an explicit test for this ordering, priority scheduling regressions could go undetected.

**Current behavior:** Existing tests (`testQosSaiDwrr`, `testQosSaiDwrrWeightChange`) only validate weighted round-robin scheduling and rate-based behavior. There is no test that verifies the fundamental strict priority contract: higher-priority queues must be fully served before lower-priority queues receive bandwidth.

## How did you do it?

Added two new files:

### 1. `tests/qos/test_qos_strict_priority.py` (pytest test)
- New test class `TestQosSaiStrictPriority` extending `QosSaiBase`
- Follows the same patterns as `testQosSaiDwrr` (dry run + real run, same fixtures, same config lookup)
- Looks for `strict_priority` parameters in the QoS config YAML
- Skips gracefully if `strict_priority` config is not defined

### 2. `tests/saitests/sai_strict_priority_test.py` (PTF dataplane test)
- New PTF test class `StrictPriorityTest` extending `QosTestBase`
- **Test procedure:**
  1. Clear queue counters on the egress port
  2. Send equal traffic volumes for each TC (using corresponding DSCP values) to the same egress port, creating congestion
  3. Wait for packet processing
  4. Read egress queue counters
  5. Validate strict priority ordering:
     - `packets_forwarded[TC_high] >= packets_forwarded[TC_low]` for all adjacent TC pairs
     - Highest priority TC achieves near line-rate throughput (within configurable tolerance)
- Supports `dry_run` mode to normalize queue state before the real test (same approach as WRR tests)

### QoS Config Parameters

To enable this test, add a `strict_priority` section to the QoS YAML config:

```yaml
strict_priority:
  pkt_count: 10000
  packet_size: 64
  tolerance: 10
  test_queues: [7, 6, 5, 4, 3, 2, 1, 0]
  dscp_list: [56, 48, 40, 32, 24, 16, 8, 0]
```

## How did you verify/test it?

- Code follows the same structure and patterns as existing QoS SAI tests (`testQosSaiDwrr`)
- Uses the same fixtures (`dutConfig`, `dutQosConfig`, `dutTestParams`, etc.)
- Uses the same PTF infrastructure (`QosTestBase`, `sai_thrift_*` helpers)
- The test gracefully skips when `strict_priority` parameters are not defined in the QoS config

## Related Issue

Closes #22405

## Platform

Generic (all platforms)