### PR TITLE
adding 8223 platforms to the watchdog.yaml file

### DIFF
--- a/tests/platform_tests/api/watchdog.yml
+++ b/tests/platform_tests/api/watchdog.yml
@@ -211,6 +211,18 @@ x86_64-8102_28fh_dpu_o-r0:
     greater_timeout: 6553
     too_big_timeout: 6554
 
+x86_64-8223_64e_mo-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
+x86_64-8223_64ef_mo-r0:
+  default:
+    valid_timeout: 10
+    greater_timeout: 6553
+    too_big_timeout: 6554
+
 # Nexthop watchdog
 x86_64-nexthop_.*:
   default:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Adding Cisco 8223-64e* platforms to platform_tests/api/watchdog.yml file. This is needed for testcase platform_tests/api/test_watchdog.py

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Adding Cisco 8223-64e* platforms to platform_tests/api/watchdog.yml file. This is needed for testcase platform_tests/api/test_watchdog.py

#### How did you do it?

#### How did you verify/test it?
Testcase passed on Cisco 8223-64e* platforms after adding platform details in platform_tests/api/watchdog.yml file

```
platform_tests/api/test_watchdog.py:18
  /data/tests/platform_tests/api/test_watchdog.py:18: PytestUnknownMarkWarning: Unknown pytest.mark.disable_memory_utilization - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.mark.disable_memory_utilization,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------------------- generated xml file: /run_logs/t2-watchdog-arm/platform_tests/api/test_watchdog_2026-03-03-05-47-31.xml ----------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------
03/03/2026 05:49:52 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
================================================================================== 7 passed, 2 warnings in 140.06s (0:02:20) ==================================================================================
sonic@sonic-TTAN-ucs-m6-41:/data/tests$                                                                                                
```

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
