### PR TITLE
[smartswitch] testbed_health_check: Skip DPU hosts in pre_check and BGP checks

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -371,6 +371,11 @@ class TestbedHealthChecker:
                 self.check_result.errmsg.append("sonichost {} is unreachable.".format(sonichost.hostname))
                 self.check_result.data[sonichost.hostname] = result
 
+            # Skip fanout connectivity check for DPU hosts - they don't have external connections
+            if "dpu" in sonichost.hostname.lower():
+                logger.info("Skipping fanout check for DPU host: {}".format(sonichost.hostname))
+                continue
+
             dut_device_conn = conn_graph_facts["ansible_facts"]["device_conn"][sonichost.hostname]
 
             peer_devices = [dut_device_conn[port]["peerdevice"] for port in dut_device_conn]
@@ -412,11 +417,16 @@ class TestbedHealthChecker:
 
         for sonichost in self.sonichosts:
 
+            # Skip MGMT_INTERFACE check for DPU hosts - they use midplane IPs, not mgmt interface
+            if "dpu" in sonichost.hostname.lower():
+                logger.info("Skipping MGMT_INTERFACE check for DPU host: {}".format(sonichost.hostname))
+                continue
+
             rst = sonichost.shell(f"jq '.MGMT_INTERFACE' {config_db_file}", module_ignore_errors=True).get("stdout",
                                                                                                            None)
 
-            # If valid stdout
-            if rst is not None and rst.strip() != "":
+            # If valid stdout (also check for "null" which jq returns when key doesn't exist)
+            if rst is not None and rst.strip() != "" and rst.strip() != "null":
 
                 mgmt_interface = json.loads(rst)
 
@@ -528,6 +538,11 @@ class TestbedHealthChecker:
             if (self.is_chassis and
                     self.duts_basic_facts[sonichost.hostname]["ansible_facts"]["dut_basic_facts"]["is_supervisor"]):
                 logger.info("Skip check_bgp_session_state on Supervisor.")
+                continue
+
+            # Skip BGP check for DPU hosts
+            if "dpu" in sonichost.hostname.lower():
+                logger.info("Skip check_bgp_session_state on DPU host: {}".format(sonichost.hostname))
                 continue
 
             hostname = sonichost.hostname


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/22622

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip DPU hosts from fanout connectivity, MGMT_INTERFACE, and BGP session checks in `testbed_health_check.py` to prevent false failures on SmartSwitch testbeds.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The `testbed_health_check.py` script fails on SmartSwitch testbeds because it attempts to run checks that are not applicable to DPU hosts:

1. **Fanout connectivity check**: DPUs don't have external connections to fanout switches - they connect internally via midplane
2. **MGMT_INTERFACE check**: DPUs use midplane IPs, not traditional management interfaces
3. **BGP session check**: DPUs don't run traditional BGP sessions like NPU hosts

These checks cause `TypeError: 'NoneType' object is not iterable` and false unhealthy testbed reports.

#### How did you do it?

Added hostname-based DPU detection (`"dpu" in sonichost.hostname.lower()`) to skip:
- Fanout connectivity check in `pre_check()`
- MGMT_INTERFACE IPv4 verification in `pre_check()`
- BGP session state check in `check_bgp_session_state()`

Also added a `"null"` check for jq output to prevent TypeError when jq returns "null" for non-existent keys.

#### How did you verify/test it?

Ran `testbed_health_check.py` against SmartSwitch testbed with NPU + 4 DPUs:
- Before: Script failed with TypeError on DPU hosts
- After: Script correctly skips DPU-specific checks and completes successfully

#### Any platform specific information?

This change is specific to SmartSwitch platforms with DPU hosts. Non-SmartSwitch testbeds are unaffected.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

N/A 