### PR TITLE
Fixing parsing get_device_capabilities show dropcounters capabilities

### DIFF
--- a/tests/drop_packets/configurable_drop_counters.py
+++ b/tests/drop_packets/configurable_drop_counters.py
@@ -71,7 +71,7 @@ def get_device_capabilities(dut):
     for line in output:
         if not line:
             continue
-        elif line in SUPPORTED_COUNTER_TYPES:
+        elif line in counters:
             curr_type = reasons[line]
         else:
             curr_type.append(line.strip())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This PR addresses parsing issues in the get_device_capabilities() function that led to incorrect mapping between drop counter types and reasons.

Motivation for this PR 
drop_packets/test_configurable_drop_counters.py test_neighbor_link_down test case failure. 

The failure occurred due to incorrect parsing of the show dropcounters capabilities CLI output. Drop reasons from PORT_EGRESS_DROPS and SWITCH_EGRESS_DROPS were incorrectly appended to the ingress drop counter reasons, leading to test failure

CLI Parsed 
```
cisco@sup-t0-dut:~$ show dropcounters capabilities
Counter Type            Total
--------------------  -------
PORT_INGRESS_DROPS       5000
PORT_EGRESS_DROPS        5000
SWITCH_INGRESS_DROPS     5000
SWITCH_EGRESS_DROPS      5000


PORT_INGRESS_DROPS
        BLACKHOLE_ROUTE
        MC_DMAC_MISMATCH
        UC_DIP_MC_DMAC
        L2_LOOPBACK_FILTER
        SIP_CLASS_E
        DIP_LOOPBACK
        UNRESOLVED_NEXT_HOP
        MPLS_MISS
        IP_HEADER_ERROR
        SMAC_EQUALS_DMAC
        LPM4_MISS
        SIP_LINK_LOCAL
        TTL
        L2_ANY
        DIP_LINK_LOCAL
        NO_L3_HEADER
        SIP_LOOPBACK
        FDB_AND_BLACKHOLE_DISCARDS
        SIP_MC
        NON_ROUTABLE
        ACL_ANY
        SMAC_MULTICAST
        L3_ANY
        SIP_UNSPECIFIED
        FDB_UC_DISCARD
        FDB_MC_DISCARD
        INGRESS_STP_FILTER
        EXCEEDS_L3_MTU
        EXCEEDS_L2_MTU
        INGRESS_VLAN_FILTER
        DMAC_RESERVED

PORT_EGRESS_DROPS
        L3_EGRESS_LINK_DOWN

SWITCH_INGRESS_DROPS
        BLACKHOLE_ROUTE
        MC_DMAC_MISMATCH
        UC_DIP_MC_DMAC
        L2_LOOPBACK_FILTER
        SIP_CLASS_E
        DIP_LOOPBACK
        UNRESOLVED_NEXT_HOP
        MPLS_MISS
        IP_HEADER_ERROR
        SMAC_EQUALS_DMAC
        LPM4_MISS
        SIP_LINK_LOCAL
        TTL
        L2_ANY
        DIP_LINK_LOCAL
        NO_L3_HEADER
        SIP_LOOPBACK
        FDB_AND_BLACKHOLE_DISCARDS
        SIP_MC
        NON_ROUTABLE
        ACL_ANY
        SMAC_MULTICAST
        L3_ANY
        SIP_UNSPECIFIED
        FDB_UC_DISCARD
        FDB_MC_DISCARD
        INGRESS_STP_FILTER
        EXCEEDS_L3_MTU
        EXCEEDS_L2_MTU
        INGRESS_VLAN_FILTER
        DMAC_RESERVED

SWITCH_EGRESS_DROPS
        L3_EGRESS_LINK_DOWN

```
by get_device_capabilities function as
```
{'counters': {'PORT_INGRESS_DROPS': 5000, 'PORT_EGRESS_DROPS': 5000, 'SWITCH_INGRESS_DROPS': 5000, 'SWITCH_EGRESS_DROPS': 5000}, 
'reasons':
 {'PORT_INGRESS_DROPS': ['BLACKHOLE_ROUTE', 'MC_DMAC_MISMATCH', 'UC_DIP_MC_DMAC', 'L2_LOOPBACK_FILTER', 'SIP_CLASS_E', 'DIP_LOOPBACK', 'UNRESOLVED_NEXT_HOP', 'MPLS_MISS', 'IP_HEADER_ERROR', 'SMAC_EQUALS_DMAC', 'LPM4_MISS', 'SIP_LINK_LOCAL', 'TTL', 'L2_ANY', 'DIP_LINK_LOCAL', 'NO_L3_HEADER', 'SIP_LOOPBACK', 'FDB_AND_BLACKHOLE_DISCARDS', 'SIP_MC', 'NON_ROUTABLE', 'ACL_ANY', 'SMAC_MULTICAST', 'L3_ANY', 'SIP_UNSPECIFIED', 'FDB_UC_DISCARD', 'FDB_MC_DISCARD', 'INGRESS_STP_FILTER', 'EXCEEDS_L3_MTU', 'EXCEEDS_L2_MTU', 'INGRESS_VLAN_FILTER', 'DMAC_RESERVED', 'PORT_EGRESS_DROPS', 'L3_EGRESS_LINK_DOWN'],
 'PORT_EGRESS_DROPS': [],
 'SWITCH_INGRESS_DROPS': ['BLACKHOLE_ROUTE', 'MC_DMAC_MISMATCH', 'UC_DIP_MC_DMAC', 'L2_LOOPBACK_FILTER', 'SIP_CLASS_E', 'DIP_LOOPBACK', 'UNRESOLVED_NEXT_HOP', 'MPLS_MISS', 'IP_HEADER_ERROR', 'SMAC_EQUALS_DMAC', 'LPM4_MISS', 'SIP_LINK_LOCAL', 'TTL', 'L2_ANY', 'DIP_LINK_LOCAL', 'NO_L3_HEADER', 'SIP_LOOPBACK', 'FDB_AND_BLACKHOLE_DISCARDS', 'SIP_MC', 'NON_ROUTABLE', 'ACL_ANY', 'SMAC_MULTICAST', 'L3_ANY', 'SIP_UNSPECIFIED', 'FDB_UC_DISCARD', 'FDB_MC_DISCARD', 'INGRESS_STP_FILTER', 'EXCEEDS_L3_MTU', 'EXCEEDS_L2_MTU', 'INGRESS_VLAN_FILTER', 'DMAC_RESERVED', 'SWITCH_EGRESS_DROPS', 'L3_EGRESS_LINK_DOWN'], 
'SWITCH_EGRESS_DROPS': []}}
```
leading to wrongly parsed values calling Ingress Counters with Egress Reason in test case
```
'config dropcounters install TEST SWITCH_INGRESS_DROPS L3_EGRESS_LINK_DOWN'
```
Leading to test failure 

