### PR TITLE
[Ansible] Adding fec for Fanout with >= 100G Port Speed

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202012.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202012.j2
@@ -15,7 +15,7 @@
             "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
             "pfc_asym": "off",
             "mtu": "9100",
-    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') | int >= 100000 %}
             "fec" : "rs",
     {% endif %}
     {% if 'peerdevice' in fanout_port_config[port_name] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202205.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202205.j2
@@ -16,7 +16,7 @@
             "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
             "pfc_asym": "off",
             "mtu": "9100",
-    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') | int >= 100000 %}
             "fec" : "rs",
     {% endif %}
     {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202305.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202305.j2
@@ -16,7 +16,7 @@
             "lanes": "{{ fanout_port_config[port_name]['lanes'] }}",
             "pfc_asym": "off",
             "mtu": "9100",
-    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') | int >= 100000 %}
             "fec" : "rs",
     {% endif %}
     {% if 'broadcom' in fanout_sonic_version["asic_type"] or 'marvell' in fanout_sonic_version["asic_type"] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202311.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202311.j2
@@ -19,7 +19,7 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
-    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') | int >= 100000 %}
             "fec" : "rs",
     {% endif %}
     {% if port_name in device_conn[inventory_hostname] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -19,7 +19,7 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
-    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "400000", "800000"] %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') | int >= 100000 %}
             "fec" : "rs",
     {% endif %}
     {% if port_name in device_conn[inventory_hostname] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -22,7 +22,7 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
-    {% if fanout_port_config[port_name]['speed'] | default('100000') == "100000" %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') | int >= 100000 %}
             "fec" : "rs",
     {% endif %}
     {% if port_name in device_conn[inventory_hostname] %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

When running add topo, the script does not add any value for fec if the fanout's port speed is greater than 100G. The `sonic_deploy_*.j2` files are only adding "fec" : "rs" when port speed is equal to 100G. To support fanouts with >= 100G port speed, we need to change the sonic_deploy_*.j2 files to use `"fec" : "rs"` for port speeds >= 100G.

Fixes # (issue [#22653](https://github.com/sonic-net/sonic-mgmt/issues/22653)) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [x] 202205
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511

Currently, there is only a fix for this in `sonic_deploy_202405.j2` in branches [202511](https://github.com/sonic-net/sonic-mgmt/blob/202511/ansible/roles/fanout/templates/sonic_deploy_202405.j2) and [master](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/roles/fanout/templates/sonic_deploy_202405.j2), but that fix is missing in `sonic_deploy_202505.j2` in [master](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/roles/fanout/templates/sonic_deploy_202505.j2). In addition, it does not account for 200G port speed. I believe this change should be updated for all of the `sonic_deploy_*.j2` files to include any port speed above 100G. I have requested to back port into all branches listed above since [`sonic_deploy_202005.j2` exists in branch 202205](https://github.com/sonic-net/sonic-mgmt/blob/202205/ansible/roles/fanout/templates/sonic_deploy_202012.j2).

### Approach
#### What is the motivation for this PR?

When adding topo, I noticed that my fanout switch had `"N/A"` for its fec value. Tests such as those in [test_auto_negotiation.py](https://github.com/upscale-ai-network/sonic-mgmt/blob/upscaleai-202505/tests/platform_tests/test_auto_negotiation.py) will manually set fec values for the fanout switch, so this bug may have not been noticed.

#### How did you do it?

I changed the sonic_deploy_*.j2 files and changed `== 100000` to `int >= 100000`.

```
{% if fanout_port_config[port_name]['speed'] | default('100000') int >= "100000" %}
        "fec" : "rs",
{% endif %}
```

#### How did you verify/test it?

I tested this by deploying T0 and T1 topology for 800G port speed in the 202505 branch.

#### Any platform specific information?

Generic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

## Old output for `show int status` for fanout with 800G port speed. 

```shell
admin@sonic:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100    N/A     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
  Ethernet8            8,9,10,11,12,13,14,15     800G   9100    N/A     Eth2   trunk      up       up  OSFP 8X Pluggable Transceiver         off
...
```

## New output for `show int status` for fanout with 800G port speed.
```shell
admin@sonic:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100     rs     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
  Ethernet8            8,9,10,11,12,13,14,15     800G   9100     rs     Eth2   trunk      up       up  OSFP 8X Pluggable Transceiver         off
...
```