### PR TITLE
Fix for ASN path number verification on DUT

### DIFF
--- a/tests/bgp/test_4-byte_asn_community.py
+++ b/tests/bgp/test_4-byte_asn_community.py
@@ -183,6 +183,15 @@ def check_bgp_neighbor(duthost, bgp_neighbors):
     )
 
 
+def dut_bgp_routes_table_body(output):
+    """Return only the route table body (lines after 'Network ... Path' header)"""
+    lines = output.split('\n')
+    for i, line in enumerate(lines):
+        if 'Network' in line and 'Path' in line:
+            return '\n'.join(lines[i + 1:])
+    return output
+
+
 def setup_ceos(tbinfo, nbrhosts, duthosts, enum_frontend_dut_hostname, enum_rand_one_frontend_asic_index, request):
     duthost = duthosts[enum_frontend_dut_hostname]
     asic_index = enum_rand_one_frontend_asic_index
@@ -493,14 +502,12 @@ def run_bgp_4_byte_asn_community_sonic(setup):
     output = setup['duthost'].shell("show ipv6 bgp summary | grep {}".format(setup['neigh_ip_v6'].lower()))['stdout']
     assert str(neighbor_4byte_asn) in output.split()[2]
     output = setup['duthost'].shell("show ip bgp neighbors {} routes".format(setup['neigh_ip_v4']))['stdout']
-    assert str(neighbor_4byte_asn) in str(output.split('\n')[9].split()[5])
+    assert str(neighbor_4byte_asn) in dut_bgp_routes_table_body(output), \
+        ("ASN {} not found in routes table".format(neighbor_4byte_asn))
     output = setup['duthost'].shell("show ipv6 bgp neighbors {} routes".format(setup['neigh_ip_v6'].lower()))['stdout']
-    # Command output 'show ipv6 bgp neighbors <xxx> routes'  may split into two lines, hence checking both the lines
-    #    Network          Next Hop             Metric LocPrf Weight Path
-    # *> 2064:100::1/128  fe80::4cc2:44ff:feee:73ff
-    #                                                       0 400001 i
-    assert (str(neighbor_4byte_asn) in str(output.split('\n')[9]) or
-            str(neighbor_4byte_asn) in str(output.split('\n')[10]))
+    # Path column may wrap to next line; assert ASN in table body only (avoids matching 'local AS' in header)
+    assert str(neighbor_4byte_asn) in dut_bgp_routes_table_body(output), \
+        ("ASN {} not found in routes table".format(neighbor_4byte_asn))
 
     output = setup['neighhost'].shell("show ip bgp summary | grep {}".format(setup['dut_ip_v4']))['stdout']
     assert str(dut_4byte_asn) in output.split()[2]
@@ -550,14 +557,11 @@ def run_bgp_4_byte_asn_community_eos(setup):
     output = setup['duthost'].shell("show ipv6 bgp summary | grep {}".format(setup['neigh_ip_v6'].lower()))['stdout']
     assert str(neighbor_4byte_asn) in output.split()[2]
     output = setup['duthost'].shell("show ip bgp neighbors {} routes".format(setup['neigh_ip_v4']))['stdout']
-    assert str(neighbor_4byte_asn) in str(output.split('\n')[9])
+    assert str(neighbor_4byte_asn) in dut_bgp_routes_table_body(output), \
+        ("ASN {} not found in routes table".format(neighbor_4byte_asn))
     output = setup['duthost'].shell("show ipv6 bgp neighbors {} routes".format(setup['neigh_ip_v6'].lower()))['stdout']
-    # show ipv6 bgp neighbors <xxx> routes  may split into two lines, hence checking both lines
-    #     Network          Next Hop            Metric LocPrf Weight Path
-    # *> 2064:100::1d/128 fe80::4059:38ff:feaa:82db
-    #                                                       0 400001 i
-    assert (str(neighbor_4byte_asn) in str(output.split('\n')[9]) or
-           str(neighbor_4byte_asn) in str(output.split('\n')[10]))
+    assert str(neighbor_4byte_asn) in dut_bgp_routes_table_body(output), (
+        "ASN {} not found in routes table".format(neighbor_4byte_asn))
 
     output = bgp_neigh.get_command_output("show ip bgp summary | include {}".format(setup['dut_ip_v4']))
     assert str(dut_4byte_asn) in output.split()[3]

