### PR TITLE
[Thinkit/Ondatra] Fix build

### DIFF
--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/config_restorer.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/config_restorer.go
@@ -26,13 +26,6 @@ var (
 	waitForSwitchStateTimeout       = 5 * time.Minute
 )
 
-var (
-	configChangedTimeout = 2 * time.Minute
-	// Using 4 minutes as the upper limit.
-	configPushAndConvergenceTimeout = 4 * time.Minute
-	waitForSwitchStateTimeout       = 5 * time.Minute
-)
-
 // DUT and CONTROL are the only restorable IDs.
 var restorableDUTIDs = map[string]bool{
 	"dut":     true,
@@ -249,7 +242,8 @@ func (cr *ConfigRestorer) restoreConfigOnDiff(ctx context.Context, t *testing.T,
 	log.InfoContextf(ctx, "Trying to restore config for device: %v by pushing default config\n", dutName)
 	configPushAndConvergenceCtx, configPushAndConvergenceCancel := context.WithTimeout(ctx, configPushAndConvergenceTimeout)
 	defer configPushAndConvergenceCancel()
-	if err := ConfigPushAndWaitForConvergence(configPushAndConvergenceCtx, t, device, nil /*(config)*/); err != nil {
+	if err := ConfigPushAndWaitForConvergence(configPushAndConvergenceCtx, t, device,
+			nil /*(config)*/, nil /*(ignorePathsWithPrefix)*/); err != nil {
 		log.InfoContextf(ctx, "ConfigPushAndWaitForConvergence(dut=%v) failed, err: %v", dutName, err)
 		return cr.reboot(ctx, t, device)
 	}


### PR DESCRIPTION
#### Description of PR 

Fixing build broken by two recent PRs

1. 4 enums added for a second time :
https://github.com/sonic-net/sonic-mgmt/pull/21791/changes#diff-24542f19d742adecb6a42733962e104499fd44875f0f56631550dc0c58ca1173R23


2. Extra argument was added to ConfigPushAndWaitForConvergence without modifying the call : 
https://github.com/sonic-net/sonic-mgmt/pull/21790/changes#diff-a8de8a07e08bad4a49c1d9998654af60b3cf2c233ad8343907473e68741c6a9cR175

#### Build and sanity


sbiyer@docker-sonic-mgmt-sbiyer_1:/data/sonic-mgmt/sdn_tests/pins_ondatra$ 
sbiyer@docker-sonic-mgmt-sbiyer_1:/data/sonic-mgmt/sdn_tests/pins_ondatra$ bazel build ...
bazel build //infrastructure/thinkit:cthinkit
build //infrastructure/thinkit:ondatra_generic_testbed
bazel build //infrastructure/thinkit:ondatra_generic_testbed_fixture
bazel build //infrastructure/thinkit:ondatra_generic_testbed_fixture_test
bazel build //infrastructure/thinkit:ondatra_mirror_testbed
bazel build //infrastructure/thinkit:ondatra_mirror_testbed_fixture
bazel build //infrastructure/thinkit:ondatra_params
bazel build //infrastructure/thinkit:ondatra_params_test
bazel build //tests/thinkit:random_blackbox_events_test
bazel build //tests/thinkit:arbitration_test
bazel build //tests/thinkit:configure_mirror_testbed_test
bazel build //tests/thinkit:arriba_test
INFO: Analyzed 45 targets (0 packages loaded, 0 targets configured).
INFO: Found 45 targets...
INFO: Elapsed time: 0.436s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //infrastructure/thinkit:cthinkit (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:cthinkit up-to-date:
  bazel-bin/infrastructure/thinkit/libcthinkit.a
  bazel-bin/infrastructure/thinkit/libcthinkit.so
INFO: Elapsed time: 0.314s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
bash: build: command not found
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture up-to-date:
  bazel-bin/infrastructure/thinkit/libondatra_generic_testbed_fixture.a
  bazel-bin/infrastructure/thinkit/libondatra_generic_testbed_fixture.so
INFO: Elapsed time: 0.352s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_generic_testbed_fixture_test up-to-date:
  bazel-bin/infrastructure/thinkit/ondatra_generic_testbed_fixture_test
INFO: Elapsed time: 0.289s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //infrastructure/thinkit:ondatra_mirror_testbed (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_mirror_testbed up-to-date (nothing to build)
INFO: Elapsed time: 0.318s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //infrastructure/thinkit:ondatra_mirror_testbed_fixture (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_mirror_testbed_fixture up-to-date:
  bazel-bin/infrastructure/thinkit/libondatra_mirror_testbed_fixture.a
  bazel-bin/infrastructure/thinkit/libondatra_mirror_testbed_fixture.so
INFO: Elapsed time: 0.346s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //infrastructure/thinkit:ondatra_params (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_params up-to-date:
  bazel-bin/infrastructure/thinkit/libondatra_params.a
  bazel-bin/infrastructure/thinkit/libondatra_params.so
INFO: Elapsed time: 0.353s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //infrastructure/thinkit:ondatra_params_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //infrastructure/thinkit:ondatra_params_test up-to-date:
  bazel-bin/infrastructure/thinkit/ondatra_params_test
INFO: Elapsed time: 0.298s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //tests/thinkit:random_blackbox_events_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:random_blackbox_events_test up-to-date:
  bazel-bin/tests/thinkit/random_blackbox_events_test
INFO: Elapsed time: 0.370s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //tests/thinkit:arbitration_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:arbitration_test up-to-date:
  bazel-bin/tests/thinkit/arbitration_test
INFO: Elapsed time: 0.361s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //tests/thinkit:configure_mirror_testbed_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:configure_mirror_testbed_test up-to-date:
  bazel-bin/tests/thinkit/configure_mirror_testbed_test
INFO: Elapsed time: 0.370s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Analyzed target //tests/thinkit:arriba_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests/thinkit:arriba_test up-to-date:
  bazel-bin/tests/thinkit/arriba_test
INFO: Elapsed time: 0.365s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
sbiyer@docker-sonic-mgmt-sbiyer_1:/data/sonic-mgmt/sdn_tests/pins_ondatra$ 




./sdn_build.sh 
==========[Building test: ethcounter_sw_dual_switch_test]==========
INFO: Analyzed target //tests:ethcounter_sw_dual_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:ethcounter_sw_dual_switch_test up-to-date:
  bazel-bin/tests/ethcounter_sw_dual_switch_test_/ethcounter_sw_dual_switch_test
INFO: Elapsed time: 0.399s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: ethcounter_sw_dual_switch_test]==========
==========[Building test: gnmi_long_stress_test]==========
INFO: Analyzed target //tests:gnmi_long_stress_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_long_stress_test up-to-date:
  bazel-bin/tests/gnmi_long_stress_test_/gnmi_long_stress_test
INFO: Elapsed time: 0.372s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_long_stress_test]==========
==========[Building test: gnmi_stress_helper]==========
INFO: Analyzed target //tests:gnmi_stress_helper (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_stress_helper up-to-date:
  bazel-bin/tests/gnmi_stress_helper.a
INFO: Elapsed time: 0.358s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_stress_helper]==========
==========[Building test: gnoi_file_test]==========
INFO: Analyzed target //tests:gnoi_file_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_file_test up-to-date:
  bazel-bin/tests/gnoi_file_test_/gnoi_file_test
