### PR TITLE
[master][sonic-mgmt]: Skip test cpu shaper until SAI 14.3

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -736,6 +736,15 @@ copp/test_copp.py::TestCOPP::test_trap_neighbor_miss:
       - "(topo_name not in ['t0', 't0-64', 't0-52', 't0-116', 't0-118', 't0-88-o8c80', 't0-isolated-d16u16s1', 't0-isolated-d32u32s2'])"
 
 #######################################
+#####         cpu_shaper          #####
+#######################################
+cpu_shaper/test_cpu_shaper.py:
+  skip:
+    reason: "shaper on queue 7 is not applied correctly, issue fixed in SAI 14.3"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/22731"
+
+#######################################
 #####            crm              #####
 #######################################
 crm/test_crm.py :


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
This is a workaround fix. We are skipping the test until we upgrade to SAI 14.3.

Summary:
The shaper configuration for queue 7 is not properly set by the Jupiter SAI. Broadcom SAI mistakenly always configures queue 0. The issue is already tracked by a CSP and it is fixed in SAI 14.3.

Fixes #22731 
Fixes: [sonic-qual](https://github.com/aristanetworks/sonic-qual.msft/issues/1115)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test_cpu_shaper.py was failing with an assertion error: `assert (expected_pps == actual_pps)`. The test asserts the default cpu shaper's pps count. Upon debugging it was found that Broadcom SAI never configures queue 7. It always mistakenly configures queue 0. 

#### How did you do it?
Skipping the test until the SAI is upgraded to SAI 14.3.

#### How did you verify/test it?
Ran the test and verified it was getting skipped.

#### Any platform specific information?
The test was verifying the shaper configuration in BRCM platforms only.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
