### PR TITLE
xFAil test_bgp_with_loopback VRF test due to known issue (#2637)

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3301,6 +3301,12 @@ vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac
     conditions:
       - "asic_type in ['barefoot', 'vs']"
 
+vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback:
+  xfail:
+    reason: "This test case may fail due to a known issue https://github.com/sonic-net/sonic-mgmt/issues/2637"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/2637
+
 #######################################
 #####           vxlan            #####
 #######################################


### PR DESCRIPTION

### Description of PR
This PR marks the test case vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback as xfail due to a known issue tracked. https://github.com/sonic-net/sonic-mgmt/issues/2637


Summary:
Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test was consistently failing due to a known issue documented. To prevent false negatives and maintain visibility without blocking progress, the test has been marked as xfail.

#### How did you do it?
Added the xFail condition in test_conditional_mark.yaml

#### How did you verify/test it?
Ran the test case and verify

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

