### PR TITLE
[ptf_runner] Log PTF test output tail on failure for better CI diagnostics

### DIFF
--- a/tests/ptf_runner.py
+++ b/tests/ptf_runner.py
@@ -239,14 +239,14 @@ def ptf_runner(host, testdir, testname, platform_dir=None, params={},
             # making failures opaque without this (see issue #22662).
             try:
                 ptf_log_tail = host.shell(
-                    "tail -50 {}".format(log_file),
+                    "tail -50 {}".format(pipes.quote(log_file)),
                     module_ignore_errors=True
                 )
                 if ptf_log_tail and ptf_log_tail.get("rc") == 0 and ptf_log_tail.get("stdout"):
                     logger.error("PTF log tail for %s:\n%s", testname, ptf_log_tail["stdout"])
                     allure.attach(ptf_log_tail["stdout"], 'ptf_log_tail', allure.attachment_type.TEXT)
-            except Exception:
-                logger.debug("Failed to fetch PTF log tail for diagnostics")
+            except Exception as e:
+                logger.debug("Failed to fetch PTF log tail for diagnostics: %s", e)
         traceback_msg = traceback.format_exc()
         allure.attach(traceback_msg, 'ptf_runner_exception_traceback', allure.attachment_type.TEXT)
         logger.error("Exception caught while executing case: {}. Error message: {}".format(testname, traceback_msg))


### PR DESCRIPTION
## What is the motivation for this PR?

When PTF tests fail in CI, the actual Python exception is only written to the PTF log file on the PTF container — not to stdout/stderr. The CI output only shows:
```
ATTENTION: SOME TESTS DID NOT PASS!!!
The following tests errored: <TestName>
```
This makes PTF test failures opaque and difficult to diagnose without manually retrieving log files from the PTF container.

For example, the VXLAN ECMP test failure tracked in #22662 shows no useful error information in CI output. The actual traceback (KeyError, RuntimeError, etc.) is hidden in `/tmp/vxlan-tests.*.log` on the PTF container.

## How did you do it?

Added diagnostic logging in `ptf_runner.py`'s exception handler. When a PTF test fails:
1. Fetch the last 50 lines of the PTF log file from the PTF container
2. Log them at ERROR level so they appear in CI output
3. Attach them as an Allure artifact for test reports

The diagnostic fetch is wrapped in a try/except to ensure it never interferes with the original error propagation.

## How did you verify/test it?

- Code review confirms the change is additive and non-breaking
- The diagnostic logging only runs in the existing exception handler path
- `module_ignore_errors=True` ensures the tail command cannot cause additional failures
- Falls back gracefully if the log file is unavailable

Signed-off-by: Ying Xie <ying.xie@microsoft.com>