### PR TITLE
Qos params t0-f2-d40u8 200g/300m, t1-f2-d10u8 400g/300m

### DIFF
--- a/tests/qos/files/qos_params.th5.yaml
+++ b/tests/qos/files/qos_params.th5.yaml
@@ -667,6 +667,99 @@ qos_params:
                     pkts_num_dismiss_pfc: 14
                     pkts_num_margin: 2
                     pkts_num_trig_pfc: 134949
+            200000_300m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 32
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 45
+                    pkts_num_hdrm_full: 1781
+                    pkts_num_hdrm_partial: 1588
+                    pkts_num_trig_pfc: 115917
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 115891
+                pkts_num_egr_mem: 206
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 117699
+                    pkts_num_trig_pfc: 115917
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 34
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 115917
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 115891
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 117699
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 115891
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 117699
+                    pkts_num_trig_pfc: 115917
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 117699
+                    pkts_num_trig_pfc: 115917
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 115917
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 115917
             800000_40m:
                 hdrm_pool_size:
                     dscps:
@@ -787,6 +880,99 @@ qos_params:
                 q6_num_of_pkts: 80
                 q7_num_of_pkts: 80
         topo-t1-f2-d10u8:
+            400000_300m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 4
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 24
+                    pkts_num_hdrm_full: 3304
+                    pkts_num_hdrm_partial: 472
+                    pkts_num_trig_pfc: 103397
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 103371
+                pkts_num_egr_mem: 714
+                pkts_num_leak_out: 0
+                wm_pg_headroom:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 106702
+                    pkts_num_trig_pfc: 103397
+                wm_pg_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    packet_size: 64
+                    pg: 3
+                    pkts_num_fill_min: 34
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 103397
+                wm_pg_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    packet_size: 64
+                    pg: 0
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 103371
+                wm_q_shared_lossless:
+                    cell_size: 254
+                    dscp: 3
+                    ecn: 1
+                    pkts_num_fill_min: 0
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 106702
+                    queue: 3
+                wm_q_shared_lossy:
+                    cell_size: 254
+                    dscp: 8
+                    ecn: 1
+                    pkts_num_fill_min: 7
+                    pkts_num_margin: 4
+                    pkts_num_trig_egr_drp: 103371
+                    queue: 0
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 106702
+                    pkts_num_trig_pfc: 103397
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_margin: 4
+                    pkts_num_trig_ingr_drp: 106702
+                    pkts_num_trig_pfc: 103397
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 103397
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 14
+                    pkts_num_margin: 4
+                    pkts_num_trig_pfc: 103397
             800000_300m: &topo-t1-f2-d10u8_800000_300m
                 hdrm_pool_size:
                     dscps:


### PR DESCRIPTION
### Description of PR
This adds qos params for:
 - t0-f2-d40u8 200g/300m
 - t1-f2-d10u8 400g/300m

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### How did you do it?
Values were generated by automated script

#### How did you verify/test it?
Manually tested