Summary:
Fixes # (issue)
The Fix SUPPORTED_COUNTER_TYPES has 
SUPPORTED_COUNTER_TYPES = [PORT_INGRESS_COUNTER_TYPE, SWITCH_INGRESS_COUNTER_TYPE]
instead use counters dictionary to parse the output correctly . 
Below is the parsed object after using counters 
```
{'counters': {'PORT_INGRESS_DROPS': 5000, 'SWITCH_EGRESS_DROPS': 5000, 'SWITCH_INGRESS_DROPS': 5000, 'PORT_EGRESS_DROPS': 5000}, 
'reasons': 
{'PORT_INGRESS_DROPS': ['BLACKHOLE_ROUTE', 'MC_DMAC_MISMATCH', 'UC_DIP_MC_DMAC', 'L2_LOOPBACK_FILTER', 'SIP_CLASS_E', 'DIP_LOOPBACK', 'UNRESOLVED_NEXT_HOP', 'MPLS_MISS', 'IP_HEADER_ERROR', 'SMAC_EQUALS_DMAC', 'LPM4_MISS', 'SIP_LINK_LOCAL', 'TTL', 'L2_ANY', 'DIP_LINK_LOCAL', 'NO_L3_HEADER', 'SIP_LOOPBACK', 'FDB_AND_BLACKHOLE_DISCARDS', 'SIP_MC', 'NON_ROUTABLE', 'ACL_ANY', 'SMAC_MULTICAST', 'L3_ANY', 'SIP_UNSPECIFIED', 'FDB_UC_DISCARD', 'FDB_MC_DISCARD', 'INGRESS_STP_FILTER', 'EXCEEDS_L3_MTU', 'EXCEEDS_L2_MTU', 'INGRESS_VLAN_FILTER', 'DMAC_RESERVED'],
 'SWITCH_EGRESS_DROPS': ['L3_EGRESS_LINK_DOWN'], 
'SWITCH_INGRESS_DROPS': ['BLACKHOLE_ROUTE', 'MC_DMAC_MISMATCH', 'UC_DIP_MC_DMAC', 'L2_LOOPBACK_FILTER', 'SIP_CLASS_E', 'DIP_LOOPBACK', 'UNRESOLVED_NEXT_HOP', 'MPLS_MISS', 'IP_HEADER_ERROR', 'SMAC_EQUALS_DMAC', 'LPM4_MISS', 'SIP_LINK_LOCAL', 'TTL', 'L2_ANY', 'DIP_LINK_LOCAL', 'NO_L3_HEADER', 'SIP_LOOPBACK', 'FDB_AND_BLACKHOLE_DISCARDS', 'SIP_MC', 'NON_ROUTABLE', 'ACL_ANY', 'SMAC_MULTICAST', 'L3_ANY', 'SIP_UNSPECIFIED', 'FDB_UC_DISCARD', 'FDB_MC_DISCARD', 'INGRESS_STP_FILTER', 'EXCEEDS_L3_MTU', 'EXCEEDS_L2_MTU', 'INGRESS_VLAN_FILTER', 'DMAC_RESERVED'], 
'PORT_EGRESS_DROPS': ['L3_EGRESS_LINK_DOWN']}}
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach


#### How did you do it?
Replaced SUPPORTED_COUNTER_TYPES with counters to fix parsing 

#### How did you verify/test it?
[test_log.txt](https://wwwin-github.cisco.com/whitebox/sonic-test/files/33007/test_log.txt)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
