### PR TITLE
[202511] Add conditional skip for test_load_minigraph_with_golden_config

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3304,6 +3304,12 @@ override_config_table/test_override_config_table.py:
     conditions:
       - "is_multi_asic==True"
 
+override_config_table/test_override_config_table.py::test_load_minigraph_with_golden_config:
+  skip:
+    reason: "Test performs multiple config reloads that cause pmon start-limit-hit due to missing sonic.target symlinks after systemd-sonic-generator rework. Fix PRs: sonic-net/sonic-buildimage#25932, sonic-net/sonic-utilities#4314"
+    conditions:
+      - "https://github.com/sonic-net/sonic-buildimage/issues/25931"
+
 #######################################
 ######       packet_trimming       #####
 ########################################


### PR DESCRIPTION
## Description
Rebased cherry-pick of PR #22775 to the 202511 branch.

This replaces PR #22793, which was failing the **Pre_test Static Analysis** check because its branch was based on 202511 before PR #22796 merged. That PR fixed a duplicate YAML key (\gp/test_bgp_vnet.py\) in \	ests_mark_conditions.yaml\, and the \check-yaml\ pre-commit hook rejects duplicate keys.

### Change
Adds a conditional skip for \	est_load_minigraph_with_golden_config\ to prevent pmon \start-limit-hit\ failures during nightly tests until the root cause fixes land:
- sonic-net/sonic-buildimage#25932 (sonic.target symlink fix)
- sonic-net/sonic-utilities#4314 (pmon restart count clearing)

### Tracking
- GitHub issue: https://github.com/sonic-net/sonic-buildimage/issues/25931
- Original master PR: #22775
- Supersedes: #22793

Signed-off-by: Storm Liang <stormliang@microsoft.com>