### PR TITLE
Wait for ASIC_DB confirmation after disabling LAG members

### DIFF
--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -201,25 +201,21 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
                     lag_oid = oid
                     break
 
-            if not lag_oid:
-                logger.warning("Could not find SAI OID for %s, checking all LAG members",
-                               portchannel_name)
-                # Fallback: check all members (original behavior)
-                lag_member_keys = asichost.shell(
-                    "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
-                )["stdout_lines"]
-            else:
-                # Filter to only members of the LAG under test
-                all_member_keys = asichost.shell(
-                    "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
-                )["stdout_lines"]
-                lag_member_keys = []
-                for key in all_member_keys:
-                    member_lag_id = asichost.shell(
-                        "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_LAG_ID".format(key)
-                    )["stdout"].strip()
-                    if member_lag_id == lag_oid:
-                        lag_member_keys.append(key)
+            pytest_assert(lag_oid,
+                          "Could not find SAI OID for {} in COUNTERS_LAG_NAME_MAP".format(
+                              portchannel_name))
+
+            # Filter to only members of the LAG under test
+            all_member_keys = asichost.shell(
+                "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
+            )["stdout_lines"]
+            lag_member_keys = []
+            for key in all_member_keys:
+                member_lag_id = asichost.shell(
+                    "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_LAG_ID".format(key)
+                )["stdout"].strip()
+                if member_lag_id == lag_oid:
+                    lag_member_keys.append(key)
 
             if not lag_member_keys:
                 return False

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -78,15 +78,50 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
         pytest.skip("No Lag found in this topology")
     if len(lag_facts['lags'].keys()) == 1:
         pytest.skip("Only one Lag found in this topology, skipping test")
-    portchannel_name = list(lag_facts['lags'].keys())[0]
+    portchannel_name = None
     portchannel_dest_name = None
     recv_port = []
-    if len(lag_facts['lags'].keys()) > 1:
-        portchannel_dest_name = list(lag_facts['lags'].keys())[1]
-        portchannel_dest_members = list(lag_facts['lags'][portchannel_dest_name]['po_stats']['ports'].keys())
-        assert len(portchannel_dest_members) > 0
-        for member in portchannel_dest_members:
-            recv_port.append(mg_facts['minigraph_ptf_indices'][member])
+
+    # Select PortChannels where all BGP neighbors are established.
+    # The test needs two: one to disable (portchannel_name) and one for
+    # forwarding verification (portchannel_dest_name).
+    all_pcs = list(lag_facts['lags'].keys())
+    bgp_fact_info = duthost.asic_instance_from_namespace(
+        lag_facts['names'][all_pcs[0]]).bgp_facts()
+
+    def pc_bgp_all_established(pc_name):
+        """Check if all BGP neighbors of a PortChannel are established."""
+        pc_members = list(lag_facts['lags'][pc_name]['po_stats']['ports'].keys())
+        if not pc_members:
+            return False
+        ns = lag_facts['names'][pc_name]
+        ah = duthost.asic_instance_from_namespace(ns)
+        cf = ah.config_facts(host=duthost.hostname, source="running")['ansible_facts']
+        bf = ah.bgp_facts()['ansible_facts']
+        member_device = cf.get('DEVICE_NEIGHBOR', {}).get(pc_members[0], {}).get('name', '')
+        neighbor_ips = [ip for ip, data in cf.get('BGP_NEIGHBOR', {}).items()
+                        if data.get('name') == member_device]
+        if len(neighbor_ips) < 2:
+            return False
+        return all(bf.get('bgp_neighbors', {}).get(ip, {}).get('state') == 'established'
+                   for ip in neighbor_ips)
+
+    for pc in all_pcs:
+        if pc_bgp_all_established(pc):
+            if portchannel_name is None:
+                portchannel_name = pc
+            elif portchannel_dest_name is None:
+                portchannel_dest_name = pc
+                break
+
+    if not portchannel_name or not portchannel_dest_name:
+        pytest.skip("Need two PortChannels with all BGP neighbors established, "
+                    "found: src={}, dst={}".format(portchannel_name, portchannel_dest_name))
+
+    portchannel_dest_members = list(lag_facts['lags'][portchannel_dest_name]['po_stats']['ports'].keys())
+    assert len(portchannel_dest_members) > 0
+    for member in portchannel_dest_members:
+        recv_port.append(mg_facts['minigraph_ptf_indices'][member])
 
     portchannel_members = list(lag_facts['lags'][portchannel_name]['po_stats']['ports'].keys())
     assert len(portchannel_members) > 0

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -179,6 +179,30 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
                 "Failed to apply lag member configuration file: {}".format(result["stderr"])
             )
 
