### PR TITLE
Fix buffer queue get logic

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -26,7 +26,6 @@ MEMORY_CHECKER_CYCLES = 60
 SUBMODE_ONCHANGE = 1
 CFG_DB_PATH = "/etc/sonic/config_db.json"
 ORIG_CFG_DB = "/etc/sonic/orig_config_db.json"
-MAX_UC_CNT = 7
 
 
 def load_new_cfg(duthost, data):
@@ -38,16 +37,13 @@ def load_new_cfg(duthost, data):
 
 
 def get_buffer_queues_cnt(duthost, ptfhost, gnxi_path, interface):
-    cnt = 0
-    for i in range(MAX_UC_CNT):
-        xpath = "COUNTERS_QUEUE_NAME_MAP/{}:{}".format(interface, i)
-        cmd = generate_client_cli(duthost, gnxi_path, "get", xpath, "COUNTERS_DB")
-
-        cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
-
-        if not cmd_output["failed"]:
-            cnt += 1
-
+    xpath = "COUNTERS_QUEUE_NAME_MAP"
+    cmd = generate_client_cli(duthost, gnxi_path, "get", xpath, "COUNTERS_DB")
+    cmd_output = ptfhost.shell(cmd, module_ignore_errors=True)
+    if cmd_output["failed"]:
+        return 0
+    output = str(cmd_output["stdout"])
+    cnt = len(re.findall(r'{}:\d+'.format(re.escape(interface)), output))
     return cnt
 
 
@@ -178,7 +174,7 @@ def test_telemetry_queue_buffer_cnt(duthosts, enum_rand_one_per_hwsku_hostname, 
     if interface_to_check is None:
         pytest.skip("Skipping test as there are none interfaces in admin'up' state with buffer queues to check")
 
-    interface_buffer_queues = [bq for bq in buffer_queues if any(val in interface_to_check for val in bq.split('|'))]
+    interface_buffer_queues = [bq for bq in buffer_queues if bq.split('|')[0] == interface_to_check]
     if len(interface_buffer_queues) == 0:
         pytest.skip("No valid entry for any interface:queue entry")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 36369120

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Get all queues in one gnmi get call instead of multiple.

Do an exact match of interface name in key after '|' separator since substring match can mislead to which interface has access to which queues.

#### How did you do it?

Change gnmi_client call and pattern match.

#### How did you verify/test it?

Manual test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
