### PR TITLE
Optimize the execution time of everflow ipv6 test cases on dualtor setup

### DIFF
--- a/tests/common/dualtor/dual_tor_utils.py
+++ b/tests/common/dualtor/dual_tor_utils.py
@@ -45,12 +45,14 @@ from tests.ptf_runner import ptf_runner
 
 __all__ = ['tor_mux_intf', 'tor_mux_intfs', 'ptf_server_intf', 't1_upper_tor_intfs', 't1_lower_tor_intfs',
            'upper_tor_host', 'lower_tor_host', 'force_active_tor', 'force_standby_tor',
-           'config_active_active_dualtor_active_standby', 'validate_active_active_dualtor_setup',
+           'config_active_active_dualtor_active_standby', 'config_active_active_dualtor_active_standby_module',
+           'validate_active_active_dualtor_setup',
            'setup_standby_ports_on_rand_selected_tor',
            'setup_standby_ports_on_rand_unselected_tor',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_host_m',
            'setup_standby_ports_on_rand_unselected_tor_unconditionally',
+           'setup_standby_ports_on_rand_unselected_tor_unconditionally_module',
            'setup_standby_ports_on_non_enum_rand_one_per_hwsku_frontend_host_m_unconditionally',
            ]
 
@@ -1780,22 +1782,32 @@ def config_active_active_dualtor(active_tor, standby_tor, ports, unconditionally
     time.sleep(90)
 
 
-@pytest.fixture
-def config_active_active_dualtor_active_standby(duthosts, active_active_ports, tbinfo):     # noqa: F811
-    """Config the active-active dualtor that one ToR as active and the other as standby."""
-    if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
-        yield
+def _check_docker_status(duthost):
+    """Check if all containers on the DUT are fully started."""
+    containers = duthost.get_all_containers()
+    for container in containers:
+        if not duthost.is_service_fully_started(container):
+            return False
+    return True
+
+
+def _restore_mux_ports(duthosts, ports_to_restore):
+    """Restore mux ports to auto mode."""
+    if not ports_to_restore:
         return
 
-    def check_docker_status(duthost):
-        containers = duthost.get_all_containers()
-        for container in containers:
-            if not duthost.is_service_fully_started(container):
-                return False
-        return True
+    restore_cmds = []
+    for port in ports_to_restore:
+        restore_cmds.append("config mux mode auto {}".format(port))
 
+    for duthost in duthosts:
+        duthost.shell_cmds(cmds=restore_cmds)
+
+
+def _create_config_active_active_dualtor_handler(active_active_ports, ports_to_restore):  # noqa: F811
+    """Create a handler function for configuring active-active dualtor."""
     def _config_active_active_dualtor_active_standby(active_tor, standby_tor, ports, unconditionally=False):
-        wait_until(300, 10, 0, check_docker_status, standby_tor)
+        wait_until(300, 10, 0, _check_docker_status, standby_tor)
         for port in ports:
             if port not in active_active_ports:
                 raise ValueError("Port {} is not in the active-active ports".format(port))
@@ -1804,20 +1816,48 @@ def config_active_active_dualtor_active_standby(duthosts, active_active_ports, t
 
         ports_to_restore.extend(ports)
 
+    return _config_active_active_dualtor_active_standby
+
+
+@pytest.fixture(scope="module")
+def config_active_active_dualtor_active_standby_module(duthosts, active_active_ports, tbinfo):  # noqa: F811
+    """Module-level fixture: Config the active-active dualtor that one ToR as active and the other as standby."""
+    if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
+        yield None
+        return
+
     ports_to_restore = []
+    handler = _create_config_active_active_dualtor_handler(active_active_ports, ports_to_restore)
 
     warnings.warn("Deprecated mux port setup fixture, please use setup_dualtor_mux_ports "
                   "(docs/tests/setup.dualtor.mux.ports.md).", DeprecationWarning)
 
-    yield _config_active_active_dualtor_active_standby
+    yield handler
 
-    if ports_to_restore:
-        restore_cmds = []
-        for port in ports_to_restore:
-            restore_cmds.append("config mux mode auto {}".format(port))
+    _restore_mux_ports(duthosts, ports_to_restore)
 
-        for duthost in duthosts:
-            duthost.shell_cmds(cmds=restore_cmds)
+
+@pytest.fixture
+def config_active_active_dualtor_active_standby(duthosts, active_active_ports, tbinfo):     # noqa: F811
+    """Config the active-active dualtor that one ToR as active and the other as standby.
+
+    This fixture is kept for backward compatibility. It defaults to function scope.
+    For explicit scope control, use config_active_active_dualtor_active_standby_module or
+    config_active_active_dualtor_active_standby instead.
+    """
+    if not ('dualtor' in tbinfo['topo']['name'] and active_active_ports):
+        yield None
+        return
+
+    ports_to_restore = []
+    handler = _create_config_active_active_dualtor_handler(active_active_ports, ports_to_restore)
+
+    warnings.warn("Deprecated mux port setup fixture, please use setup_dualtor_mux_ports "
+                  "(docs/tests/setup.dualtor.mux.ports.md).", DeprecationWarning)
+
+    yield handler
+
+    _restore_mux_ports(duthosts, ports_to_restore)
 
 
 @pytest.fixture
@@ -2000,6 +2040,19 @@ def setup_standby_ports_on_rand_unselected_tor_unconditionally(
 ):
     if active_active_ports:
         config_active_active_dualtor_active_standby(rand_selected_dut, rand_unselected_dut, active_active_ports, True)
+    return
+
+
+@pytest.fixture(scope='module')
+def setup_standby_ports_on_rand_unselected_tor_unconditionally_module(
+    active_active_ports,                                                   # noqa: F811
+    rand_selected_dut,
+    rand_unselected_dut,
+    config_active_active_dualtor_active_standby_module
+):
+    if active_active_ports:
+        config_active_active_dualtor_active_standby_module(rand_selected_dut, rand_unselected_dut,
+                                                           active_active_ports, True)
     return
 
 

--- a/tests/everflow/test_everflow_ipv6.py
+++ b/tests/everflow/test_everflow_ipv6.py
@@ -116,8 +116,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
         yield direction
 
     @pytest.fixture(scope='function', autouse=True)
-    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut,  # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally):     # noqa F811
+    def background_traffic(self, ptfadapter, everflow_direction, setup_info, everflow_dut,      # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally_module):  # noqa F811
         stop_thread = threading.Event()
         src_port = EverflowIPv6Tests.rx_port_ptf_id
 
@@ -250,7 +250,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         return 6
 
     def test_src_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
+                                setup_standby_ports_on_rand_unselected_tor_unconditionally_module,      # noqa F811
                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
                                 erspan_ip_ver):                                                         # noqa F811
         """Verify that we can match on Source IPv6 addresses."""
@@ -270,7 +270,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_dst_ipv6_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
+                                setup_standby_ports_on_rand_unselected_tor_unconditionally_module,      # noqa F811
                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
                                 erspan_ip_ver):                                                         # noqa F811
         """Verify that we can match on Destination IPv6 addresses."""
@@ -290,7 +290,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_next_header_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                                   setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                                    erspan_ip_ver):                                                          # noqa F811
         """Verify that we can match on the Next Header field."""
