### PR TITLE
Add 1600G fanout FEC handling and extend test_force_speed with 800G/1.6T RS-FEC mapping

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202405.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202405.j2
@@ -19,7 +19,7 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
-    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "200000", "400000", "800000"] %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "200000", "400000", "800000", "1600000"] %}
             "fec" : "rs",
     {% endif %}
     {% if port_name in device_conn[inventory_hostname] %}

--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -22,7 +22,7 @@
     {% if fanout_hwsku == "Arista-720DT-G48S4" and (fanout_port_config[port_name]['lanes'] | int) <= 24 %}
             "autoneg": "on",
     {% endif %}
-    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "200000", "400000", "800000"] %}
+    {% if fanout_port_config[port_name]['speed'] | default('100000') in ["100000", "200000", "400000", "800000", "1600000"] %}
             "fec" : "rs",
     {% endif %}
     {% if port_name in device_conn[inventory_hostname] %}

--- a/tests/platform_tests/test_auto_negotiation.py
+++ b/tests/platform_tests/test_auto_negotiation.py
@@ -333,7 +333,9 @@ def test_force_speed(enum_speed_per_dutport_fixture):
         50000: 'fc',
         100000: 'rs',
         200000: 'rs',
-        400000: 'rs'
+        400000: 'rs',
+        800000: 'rs',
+        1600000: 'rs'
     }
 
     fec_mode = FEC_FOR_SPEED.get(int(speed))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

This PR is a combination of https://github.com/sonic-net/sonic-mgmt/pull/22669 and https://github.com/sonic-net/sonic-mgmt/pull/22654 to consolidate based on @bpar9's recommendation

When running add topo, the script does not add any value for fec if the fanout's port speed is greater than 800G. The `sonic_deploy_*.j2` files are only adding "fec" : "rs" when port speed is up to 800G. To support fanouts with 1600G port speed, we need to change the sonic_deploy_*.j2 files to use `"fec" : "rs"` for port speeds including 1600G.

The FEC_FOR_SPEED dict was missing entries for 800G and 1.6T port speeds. Both require RS-FEC per IEEE 802.3df (800G) and IEEE 802.3dj (1.6T). Without this, test_force_speed sets fec_mode=None for these speeds.
- 1.6T is not hardware-validated, but I included it with anticipation to support 1.6T

For example, when the test is running for 800G, the DUT and fanout will both have "none" for fec value.

The following outputs were taken prior to the PR https://github.com/sonic-net/sonic-mgmt/pull/23107. This PR originally was to support >=100G port speed up to 1600G.

**Test**
```
platform_tests/test_auto_negotiation.py::test_force_speed[switch1|Ethernet0|800000]
```

DUT & Fanout Ethernet0 status during test
```shell
sonic:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100   none     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
```

When the test completes, config reload resets DUT but fanout remains fec = none.
```shell
fanout:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100   none     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
```

Fixes Issue https://github.com/sonic-net/sonic-mgmt/issues/22653
Fixes Issue https://github.com/sonic-net/sonic-mgmt/issues/22667

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [] 202205
- [] 202305
- [] 202311
- [] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

When adding topo, I noticed that my fanout switch had `"N/A"` for its fec value. Tests such as those in [test_auto_negotiation.py](https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/test_auto_negotiation.py) will manually set fec values for the fanout switch, so this bug may have not been noticed.

When running `test_auto_negotiation.py` with 800G port speed, I noticed that the fec value was "none" instead of rs. 

#### How did you do it?

I added 1600G as a check for fanout port speed for fec : rs in sonic_deploy_*.j2.

I added `800000` and `1600000` to FEC_FOR_SPEED
```python
    FEC_FOR_SPEED = {
        25000: 'fc',
        50000: 'fc',
        100000: 'rs',
        200000: 'rs',
        400000: 'rs',
        800000: 'rs',
        1600000: 'rs'
    }
```

#### How did you verify/test it?

I tested this by deploying T0 and T1 topology for 800G port speed in the 202505 branch.

Run using sonic-mgmt T0 topology

**Test**
```
platform_tests/test_auto_negotiation.py::test_force_speed[switch1|Ethernet0|800000]
```

#### Any platform specific information?

Generic

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

## Old output for `show int status` for fanout with 800G port speed. 

```shell
admin@sonic:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100    N/A     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
  Ethernet8            8,9,10,11,12,13,14,15     800G   9100    N/A     Eth2   trunk      up       up  OSFP 8X Pluggable Transceiver         off
...
```

## New output for `show int status` for fanout with 800G port speed.
```shell
admin@sonic:~$ show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                           Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     800G   9100     rs     Eth1   trunk      up       up  OSFP 8X Pluggable Transceiver         off
  Ethernet8            8,9,10,11,12,13,14,15     800G   9100     rs     Eth2   trunk      up       up  OSFP 8X Pluggable Transceiver         off
...
```