### PR TITLE
[cisco platform] Fix route add fixture in snappi tests 

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1862,11 +1862,18 @@ def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True)
         arp_opt = f"-d {addr}"
 
     try:
-        dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
-        dut.shell(
-            "{} config route {} prefix {}/32 nexthop {} {}".format(
-                asic_arg, cmd, DEST_TO_GATEWAY_MAP[addr]['dest'], addr,
-                DEST_TO_GATEWAY_MAP[addr]['intf']))
+        if setup:
+            dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
+            dut.shell(
+                f"{asic_arg} config route {cmd} prefix {DEST_TO_GATEWAY_MAP[addr]['dest']}/32 nexthop "
+                f"{addr} dev {DEST_TO_GATEWAY_MAP[addr]['intf']}"
+            )
+        else:
+            dut.shell(
+                f"{asic_arg} config route {cmd} prefix {DEST_TO_GATEWAY_MAP[addr]['dest']}/32 nexthop "
+                f"{addr} dev {DEST_TO_GATEWAY_MAP[addr]['intf']}"
+            )
+            dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
     except RunAnsibleModuleFail:
         if setup:
             raise


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The route add commands needs to have `dev` options in 202505 and later release. The behavior was changed in https://github.com/sonic-net/sonic-utilities/pull/3836

e.g. so we should use
```
config route add prefix 4.0.0.33/32 nexthop 1.0.0.33 dev Ethernet188
```
instead of:
```
config route add prefix 4.0.0.33/32 nexthop 1.0.0.33 Ethernet188
```
which was causing the following error:

```
-------------------------------- live log setup --------------------------------
28/02/2026 09:38:40 snappi.api                               L0106 WARNING| Version check is disabled
28/02/2026 09:39:02 __init__._fixture_func_decorator         L0073 ERROR  | 
run module shell failed, Ansible Results =>
failed = True
changed = True
rc = 2
cmd =  config route add prefix 4.0.0.33/32 nexthop 1.0.0.33 Ethernet188
start = 2026-02-28 09:42:54.626470
end = 2026-02-28 09:42:55.791178
delta = 0:00:01.164708
msg = non-zero return code
invocation = {'module_args': {'_raw_params': ' config route add prefix 4.0.0.33/32 nexthop 1.0.0.33 Ethernet188', '_uses_shell': True, 'expand_argument_vars': True, 'stdin_add_newline': True, 'strip_empty_ends': True, 'argv': None, 'chdir': None, 'executable': None, 'creates': None, 'removes': None, 'stdin': None}}
_ansible_no_log = False
stdout =
stderr =
Usage: config route add [OPTIONS] prefix [vrf <vrf_name>] <A.B.C.D/M> nexthop
                        [vrf <vrf_name>]                 <A.B.C.D>|<dev
                        <dev_name>>|<A.B.C.D dev <dev_name>>
Try 'config route add -h' for help.

```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix test running error.

#### How did you do it?
corrected the cmd being used.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