@@ -305,7 +305,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_l4_src_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                                   setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                                    erspan_ip_ver):                                                          # noqa F811
         """Verify that we can match on the L4 Source Port."""
@@ -320,7 +320,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_l4_dst_port_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                                   setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                                   setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                                    everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                                    erspan_ip_ver):                                                          # noqa F811
         """Verify that we can match on the L4 Destination Port."""
@@ -334,11 +334,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
+    def test_l4_src_port_range_mirroring(self, setup_info, setup_mirror_session,                             # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
-                                         setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                         toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
-                                         erspan_ip_ver):                                              # noqa F811
+                                         setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
+                                         toggle_all_simulator_ports_to_rand_selected_tor,                    # noqa F811
+                                         erspan_ip_ver):                                                     # noqa F811
         """Verify that we can match on a range of L4 Source Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, sport=10200)
 
@@ -350,11 +350,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
+    def test_l4_dst_port_range_mirroring(self, setup_info, setup_mirror_session,                             # noqa F811
                                          ptfadapter, everflow_dut, everflow_direction,
-                                         setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                         toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
-                                         erspan_ip_ver):                                              # noqa F811
+                                         setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
+                                         toggle_all_simulator_ports_to_rand_selected_tor,                    # noqa F811
+                                         erspan_ip_ver):                                                     # noqa F811
         """Verify that we can match on a range of L4 Destination Ports."""
         test_packet = self._base_tcpv6_packet(everflow_direction, ptfadapter, setup_info, dport=10700)
 
@@ -367,7 +367,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_tcp_flags_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
-                                 setup_standby_ports_on_rand_unselected_tor_unconditionally,                # noqa F811
+                                 setup_standby_ports_on_rand_unselected_tor_unconditionally_module,         # noqa F811
                                  everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
                                  erspan_ip_ver):                                                            # noqa F811
         """Verify that we can match on TCP Flags."""
@@ -382,7 +382,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_dscp_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,               # noqa F811
-                            setup_standby_ports_on_rand_unselected_tor_unconditionally,                     # noqa F811
+                            setup_standby_ports_on_rand_unselected_tor_unconditionally_module,              # noqa F811
                             everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,            # noqa F811
                             erspan_ip_ver):                                                                 # noqa F811
         """Verify that we can match on DSCP."""
@@ -397,7 +397,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_l4_range_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,           # noqa F811
-                                setup_standby_ports_on_rand_unselected_tor_unconditionally,                 # noqa F811
+                                setup_standby_ports_on_rand_unselected_tor_unconditionally_module,          # noqa F811
                                 everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,        # noqa F811
                                 erspan_ip_ver):                                                             # noqa F811
         """Verify that we can match from a source port to a range of destination ports and vice-versa."""
@@ -438,7 +438,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_tcp_response_mirroring(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,             # noqa F811
+                                    setup_standby_ports_on_rand_unselected_tor_unconditionally_module,      # noqa F811
                                     everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,    # noqa F811
                                     erspan_ip_ver):                                                         # noqa F811
         """Verify that we can match a SYN -> SYN-ACK pattern."""
@@ -476,11 +476,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_tcp_application_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
+    def test_tcp_application_mirroring(self, setup_info, setup_mirror_session,                             # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                       toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
-                                       erspan_ip_ver):                                              # noqa F811
+                                       setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor,                    # noqa F811
+                                       erspan_ip_ver):                                                     # noqa F811
         """Verify that we can match a TCP handshake between a client and server."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -520,11 +520,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_udp_application_mirroring(self, setup_info, setup_mirror_session,                      # noqa F811
