### PR TITLE
Fix the usage of is_ipv6_only_topology in test_crm_route so it will check properly if is_ipv6_only_topology

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -626,7 +626,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_route".format(ip_ver=ip_ver)
-    if is_ipv6_only_topology and ip_ver == "4":
+    if is_ipv6_only_topology(tbinfo) and ip_ver == "4":
         pytest.skip("Skipping IPv4 test on IPv6-only topology")
 
     # Template used to speedup execution of many similar commands on DUT


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
is_ipv6_only_topology function is use to detect if the test running over IPV6 only topo,
this PR fix the usage of this method in  test_crm_route.
Summary:
Fix the usage of is_ipv6_only_topology in test_crm_route so it will
check properly if is_ipv6_only_topology

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix the usage of is_ipv6_only_topology in test_crm_route so it will
check properly if is_ipv6_only_topology

The function reference is truth, so the condition is always True when ip_ver == "4", causing the IPv4 test to always be skipped

#### How did you do it?
Change the condition of skip from checking the function reference to function result 
#### How did you verify/test it?

#### Any platform specific information?
No platform specific information
#### Supported testbed topology if it's a new test case?
Bug fix on a existing test case
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
