### PR TITLE
Update add_topo and remove_topo functions to support parallel execution

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -190,7 +190,7 @@ become_ask_pass=False
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use
 # paramiko on older platforms rather than removing it
-ssh_args = -o ControlMaster=auto -o ControlPersist=180s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=40
+ssh_args = -o ControlMaster=auto -o ControlPersist=7200s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=70
 
 
 # The path to use for the ControlPath sockets. This defaults to

--- a/ansible/testbed-cli.sh
+++ b/ansible/testbed-cli.sh
@@ -54,9 +54,12 @@ function usage
   echo "To deploy topology for specified testbed on a server: $0 add-topo 'testbed-name' ~/.password"
   echo "    Optional argument for add-topo:"
   echo "        -e ptf_imagetag=<tag>    # Use PTF image with specified tag for creating PTF container"
+  echo "        --parallel               # Deploy topology on multiple servers in parallel"
   echo "To deploy topology with the help of the last cached deployed topology for the specified testbed on a server:"
   echo "        $0 deploy-topo-with-cache 'testbed-name' 'inventory' ~/.password"
   echo "To remove topology for specified testbed on a server: $0 remove-topo 'testbed-name' ~/.password"
+  echo "    Optional arguments for remove-topo:"
+  echo "        --parallel                    # Remove topology on multiple servers in parallel"
   echo "To remove topology and keysight-api-server container for specified testbedon a server:"
   echo "        $0 remove-topo 'testbed-name' ~/.password remove_keysight_api_server"
   echo "To renumber topology for specified testbed on a server: $0 renumber-topo 'testbed-name' ~/.password"
@@ -376,6 +379,58 @@ function parse_servers
   fi
 }
 