INFO: Elapsed time: 0.339s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnoi_file_test]==========
==========[Building test: gnoi_factory_reset_test]==========
INFO: Analyzed target //tests:gnoi_factory_reset_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_factory_reset_test up-to-date:
  bazel-bin/tests/gnoi_factory_reset_test_/gnoi_factory_reset_test
INFO: Elapsed time: 3.811s, Critical Path: 3.42s
INFO: 8 processes: 3 internal, 5 processwrapper-sandbox.
INFO: Build completed successfully, 8 total actions
==========[Build Complete: gnoi_factory_reset_test]==========
==========[Building test: lacp_timeout_test]==========
INFO: Analyzed target //tests:lacp_timeout_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:lacp_timeout_test up-to-date:
  bazel-bin/tests/lacp_timeout_test_/lacp_timeout_test
INFO: Elapsed time: 0.349s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: lacp_timeout_test]==========
==========[Building test: link_event_damping_test]==========
INFO: Analyzed target //tests:link_event_damping_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:link_event_damping_test up-to-date:
  bazel-bin/tests/link_event_damping_test_/link_event_damping_test
INFO: Elapsed time: 0.356s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: link_event_damping_test]==========
==========[Building test: port_debug_data_test]==========
INFO: Analyzed target //tests:port_debug_data_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:port_debug_data_test up-to-date:
  bazel-bin/tests/port_debug_data_test_/port_debug_data_test
INFO: Elapsed time: 0.375s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: port_debug_data_test]==========
==========[Building test: platforms_hardware_component_test]==========
INFO: Analyzed target //tests:platforms_hardware_component_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:platforms_hardware_component_test up-to-date:
  bazel-bin/tests/platforms_hardware_component_test_/platforms_hardware_component_test
INFO: Elapsed time: 0.341s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: platforms_hardware_component_test]==========
==========[Building test: module_reset_test]==========
INFO: Analyzed target //tests:module_reset_test_dualnode (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:module_reset_test_dualnode up-to-date:
  bazel-bin/tests/module_reset_test_dualnode_/module_reset_test_dualnode
INFO: Elapsed time: 0.320s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: module_reset_test]==========
==========[Building test: installation_test]==========
INFO: Analyzed target //tests:installation_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:installation_test up-to-date:
  bazel-bin/tests/installation_test_/installation_test
INFO: Elapsed time: 0.327s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: installation_test]==========
==========[Building test: inband_sw_interface_dual_switch_test]==========
INFO: Analyzed target //tests:inband_sw_interface_dual_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:inband_sw_interface_dual_switch_test up-to-date:
  bazel-bin/tests/inband_sw_interface_dual_switch_test_/inband_sw_interface_dual_switch_test
INFO: Elapsed time: 0.351s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: inband_sw_interface_dual_switch_test]==========
==========[Building test: gnmi_get_modes_test]==========
INFO: Analyzed target //tests:gnmi_get_modes_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_get_modes_test up-to-date:
  bazel-bin/tests/gnmi_get_modes_test_/gnmi_get_modes_test
