### PR TITLE
[202511] Fix duplicate key 'bgp/test_bgp_vnet.py' in tests_mark_conditions.yaml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -482,12 +482,6 @@ bgp/test_bgp_vnet.py:
     conditions:
       - "asic_type not in ['vs', 'cisco-8000', 'mellanox']"
 
-bgp/test_bgp_vnet.py:
-  skip:
-    reason: "Test is only enabled for VS, Cisco and Nvidia mellanox platforms"
-    conditions:
-      - "asic_type not in ['vs', 'cisco-8000', 'mellanox']"
-
 bgp/test_bgpmon.py:
   skip:
     reason: "Not supported on T2 topology or topology backend"


### PR DESCRIPTION
## Description
Remove duplicate `bgp/test_bgp_vnet.py` entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml`. The key appeared twice (identical content), causing the `check-yaml` pre-commit hook to fail.

## Impact
This duplicate key is blocking the following open PRs targeting `202511`:
- #22793
- #22779
- #22321
- #22112
- #22041
- #22006

## Change
Removed the second identical `bgp/test_bgp_vnet.py` block (6 lines). No functional change.

cc @vmittal-msft @liushilongbuaa