### PR TITLE
Mark test_vrf1_neigh_with_default_router_mac as xfail due to sonic-swss#1833

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3307,6 +3307,13 @@ vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback:
     conditions:
       - https://github.com/sonic-net/sonic-mgmt/issues/2637
 
+vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac:
+  xfail:
+    reason: "This test case may fail due to a known issue https://github.com/sonic-net/sonic-swss/issues/1833"
+    conditions:
+      - https://github.com/sonic-net/sonic-swss/issues/1833
+
+
 #######################################
 #####           vxlan            #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3301,6 +3301,12 @@ vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac
     conditions:
       - "asic_type in ['barefoot', 'vs']"
 
+vrf/test_vrf.py::TestVrfLoopbackIntf::test_bgp_with_loopback:
+  xfail:
+    reason: "This test case may fail due to a known issue https://github.com/sonic-net/sonic-mgmt/issues/2637"
+    conditions:
+      - https://github.com/sonic-net/sonic-mgmt/issues/2637
+
 #######################################
 #####           vxlan            #####
 #######################################


### PR DESCRIPTION
### Description of PR
This PR marks the test case vrf/test_vrf_attr.py::TestVrfAttrSrcMac::test_vrf1_neigh_with_default_router_mac as xfail due to a known issue tracked in sonic-swss#1833.

Summary:
Fixes #(issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test case was failing consistently due to a known issue in sonic-swss. To avoid false negatives in CI pipelines and maintain clarity, the test has been marked as xfail.

#### How did you do it?
Added xfail marker in tests_mark_conditions.yaml for the specific test case.

#### How did you verify/test it?
Ran the test locally and confirmed it now reports as expected failure (xfail).

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA