### PR TITLE
Backport: Fix platform_tests/api and gnmi test mgmt IP for T2

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -2927,6 +2927,28 @@ Totals               6450                 6449
                 logging.error(f"Error starting bgpd process: {str(e)}")
                 return {'rc': 1, 'stdout': '', 'stderr': str(e)}
 
+    def get_mgmt_ip(self):
+        """
+        Gets the management IP address (v4 or v6) on eth0.
+        Defaults to IPv4 on a dual stack configuration.
+        """
+        ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
+        ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
+
+        mgmt_interface = self.shell("show ip interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+        if mgmt_interface:
+            match = ipv4_regex.search(mgmt_interface)
+            if match:
+                return {"mgmt_ip": match.group(1), "version": "v4"}
+
+        mgmt_interface = self.shell("show ipv6 interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
+        if mgmt_interface:
+            match = ipv6_regex.search(mgmt_interface)
+            if match:
+                return {"mgmt_ip": match.group(1), "version": "v6"}
+
+        assert False, "Failed to find duthost mgmt ip"  # noqa: F631
+
 
 def assert_exit_non_zero(shell_output):
     if shell_output['rc'] != 0:

--- a/tests/common/fixtures/duthost_utils.py
+++ b/tests/common/fixtures/duthost_utils.py
@@ -8,7 +8,6 @@ import collections
 import ipaddress
 import time
 import json
-import re
 
 from pytest_ansible.errors import AnsibleConnectionFailure
 from paramiko.ssh_exception import AuthenticationException
@@ -851,30 +850,6 @@ def duthosts_ipv6_mgmt_only(duthosts, backup_and_restore_config_db_on_duts):
                               cmd_desc="netstat")
 
     return duthosts
-
-
-@pytest.fixture(scope="module")
-def duthost_mgmt_ip(duthost):
-    """
-    Gets the management IP address (v4 or v6) on eth0.
-    Defaults to IPv4 on a dual stack configuration.
-    """
-    ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
-    ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
-
-    mgmt_interface = duthost.shell("show ip interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
-    if mgmt_interface:
-        match = ipv4_regex.search(mgmt_interface)
-        if match:
-            return {"mgmt_ip": match.group(1), "version": "v4"}
-
-    mgmt_interface = duthost.shell("show ipv6 interface | egrep '^eth0 '", module_ignore_errors=True)["stdout"]
-    if mgmt_interface:
-        match = ipv6_regex.search(mgmt_interface)
-        if match:
-            return {"mgmt_ip": match.group(1), "version": "v6"}
-
-    pt_assert(False, "Failed to find duthost mgmt ip")
 
 
 def assert_addr_in_output(addr_set: Dict[str, List], hostname: str,

--- a/tests/common/platform/device_utils.py
+++ b/tests/common/platform/device_utils.py
@@ -18,7 +18,6 @@ from tests.common.broadcom_data import is_broadcom_device
 from tests.common.mellanox_data import is_mellanox_device
 from tests.common.platform.reboot_timing_constants import SERVICE_PATTERNS, OTHER_PATTERNS, SAIREDIS_PATTERNS, \
     OFFSET_ITEMS, TIME_SPAN_ITEMS, REQUIRED_PATTERNS
-from tests.common.fixtures.duthost_utils import duthost_mgmt_ip  # noqa: F401
 
 """
 Helper script for fanout switch operations
@@ -1079,10 +1078,12 @@ def advanceboot_neighbor_restore(duthosts, enum_rand_one_per_hwsku_frontend_host
 
 
 @pytest.fixture(scope='function')
-def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, duthost_mgmt_ip,  # noqa: F811
+def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname,
                                localhost, request):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    dut_ip = duthost_mgmt_ip['mgmt_ip']
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    dut_ip = duthost_mgmt_info['mgmt_ip']
+    dut_mgmt_ver = duthost_mgmt_info['version']
 
     res = localhost.wait_for(host=dut_ip,
                              port=SERVER_PORT,
@@ -1100,7 +1101,7 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, dutho
             'command=/usr/bin/python{} /opt/platform_api_server.py --port {} {}'.format(
                 '3' if py3_platform_api_available else '2',
                 SERVER_PORT,
-                '--ipv6' if duthost_mgmt_ip['version'] == 'v6' else ''),
+                '--ipv6' if dut_mgmt_ver == 'v6' else ''),
             'autostart=True',
             'autorestart=True',
             'stdout_logfile=syslog',
@@ -1119,7 +1120,7 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, dutho
         duthost.command('docker cp {} pmon:{}'.format(dest_path, pmon_path))
 
         # Prepend an iptables rule to allow incoming traffic to the HTTP server
-        if duthost_mgmt_ip['version'] == 'v6':
+        if dut_mgmt_ver == 'v6':
             duthost.command(IP6TABLES_PREPEND_RULE_CMD)
         else:
             duthost.command(IPTABLES_PREPEND_RULE_CMD)
@@ -1133,8 +1134,9 @@ def start_platform_api_service(duthosts, enum_rand_one_per_hwsku_hostname, dutho
 
 
 @pytest.fixture(scope='function')
-def platform_api_conn(duthost_mgmt_ip, start_platform_api_service):  # noqa: F811
-    dut_ip = duthost_mgmt_ip['mgmt_ip']
+def platform_api_conn(duthosts, enum_rand_one_per_hwsku_hostname, start_platform_api_service):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    dut_ip = duthost.get_mgmt_ip()["mgmt_ip"]
 
     conn = http.client.HTTPConnection(dut_ip, 8000)
     try:

--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -199,10 +199,12 @@ def check_system_time_sync(duthost):
 
 def gnmi_capabilities(duthost, localhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.GNMI_MODE)
-    ip = duthost.mgmt_ip
+    duthost_mgmt_info = duthost.get_mgmt_ip()
+    ip = duthost_mgmt_info['mgmt_ip']
+    addr = f"[{ip}]" if duthost_mgmt_info['version'] == 'v6' else f"{ip}"
     port = env.gnmi_port
     # Run gnmi_cli in gnmi container as workaround
-    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, ip, port)
+    cmd = "docker exec %s gnmi_cli -client_types=gnmi -a %s:%s " % (env.gnmi_container, addr, port)
     cmd += "-client_crt /etc/sonic/telemetry/gnmiclient.crt "
     cmd += "-client_key /etc/sonic/telemetry/gnmiclient.key "
     cmd += "-ca_crt /etc/sonic/telemetry/gnmiCA.pem "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach
#### What is the motivation for this PR?

Refactor duthost_mgmt_ip fixture to be a function inside duthost (SonicHost). This is a cleaner way to obtain the mgmt IP of a specific duthost without excess fixture calls.

This method will also select the appropriate linecard duthost for T2 chassis linecards, and originally intends to fix platform_tests/api and gnmi T2 test regressions.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