+    def test_udp_application_mirroring(self, setup_info, setup_mirror_session,                             # noqa F811
                                        ptfadapter, everflow_dut, everflow_direction,
-                                       setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                       toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
-                                       erspan_ip_ver):                                              # noqa F811
+                                       setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
+                                       toggle_all_simulator_ports_to_rand_selected_tor,                    # noqa F811
+                                       erspan_ip_ver):                                                     # noqa F811
         """Verify that we can match UDP traffic between a client and server application."""
         test_packet = self._base_udpv6_packet(
             everflow_direction,
@@ -564,7 +564,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_any_protocol(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                          setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
+                          setup_standby_ports_on_rand_unselected_tor_unconditionally_module,        # noqa F811
                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
                           erspan_ip_ver):                                                           # noqa F811
         """Verify that the protocol number is ignored if it is not specified in the ACL rule."""
@@ -617,11 +617,11 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_any_transport_protocol(self, setup_info, setup_mirror_session,                      # noqa F811
+    def test_any_transport_protocol(self, setup_info, setup_mirror_session,                             # noqa F811
                                     ptfadapter, everflow_dut, everflow_direction,
-                                    setup_standby_ports_on_rand_unselected_tor_unconditionally,  # noqa F811
-                                    toggle_all_simulator_ports_to_rand_selected_tor,             # noqa F811
-                                    erspan_ip_ver):                                              # noqa F811
+                                    setup_standby_ports_on_rand_unselected_tor_unconditionally_module,  # noqa F811
+                                    toggle_all_simulator_ports_to_rand_selected_tor,                    # noqa F811
+                                    erspan_ip_ver):                                                     # noqa F811
         """Verify that src port and dst port rules match regardless of whether TCP or UDP traffic is sent."""
         test_packet = self._base_tcpv6_packet(
             everflow_direction,
@@ -660,7 +660,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_invalid_tcp_rule(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                              setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
+                              setup_standby_ports_on_rand_unselected_tor_unconditionally_module,        # noqa F811
                               everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor):     # noqa F811
         """Verify that the ASIC does not reject rules with TCP flags if the protocol is not TCP."""
         pass
@@ -671,7 +671,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
         # suite + loganaylzer + the sanity check to fail.
 
     def test_source_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,            # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally,                  # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally_module,           # noqa F811
                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,         # noqa F811
                            erspan_ip_ver):                                                              # noqa F811
         """Verify that we can match packets with a Source IPv6 Subnet."""
@@ -694,7 +694,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_dest_subnet(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,          # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,                # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally_module,         # noqa F811
                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,       # noqa F811
                          erspan_ip_ver):                                                            # noqa F811
         """Verify that we can match packets with a Destination IPv6 Subnet."""
@@ -717,7 +717,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_both_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,         # noqa F811
-                          setup_standby_ports_on_rand_unselected_tor_unconditionally,               # noqa F811
+                          setup_standby_ports_on_rand_unselected_tor_unconditionally_module,        # noqa F811
                           everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,      # noqa F811
                           erspan_ip_ver):                                                           # noqa F811
         """Verify that we can match packets with both source and destination subnets."""
