### PR TITLE
[memory_utilization] Add two-tier threshold for frr_zebra memory monitoring

### DIFF
--- a/tests/common/plugins/memory_utilization/__init__.py
+++ b/tests/common/plugins/memory_utilization/__init__.py
@@ -1,44 +1,12 @@
 import logging
 import pytest
 from tests.common.plugins.memory_utilization.memory_utilization import MemoryMonitor
-from tests.common.utilities import wait_until
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-ROUTECHECK_WAIT_TIMEOUT = 120  # Max seconds to wait for routeCheck to finish
-ROUTECHECK_POLL_INTERVAL = 5   # Seconds between polls
-
 # Add this to store memory errors per test
 _memory_errors_by_test = {}
-
-
-def _is_routecheck_not_running(duthost):
-    """Check if route_check.py is not currently running on the DUT.
-
-    Uses 'pgrep -f route_check.py -l | grep -v bash' to avoid false positives
-    from the bash wrapper process that Ansible's shell module creates (bash -c "pgrep ..."),
-    which contains the search pattern in its own cmdline.
-
-    Returns:
-        True if route_check.py is not running, False if it is still running.
-    """
-    result = duthost.shell("pgrep -f route_check.py -l | grep -v bash", module_ignore_errors=True)
-    return result["rc"] != 0
-
-
-def _wait_for_routecheck_to_finish(duthost, timeout=ROUTECHECK_WAIT_TIMEOUT, interval=ROUTECHECK_POLL_INTERVAL):
-    """Wait for any running route_check.py process to finish before collecting memory measurements.
-
-    The route_check.py script runs every 5 minutes (via monit) and can cause significant temporary
-    memory spikes in zebra (e.g., 34 MB -> 102 MB), leading to false memory utilization alarms.
-    See https://github.com/sonic-net/sonic-mgmt/issues/22548
-    """
-    if not wait_until(timeout, interval, 0, _is_routecheck_not_running, duthost):
-        logger.warning("route_check.py still running on {} after {}s timeout, proceeding anyway".format(
-            duthost.hostname, timeout))
-        return False
-    return True
 
 
 def pytest_addoption(parser):
@@ -84,9 +52,6 @@ def pytest_runtest_setup(item):
         if duthost.topo_type == 't2':
             continue
 
-        # Wait for routeCheck to finish to avoid memory spikes affecting measurements
-        _wait_for_routecheck_to_finish(duthost)
-
         # Initial memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:
             try:
@@ -125,9 +90,6 @@ def pytest_runtest_teardown(item, nextitem):
     for duthost in duthosts:
         if duthost.topo_type == 't2':
             continue
-
-        # Wait for routeCheck to finish to avoid memory spikes affecting measurements
-        _wait_for_routecheck_to_finish(duthost)
 
         # memory check for all registered commands
         for name, cmd, memory_params, memory_check in memory_monitors[duthost.hostname].commands:

--- a/tests/common/plugins/memory_utilization/memory_utilization.py
+++ b/tests/common/plugins/memory_utilization/memory_utilization.py
@@ -86,18 +86,44 @@ class MemoryMonitor:
                             previous_values, current_values, is_current=True
                         )
 
-                # Get increase threshold and determine if it's a percentage or absolute value
+                # Get increase thresholds: warning (soft) and fail (hard)
+                # memory_increase_threshold: warning level (log warning but don't fail)
+                # memory_increase_fail_threshold: fail level (store error, fail the test)
+                # If memory_increase_fail_threshold is not set, memory_increase_threshold acts as the fail level
+                # (backward compatible)
                 increase_threshold_raw = normalized_thresholds.get("memory_increase_threshold", float('inf'))
                 logger.debug("Raw increase threshold for {}:{}: {}".format(name, mem_item, increase_threshold_raw))
                 increase_threshold = self._parse_threshold(increase_threshold_raw, previous_value)
                 logger.info("Calculated increase threshold for {}:{}: {}".format(name, mem_item, increase_threshold))
 
+                increase_fail_threshold_raw = normalized_thresholds.get("memory_increase_fail_threshold", None)
+                if increase_fail_threshold_raw is not None:
+                    increase_fail_threshold = self._parse_threshold(increase_fail_threshold_raw, previous_value)
+                    logger.info("Calculated increase fail threshold for {}:{}: {}".format(
+                        name, mem_item, increase_fail_threshold))
+                else:
+                    increase_fail_threshold = None
+
                 increase = current_value - previous_value
