### PR TITLE
Add 800G and 1.6T RS-FEC mapping to test_force_speed

### DIFF
--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -333,7 +333,9 @@ def test_force_speed(enum_speed_per_dutport_fixture):
         50000: 'fc',
         100000: 'rs',
         200000: 'rs',
-        400000: 'rs'
+        400000: 'rs',
+        800000: 'rs',
+        1600000: 'rs'
     }
 
     fec_mode = FEC_FOR_SPEED.get(int(speed))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The FEC_FOR_SPEED dict was missing entries for 800G and 1.6T port speeds. Both require RS-FEC per IEEE 802.3df (800G) and IEEE 802.3dj (1.6T). Without this, test_force_speed sets fec_mode=None for these speeds.

For example, when the test is running for 800G, the DUT and fanout will both have "none" for fec value.

**Test**
```
platform_tests/test_auto_negotiation.py::test_force_speed[switch1|Ethernet0|800000]
```

DUT & Fanout Ethernet0 status during test
```shell
sonic:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100   none     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
```

When the test completes, config reload resets DUT but fanout remains fec = none.
```shell
fanout:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100   none     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
```

Fixes Issue https://github.com/sonic-net/sonic-mgmt/issues/22667

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

When running `test_auto_negotation.py` with 800G port speed, I noticed that the fec value was "none" instead of rs. 

#### How did you do it?

I added `800000` and `1600000` to FEC_FOR_SPEED
```python
    FEC_FOR_SPEED = {
        25000: 'fc',
        50000: 'fc',
        100000: 'rs',
        200000: 'rs',
        400000: 'rs',
        800000: 'rs',
        1600000: 'rs'
    }
```

#### How did you verify/test it?

Run using sonic-mgmt T0 topology

**Test**
```
platform_tests/test_auto_negotiation.py::test_force_speed[switch1|Ethernet0|800000]
```

#### Any platform specific information?

Generic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
