### PR TITLE
verify telemetry output for port after port speed change

### DIFF
--- a/tests/generic_config_updater/add_cluster/test_port_speed_change.py
+++ b/tests/generic_config_updater/add_cluster/test_port_speed_change.py
@@ -715,7 +715,7 @@ def test_port_speed_change(tbinfo,
                            initialize_random_variables,
                            initialize_facts,
                            ptfadapter,
-                           setup_port_speed_change):
+                           setup_port_speed_change, ptfhost, gnxi_path, localhost):
     """
     Validates port speed change functionality via Generic Config Updater (GCU).
     This test verifies that port speed changes are correctly applied, including updates to

--- a/tests/generic_config_updater/add_cluster/test_port_speed_change.py
+++ b/tests/generic_config_updater/add_cluster/test_port_speed_change.py
@@ -801,7 +801,6 @@ def test_port_speed_change(tbinfo,
 
     with allure.step("Verify telemetry data for port after port speed change"):
         with setup_streaming_telemetry_context(False, duthost, localhost, ptfhost, gnxi_path):
-            add_route_to_ptf_setup(duthosts, tbinfo, request)
             GNMI_SERVER_START_WAIT_TIME = 15
             env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
             # Set up telemetry server
@@ -811,8 +810,9 @@ def test_port_speed_change(tbinfo,
                           module_ignore_errors=False)
             time.sleep(GNMI_SERVER_START_WAIT_TIME)
             logger.info("entering verifying port telemetry info Amol")
-            cmd = generate_client_cli(duthost, gnxi_path, method="get", xpath=f"COUNTERS/{selected_random_port}",
-                                      target="COUNTERS_DB")
+            cmd = f'. /root/env-python3/bin/activate && cd {gnxi_path}gnmi_cli_py ' \
+                  f'&& python py_gnmicli.py -g -t {duthost.mgmt_ip} -p {env.gnmi_port} ' \
+                  f'-m get -x COUNTERS/{selected_random_port} -xt COUNTERS_DB -o ndastreamingservertest'
             show_gnmi_out = ptfhost.shell(cmd)['stdout']
             logger.info("GNMI Server output")
             logger.info(show_gnmi_out)

--- a/tests/generic_config_updater/add_cluster/test_port_speed_change.py
+++ b/tests/generic_config_updater/add_cluster/test_port_speed_change.py
@@ -2,6 +2,7 @@ import logging
 import random
 import re
 import pytest
+import time
 from tests.generic_config_updater.add_cluster.helpers import get_cfg_info_from_dut
 from tests.generic_config_updater.add_cluster.helpers import acl_asic_shell_wrappper
 from .platform_constants import PLATFORM_SUPPORTED_SPEEDS_MAP, PLATFORM_SPEED_LANES_MAP, SPEED_FEC_MAP
@@ -11,6 +12,9 @@ from tests.common.utilities import wait_until, is_ipv4_address, is_ipv6_address
 from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.config_reload import config_reload
+from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_context
+from tests.telemetry.telemetry_utils import generate_client_cli
+from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.gu_utils import delete_tmpfile, expect_op_success, generate_tmpfile, apply_patch
 from tests.generic_config_updater.add_cluster.helpers import get_active_interfaces, \
     remove_dataacl_table_single_dut, send_and_verify_traffic
@@ -794,6 +798,29 @@ def test_port_speed_change(tbinfo,
         pytest_assert(initial_pg_lossless_profile_name in current_buffer_profile_info_appl_db,
                       "Expected buffer profile {} was not created in APPL_DB.".format(
                           initial_pg_lossless_profile_name))
+
+    with allure.step("Verify telemetry data for port after port speed change"):
+        with setup_streaming_telemetry_context(False, duthost, localhost, ptfhost, gnxi_path):
+            add_route_to_ptf_setup(duthosts, tbinfo, request)
+            GNMI_SERVER_START_WAIT_TIME = 15
+            env = GNMIEnvironment(duthost, GNMIEnvironment.TELEMETRY_MODE)
+            # Set up telemetry server
+            duthost.shell('sonic-db-cli CONFIG_DB hset "%s|gnmi" user_auth none' % (env.gnmi_config_table),
+                          module_ignore_errors=False)
+            duthost.shell('docker exec %s supervisorctl reload' % (env.gnmi_container),
+                          module_ignore_errors=False)
+            time.sleep(GNMI_SERVER_START_WAIT_TIME)
+            logger.info("entering verifying port telemetry info Amol")
+            cmd = generate_client_cli(duthost, gnxi_path, method="get", xpath=f"COUNTERS/{selected_random_port}",
+                                      target="COUNTERS_DB")
+            show_gnmi_out = ptfhost.shell(cmd)['stdout']
+            logger.info("GNMI Server output")
+            logger.info(show_gnmi_out)
+            result = str(show_gnmi_out)
+            inerrors_match = re.search("SAI_PORT_STAT_IF_IN_ERRORS", result)
+            pytest_assert(inerrors_match is not None,
+                          "COUNTERS  not found in gnmi_output for port {}".format(selected_random_port))
+
 
     # add acl config
     setup_acl_config(duthost, ip_netns_namespace_prefix)

--- a/tests/generic_config_updater/add_cluster/test_port_speed_change.py
+++ b/tests/generic_config_updater/add_cluster/test_port_speed_change.py
@@ -13,7 +13,6 @@ from tests.common.plugins.allure_wrapper import allure_step_wrapper as allure
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.common.config_reload import config_reload
 from tests.common.helpers.telemetry_helper import setup_streaming_telemetry_context
-from tests.telemetry.telemetry_utils import generate_client_cli
 from tests.common.helpers.gnmi_utils import GNMIEnvironment
 from tests.common.gu_utils import delete_tmpfile, expect_op_success, generate_tmpfile, apply_patch
 from tests.generic_config_updater.add_cluster.helpers import get_active_interfaces, \

--- a/tests/generic_config_updater/add_cluster/test_port_speed_change.py
+++ b/tests/generic_config_updater/add_cluster/test_port_speed_change.py
@@ -820,7 +820,6 @@ def test_port_speed_change(tbinfo,
             pytest_assert(inerrors_match is not None,
                           "COUNTERS  not found in gnmi_output for port {}".format(selected_random_port))
 
-
     # add acl config
     setup_acl_config(duthost, ip_netns_namespace_prefix)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Add verification for telemetry to get counter for port after speed change
Summary:
Fixes # (issue)
Address test gap  #22245 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X ] 202511

### Approach
#### What is the motivation for this PR?
addresses test gap #22245 

#### How did you do it?
Added step to verify telemetry to get counter for port after speed change 

#### How did you verify/test it?
Verified telemetry output  for port after port change with t2 chassis
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
