### PR TITLE
[ 202511 ] [ Backport 20100 and 22665 ] Add multi-asic support to test_telemety_poll.py on multi-asic

### DIFF
--- a/tests/telemetry/telemetry_utils.py
+++ b/tests/telemetry/telemetry_utils.py
@@ -55,7 +55,8 @@ def skip_201911_and_older(duthost):
 
 def check_gnmi_cli_running(duthost, ptfhost):
     env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
-    res = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"")
+    res = ptfhost.shell(f"netstat -tn | grep \":{env.gnmi_port} .*ESTABLISHED\"",
+                        module_ignore_errors=True)
     return res and res["rc"] == 0
 
 

--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -31,10 +31,10 @@ def invoke_py_cli_from_ptf(ptfhost, cmd, callback):
     callback(ret["stdout"])
 
 
-def modify_fake_appdb_table(duthost, add=True, entries=1):
+def modify_fake_appdb_table(duthost, add=True, entries=1, namespace=""):
     cmd_prefix = "sonic-db-cli"
     if duthost.is_multi_asic:
-        cmd_prefix = "sonic-db-cli -n asic0"
+        cmd_prefix = "sonic-db-cli -n {}".format(namespace)
     for entry in range(entries):
         command = cmd_prefix + " APPL_DB {} FAKE_APPL_DB_TABLE_{}:fake_key{} {}"
         if add:
@@ -46,16 +46,18 @@ def modify_fake_appdb_table(duthost, add=True, entries=1):
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_no_table_or_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                   setup_streaming_telemetry, gnxi_path):
+                                   setup_streaming_telemetry, gnxi_path,
+                                   enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query a non existing table and key, ensure no errors
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info('Start telemetry poll mode testing')
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=5,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=5, update_count=0, timeout=30)
+                              max_sync_count=5, update_count=0, timeout=30, namespace=namespace)
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -68,18 +70,20 @@ def test_poll_mode_no_table_or_key(duthosts, enum_rand_one_per_hwsku_hostname, p
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                             setup_streaming_telemetry, gnxi_path):
+                                             setup_streaming_telemetry, gnxi_path,
+                                             enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and missing key, ensure no errors and present data
     After that, begin querying again and put the key and ensure no errors and new data
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info('Start telemetry poll mode testing')
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=-1, update_count=5, timeout=30)
-    modify_fake_appdb_table(duthost)  # Add first table data
+                              max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
+    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -92,7 +96,7 @@ def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_h
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=1,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=-1, update_count=10, timeout=30)
+                              max_sync_count=-1, update_count=10, timeout=30, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)
@@ -105,26 +109,28 @@ def test_poll_mode_present_table_delayed_key(duthosts, enum_rand_one_per_hwsku_h
 
     wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
-    modify_fake_appdb_table(duthost, True, 2)  # Add second table data
+    modify_fake_appdb_table(duthost, True, 2, namespace)  # Add second table data
     client_thread.join(30)
 
-    modify_fake_appdb_table(duthost, False, 2)  # Remove all added tables
+    modify_fake_appdb_table(duthost, False, 2, namespace)  # Remove all added tables
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                          setup_streaming_telemetry, gnxi_path):
+                          setup_streaming_telemetry, gnxi_path,
+                          enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and key, ensure no errors and present data
     After that, delete both and ensure no errors and delete notifications
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info('Start telemetry poll mode testing')
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=1,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=-1, update_count=10, timeout=30)
-    modify_fake_appdb_table(duthost, True, 2)  # Add both tables data
+                              max_sync_count=-1, update_count=10, timeout=30, namespace=namespace)
+    modify_fake_appdb_table(duthost, True, 2, namespace)  # Add both tables data
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -137,7 +143,7 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=6, update_count=0, timeout=30)
+                              max_sync_count=6, update_count=0, timeout=30, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)
@@ -150,13 +156,14 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
 
     wait_until(5, 1, 0, check_gnmi_cli_running, duthost, ptfhost)
 
-    modify_fake_appdb_table(duthost, False, 2)  # Remove all added tables
+    modify_fake_appdb_table(duthost, False, 2, namespace)  # Remove all added tables
     client_thread.join(30)
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
-def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                 setup_streaming_telemetry, gnxi_path):
+def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost, enum_upstream_dut_hostname,
+                                 setup_streaming_telemetry, gnxi_path,
+                                 enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and no default route, ensure no errors and present data
     Test query again and add default route and ensure data comes.
@@ -164,15 +171,18 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     if duthost.is_supervisor_node():
         pytest.skip("Skipping for supervisor node since there is no default route")
-    namespace = ""
-    if duthost.is_multi_asic:
-        namespace = "asic0"
+
+    upstream_lc = duthosts[enum_upstream_dut_hostname]
+    if upstream_lc != duthost:
+        pytest.skip("Skipping for {}. This is not valid for downstream node".format(duthost))
+
     logger.info('Start telemetry poll mode testing')
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/0.0.0.0\/0\"",  # noqa: W605
                               target="APPL_DB", max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
