### PR TITLE
[SmartSwitch] Update the get_mgmt_ip for DPU

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -3373,6 +3373,11 @@ print(device_prefix)
         Gets the management IP address (v4 or v6) on eth0.
         Defaults to IPv4 on a dual stack configuration.
         """
+        # For SmartSwitch DPU, the exposed mgmt IP is the switch mgmt IP with a NAT port
+        # And it's IPv4 only
+        if self.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_dpu"):
+            return {"mgmt_ip": self.mgmt_ip, "version": "v4"}
+
         ipv4_regex = re.compile(r"(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/\d+")
         ipv6_regex = re.compile(r"([a-fA-F0-9:]+)/\d+")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When test runs on a SmartSwitch DPU(with the DPU host as the host-pattern in the pytest command), the exposed mgmt interface is the switch mgmt IP with a NAT port. And it's IPv4 only for now.
So we need return the switch IP directly instead of getting the IP of "eth0"(which also not exist in a DPU).
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Update the get_mgmt_ip in sonic host for SmartSwitch DPU
#### How did you do it?
Return the switch IP directly when it's DPU.
#### How did you verify/test it?
Run the test platform_tests/api/test_watchdog.py on a DPU host-pattern, all passed.
#### Any platform specific information?
Only for smartswitch
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
