### PR TITLE
community testbed lab6 - static 4k router lab

### DIFF
--- a/tests/community/conftest.py
+++ b/tests/community/conftest.py
@@ -1,0 +1,113 @@
+import pytest
+import logging
+
+from tests.community.route_helpers import NUM_ROUTES, ROUTE_PREFIX, apply_routes
+
+logger = logging.getLogger(__name__)
+
+_summary_data = {}
+
+
+@pytest.fixture(scope="module")
+def nexthop_ip(duthost):
+    """Get a gateway address from the DUT's default route."""
+    output = duthost.shell("ip -4 route show default", module_ignore_errors=True)["stdout"]
+    for line in output.split('\n'):
+        if 'via' in line:
+            parts = line.split()
+            return parts[parts.index('via') + 1]
+    pytest.fail("No default gateway found on DUT")
+
+
+@pytest.fixture(scope="module")
+def baseline_route_count(duthost):
+    """Snapshot how many routes already match ROUTE_PREFIX before any test routes are added."""
+    result = duthost.shell(
+        "show ip route | grep -c '{}'".format(ROUTE_PREFIX),
+        module_ignore_errors=True
+    )
+    count = int(result["stdout"].strip() or "0")
+    logger.info("Baseline routes matching '%s': %d", ROUTE_PREFIX, count)
+    return count
+
+
+@pytest.fixture(scope="module")
+def test_summary():
+    """Module-scoped dict to accumulate test results for the final summary."""
+    return _summary_data
+
+
+@pytest.fixture(scope="module", autouse=True)
+def manage_routes_cleanup(duthost, nexthop_ip):
+    """Remove all test routes and temp files after the module finishes."""
+    yield
+    logger.info("Cleanup: removing test routes")
+    apply_routes(duthost, "del", NUM_ROUTES, nexthop_ip)
+    duthost.shell("rm -f /tmp/routes_*.txt", module_ignore_errors=True)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Print the 40K routes stress test summary at the very end of output."""
+    if not _summary_data:
+        return
+
+    write = terminalreporter.write_line
+    sep = "=" * 80
+
+    write("")
+    write(sep)
+    write("  40K STATIC ROUTES STRESS TEST SUMMARY")
+    write(sep)
+
+    add_info = _summary_data.get("add", {})
+    write("")
+    write("1. Configure 40K static routes and verify how much time it takes")
+    write("   for them to be shown in the CLI show commands.")
+    write("   (Note: If routes are configured by directly writing redis db,")
+    write("   they will not be displayed by 'show ip route' CLI command.)")
+    if add_info:
+        write("   - Pre-existing routes (baseline)       : {}".format(
+            add_info["baseline"]))
+        write("   - Route addition (ip -batch) duration : {:.2f} seconds".format(
+            add_info["add_duration"]))
+        write("   - Time for routes to appear in CLI     : {:.2f} seconds".format(
+            add_info["convergence_time"]))
+        write("   - 'show ip route' execution time       : {:.2f} seconds".format(
+            add_info["show_duration"]))
+        write("   - Routes found in 'show ip route'      : {} (baseline {} + added {})".format(
+            add_info["route_count"], add_info["baseline"],
+            add_info["route_count"] - add_info["baseline"]))
+    else:
+        write("   - SKIPPED (test_add_40k_static_routes did not run)")
+
+    cpu_mem = _summary_data.get("cpu_memory", {})
+    write("")
+    write("2. Verify memory and CPU (monitored using 'top'):")
+    if cpu_mem:
+        write("   --- top output ---")
+        for line in cpu_mem["top_output"].splitlines():
+            write("   {}".format(line))
+        write("   --- system-memory ---")
+        for line in cpu_mem["mem_output"].splitlines():
+            write("   {}".format(line))
+    else:
+        write("   - SKIPPED (test_verify_cpu_and_memory did not run)")
+
+    remove_info = _summary_data.get("remove", {})
+    write("")
+    write("3. Remove 40K static routes and verify how much time it takes")
+    write("   for them to be not shown in the CLI show commands:")
+    if remove_info:
+        write("   - Route removal (ip -batch) duration   : {:.2f} seconds".format(
+            remove_info["del_duration"]))
+        write("   - Time for routes to disappear from CLI: {:.2f} seconds".format(
+            remove_info["convergence_time"]))
+        write("   - 'show ip route' execution time       : {:.2f} seconds".format(
+            remove_info["show_duration"]))
+        write("   - Routes remaining in 'show ip route'  : {} (baseline was {})".format(
+            remove_info["remaining_routes"], remove_info["baseline"]))
+    else:
+        write("   - SKIPPED (test_remove_40k_static_routes did not run)")
+
+    write("")
+    write(sep)

--- a/tests/community/route_helpers.py
+++ b/tests/community/route_helpers.py
@@ -1,0 +1,46 @@
+"""Helpers for generating and applying bulk static routes on a DUT."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+NUM_ROUTES = 40000
+ROUTE_PREFIX = "40.0"
+
+
+def generate_ip_route_commands(action, num_routes, nexthop):
+    """
+    Build a list of 'ip route' commands for the given action.
+
+    Args:
+        action: "add" or "del"
+        num_routes: how many /32 routes to generate (starting at 40.0.0.0)
+        nexthop: gateway IP address
+
+    Returns:
+        list of command strings, e.g.
+        ["ip route add 40.0.0.0/32 via 10.0.0.1", ...]
+    """
+    commands = []
+    for i in range(num_routes):
+        commands.append("ip route {} 40.0.{}.{}/32 via {}".format(
+            action, i // 256, i % 256, nexthop))
+    return commands
+
+
+def apply_routes(duthost, action, num_routes, nexthop):
+    """
+    Generate route commands and execute them on the DUT in one shot
+    using 'ip -batch'.
+
+    Returns the batch text that was applied (useful for logging/debug).
+    """
+    commands = generate_ip_route_commands(action, num_routes, nexthop)
+    batch_text = "\n".join(
+        cmd.replace("ip ", "", 1) for cmd in commands
+    ) + "\n"
+    batch_file = "/tmp/routes_{}.txt".format(action)
+
+    duthost.copy(content=batch_text, dest=batch_file)
+    duthost.shell("ip -batch {}".format(batch_file), module_ignore_errors=True)
+    return batch_text

--- a/tests/community/test_stress_40k_routes.py
+++ b/tests/community/test_stress_40k_routes.py
@@ -1,0 +1,139 @@
+"""
+Test: 40K static routes stress test.
+
+Three steps:
+  1. Add 40K routes with 'ip route add', measure time for 'show ip route'
+     to reflect them.
+  2. Check CPU and memory with 'top'.
+  3. Remove 40K routes with 'ip route del', measure time for 'show ip route'
+     to reflect removal.
+
+Routes are added via 'ip route add' (not redis DB) so they appear in
+'show ip route'.  The loganalyzer fixture validates syslog automatically.
+"""
+
+import time
+import logging
+
+import pytest
+from tests.community.route_helpers import NUM_ROUTES, ROUTE_PREFIX, apply_routes
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+POLL_INTERVAL = 5
+
+
+def _count_routes(duthost):
+    """Return number of routes matching ROUTE_PREFIX in 'show ip route'."""
+    result = duthost.shell(
+        "show ip route | grep -c '{}'".format(ROUTE_PREFIX),
+        module_ignore_errors=True
+    )
+    return int(result["stdout"].strip() or "0")
+
+
+def _wait_for_routes(duthost, target, compare, label):
+    """
+    Poll 'show ip route' until compare(count, target) is True.
+    No timeout -- polls until convergence is reached.
+
+    Returns (elapsed_seconds, final_count).
+    """
+    start = time.time()
+    while True:
+        count = _count_routes(duthost)
+        elapsed = time.time() - start
+        logger.info("[%s] routes matching '%s': %d  (%.1fs elapsed)",
+                    label, ROUTE_PREFIX, count, elapsed)
+        if compare(count, target):
+            return elapsed, count
+        time.sleep(POLL_INTERVAL)
+
+
+def test_add_40k_static_routes(duthost, nexthop_ip, loganalyzer,
+                               baseline_route_count, test_summary):
+    """Add 40K static routes and verify how long until 'show ip route' reflects them."""
+    logger.info("Baseline routes before add: %d", baseline_route_count)
+    logger.info("Adding %d static routes via 'ip route add' ...", NUM_ROUTES)
+    start_time = time.time()
+    apply_routes(duthost, "add", NUM_ROUTES, nexthop_ip)
+    add_duration = time.time() - start_time
+    logger.info("Route addition took %.2f seconds", add_duration)
+
+    target = baseline_route_count + int(NUM_ROUTES * 0.99)
+    logger.info("Waiting for routes to appear in 'show ip route' (target >= %d) ...", target)
+    convergence_time, final_count = _wait_for_routes(
+        duthost,
+        target,
+        lambda count, tgt: count >= tgt,
+        "add-convergence",
+    )
+
+    start_time = time.time()
+    duthost.shell("show ip route > /dev/null 2>&1")
+    show_duration = time.time() - start_time
+    logger.info("'show ip route' took %.2f seconds with %d routes loaded",
+                show_duration, final_count)
+
+    test_summary["add"] = {
+        "add_duration": add_duration,
+        "convergence_time": convergence_time,
+        "show_duration": show_duration,
+        "route_count": final_count,
+        "baseline": baseline_route_count,
+    }
+
+
+def test_verify_cpu_and_memory(duthost, loganalyzer, test_summary):
+    """Check CPU and memory while 40K routes are loaded."""
+    logger.info("=== CPU (top) ===")
+    top_output = duthost.shell(
+        "top -b -n 1 | head -20", module_ignore_errors=True)["stdout"]
+    logger.info(top_output)
+
+    logger.info("=== Memory ===")
+    mem_output = duthost.shell(
+        "show system-memory", module_ignore_errors=True)["stdout"]
+    logger.info(mem_output)
+
+    test_summary["cpu_memory"] = {
+        "top_output": top_output,
+        "mem_output": mem_output,
+    }
+
+
+def test_remove_40k_static_routes(duthost, nexthop_ip, loganalyzer,
+                                  baseline_route_count, test_summary):
+    """Remove 40K static routes and verify how long until 'show ip route' reflects removal."""
+    logger.info("Baseline routes before test: %d", baseline_route_count)
+    logger.info("Removing %d static routes via 'ip route del' ...", NUM_ROUTES)
+    start_time = time.time()
+    apply_routes(duthost, "del", NUM_ROUTES, nexthop_ip)
+    del_duration = time.time() - start_time
+    logger.info("Route removal took %.2f seconds", del_duration)
+
+    logger.info("Waiting for routes to return to baseline (<= %d) ...",
+                baseline_route_count)
+    convergence_time, final_count = _wait_for_routes(
+        duthost,
+        baseline_route_count,
+        lambda count, tgt: count <= tgt,
+        "del-convergence",
+    )
+
+    start_time = time.time()
+    duthost.shell("show ip route > /dev/null 2>&1")
+    show_duration = time.time() - start_time
+    logger.info("'show ip route' took %.2f seconds after removal", show_duration)
+
+    test_summary["remove"] = {
+        "del_duration": del_duration,
+        "convergence_time": convergence_time,
+        "show_duration": show_duration,
+        "remaining_routes": final_count,
+        "baseline": baseline_route_count,
+    }


### PR DESCRIPTION
### Description of PR

Add a community stress test for 40K static routes. The test adds routes via `ip -batch`, polls `show ip route` to measure CLI convergence time, captures CPU/memory with `top`, then removes all routes and measures how long until they disappear. A structured summary is printed at the end of every run.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Provide a repeatable stress test to evaluate SONiC's handling of a large routing table -- covering route programming latency, CLI responsiveness, and system resource consumption.

#### How did you do it?

Added `tests/community/` with three files:

- **`route_helpers.py`** -- Generates and applies 40K `/32` routes via `ip -batch`.
- **`test_stress_40k_routes.py`** -- Three test cases: add 40K routes and measure convergence, capture CPU/memory, remove routes and measure convergence back to baseline.
- **`conftest.py`** -- Fixtures, automatic cleanup, and a `pytest_terminal_summary` hook for end-of-run summary.

Routes use `ip route add` (not redis DB) so they appear in `show ip route`. A baseline count is captured first to account for pre-existing routes on the DUT.

#### How did you verify/test it?

Ran on a SONiC community testbed. All 3 tests passed. Route add/remove completed in seconds, CLI convergence confirmed, CPU/memory captured.

Use below command to run it on sonic mgmt docker inside sonic-mgmt/tests dir
```
python3 -m pytest community/test_stress_40k_routes.py \
  --setup_name=r-leopard-58_setup \
  --inventory="../ansible/inventory,../ansible/veos" \
  --host-pattern r-leopard-58 \
  --module-path ../ansible/library/ \
  --testbed r-leopard-58-t0 \
  --testbed_file=../ansible/testbed.yaml \
  --allow_recover \
  --assert plain \
  --disable_loganalyzer \
  --log-cli-level debug \
  --show-capture=no -ra --showlocals -v \
  --skip_sanity \
  --dynamic_update_skip_reason \
  --topology t0,any,util
```
test result
<img width="505" height="591" alt="image" src="https://github.com/user-attachments/assets/91aa1b83-2cfc-49ac-8b90-0d8b7ba547c9" />

#### Any platform specific information?

None. Uses standard `ip route` and SONiC CLI commands.

#### Supported testbed topology if it's a new test case?

`any` -- works on any community testbed topology.

### Documentation

N/A