### PR TITLE
fix for memory_utilization ALARM log when memory utilization threshold is configured as percentage.

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -319,7 +319,6 @@ class MemoryMonitor:
                     break
 
         if is_increase:
-            val_str, th_str = format_threshold_and_value(threshold, value)
             # For percentage threshold, display actual % increase; otherwise display raw increase (e.g. MB)
             prev_f = float(prev_val)
             if threshold_type == 'percentage' and prev_f > 0:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #22719 

File - tests/common/plugins/memory_utilization/memory_utilization.py

Relevant code:
```
                if increase > increase_threshold:
                    self._handle_memory_threshold_exceeded(
                        name, mem_item, increase, increase_threshold_raw,
                        previous_values, current_values, is_increase=True
                    )
```

```
        if is_increase:
            val_str, th_str = format_threshold_and_value(threshold, value)
            message = (
                "[ALARM]: {}:{} memory usage increased by {}, exceeds increase threshold {} (previous: {}, current: {})"
                .format(name, mem_item, val_str, th_str, fmt(prev_val, threshold_type), fmt(curr_val, threshold_type))
            )
```

```
        def format_threshold_and_value(threshold, value):
            if isinstance(threshold, dict) and 'type' in threshold:
                threshold_type = threshold['type']
                if threshold_type == 'percentage':
                    return f"{value:.1f}%", f"{threshold['value']}%"
                elif threshold_type == 'percentage_points':
                    return f"{value:.1f}%", f"{threshold['value']}%"
                else:  # 'value' type
                    return fmt(value), fmt(float(threshold['value']))
            elif isinstance(threshold, list):
                for t in threshold:
                    if isinstance(t, dict) and 'type' in t:
                        return format_threshold_and_value(t, value)
                return str(value), str(threshold)
            else:
                return fmt(value), str(threshold)
```
In memory_utilization_dependence.json:
```
    {
      "name": "free",
      "cmd": "free -m",
      "memory_params": {
        "used": {
          "memory_increase_threshold": {
            "type": "percentage",
            "value": "20%"
          },
          "memory_high_threshold": null
        }
      },
      "memory_check": "parse_free_output"
    },
```

Issue:
Here value is the raw increase in MB (current_value - previous_value), e.g. 50 (MB).
- If the increase threshold is percentage (e.g. “max 10% increase”), format_threshold_and_value will treat that number as a percentage and format it as "50%".
- The alarm would say something like: “memory usage increased by 50%, exceeds increase threshold 10%” even when the real increase was 50 MB, which might be only 10% of the previous value.

For percentage increase thresholds, the existing code is:
- Using absolute increase (MB) as if it were percentage.
- Showing a wrong “increased by X%” in the message (e.g. 50% instead of 10%).

@rawal01 , @vmittal-msft , @sdszhang for review.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The ALARM showed wrong info when threshold type is percentage. It computes the difference between current value and previous value and shows it as percentage, if the threshold type is percentage.

Percentage threshold: display_value = actual % increase → message shows correct “increased by X%”.
Absolute (value) threshold: display_value = raw increase in MB → message shows “increased by X MB”.
The bug was: for percentage increase thresholds, the before code passed the raw MB increase to format_threshold_and_value, hence the alarm shows a wrong “increased by” value (e.g. 50% instead of the real percentage).

The fix is to pass the computed percentage when threshold_type == 'percentage', and the raw value otherwise.

#### How did you do it?
If the type is percentage, then computes percentage increase in utilization and displays ALARM. If type is value, then existing code is used:

```
            val_str, th_str = format_threshold_and_value(threshold, value)
            # For percentage threshold, display actual % increase; otherwise display raw increase (e.g. MB)
            prev_f = float(prev_val)
            if threshold_type == 'percentage' and prev_f > 0:
                display_value = (float(curr_val) - prev_f) / prev_f * 100
            else:
                display_value = value
            val_str, th_str = format_threshold_and_value(threshold, display_value)
            message = (
                "[ALARM]: {}:{} memory usage increased by {}, exceeds increase threshold {} (previous: {}, current: {})"
                .format(name, mem_item, val_str, th_str, fmt(prev_val, threshold_type), fmt(curr_val, threshold_type))
            )
```
#### How did you verify/test it?
Tested it on local master repo

Previous alarm:
```
['[ALARM]: free:used memory usage increased by 877.0%, exceeds increase threshold 20%% (previous: 3555.0 MB, current: 4432.0 MB)']
```

With the fix:
```
[ALARM]: free:used memory usage increased by 22.8%, exceeds increase threshold 20%% (previous: 3498.0 MB, current: 4297.0 MB)
```
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
