### PR TITLE
[generic_config_updater] Fix fixture mismatch in test_vlan_interface_tc1_suite

### DIFF
--- a/tests/generic_config_updater/test_vlan_interface.py
+++ b/tests/generic_config_updater/test_vlan_interface.py
@@ -416,8 +416,8 @@ def vlan_interface_tc1_remove(duthost, vlan_info):
 def test_vlan_interface_tc1_suite(rand_selected_dut, vlan_info, loganalyzer, tbinfo, duthost):
     if loganalyzer:
         if tbinfo["topo"]["name"] == "m0-2vlan":
-            loganalyzer[duthost.hostname].ignore_regex.extend(IGNORE_REG_LIST)
-        loganalyzer[duthost.hostname].ignore_regex.extend([
+            loganalyzer[rand_selected_dut.hostname].ignore_regex.extend(IGNORE_REG_LIST)
+        loganalyzer[rand_selected_dut.hostname].ignore_regex.extend([
             ".*ERR GenericConfigUpdater: Change Applier: service invoked: "
             "generic_config_updater.services_validator.vlanintf_validator failed.*"
         ])


### PR DESCRIPTION

### Description of PR

This PR fixes the  fixture mismatch in test_vlan_interface_tc1_suite

Replace session-scoped duthost fixture with module-scoped rand_selected_dut
in loganalyzer configuration to match test execution scope.

The test uses rand_selected_dut for operations but was configuring loganalyzer
errors to be ignored only on the session-scoped duthost. This caused intermittent failures dualtor topologies when rand_selected_dut selected
a different DUT than duthost


Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/22813

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The goal of this PR is to fix intermittent test failures in the test_vlan_interface_tc1_suite when running on dual-tor setups. Currently, the test fails about 50% of the time because it sometimes performs operations on one device but only tells the log analyzer to ignore expected errors on a different device. This fix ensures the test correctly ignores expected errors on the device where the test is actually running.

#### How did you do it?
I updated the log analyzer configuration to use the same device fixture as the test operations. Instead of hardcoding the log analyzer to only ignore errors on the default first device (duthost), I changed it to use the randomly selected device (rand_selected_dut) that the test is actually using for its operations. This keeps the log analyzer and the test execution in sync on the same device.

#### How did you verify/test it?
I verified this by analyzing the test execution logs and identifying that failures occurred specifically when rand_selected_dut chose a secondary device like 'ld302' while the log analyzer was still looking at 'ld301'. By aligning these fixtures, the expected vlanintf_validator errors are now correctly ignored on the standby device, preventing false-positive failures during the teardown phase

#### Any platform specific information?
No. Applies to all platforms in dualtor testbeds.

#### Supported testbed topology if it's a new test case?
N/A - Bug fix for existing test.

### Documentation
No documentation needed. Internal test fixture fix only.
