### PR TITLE
Increase timeout for announce routes in bgp/test_seq_idf_isolation.py

### DIFF
--- a/tests/bgp/test_seq_idf_isolation.py
+++ b/tests/bgp/test_seq_idf_isolation.py
@@ -217,7 +217,7 @@ def test_idf_isolation_no_export_with_config_reload(rand_one_downlink_duthost,
         cur_v4_routes = {}
         cur_v6_routes = {}
         # Verify that all routes advertised to neighbor at the start of the test
-        if not wait_until(600, 3, 0, verify_current_routes_announced_to_neighs,
+        if not wait_until(1000, 3, 0, verify_current_routes_announced_to_neighs,
                           duthost, nbrs, orig_v4_routes, cur_v4_routes, 4, exp_community):
             if not check_and_log_routes_diff(duthost, nbrs, orig_v4_routes, cur_v4_routes, 4):
                 pytest.fail("Not all ipv4 routes are announced to neighbors")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202503
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
We were seeing failures in this test due to a timeout.

#### How did you do it?
Increasing the timeout reduced the number of failures.

#### How did you verify/test it?
Verified the failure went away when manually running the test. Verified the test pass rate went up after the change merged.

#### Any platform specific information?
This was only required for the lt2-o128 topo

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