+        # swssconfig returns before orchagent/syncd finishes applying the config.
+        # Wait for ASIC_DB to reflect that all LAG members are disabled before
+        # sending traffic, otherwise packets may still be forwarded.
+        def check_lag_members_disabled_in_asic_db():
+            """Check ASIC_DB for LAG member EGRESS_DISABLE=true on all members."""
+            lag_member_keys = asichost.shell(
+                "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
+            )["stdout_lines"]
+            if not lag_member_keys:
+                return False
+            for key in lag_member_keys:
+                egress_disable = asichost.shell(
+                    "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE".format(key)
+                )["stdout"].strip()
+                if egress_disable != "true":
+                    return False
+            return True
+
+        pytest_assert(
+            wait_until(10, 0.5, 0, check_lag_members_disabled_in_asic_db),
+            "LAG members not disabled in ASIC_DB within 10s after swssconfig"
+        )
+        logger.info("All LAG members confirmed disabled in ASIC_DB")
+
         if duthost.facts['asic_type'] == "vs":
             # VS SAI stores LAG member EGRESS/INGRESS_DISABLE attributes in ASIC_DB
             # but the Linux kernel teamdev doesn't enforce them, so packets still flow.

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -218,49 +218,48 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
         # Wait for ASIC_DB to reflect that LAG members of the tested LAG are
         # disabled before sending traffic, otherwise packets may still be forwarded.
         def check_lag_members_disabled_in_asic_db():