INFO: Elapsed time: 0.319s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_get_modes_test]==========
==========[Building test: transceiver_test]==========
INFO: Analyzed target //tests:transceiver_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:transceiver_test up-to-date:
  bazel-bin/tests/transceiver_test_/transceiver_test
INFO: Elapsed time: 0.354s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: transceiver_test]==========
==========[Building test: inband_sw_interface_test]==========
INFO: Analyzed target //tests:inband_sw_interface_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:inband_sw_interface_test up-to-date:
  bazel-bin/tests/inband_sw_interface_test_/inband_sw_interface_test
INFO: Elapsed time: 0.319s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: inband_sw_interface_test]==========
==========[Building test: platforms_software_component_test]==========
INFO: Analyzed target //tests:platforms_software_component_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:platforms_software_component_test up-to-date:
  bazel-bin/tests/platforms_software_component_test_/platforms_software_component_test
INFO: Elapsed time: 0.335s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: platforms_software_component_test]==========
==========[Building test: gnoi_reboot_test]==========
INFO: Analyzed target //tests:gnoi_reboot_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnoi_reboot_test up-to-date:
  bazel-bin/tests/gnoi_reboot_test_/gnoi_reboot_test
INFO: Elapsed time: 0.360s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnoi_reboot_test]==========
==========[Building test: cpu_sw_single_switch_test]==========
INFO: Analyzed target //tests:cpu_sw_single_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:cpu_sw_single_switch_test up-to-date:
  bazel-bin/tests/cpu_sw_single_switch_test_/cpu_sw_single_switch_test
INFO: Elapsed time: 0.344s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: cpu_sw_single_switch_test]==========
==========[Building test: ethcounter_sw_single_switch_test]==========
INFO: Analyzed target //tests:ethcounter_sw_single_switch_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:ethcounter_sw_single_switch_test up-to-date:
  bazel-bin/tests/ethcounter_sw_single_switch_test_/ethcounter_sw_single_switch_test
INFO: Elapsed time: 0.389s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: ethcounter_sw_single_switch_test]==========
==========[Building test: gnmi_set_get_test]==========
INFO: Analyzed target //tests:gnmi_set_get_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_set_get_test up-to-date:
  bazel-bin/tests/gnmi_set_get_test_/gnmi_set_get_test
INFO: Elapsed time: 0.338s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_set_get_test]==========
==========[Building test: lacp_test]==========
INFO: Analyzed target //tests:lacp_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:lacp_test up-to-date:
  bazel-bin/tests/lacp_test_/lacp_test
INFO: Elapsed time: 0.369s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: lacp_test]==========
==========[Building test: z_gnmi_stress_test]==========
INFO: Analyzed target //tests:z_gnmi_stress_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:z_gnmi_stress_test up-to-date:
  bazel-bin/tests/z_gnmi_stress_test_/z_gnmi_stress_test
INFO: Elapsed time: 0.330s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: z_gnmi_stress_test]==========
==========[Building test: system_paths_test]==========
INFO: Analyzed target //tests:system_paths_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:system_paths_test up-to-date:
  bazel-bin/tests/system_paths_test_/system_paths_test
INFO: Elapsed time: 0.341s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: system_paths_test]==========
==========[Building test: gnmi_wildcard_subscription_test]==========
INFO: Analyzed target //tests:gnmi_wildcard_subscription_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_wildcard_subscription_test up-to-date:
  bazel-bin/tests/gnmi_wildcard_subscription_test_/gnmi_wildcard_subscription_test
INFO: Elapsed time: 0.332s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: gnmi_wildcard_subscription_test]==========
==========[Building test: mgmt_interface_test]==========
INFO: Analyzed target //tests:mgmt_interface_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:mgmt_interface_test up-to-date:
  bazel-bin/tests/mgmt_interface_test_/mgmt_interface_test
INFO: Elapsed time: 9.033s, Critical Path: 8.65s
INFO: 8 processes: 3 internal, 5 processwrapper-sandbox.
INFO: Build completed successfully, 8 total actions
==========[Build Complete: mgmt_interface_test]==========
==========[Building test: gnmi_subscribe_modes_test]==========
INFO: Analyzed target //tests:gnmi_subscribe_modes_test (0 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //tests:gnmi_subscribe_modes_test up-to-date:
  bazel-bin/tests/gnmi_subscribe_modes_test_/gnmi_subscribe_modes_test
INFO: Elapsed time: 9.538s, Critical Path: 9.14s
INFO: 8 processes: 3 internal, 5 processwrapper-sandbox.
INFO: Build completed successfully, 8 total actions
==========[Build Complete: gnmi_subscribe_modes_test]==========
==========[Building test: all_tests]==========
INFO: Analyzed 22 targets (0 packages loaded, 0 targets configured).
INFO: Found 22 targets...
INFO: Elapsed time: 0.322s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
==========[Build Complete: all_tests]==========
sbiyer@docker-sonic-mgmt-sbiyer_1:/data/sonic-mgmt/sdn_tests/pins_ondatra$ 

