### PR TITLE
Fix cSONiC neighbor: create backplane bridge in csonic_network module

### DIFF
--- a/ansible/roles/vm_set/library/csonic_network.py
+++ b/ansible/roles/vm_set/library/csonic_network.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import subprocess
 import shlex
 import traceback
@@ -295,6 +296,9 @@ class CsonicNetwork(object):
 
         # Connect backplane to bridge if specified
         if self.bp_bridge:
+            if not os.path.exists('/sys/class/net/%s' % self.bp_bridge):
+                CsonicNetwork.cmd('brctl addbr %s' % self.bp_bridge)
+                CsonicNetwork.cmd('ip link set %s up' % self.bp_bridge)
             self.add_if_to_bridge(bp_name, self.bp_bridge)
 
     def add_veth_if_to_docker(self, ext_if, t_int_if, int_if):


### PR DESCRIPTION
## Description
When deploying a cSONiC testbed, `add_csonic.yml` passes `bp_bridge` (`br-b-<vm_set_name>`) to the `csonic_network` module, but the bridge is assumed to already exist. If it does not, `init_network()` fails when trying to add the backplane veth to a non-existent bridge:

```
bridge br-b-vms6-1 does not exist!
```

Unlike cEOS testbeds where the backplane bridge is created by a separate task, the cSONiC flow has no such task.

Fixes #22648

### Changes
- `ansible/roles/vm_set/library/csonic_network.py`: In `init_network()`, create the backplane bridge on-demand if it does not exist before adding the backplane veth to it.

### Testing
Tested on a T0 cSONiC testbed (`vms-kvm-t0-csonic`). Deployment completes successfully with the bridge auto-created by the module.

Signed-off-by: securely1g <securely1g@users.noreply.github.com>