### PR TITLE
Add test to verify pmon grep does not cause kernel panic

### DIFF
--- a/tests/platform_tests/test_pmon_grep_safe.py
+++ b/tests/platform_tests/test_pmon_grep_safe.py
@@ -13,9 +13,11 @@ that the fix is in place across all platforms.
 """
 import logging
 import re
+import time
 import pytest
 
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.dut_utils import is_container_running
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +27,10 @@ pytestmark = [
     pytest.mark.disable_loganalyzer
 ]
 
-GREP_CMD = 'docker exec pmon grep -r "test_string_placeholder" /sys/kernel/debug/'
-DMESG_CMD = "dmesg --level=emerg,alert,crit -T"
+# The search string is intentionally a dummy — the kernel panic is triggered by
+# traversing /sys/kernel/debug, not by matching any particular content.
+GREP_CMD = 'docker exec pmon grep -r "PMON_GREP_SAFE_TEST" /sys/kernel/debug/'
+DMESG_CMD = "dmesg --level=emerg,alert,crit"
 
 KERNEL_PANIC_PATTERNS = [
     r"kernel\s*panic",
@@ -35,6 +39,10 @@ KERNEL_PANIC_PATTERNS = [
     r"BUG:",
     r"RIP:.*\[",
 ]
+
+# Seconds to wait after grep before checking dmesg, giving the kernel time to
+# flush any panic indicators to the log buffer.
+POST_GREP_SETTLE_SECS = 5
 
 
 def test_pmon_grep_no_kernel_panic(duthosts, enum_rand_one_per_hwsku_hostname):
@@ -49,21 +57,27 @@ def test_pmon_grep_no_kernel_panic(duthosts, enum_rand_one_per_hwsku_hostname):
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
-    # Capture dmesg baseline before the grep
-    pre_dmesg = duthost.command(DMESG_CMD, module_ignore_errors=True)
-    pre_line_count = len(pre_dmesg.get("stdout_lines", []))
+    # Pre-check: pmon container must be running, otherwise the grep is a no-op
+    pytest_assert(is_container_running(duthost, "pmon"),
+                  "pmon container is not running on '{}'".format(duthost.hostname))
+
+    # Record a timestamp before the grep so we can filter dmesg to only new messages
+    timestamp_result = duthost.command("date '+%Y-%m-%dT%H:%M:%S'", module_ignore_errors=True)
+    pre_timestamp = timestamp_result.get("stdout", "").strip()
 
     # Run grep inside pmon container — errors from grep itself are expected
     # (Invalid argument, Resource temporarily unavailable, etc.).
     # We only care that it does not crash the kernel.
     duthost.command(GREP_CMD, module_ignore_errors=True)
 
-    # Check dmesg for any new critical messages after the grep
-    post_dmesg = duthost.command(DMESG_CMD, module_ignore_errors=True)
-    post_lines = post_dmesg.get("stdout_lines", [])
+    # Allow kernel time to flush any panic indicators to the log buffer
+    time.sleep(POST_GREP_SETTLE_SECS)
 
-    # Only inspect lines that appeared after the grep
-    new_lines = post_lines[pre_line_count:]
+    # Check dmesg for any new critical messages since our timestamp
+    post_dmesg_cmd = "dmesg --level=emerg,alert,crit --since='{}'".format(pre_timestamp)
+    post_dmesg = duthost.command(post_dmesg_cmd, module_ignore_errors=True)
+    new_lines = post_dmesg.get("stdout_lines", [])
+
     if not new_lines:
         logger.info("No new critical kernel messages after pmon grep on '{}'".format(
             duthost.hostname))


### PR DESCRIPTION
### Description of PR

Summary:
Adds `test_pmon_grep_no_kernel_panic` which verifies that running `grep -r` inside the pmon container over `/sys/kernel/debug` does not trigger a kernel panic or other critical kernel errors.

**Background:** On some platforms (e.g. Cisco 8800 chassis), running grep inside the pmon container over `/sys/kernel/debug` triggered kernel panics due to accessing debug filesystem entries. The fix is to ensure the debug filesystem is not mounted or its contents are removed inside the pmon container.

**What this test does:**
1. Verifies the pmon container is running (fails explicitly if not)
2. Records a timestamp baseline before the grep
3. Runs `grep -r` inside pmon container with `module_ignore_errors` (grep errors are expected)
4. Waits for kernel log buffer to flush
5. Checks dmesg (filtered by `--since` timestamp) for any new critical kernel messages (panic, Oops, Call Trace, BUG, RIP)
6. Fails if kernel panic indicators are found

Fixes #18394

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Address test gap for pmon container kernel panic issue (#18394). On certain platforms, `grep -r` inside pmon over `/sys/kernel/debug` caused kernel panics. This test ensures the fix stays in place.

#### How did you do it?
Added a new test file `tests/platform_tests/test_pmon_grep_safe.py` that:
- Asserts pmon container is running via `is_container_running()` (avoids silent no-op)
- Captures a timestamp before the grep operation
- Runs the grep operation inside pmon container
- Waits `POST_GREP_SETTLE_SECS` (5s) for kernel log buffer flush
- Uses `dmesg --since` with the pre-recorded timestamp for robust new-message detection (no line-count fragility)
- Checks for kernel panic patterns in newly appeared dmesg lines

#### How did you verify/test it?
- Code review and static analysis
- Test uses `module_ignore_errors=True` for the grep command (grep failures are expected and harmless) and only asserts on new kernel panic indicators in dmesg
- https://elastictest.org/scheduler/testplan/69b283c788eba34838db536b

#### Any platform specific information?
Originally observed on Cisco 8800 chassis. Test is platform-generic and should pass on all platforms where the fix is applied.

#### Supported testbed topology if it's a new test case?
Any topology with DUT running pmon container (all standard topologies). Marked with `pytest.mark.topology('any')` and `pytest.mark.device_type('physical')`.

### Documentation
N/A - test case only