### PR TITLE
[202511] Add syslog identity to pfc_gen scripts to fix silent log drops (#21881)

### DIFF
--- a/ansible/roles/test/files/mlnx/docker-tests-pfcgen-asic/pfc_gen.py
+++ b/ansible/roles/test/files/mlnx/docker-tests-pfcgen-asic/pfc_gen.py
@@ -252,6 +252,7 @@ def main():
     logger.setLevel(logging.DEBUG)
     # Configure logging
     handler = logging.handlers.SysLogHandler(address=(args.rsyslog_server, 514))
+    handler.ident = 'pfc_gen: '
     logger.addHandler(handler)
 
     if args.disable:

--- a/tests/common/helpers/pfc_gen.py
+++ b/tests/common/helpers/pfc_gen.py
@@ -109,6 +109,7 @@ def main():
 
     # Configure logging
     handler = logging.handlers.SysLogHandler(address=(options.rsyslog_server, 514))
+    handler.ident = 'pfc_gen: '
     logger.addHandler(handler)
 
     """

--- a/tests/common/helpers/pfc_gen_brcm_xgs.py
+++ b/tests/common/helpers/pfc_gen_brcm_xgs.py
@@ -219,6 +219,7 @@ def main():
 
     # Configure logging
     handler = logging.handlers.SysLogHandler(address=(options.rsyslog_server, 514))
+    handler.ident = 'pfc_gen: '
     logger.addHandler(handler)
 
     # List of front panel kernel intfs

--- a/tests/common/helpers/pfc_gen_t2.py
+++ b/tests/common/helpers/pfc_gen_t2.py
@@ -145,6 +145,7 @@ def main():
 
     # Configure logging
     handler = logging.handlers.SysLogHandler(address=(options.rsyslog_server, 514))
+    handler.ident = 'pfc_gen: '
     my_logger.addHandler(handler)
 
     for s, interface in zip(sockets, interfaces):


### PR DESCRIPTION
Rsyslog was incorrectly parsing the message like `PFC_STORM_START` to hostname due to missing tag on the script sent logs ((e.g., <15>PFC_STORM_START)). Due to recent change we've hardcoded the hostname that lead to omission of the msg that test looks for.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Pick to 202511 conflict, pick it manually
https://github.com/sonic-net/sonic-mgmt/pull/21881

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
