### PR TITLE
Fix testbed deadlock from fork in threads

### DIFF
--- a/tests/common/plugins/sanity_check/__init__.py
+++ b/tests/common/plugins/sanity_check/__init__.py
@@ -7,7 +7,6 @@ import pytest
 
 from collections import defaultdict
 
-from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.helpers.parallel_utils import ParallelCoordinator, ParallelStatus
 from tests.common.plugins.sanity_check import constants
 from tests.common.plugins.sanity_check import checks
@@ -110,9 +109,8 @@ def print_logs(duthosts, ptfhost, print_dual_tor_logs=False, check_ptf_mgmt=True
             outputs.append(res)
         logger.info("dut={}, cmd_outputs={}".format(dut.hostname, json.dumps(outputs, indent=4)))
 
-    with SafeThreadPoolExecutor(max_workers=8) as executor:
-        for duthost in duthosts:
-            executor.submit(print_cmds_output_from_duthost, duthost, print_dual_tor_logs, ptfhost)
+    for duthost in duthosts:
+        print_cmds_output_from_duthost(duthost, print_dual_tor_logs, ptfhost)
 
 
 def filter_check_items(tbinfo, duthosts, check_items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2944,9 +2944,8 @@ def core_dump_and_config_check(duthosts, tbinfo, parallel_run_context, request,
                             json.loads(dut.shell("cat /etc/sonic/running_golden_config{}.json".format(asic_index),
                                                  verbose=False)['stdout'])
 
-            with SafeThreadPoolExecutor(max_workers=8) as executor:
-                for duthost in duthosts:
-                    executor.submit(collect_before_test, duthost)
+            for duthost in duthosts:
+                collect_before_test(duthost)
 
         if par_ctx.is_par_run and par_ctx.is_par_leader:
             parallel_coordinator.set_new_status(
@@ -3017,9 +3016,8 @@ def core_dump_and_config_check(duthosts, tbinfo, parallel_run_context, request,
                             json.loads(dut.shell("sonic-cfggen -n {} -d --print-data".format(asic_ns),
                                                  verbose=False)['stdout'])
 
-            with SafeThreadPoolExecutor(max_workers=8) as executor:
-                for duthost in duthosts:
-                    executor.submit(collect_after_test, duthost)
+            for duthost in duthosts:
+                collect_after_test(duthost)
 
             for duthost in duthosts:
                 if new_core_dumps[duthost.hostname]:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fixes deadlock observed in a few servers  where tests would hang indefinitely. Root cause was fork() being called within
thread context via SafeThreadPoolExecutor, causing child processes to inherit locked import mutex that could never be released (orphan lock scenario). This is more prevalent in DualToR scenarios where shell commands run in parallel across two threads.

#### How did you do it?
Solution serializes collect_before_test, collect_after_test, and print_logs operations to eliminate fork within threading context.

#### How did you verify/test it?
Tested on Arista-7050CX3 running dualtor-aa topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
