### PR TITLE
Fix test issue for test_ipv6_bgp_scale.py

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -16,6 +16,7 @@ import time
 from copy import deepcopy
 from threading import Thread, Event
 from tests.common.helpers.assertions import pytest_assert
+import ptf
 import ptf.packet as scapy
 from ptf.testutils import simple_icmpv6_packet
 from ptf.mask import Mask
@@ -52,6 +53,7 @@ ICMP_TYPE_MAX = 125
 _icmp_type_generator = itertools.cycle(range(ICMP_TYPE_MIN, ICMP_TYPE_MAX + 1))
 test_results = {}
 current_test = ""
+global_icmp_type = ICMP_TYPE_MIN
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -279,10 +281,19 @@ def validate_dut_routes(duthost, tbinfo, expected_routes):
     return identical
 
 
+def _get_backplane_ports():
+    """Identify backplane ports from PTF port_map config so they can be excluded from rx counters."""
+    return {k for k, v in ptf.config.get('port_map', {}).items() if v == 'backplane'}
+
+
 def calculate_downtime(ptf_dp, end_time, start_time, masked_exp_pkt):
     logger.warning("Waiting %d seconds for mask counters to be updated", MASK_COUNTER_WAIT_TIME)
     time.sleep(MASK_COUNTER_WAIT_TIME)
-    rx_total = sum(list(ptf_dp.mask_rx_cnt[masked_exp_pkt].values())[:-1])  # Exclude the backplane
+    backplane_ports = _get_backplane_ports()
+    rx_total = sum(
+        cnt for port_key, cnt in ptf_dp.mask_rx_cnt[masked_exp_pkt].items()
+        if port_key not in backplane_ports
+    )
     tx_total = sum(ptf_dp.mask_tx_cnt[masked_exp_pkt].values())
     if tx_total == 0:
         logger.warning("No packets are sent")
@@ -318,7 +329,7 @@ def calculate_downtime(ptf_dp, end_time, start_time, masked_exp_pkt):
 
 def validate_rx_tx_counters(ptf_dp, end_time, start_time, masked_exp_pkt, downtime_threshold=10):
     downtime = calculate_downtime(ptf_dp, end_time, start_time, masked_exp_pkt)
-    return downtime < downtime_threshold
+    return downtime < downtime_threshold, downtime
 
 
 def flush_counters(ptf_dp, masked_exp_pkt):
@@ -614,7 +625,7 @@ def flapper(duthost, ptfadapter, bgp_peers_info, transient_setup, flapping_count
         prefixes,
         duthost.facts['router_mac'],
         pdp.get_mac(pdp.port_to_device(injection_port), injection_port),
-        icmp_type
+        global_icmp_type
     )
     # Downtime ratio is calculated by dividing the number of flapping neighbors by 5, from test data
     downtime_ratio = len(flapping_connections) / 5
