### PR TITLE
Fix trimming counter test race condition

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -14,7 +14,7 @@ from tests.packet_trimming.packet_trimming_helper import (
     verify_trimmed_packet, reboot_dut, check_connected_route_ready, get_switch_trim_counters_json,
     get_port_trim_counters_json, disable_egress_data_plane, enable_egress_data_plane,
     verify_queue_and_port_trim_counter_consistency, get_queue_trim_counters_json, compare_counters,
-    configure_port_mirror_session, remove_port_mirror_session)
+    configure_port_mirror_session, remove_port_mirror_session, check_trim_drop_counter_zero)
 
 logger = logging.getLogger(__name__)
 
@@ -344,6 +344,7 @@ class BasePacketTrimming:
             self.configure_trimming_global_by_mode(duthost)
 
         with allure.step("Enable trimming in buffer profile"):
+            duthost.shell("sonic-clear switchcounters")
             for buffer_profile in test_params['trim_buffer_profiles']:
                 configure_trimming_action(duthost, test_params['trim_buffer_profiles'][buffer_profile], "on")
             for buffer_profile in trim_counter_params['trim_buffer_profiles']:
@@ -409,6 +410,14 @@ class BasePacketTrimming:
                     for dut_member in port['dut_members']:
                         original_scheduler = original_schedulers.get(dut_member)
                         enable_egress_data_plane(duthost, dut_member, trim_queue, original_scheduler)
+                        # Known limitation: TRIM_DRP_PKTS is a calculated counter (TRIM_PKTS - TRIM_TX_PKTS)
+                        # rather than a real hardware counter. After restoring the blocked trim queue,
+                        # queued packets drain out and TRIM_DRP_PKTS gradually decreases to 0.
+                        # Wait for it to stabilize before reading baseline counters for the next step.
+                        pytest_assert(
+                            wait_until(30, 2, 0, check_trim_drop_counter_zero, duthost, dut_member),
+                            f"TRIM_DRP_PKTS on port {dut_member} did not stabilize to 0"
+                        )
 
     def test_trimming_counters_with_feature_toggle(self, duthost, ptfadapter, test_params, trim_counter_params):
         """

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -2877,6 +2877,22 @@ def compare_counters(counter1, counter2, keys_to_compare):
     logger.info("All specified counters match")
 
 
+def check_trim_drop_counter_zero(duthost, port):
+    """
+    Check if TRIM_DRP_PKTS counter on the specified port is 0.
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+
+    Returns:
+        bool: True if TRIM_DRP_PKTS is 0, False otherwise
+    """
+    trim_drop = get_port_trim_counters_json(duthost, port)['TRIM_DRP_PKTS']
+    logger.info(f"TRIM_DRP_PKTS on port {port}: {trim_drop}")
+    return trim_drop == 0
+
+
 def verify_queue_and_port_trim_counter_consistency(duthost, port):
     """
     Verify the consistency of the trim counter on the queue and the port level.


### PR DESCRIPTION
Summary: Fix trimming counter test race condition
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
1. Wait for `TRIM_DRP_PKTS` to stabilize to 0 after restoring the blocked trim queue before reading baseline counters. The `TRIM_DRP_PKTS` is a calculated counter (TRIM_PKTS - TRIM_TX_PKTS), so after unblocking the queue, queued packets drain out and the drop counter gradually decreases to 0, causing a race condition in the "Verify trimming counter when trimming feature toggles" step.

2. Clear switch counters before the trimming counter test since trimming switch counters can only be cleared when trimming is enabled in the buffer profile. This change is used for debug, no functional change.

#### How did you do it?

#### How did you verify/test it?
Run regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
