### PR TITLE
[system_health] Replace time.sleep with wait_until in test_system_health

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -193,18 +193,16 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
         if asic_mock_result and psu_mock_result:
             logger.info('Mocked ASIC overheated')
             logger.info('Mocked PSU absence for {}'.format(psu_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
+            logger.info('Waiting for mock ASIC/PSU state to appear in STATE_DB')
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_system_health_info, duthost, psu_name, psu_expect_value), \
+                'Mock PSU absence, expect {}, but got {}'.format(
+                    psu_expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name))
             if is_support_mock_asic:
                 value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
-                assert value and asic_expect_value in value,\
+                assert value and asic_expect_value in value, \
                     'Mock ASIC temperature overheated, expect {}, but got {}'.format(asic_expect_value, value)
-
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert value and psu_expect_value == value,\
-                'Mock PSU absence, expect {}, but got {}'.format(psu_expect_value, value)
 
         if is_support_mock_asic:
             asic_mock_result = device_mocker.mock_asic_temperature(True)
@@ -212,18 +210,14 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
         if asic_mock_result and psu_mock_result:
             logger.info('Mocked ASIC normal temperatue')
             logger.info('Mocked PSU presence for {}'.format(psu_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-
+            logger.info('Waiting for mock ASIC/PSU state to clear in STATE_DB')
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_equal, duthost, psu_name, psu_expect_value), \
+                'Mock PSU presence, but it is still absence'
             if is_support_mock_asic:
                 value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, 'ASIC')
-                assert not value or asic_expect_value not in value,\
+                assert not value or asic_expect_value not in value, \
                     'Mock ASIC normal temperature, but it is still overheated'
-
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert not value or psu_expect_value != value, 'Mock PSU presence, but it is still absence'
 
         fan_mock_result, fan_name = device_mocker.mock_fan_presence(False)
         fan_expect_value = EXPECT_FAN_MISSING.format(fan_name)
@@ -232,35 +226,30 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
         if fan_mock_result and psu_mock_result:
             logger.info('Mocked fan absence {}'.format(fan_name))
             logger.info('Mocked PSU no power for {}'.format(psu_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert value and value == fan_expect_value,\
-                'Mock fan absence, expect {}, but got {}'.format(fan_expect_value, value)
-
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert value and psu_expect_value == value,\
-                'Mock PSU no power, expect {}, but got {}'.format(psu_expect_value, value)
+            logger.info('Waiting for mock fan/PSU state to appear in STATE_DB')
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_system_health_info, duthost, fan_name, fan_expect_value), \
+                'Mock fan absence, expect {}, but got {}'.format(
+                    fan_expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name))
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_system_health_info, duthost, psu_name, psu_expect_value), \
+                'Mock PSU no power, expect {}, but got {}'.format(
+                    psu_expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name))
 
         fan_mock_result, fan_name = device_mocker.mock_fan_presence(True)
         psu_mock_result, psu_name = device_mocker.mock_psu_status(True)
         if fan_mock_result and psu_mock_result:
             logger.info('Mocked fan presence for {}'.format(fan_name))
             logger.info('Mocked PSU good power for {}'.format(psu_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert not value or value != fan_expect_value, 'Mock fan presence, but it still report absence'
-
-            time.sleep(PSU_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert not value or psu_expect_value != value, 'Mock PSU power good, but it is still out of power'
+            logger.info('Waiting for mock fan/PSU state to clear in STATE_DB')
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_equal, duthost, fan_name, fan_expect_value), \
+                'Mock fan presence, but it still report absence'
+            assert wait_until(THERMAL_CHECK_INTERVAL + PSU_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_equal, duthost, psu_name, psu_expect_value), \
+                'Mock PSU power good, but it is still out of power'
 
         fan_mock_result, fan_name = device_mocker.mock_fan_status(False)
         fan_expect_value = EXPECT_FAN_BROKEN.format(fan_name)
@@ -269,18 +258,17 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
         if fan_mock_result and psu_mock_result:
             logger.info('Mocked fan broken for {}'.format(fan_name))
             logger.info('Mocked PSU overheated for {}'.format(psu_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert value and value == fan_expect_value,\
-                'Mock fan broken, expect {}, but got {}'.format(fan_expect_value, value)
-
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert value and psu_expect_value in value,\
-                'Mock PSU overheated, expect {}, but got {}'.format(psu_expect_value, value)
+            logger.info('Waiting for mock fan/PSU state to appear in STATE_DB')
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_system_health_info, duthost, fan_name, fan_expect_value), \
+                'Mock fan broken, expect {}, but got {}'.format(
+                    fan_expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name))
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_contains, duthost, psu_name, psu_expect_value), \
+                'Mock PSU overheated, expect {}, but got {}'.format(
+                    psu_expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name))
 
         fan_mock_result, fan_name = device_mocker.mock_fan_status(True)
         psu_mock_result, psu_name = device_mocker.mock_psu_temperature(True)