@@ -740,7 +740,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_fuzzy_subnets(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                           setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                           setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                            everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                            erspan_ip_ver):                                                          # noqa F811
         """Verify that we can match packets with non-standard subnet sizes."""
@@ -763,7 +763,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_icmpv6_type(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                          erspan_ip_ver):                                                          # noqa F811
         """Verify that we can match packets with icmp type field"""
@@ -782,8 +782,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_icmpv6_code(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+    def test_icmpv6_code(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                          erspan_ip_ver):                                                          # noqa F811
         """Verify that we can match packets with icmp code field"""
@@ -803,8 +803,8 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            dest_ports=EverflowIPv6Tests.tx_port_ids,
                                            erspan_ip_ver=erspan_ip_ver)
 
-    def test_ip_type_any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,       # noqa F811
-                         setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+    def test_ip_type_any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
+                         setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                          everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                          erspan_ip_ver):                                                          # noqa F811
         test_packet = self._base_tcpv6_packet(
@@ -823,7 +823,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_ip_type_ip(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                        setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                        setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                         everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                         erspan_ip_ver):                                                          # noqa F811
         test_packet = self._base_tcpv6_packet(
@@ -842,7 +842,7 @@ class EverflowIPv6Tests(BaseEverflowTest):
                                            erspan_ip_ver=erspan_ip_ver)
 
     def test_ip_type_ipv6any(self, setup_info, setup_mirror_session, ptfadapter, everflow_dut,        # noqa F811
-                             setup_standby_ports_on_rand_unselected_tor_unconditionally,              # noqa F811
+                             setup_standby_ports_on_rand_unselected_tor_unconditionally_module,       # noqa F811
                              everflow_direction, toggle_all_simulator_ports_to_rand_selected_tor,     # noqa F811
                              erspan_ip_ver):                                                          # noqa F811
         test_packet = self._base_tcpv6_packet(


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
The port toggle fixture is function scope, so it would be executed 100 times across the script running
4 hours would be used for the port toggle in total Change the fixture to module scope

Change-Id: I43e2c3f7b58727f6025ce816c67f6445746274df

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The port toggle fixture is function scope, so it would be executed 100 times across the script tests/everflow/test_everflow_ipv6.py run time.
4 hours would be used for the port toggle in total 
Change the fixture to module scope

Change-Id: I43e2c3f7b58727f6025ce816c67f6445746274df
#### How did you do it?
Change the functional port toggle fixture to module scope. It would save hours during IPv6 everflow test run.
#### How did you verify/test it?
Run it in local setup
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
