### PR TITLE
fix for led color in test_system_health.py

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -69,6 +69,7 @@ DEFAULT_LED_CONFIG = {
     'booting': 'red'
 }
 
+
 @pytest.fixture(autouse=True, scope="module")
 def check_image_version(duthost):
     """Skip the test for unsupported images."""
@@ -532,7 +533,8 @@ def check_system_health_led_info(duthost):
     else:
         # Logic for faulted system: Iterate through led_cfg to find a match among non-normal keys
         not_normal = {color for key, color in led_cfg.items() if key != "normal"}
-        assert system_status_lower in not_normal, f"System status LED '{system_led_status}' does not match any non-normal colors defined in config: {not_normal}"
+        assert system_status_lower in not_normal, \
+            f"System status LED '{system_led_status}' does not match any colors defined in config: {not_normal}"
 
     return True
 


### PR DESCRIPTION

### Description of PR
Changed the code in check_system_health_led_info() to use the keys to led_color, rather then hard coded (and incorrect in default case) colors.


### Type of change

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The assert in this function was triggering when run on simulators and HW devices
#### How did you do it?

#### How did you verify/test it?
Verified with SIM
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
Note that this bug has been seen in different topologies and may have duplicates.