@@ -288,59 +276,47 @@ def test_device_checker(duthosts, enum_rand_one_per_hwsku_hostname,
             logger.info('Mocked fan good for {}'.format(fan_name))
             logger.info(
                 'Mocked PSU normal temperature for {}'.format(psu_name))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert not value or value != fan_expect_value, 'Mock fan normal, but it still report broken'
-
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert not value or psu_expect_value not in value,\
+            logger.info('Waiting for mock fan/PSU state to clear in STATE_DB')
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_equal, duthost, fan_name, fan_expect_value), \
+                'Mock fan normal, but it still report broken'
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_contains, duthost, psu_name, psu_expect_value), \
                 'Mock PSU normal temperature, but it is still overheated'
 
         fan_mock_result, fan_name = device_mocker.mock_fan_direction(False)
         expect_value = EXPECT_FAN_INVALID_DIRECTION.format(fan_name)
         if fan_mock_result:
-            logger.info('Mocked fan invalid direction for {}, waiting {} seconds for it to take effect'.format(
-                fan_name,
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert value and expect_value in value, 'Mock fan invalid direction, expect {}, but got {}'.format(
-                expect_value,
-                value)
+            logger.info('Mocked fan invalid direction for {}'.format(fan_name))
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_contains, duthost, fan_name, expect_value), \
+                'Mock fan invalid direction, expect {}, but got {}'.format(
+                    expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name))
 
         fan_mock_result, fan_name = device_mocker.mock_fan_direction(True)
         if fan_mock_result:
-            logger.info('Mocked fan valid direction for {}, waiting {} seconds for it to take effect'.format(
-                fan_name,
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert not value or expect_value not in value, 'Mock fan valid direction, but it is still invalid'
+            logger.info('Mocked fan valid direction for {}'.format(fan_name))
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_contains, duthost, fan_name, expect_value), \
+                'Mock fan valid direction, but it is still invalid'
 
         mock_result, psu_name = device_mocker.mock_psu_voltage(False)
         expect_value = EXPECT_PSU_INVALID_VOLTAGE.format(psu_name)
         if mock_result:
-            logger.info('Mocked PSU bad voltage for {}, waiting {} seconds for it to take effect'
-                        .format(psu_name, THERMAL_CHECK_INTERVAL))
-            time.sleep(PSU_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert value and expect_value in value, 'Mock PSU invalid voltage, expect {}, but got {}'.format(
-                expect_value,
-                value)
+            logger.info('Mocked PSU bad voltage for {}'.format(psu_name))
+            assert wait_until(PSU_CHECK_INTERVAL, 5, 2,
+                              check_health_field_contains, duthost, psu_name, expect_value), \
+                'Mock PSU invalid voltage, expect {}, but got {}'.format(
+                    expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name))
 
         mock_result, psu_name = device_mocker.mock_psu_voltage(True)
         if mock_result:
-            logger.info('Mocked PSU good voltage for {}, waiting {} seconds for it to take effect'
-                        .format(psu_name, THERMAL_CHECK_INTERVAL))
-            time.sleep(FAST_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, psu_name)
-            assert not value or expect_value not in value, 'Mock PSU good voltage, but it is still invalid'
+            logger.info('Mocked PSU good voltage for {}'.format(psu_name))
+            assert wait_until(FAST_INTERVAL, 5, 2,
+                              check_health_field_not_contains, duthost, psu_name, expect_value), \
+                'Mock PSU good voltage, but it is still invalid'
 
 
 def test_external_checker(duthosts, enum_rand_one_per_hwsku_hostname):
@@ -375,11 +351,9 @@ def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
         mock_result, fan_name = device_mocker.mock_fan_presence(False)
         expect_value = EXPECT_FAN_MISSING.format(fan_name)
         if mock_result:
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert not value or expect_value != value, 'Fan check is still performed after it ' \
-                                                       'is configured to be ignored'
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_equal, duthost, fan_name, expect_value), \
+                'Fan check is still performed after it is configured to be ignored'
 
     logger.info(
         'Ignore ASIC check, verify there is no error information about ASIC')
