### PR TITLE
[Draft]Fix fwutil FPGA update cmd, no reboot is needed.

### DIFF
--- a/tests/platform_tests/fwutil/fwutil_common.py
+++ b/tests/platform_tests/fwutil/fwutil_common.py
@@ -76,6 +76,9 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
                      next_image=None, timeout=TIMEOUT, pdu_delay=60):
     hn = duthost.mgmt_ip
 
+    if not isinstance(component, str) or not component:
+        pytest.fail("Component is None or not a string")
+
     if boot_type != "none":
         if not auto_reboot:
             logger.info("Waiting on install to finish.")
@@ -96,29 +99,44 @@ def complete_install(duthost, localhost, boot_type, res, pdu_ctrl, component, au
         else:
             # For auto reboot scenario, it takes some time in ONIE to update the firmware
             logger.info("Waiting on switch to shutdown after auto reboot...")
-            if 'CPLD' in component or 'FPGA' in component:
-                # For CPLD/FPGA update, most time is spend before the reboot
-                pre_reboot_timeout = timeout
-                post_reboot_timeout = COMMON_REBOOT_TIMEOUT
+            if 'FPGA' in component:
+                # For FPGA update, no reboot is needed.
+                logger.info("Waiting for switch update result...")
+                res.get(timeout)
+                if res._value['failed']:
+                    pytest.fail(f"The component installation is not successful: {res._value}")
+                logger.info("FPGA update is successful")
             else:
-                # For BIOS/ONIE, most time is spend after the reboot in ONIE
-                pre_reboot_timeout = 120
-                if duthost.facts["platform"] == "x86_64-nvidia_sn4280-r0":
-                    pre_reboot_timeout += 240
-                post_reboot_timeout = timeout
-            localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=pre_reboot_timeout)
-            # Wait for 30s in case there is ssh flap
-            time.sleep(30)
-            logger.info("Waiting on switch to come up in SONiC....")
-            localhost.wait_for(
-                host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10, timeout=post_reboot_timeout)
+                if 'CPLD' in component:
+                    # For CPLD update, most time is spend before the reboot
+                    pre_reboot_timeout = timeout
+                    post_reboot_timeout = COMMON_REBOOT_TIMEOUT
+                else:
+                    # For BIOS/ONIE, most time is spend after the reboot in ONIE
+                    pre_reboot_timeout = 120
+                    if duthost.facts["platform"] == "x86_64-nvidia_sn4280-r0":
+                        pre_reboot_timeout += 240
+                    post_reboot_timeout = timeout
+                localhost.wait_for(host=hn, port=22, state='stopped', delay=1, timeout=pre_reboot_timeout)
+                # Wait for 30s in case there is ssh flap
+                time.sleep(30)
+                logger.info("Waiting on switch to come up in SONiC....")
+                localhost.wait_for(
+                    host=hn, port=22, state='started', search_regex=SONIC_SSH_REGEX, delay=10,
+                    timeout=post_reboot_timeout)
 
-        logger.info("Waiting for docker service to start")
-        pytest_assert(wait_until(300, 10, 0, duthost.is_host_service_running, "docker"),
-                      "Docker service failed to start")
-        logger.info("Waiting on critical systems to come online...")
-        wait_until(300, 30, 0, duthost.critical_services_fully_started)
-        time.sleep(60)
+        fpga_no_reboot = auto_reboot and 'FPGA' in component
+        reboot_occurred = not auto_reboot or not fpga_no_reboot
+        # Only wait for critical systems when a reboot actually occurred (FPGA update does not reboot).
+        if reboot_occurred:
+            logger.info("Waiting for docker service to start")
+            pytest_assert(
+                wait_until(300, 10, 0, duthost.is_host_service_running, "docker"),
+                "Docker service failed to start",
+            )
+            logger.info("Waiting on critical systems to come online...")
+            wait_until(300, 30, 0, duthost.critical_services_fully_started)
+            time.sleep(60)
 
         # Reboot back into original image if neccesary
         if next_image and auto_reboot:


### PR DESCRIPTION

### Description of PR

Summary:
Fix complete_install() in the fwutil test framework so FPGA firmware updates are handled correctly when no reboot occurs. Previously, FPGA updates were treated like CPLD/BIOS/ONIE and the test waited for a system reboot, which caused timeouts or false failures on platforms where FPGA update completes in-place.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202605

### Approach
#### What is the motivation for this PR?
On platforms such as SN4280, fwutil update for FPGA components does not trigger a system reboot — the update completes in-place. The existing complete_install() logic assumed all auto-reboot firmware updates (CPLD, BIOS, ONIE, FPGA) would cause SSH to stop and restart. For FPGA, this led to the test waiting indefinitely for a reboot that never happens, causing timeouts.

#### How did you do it?
Updated complete_install() in tests/platform_tests/fwutil/fwutil_common.py:

1. Input validation — Fail early if component is None or not a string.
2. FPGA-specific path — When auto_reboot=True and component name contains FPGA, wait only for the async fwutil command to finish (res.get(timeout)) instead of waiting for SSH stop/start.
3. Skip post-reboot checks for FPGA — Docker and critical-services readiness checks run only when a reboot actually occurred; FPGA updates skip this since the switch stays online.
4. Preserve existing behavior — CPLD, BIOS, and ONIE update flows are unchanged.
#### How did you verify/test it?
Test passed
#### Any platform specific information?
SN4280
#### Supported testbed topology if it's a new test case?
Any
### Documentation
No