-                if increase > increase_threshold:
-                    self._handle_memory_threshold_exceeded(
-                        name, mem_item, increase, increase_threshold_raw,
-                        previous_values, current_values, is_increase=True
-                    )
+                if increase_fail_threshold is not None:
+                    # Two-tier mode: warn at lower threshold, fail at higher threshold
+                    if increase > increase_fail_threshold:
+                        self._handle_memory_threshold_exceeded(
+                            name, mem_item, increase, increase_fail_threshold_raw,
+                            previous_values, current_values, is_increase=True
+                        )
+                    elif increase > increase_threshold:
+                        self._handle_memory_warning(
+                            name, mem_item, increase, increase_threshold_raw,
+                            previous_values, current_values
+                        )
+                else:
+                    # Legacy single-tier mode: threshold acts as fail level
+                    if increase > increase_threshold:
+                        self._handle_memory_threshold_exceeded(
+                            name, mem_item, increase, increase_threshold_raw,
+                            previous_values, current_values, is_increase=True
+                        )
 
     def _normalize_thresholds(self, thresholds):
         """
@@ -314,6 +340,24 @@ class MemoryMonitor:
             # Store error instead of failing immediately
             self.memory_errors.append(message)
             logger.debug("Stored memory error: {}".format(message))
+
+    def _handle_memory_warning(self, name, mem_item, value, threshold,
+                               previous_values, current_values):
+        """Handle memory increase that exceeds warning threshold but not fail threshold.
+
+        Logs a warning for visibility but does not store an error or fail the test.
+        This is used in two-tier mode where memory_increase_threshold is the warning level
+        and memory_increase_fail_threshold is the fail level.
+        """
+        prev_val = previous_values.get(name, {}).get(mem_item, 0)
+        curr_val = current_values.get(name, {}).get(mem_item, 0)
+
+        threshold_str = self._format_threshold_for_display(threshold)
+        logger.warning(
+            "[WARNING]: {}:{} memory usage increased by {:.1f} MB, exceeds warning threshold {} "
+            "(previous: {:.1f} MB, current: {:.1f} MB). Not failing - within fail threshold."
+            .format(name, mem_item, value, threshold_str, prev_val, curr_val)
+        )
 
     def get_memory_errors(self):
         return self.memory_errors

--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -193,6 +193,10 @@
             {"type": "value", "value": 64},
             {"type": "comparison", "value": "max"}
           ],
+          "memory_increase_fail_threshold": {
+            "type": "value",
+            "value": 128
+          },
           "memory_high_threshold": {
             "type": "value",
             "value": 128


### PR DESCRIPTION
### Description of PR

Summary:
Introduce a two-tier memory increase threshold system for the `memory_utilization` plugin to handle transient memory spikes (e.g., from `route_check.py`) without failing tests.

Fixes #22548

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `route_check.py` script (run by monit every 5 minutes) causes temporary zebra memory spikes (~34 MB → ~102 MB, a ~68 MB increase). The existing `memory_increase_threshold` for `frr_zebra` is max(50%, 64 MB), so a 68 MB spike exceeds it and fails tests — even though this is a transient spike, not a real memory leak.

The original approach (PR v1) tried to wait for `route_check.py` to finish before measuring memory, but this had issues:
1. **Performance**: 120s wait timeout per test × setup + teardown = 240s overhead per test, causing CI timeouts
2. **Race condition**: `route_check.py` could start between the wait and memory collection
3. **Self-matching bug**: Ansible shell module wraps commands in `/bin/sh -c "..."`, causing `pgrep` to match the wrapper process

#### How did you do it?

Replaced the wait-based approach with a two-tier threshold system:

- **`memory_increase_threshold`** (existing): now acts as a **warning** level — logs a warning but does NOT fail the test
- **`memory_increase_fail_threshold`** (new): a higher **fail** level — stores an error and fails the test

When `memory_increase_fail_threshold` is not configured, the existing `memory_increase_threshold` acts as the fail level (fully backward compatible).

For `frr_zebra`:
- Warning at max(50%, 64 MB) — catches spikes for visibility
- Fail at 128 MB — only real memory leaks trigger test failure

#### How did you verify/test it?

1. Local KVM test runs on both master and fix branch confirmed identical test results (no regressions)
2. Verified via Ansible that the `pgrep` self-matching bug exists (Ansible shell module uses `/bin/sh -c`, not `bash`)
3. Confirmed route_check.py spike (~68 MB) falls between warning (64 MB) and fail (128 MB) thresholds

#### Any platform specific information?

None — the two-tier threshold is generic and can be applied to any monitor. Only `frr_zebra` uses it in this PR.

#### Supported testbed topology if it's a new test case?

N/A (framework change)

### Documentation
N/A