### PR TITLE
[tests/acl]: Check ACL rule active status in acl_rule_loaded

### DIFF
--- a/tests/acl/test_stress_acl.py
+++ b/tests/acl/test_stress_acl.py
@@ -252,6 +252,18 @@ def verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
             testutils.verify_no_packet_any(test=ptfadapter, pkt=exp_pkt, ports=ptf_dst_ports)
 
 
+def acl_table_created(rand_selected_dut, table_name):
+    acl_table_infos = rand_selected_dut.show_and_parse("show acl table {}".format(table_name))
+    for info in acl_table_infos:
+        if info.get('name') == table_name:
+            if info.get('status', '').lower() != 'active':
+                logger.debug("ACL table {} exists but not yet active (status: {})".format(
+                    table_name, info.get('status')))
+                return False
+            return True
+    return False
+
+
 def acl_rule_loaded(rand_selected_dut, acl_rule_list):
     acl_rule_infos = rand_selected_dut.show_and_parse("show acl rule")
     acl_id_list = []
@@ -288,6 +300,7 @@ def test_acl_add_del_stress(rand_selected_dut, tbinfo, ptfadapter, prepare_test_
 
     rand_selected_dut.shell(cmd_create_table)
     acl_rule_list = list(range(1, ACL_RULE_NUMS + 1))
+    wait_until(wait_timeout, 2, 0, acl_table_created, rand_selected_dut, "STRESS_ACL")
     verify_acl_rules(rand_selected_dut, ptfadapter, ptf_src_port, ptf_dst_ports,
                      acl_rule_list, 0, "forward", dst_ip_addr=dst_ip_addr)
     try:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Currently the logic in acl_rule_loaded(), checks for the presence of ACL rule and gives a false positive and returns True even if the rule is not active. Due to this the wait_until() function which has a wait timeout of 15s, returns immediately and the tests proceeds even though the rule is not active and the test fails in traffic validation.

Enhanced acl_rule_loaded() to verify that all expected ACL rules are not only present but also in 'Active' state before returning True. This will make sure that the test waits until the timeout if rule is not installed before traffic validation.

Also added a helper function to check if ACL table is created and active before verifying traffic.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Sonic Mgmt run:
Test Name: test_acl_add_del_stress
Class Name: acl.test_stress_acl
File Path: acl/test_stress_acl.py
Line Number: 265
Status: Passed
Duration: 976.090 seconds
Start Time: 2026-03-12 22:30:11.814434
End Time: 2026-03-12 22:46:27.905302

[acl_2026-03-13-00-09-17_stress.log](https://github.com/user-attachments/files/25959966/acl_2026-03-13-00-09-17_stress.log)


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