@@ -429,23 +403,17 @@ def test_device_fan_speed_checker(duthosts, enum_rand_one_per_hwsku_hostname,
 
         if fan_mock_result:
             logger.info('Mocked invalid fan speed for {}'.format(fan_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert value and fan_expect_value in value, \
-                'Mock fan invalid speed, expect {}, but got {}'.format(fan_expect_value, value)
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_contains, duthost, fan_name, fan_expect_value), \
+                'Mock fan invalid speed, expect {}, but got {}'.format(
+                    fan_expect_value,
+                    redis_get_field_value(duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name))
 
         fan_mock_result, fan_name = device_mocker.mock_fan_speed(True)
         if fan_mock_result:
             logger.info('Mocked valid fan speed for {}'.format(fan_name))
-            logger.info('Waiting {} seconds for it to take effect'.format(
-                THERMAL_CHECK_INTERVAL))
-            time.sleep(THERMAL_CHECK_INTERVAL)
-            value = redis_get_field_value(
-                duthost, STATE_DB, HEALTH_TABLE_NAME, fan_name)
-            assert not value or fan_expect_value not in value, \
+            assert wait_until(THERMAL_CHECK_INTERVAL, 10, 2,
+                              check_health_field_not_contains, duthost, fan_name, fan_expect_value), \
                 'Mock fan valid speed, expect {}, but it still report invalid speed'.format(fan_expect_value)
 
 
@@ -506,6 +474,27 @@ def check_system_health_info(duthost, category, expected_value):
     value = redis_get_field_value(
         duthost, STATE_DB, HEALTH_TABLE_NAME, category)
     return value == expected_value
+
+
+def check_health_field_contains(duthost, field, expected):
+    """Check that STATE_DB HEALTH_TABLE field contains expected substring."""
+    value = redis_get_field_value(
+        duthost, STATE_DB, HEALTH_TABLE_NAME, field)
+    return bool(value) and expected in value
+
+
+def check_health_field_not_contains(duthost, field, unexpected):
+    """Check that STATE_DB HEALTH_TABLE field does NOT contain substring."""
+    value = redis_get_field_value(
+        duthost, STATE_DB, HEALTH_TABLE_NAME, field)
+    return not value or unexpected not in value
+
+
+def check_health_field_not_equal(duthost, field, unexpected):
+    """Check that STATE_DB HEALTH_TABLE field is absent or != unexpected."""
+    value = redis_get_field_value(
+        duthost, STATE_DB, HEALTH_TABLE_NAME, field)
+    return not value or value != unexpected
 
 
 def check_system_health_led_info(duthost):


### PR DESCRIPTION
Replace 14 time.sleep calls with wait_until polling for system health STATE_DB verification. 5 sleeps waiting for config file load by the system health daemon (no observable intermediate state) are preserved.

**Changes:**
- 14 `time.sleep(THERMAL_CHECK_INTERVAL)` / `time.sleep(PSU_CHECK_INTERVAL)` → `wait_until` polling STATE_DB
- 5 config-load waits preserved (no pollable state before mock action)
- Added helper functions: `check_system_health_info`, `check_health_field_not_equal`, `check_health_field_contains`, `check_health_field_not_contains`

Fixes #20256