### PR TITLE
Xfail test_acl.py due to github issue 21788

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -80,6 +80,13 @@ acl/test_acl.py:
     conditions:
       - "'t0-isolated-d256u256s2' in topo_name and platform in ['x86_64-nvidia_sn5640-r0']"
 
+acl/test_acl.py::.*_forwarded\[ipv6-.*uplink->downlink:
+  regex: true
+  xfail:
+    reason: "IPv6 forwarded tests with uplink->downlink direction fail on v6 topology"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/21788 and '-v6-' in topo_name and asic_type in ['mellanox', 'nvidia']"
+
 acl/test_acl.py::TestMultiBindingAcl:
   skip:
     reason: "MultiBinding only supports dualtor topo"


### PR DESCRIPTION

Summary: Xfail test_acl.py due to github issue #21788
Fixes #

When the test_acl.py cases match the following pattern, they will hit the github issue #21788 and fail with "No matching ACL rule found for the packet" error:
- Test function name ends with "_forwarded"
- Direction parameter is "uplink->downlink"
- IP version is "ipv6"

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
