### PR TITLE
Fix "override config" tests to support LT2/FT2

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -10,6 +10,9 @@ from tests.common.utilities import backup_config, restore_config, get_running_co
 from tests.common import mellanox_data
 from tests.common import broadcom_data
 
+# Tables known to be overriden in run-time config, which will appear different
+# if the golden config is overridden empty.
+GOLDEN_OVERRRIDDEN_TABLES = ["FEATURE", "PORT"]
 
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
@@ -95,7 +98,7 @@ def load_minigraph_with_golden_empty_input(duthost):
     current_config = get_running_config(duthost)
     problem_tables = []
     for table in initial_config:
-        if table in NON_USER_CONFIG_TABLES:
+        if table in NON_USER_CONFIG_TABLES or table in GOLDEN_OVERRRIDDEN_TABLES:
             continue
 
         if table == "ACL_TABLE":

--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -93,20 +93,19 @@ def load_minigraph_with_golden_empty_input(duthost):
     reload_minigraph_with_golden_config(duthost, empty_input)
 
     current_config = get_running_config(duthost)
+    problem_tables = []
     for table in initial_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
 
         if table == "ACL_TABLE":
-            pytest_assert(
-                compare_dicts_ignore_list_order(initial_config[table], current_config[table]),
-                "empty input ACL_TABLE compare fail!"
-            )
+            if not compare_dicts_ignore_list_order(initial_config[table], current_config[table]):
+                problem_tables.append(table)
         else:
-            pytest_assert(
-                initial_config[table] == current_config[table],
-                "empty input compare fail! {}".format(table)
-            )
+            if not initial_config[table] == current_config[table]:
+                problem_tables.append(table)
+
+    pytest_assert(not problem_tables, "empty input compare fail: {}".format(problem_tables))
 
 
 def load_minigraph_with_golden_partial_config(duthost):

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -9,6 +9,10 @@ from tests.common.utilities import backup_config, restore_config, get_running_co
     reload_minigraph_with_golden_config, file_exists_on_dut, compare_dicts_ignore_list_order, \
     NON_USER_CONFIG_TABLES
 
+# Tables known to be overriden in run-time config, which will appear different
+# if the golden config is overridden empty.
+GOLDEN_OVERRRIDDEN_TABLES = ["FEATURE", "PORT"]
+
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
 CONFIG_DB = "/etc/sonic/config_db.json"
@@ -98,7 +102,7 @@ def load_minigraph_with_golden_empty_input(duthost):
     # Test host running config override
     host_current_config = get_running_config(duthost)
     for table in initial_host_config:
-        if table in NON_USER_CONFIG_TABLES:
+        if table in NON_USER_CONFIG_TABLES or table in GOLDEN_OVERRRIDDEN_TABLES:
             continue
 
         if table == "ACL_TABLE":
@@ -112,7 +116,7 @@ def load_minigraph_with_golden_empty_input(duthost):
     # Test asic0 running config override
     asic0_current_config = get_running_config(duthost, "asic0")
     for table in initial_asic0_config:
-        if table in NON_USER_CONFIG_TABLES:
+        if table in NON_USER_CONFIG_TABLES or table in GOLDEN_OVERRRIDDEN_TABLES:
             continue
 
         if table == "ACL_TABLE":

--- a/tests/override_config_table/test_override_config_table_masic.py
+++ b/tests/override_config_table/test_override_config_table_masic.py
@@ -6,7 +6,8 @@ from tests.common.utilities import skip_release
 from tests.common.utilities import update_pfcwd_default_state
 from tests.common.config_reload import config_reload
 from tests.common.utilities import backup_config, restore_config, get_running_config,\
-    reload_minigraph_with_golden_config, file_exists_on_dut, NON_USER_CONFIG_TABLES
+    reload_minigraph_with_golden_config, file_exists_on_dut, compare_dicts_ignore_list_order, \
+    NON_USER_CONFIG_TABLES
 
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"
 GOLDEN_CONFIG_BACKUP = "/etc/sonic/golden_config_db.json_before_override"
@@ -89,6 +90,9 @@ def load_minigraph_with_golden_empty_input(duthost):
     initial_asic0_config = get_running_config(duthost, "asic0")
 
     empty_input = {}
+
+    problem_tuples = []
+
     reload_minigraph_with_golden_config(duthost, empty_input)
 
     # Test host running config override
@@ -96,20 +100,30 @@ def load_minigraph_with_golden_empty_input(duthost):
     for table in initial_host_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
-        pytest_assert(
-            initial_host_config[table] == host_current_config[table],
-            "empty input compare fail! {}".format(table)
-        )
+
+        if table == "ACL_TABLE":
+            if not compare_dicts_ignore_list_order(initial_host_config[table],
+                                                   host_current_config[table]):
+                problem_tuples.append((table, None))
+        else:
+            if not initial_host_config[table] == host_current_config[table]:
+                problem_tuples.append((table, None))
 
     # Test asic0 running config override
     asic0_current_config = get_running_config(duthost, "asic0")
     for table in initial_asic0_config:
         if table in NON_USER_CONFIG_TABLES:
             continue
-        pytest_assert(
-            initial_asic0_config[table] == asic0_current_config[table],
-            "empty input compare fail! {}".format(table)
-        )
+
+        if table == "ACL_TABLE":
+            if not compare_dicts_ignore_list_order(initial_asic0_config[table],
+                                                   asic0_current_config[table]):
+                problem_tuples.append((table, "asic0"))
+        else:
+            if not initial_asic0_config[table] == asic0_current_config[table]:
+                problem_tuples.append((table, "asic0"))
+
+    pytest_assert(not problem_tuples, "empty input compare fail: {}".format(problem_tuples))
 
 
 def load_minigraph_with_golden_partial_config(duthost):


### PR DESCRIPTION
### Description of PR

This PR gets two test cases working, which fail due to finding a discrepancy
in two tables.

The fix is to ignore the FEATURE and PORT tables in the test, which
have some run-time configuration state that is altered when the golden
config is overridden empty. FEATURE is missing the "BMP" node, and
records in PORT are missing "fec" : "rs" fields.

The first commit in the PR is an improvement in the diagnostic that occurs
when these tests fail due to a configuration discrepancy. Rather than stopping
on the first discrepancy (non-matching configuration table), all mismatches
are identified, and reported in a single exception.

Fixes #26027

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X ] 202505
- [X ] 202511
- [X ] 202605

#### How did you verify/test it?

Failing tests went green on LT2 and FT2 DUTs in our test bed, without regressions in numerous other duts.
