### PR TITLE
[acl] Add explicit skip for IPv6 egress tests in test_acl_outer_vlan

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -129,6 +129,10 @@ acl/test_stress_acl.py::test_acl_add_del_stress:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::*[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+
 #######################################
 #####          acstests              #####
 #######################################

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -99,6 +99,11 @@ acl/test_acl_outer_vlan.py:
     reason: "Skip running on dualtor testbed"
     conditions:
       - "'dualtor' in topo_name"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::*[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+
 acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv4]:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
@@ -128,10 +133,6 @@ acl/test_stress_acl.py::test_acl_add_del_stress:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
-
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::*[ipv6]:
-  skip:
-    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
 
 #######################################
 #####          acstests              #####

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -100,25 +100,7 @@ acl/test_acl_outer_vlan.py:
     conditions:
       - "'dualtor' in topo_name"
 
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv6]:
-  skip:
-    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
-    conditions:
-      - "True"
-
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv6]:
-  skip:
-    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
-    conditions:
-      - "True"
-
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv6]:
-  skip:
-    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
-    conditions:
-      - "True"
-
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv6]:
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv6]:
   skip:
     reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
     conditions:
@@ -130,7 +112,7 @@ acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwar
     conditions:
       - "True"
 
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv6]:
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv6]:
   skip:
     reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
     conditions:
@@ -142,17 +124,17 @@ acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forw
     conditions:
       - "True"
 
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv6]:
-  skip:
-    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
-    conditions:
-      - "True"
-
 acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv4]:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
 
 acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv4]:
   xfail:
@@ -160,11 +142,29 @@ acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv4]
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
 acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv4]:
   xfail:
     reason: "Test case has issue on the t0-isolated-d256u256s2 topo."
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
 
 acl/test_stress_acl.py:
   skip:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -100,9 +100,53 @@ acl/test_acl_outer_vlan.py:
     conditions:
       - "'dualtor' in topo_name"
 
-acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::*[ipv6]:
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_forwarded[ipv6]:
   skip:
     reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_forwarded[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_untagged_dropped[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_forwarded[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_tagged_dropped[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_forwarded[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
+
+acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_combined_untagged_dropped[ipv6]:
+  skip:
+    reason: "IPV6 EGRESS test not supported - arp_responder doesn't support IPv6"
+    conditions:
+      - "True"
 
 acl/test_acl_outer_vlan.py::TestAclVlanOuter_Egress::test_tagged_dropped[ipv4]:
   xfail:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add explicit skip marker for IPv6 egress tests in test_acl_outer_vlan.py to properly handle tests that are skipped due to arp_responder not supporting IPv6.

Previously, IPv6 egress tests were marked with xfail at the module level but skipped at runtime via pytest_require(), causing confusing xfail_expected results in test reporting dashboards (Grafana).

This change adds a proper skip marker for IPv6 egress tests in tests_mark_conditions.yaml to improve test result clarity.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
IPv6 egress tests in test_acl_outer_vlan.py are skipped at runtime because the arp_responder helper script doesn't support IPv6 NDP. However, these tests also have a module-level xfail marker applied via tests_mark_conditions.yaml. This creates a conflict where:

- Tests show as xfail_expected in Grafana instead of skip
- The test results are confusing and don't accurately represent the test state

#### How did you do it?
Added an explicit skip marker in tests_mark_conditions.yaml for IPv6 egress tests

#### How did you verify/test it?

- Verified the marker syntax is consistent with other entries in tests_mark_conditions.yaml
- Confirmed the existing xfail markers for Cisco-8000 and t0-isolated-d256u256s2 remain in place

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
