### PR TITLE
loganalyzer: write markers directly to /var/log/syslog to prevent UDP drop

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -236,15 +236,23 @@ class AnsibleLogAnalyzer:
 
     def place_marker(self, log_file_list, marker, wait_for_marker=False):
         '''
-        @summary: Place marker into '/dev/log' and each log file specified.
+        @summary: Place marker directly into each log file specified.
         @param log_file_list : List of file paths, to be applied with marker.
+                               Must include /var/log/syslog (callers are
+                               responsible for ensuring this).
         @param marker:         Marker to be placed into log files.
+
+        Markers are written directly to log files via place_marker_to_file()
+        (open + append + flush).  The previous implementation also wrote
+        markers through the syslog UDP socket (/dev/log), but under heavy
+        system load the host rsyslogd UDP receive buffer can overflow and
+        silently drop the message, causing wait_for_marker() to time out.
+        Direct file writes are immune to this problem.
         '''
 
         for log_file in log_file_list:
             self.place_marker_to_file(log_file, marker)
 
-        self.place_marker_to_syslog(marker)
         if wait_for_marker:
             if self.wait_for_marker(marker) is False:
                 raise RuntimeError(

--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -109,11 +109,22 @@ class LogAnalyzer:
         """
         @summary: Add stop marker into syslog on the DUT.
 
+        Always pass --logs /var/log/syslog so that the marker is written
+        directly to the file via place_marker_to_file(), in addition to
+        the normal syslog-socket path (place_marker_to_syslog()).
+
+        When the system is under heavy load (e.g. config_reload with CPU
+        stress), the host rsyslogd UDP receive buffer can overflow and
+        silently drop messages sent through /dev/log.  Writing the marker
+        directly to /var/log/syslog guarantees that wait_for_marker() will
+        always find it, regardless of system load.
+
         @return: True for successful execution False otherwise
         """
         self.ansible_host.copy(src=ANSIBLE_LOGANALYZER_MODULE, dest=os.path.join(self.dut_run_dir, "loganalyzer.py"))
 
-        cmd = "python {run_dir}/loganalyzer.py --action add_end_marker --run_id {marker}"\
+        cmd = "python {run_dir}/loganalyzer.py --action add_end_marker --run_id {marker}" \
+              " --logs /var/log/syslog"\
             .format(run_dir=self.dut_run_dir, marker=marker)
 
         logging.debug("Adding end marker '{}'".format(marker))
@@ -325,13 +336,23 @@ class LogAnalyzer:
 
     def _setup_marker(self, log_files=None):
         """
-        Adds the marker to the log files
+        Adds the marker to the log files.
+
+        Always include /var/log/syslog in --logs so the start marker is
+        written directly to the file via place_marker_to_file(), not only
+        through the syslog UDP socket.  Under heavy system load the host
+        rsyslogd may drop UDP messages, causing markers sent solely via
+        /dev/log to be silently lost.  Direct file writes are immune to
+        this.  See also: _add_end_marker().
         """
         start_marker = ".".join((self.marker_prefix, time.strftime("%Y-%m-%d-%H:%M:%S", time.gmtime())))
         cmd = "python {run_dir}/loganalyzer.py --action init --run_id {start_marker}"\
             .format(run_dir=self.dut_run_dir, start_marker=start_marker)
-        if log_files:
-            cmd += " --logs {}".format(','.join(log_files))
+        if not log_files:
+            log_files = []
+        if '/var/log/syslog' not in log_files:
+            log_files.append('/var/log/syslog')
+        cmd += " --logs {}".format(','.join(log_files))
 
         logging.debug("Adding start marker '{}'".format(start_marker))
         self.ansible_host.command(cmd)


### PR DESCRIPTION
### Description of PR

Summary:
Fix LogAnalyzer marker placement to write directly to `/var/log/syslog` instead of relying solely on the syslog UDP socket (`/dev/log`), which can silently drop messages under heavy system load.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?

`test_po_cleanup_after_reload` fails intermittently with:

```
RuntimeError: cannot find marker end-LogAnalyzer-port_channel_cleanup.2026-03-04-08:34:39 in /var/log/syslog
```

Full error trace:

```
tests.common.errors.RunAnsibleModuleFail: run module command failed, Ansible Results =>
failed = True
changed = True
rc = 1
cmd = ['python', '/tmp/loganalyzer.py', '--action', 'add_end_marker', '--run_id', 'port_channel_cleanup.2026-03-04-08:34:39']
start = 2026-03-04 08:48:07.817786
end = 2026-03-04 08:50:19.294633
delta = 0:02:11.476847
msg = non-zero return code
stderr =
Traceback (most recent call last):
  File "/tmp/loganalyzer.py", line 877, in <module>
    main(sys.argv[1:])
  File "/tmp/loganalyzer.py", line 858, in main
    analyzer.place_marker(
  File "/tmp/loganalyzer.py", line 262, in place_marker
    raise RuntimeError(
RuntimeError: cannot find marker end-LogAnalyzer-port_channel_cleanup.2026-03-04-08:34:39 in /var/log/syslog
```

**Root cause analysis:**

The test creates heavy CPU load (16 cores running `yes`) and then calls `config_reload`, which restarts all containers. During this period:

1. `_add_end_marker()` calls `loganalyzer.py --action add_end_marker` **without `--logs`**, so `log_file_list` is empty.
2. `place_marker()` skips `place_marker_to_file()` (no files in list) and only calls `place_marker_to_syslog()`, which writes through the `/dev/log` Unix domain socket (UDP/`SOCK_DGRAM`).
3. The host `rsyslogd` receives massive syslog traffic from all restarting containers (orchagent, syncd, teamd, etc.). Its UDP receive buffer overflows and the kernel **silently drops** the marker message.
4. `wait_for_marker()` polls `/var/log/syslog` for 120 seconds but the marker never appears, resulting in `RuntimeError`.

This is a generic issue affecting any test that uses `LogAnalyzer` under heavy system load, not just `test_po_cleanup_after_reload`.

Note: PR #20327 attempted to fix this by stopping swss rsyslogd before config_reload, but `config_reload` restarts the swss container, bringing rsyslogd back. Even with swss rsyslogd stopped, other containers still generate enough syslog traffic to overflow the UDP buffer.

#### How did you do it?

Three changes:

1. **`_add_end_marker()`** (`tests/common/plugins/loganalyzer/loganalyzer.py`): Always pass `--logs /var/log/syslog` so the end marker is written directly to the file.

2. **`_setup_marker()`** (`tests/common/plugins/loganalyzer/loganalyzer.py`): Ensure `/var/log/syslog` is always included in `--logs`, so the start marker is also written directly to the file.

3. **`place_marker()`** (`ansible/roles/test/files/tools/loganalyzer/loganalyzer.py`): Remove the `place_marker_to_syslog()` call. Since callers now always include `/var/log/syslog` in `log_file_list`, `place_marker_to_file()` writes the marker directly via `open()` + `write()` + `flush()`. The unreliable UDP socket path is no longer needed.

Direct file writes (`open` + `append` + `flush`) are immune to UDP buffer overflow — they always succeed regardless of system load.

#### How did you verify/test it?

Ran `test_po_cleanup_after_reload` on sn5640 (str4-sn5640-3, t1 topology, 16 vCPUs). Previously failed consistently; passes reliably after the fix.

#### Any platform specific information?

No. This is a generic loganalyzer issue affecting all platforms.

#### Supported testbed topology if it's a new test case?

N/A (bug fix)

### Documentation

N/A