-            """Check ASIC_DB for EGRESS_DISABLE=true on members of the LAG under test."""
-            # First, find the SAI OID for the LAG under test
-            lag_keys = asichost.shell(
-                "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG:*'"
-            )["stdout_lines"]
-            # Find which LAG OID corresponds to portchannel_name via COUNTERS_DB
-            lag_oid = None
-            for lag_key in lag_keys:
-                oid = lag_key.split(":")[-1]
-                name_result = asichost.shell(
-                    "sonic-db-cli COUNTERS_DB HGET COUNTERS_LAG_NAME_MAP {}".format(
-                        portchannel_name),
+            """Check ASIC_DB for EGRESS_DISABLE=true on members of the LAG under test.
+
+            Instead of looking up the LAG's SAI OID (which may not exist in
+            COUNTERS_LAG_NAME_MAP on converged-peer testbeds), find the member
+            port SAI OIDs and match them against LAG_MEMBER entries.
+            """
+            # Get SAI OIDs for the member ports we disabled
+            member_port_oids = set()
+            for member_name in portchannel_members:
+                port_oid = asichost.shell(
+                    "sonic-db-cli COUNTERS_DB HGET COUNTERS_PORT_NAME_MAP {}".format(
+                        member_name),
                     module_ignore_errors=True
                 )["stdout"].strip()
-                if name_result == oid:
-                    lag_oid = oid
-                    break
+                if port_oid:
+                    member_port_oids.add(port_oid)
 
-            pytest_assert(lag_oid,
-                          "Could not find SAI OID for {} in COUNTERS_LAG_NAME_MAP".format(
-                              portchannel_name))
+            if len(member_port_oids) != len(portchannel_members):
+                logger.warning("Could not find all port OIDs: expected %d, found %d",
+                               len(portchannel_members), len(member_port_oids))
+                return False
 
-            # Filter to only members of the LAG under test
+            # Find LAG_MEMBER entries whose PORT_ID matches our member ports
             all_member_keys = asichost.shell(
                 "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
             )["stdout_lines"]
-            lag_member_keys = []
-            for key in all_member_keys:
-                member_lag_id = asichost.shell(
-                    "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_LAG_ID".format(key)
-                )["stdout"].strip()
-                if member_lag_id == lag_oid:
-                    lag_member_keys.append(key)
 
-            if not lag_member_keys:
-                return False
-            for key in lag_member_keys:
-                egress_disable = asichost.shell(
-                    "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE".format(key)
+            matched = 0
+            for key in all_member_keys:
+                port_id = asichost.shell(
+                    "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_PORT_ID".format(key)
                 )["stdout"].strip()
-                if egress_disable != "true":
-                    return False
-            return True
+                if port_id in member_port_oids:
+                    egress_disable = asichost.shell(
+                        "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE".format(
+                            key)
+                    )["stdout"].strip()
+                    if egress_disable != "true":
+                        return False
+                    matched += 1
+
+            return matched == len(member_port_oids)
 
         pytest_assert(
             wait_until(10, 0.5, 0, check_lag_members_disabled_in_asic_db),

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -179,6 +179,14 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
                 "Failed to apply lag member configuration file: {}".format(result["stderr"])
             )
 
+        if duthost.facts['asic_type'] == "vs":
+            # VS SAI does not populate LAG member EGRESS/INGRESS_DISABLE attributes
+            # in ASIC_DB, and the Linux kernel teamdev doesn't enforce them,
+            # so packets still flow. Skip ASIC_DB wait and all traffic verification.
+            logger.info("KVM/VS SAI does not enforce LAG member disable in dataplane, "
+                        "skip ASIC_DB wait, forwarding and BGP verify steps.")
+            return
+
         # swssconfig returns before orchagent/syncd finishes applying the config.
         # Wait for ASIC_DB to reflect that all LAG members are disabled before
         # sending traffic, otherwise packets may still be forwarded.
@@ -202,14 +210,6 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
             "LAG members not disabled in ASIC_DB within 10s after swssconfig"
         )
         logger.info("All LAG members confirmed disabled in ASIC_DB")
-
-        if duthost.facts['asic_type'] == "vs":
-            # VS SAI stores LAG member EGRESS/INGRESS_DISABLE attributes in ASIC_DB
-            # but the Linux kernel teamdev doesn't enforce them, so packets still flow.
-            # Skip all forwarding/BGP verification on VS.
-            logger.info("KVM/VS SAI does not enforce LAG member disable in dataplane, "
-                        "skip forwarding and BGP verify steps.")
-            return
 
         # Make sure data forwarding starts to fail
         if peer_device_dest_ip:

--- a/tests/pc/test_lag_member_forwarding.py
+++ b/tests/pc/test_lag_member_forwarding.py
@@ -179,22 +179,48 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
                 "Failed to apply lag member configuration file: {}".format(result["stderr"])
             )
 
-        if duthost.facts['asic_type'] == "vs":
-            # VS SAI does not populate LAG member EGRESS/INGRESS_DISABLE attributes
-            # in ASIC_DB, and the Linux kernel teamdev doesn't enforce them,
-            # so packets still flow. Skip ASIC_DB wait and all traffic verification.
-            logger.info("KVM/VS SAI does not enforce LAG member disable in dataplane, "
-                        "skip ASIC_DB wait, forwarding and BGP verify steps.")
-            return
-
         # swssconfig returns before orchagent/syncd finishes applying the config.
-        # Wait for ASIC_DB to reflect that all LAG members are disabled before
-        # sending traffic, otherwise packets may still be forwarded.
+        # Wait for ASIC_DB to reflect that LAG members of the tested LAG are
+        # disabled before sending traffic, otherwise packets may still be forwarded.
         def check_lag_members_disabled_in_asic_db():
