### PR TITLE
Add pytest.mark.disable_route_check to static route tests

### DIFF
--- a/tests/generic_config_updater/test_static_route.py
+++ b/tests/generic_config_updater/test_static_route.py
@@ -9,6 +9,7 @@ from tests.common.gu_utils import format_json_patch_for_multiasic
 
 pytestmark = [
     pytest.mark.topology('any'),
+    pytest.mark.disable_route_check,
 ]
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

**Summary:**
Add `pytest.mark.disable_route_check` to the generic config updater static route tests so the route-check service is not run for these tests. This avoids failures from routeCheck during teardown/rollback (e.g. on multi-ASIC) that are expected and do not affect the DUT, and matches the pattern used by other GCU tests that change routing state.

- Static route tests add/update/remove routes and use checkpoint rollback. During rollback, route convergence can briefly make routeCheck fail; those failures are logged but are not real test failures.
- Marking the module with `disable_route_check` skips the route-check validation for these tests and prevents those expected convergence-related failures from failing the run.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