-    modify_fake_appdb_table(duthost)  # Add first table data
+    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
 
     # Remove default route and wait till there is no entry
     duthost.shell("config bgp shutdown all")
@@ -212,12 +222,13 @@ def test_poll_mode_default_route(duthosts, enum_rand_one_per_hwsku_hostname, ptf
     # Give 60 seconds for client to connect to server and then 60 for default route to populate after bgp session start
     client_thread.join(120)
 
-    modify_fake_appdb_table(duthost, False, 1)  # Remove all added tables
+    modify_fake_appdb_table(duthost, False, 1, namespace)  # Remove all added tables
 
 
 @pytest.mark.parametrize('setup_streaming_telemetry', [False], indirect=True)
 def test_poll_mode_default_route_supervisor(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
-                                            setup_streaming_telemetry, gnxi_path):
+                                            setup_streaming_telemetry, gnxi_path,
+                                            enum_rand_one_asic_index):
     """
     Test poll mode from APPL_DB and query an existing table and no default route, ensure no errors and present data
     """
@@ -225,11 +236,12 @@ def test_poll_mode_default_route_supervisor(duthosts, enum_rand_one_per_hwsku_ho
     if not duthost.is_supervisor_node():
         pytest.skip("Testing only for supervisor node")
     logger.info('Start telemetry poll mode testing')
+    namespace = duthost.get_namespace_from_asic_id(enum_rand_one_asic_index)
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="\"FAKE_APPL_DB_TABLE_0\" \"ROUTE_TABLE/0.0.0.0\/0\"",  # noqa: W605
-                              target="APPL_DB", max_sync_count=-1, update_count=5, timeout=30)
-    modify_fake_appdb_table(duthost)  # Add first table data
+                              target="APPL_DB", max_sync_count=-1, update_count=5, timeout=30, namespace=namespace)
+    modify_fake_appdb_table(duthost, namespace=namespace)  # Add first table data
     ptf_result = ptfhost.shell(cmd)
     pytest_assert(ptf_result['rc'] == 0, "ptf cmd command {} failed".format(cmd))
     show_gnmi_out = ptf_result['stdout']
@@ -238,4 +250,4 @@ def test_poll_mode_default_route_supervisor(duthosts, enum_rand_one_per_hwsku_ho
     result = str(show_gnmi_out)
     update_responses_match = re.findall("json_ietf_val", result)
     pytest_assert(len(update_responses_match) == 5, "Missing update responses")
-    modify_fake_appdb_table(duthost, False, 1)  # Remove added table
+    modify_fake_appdb_table(duthost, False, 1, namespace)  # Remove added table


### PR DESCRIPTION

### Description of PR

Summary:

https://github.com/sonic-net/sonic-mgmt/pull/20100 added multi-asic support for test_telemetry_poll test but changes were not backported to 202511. Also it hardcoded namespaces to `asic0` in test cases on mutli-asic.

This PR is created to manually backports changes https://github.com/sonic-net/sonic-mgmt/pull/20100 [MERGED to master] and https://github.com/sonic-net/sonic-mgmt/pull/22665.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

- To add multi-asic support to all testcases.
- skip test_poll_mode_default_route testcase for downstream LCs.
- Gracefully handle failure in `check_gnmi_cli_running` 

#### How did you do it?

- Added `enum_rand_one_asic_index` fixture to test functions to replace hardcoded `asic0` on mutli-asic
- Made use of namespace to all call sites so DB operations and verifications target the correct ASIC
- Added `module_ignore_errors=True` to the netstat shell call and grep check in `check_gnmi_cli_running` so it returns False gracefully on failure until the connection is established.
- Skipped test_poll_mode_default_route testcase for downstream LCs.

Test behavior remains unchanged on single-asic systems.

#### How did you verify/test it?

Test passes on multi-asic system with the changes
```
telemetry/test_telemetry_poll.py::test_poll_mode_no_table_or_key[qzd502-0-False] PASSED                                             [ 20%]
telemetry/test_telemetry_poll.py::test_poll_mode_present_table_delayed_key[qzd502-0-False] PASSED                                   [ 40%]
telemetry/test_telemetry_poll.py::test_poll_mode_delete[qzd502-0-False] PASSED                                                      [ 60%]
telemetry/test_telemetry_poll.py::test_poll_mode_default_route[qzd502-0-False] PASSED                                               [ 80%]
telemetry/test_telemetry_poll.py::test_poll_mode_default_route_supervisor[qzd502-0-False] SKIPPED (Testing only for supervisor ...) [100%]
```
#### Any platform specific information?

Affects multi-ASIC platforms only. Single-ASIC behavior is unchanged since get_namespace_from_asic_id returns empty string for single-ASIC devices.
