### PR TITLE
cSONiC: poll for bgpcfgd FRR config instead of fixed pause

### DIFF
--- a/ansible/roles/sonic/tasks/csonic.yml
+++ b/ansible/roles/sonic/tasks/csonic.yml
@@ -67,8 +67,15 @@
   failed_when: false
 
 - name: Wait for bgpcfgd to configure FRR from ConfigDB
-  pause:
-    seconds: 10
+  become: yes
+  command: >
+    docker exec csonic_{{ vm_set_name }}_{{ inventory_hostname }}
+    vtysh -c "show running-config"
+  delegate_to: "{{ VM_host[0] }}"
+  register: frr_config
+  until: frr_config.stdout is search("router bgp")
+  retries: 30
+  delay: 2
 
 - name: Check FRR daemon status
   become: yes


### PR DESCRIPTION
Replace hardcoded `pause: seconds: 10` with a polling loop that checks
`vtysh 'show running-config'` for `router bgp` presence. Polls every 2s
for up to 60s, confirming bgpcfgd has actually pushed CONFIG_DB BGP
entries to FRR before proceeding.

This is more robust than a fixed delay — it adapts to slow and fast hosts
alike. Tested on cSONiC testbed: polling completed after ~12s (6 retries).

Addresses review comment from @hdwhdw on PR #22747.

Signed-off-by: securely1g <securely1g@users.noreply.github.com>