### PR TITLE
Ignore expect message (#21385)

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -428,6 +428,9 @@ r, ".*ERR bgp\#bgpmon:\s+\*ERROR\*\s+Failed\s+with\s+rc:\d+\s+when\s+execute:\s+
 # https://github.com/sonic-net/sonic-buildimage/issues/24966
 r, ".* ERR bgp#mgmtd.*mgmt_ds_lock: ERROR: lock already taken on DS:running by session-id.*"
 
+# This is an info log which matches the regex "kernel:.*\serr", not an err
+r, ".*ACPI.*System may be unstable or behave erratically.*"
+
 # Ignore systemd-networkd.socket not being able to be started. This is expected on non-DPU platforms.
 r, ".*ERR systemd\[1\]: Failed to listen on systemd-networkd.socket - Network Service Netlink Socket.*"
 


### PR DESCRIPTION
Summary:  Ignore expect message (#21385)
Fixes # Manually cherry-pick PR https://github.com/sonic-net/sonic-mgmt/pull/21385 to 202511 branch

This is an info log, but they are matched by the log_analyzer regex kernel:.*\serr as an error log. It is incorrect, so ignore the message
```
2025-06-26T14: 58:46.985225+00:00 sonic kernel: [    1.755529] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985237+00:00 sonic kernel: [    1.755545] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985240+00:00 sonic kernel: [    1.755554] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985251+00:00 sonic kernel: [    1.755563] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985225+00:00 sonic kernel: [    1.755529] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985237+00:00 sonic kernel: [    1.755545] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985240+00:00 sonic kernel: [    1.755554] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
2025-06-26T14: 58:46.985251+00:00 sonic kernel: [    1.755563] ACPI: OSL: Resource conflict: System may be unstable or behave erratically
```


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
