### PR TITLE
[restapi] Replace time.sleep with wait_until in test_restapi

### DIFF
--- a/tests/restapi/test_restapi.py
+++ b/tests/restapi/test_restapi.py
@@ -1,5 +1,5 @@
 import pytest
-import time
+from tests.common.utilities import wait_until
 import logging
 import json
 
@@ -215,21 +215,23 @@ def test_data_path(construct_url, vlan_members, cleanup_after_testing):
     pytest_assert(r.status_code == 204)
 
     # Verify routes
-    # Add some delay before query
-    time.sleep(5)
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-2', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036001},
-                {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32",
-                    "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036001},
-                {"nexthop": "100.3.152.52",
-                    "ip_prefix": "100.0.20.4/32", "vnid": 7036001},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036001}]
-    for route in expected:
-        pytest_assert(route in r.json())
+    def _check_vnet2_routes_exist():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-2', params)
+        if r.status_code != 200:
+            return False
+        routes = r.json()
+        expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32",
+                        "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52",
+                        "ip_prefix": "100.0.20.4/32", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036001}]
+        return all(route in routes for route in expected)
+
+    pytest_assert(wait_until(30, 5, 0, _check_vnet2_routes_exist),
+                  "Routes with vnid 7036001 not found in VNET vnet-guid-2")
     logger.info(
         "Routes with vnid: 7036001 to VNET vnet-guid-2 have been added successfully")
 
@@ -245,17 +247,19 @@ def test_data_path(construct_url, vlan_members, cleanup_after_testing):
     pytest_assert(r.status_code == 207)
 
     # Verify routes have not been added
-    # Add some delay before query
-    time.sleep(5)
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-2', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "100.0.50.4/24", "vnid": 7036001},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.70.0/16", "vnid": 7036001}]
-    for route in expected:
-        pytest_assert(route not in r.json())
+    def _check_vnet2_bad_routes_absent():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-2', params)
+        if r.status_code != 200:
+            return False
+        routes = r.json()
+        expected = [{"nexthop": "100.3.152.52", "ip_prefix": "100.0.50.4/24", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "100.0.70.0/16", "vnid": 7036001}]
+        return all(route not in routes for route in expected)
+
+    pytest_assert(wait_until(30, 5, 0, _check_vnet2_bad_routes_absent),
+                  "Invalid CIDR routes should not be present in VNET vnet-guid-2")
     logger.info(
         "Routes with incorrect CIDR addresses with vnid: 7036001 to VNET vnet-guid-2 have not been added successfully")
 
@@ -345,21 +349,23 @@ def test_data_path(construct_url, vlan_members, cleanup_after_testing):
     pytest_assert(r.status_code == 204)
 
     # Verify routes
-    # Add some delay before query
-    time.sleep(5)
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-3', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036002},
-                {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32",
-                    "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036002},
-                {"nexthop": "100.3.152.52",
-                    "ip_prefix": "100.0.20.4/32", "vnid": 7036002},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036002}]
-    for route in expected:
-        pytest_assert(route in r.json())
+    def _check_vnet3_routes_exist():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-3', params)
+        if r.status_code != 200:
+            return False
+        routes = r.json()
+        expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036002},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32",
+                        "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036002},
+                    {"nexthop": "100.3.152.52",
+                        "ip_prefix": "100.0.20.4/32", "vnid": 7036002},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036002}]
+        return all(route in routes for route in expected)
+
+    pytest_assert(wait_until(30, 5, 0, _check_vnet3_routes_exist),
+                  "Routes with vnid 7036002 not found in VNET vnet-guid-3")
     logger.info(
         "Routes with vnid: 3000 to VNET vnet-guid-3 have been added successfully")
 
@@ -375,17 +381,19 @@ def test_data_path(construct_url, vlan_members, cleanup_after_testing):
     pytest_assert(r.status_code == 207)
 
     # Verify routes have not been added
-    # Add some delay before query
-    time.sleep(5)
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-3', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "100.0.50.4/24", "vnid": 7036002},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.70.0/16", "vnid": 7036002}]
-    for route in expected:
-        pytest_assert(route not in r.json())
+    def _check_vnet3_bad_routes_absent():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-3', params)
+        if r.status_code != 200:
+            return False
+        routes = r.json()
+        expected = [{"nexthop": "100.3.152.52", "ip_prefix": "100.0.50.4/24", "vnid": 7036002},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "100.0.70.0/16", "vnid": 7036002}]
+        return all(route not in routes for route in expected)
+
+    pytest_assert(wait_until(30, 5, 0, _check_vnet3_bad_routes_absent),
+                  "Invalid CIDR routes should not be present in VNET vnet-guid-3")
     logger.info(
         "Routes with incorrect CIDR addresses with vnid: 7036002 to VNET vnet-guid-3 have not been added successfully")
 
