### PR TITLE
Add unique mac in test_crm_neighbor to handle resource optimization for Cisco ASICs

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -522,10 +522,34 @@ def increase_arp_cache(duthost, max_value, ip_ver, test_name):
         logger.info("{}".format(cmd))
 
 
-def configure_neighbors(amount, interface, ip_ver, asichost, test_name):
+def configure_neighbors(amount, interface, ip_ver, asichost, test_name, unique_mac=False):
     """ Configure bunch of IP neighbors on DUT. Bash template is used to speedup configuration """
     # Template used to speedup execution many similar commands on DUT
-    del_template = """
+    if unique_mac:
+        # Cisco-8000 needs to use unique MAC when adding neighbors to increment per resource optimization
+        del_template = """
+    %s
+    c=0
+    for s in {{neigh_ip_list}}
+    do
+        mac=$(printf "02:01:%%02x:%%02x:%%02x:%%02x" $((c>>24&255)) $((c>>16&255)) $((c>>8&255)) $((c&255)))
+        ip {{ns_prefix}} neigh del ${s} lladdr ${mac} dev {{iface}}
+        echo deleted - ${s}
+        c=$((c+1))
+    done""" % (NS_PREFIX_TEMPLATE)
+
+        add_template = """
+    %s
+    c=0
+    for s in {{neigh_ip_list}}
+    do
+        mac=$(printf "02:01:%%02x:%%02x:%%02x:%%02x" $((c>>24&255)) $((c>>16&255)) $((c>>8&255)) $((c&255)))
+        ip {{ns_prefix}} neigh replace ${s} lladdr ${mac} dev {{iface}}
+        echo added - ${s}
+        c=$((c+1))
+    done""" % (NS_PREFIX_TEMPLATE)
+    else:
+        del_template = """
     %s
     for s in {{neigh_ip_list}}
     do
@@ -533,7 +557,7 @@ def configure_neighbors(amount, interface, ip_ver, asichost, test_name):
         echo deleted - ${s}
     done""" % (NS_PREFIX_TEMPLATE)
 
-    add_template = """
+        add_template = """
     %s
     for s in {{neigh_ip_list}}
     do
@@ -945,10 +969,11 @@ def test_crm_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_neighbor".format(ip_ver=ip_ver)
-    neighbor_add_cmd = "{ip_cmd} neigh replace {neighbor} lladdr 11:22:33:44:55:66 dev {iface}"\
-                       .format(ip_cmd=asichost.ip_cmd, neighbor=neighbor, iface=crm_interface[0])
-    neighbor_del_cmd = "{ip_cmd} neigh del {neighbor} lladdr 11:22:33:44:55:66 dev {iface}"\
-                       .format(ip_cmd=asichost.ip_cmd, neighbor=neighbor, iface=crm_interface[0])
+    neigh_mac = "02:01:00:00:00:01" if is_cisco_device(duthost) else "11:22:33:44:55:66"
+    neighbor_add_cmd = "{ip_cmd} neigh replace {neighbor} lladdr {mac} dev {iface}"\
+                       .format(ip_cmd=asichost.ip_cmd, neighbor=neighbor, mac=neigh_mac, iface=crm_interface[0])
+    neighbor_del_cmd = "{ip_cmd} neigh del {neighbor} lladdr {mac} dev {iface}"\
+                       .format(ip_cmd=asichost.ip_cmd, neighbor=neighbor, mac=neigh_mac, iface=crm_interface[0])
 
     # Get "crm_stats_ipv[4/6]_neighbor" used and available counter value
     get_neighbor_stats = "{db_cli} COUNTERS_DB HMGET CRM:STATS \
@@ -995,7 +1020,8 @@ def test_crm_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
         # Add new neighbor entries to correctly calculate used CRM resources in percentage
         configure_neighbors(amount=neighbours_num, interface=crm_interface[0], ip_ver=ip_ver,
-                            asichost=asichost, test_name="test_crm_neighbor")
+                            asichost=asichost, test_name="test_crm_neighbor",
+                            unique_mac=is_cisco_device(duthost))
 
         # Wait for neighbor resources to stabilize using polling
         expected_neighbor_used = new_crm_stats_neighbor_used + neighbours_num - CRM_COUNTER_TOLERANCE


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
For cisco asics, we need to update the CRM neighbor testcase due to a resource optimization where if multiple neighbors are added with the same MAC, it will not report it as a "new" neighbor even with different IPs. To handle this we added a cisco specific 'unique_mac' param that is default set to false by default to not effect other vendors that adds unique macs up to 2^32 scale as needed for this TC for cisco asics. 
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
handles resource optimization on cisco asics where if the same mac is used, it will not be seen as "new" neighbor

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
refer to description
#### How did you do it?
added functionality to add unique macs in this test case up to 2^32 scale
#### How did you verify/test it?
ran TC and passed as seen below:
`
------------------------------------------------------------------------ generated xml file: /crm/test_crm.py::test_crm_neighbor.xml -------------------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
-------------------------------------------------------------------------------------------------------------- live log sessionfinish --------------------------------------------------------------------------------------------------------------
27/02/2026 19:38:57 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
===================================================================================================== 2 passed, 1 warning in 330.44s (0:05:30) =====================================================================================================
`
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
