### PR TITLE
Allow partially online DPUs when deploying minigraph

### DIFF
--- a/ansible/library/load_extra_dpu_config.py
+++ b/ansible/library/load_extra_dpu_config.py
@@ -223,7 +223,7 @@ class LoadExtraDpuConfigModule(object):
         for line in out.split("\n"):
             if "up" in line and "dpu_midplane_link_state" in line:
                 dpu_midplane_up_count += 1
-            if line.startswith("DPU") and "Online" in line and "Partial" not in line:
+            if line.startswith("DPU") and "Online" in line:
                 dpu_online_count += 1
         return dpu_online_count, dpu_midplane_up_count
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
It's possible for DPUs to be available to run traffic but still be listed as 'partially online' in the output from `show system-health dpu all`. This causes the `deploy-mg` operation to fail.

#### How did you do it?
When deploying config to DPUs, allow 'partially online' DPUs.

#### How did you verify/test it?
Run the `deploy-mg` operation on a smartswitch testbed and verify that it passes.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
