### PR TITLE
Refactor telemetry poll mode tests for multi-ASIC namespace handling

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -55,7 +55,8 @@ def skip_201911_and_older(duthost):
 
 def check_gnmi_cli_running(duthost, ptfhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    res = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"")
+    res = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"",
+                        module_ignore_errors=True)
     return res and res["rc"] == 0
 
 

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -30,10 +30,10 @@ def verify_route_table_status(duthost, namespace, expected_status="1", is_ipv6_o
     return status == expected_status
 
 
-def modify_fake_appdb_table(duthost, add=True, entries=1):
+def modify_fake_appdb_table(duthost, add=True, entries=1, namespace=""):
     cmd_prefix = "sonic-db-cli"
     if duthost.is_multi_asic:
-        cmd_prefix = "sonic-db-cli -n asic0"
+        cmd_prefix = "sonic-db-cli -n {}".format(namespace)
     for entry in range(entries):
         command = cmd_prefix + " APPL_DB {} FAKE_APPL_DB_TABLE_{}:fake_key{} {}"
         if add:
@@ -45,15 +45,14 @@ def modify_fake_appdb_table(duthost, add=True, entries=1):
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_no_table_or_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                   setup_streaming_telemetry, gnxi_path):
+                                   setup_streaming_telemetry, gnxi_path,
+                                   enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query a non existing table and key, ensure no errors
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info('Start telemetry poll mode testing')
-    namespace = ""
-    if duthost.is_multi_asic:
-        namespace = "asic0"
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=5,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
@@ -70,21 +69,20 @@ def test_poll_mode_no_table_or_key(duthosts, enum_rand_one_per_hwsku_hostname, p
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                             setup_streaming_telemetry, gnxi_path):
+                                             setup_streaming_telemetry, gnxi_path,
+                                             enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and missing key, ensure no errors and present data
     After that, begin querying again and put the key and ensure no errors and new data
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info('Start telemetry poll mode testing')
-    namespace = ""
-    if duthost.is_multi_asic:
-        namespace = "asic0"
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
                               max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
-    modify_fake_appdb_table(duthost)  # Add first table data
+    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -110,29 +108,28 @@ def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_h
 
     wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
-    modify_fake_appdb_table(duthost, True, 2)  # Add second table data
+    modify_fake_appdb_table(duthost, True, 2, namespace)  # Add second table data
     client_thread.join(60)
 
-    modify_fake_appdb_table(duthost, False, 2)  # Remove all added tables
+    modify_fake_appdb_table(duthost, False, 2, namespace)  # Remove all added tables
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                          setup_streaming_telemetry, gnxi_path):
+                          setup_streaming_telemetry, gnxi_path,
+                          enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and key, ensure no errors and present data
     After that, delete both and ensure no errors and delete notifications
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info('Start telemetry poll mode testing')
-    namespace = ""
-    if duthost.is_multi_asic:
-        namespace = "asic0"
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=1,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
                               max_sync_count=-1, update_count=10, timeout=30, namespace=namespace)
-    modify_fake_appdb_table(duthost, True, 2)  # Add both tables data
+    modify_fake_appdb_table(duthost, True, 2, namespace)  # Add both tables data
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -158,41 +155,38 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
 
     wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
-    modify_fake_appdb_table(duthost, False, 2)  # Remove all added tables
+    modify_fake_appdb_table(duthost, False, 2, namespace)  # Remove all added tables
     client_thread.join(30)
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, enum_upstream_dut_hostname,
-                                 tbinfo, setup_streaming_telemetry, gnxi_path):
+                                 tbinfo, setup_streaming_telemetry, gnxi_path, enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and no default route, ensure no errors and present data
     Test query again and add default route and ensure data comes.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    is_ipv6_only = is_ipv6_only_topology(tbinfo)
-    upstream_lc = duthosts[enum_upstream_dut_hostname]
-
     if duthost.is_supervisor_node():
         pytest.skip("Skipping for supervisor node since there is no default route")
 
