### PR TITLE
bgp: reset failed state before restart in bgp session test

### DIFF
--- a/tests/bgp/test_bgp_session.py
+++ b/tests/bgp/test_bgp_session.py
@@ -239,6 +239,7 @@ def test_bgp_session_interface_down(duthosts, rand_one_dut_hostname, fanouthosts
         )
 
         if test_type == "bgp_docker":
+            duthost.shell("systemctl reset-failed bgp", module_ignore_errors=True)
             duthost.shell("systemctl restart bgp")
         elif test_type == "swss_docker":
             duthost.shell("systemctl restart swss")


### PR DESCRIPTION
### Description of PR

Add a line to reset the restart limit for bgp in test_bgp_session.py script to avoid hitting the restart limit during tests in some conditions.

Summary:
Fixes # Hitting the restart limit would cause bgp container to be not run, and all subsequent tests failing.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
