### PR TITLE
[SmartSwitch] Ignore the DPU hostname in test_dpu_console to align with sonic-mgmt PR#22610

### DIFF
--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -235,7 +235,7 @@ def test_dpu_console(duthosts, enum_rand_one_per_hwsku_hostname,
                        'child.sendline(\'exit\\rexit\\r\'); '
                        'child.expect(r\'Terminal\'); '
                        'child.sendline(\'\'); '
-                       'child.expect(r\'sonic login: \'); '
+                       'child.expect(r\' login: \'); '
                        'print(child.after.decode()); child.close()"'
                        % (index))
         else:
@@ -245,13 +245,13 @@ def test_dpu_console(duthosts, enum_rand_one_per_hwsku_hostname,
                        'child.sendline(\'\\r\\r\'); '
                        'child.expect(r\' \'); '
                        'child.sendline(\'exit\\rexit\\r\'); '
-                       'child.expect(r\'sonic login: \'); '
+                       'child.expect(r\' login: \'); '
                        'print(child.after.decode()); child.close()"'
                        % (index))
 
         logging.info("Checking console access of {}".format(dpu_name))
         output_dpu_console = duthost.shell(command)
-        pytest_assert(output_dpu_console['stdout'] == 'sonic login: ',
+        pytest_assert(output_dpu_console['stdout'] == ' login: ',
                       "{} console is not accessible"
                       .format(dpu_name))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Update test_dpu_console to align with sonic-mgmt [PR#22610.](https://github.com/sonic-net/sonic-mgmt/pull/22610)
The hostname of smartswitch DPUs are changed. Need align the test.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Ignore the hostname in the console output check.
#### How did you verify/test it?
Run the test on SN4280.
#### Any platform specific information?
Only for smartswitch.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
