### PR TITLE
dualtor: fix UnboundLocalError in setup_faulted_y_cable_driver teardown

### DIFF
--- a/tests/dualtor/test_switchover_faulty_ycable.py
+++ b/tests/dualtor/test_switchover_faulty_ycable.py
@@ -44,6 +44,7 @@ def simulated_good_side(rand_selected_dut):
 @contextlib.contextmanager
 def setup_faulted_y_cable_driver(duthost, simulate_probe_unknown=False, simulate_peer_link_down=False):
     """Setup the faulted Y cable driver on the active ToR."""
+    y_cable_simulated_path = None
     try:
         extra_vars = {
             "SIMULATE_PROBE_UNKNOWN": simulate_probe_unknown,
@@ -74,11 +75,12 @@ def setup_faulted_y_cable_driver(duthost, simulate_probe_unknown=False, simulate
         time.sleep(10)
         yield
     finally:
-        duthost.shell(
-            "docker exec pmon mv {path}/y_cable_simulated.py.orig {path}/y_cable_simulated.py".format(
-                path=y_cable_simulated_path
+        if y_cable_simulated_path:
+            duthost.shell(
+                "docker exec pmon mv {path}/y_cable_simulated.py.orig {path}/y_cable_simulated.py".format(
+                    path=y_cable_simulated_path
+                )
             )
-        )
         duthost.shell(
             "docker exec pmon supervisorctl restart ycabled")
         # Sleep 10 seconds for ycabled restart


### PR DESCRIPTION
### Description of PR

Summary:
Fix `UnboundLocalError: local variable 'y_cable_simulated_path' referenced before assignment` in `setup_faulted_y_cable_driver` teardown.

In `setup_faulted_y_cable_driver`, `y_cable_simulated_path` is only assigned inside the `try` block after both the `find` and `stat` commands succeed. If `stat` raises before the assignment, execution jumps to the `finally` block where `y_cable_simulated_path` is referenced — causing an `UnboundLocalError` that masks the original exception.

**Observed failure (ADO#36386419):**
```
cmd    = docker exec pmon find / -name y_cable_simulated.py
rc     = 1  (find hit stale /proc entry)
stdout = /usr/local/.../y_cable_simulated.py
stderr = find: '/proc/83905': No such file or directory

UnboundLocalError: local variable 'y_cable_simulated_path' referenced before assignment
```

Fix:
1. Initialize `y_cable_simulated_path = None` before the `try` block.
2. Guard the `mv` restore in `finally` with `if y_cable_simulated_path:` — skips restore only when setup never located and backed up the file. The `ycabled` restart remains unconditional.

Fixes ADO#36386419

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?
`setup_faulted_y_cable_driver` can raise `UnboundLocalError` during teardown when the `find` command returns RC=1 (e.g. due to stale `/proc` entries) before `y_cable_simulated_path` is assigned, masking the real failure and leaving the DUT in a broken state.

- Microsoft ADO **(number only)**: 36386419

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Initialized `y_cable_simulated_path = None` before the `try` block and added an `if y_cable_simulated_path:` guard around the `mv` restore command in `finally`.

#### How did you verify/test it?
Analyzed the failure from ElasticTest logs (ADO#36386419) and traced through the code path. The fix follows the standard Python pattern for safe `finally` cleanup when a variable may not be assigned.

#### Any platform specific information?
Observed on Arista-7050CX3-32S-C32 with dualtor topology.

#### Supported testbed topology if it's a new test case?
N/A (bug fix)

### Documentation
N/A