+# Parse parallel execution arguments
+function parse_parallel_args() {
+  # Check for parallel execution flag
+  parallel_execution=false
+  for arg in "$@"; do
+    if [[ "$arg" == "--parallel" ]]; then
+      parallel_execution=true
+      break
+    fi
+  done
+
+  # Remove --parallel from arguments if present
+  args=()
+  for arg in "$@"; do
+    if [[ "$arg" != "--parallel" ]]; then
+      args+=("$arg")
+    fi
+  done
+}
+
+# Wait for all parallel processes to complete and output logs
+function wait_parallel_processes() {
+  local operation_type=$1
+  local -n pids_ref=$2
+  local server_count=$3
+
+  # Wait for all parallel processes to complete
+  if [[ "$parallel_execution" == "true" ]]; then
+    for i in $(seq 0 $(($server_count-1))); do
+      if [[ -n "${pids_ref[$i]}" ]]; then
+        wait ${pids_ref[$i]}
+      fi
+    done
+
+    # Output logs from parallel execution
+    for i in $(seq 0 $(($server_count-1)))
+    do
+      if [ -n "$servers" ]; then
+        parse_servers "$i" "$servers"
+        echo "${operation_type}_topo output for server $server:"
+      else
+        echo "${operation_type}_topo output for server $i:"
+      fi
+      if [ -f "/tmp/${operation_type}_topo_$i.log" ]; then
+        cat "/tmp/${operation_type}_topo_$i.log"
+      else
+        echo "Warning: Log file /tmp/${operation_type}_topo_$i.log not found"
+      fi
+    done
+  fi
+}
+
 function add_topo
 {
   testbed_name=$1
@@ -383,6 +438,9 @@ function add_topo
   shift
   shift
   echo "Deploying topology for testbed '${testbed_name}'"
+
+  # Parse parallel execution arguments
+  parse_parallel_args "$@"
 
   read_file ${testbed_name}
 
@@ -401,6 +459,9 @@ function add_topo
     server_count=$(python -c "from __future__ import print_function; print(len(eval(\"$servers\")))")
   fi
 
+  # Array to store process IDs for parallel execution
+  declare -a pids
+
   for i in $(seq 0 $(($server_count-1)))
   do
     if [ -n "$servers" ]; then
@@ -408,14 +469,35 @@ function add_topo
       ansible_options+=" -e dut_interfaces=$dut_interfaces"
     fi
 
-    ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile -i ${inv_name} testbed_add_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-          -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
-          -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
-          -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
-          -e ptf_extra_mgmt_ip="$ptf_extra_mgmt_ip" -e netns_mgmt_ip="$netns_mgmt_ip" \
-          -e upstream_neighbor_groups="$upstream_neighbor_groups" -e downstream_neighbor_groups="$downstream_neighbor_groups" \
-          -e use_converged_peers="$use_converged_peers" \
-          $ansible_options $@
+    # Build the ansible-playbook command
+    ansible_cmd="ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile -i ${inv_name} testbed_add_vm_topology.yml --vault-password-file=\"${passwd}\" -l \"$server\" \
+          -e testbed_name=\"$testbed_name\" -e duts_name=\"$duts\" -e VM_base=\"$vm_base\" \
+          -e ptf_ip=\"$ptf_ip\" -e topo=\"$topo\" -e vm_set_name=\"$vm_set_name\" \
+          -e ptf_imagename=\"$ptf_imagename\" -e vm_type=\"$vm_type\" -e ptf_ipv6=\"$ptf_ipv6\" \
+          -e ptf_extra_mgmt_ip=\"$ptf_extra_mgmt_ip\" -e netns_mgmt_ip=\"$netns_mgmt_ip\" \
+          -e upstream_neighbor_groups=\"$upstream_neighbor_groups\" -e downstream_neighbor_groups=\"$downstream_neighbor_groups\" \
+	  -e use_converged_peers=\"$use_converged_peers\" \
+          $ansible_options ${args[*]}"
+
+    if [[ "$parallel_execution" == "true" ]]; then
+      # Parallel execution: run in background and capture PID
+      eval "$ansible_cmd" > "/tmp/add_topo_$i.log" 2>&1 &
+      pids[$i]=$!
+    else
+      # Serial execution: run synchronously
+      eval "$ansible_cmd"
+    fi
+  done
+
+  # Wait for all parallel processes to complete
+  wait_parallel_processes "add" pids "$server_count"
+
+  # Execute fanout connection and cleanup steps
+  for i in $(seq 0 $(($server_count-1)))
+  do
+    if [ -n "$servers" ]; then
+      parse_servers "$i" "$servers"
+    fi
 
     if [ $i -eq 0 ]; then
       fanout_options+=" -e clean_before_add=y"
@@ -462,6 +544,9 @@ function remove_topo
     fi
   done
 
+  # Parse parallel execution arguments
+  parse_parallel_args "$@"
+
   if [ -n "$sonic_vm_dir" ]; then
       ansible_options="-e sonic_vm_storage_location=$sonic_vm_dir"
   fi
@@ -471,6 +556,9 @@ function remove_topo
     server_count=$(python -c "from __future__ import print_function; print(len(eval(\"$servers\")))")
   fi
 
+  # Array to store process IDs for parallel execution
+  declare -a pids
+
   for i in $(seq 0 $(($server_count-1)))
   do
     if [ -n "$servers" ]; then
@@ -478,15 +566,27 @@ function remove_topo
       ansible_options+=" -e dut_interfaces=$dut_interfaces"
     fi
 
-  ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile -i ${inv_name} testbed_remove_vm_topology.yml --vault-password-file="${passwd}" -l "$server" \
-      -e testbed_name="$testbed_name" -e duts_name="$duts" -e VM_base="$vm_base" \
-      -e ptf_ip="$ptf_ip" -e topo="$topo" -e vm_set_name="$vm_set_name" \
-      -e ptf_imagename="$ptf_imagename" -e vm_type="$vm_type" -e ptf_ipv6="$ptf_ipv6" \
-      -e ptf_extra_mgmt_ip="$ptf_extra_mgmt_ip" -e netns_mgmt_ip="$netns_mgmt_ip" \
-      -e remove_keysight_api_server="$remove_keysight_api_server" \
-      $ansible_options $@
+    # Build the ansible-playbook command
+    ansible_cmd="ANSIBLE_SCP_IF_SSH=y ansible-playbook -i $vmfile -i ${inv_name} testbed_remove_vm_topology.yml --vault-password-file=\"${passwd}\" -l \"$server\" \
+          -e testbed_name=\"$testbed_name\" -e duts_name=\"$duts\" -e VM_base=\"$vm_base\" \
+          -e ptf_ip=\"$ptf_ip\" -e topo=\"$topo\" -e vm_set_name=\"$vm_set_name\" \
+          -e ptf_imagename=\"$ptf_imagename\" -e vm_type=\"$vm_type\" -e ptf_ipv6=\"$ptf_ipv6\" \
+          -e ptf_extra_mgmt_ip=\"$ptf_extra_mgmt_ip\" -e netns_mgmt_ip=\"$netns_mgmt_ip\" \
+          -e remove_keysight_api_server=\"$remove_keysight_api_server\" \
+          $ansible_options ${args[*]}"
 
+    if [[ "$parallel_execution" == "true" ]]; then
+      # Parallel execution: run in background and capture PID
+      eval "$ansible_cmd" > "/tmp/remove_topo_$i.log" 2>&1 &
+      pids[$i]=$!
+    else
+      # Serial execution: run synchronously
+      eval "$ansible_cmd"
+    fi
   done
+
+  # Wait for all parallel processes to complete
+  wait_parallel_processes "remove" pids "$server_count"
 
   echo Done
 }


### PR DESCRIPTION
Summary: Update add_topo and remove_topo functions to support parallel execution
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202505

### Approach
#### What is the motivation for this PR?
We already support deploy setup on multi server, which is mainly used for large scale topo, such as t0-isolated-d2u510s2. It can reduce the overload for the server.
Currently, when deploy testbed on multi server, add-topo / remove-topo will be executed on each server serially, which is time consuming.

#### How did you do it?
With this code change, the library support execute add-topo / remove-topo in parallel on each server to speed up the process.
- We can use `--parallel` option to enable this feature when executing add-topo / remove-topo command.
- If did not add `--parallel` option, the add-topo / remove-topo command will be executed on each server serially as before, no functional change.

Example:
- `remove-topo ./testbed-cli.sh -k ceos remove-topo test-router-t0-isolated-d32u32s2 vault --parallel`
- `add-topo ./testbed-cli.sh -k ceos -h Mellanox-SN5640-C512S2 add-topo test-router-t0-isolated-d32u32s2 vault -e ptf_imagetag=669063 -vvvvv --parallel`

#### How did you verify/test it?
Test deploy testbed with and without `--parallel`, all success

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
