### PR TITLE
[smartswitch][config_reload] Wait for DPU states after config reload on smartswitch

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -72,28 +72,29 @@ def config_force_option_supported(duthost):
     return False
 
 
-def _check_dpu_module_status(sonic_host, expected_status, dpu_name):
+def _check_all_dpu_module_states(sonic_host, dpu_expected_states):
     """
-    Check if a DPU module has reached the expected status.
+    Check if all DPU modules have reached their expected states.
     Args:
         sonic_host: SONiC host object
-        expected_status: "on" or "off"
-        dpu_name: name of the DPU module
+        dpu_expected_states: dict mapping dpu_name to expected status ("on" or "off")
     Returns:
-        True if the DPU is in the expected status, False otherwise
+        True if all DPUs are in their expected states, False otherwise
     """
-    output = sonic_host.shell(
-        'show chassis module status | grep %s' % dpu_name,
-        module_ignore_errors=True
-    )
-    if output['rc'] != 0:
-        return False
+    for dpu_name, expected_status in dpu_expected_states.items():
+        output = sonic_host.shell(
+            'show chassis module status | grep %s' % dpu_name,
+            module_ignore_errors=True
+        )
+        if output['rc'] != 0:
+            return False
 
-    is_offline = "offline" in output["stdout"].lower()
-    if expected_status == "off":
-        return is_offline
-    else:
-        return not is_offline
+        is_offline = "offline" in output["stdout"].lower()
+        if expected_status == "off" and not is_offline:
+            return False
+        if expected_status != "off" and is_offline:
+            return False
+    return True
 
 
 def _wait_for_smartswitch_dpu_states(sonic_host):
@@ -135,12 +136,10 @@ def _wait_for_smartswitch_dpu_states(sonic_host):
 
     logger.info("Waiting for smartswitch DPU states: %s", dpu_expected_states)
 
-    for dpu_name, expected_status in dpu_expected_states.items():
-        if not wait_until(DPU_STATE_TIMEOUT, DPU_STATE_INTERVAL, 0,
-                          _check_dpu_module_status, sonic_host,
-                          expected_status, dpu_name):
-            logger.warning("DPU %s did not reach expected state '%s' within timeout",
-                           dpu_name, expected_status)
+    if not wait_until(DPU_STATE_TIMEOUT, DPU_STATE_INTERVAL, 0,
+                      _check_all_dpu_module_states, sonic_host,
+                      dpu_expected_states):
+        pytest_assert(False, "Not all DPUs reached expected states %s within timeout" % dpu_expected_states)
 
     logger.info("Smartswitch DPU state wait completed")
 


### PR DESCRIPTION
### Description of PR

Summary:
On smartswitch platforms in lit mode, `config_reload()` applies `CHASSIS_MODULE` entries from config_db which trigger DPU admin state transitions (powering on/off). The common `config_reload()` utility in `tests/common/config_reload.py` had no smartswitch/DPU awareness, so it returned immediately without waiting for these transitions to complete. When consecutive config reloads occur (e.g. in golden config infra tests or setup/teardown), the second reload fires while DPUs are still transitioning from the first, causing log errors and instability.

This PR adds smartswitch DPU state wait logic to `config_reload()` so that after any config reload on a smartswitch, the function queries `CHASSIS_MODULE` admin_status from config_db and waits for each DPU to reach its expected state (online if admin_status is "up", offline if admin_status is "down") before returning.

Fixes #21354

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

The `config_reload()` function in `tests/common/config_reload.py` is used across the entire test suite. On smartswitch platforms, config reload applies `CHASSIS_MODULE` entries which control DPU power states. Without waiting for DPU state transitions to complete, consecutive config reloads (common in test setup/teardown flows) cause race conditions where DPUs are mid-transition when a new reload starts.

This is analogous to how `tests/common/reboot.py` already handles smartswitch differently via `reboot_smartswitch()` — the config reload path needed the same treatment.

#### How did you do it?

Added three components to `tests/common/config_reload.py`:

1. **`_check_dpu_module_status()`** — Checks if a DPU module has reached its expected online/offline status by parsing `show chassis module status`. Mirrors the logic from `tests/smartswitch/common/device_utils_dpu.py:check_dpu_module_status()` but is self-contained to avoid cross-module dependencies.

2. **`_wait_for_smartswitch_dpu_states()`** — After config reload, queries all `CHASSIS_MODULE|*` entries from config_db (database 4) to determine each DPU's expected state based on `admin_status`. Uses `wait_until()` with a 360s timeout (matching `DPU_MAX_ONLINE_TIMEOUT` from the smartswitch test helpers) to wait for each DPU to reach its expected state.

3. **Integration in `config_reload()`** — After the existing modular chassis wait adjustment and before safe_reload/BGP checks, detects smartswitch using `sonic_host.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch")` (same pattern as `reboot.py:393`) and calls the DPU state wait function. Gated on `is_dut` to avoid running on neighbor devices.

#### How did you verify/test it?

- Verified Python syntax compiles cleanly
- Confirmed the smartswitch detection pattern matches existing usage across the codebase (`tests/common/reboot.py:393`, `tests/cacl/test_cacl_application.py:515`, etc.)
- Confirmed timeout values align with existing smartswitch test helpers (`DPU_MAX_ONLINE_TIMEOUT = 360` in `tests/smartswitch/common/device_utils_dpu.py`)
- On non-smartswitch platforms, the `is_smartswitch` check returns False and the new code path is never entered, so there is no impact on existing tests

#### Any platform specific information?

This change only affects smartswitch platforms. On all other platforms, `dut_basic_facts().get("is_smartswitch")` returns False and the new code is skipped entirely.

#### Supported testbed topology if it's a new test case?

N/A — this is a bug fix to the common config_reload utility, not a new test case.

### Documentation

N/A — no new features or test cases; this is a bug fix to existing infrastructure.