### PR TITLE
Fix telemetry container not restarted after gnmi cert config test

### DIFF
--- a/tests/gnmi/helper.py
+++ b/tests/gnmi/helper.py
@@ -8,6 +8,7 @@ from tests.common.helpers.gnmi_utils import GNMIEnvironment, add_gnmi_client_com
                                             dump_gnmi_log, dump_system_status
 from tests.common.helpers.gnmi_utils import gnmi_container   # noqa: F401
 from tests.common.helpers.ntp_helper import NtpDaemon, get_ntp_daemon_in_use   # noqa: F401
+from tests.common.helpers.dut_utils import check_container_state
 
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,12 @@ def recover_cert_config(duthost):
         output = duthost.shell(dut_command, module_ignore_errors=True)
         logger.error("GNMI service failed to start. GNMI log: {}".format(output['stdout']))
         pytest.fail("Failed to recover GNMI client cert configuration.")
+
+    # Restart telemetry container if it was stopped during cert config change
+    # apply_cert_config may trigger ctrmgrd to stop the telemetry container
+    if not check_container_state(duthost, "telemetry", should_be_running=True):
+        logger.info("Telemetry container is not running after cert config recovery, restarting it")
+        duthost.shell("sudo systemctl restart telemetry", module_ignore_errors=True)
 
 
 def check_ntp_sync_status(duthost):


### PR DESCRIPTION
### Description
`apply_cert_config()` in gnmi tests triggers SONiC `ctrmgrd` to stop the telemetry container due to configuration changes. However, `recover_cert_config()` only restarts supervisor programs (gnmi-native, telemetry) **inside** the gnmi container — it never checks or restarts the separate telemetry Docker container.

This causes the telemetry container to remain in `Exited` state after gnmi tests complete, leading to post-test sanity check failures in subsequent tests.

### Root Cause
1. `apply_cert_config()` modifies GNMI_CLIENT_CERT config entries
2. SONiC `ctrmgrd` detects the config change and stops the telemetry container
3. `recover_cert_config()` restores gnmi container's internal processes but doesn't restart the telemetry container
4. On SONiC 202511+, gnmi and telemetry run as separate Docker containers

### Fix
Add a check at the end of `recover_cert_config()` to detect if the telemetry container is not running and restart it via `systemctl restart telemetry`.

### Test Evidence
Tested on physical testbed `testbed-bjw2-can-720dt-8` (Arista 720DT, SONiC 20251110) with post-test sanity check enabled:

```
INFO     tests.common.plugins.sanity_check:__init__.py:382 No post-test sanity check item failed, post-test sanity check passed.
1 passed, 248 warnings in 293.19s (0:04:53)
```

Before this fix, the telemetry container remained in `Exited` state after `test_gnoi_system_grpc.py` completed, causing downstream test failures.