### PR TITLE
Temporarily skip PR test jobs for non-t0/t1-lag/t2 topologies

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -114,46 +114,46 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  - job: impacted_area_t0_2vlans_elastictest
-    displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
-    dependsOn:
-    - get_impacted_area
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: false
-    pool: ${{ parameters.AGENT_POOL }}
-    steps:
-      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-          displayName: "Checkout sonic-mgmt repository"
+  # - job: impacted_area_t0_2vlans_elastictest
+  #   displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
+  #   dependsOn:
+  #   - get_impacted_area
+  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
+  #   variables:
+  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: false
+  #   pool: ${{ parameters.AGENT_POOL }}
+  #   steps:
+  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+  #         displayName: "Checkout sonic-mgmt repository"
 
-      - template: impacted_area_testing/calculate-instance-numbers.yml
-        parameters:
-          TOPOLOGY: t0-2vlans
-          BUILD_BRANCH: $(BUILD_BRANCH)
+  #     - template: impacted_area_testing/calculate-instance-numbers.yml
+  #       parameters:
+  #         TOPOLOGY: t0-2vlans
+  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-          TOPOLOGY: t0
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          ${{ each param in parameters.OVERRIDE_PARAMS }}:
-            ${{ param.key }}: ${{ param.value }}
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+  #         TOPOLOGY: t0
+  #         SCRIPTS: $(SCRIPTS)
+  #         MIN_WORKER: $(INSTANCE_NUMBER)
+  #         MAX_WORKER: $(INSTANCE_NUMBER)
+  #         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
+  #           ${{ param.key }}: ${{ param.value }}
 
   - job: impacted_area_t1_lag_elastictest
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
@@ -195,175 +195,175 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  - job: impacted_area_dualtor_elastictest
-    displayName: "impacted-area-kvmtest-dualtor by Elastictest"
-    dependsOn:
-    - get_impacted_area
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: false
-    pool: ${{ parameters.AGENT_POOL }}
-    steps:
-      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-          displayName: "Checkout sonic-mgmt repository"
+  # - job: impacted_area_dualtor_elastictest
+  #   displayName: "impacted-area-kvmtest-dualtor by Elastictest"
+  #   dependsOn:
+  #   - get_impacted_area
+  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
+  #   variables:
+  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: false
+  #   pool: ${{ parameters.AGENT_POOL }}
+  #   steps:
+  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+  #         displayName: "Checkout sonic-mgmt repository"
 
-      - template: impacted_area_testing/calculate-instance-numbers.yml
-        parameters:
-          TOPOLOGY: dualtor
-          BUILD_BRANCH: $(BUILD_BRANCH)
+  #     - template: impacted_area_testing/calculate-instance-numbers.yml
+  #       parameters:
+  #         TOPOLOGY: dualtor
+  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-          TOPOLOGY: dualtor
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          ${{ each param in parameters.OVERRIDE_PARAMS }}:
-            ${{ param.key }}: ${{ param.value }}
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+  #         TOPOLOGY: dualtor
+  #         SCRIPTS: $(SCRIPTS)
+  #         MIN_WORKER: $(INSTANCE_NUMBER)
+  #         MAX_WORKER: $(INSTANCE_NUMBER)
+  #         COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
+  #           ${{ param.key }}: ${{ param.value }}
 
-  - job: impacted_area_t0_sonic_elastictest
-    displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
-    dependsOn:
-    - get_impacted_area
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: false
-    pool: ${{ parameters.AGENT_POOL }}
-    steps:
-      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-          displayName: "Checkout sonic-mgmt repository"
+  # - job: impacted_area_t0_sonic_elastictest
+  #   displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
+  #   dependsOn:
+  #   - get_impacted_area
+  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
+  #   variables:
+  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: false
+  #   pool: ${{ parameters.AGENT_POOL }}
+  #   steps:
+  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+  #         displayName: "Checkout sonic-mgmt repository"
 