+    upstream_lc = duthosts[enum_upstream_dut_hostname]
     if upstream_lc != duthost:
         pytest.skip("Skipping for {}. This is not valid for downstream node".format(duthost))
 
-    namespace = ""
-    if duthost.is_multi_asic:
-        namespace = "asic0"
+    is_ipv6_only = is_ipv6_only_topology(tbinfo)
     if is_ipv6_only:
         xpath = "\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/::\\/0\""
     else:
         xpath = "\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/0.0.0.0\\/0\""
 
     logger.info('Start telemetry poll mode testing')
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath=xpath,
                               target="APPL_DB", max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
-    modify_fake_appdb_table(duthost)  # Add first table data
+    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
 
     # Remove default route and wait till there is no entry
     duthost.shell("config bgp shutdown all")
@@ -232,12 +226,13 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     # Give 60 seconds for client to connect to server and then 60 for default route to populate after bgp session start
     client_thread.join(120)
 
-    modify_fake_appdb_table(duthost, False, 1)  # Remove all added tables
+    modify_fake_appdb_table(duthost, False, 1, namespace)  # Remove all added tables
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_default_route_supervisor(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                            setup_streaming_telemetry, gnxi_path):
+                                            setup_streaming_telemetry, gnxi_path,
+                                            enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and no default route, ensure no errors and present data
     """
@@ -245,14 +240,12 @@ def test_poll_mode_default_route_supervisor(duthosts, enum_rand_one_per_hwsku_ho
     if not duthost.is_supervisor_node():
         pytest.skip("Testing only for supervisor node")
     logger.info('Start telemetry poll mode testing')
-    namespace = ""
-    if duthost.is_multi_asic:
-        namespace = "asic0"
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/0.0.0.0\/0\"",  # noqa: W605
                               target="APPL_DB", max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
-    modify_fake_appdb_table(duthost)  # Add first table data
+    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -261,4 +254,4 @@ def test_poll_mode_default_route_supervisor(duthosts, enum_rand_one_per_hwsku_ho
     result = str(show_gnmi_out)
     update_responses_match = re.findall("json_ietf_val", result)
     pytest_assert(len(update_responses_match) == 5, "Missing update responses")
-    modify_fake_appdb_table(duthost, False, 1)  # Remove added table
+    modify_fake_appdb_table(duthost, False, 1, namespace)  # Remove added table


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

https://github.com/sonic-net/sonic-mgmt/pull/20100 added multi-asic support for test_telemetry_poll test but hardcoded namespaces to `asic0`. 

This PR refactors telemetry poll mode tests to use dynamic ASIC namespace instead of hardcoding it. Also handle netstat shell call and grep command failure gracefully `check_gnmi_cli_running` while waiting and checking gnmi cli client is running.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Manually created this backport PR to 202511 : https://github.com/sonic-net/sonic-mgmt/pull/22666 -- which includes fixes in https://github.com/sonic-net/sonic-mgmt/pull/20100  [MERGED] plus changes proposed in this PR 

### Approach
#### What is the motivation for this PR?

- Test cases in telemetry_poll test were hardcoded to use `asic0` namespace on mutli-asic. 
- Gracefully handle failure in `check_gnmi_cli_running` 

#### How did you do it?

- Added `enum_rand_one_asic_index` fixture to test functions to replace hardcoded `asic0` on mutli-asic
- Made use of namespace to all call sites so DB operations and verifications target the correct ASIC
- Added `module_ignore_errors=True` to the netstat shell call and grep check in `check_gnmi_cli_running` so it returns False gracefully on failure until the connection is established.

Test behavior remains unchanged on single-asic systems.

#### How did you verify/test it?

Test passes on multi-asic system with the changes

#### Any platform specific information?

Affects multi-ASIC platforms only. Single-ASIC behavior is unchanged since get_namespace_from_asic_id returns empty string for single-ASIC devices.
