### PR TITLE
Fix cSONiC neighbor: add front-panel interface IP addresses in zebra template

### DIFF
--- a/ansible/roles/sonic/templates/zebra-t0_csonic-csonic.j2
+++ b/ansible/roles/sonic/templates/zebra-t0_csonic-csonic.j2
@@ -12,7 +12,13 @@ log facility local4
 ! Enable link-detect (default disabled)
 {% for name, iface in host['interfaces'].items() %}
 interface {{ name }}
-link detect
+{% if iface['ipv4'] is defined %}
+ ip address {{ iface['ipv4'] }}
+{% endif %}
+{% if iface['ipv6'] is defined %}
+ ipv6 address {{ iface['ipv6'] }}
+{% endif %}
+ link detect
 !
 {% endfor %}
 {% if host['bp_interface'] is defined %}


### PR DESCRIPTION
## Description
The zebra template for cSONiC neighbors (zebra-t0_csonic-csonic.j2) only enables link-detect on front-panel interfaces but never assigns IPv4/IPv6 addresses. The backplane interface section immediately below correctly assigns IPs — this is an oversight.

Without this fix, BGP sessions between the DUT and all cSONiC neighbor containers remain in Active state because the peering IPs are never assigned to the kernel interfaces.

Fixes #22647

### Changes
- ansible/roles/sonic/templates/zebra-t0_csonic-csonic.j2: Add ip/ipv6 address assignment to front-panel interface loop

### Testing
Tested on a T0 cSONiC testbed (vms-kvm-t0-csonic). After the fix, all 4 BGP sessions establish successfully.

Signed-off-by: securely1g <securely1g@users.noreply.github.com>