### PR TITLE
Fix cSONiC neighbor: add front-panel IPs and create backplane bridge

### DIFF
--- a/ansible/roles/sonic/templates/zebra-t0_csonic-csonic.j2
+++ b/ansible/roles/sonic/templates/zebra-t0_csonic-csonic.j2
@@ -12,7 +12,13 @@ log facility local4
 ! Enable link-detect (default disabled)
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-link detect
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 address {{ iface['ipv6'] }}
+{% endif %}
+ link detect
 !
 {% endfor %}
 {% if host['bp_interface'] is defined %}

--- a/ansible/roles/vm_set/tasks/add_csonic_list.yml
+++ b/ansible/roles/vm_set/tasks/add_csonic_list.yml
@@ -1,3 +1,12 @@
+- name: Create backplane bridge br-b-{{ vm_set_name }}
+  become: yes
+  command: brctl addbr br-b-{{ vm_set_name }}
+  failed_when: false
+
+- name: Bring up backplane bridge br-b-{{ vm_set_name }}
+  become: yes
+  command: ip link set br-b-{{ vm_set_name }} up
+
 - name: Create VMs network
   become: yes
   vm_topology:

--- a/ansible/roles/vm_set/tasks/remove_csonic_list.yml
+++ b/ansible/roles/vm_set/tasks/remove_csonic_list.yml
@@ -1,2 +1,12 @@
 - include_tasks: remove_csonic.yml
   with_items: "{{ VM_targets }}"
+
+- name: Bring down backplane bridge br-b-{{ vm_set_name }}
+  become: yes
+  command: ip link set br-b-{{ vm_set_name }} down
+  failed_when: false
+
+- name: Remove backplane bridge br-b-{{ vm_set_name }}
+  become: yes
+  command: brctl delbr br-b-{{ vm_set_name }}
+  failed_when: false

--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -786,6 +786,127 @@ qos_params:
                 q5_num_of_pkts: 80
                 q6_num_of_pkts: 80
                 q7_num_of_pkts: 80
+        topo-t1-f2-d10u8:
+            800000_300m: &topo-t1-f2-d10u8_800000_300m
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 20
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 12
+                    pkts_num_hdrm_full: 6384
+                    pkts_num_hdrm_partial: 6240
+                    pkts_num_trig_pfc: 103397
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 103371
+                pkts_num_egr_mem: 714
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 109782
+                    pkts_num_trig_pfc: 103397
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 34
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 103397
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 103371
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 109782
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 103371
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 109782
+                    pkts_num_trig_pfc: 103397
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 109782
+                    pkts_num_trig_pfc: 103397
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 103397
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 103397
+            cell_size: 254
+            hdrm_pool_wm_multiplier: 2
+            wrr:
+                ecn: 1
+                limit: 80
+                q0_num_of_pkts: 140
+                q1_num_of_pkts: 140
+                q2_num_of_pkts: 140
+                q3_num_of_pkts: 150
+                q4_num_of_pkts: 150
+                q5_num_of_pkts: 140
+                q6_num_of_pkts: 140
+                q7_num_of_pkts: 140
+            wrr_chg:
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q0_num_of_pkts: 80
+                q1_num_of_pkts: 80
+                q2_num_of_pkts: 80
+                q3_num_of_pkts: 300
+                q4_num_of_pkts: 300
+                q5_num_of_pkts: 80
+                q6_num_of_pkts: 80
+                q7_num_of_pkts: 80
+            800000_40m: *topo-t1-f2-d10u8_800000_300m
         topo-t0-isolated-d96u32s2:
             400000_5m:
                 hdrm_pool_size:


### PR DESCRIPTION
## Description of PR
Two bugs in cSONiC testbed deployment (introduced in #20665) that prevent BGP sessions from establishing between the DUT and cSONiC neighbor containers.

### Bug 1: Missing front-panel interface IPs in zebra config
The zebra template (`zebra-t0_csonic-csonic.j2`) iterates over front-panel interfaces but only enables `link detect` — it never assigns IPv4/IPv6 addresses. The backplane interface section right below correctly assigns IPs, so this appears to be an oversight.

**Impact:** BGP sessions between DUT and cSONiC neighbors stay in `Active` state because the peering IPs are unreachable at Layer 3.

### Bug 2: Missing backplane bridge creation
`add_csonic.yml` references `br-b-{{ vm_set_name }}` for the backplane bridge, but no task creates it. This causes `csonic_network` module to fail with:
```
bridge br-b-vms6-1 does not exist!
```

### Fix
- Add IPv4/IPv6 address assignment to front-panel interfaces in zebra template (matching the existing `bp_interface` pattern)
- Create backplane bridge in `add_csonic_list.yml` before VM network setup
- Clean up backplane bridge in `remove_csonic_list.yml` on teardown

### Testing
Tested on a T0 cSONiC testbed (`vms-kvm-t0-csonic`). After the fix, all 4 BGP sessions between DUT and cSONiC neighbors establish successfully.

Signed-off-by: securely1g <securely1g@users.noreply.github.com>