@@ -642,11 +653,16 @@ def flapper(duthost, ptfadapter, bgp_peers_info, transient_setup, flapping_count
         terminated.set()
         traffic_thread.join()
         end_time = datetime.datetime.now()
-        acceptable_downtime = validate_rx_tx_counters(pdp, end_time, start_time, exp_mask, downtime_threshold)
+        acceptable_downtime, actual_downtime = validate_rx_tx_counters(
+            pdp, end_time, start_time, exp_mask, downtime_threshold
+        )
         if not acceptable_downtime:
             if action == 'shutdown':
                 _restore(duthost, connection_type, flapping_connections, all_flap)
-            pytest.fail(f"Dataplane downtime is too high, threshold is {downtime_threshold} seconds")
+            pytest.fail(
+                f"Dataplane downtime is too high: actual {actual_downtime:.4f} seconds, "
+                f"threshold is {downtime_threshold} seconds"
+            )
         if not result.get("converged"):
             pytest.fail("BGP routes are not stable in long time")
     finally:
@@ -778,14 +794,17 @@ def test_nexthop_group_member_scale(
         terminated.set()
         traffic_thread.join()
         end_time = datetime.datetime.now()
-        acceptable_downtime = validate_rx_tx_counters(pdp, end_time, start_time, exp_mask,
-                                                      _get_max_time('dataplane_downtime', 1))
+        acceptable_downtime, actual_downtime = validate_rx_tx_counters(
+            pdp, end_time, start_time, exp_mask, _get_max_time('dataplane_downtime', 1)
+        )
         if not acceptable_downtime:
             for ptfhost in ptfhosts:
                 ptf_ip = ptfhost.mgmt_ip
                 announce_routes(localhost, tbinfo, ptf_ip, servers_dut_interfaces.get(ptf_ip, ''))
-            pytest.fail(f"Dataplane downtime is too high, threshold is "
-                        f"{_get_max_time('dataplane_downtime', 1)} seconds")
+            pytest.fail(
+                f"Dataplane downtime is too high: actual {actual_downtime:.4f} seconds, "
+                f"threshold is {_get_max_time('dataplane_downtime', 1)} seconds"
+            )
         if not result.get("converged"):
             pytest.fail("BGP routes are not stable in long time")
     finally:
@@ -825,10 +844,14 @@ def test_nexthop_group_member_scale(
     terminated.set()
     traffic_thread.join()
     end_time = datetime.datetime.now()
-    acceptable_downtime = validate_rx_tx_counters(pdp, end_time, start_time, exp_mask,
-                                                  _get_max_time('dataplane_downtime', 1))
+    acceptable_downtime, actual_downtime = validate_rx_tx_counters(
+        pdp, end_time, start_time, exp_mask, _get_max_time('dataplane_downtime', 1)
+    )
     if not acceptable_downtime:
-        pytest.fail(f"Dataplane downtime is too high, threshold is {_get_max_time('dataplane_downtime', 1)} seconds")
+        pytest.fail(
+            f"Dataplane downtime is too high: actual {actual_downtime:.4f} seconds, "
+            f"threshold is {_get_max_time('dataplane_downtime', 1)} seconds"
+        )
     if not result.get("converged"):
         pytest.fail("BGP routes are not stable in long time")
 


### PR DESCRIPTION
Summary: Fix test issue for test_ipv6_bgp_scale.py
Fixes # (issue)
---------------------
1. Fix test issue in `calculate_downtime()` function. Please see the detail info as below
---------------------
2. Print actual downtime in the logs
- Before change, when case fail, we do not know the actual downtime value, it is inconvenient
```
Failed: Dataplane downtime is too high, threshold is 2.0 seconds
```
- After change, we can see the actual downtime value in the error message
```
Failed: Dataplane downtime is too high: actual 5.5822 seconds, threshold is 2.0 seconds
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The `calculate_downtime()` function in `test_ipv6_bgp_scale.py` uses `[:-1]` on the `mask_rx_cnt` dict values to exclude the backplane port from the RX total:

```python
rx_total = sum(list(ptf_dp.mask_rx_cnt[masked_exp_pkt].values())[:-1])  # Exclude the backplane
```

This is incorrect because `[:-1]` removes the **last entry by dict insertion order**, not the backplane port. The dict insertion order depends on which port first receives a matching packet, which is non-deterministic and varies between runs.

In topologies without a backplane (e.g., `t1-isolated-*`), `mask_rx_cnt` contains only legitimate data port entries and no backplane entry at all. The `[:-1]` unconditionally removes a valid egress port's counter, causing false packet loss to be reported.

For example, in a `test_bgp_admin_flap[1]` failure:
- `mask_rx_cnt` had exactly 32 entries, all corresponding to BGP neighbor ports (no backplane)
- `[:-1]` excluded port `(0, 176)` (Ethernet176 / ARISTA113T1) which received 1019 packets
- This caused `missing_pkt_cnt = 1019` and `downtime = 0.4185s`, exceeding the 0.2s threshold
- In reality, all 31,990 sent packets were received (TX total == full RX sum), meaning **zero actual packet loss**

The bug also makes the test flaky — depending on which port happens to be last in the dict, the "missing" count changes, causing random pass/fail results.

#### How did you do it?
Replaced the fragile `[:-1]` approach with explicit backplane port identification using `ptf.config['port_map']`.

When PTF initializes, backplane ports are registered in `ptf.config['port_map']` with interface name `"backplane"` (see `ptfadapter/__init__.py` `get_ifaces_map()`). The new helper `_get_backplane_ports()` queries this config to find backplane port keys, and `calculate_downtime()` excludes only those specific ports from the RX sum.

- In topologies **with** backplane (e.g., `ciscovs-7nodes`): backplane ports are correctly identified and excluded
- In topologies **without** backplane: `_get_backplane_ports()` returns an empty set, no ports are excluded

#### How did you verify/test it?
Run regression test, pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
