### PR TITLE
[dualtor-aa] Fix pmon restart failure in deploy-mg

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -1017,10 +1017,22 @@
               var: grpc_secrets_after
 
           - name: restart the pmon service
-            service:
-              name: pmon
-              state: restarted
-            become: true
+            block:
+              - name: attempt to restart pmon service
+                service:
+                  name: pmon
+                  state: restarted
+                become: true
+            rescue:
+              - name: reset failed state for pmon service
+                command: systemctl reset-failed pmon.service
+                become: true
+
+              - name: start pmon service after reset
+                service:
+                  name: pmon
+                  state: started
+                become: true
 
           when: stat_result.stat.exists
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix the following pmon not running issue:
```
TASK [restart the pmon service] ************************************************
fatal: [bjw-can-7260-14]: FAILED! => {"changed": false, "msg": "Unable to start service pmon: Job for pmon.service failed because start of the service was attempted too often.\nSee \"systemctl status pmon.service\" and \"journalctl -xeu pmon.service\" for details.\nTo force a start use \"systemctl reset-failed pmon.service\"\nfollowed by \"systemctl start pmon.service\" again.\n"}
fatal: [bjw-can-7260-16]: FAILED! => {"changed": false, "msg": "Unable to start service pmon: Job for pmon.service failed because start of the service was attempted too often.\nSee \"systemctl status pmon.service\" and \"journalctl -xeu pmon.service\" for details.\nTo force a start use \"systemctl reset-failed pmon.service\"\nfollowed by \"systemctl start pmon.service\" again.\n"}
```
The restart pmon failure is due to the pmon is restart multiple times in the deploy-mg.

Microsoft ADO (number only): 36996343

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Add a rescue path, if the restart fails, reset the failure then start pmon.

#### How did you verify/test it?
Run again the same testbed and deploy-mg is finished:
```

TASK [attempt to restart pmon service] ***************************************************************************************************************************************************************************************************************************************
fatal: [bjw-can-7260-14]: FAILED! => {"changed": false, "msg": "Unable to restart service pmon: Job for pmon.service failed because start of the service was attempted too often.\nSee \"systemctl status pmon.service\" and \"journalctl -xeu pmon.service\" for details.\nTo force a start use \"systemctl reset-failed pmon.service\"\nfollowed by \"systemctl start pmon.service\" again.\n"}
changed: [bjw-can-7260-16]

TASK [reset failed state for pmon service] ***********************************************************************************************************************************************************************************************************************************
changed: [bjw-can-7260-14]

TASK [start pmon service after reset] ****************************************************************************************************************************************************************************************************************************************
changed: [bjw-can-7260-14]
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
