### PR TITLE
Added a syslog check to restapi tests

### DIFF
--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -15,7 +15,7 @@
         "parameters": "--pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"
     },
     "docker-sonic-restapi": {
-        "parameters": "--net=host -v /var/run/redis/redis.sock:/var/run/redis/redis.sock -v /etc/sonic/credentials:/etc/sonic/credentials:ro -v /etc/localtime:/etc/localtime:ro"
+        "parameters": "--net=host -v /var/run/redis/redis.sock:/var/run/redis/redis.sock -v /etc/sonic/credentials:/etc/sonic/credentials:ro -v /etc/localtime:/etc/localtime:ro -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-chassis:/var/run/redis-chassis:ro -v /etc/fips/fips_enable:/etc/fips/fips_enable:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -e RUNTIME_OWNER=local -e NAMESPACE_PREFIX=asic -e CONTAINER_NAME=restapi -e SYSLOG_TARGET_IP=127.0.0.1"
     },
     "docker-restapi-watchdog": {
         "parameters": "--net=host -v /etc/localtime:/etc/localtime:ro"

--- a/tests/restapi/conftest.py
+++ b/tests/restapi/conftest.py
@@ -7,18 +7,28 @@ from six.moves.urllib.parse import urlunparse
 from tests.common import config_reload
 from tests.common.helpers.assertions import pytest_require as pyrequire
 from tests.common.helpers.dut_utils import check_container_state
+from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer, LogAnalyzerError
 
 from helper import apply_cert_config
 
 RESTAPI_CONTAINER_NAME = 'restapi'
 
 
+@pytest.fixture(scope="module")
+def setup_loganalyzer(duthosts, rand_one_dut_hostname):
+    duthost = duthosts[rand_one_dut_hostname]
+    loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="TestRestapi")
+    loganalyzer.expect_regex = [".*restapi#.*https endpoint started.*"]
+    return loganalyzer
+
+
 @pytest.fixture(scope="module", autouse=True)
-def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost):
+def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost, setup_loganalyzer):
     '''
     Create RESTAPI client certificates and copy the subject names to the config DB
     '''
     duthost = duthosts[rand_one_dut_hostname]
+    loganalyzer = setup_loganalyzer
 
     # Check if RESTAPI is enabled on the device
     pyrequire(check_container_state(duthost, RESTAPI_CONTAINER_NAME, should_be_running=True),
@@ -95,18 +105,22 @@ def setup_restapi_server(duthosts, rand_one_dut_hostname, localhost):
     duthost.copy(src='restapiserver.key',
                  dest='/etc/sonic/credentials/testrestapiserver.key')
 
-    apply_cert_config(duthost)
-    urllib3.disable_warnings()
-
-    yield
-    # Perform a config load_minigraph to ensure config_db is not corrupted
-    config_reload(duthost, config_source='minigraph')
-    # Delete all created certs
-    local_command = "rm \
-                        restapiCA.* \
-                        restapiserver.* \
-                        restapiclient.*"
-    localhost.shell(local_command)
+    try:
+        with loganalyzer:
+            apply_cert_config(duthost)
+        urllib3.disable_warnings()
+        yield
+    except LogAnalyzerError as err:
+        pytest.fail(str(err))
+    finally:
+        # Perform a config load_minigraph to ensure config_db is not corrupted
+        config_reload(duthost, config_source='minigraph')
+        # Delete all created certs
+        local_command = "rm \
+                            restapiCA.* \
+                            restapiserver.* \
+                            restapiclient.*"
+        localhost.shell(local_command)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Added a syslog check to restapi tests and updated container upgrade parameters for restapi.

Summary:
Microsoft ADO ID: 36995635
1. Added a syslog check when setting up the `restapi` container during restapi tests to ensure that the `restapi` container is running and its logs are added to syslog.
2. Updated parameters used to create the `restapi` container during container upgrade tests so that restapi's logs are added to the syslog.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
If the environment variable `SYSLOG_TARGET_IP` is not set inside the `restapi` container, its logs are not added to syslog. The current restapi tests don't catch this issue since they don't check the syslog.

#### How did you do it?
Added a syslog check to ensure that `restapi` is accepting HTTPS connections and its logs are added to syslog.

#### How did you verify/test it?
Ran the test on a testbed.
Without defining the `SYSLOG_TARGET_IP` environment variable inside `restapi`:
```
E           Failed: match: 0
E           expected_match: 0
E           expected_missing_match: 1
E
E           Expected Messages that are missing:
E           .*restapi#.*https endpoint started.*

FAILED restapi/test_restapi_client_cert_auth.py::test_client_cert_subject_name_matching - Failed: match: 0
```

After setting `SYSLOG_TARGET_IP=127.0.0.1` inside `restapi`:
```
tests/restapi/test_restapi_client_cert_auth.py::test_client_cert_subject_name_matching ✓                                                     100% ██████████
```

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
