### PR TITLE
Adjust memory utilization thresholds to reduce false ALARM failures

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -4,7 +4,8 @@
     "Mellanox-SN4600C": ["Mellanox-SN4600C-C64"],
     "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128"],
     "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2"],
-    "Arista-7060CX": ["Arista-7060CX-32S-C32", "Arista-7060CX-32S-D48C8"]
+    "Arista-7060CX": ["Arista-7060CX-32S-C32", "Arista-7060CX-32S-D48C8"],
+    "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"]
   },
   "COMMON": [
     {
@@ -116,11 +117,11 @@
         "syncd": {
           "memory_increase_threshold": {
             "type": "percentage_points",
-            "value": 5
+            "value": 7
           },
           "memory_high_threshold": {
             "type": "percentage_points",
-            "value": 18
+            "value": 22
           }
         },
         "bgp": {
@@ -146,11 +147,11 @@
         "swss": {
           "memory_increase_threshold": {
             "type": "percentage_points",
-            "value": 3
+            "value": 5
           },
           "memory_high_threshold": {
             "type": "percentage_points",
-            "value": 8
+            "value": 10
           }
         },
         "database": {
@@ -337,6 +338,25 @@
         }
       },
       "memory_check": "parse_monit_validate_output"
+    }
+  ],
+  "Arista-7260CX3": [
+    {
+      "name": "docker",
+      "cmd": "docker stats --no-stream",
+      "memory_params": {
+        "syncd": {
+          "memory_increase_threshold": {
+            "type": "percentage_points",
+            "value": 8
+          },
+          "memory_high_threshold": {
+            "type": "percentage_points",
+            "value": 25
+          }
+        }
+      },
+      "memory_check": "parse_docker_stats_output"
     }
   ]
 }


### PR DESCRIPTION
#### Why I did it

The memory utilization monitoring thresholds in `memory_utilization_dependence.json` are too tight, causing **409 false test failures** across **49 test cases**, **32 modules**, **63 testbeds**, and **17 HwSKUs** in 30 days on the 202511 branch.

**Root cause analysis (from Kusto `TestReportUnionData`):**
- `docker:swss` (3% increase threshold -> 190 failures): Heavy route operations (BGP update replication, link flap) naturally cause orchagent to allocate more memory. A 3-5% increase during these operations is expected behavior, not a memory leak.
- `docker:syncd` (5% increase / 18% high -> 119 failures): On broadcom TH2 platforms (Arista-7260CX3), syncd baseline usage is 9-10% and can reach 15-20% during heavy ASIC operations.
- `monit:memory_usage` (10% increase -> 68 failures): CoPP tests involving reboot and config reload cause transient system-wide memory spikes of 15-19%.

##### Work item tracking
- Microsoft ADO **(number only)**: 37010532

#### How I did it

1. Increased `swss` increase threshold from 3% -> 5% and high threshold from 8% -> 10%
2. Increased `syncd` increase threshold from 5% -> 7% and high threshold from 18% -> 22%
3. Added `Arista-7260CX3` HWSKU group mapping (C64, D108C8, D108C10 variants)
4. Added Arista-7260CX3 specific syncd overrides (8% increase / 25% high) since TH2 broadcom platforms consistently show higher syncd memory usage

#### How to verify it

Run nightly tests on Arista-7260CX3 platforms and verify that `bgp.test_bgp_update_replication`, `platform_tests.link_flap.test_cont_link_flap`, `bgp.test_bgp_session`, `crm.test_crm`, `lldp.test_lldp_syncd`, `copp.test_copp` no longer fail with memory ALARM errors on teardown.