### PR TITLE
everflow: add shared capabilities fixture for mirror checks

### DIFF
--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def everflow_capabilities(duthosts):
+    """Collect switch capability facts once for Everflow tests.
+
+    Returns:
+        dict: hostname -> switch capability dict (STATE_DB switch_capabilities)
+    """
+    caps = {}
+    for dut in duthosts:
+        facts = dut.switch_capabilities_facts()
+        switch_caps = (facts
+                       .get("ansible_facts", {})
+                       .get("switch_capabilities", {})
+                       .get("switch", {}))
+        caps[dut.hostname] = switch_caps
+    return caps

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -675,7 +675,7 @@ class BaseEverflowTest(object):
         return duthost_set
 
     @pytest.fixture(scope="class")
-    def setup_mirror_session(self, config_method, setup_info, erspan_ip_ver):
+    def setup_mirror_session(self, config_method, setup_info, erspan_ip_ver, everflow_capabilities):
         """
         Set up a mirror session for Everflow.
 
@@ -703,11 +703,7 @@ class BaseEverflowTest(object):
             # sonic-utilities (config/main.py is_port_mirror_capability_supported) which
             # reads STATE_DB directly and rejects when keys are missing.
             if config_method == CONFIG_MODE_CLI:
-                facts = duthost.switch_capabilities_facts()
-                switch_caps = (facts
-                               .get("ansible_facts", {})
-                               .get("switch_capabilities", {})
-                               .get("switch", {}))
+                switch_caps = everflow_capabilities.get(duthost.hostname, {})
                 ingress_capable = switch_caps.get("PORT_INGRESS_MIRROR_CAPABLE", "false")
                 egress_capable = switch_caps.get("PORT_EGRESS_MIRROR_CAPABLE", "false")
                 if ingress_capable != "true" or egress_capable != "true":


### PR DESCRIPTION
## Summary\nAdd a shared Everflow capabilities fixture to collect switch capabilities once and reuse across tests. Use it in setup_mirror_session to decide whether to skip bidirectional mirror config when ASIC lacks support.\n\n## Motivation\nAvoid repeated capability queries and ensure all tests can branch consistently on mirror capability (addresses failures like port mirror direction 'both' unsupported).\n\n## Testing\nNot run (logic-only test helper/fixture).\n\nFixes/Relates: #22663\n\nAI agent on behalf of Ying.