@@ -532,21 +540,23 @@ def test_data_path_sad(construct_url, vlan_members, cleanup_after_testing, is_su
     pytest_assert(r.status_code == 204)
 
     # Verify routes
-    # Add some delay before query
-    time.sleep(5)
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-2', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036001},
-                {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32",
-                    "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036001},
-                {"nexthop": "100.3.152.52",
-                    "ip_prefix": "100.0.20.4/32", "vnid": 7036001},
-                {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036001}]
-    for route in expected:
-        pytest_assert(route in r.json())
+    def _check_sad_vnet2_routes_exist():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-2', params)
+        if r.status_code != 200:
+            return False
+        routes = r.json()
+        expected = [{"nexthop": "100.3.152.52", "ip_prefix": "192.168.20.4/32", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "101.0.20.5/32",
+                        "mac_address": "1c:34:da:72:b0:8a", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52",
+                        "ip_prefix": "100.0.20.4/32", "vnid": 7036001},
+                    {"nexthop": "100.3.152.52", "ip_prefix": "100.0.30.0/24", "vnid": 7036001}]
+        return all(route in routes for route in expected)
+
+    pytest_assert(wait_until(30, 5, 0, _check_sad_vnet2_routes_exist),
+                  "Routes with vnid 7036001 not found in VNET vnet-guid-2")
     logger.info(
         "Routes with vnid: 7036001 to VNET vnet-guid-2 have been added successfully")
 
@@ -611,26 +621,29 @@ def test_create_vrf(construct_url, cleanup_after_testing):
     r = restapi.patch_config_vrouter_vrf_id_routes(
         construct_url, 'vnet-guid-10', params)
     pytest_assert(r.status_code == 204)
-    # Wait 2 seconds for routes to be syncd
-    time.sleep(2)
+
     # Verify routes
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-10', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    expected = [{"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.1/32",
-                 "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
-                {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.2/32",
-                 "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
-                {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.3/32",
-                 "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
-                {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.4/32",
-                 "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
-                {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.5/32",
-                 "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"}]
-    for route in expected:
-        pytest_assert(route in r.json())
+    def _check_vnet10_routes_exist():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-10', params)
+        if r.status_code != 200:
+            return False
+        routes = r.json()
+        expected = [{"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.1/32",
+                     "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
+                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.2/32",
+                     "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
+                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.3/32",
+                     "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
+                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.4/32",
+                     "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"},
+                    {"nexthop": "100.78.60.37", "ip_prefix": "10.1.0.5/32",
+                     "vnid": 7039114, "mac_address": "00:0d:3a:f9:1a:20"}]
+        return all(route in routes for route in expected)
+
+    pytest_assert(wait_until(30, 5, 0, _check_vnet10_routes_exist),
+                  "Routes with vnid 7039114 not found in VNET vnet-guid-10")
     logger.info(
         "Routes with vnid: 7039114 to VNET vnet-guid-10 have been added successfully")
 
@@ -649,15 +662,18 @@ def test_create_vrf(construct_url, cleanup_after_testing):
     r = restapi.patch_config_vrouter_vrf_id_routes(
         construct_url, 'vnet-guid-10', params)
     pytest_assert(r.status_code == 204)
-    # Wait 2 seconds for routes to be syncd
-    time.sleep(2)
-    # Verify routes
-    params = '{}'
-    r = restapi.get_config_vrouter_vrf_id_routes(
-        construct_url, 'vnet-guid-10', params)
-    pytest_assert(r.status_code == 200)
-    logger.info(r.json())
-    pytest_assert(len(r.json()) == 0)
+
+    # Verify routes deleted
+    def _check_vnet10_routes_deleted():
+        params = '{}'
+        r = restapi.get_config_vrouter_vrf_id_routes(
+            construct_url, 'vnet-guid-10', params)
+        if r.status_code != 200:
+            return False
+        return len(r.json()) == 0
+
+    pytest_assert(wait_until(30, 5, 0, _check_vnet10_routes_deleted),
+                  "Routes in VNET vnet-guid-10 were not deleted")
     logger.info(
         "Routes with vnid: 7039114 from VNET vnet-guid-10 have been deleted successfully")
 


### PR DESCRIPTION
Replace 7 time.sleep calls with wait_until polling for route sync verification. Each sleep-then-GET pattern now polls the REST API endpoint directly until routes are confirmed present or absent.

**Changes:**
- 5× `time.sleep(5)` and 2× `time.sleep(2)` replaced with `wait_until(30, 5, 0, ...)`
- 7 helper functions poll REST API GET endpoints directly
- `import time` removed (no remaining usage)

Fixes #20256