### PR TITLE
fix: fix l1 reset previous connection

### DIFF
--- a/ansible/roles/testbed/nut/tasks/l1_create_config_patch.yml
+++ b/ansible/roles/testbed/nut/tasks/l1_create_config_patch.yml
@@ -38,6 +38,10 @@
   debug:
     var: device_l1_existing_cross_connects
 
+- name: set default for reset_previous_connection
+  set_fact:
+    _reset_previous_connection: "{{ reset_previous_connection | default(true) | bool }}"
+
 - name: generate config patch for L1 switches on local machine
   when: "device_from_l1_links[inventory_hostname] is defined and device_from_l1_links[inventory_hostname] | length > 0"
   template:
@@ -49,4 +53,4 @@
     l1_links: "{{ device_from_l1_links[inventory_hostname] }}"
     l1_cross_connects: "{{ device_l1_cross_connects[inventory_hostname] }}"
     l1_existing_cross_connects: "{{ device_l1_existing_cross_connects }}"
-    reset_previous_connection: "{{ reset_previous_connection | default(true) | bool }}"
+    reset_previous_connection: "{{ _reset_previous_connection | default(true) | bool }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Currently reset_previous_connection param could fail into a recursion loop if it's not defined as `-e reset_previous_connection` at the testbed-cli command line.

This PR is to address that issue.

Fixes # (issue) 38098279

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
