### PR TITLE
Issue 22656: Check for no packets received in sflow PTF test

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/sflow_test.py
+++ b/ansible/roles/test/files/ptftests/py3/sflow_test.py
@@ -231,7 +231,8 @@ class SflowTest(BaseTest):
     # ---------------------------------------------------------------------------
 
     def analyze_flow_sample(self, data, collector):
-        self.assertTrue(data.get('flow_port_count', False), "No packets collected on any interface")
+        self.assertTrue(data['total_flow_count'] > 0,
+                        "No flow packets are received in collector %s" % collector)
         logging.info("packets collected from interfaces ifindex : %s" %
                      data['flow_port_count'])
         logging.info("Expected number of packets from each port : %s to %s" % (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Currently the test will fail with a KeyError somewhere random, because it assumes it will always get at least one packet. But if the test is badly failing, that might not be true. Better to have a clear error and failure point.

Fixes #22656

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
