### PR TITLE
define get_bgp_confed_asn function in sonic host

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -3367,6 +3367,15 @@ print(device_prefix)
 
         logging.info("Successfully cleaned up all console sessions")
 
+    def get_bgp_confed_asn(self):
+        """
+        Get BGP confederation ASN from running config
+        Return None if not configured
+        """
+        config_facts = self.config_facts(host=self.hostname, source="running")['ansible_facts']
+        bgp_confed_asn = config_facts.get('BGP_DEVICE_GLOBAL', {}).get('CONFED', {}).get('asn', None)
+        return bgp_confed_asn
+
     def get_mgmt_ip(self):
         """
         Gets the management IP address (v4 or v6) on eth0.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
```
failed on setup with "AttributeError: '<class 'tests.common.devices.sonic.SonicHost'>' object has no attribute 'get_bgp_confed_asn'"
```
#### How did you do it?
https://github.com/sonic-net/sonic-mgmt/pull/21890/changes
Define get_bgp_confed_asn in SonicHost

#### How did you verify/test it?
https://elastictest.org/scheduler/testplan/69a528f78fe9299bbb5c071d

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
