### PR TITLE
Don't wait for ACL rules with Broadcom ASICs

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -996,7 +996,7 @@ class BaseEverflowTest(object):
         duthost.template(src=os.path.join(FILE_DIR, rule_file), dest=dest_path)
         duthost.shell("config load -y {}".format(dest_path))
 
-        if duthost.facts['asic_type'] != 'vs':
+        if duthost.facts['asic_type'] not in ['vs', 'broadcom']:
             pytest_assert(wait_until(60, 2, 0, self.check_rule_active, duthost, table_name),
                           "Acl rule counters are not ready")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
With Broadcom ASICs, don't wait for the ACL rule counters to change from 'N/A' to 0 since it isn't needed (and will cause the test to time out and fail).

Backport of https://github.com/sonic-net/sonic-mgmt/pull/22555 to fix merge conflicts.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement
