### PR TITLE
Remove the skip condition for test_link_local_ip

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3346,11 +3346,6 @@ iface_namingmode/test_iface_namingmode.py::test_show_pfc_counters:
 #######################################
 #####            ip               #####
 #######################################
-ip/link_local/test_link_local_ip.py:
-  skip:
-    reason: "New test case, failing badly, need owner to enhance"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/19897"
 ip/test_ip_packet.py:
   skip:
     reason: "Skipping ip packet test since can't provide enough interfaces"

--- a/tests/ip/link_local/test_link_local_ip.py
+++ b/tests/ip/link_local/test_link_local_ip.py
@@ -115,7 +115,7 @@ class TestLinkLocalIPacket:
         duthost.command("rm -rf {}".format(PACKET_SAVE_PATH))
 
         # Get 2 downlinks
-        rx_iface, tx_iface = random.sample(downlinks, 2)
+        rx_iface, tx_iface = random.sample(sorted(downlinks), 2)
         ptf_rx_idx = mg_facts["minigraph_ptf_indices"][rx_iface]
         ptf_tx_idx = mg_facts["minigraph_ptf_indices"][tx_iface]
         link_local_src = self.get_port_default_ipv6_link_local_address(ptfhost, 'eth{}'.format(ptf_rx_idx))


### PR DESCRIPTION
Change-Id: Ic440ded1578c4086823ba2ed4d9ecea9630b3225

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:Remove the skip condition for test_link_local_ip
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