--- a/tests/bgp/test_4-byte_asn_community.py
+++ b/tests/bgp/test_4-byte_asn_community.py
@@ -514,9 +514,11 @@ def run_bgp_4_byte_asn_community_sonic(setup):
     output = setup['neighhost'].shell("show ipv6 bgp summary | grep {}".format(setup['dut_ip_v6'].lower()))['stdout']
     assert str(dut_4byte_asn) in output.split()[2]
     output = setup['neighhost'].shell("show ip bgp neighbors {} routes".format(setup['dut_ip_v4']))['stdout']
-    assert str(dut_4byte_asn) in str(output.split('\n')[9].split()[5])
+    assert str(dut_4byte_asn) in dut_bgp_routes_table_body(output), (
+        "ASN {} not found in neighbor IPv4 routes table".format(dut_4byte_asn))
     output = setup['neighhost'].shell("show ipv6 bgp neighbors {} routes".format(setup['dut_ip_v6'].lower()))['stdout']
-    assert str(dut_4byte_asn) in str(output.split('\n')[9].split()[5])
+    assert str(dut_4byte_asn) in dut_bgp_routes_table_body(output), (
+        "ASN {} not found in neighbor IPv6 routes table".format(dut_4byte_asn))
 
 
 def run_bgp_4_byte_asn_community_eos(setup):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes '_test_4_byte_asn_community_' test for eos/sonic neighbors' case.
- The above test fails when asserting 'neighbor_4byte_asn' variable for '_show ipv6 neighbors xxxxx routes_' command output on sonic dut.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
"_show ipv6 neighbors xxxx routes_" command output on sonic dut, gives output in such a way that, neighbor ASN can either be on lines 9,10,11. For example,

```shell
BGP table version is 1, local router ID is 10.1.0.32, vrf id 0
\nDefault local pref 100, local AS 400003
\nStatus codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
\n               i internal, r RIB-failure, S Stale, R Removed
\nNexthop codes: @NNN nexthop's vrf id, < announce-nh-self
\nOrigin codes:  i - IGP, e - EGP, ? - incomplete
\nRPKI validation codes: V valid, I invalid, N Not found
\n
\n     Network          Next Hop            Metric LocPrf Weight Path
\n *>  2064:100:0:1::/128
\n                    fe80::18bb:9eff:fe3a:5ad8
\n                                                           0 400001 i
\n
\nDisplayed 1 routes and 2 total paths
```
```shell
BGP table version is 2, local router ID is 8.0.0.2, vrf id 0
\nDefault local pref 100, local AS 400003
\nStatus codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
\n               i internal, r RIB-failure, S Stale, R Removed
\nNexthop codes: @NNN nexthop's vrf id, < announce-nh-self
\nOrigin codes:  i - IGP, e - EGP, ? - incomplete
\nRPKI validation codes: V valid, I invalid, N Not found
\n
\n     Network          Next Hop            Metric LocPrf Weight Path
\n *>  2064:100::33/128 fe80::2496:bff:fe18:b8d9
\n                                                           0 400001 i
\n\
nDisplayed 1 routes and 2 total paths
``` 

#### How did you do it?

- Instead of asserting on specific line indices (e.g. output.split('\n')[9] or [10]), the test now checks that the expected ASN appears in the command output with assertion only looks at the table body (path column and any wrapped lines). 
- That works regardless of whether the Path column is on line 9, 10, or 11.

#### How did you verify/test it?

Ran the above test on T2/LT2 duts connected to both sonic and eos neighbors, made sure the tests are working as expected.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
