### PR TITLE
ci: cancel previous test_plans implementation & fix cancel CI task

### DIFF
--- a/.azure-pipelines/cancel-previous-elastictest-testplan.yml
+++ b/.azure-pipelines/cancel-previous-elastictest-testplan.yml
@@ -1,0 +1,82 @@
+steps:
+  - ${{ if not(contains(variables['BUILD.REPOSITORY.NAME'], 'sonic-mgmt')) }}:
+      - script: |
+          # If not sonic-mgmt/sonic-mgmt-int repo, need to download test_plan.py and pr_test_scripts.yaml
+          set -ex
+          curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+        displayName: "Download Test Plan Script"
+      - script: |
+          # If not sonic-mgmt/sonic-mgmt-int repo, need to download pr_test_scripts.yaml
+          set -ex
+
+          # If public build image repo, download pr test scripts from public sonic-mgmt repo
+          if [[ "$(BUILD.REPOSITORY.NAME)" = "sonic-net/sonic-buildimage" || "$(BUILD.REPOSITORY.NAME)" = "Azure/sonic-buildimage-msft" ]]; then
+            curl "${{ parameters.MGMT_URL }}/${{ parameters.MGMT_BRANCH }}/.azure-pipelines/pr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
+
+          # Else, internal build image repo, download from internal sonic-mgmt repo
+          else
+            curl -u :$(System.AccessToken) "${{ parameters.MGMT_URL }}&commitOrBranch=${{ parameters.MGMT_BRANCH }}&api-version=5.0-preview.1&path=.azure-pipelines%2Fpr_test_scripts.yaml" -o ./.azure-pipelines/pr_test_scripts.yaml
+          fi
+        displayName: "Download Pr Script"
+  - ${{ else }}:
+        - script: |
+            # Else, sonic-mgmt repo, if not master branch, need to download test_plan.py
+            set -ex
+            CURRENT_BRANCH=${{ parameters.MGMT_BRANCH }}
+            echo "Current branch: $CURRENT_BRANCH"
+            if [[ "$CURRENT_BRANCH" != "master" ]]; then
+              echo "Current mgmt branch is not master, need to download test_plan.py"
+              curl "https://raw.githubusercontent.com/sonic-net/sonic-mgmt/master/.azure-pipelines/test_plan.py" -o ./.azure-pipelines/test_plan.py
+            else
+              echo "Current mgmt branch is master, no need to download test_plan.py"
+            fi
+          displayName: "Download Test Plan Script"
+
+  - script: |
+      # Check if azure cli is installed. If not, try to install it
+      if ! command -v az; then
+        echo "Azure CLI is not installed. Trying to install it..."
+
+        echo "Get packages needed for the installation process"
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 -y install apt-transport-https ca-certificates curl gnupg lsb-release
+
+        echo "Download and install the Microsoft signing key"
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+          gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+        echo "Add the Azure CLI software repository"
+        AZ_DIST=$(lsb_release -cs)
+        echo "Types: deb
+      URIs: https://packages.microsoft.com/repos/azure-cli/
+      Suites: ${AZ_DIST}
+      Components: main
+      Architectures: $(dpkg --print-architecture)
+      Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+
+        echo "Update repository information and install the azure-cli package"
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 -y install azure-cli
+      else
+        echo "Azure CLI is already installed"
+      fi
+    displayName: "Install Azure-CLI"
+
+  - script: |
+      set -e
+      echo "Step: cancel previous testplans for PR"
+
+      pip install PyYAML
+
+      rm -f new_test_plan_id.txt
+
+      # Enable verbose debugging output for the creation call in test_plan.py
+      set -x
+
+      python ./.azure-pipelines/test_plan.py cancel_pr
+
+      echo -e "\033[33mSONiC PR system-level test is powered by SONiC Elastictest, for any issue, please send email to sonicelastictest@microsoft.com \033[0m"
+
+    displayName: "Cancel previously created testplans for PR"

--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -82,14 +82,23 @@ jobs:
           BUILD_BRANCH: $(BUILD_BRANCH)
           IMPACT_AREA_INFO: ${{ parameters.IMPACT_AREA_INFO }}
 
+  - job: cancel_previous_test_plan_for_same_pr
+    displayName: "Cancel previous test plans for same PR"
+    continueOnError: true
+    pool: ${{ parameters.AGENT_POOL }}
+    timeoutInMinutes: 10
+    steps:
+      - template: cancel-previous-elastictest-testplan.yml
+
   - job: impacted_area_t0_elastictest
     displayName: "impacted-area-kvmtest-t0 by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't0_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -128,10 +137,11 @@ jobs:
     displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't0_2vlans_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -171,10 +181,11 @@ jobs:
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't1_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -213,10 +224,11 @@ jobs:
     displayName: "impacted-area-kvmtest-dualtor by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 'dualtor_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -255,10 +267,11 @@ jobs:
     displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't0_sonic_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -302,10 +315,11 @@ jobs:
     displayName: "impacted-area-kvmtest-dpu by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 'dpu_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -348,10 +362,11 @@ jobs:
     displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't1_multi_asic_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -391,10 +406,11 @@ jobs:
     displayName: "impacted-area-kvmtest-t2 by Elastictest"
     dependsOn:
     - get_impacted_area
+    - cancel_previous_test_plan_for_same_pr
     variables:
       TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
       RUN_BY_INCLUDE_JOBS: ${{ or(eq(parameters.INCLUDE_JOBS, 'all'), contains(parameters.INCLUDE_JOBS, 't2_job')) }}
-    condition: and(contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't2_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
+    condition: and(not(canceled()), succeeded(), not(canceled()), succeeded(), contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't2_checker'), eq(variables['RUN_BY_INCLUDE_JOBS'], 'True'))
     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
     continueOnError: false
     pool: ${{ parameters.AGENT_POOL }}
@@ -432,6 +448,9 @@ jobs:
 
 #   - job: t1_lag_vpp_elastictest
 #     displayName: "kvmtest-t1-lag-vpp by Elastictest [OPTIONAL]"
+#     dependsOn:
+#     - get_impacted_area
+#     - cancel_previous_test_plan_for_same_pr
 #     timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
 #     continueOnError: true
 #     pool: ${{ parameters.AGENT_POOL }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
 
 - stage: Test
   dependsOn: Pre_test
-  condition: and(succeeded(), in(dependencies.Pre_test.result, 'Succeeded'))
+  condition: and(succeeded(), not(canceled()), in(dependencies.Pre_test.result, 'Succeeded'))
   variables:
   - group: SONiC-Elastictest
   - name: BUILD_BRANCH


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
PREREQUISITE: https://github.com/sonic-net/sonic-mgmt/pull/23101 to be merged


Summary: PRs that triggered multiply with `/azpw run` don't have the clean up resources by default. This will make sure for every new pipeline start, we will try to clear previous test plans from Elastictest to optimise resource utilisation

This PR also fix the problem where pressing the 'Cancel' button doesn't cancel the testplan/job

Fixes # (issue) 37065882

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

There are 2 problems:
1. When trigger /azpw run and there is a running pipeline. The new run will not cancel previous test plans. Which led to duplicated test plans for the same PR. 
2. If the user want to cancel the pipeline by pressing the 'Cancel' button, the current behavior doesn't let user cancel.

#### How did you do it?

For 1. Introduce https://github.com/sonic-net/sonic-mgmt/pull/23101 mechanism to cancel all the related pipeline before starting the test plan. This will make sure that before the pipeline start, all the related resources previously is cleaned up

For 2. This PR implement a guard condition that cancel the job when the Cancel button pressed.

#### How did you verify/test it?

Verified manually

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