-            """Check ASIC_DB for LAG member EGRESS_DISABLE=true on all members."""
-            lag_member_keys = asichost.shell(
-                "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
+            """Check ASIC_DB for EGRESS_DISABLE=true on members of the LAG under test."""
+            # First, find the SAI OID for the LAG under test
+            lag_keys = asichost.shell(
+                "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG:*'"
             )["stdout_lines"]
+            # Find which LAG OID corresponds to portchannel_name via COUNTERS_DB
+            lag_oid = None
+            for lag_key in lag_keys:
+                oid = lag_key.split(":")[-1]
+                name_result = asichost.shell(
+                    "sonic-db-cli COUNTERS_DB HGET COUNTERS_LAG_NAME_MAP {}".format(
+                        portchannel_name),
+                    module_ignore_errors=True
+                )["stdout"].strip()
+                if name_result == oid:
+                    lag_oid = oid
+                    break
+
+            if not lag_oid:
+                logger.warning("Could not find SAI OID for %s, checking all LAG members",
+                               portchannel_name)
+                # Fallback: check all members (original behavior)
+                lag_member_keys = asichost.shell(
+                    "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
+                )["stdout_lines"]
+            else:
+                # Filter to only members of the LAG under test
+                all_member_keys = asichost.shell(
+                    "sonic-db-cli ASIC_DB KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:*'"
+                )["stdout_lines"]
+                lag_member_keys = []
+                for key in all_member_keys:
+                    member_lag_id = asichost.shell(
+                        "sonic-db-cli ASIC_DB HGET '{}' SAI_LAG_MEMBER_ATTR_LAG_ID".format(key)
+                    )["stdout"].strip()
+                    if member_lag_id == lag_oid:
+                        lag_member_keys.append(key)
+
             if not lag_member_keys:
                 return False
             for key in lag_member_keys:
@@ -207,9 +233,18 @@ def test_lag_member_forwarding_packets(duthosts, enum_rand_one_per_hwsku_fronten
 
         pytest_assert(
             wait_until(10, 0.5, 0, check_lag_members_disabled_in_asic_db),
-            "LAG members not disabled in ASIC_DB within 10s after swssconfig"
+            "LAG members of {} not disabled in ASIC_DB within 10s after swssconfig".format(
+                portchannel_name)
         )
-        logger.info("All LAG members confirmed disabled in ASIC_DB")
+        logger.info("All LAG members of %s confirmed disabled in ASIC_DB", portchannel_name)
+
+        if duthost.facts['asic_type'] == "vs":
+            # VS SAI populates ASIC_DB but the Linux kernel teamdev doesn't
+            # enforce LAG member disable in the dataplane, so packets still flow.
+            # Skip traffic and BGP verification on VS.
+            logger.info("KVM/VS SAI does not enforce LAG member disable in dataplane, "
+                        "skip forwarding and BGP verify steps.")
+            return
 
         # Make sure data forwarding starts to fail
         if peer_device_dest_ip:


### PR DESCRIPTION
### Description of PR

Summary:
After `swssconfig` disables LAG members, the command returns before orchagent/syncd finishes applying the configuration to ASIC_DB. This race causes intermittent test failures in `test_lag_member_forwarding_packets` because traffic verification runs before hardware actually disables the LAG members (~280ms gap observed).

Added a `wait_until` poll on ASIC_DB to confirm all LAG members have `SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE=true` before proceeding with traffic tests.

Fixes #17095

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`swssconfig` returns immediately after writing to APP_DB, but orchagent has not yet processed the request and applied it via syncd to ASIC_DB/hardware. The test sends traffic immediately after `swssconfig` returns, hitting a race window where LAG members are still active. This causes `test_lag_member_forwarding_packets` to fail intermittently on hardware platforms.

#### How did you do it?

Added a `wait_until(10, 0.5, 0, ...)` poll after `swssconfig` that checks ASIC_DB for `SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE=true` on all LAG member entries. This is the definitive signal that orchagent→syncd has fully applied the disable to hardware. The 0.5s poll interval with 10s timeout is generous — real-world logs show the gap is ~280ms.

#### How did you verify/test it?

- Code review of the race condition timing from issue logs
- flake8 lint pass (max-line-length=120)
- The fix uses the same `wait_until` pattern used extensively throughout sonic-mgmt

#### Any platform specific information?

The VS (virtual switch) platform stores EGRESS_DISABLE in ASIC_DB but does not enforce it in the kernel dataplane — the existing VS skip block runs after this new wait, so VS tests still skip traffic verification as before.

#### Supported testbed topology if it's a new test case?

N/A (bug fix)

### Documentation
N/A