### PR TITLE
[everflow][202511] Skip tests when ASIC does not support bidirectional port mirroring

### DIFF
--- a/tests/everflow/conftest.py
+++ b/tests/everflow/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def everflow_capabilities(duthosts):
+    """Collect switch capability facts once for Everflow tests.
+
+    Returns:
+        dict: hostname -> switch capability dict (STATE_DB switch_capabilities)
+    """
+    caps = {}
+    for dut in duthosts:
+        facts = dut.switch_capabilities_facts()
+        switch_caps = (facts
+                       .get("ansible_facts", {})
+                       .get("switch_capabilities", {})
+                       .get("switch", {}))
+        caps[dut.hostname] = switch_caps
+    return caps

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -28,6 +28,8 @@ from tests.common.dualtor.dual_tor_common import mux_config              # noqa:
 from tests.common.helpers.sonic_db import AsicDbCli
 import json
 
+logger = logging.getLogger(__name__)
+
 # TODO: Add suport for CONFIGLET mode
 CONFIG_MODE_CLI = "cli"
 CONFIG_MODE_CONFIGLET = "configlet"
@@ -674,7 +676,7 @@ class BaseEverflowTest(object):
         return duthost_set
 
     @pytest.fixture(scope="class")
-    def setup_mirror_session(self, config_method, setup_info, erspan_ip_ver):
+    def setup_mirror_session(self, config_method, setup_info, erspan_ip_ver, everflow_capabilities):
         """
         Set up a mirror session for Everflow.
 
@@ -695,6 +697,24 @@ class BaseEverflowTest(object):
             if duthost.facts['platform'] in ('x86_64-arista_7260cx3_64', 'x86_64-arista_7060_cx32s') and erspan_ip_ver == 6: # noqa E501
                 pytest.skip("Skip IPv6 mirror session on unsupported platforms")
 
+            # Skip if the ASIC does not support bidirectional port mirroring (issue #22661).
+            # The CLI defaults to direction='both' when no direction is specified,
+            # which requires both PORT_INGRESS_MIRROR_CAPABLE and PORT_EGRESS_MIRROR_CAPABLE.
+            # Default to "false" when keys are absent — this matches the CLI behavior in
+            # sonic-utilities (config/main.py is_port_mirror_capability_supported) which
+            # reads STATE_DB directly and rejects when keys are missing.
+            if config_method == CONFIG_MODE_CLI:
+                switch_caps = everflow_capabilities.get(duthost.hostname, {})
+                ingress_capable = switch_caps.get("PORT_INGRESS_MIRROR_CAPABLE", "false")
+                egress_capable = switch_caps.get("PORT_EGRESS_MIRROR_CAPABLE", "false")
+                mirror_type = self.mirror_type()
+                if mirror_type == "ingress" and ingress_capable != "true":
+                    pytest.skip("ASIC does not support ingress port mirroring")
+                elif mirror_type == "egress" and egress_capable != "true":
+                    pytest.skip("ASIC does not support egress port mirroring")
+                elif mirror_type == "both" and (ingress_capable != "true" or egress_capable != "true"):
+                    pytest.skip("ASIC does not support bidirectional port mirroring")
+
             BaseEverflowTest.apply_mirror_config(duthost, session_info, config_method, erspan_ip_ver=erspan_ip_ver)
 
         yield session_info
@@ -703,7 +723,7 @@ class BaseEverflowTest(object):
             BaseEverflowTest.remove_mirror_config(duthost, session_info["session_name"], config_method)
 
     @pytest.fixture(scope="class")
-    def policer_mirror_session(self, config_method, setup_info, erspan_ip_ver):
+    def policer_mirror_session(self, config_method, setup_info, erspan_ip_ver, everflow_capabilities):
         """
         Set up a mirror session with a policer for Everflow.
 
@@ -722,6 +742,20 @@ class BaseEverflowTest(object):
         for duthost in duthost_set:
             if not session_info:
                 session_info = BaseEverflowTest.mirror_session_info("TEST_POLICER_SESSION", duthost.facts["asic_type"])
+
+            # Skip if the ASIC does not support bidirectional port mirroring (issue #22661).
+            if config_method == CONFIG_MODE_CLI:
+                switch_caps = everflow_capabilities.get(duthost.hostname, {})
+                ingress_capable = switch_caps.get("PORT_INGRESS_MIRROR_CAPABLE", "false")
+                egress_capable = switch_caps.get("PORT_EGRESS_MIRROR_CAPABLE", "false")
+                mirror_type = self.mirror_type()
+                if mirror_type == "ingress" and ingress_capable != "true":
+                    pytest.skip("ASIC does not support ingress port mirroring")
+                elif mirror_type == "egress" and egress_capable != "true":
+                    pytest.skip("ASIC does not support egress port mirroring")
+                elif mirror_type == "both" and (ingress_capable != "true" or egress_capable != "true"):
+                    pytest.skip("ASIC does not support bidirectional port mirroring")
+
             # Create a policer that allows 100 packets/sec through
             self.apply_policer_config(duthost, policer, config_method)
             BaseEverflowTest.apply_mirror_config(duthost, session_info, config_method, policer=policer,


### PR DESCRIPTION
## What is the motivation for this PR?

Cherry-pick of #22663 for the 202511 branch.

The everflow tests fail on ASICs that do not support bidirectional port mirroring. When `config mirror_session add` is called without an explicit `--direction` flag, SONiC defaults to `both`, which requires both `PORT_INGRESS_MIRROR_CAPABLE` and `PORT_EGRESS_MIRROR_CAPABLE` to be `true` in `STATE_DB SWITCH_CAPABILITY|switch`. On ASICs that don't support both directions, the command fails with:
```
Error: Port mirror direction 'both' is not supported by the ASIC
```
This causes test failures unrelated to the test logic itself.

Fixes #22661

## How did you do it?

Added a capability check in the `setup_mirror_session` and `policer_mirror_session` fixtures in `everflow_test_utilities.py`. Before attempting to create a mirror session via CLI, the fixtures now query `switch_capabilities_facts` for `PORT_INGRESS_MIRROR_CAPABLE` and `PORT_EGRESS_MIRROR_CAPABLE`. If either capability is not `true`, the test is skipped with a descriptive message.

The check is only applied for `CONFIG_MODE_CLI` since the direct DB write path (used for IPv6 ERSPAN) bypasses the CLI validation.

## How did you verify/test it?

- Code review of SONiC's `config/main.py` confirms `is_port_mirror_capability_supported()` checks these exact fields when direction is `None` (defaults to 'both')
- The skip message includes actual capability values for debugging
- Existing tests on platforms that support bidirectional mirroring are unaffected (capabilities default to `true` when not present in STATE_DB)
- Master version merged as #22663

Signed-off-by: Ying Xie <ying.xie@microsoft.com>