### PR TITLE
Fix pfcwd storm detection regex to handle integer timestamps

### DIFF
--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -20,8 +20,8 @@ EXPECT_PFC_WD_DETECT_RE = ".* detected PFC storm .*"
 VENDOR_SPEC_ADDITIONAL_INFO_RE = {
     "mellanox":
         r"additional info: occupancy:[0-9]+\|packets:[0-9]+\|packets_last:[0-9]+\|pfc_rx_packets:[0-9]+\|"
-        r"pfc_rx_packets_last:[0-9]+\|pfc_duration:[0-9]+\|pfc_duration_last:[0-9]+\|timestamp:[0-9]+(\.[0-9]+)?\|"
-        r"timestamp_last:[0-9]+(\.[0-9]+)?\|(effective|real)_poll_time:[0-9]+(\.[0-9]+)?"
+        r"pfc_rx_packets_last:[0-9]+\|pfc_duration:[0-9]+\|pfc_duration_last:[0-9]+\|timestamp:[0-9]+(?:\.[0-9]+)?\|"
+        r"timestamp_last:[0-9]+(?:\.[0-9]+)?\|(?:effective|real)_poll_time:[0-9]+(?:\.[0-9]+)?"
     }
 
 EXPECT_PFC_WD_RESTORE_RE = ".*storm restored.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Make the decimal portion optional in the Mellanox `VENDOR_SPEC_ADDITIONAL_INFO_RE` regex (`[0-9]+\.[0-9]+` → `[0-9]+(\.[0-9]+)?`) so that pfcwd storm detection matches syslog entries with integer timestamps, fixing intermittent `test_all_port_storm_restore` failures.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

test_all_port_storm_restore intermittently fails with LogAnalyzerError: expected_missing_match: 1 even though the "detected PFC storm" message is present in syslog. The root cause is that the Mellanox pfcwd Lua script uses Lua tostring() (which formats with %.14g) to convert timestamps. When the Redis TIME command returns exactly zero microseconds, the resulting epoch timestamp has no decimal point (e.g., 1772217108 instead of 1772217108.3768). The test regex requires a mandatory decimal point in timestamp and timestamp_last fields, so it fails to match.

#### How did you do it?

Made the decimal portion optional in the VENDOR_SPEC_ADDITIONAL_INFO_RE regex for the timestamp and timestamp_last fields by changing [0-9]+\.[0-9]+ to [0-9]+(\.[0-9]+)?.

#### How did you verify/test it?

Verified the updated regex matches both the failing syslog message (integer timestamp_last:1772217108) and normal syslog messages (decimal timestamp_last:1772214961.0663).

#### Any platform specific information?

Mellanox only. The VENDOR_SPEC_ADDITIONAL_INFO_RE regex is specific to the mellanox ASIC typ

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
