### PR TITLE
Change BGP peering timeout to 120

### DIFF
--- a/tests/bgp/test_bgp_slb.py
+++ b/tests/bgp/test_bgp_slb.py
@@ -15,6 +15,7 @@ pytestmark = [
 
 PEER_COUNT = 1
 NEIGHBOR_EXABGP_PORT = 11000
+WAIT_TIMEOUT = 120
 
 
 @pytest.fixture(params=["warm", "fast"])
@@ -82,7 +83,7 @@ def test_bgp_slb_neighbor_persistence_across_advanced_reboot(
 
     try:
         neighbor.start_session()
-        if not wait_until(40, 5, 10, verify_bgp_session, duthost, neighbor):
+        if not wait_until(WAIT_TIMEOUT, 5, 10, verify_bgp_session, duthost, neighbor):
             pytest.fail("dynamic BGP session is not established")
         reboot(duthost, localhost, reboot_type=reboot_type, wait_warmboot_finalizer=True)
         if not wait_until(40, 5, 10, verify_bgp_session, duthost, neighbor):


### PR DESCRIPTION
Description of PR
In test_bgp_slb.py, the dynamic peers bring up timeout is set at 40 seconds using the number "40", while in many other tests, it is using WAIT_TIMEOUT, with value of 120. So I'm changing it to do the same.

Other uses of "WAIT_TIMEOUT":

fkong@vxr-slurm-254:/nobackup/fkong/sonic-mgmt-tests/sonic-test/sonic-mgmt/tests/bgp$ grep WAIT_TIMEOUT * | grep "="
grep: reliable_tsabgp_helpers.py:WAIT_TIMEOUT = 120
bgp_helpers.py:TCPDUMP_WAIT_TIMEOUT = 20
: Is a directory
grep: templates: Is a directory
test_bgp_peer_shutdown.py:WAIT_TIMEOUT = 120
test_bgp_slb.py:WAIT_TIMEOUT = 120
test_bgp_update_replication.py:WAIT_TIMEOUT = 120
test_bgp_update_timer.py:WAIT_TIMEOUT = 120
fkong@vxr-slurm-254:/nobackup/fkong/sonic-mgmt-tests/sonic-test/sonic-mgmt/tests/bgp$

Summary:
Fixes # MIGSOFTWAR-33363

Type of change
Script change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311