### PR TITLE
Fix excessive tcpdump buffer size in dhcp_relay stress tests

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -1280,7 +1280,7 @@ def capture_and_check_packet_on_dut(
     pkts_validator_args=[],
     pkts_validator_kwargs={},
     wait_time=1,
-    tcpdump_buffer_size=102400
+    tcpdump_buffer_size=4096
 ):
     """
     Capture packets on DUT and check if the packet is expected

--- a/tests/dhcp_relay/test_dhcp_counter_stress.py
+++ b/tests/dhcp_relay/test_dhcp_counter_stress.py
@@ -21,7 +21,7 @@ BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
 DEFAULT_DHCP_CLIENT_PORT = 68
 DEFAULT_DHCP_SERVER_PORT = 67
 DUAL_TOR_MODE = 'dual'
-BUFFER_SIZE = 1024 * 1024  # 1MB
+BUFFER_SIZE = 1024  # 1 MiB (tcpdump --buffer-size is in KiB)
 logger = logging.getLogger(__name__)
 PACKET_RATE_PER_SEC_MAP = {
     "Mellanox-SN2700": 20


### PR DESCRIPTION
### Description of PR

Summary:
Fix excessive tcpdump `--buffer-size` values that cause ~2 GiB RSS memory usage from tcpdump, triggering memory_utilization test failures.

The `--buffer-size` option in tcpdump accepts values in **KiB**. The default in `capture_and_check_packet_on_dut()` was set to `102400` (100 MiB), and `test_dhcp_counter_stress.py` overrode it to `1024 * 1024` (1 GiB) with a misleading "1MB" comment.

Changes:
- Reduce default `tcpdump_buffer_size` from `102400` to `4096` (4 MiB) in `utilities.py`
- Fix `BUFFER_SIZE` in `test_dhcp_counter_stress.py` from `1024 * 1024` to `1024` (1 MiB actual)

Fixes #22869

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511