### PR TITLE
[202511]Revert "Enable orch_northbond_route_zmq_enabled feature in sonic-mgmt test(#20441)"

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -526,38 +526,6 @@ class GenerateGoldenConfigDBModule(object):
         else:
             return config
 
-    def generate_default_init_config_db(self):
-        rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
-        if rc != 0:
-            self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
-
-        # Generate config table from init_cfg.ini
-        ori_config_db = json.loads(out)
-
-        golden_config_db = {}
-        if "DEVICE_METADATA" in ori_config_db:
-            golden_config_db["DEVICE_METADATA"] = ori_config_db["DEVICE_METADATA"]
-
-        # Set buffer_model to traditional to prevent regression, as it is currently hardcoded here:
-        #     https://github.com/sonic-net/sonic-utilities/blob/19594b99129f3c881d500ff65d4955d077accb25/config/main.py#L2216
-        golden_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
-
-        return json.dumps(golden_config_db, indent=4)
-
-    def update_zmq_config(self, config):
-        ori_config_db = json.loads(config)
-        if "DEVICE_METADATA" not in ori_config_db:
-            ori_config_db["DEVICE_METADATA"] = {}
-        if "localhost" not in ori_config_db["DEVICE_METADATA"]:
-            ori_config_db["DEVICE_METADATA"]["localhost"] = {}
-
-        # Older version image may not support ZMQ feature flag
-        rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
-        if "orch_northbond_route_zmq_enabled" in out:
-            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
-
-        return json.dumps(ori_config_db, indent=4)
-
     def generate_lt2_ft2_golden_config_db(self):
         """
         Generate golden_config for FT2 to enable FEC.
@@ -601,10 +569,7 @@ class GenerateGoldenConfigDBModule(object):
         elif self.topo_name in ["t1-filterleaf-lag"]:
             config = self.generate_filterleaf_golden_config_db()
         else:
-            config = self.generate_default_init_config_db()
-
-        # update ZMQ config
-        config = self.update_zmq_config(config)
+            config = "{}"
 
         # update dns config
         config = self.update_dns_config(config)


### PR DESCRIPTION

This reverts commit 111e63535acdb0c9b9d5edf4b1da972b889cb8d1.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Revert https://github.com/sonic-net/sonic-mgmt/pull/20441/
ZMQ Nothbound for routes need to be validated in Master first. It can be enabled from 202605 branch onwards. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Northbound ZMQ cant be enabled by default for sonic-mgmt tests in 202511. It bypasses the default code flow(through redis).
It needs to be thoroughly tested in master first and can be enabled from 202605 branch onwards.

#### How did you do it?
revert https://github.com/sonic-net/sonic-mgmt/pull/20441/ from 202511
#### How did you verify/test it?
NA

#### Any platform specific information?
NA
#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
