### PR TITLE
fix incorrect port in ipfwd/test_dir_bcast.py

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dir_bcast_test.py
@@ -92,7 +92,7 @@ class BcastTest(BaseTest):
         '''
         ip_src = self.TEST_SRC_IP
         ip_dst = dst_bcast_ip
-        src_mac = self.dataplane.get_mac(0, 0)
+        src_mac = self.dataplane.get_mac(0, self.src_ports[0])
         bcast_mac = self.BROADCAST_MAC
 
         pkt = simple_ip_packet(eth_dst=self.router_mac,
@@ -135,7 +135,7 @@ class BcastTest(BaseTest):
         '''
         ip_src = self.TEST_SRC_IP
         ip_dst = dst_bcast_ip
-        src_mac = self.dataplane.get_mac(0, 0)
+        src_mac = self.dataplane.get_mac(0, self.src_ports[0])
         bcast_mac = self.BROADCAST_MAC
         udp_port = self.DHCP_SERVER_PORT
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the following error in  ipfwd/test_dir_bcast.py:

```
......
======================================================================
ERROR: dir_bcast_test.BcastTest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ptftests/py3/dir_bcast_test.py", line 185, in runTest
    self.check_all_dir_bcast()
  File "ptftests/py3/dir_bcast_test.py", line 84, in check_all_dir_bcast
    self.check_ip_dir_bcast(bcast_ip, dst_ports)
  File "ptftests/py3/dir_bcast_test.py", line 95, in check_ip_dir_bcast
    src_mac = self.dataplane.get_mac(0, 0)
  File "/root/env-python3/lib/python3.7/site-packages/ptf/dataplane.py", line 1002, in get_mac
    return self.ports[(device_number, port_number)].mac()
KeyError: (0, 0)
......
=========================== short test summary info ============================
FAILED ipfwd/test_dir_bcast.py::test_dir_bcast - tests.common.errors.RunAnsib...
=================== 1 failed, 1 warning in 171.43s (0:02:51) ===================
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
In current code, it always use port (0,0) to get the mac.  But in t0-f2-d40u8 topo, port(0,0) is not used, causing KeyError.

#### How did you do it?
Use the mac addr of the first src_port.

#### How did you verify/test it?
In local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
