### PR TITLE
[infra][parallel] Fix "cannot release un-acquired lock" error

### DIFF
--- a/tests/common/helpers/parallel.py
+++ b/tests/common/helpers/parallel.py
@@ -39,11 +39,11 @@ _forked_handlers = set()
 _forked_handlers_lock = threading.Lock()
 os.register_at_fork(before=logging._acquireLock,
                     after_in_parent=logging._releaseLock,
-                    after_in_child=logging._releaseLock)
+                    after_in_child=logging._lock._at_fork_reinit)
 display = ansible.utils.display.Display()
 os.register_at_fork(before=display._lock.acquire,
                     after_in_parent=display._lock.release,
-                    after_in_child=display._lock.release)
+                    after_in_child=display._lock._at_fork_reinit)
 
 
 def fix_logging_handler_fork_lock():
@@ -60,7 +60,7 @@ def fix_logging_handler_fork_lock():
             if handler not in _forked_handlers and handler.lock is not None:
                 os.register_at_fork(before=handler.lock.acquire,
                                     after_in_parent=handler.lock.release,
-                                    after_in_child=handler.lock.release)
+                                    after_in_child=handler.lock._at_fork_reinit)
                 new_handlers.append(handler)
                 _forked_handlers.add(handler)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix the upgrade image script lock release error:

```
2026-03-01 07:55:44,890 ansible_hosts.py#444 DEBUG - /var/src/sonic-mgmt_testbed-bjw2-can-dual-t0-7050-1/ansible/../.azure-pipelines/upgrade_image.py::main#94: "localhost" -> AnsibleModule::conn_graph_facts, {"module_name": "conn_graph_facts", "args": [], "kwargs": {"hosts": ["bjw2-can-7050-3", "bjw2-can-7050-4"], "filepath": "/var/src/sonic-mgmt_testbed-bjw2-can-dual-t0-7050-1/ansible/files"}, "module_attrs": {}}
Exception ignored in: <function _releaseLock at 0x7fd2cfd3a7a0>
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 248, in _releaseLock
    _lock.release()
RuntimeError: cannot release un-acquired lock
```

* Root cause:
The issue is due to that, in the child process, after fork, the logging global lock is reinit first by `_after_at_fork_child_reinit_locks` then released by `_releaseLock`; the error is from the release on a reinitialized unlocked lock.
And `_releaseLock` is registerd in sonic-mgmt.

```
Registering at fork handlers: (), {'before': <function _acquireLock at 0x7fbb09f0a7a0>, 'after_in_child': <function _after_at_fork_child_reinit_locks at 0x7fbb09f0aa20>, 'after_in_parent': <function _releaseLock at 0x7fbb09f0a840>}
Registering at fork handlers: (), {'before': <function _acquireLock at 0x7fbb09f0a7a0>, 'after_in_parent': <function _releaseLock at 0x7fbb09f0a840>, 'after_in_child': <function _releaseLock at 0x7fbb09f0a840>}
```
Microsoft ADO (number only): 36996371


#### How did you do it?
Let's use the same approach to reinit the lock.

#### How did you verify/test it?
Run image upgrade script.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
