### PR TITLE
Add conditional skip for test_load_minigraph_with_golden_config

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3535,6 +3535,12 @@ override_config_table/test_override_config_table.py:
     conditions:
       - "is_multi_asic==True"
 
+override_config_table/test_override_config_table.py::test_load_minigraph_with_golden_config:
+  skip:
+    reason: "Test performs multiple config reloads that cause pmon start-limit-hit due to missing sonic.target symlinks after systemd-sonic-generator rework. Fix PRs: sonic-net/sonic-buildimage#25932, sonic-net/sonic-utilities#4314"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/25931"
+
 #######################################
 ######       packet_trimming       #####
 ########################################


### PR DESCRIPTION
#### Why I did it

The test `override_config_table/test_override_config_table.py::test_load_minigraph_with_golden_config` performs 4 consecutive `config load_minigraph` operations. After the systemd-sonic-generator rework (sonic-net/sonic-buildimage#23340), container services like pmon are no longer listed as `sonic.target` dependencies, so their systemd start rate limit counters are never reset between reloads. This causes pmon to hit `start-limit-hit` on the 4th reload, leaving pmon in a failed state that affects subsequent tests in the nightly run.

**Root cause issue**: https://github.com/sonic-net/sonic-buildimage/issues/25931

**Fix PRs** (in progress):
- sonic-net/sonic-buildimage#25932 — adds missing `[Install] WantedBy=sonic.target` to 9 container service templates
- sonic-net/sonic-utilities#4314 — fixes `_reset_failed_services()` to include reverse dependencies

#### How I did it

Added a conditional skip entry in `tests_mark_conditions.yaml` for `test_load_minigraph_with_golden_config` linked to issue sonic-net/sonic-buildimage#25931. The skip will **automatically resolve** (test re-enabled) when the issue is closed.

#### How to verify it

The test will be skipped in nightly runs until the fix PRs are merged and issue #25931 is closed.

#### Which release branch to backport

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Add conditional skip for test_load_minigraph_with_golden_config to prevent pmon start-limit-hit failures in nightly runs.