-      - template: impacted_area_testing/calculate-instance-numbers.yml
-        parameters:
-          TOPOLOGY: t0-sonic
-          BUILD_BRANCH: $(BUILD_BRANCH)
+  #     - template: impacted_area_testing/calculate-instance-numbers.yml
+  #       parameters:
+  #         TOPOLOGY: t0-sonic
+  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-          TOPOLOGY: t0-64-32
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
-          VM_TYPE: vsonic
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          SPECIFIC_PARAM: '[
-              {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
-              {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
-            ]'
-          ${{ each param in parameters.OVERRIDE_PARAMS }}:
-            ${{ param.key }}: ${{ param.value }}
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+  #         TOPOLOGY: t0-64-32
+  #         SCRIPTS: $(SCRIPTS)
+  #         MIN_WORKER: $(INSTANCE_NUMBER)
+  #         MAX_WORKER: $(INSTANCE_NUMBER)
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
+  #         VM_TYPE: vsonic
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         SPECIFIC_PARAM: '[
+  #             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
+  #             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
+  #           ]'
+  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
+  #           ${{ param.key }}: ${{ param.value }}
 
-  - job: impacted_area_dpu_elastictest
-    displayName: "impacted-area-kvmtest-dpu by Elastictest"
-    dependsOn:
-    - get_impacted_area
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: false
-    pool: ${{ parameters.AGENT_POOL }}
-    steps:
-      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-          displayName: "Checkout sonic-mgmt repository"
+  # - job: impacted_area_dpu_elastictest
+  #   displayName: "impacted-area-kvmtest-dpu by Elastictest"
+  #   dependsOn:
+  #   - get_impacted_area
+  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
+  #   variables:
+  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: false
+  #   pool: ${{ parameters.AGENT_POOL }}
+  #   steps:
+  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+  #         displayName: "Checkout sonic-mgmt repository"
 
-      - template: impacted_area_testing/calculate-instance-numbers.yml
-        parameters:
-          TOPOLOGY: dpu
-          BUILD_BRANCH: $(BUILD_BRANCH)
+  #     - template: impacted_area_testing/calculate-instance-numbers.yml
+  #       parameters:
+  #         TOPOLOGY: dpu
+  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-          TOPOLOGY: dpu
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          SPECIFIC_PARAM: '[
-              {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
-            ]'
-          ${{ each param in parameters.OVERRIDE_PARAMS }}:
-            ${{ param.key }}: ${{ param.value }}
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+  #         TOPOLOGY: dpu
+  #         SCRIPTS: $(SCRIPTS)
+  #         MIN_WORKER: $(INSTANCE_NUMBER)
+  #         MAX_WORKER: $(INSTANCE_NUMBER)
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+  #         SPECIFIC_PARAM: '[
+  #             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
+  #           ]'
+  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
+  #           ${{ param.key }}: ${{ param.value }}
 
-  # This PR checker aims to run all t1 test scripts on multi-asic topology.
-  - job: impacted_area_multi_asic_t1_elastictest
-    displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
-    dependsOn:
-    - get_impacted_area
-    condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
-    variables:
-      TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: false
-    pool: ${{ parameters.AGENT_POOL }}
-    steps:
-      - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-        - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-          displayName: "Checkout sonic-mgmt repository"
+  # # This PR checker aims to run all t1 test scripts on multi-asic topology.
+  # - job: impacted_area_multi_asic_t1_elastictest
+  #   displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
+  #   dependsOn:
+  #   - get_impacted_area
+  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
+  #   variables:
+  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: false
+  #   pool: ${{ parameters.AGENT_POOL }}
+  #   steps:
+  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+  #         displayName: "Checkout sonic-mgmt repository"
 
-      - template: impacted_area_testing/calculate-instance-numbers.yml
-        parameters:
-          TOPOLOGY: t1
-          BUILD_BRANCH: $(BUILD_BRANCH)
+  #     - template: impacted_area_testing/calculate-instance-numbers.yml
+  #       parameters:
+  #         TOPOLOGY: t1
+  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-      - template: run-test-elastictest-template.yml
-        parameters:
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-          TOPOLOGY: t1-8-lag
-          SCRIPTS: $(SCRIPTS)
-          MIN_WORKER: $(INSTANCE_NUMBER)
-          MAX_WORKER: $(INSTANCE_NUMBER)
-          NUM_ASIC: 4
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-          ${{ each param in parameters.OVERRIDE_PARAMS }}:
-            ${{ param.key }}: ${{ param.value }}
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+  #         TOPOLOGY: t1-8-lag
+  #         SCRIPTS: $(SCRIPTS)
+  #         MIN_WORKER: $(INSTANCE_NUMBER)
+  #         MAX_WORKER: $(INSTANCE_NUMBER)
+  #         NUM_ASIC: 4
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
+  #           ${{ param.key }}: ${{ param.value }}
 
   - job: impacted_area_t2_elastictest
     displayName: "impacted-area-kvmtest-t2 by Elastictest"
@@ -406,26 +406,26 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  - job: t1_lag_vpp_elastictest
-    displayName: "kvmtest-t1-lag-vpp by Elastictest [OPTIONAL]"
-    timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-    continueOnError: true
-    pool: sonic-ubuntu-1c
-    steps:
-      - template: run-test-elastictest-template.yml
-        parameters:
-          BUILD_REASON: ${{ parameters.BUILD_REASON }}
-          RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-          TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-          MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-          MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-          PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-          EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-          TOPOLOGY: t1-lag-vpp
-          MIN_WORKER: $(T1_LAG_VPP_INSTANCE_NUM)
-          MAX_WORKER: $(T1_LAG_VPP_INSTANCE_NUM)
-          KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-          MGMT_BRANCH: $(BUILD_BRANCH)
-          ASIC_TYPE: "vpp"
-          KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
-          COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"
+  # - job: t1_lag_vpp_elastictest
+  #   displayName: "kvmtest-t1-lag-vpp by Elastictest [OPTIONAL]"
+  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+  #   continueOnError: true
+  #   pool: sonic-ubuntu-1c
+  #   steps:
+  #     - template: run-test-elastictest-template.yml
+  #       parameters:
+  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
+  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+  #         TOPOLOGY: t1-lag-vpp
+  #         MIN_WORKER: $(T1_LAG_VPP_INSTANCE_NUM)
+  #         MAX_WORKER: $(T1_LAG_VPP_INSTANCE_NUM)
+  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+  #         MGMT_BRANCH: $(BUILD_BRANCH)
+  #         ASIC_TYPE: "vpp"
+  #         KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
+  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Due to limited CPU and agent resources, PR tests are currently unable to acquire sufficient KVM testbeds.
To ensure PRs can complete testing and merge in a timely manner, we are temporarily limiting PR test jobs to t0, t1-lag, and t2 topologies and skipping the rest.
#### How did you do it?
Temporarily keep PR test jobs for t0, t1-lag, and t2 topologies and skip the remaining topology test jobs.
Scope: sonic-mgmt, sonic-buildimage
Branches: master, 202511
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
