### PR TITLE
GCU T2: enable downstream multiasic addcluster test

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -375,6 +375,14 @@ def load_basic_facts(dut_name, session):
 
     tbinfo = TestbedInfo(testbed_file).testbed_topo.get(testbed_name, None)
 
+    if tbinfo is None:
+        logger.error("Testbed '{}' not found in testbed file '{}'. "
+                     "Available testbeds: {}".format(
+                         testbed_name, testbed_file,
+                         list(TestbedInfo(testbed_file).testbed_topo.keys())))
+        raise ValueError("Testbed '{}' not found in testbed file '{}'".format(
+            testbed_name, testbed_file))
+
     results['topo_type'] = tbinfo['topo']['type']
     results['topo_name'] = tbinfo['topo']['name']
     results['testbed'] = testbed_name

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -7,14 +7,19 @@ neighbor needs to be (re)configured on existing physical ports.
 Key Design Notes:
 -----------------
 1. PORT ENTRIES ALWAYS EXIST: After `config load_minigraph`, all physical ports defined
-   in platform.json exist in CONFIG_DB, regardless of device links. The test reconfigures
+   in platform.json exist in CONFIG_DB, regardless of device links. The test configures
    these existing ports rather than creating them from nothing.
 
-2. RFC 6902 "add" SEMANTICS: The generated patches use "add" operations which per RFC 6902
+2. ADMIN STATUS LIFECYCLE: When port interface definitions (PortChannels, IPInterfaces)
+   are removed from minigraph, the affected ports revert to defaults from port_config.ini
+   which sets admin_status=down. When GCU restores the configuration, admin_status
+   transitions back to 'up'. This test verifies this lifecycle.
+
+3. RFC 6902 "add" SEMANTICS: The generated patches use "add" operations which per RFC 6902
    mean "add or replace". For existing PORT entries, this replaces the platform-default
    config (e.g., 400G) with neighbor-specific config (e.g., 100G with FEC).
 
-3. VALID PRODUCTION SCENARIO: This test validates a realistic datacenter expansion use
+4. VALID PRODUCTION SCENARIO: This test validates a realistic datacenter expansion use
    case where physical ports exist but need to be configured for a new neighbor.
 
 See test_addcluster_workflow() docstring for detailed explanation.
@@ -1257,14 +1262,19 @@ def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
     duthost.shell(f"rm -f {dut_config_path}")
 
     # Step 3: Modify minigraph to remove target_t1
+    # This removes the neighbor device AND all port interface definitions (PortChannels,
+    # IPInterfaces) that use the ports connected to this neighbor. After minigraph reload,
+    # these ports should have admin_status=down (defaults from port_config.ini).
     logger.info(f"Modifying minigraph to remove {target_t1}")
     local_dir = "/tmp/minigraph_modified"
     local_minigraph = os.path.join(local_dir, f"{duthost.hostname}-minigraph.xml")
     duthost.fetch(src=MINIGRAPH, dest=local_minigraph, flat=True)
     refactor = MinigraphRefactor(target_t1)
-    if not refactor.process_minigraph(local_minigraph, local_minigraph):
+    success, affected_ports = refactor.process_minigraph(local_minigraph, local_minigraph)
+    if not success:
         logger.info(f"Skipping test - testbed topology does not match required conditions for {target_t1}")
         pytest.skip(f"Testbed topology does not match required conditions for {target_t1}")
+    logger.info(f"Minigraph modification complete. Affected ports: {sorted(affected_ports)}")
     duthost.copy(src=local_minigraph, dest=MINIGRAPH)
 
     # Step 4: Reload minigraph
@@ -1273,6 +1283,21 @@ def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
     if not wait_until(300, 20, 0, duthost.critical_services_fully_started):
         logger.error("Not all critical services fully started!")
         pytest.fail("Critical services not fully started after minigraph reload")
+
+    # Step 4.1: Verify affected ports have admin_status=down after minigraph reload
+    # When port interface definitions are removed from minigraph, the ports should
+    # fall back to defaults from port_config.ini which sets admin_status=down.
+    if affected_ports:
+        logger.info(f"Verifying admin_status=down for affected ports: {sorted(affected_ports)}")
+        for port in affected_ports:
+            redis_cmd = f'sonic-db-cli {ns_arg} CONFIG_DB hget "PORT|{port}" admin_status'
+            result = duthost.shell(redis_cmd, module_ignore_errors=True)
+            admin_status = result['stdout'].strip() if result['rc'] == 0 else "unknown"
+            if admin_status != "down":
+                logger.warning(f"Port {port} has admin_status={admin_status}, expected 'down'")
+                # Note: We warn rather than fail because some platforms may have different defaults
+            else:
+                logger.info(f"Verified port {port} has admin_status=down (as expected)")
 
     # Capture pre-patch CONFIG_DB state (neighbor removed via minigraph)
     if CAPTURE_CONFIGS and capture_dir:

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -63,6 +63,50 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEMPLATES_DIR = os.path.join(THIS_DIR, "templates")
 ADDCLUSTER_FILE = os.path.join(TEMPLATES_DIR, "addcluster.json")
 
+# Loganalyzer ignore patterns for expected TRANSIENT errors during port reconfiguration.
+#
+# These errors occur during a brief race window when GCU patches transition ports from
+# admin_status='down' to 'up'. Orchagent attempts to apply speed/PFC config before the
+# admin_status change fully propagates, causing temporary failures:
+#   - "Unsupported port speed" - speed config rejected on admin-down port
+#   - "Failed to start PFC Watchdog" - PFC can't start on admin-down port
+#   - "Unable to find key NPU_SI_SETTINGS" - xcvrd can't query admin-down port
+#
+# Why these are safe to ignore:
+#   1. verify_oper_status_after_patches() waits up to 300s for ports to become oper 'up'
+#   2. CONFIG_DB verification (Steps 9-12) confirms all entries are correctly applied
+#   3. If config permanently failed, ports wouldn't reach oper='up' and test would fail
+LOGANALYZER_IGNORE_REGEX = [
+    ".*doPortTask: Unsupported port .* speed.*",
+    ".*createEntry: Failed to start PFC Watchdog on port.*",
+    ".*Unable to find key NPU_SI_SETTINGS_SYNC_STATUS.*",
+]
+
+
+@pytest.fixture(autouse=True)
+def ignore_expected_loganalyzer_errors(duthosts, loganalyzer):
+    """Ignore expected transient errors during port reconfiguration.
+
+    When GCU patches transition ports from admin_status='down' to 'up', there's a
+    brief race where orchagent tries to configure speed/PFC before admin_status
+    propagates. These errors resolve once the transition completes.
+
+    The test validates this by:
+    - verify_oper_status_after_patches(): confirms ports reach oper='up' (would fail
+      if speed config permanently failed)
+    - CONFIG_DB verification: confirms PFC_WD and other entries exist
+
+    Args:
+        duthosts: DUT hosts fixture
+        loganalyzer: Loganalyzer utility fixture
+    """
+    if loganalyzer:
+        for duthost in duthosts:
+            if duthost.hostname in loganalyzer:
+                loganalyzer[duthost.hostname].ignore_regex.extend(LOGANALYZER_IGNORE_REGEX)
+    yield
+
+
 # Configuration capture settings
 # If the environment variable GCU_CAPTURE_CONFIGS is set to 'true', '1', 'y', or 'yes'
 # regardless of case, the test will capture pre- and post-patch configuration files for

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -1,71 +1,555 @@
 import json
 import logging
 import os
+import shutil
 import pytest
 
+from datetime import datetime
+
+from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.gu_utils import apply_patch, generate_tmpfile, delete_tmpfile
-from tests.common.gu_utils import create_checkpoint, delete_checkpoint, rollback_or_reload
+from tests.common.gu_utils import create_checkpoint, delete_checkpoint
 from tests.common.utilities import wait_until
-from tests.generic_config_updater.util.generate_patch import generate_config_patch
+from tests.generic_config_updater.util.generate_patch import generate_config_patch, is_front_panel_port
 
 from .util.process_minigraph import MinigraphRefactor
 
+# Multi-ASIC addcluster tests modify BGP and interface configurations across namespaces.
+# disable_intf_up_check: Skip interface up verification during config reload - on multi-ASIC
+#   chassis systems, interfaces may take extended time to come up after GCU changes.
+# skip_config_db_check: Skip automatic config_db restoration in core_dump_and_config_check
+#   fixture - this test handles its own cleanup via checkpoint/rollback mechanism.
 pytestmark = [
     pytest.mark.topology('t2'),
+    pytest.mark.disable_intf_up_check,
+    pytest.mark.skip_config_db_check,
 ]
 
 logger = logging.getLogger(__name__)
 
 MINIGRAPH = "/etc/sonic/minigraph.xml"
 MINIGRAPH_BACKUP = "/etc/sonic/minigraph.xml.backup"
-TARGET_LEAF = "ARISTA01T1"
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEMPLATES_DIR = os.path.join(THIS_DIR, "templates")
 ADDCLUSTER_FILE = os.path.join(TEMPLATES_DIR, "addcluster.json")
-ASICID = "asic0"
+
+# Configuration capture settings
+# Set to True to save config_db.json files and generated patches for debugging/analysis.
+# Captured files are saved to: tests/generic_config_updater/captures/<hostname>/<timestamp>/
+CAPTURE_CONFIGS = True
+
+
+def get_capture_dir(hostname):
+    """Get the directory path for captured configuration files.
+
+    Creates a timestamped directory for storing captured configs and patches.
+    Only creates the directory if CAPTURE_CONFIGS is enabled.
+
+    Args:
+        hostname: DUT hostname for directory naming
+
+    Returns:
+        str: Path to capture directory, or None if capture is disabled
+    """
+    if not CAPTURE_CONFIGS:
+        return None
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    captures_root = os.path.join(THIS_DIR, "captures")
+    capture_dir = os.path.join(captures_root, hostname, timestamp)
+    os.makedirs(capture_dir, exist_ok=True)
+
+    # Create .gitignore to prevent accidental commit of debug captures
+    gitignore_path = os.path.join(captures_root, ".gitignore")
+    if not os.path.exists(gitignore_path):
+        with open(gitignore_path, "w") as f:
+            f.write("# Auto-generated: ignore captured config files\n*\n!.gitignore\n")
+
+    logger.info(f"Configuration capture enabled. Saving to: {capture_dir}")
+    return capture_dir
+
+
+def capture_config_db(duthost, namespace, capture_dir, filename, description):
+    """Capture config_db.json from the DUT and save locally.
+
+    Exports the current CONFIG_DB from Redis for the specified namespace and saves
+    it to the capture directory with the given filename. Uses sonic-cfggen to dump
+    the running configuration since config_db.json files don't exist on disk for
+    ASIC namespaces on multi-ASIC systems.
+
+    Args:
+        duthost: DUT host object
+        namespace: ASIC namespace (e.g., 'asic0') or None for host config
+        capture_dir: Local directory to save captured file
+        filename: Name for the saved file (without path)
+        description: Human-readable description for logging
+
+    Returns:
+        str: Path to saved file, or None if capture is disabled
+    """
+    if not capture_dir:
+        return None
+
+    # Build namespace argument for sonic-cfggen
+    ns_arg = f"-n {namespace}" if namespace and duthost.is_multi_asic else ""
+    remote_path = f"/tmp/capture_{filename}"
+
+    local_path = os.path.join(capture_dir, filename)
+
+    logger.info(f"Capturing {description} via sonic-cfggen {ns_arg}")
+    try:
+        # Export CONFIG_DB from Redis to JSON file
+        duthost.shell(f"sonic-cfggen -d {ns_arg} --print-data > {remote_path}")
+        duthost.fetch(src=remote_path, dest=local_path, flat=True)
+        duthost.shell(f"rm -f {remote_path}")
+        logger.info(f"Saved {description} to {local_path}")
+        return local_path
+    except Exception as e:
+        logger.warning(f"Failed to capture {description}: {e}")
+        return None
+
+
+def capture_file(src_path, capture_dir, filename, description):
+    """Copy a local file to the capture directory.
+
+    Args:
+        src_path: Source file path
+        capture_dir: Destination capture directory
+        filename: Name for the saved file
+        description: Human-readable description for logging
+
+    Returns:
+        str: Path to saved file, or None if capture is disabled
+    """
+    if not capture_dir:
+        return None
+
+    dest_path = os.path.join(capture_dir, filename)
+    logger.info(f"Capturing {description}: {src_path} -> {dest_path}")
+    try:
+        shutil.copy2(src_path, dest_path)
+        logger.info(f"Saved {description} to {dest_path}")
+        return dest_path
+    except Exception as e:
+        logger.warning(f"Failed to capture {description}: {e}")
+        return None
+
+
+def get_downstream_t1_neighbor(duthost):
+    """Get a downstream T1 neighbor from minigraph facts.
+
+    In T2 topology, T1 neighbors are downstream devices connected to linecards.
+    This function finds a T1 neighbor and returns its name along with the
+    ASIC namespace it's connected to.
+
+    Args:
+        duthost: DUT host object (should be a frontend/linecard node)
+
+    Returns:
+        tuple: (asic_namespace, neighbor_name) where:
+               - asic_namespace is the ASIC namespace (e.g., 'asic0')
+               - neighbor_name is the T1 device name (e.g., 'ARISTA01T1')
+               Returns (None, None) if no T1 neighbor found.
+    """
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    minigraph_devices = mg_facts.get('minigraph_devices', {})
+    minigraph_neighbors = mg_facts.get('minigraph_neighbors', {})
+
+    # Find a T1 neighbor from the minigraph
+    for neighbor_info in minigraph_neighbors.values():
+        neighbor_name = neighbor_info.get('name')
+        namespace = neighbor_info.get('namespace', '')
+
+        # Check if neighbor is a T1 device in T2 topology
+        device_info = minigraph_devices.get(neighbor_name, {})
+        # "LeafRouter" is an ambiguous term among vendors, but we use it here to 
+        # identify T1 devices. Do we need something more robust here?
+        if device_info.get('type') == 'LeafRouter':
+            # Determine the ASIC namespace for this neighbor
+            # namespace is empty string for single-asic or 'asicN' for multi-asic
+            asic_namespace = namespace if namespace else 'asic0'
+            logger.info(f"Found downstream T1 neighbor: {neighbor_name} on {asic_namespace}")
+            return (asic_namespace, neighbor_name)
+
+    return (None, None)
+
+
+def get_namespace_arg(duthost, namespace):
+    """Build namespace argument for CLI commands.
+
+    For multi-ASIC systems, returns '-n {namespace}' for commands that need it.
+    For single-ASIC systems, returns empty string.
+
+    Args:
+        duthost: DUT host object
+        namespace: Namespace string (e.g., 'asic0') or None
+
+    Returns:
+        str: Namespace argument string, or empty string if not needed
+    """
+    if duthost.is_multi_asic and namespace:
+        return f"-n {namespace}"
+    return ""
+
+
+def get_asic_index_from_namespace(namespace):
+    """Extract numeric ASIC index from namespace string.
+
+    Some commands (like vtysh) use numeric index instead of full namespace.
+
+    Args:
+        namespace: Namespace string like 'asic0' or 'asic1'
+
+    Returns:
+        int: Numeric ASIC index, or 0 if not parseable
+    """
+    if namespace and namespace.startswith('asic'):
+        try:
+            return int(namespace.replace('asic', ''))
+        except ValueError:
+            pass
+    return 0
+
+
+def get_interfaces_for_neighbor(duthost, neighbor_name):
+    """Get the list of interfaces connected to a specific neighbor.
+
+    Args:
+        duthost: DUT host object
+        neighbor_name: Name of the neighbor device (e.g., 'ARISTA01T1')
+
+    Returns:
+        list: List of interface names connected to the neighbor
+    """
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+    minigraph_neighbors = mg_facts.get('minigraph_neighbors', {})
+
+    interfaces = []
+    for interface, neighbor_info in minigraph_neighbors.items():
+        if neighbor_info.get('name') == neighbor_name:
+            interfaces.append(interface)
+
+    return interfaces
+
+
+def check_ports_require_dpb(duthost, interfaces, namespace):
+    """Check if any interfaces are in a breakout configuration that would require DPB.
+
+    When a neighbor is removed and minigraph is reloaded, ports may revert to their
+    native lane configuration (e.g., 400G with 8 lanes). If the current configuration
+    has ports in breakout mode (e.g., 4x100G with 2 lanes each), the GCU patch cannot
+    restore them without Dynamic Port Breakout (DPB) commands.
+
+    This function uses multiple heuristics to detect breakout configurations:
+    1. Port index alignment - breakout ports often have non-standard spacing
+    2. Sibling ports - multiple ports sharing the same physical lane group base
+    3. Speed-to-lane ratio - comparing configured speed against lane count
+    4. Lane count combined with other factors
+
+    Args:
+        duthost: DUT host object
+        interfaces: List of interface names to check
+        namespace: ASIC namespace (e.g., 'asic0')
+
+    Returns:
+        tuple: (requires_dpb, breakout_ports) where:
+               - requires_dpb: True if any ports are in breakout configuration
+               - breakout_ports: Dict of {port: {'lanes': str, 'lane_count': int, 'reason': str}}
+    """
+    if not interfaces:
+        return False, {}
+
+    ns_arg = get_namespace_arg(duthost, namespace)
+    breakout_ports = {}
+
+    # Collect port information for all interfaces
+    port_info = {}
+    for interface in interfaces:
+        # Skip non-Ethernet interfaces (e.g., PortChannels)
+        if not interface.startswith('Ethernet'):
+            continue
+
+        # Get port configuration from CONFIG_DB
+        redis_cmd = f'sonic-db-cli {ns_arg} CONFIG_DB hgetall "PORT|{interface}"'
+        result = duthost.shell(redis_cmd, module_ignore_errors=True)
+
+        if result['rc'] != 0 or not result['stdout'].strip():
+            logger.warning(f"Could not get config for {interface}")
+            continue
+
+        # Parse the redis output (format: {'key1': 'val1', 'key2': 'val2', ...})
+        config_str = result['stdout'].strip()
+        try:
+            # Handle Python dict string format from redis
+            config = eval(config_str)  # Safe here as we control the source
+        except (SyntaxError, ValueError):
+            logger.warning(f"Could not parse config for {interface}: {config_str}")
+            continue
+
+        lanes = config.get('lanes', '')
+        speed = config.get('speed', '')
+        lane_count = len(lanes.split(',')) if lanes else 0
+
+        # Extract port index number
+        try:
+            port_index = int(interface.replace('Ethernet', ''))
+        except ValueError:
+            continue
+
+        port_info[interface] = {
+            'lanes': lanes,
+            'lane_count': lane_count,
+            'speed': speed,
+            'port_index': port_index,
+            'lane_start': int(lanes.split(',')[0]) if lanes else -1
+        }
+
+    # Analyze ports for breakout indicators
+    for interface, info in port_info.items():
+        reasons = []
+        lane_count = info['lane_count']
+        port_index = info['port_index']
+        speed = info['speed']
+        lane_start = info['lane_start']
+
+        # Heuristic 1: Port index alignment
+        # Native 8-lane ports typically align to multiples of 8 (Ethernet0, 8, 16, 24...)
+        # Native 4-lane ports align to multiples of 4
+        # Breakout ports often have indices like 2, 4, 6 within an 8-port group
+        if lane_count <= 2:
+            # For 1-2 lane ports, check if index suggests breakout
+            # (not aligned to 8-port boundary AND not the base port of a group)
+            group_base = (port_index // 8) * 8
+            if port_index != group_base and port_index % 4 != 0:
+                reasons.append(f"port index {port_index} suggests breakout (not aligned to 4/8 boundary)")
+            elif port_index % 8 != 0:
+                # Index like 4, 12, 20 - could be 2x breakout of 8-lane port
+                reasons.append(f"port index {port_index} may be breakout of 8-lane native port")
+
+        # Heuristic 2: Check for sibling ports in same lane group
+        # If we see Ethernet0 and Ethernet2 both with 2 lanes starting near each other,
+        # they're likely breakout ports from the same physical port
+        if lane_count < 8:
+            group_base = (lane_start // 8) * 8 if lane_start >= 0 else -1
+            siblings = [
+                p for p, i in port_info.items()
+                if p != interface
+                and i['lane_start'] >= 0
+                and (i['lane_start'] // 8) * 8 == group_base
+            ]
+            if siblings:
+                reasons.append(f"shares lane group with sibling ports: {siblings}")
+
+        # Heuristic 3: Speed-to-lane ratio analysis
+        # Common configurations:
+        # - 400G: 8 lanes (50G/lane) or 4 lanes (100G/lane PAM4)
+        # - 200G: 4 lanes (50G/lane) or 2 lanes (100G/lane PAM4)
+        # - 100G: 4 lanes (25G/lane), 2 lanes (50G/lane), or 1 lane (100G/lane)
+        # - 50G: 2 lanes (25G/lane) or 1 lane (50G/lane)
+        # - 25G/10G: 1 lane
+        if speed and speed.isdigit():
+            speed_gbps = int(speed) // 1000
+            if lane_count > 0:
+                gbps_per_lane = speed_gbps / lane_count
+                # Unusual ratios may indicate breakout
+                # Standard ratios: 25, 50, 100 Gbps per lane
+                if gbps_per_lane not in [10, 25, 50, 100]:
+                    reasons.append(f"unusual speed/lane ratio: {speed_gbps}G / {lane_count} lanes = {gbps_per_lane}G/lane")
+
+        # Heuristic 4: Low lane count with high speed (likely PAM4 breakout)
+        # 2-lane 100G is often from 4x100G breakout of 400G port
+        if lane_count == 2 and speed and int(speed) >= 100000:
+            reasons.append(f"{lane_count} lanes at {int(speed)//1000}G suggests breakout configuration")
+
+        # Heuristic 5: Lane count less than 4 is almost always breakout on modern platforms
+        # (except for some 25G/10G single-lane ports which are typically native)
+        if lane_count < 4 and speed and int(speed) >= 50000:
+            reasons.append(f"low lane count ({lane_count}) with high speed ({int(speed)//1000}G)")
+
+        # If we have multiple strong indicators, flag as breakout
+        if len(reasons) >= 2 or (lane_count <= 2 and len(reasons) >= 1):
+            breakout_ports[interface] = {
+                'lanes': info['lanes'],
+                'lane_count': lane_count,
+                'speed': speed,
+                'reasons': reasons
+            }
+            logger.info(f"Port {interface} detected as breakout: {'; '.join(reasons)}")
+        elif reasons:
+            # Single weak indicator - log but don't flag
+            logger.debug(f"Port {interface} has possible breakout indicator: {reasons[0]}")
+
+    requires_dpb = len(breakout_ports) > 0
+    return requires_dpb, breakout_ports
+
+
+def parse_mirror_acl_bindings(acl_table_output):
+    """Parse 'show acl table' output to extract MIRROR/MIRRORV6 ACL bindings.
+
+    Parses the output of 'show acl table' command and returns the set of ports/portchannels
+    that are bound to MIRROR or MIRRORV6 type ACL tables.
+
+    Example output format:
+        admin@bjw-can-7250-lc2-1:~$ show acl table
+        Name        Type       Binding         Description    Stage    Status
+        ----------  ---------  --------------  -------------  -------  --------
+        NTP_ACL     CTRLPLANE  NTP             NTP_ACL        ingress  Active
+        DATAACL     L3         Ethernet48      DATAACL        ingress  Active
+                               Ethernet208
+                               PortChannel101
+        EVERFLOW    MIRROR     Ethernet48      EVERFLOW       ingress  Active
+                               Ethernet208
+                               PortChannel101
+        EVERFLOWV6  MIRRORV6   Ethernet48      EVERFLOWV6     ingress  Active
+                               Ethernet208
+                               PortChannel101
+
+    Args:
+        acl_table_output: String output from 'show acl table' command
+
+    Returns:
+        set: Set of port/portchannel names bound to MIRROR or MIRRORV6 ACL tables
+    """
+    current_table = None
+    mirror_bindings = set()
+
+    for line in acl_table_output.splitlines():
+        if not line.strip() or '----' in line:
+            continue
+
+        # If line starts with name, it's a new table entry
+        if not line.startswith(' '):
+            fields = [f for f in line.split() if f]
+            if len(fields) >= 2 and fields[1] in ('MIRROR', 'MIRRORV6'):
+                current_table = fields[0]
+                # Capture binding on the same line as the table name (field index 2)
+                if len(fields) >= 3:
+                    mirror_bindings.add(fields[2])
+            else:
+                current_table = None
+        # If line starts with space and we're in a MIRROR table, it's a binding
+        elif current_table:
+            port = line.strip()
+            if port:
+                mirror_bindings.add(port)
+
+    return mirror_bindings
 
 
 @pytest.fixture(autouse=True)
-def setup_env(duthosts, rand_one_dut_hostname):
-    duthost = duthosts[rand_one_dut_hostname]
+def setup_env(duthosts, rand_one_dut_front_end_hostname):
+    """Setup and teardown fixture using a frontend (linecard) DUT.
+
+    Uses rand_one_dut_front_end_hostname to ensure we get a linecard in T2 topology,
+    which is where downstream T1 neighbors are connected.
+
+    Teardown Strategy:
+    ------------------
+    This test uses config_reload() instead of GCU rollback for cleanup because:
+
+    1. The test modifies minigraph.xml (removes target_t1 neighbor)
+    2. Reloads config from the modified minigraph
+    3. Applies GCU patches on top of that modified config
+
+    GCU rollback would need to compute a diff from this complex state back to the
+    original checkpoint, which consistently fails due to:
+    - YANG validation errors on intermediate states
+    - Dependency ordering issues with the patch sorter
+    - References to ports/interfaces that exist in checkpoint but not in current minigraph
+
+    Since we backup the original minigraph before modification, restoring it and doing
+    a config_reload reliably returns the DUT to its original state. This achieves the
+    same cleanup goal without the fragility of GCU rollback.
+
+    Note: This test validates GCU apply_patch functionality, not rollback. Rollback
+    is tested separately in other GCU test modules.
+    """
+    duthost = duthosts[rand_one_dut_front_end_hostname]
     create_checkpoint(duthost)
     yield
     try:
-        logger.info("Rolled back to original checkpoint")
-        rollback_or_reload(duthost)
+        # Restore original minigraph if it was backed up during the test.
+        # The test modifies minigraph.xml to remove target_t1, so we must
+        # restore it before config_reload to get back to the original state.
+        if duthost.stat(path=MINIGRAPH_BACKUP)["stat"]["exists"]:
+            logger.info(f"Restoring original minigraph from {MINIGRAPH_BACKUP}")
+            duthost.shell(f"sudo cp {MINIGRAPH_BACKUP} {MINIGRAPH}")
+            duthost.shell(f"sudo rm -f {MINIGRAPH_BACKUP}")
+
+        # Use config_reload instead of rollback_or_reload() for reliable cleanup.
+        # See docstring above for detailed rationale.
+        logger.info("Reloading minigraph to restore original configuration")
+        config_reload(duthost)
     finally:
         delete_checkpoint(duthost)
 
 
-def create_table_if_not_exist(duthost, tables):
-    """
-    Create tables in CONFIG_DB if they do not exist.
-    :param duthost: DUT host object
-    :param tables: List of table names to check and create
-    """
-    for table in tables:
-        result = duthost.shell(f"sonic-db-cli -n {ASICID} CONFIG_DB keys '{table}|*'")["stdout"]
-        if not result:
-            logger.info(f"Table {table} does not exist, creating it")
-            json_patch = [
-                {
-                    "op": "add",
-                    "path": "/{}/{}".format(ASICID, table),
-                    "value": {}
-                }
-            ]
-            tmpfile = generate_tmpfile(duthost)
-            try:
-                apply_patch_result = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
-                if (apply_patch_result['rc'] != 0 or
-                        "Patch applied successfully"not in apply_patch_result['stdout']):
-                    pytest.fail(f"Failed to apply patch: {apply_patch_result['stdout']}")
-            finally:
-                delete_tmpfile(duthost, tmpfile)
+def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
+    """Test adding a downstream T1 neighbor cluster via GCU.
 
+    This test validates that a T1 neighbor can be added to a multi-ASIC 
+    SONiC device using GCU JSON patches.
 
-def test_addcluster_workflow(duthost):
+    The test:
+    1. Uses a frontend/linecard DUT (rand_one_dut_front_end_hostname)
+    2. Dynamically discovers a T1 neighbor from minigraph facts
+    3. Tests on the specific ASIC where the T1 neighbor is connected
+
+    Args:
+        duthosts: DUT hosts fixture
+        rand_one_dut_front_end_hostname: Fixture that provides a frontend DUT hostname
+    """
+    duthost = duthosts[rand_one_dut_front_end_hostname]
+
+    # Dynamically discover a downstream T1 neighbor
+    asic_id, target_t1 = get_downstream_t1_neighbor(duthost)
+    if not target_t1:
+        pytest.skip("No downstream T1 neighbor found in minigraph")
+
+    # Build namespace argument for CLI commands (handles single-ASIC vs multi-ASIC)
+    ns_arg = get_namespace_arg(duthost, asic_id)
+    asic_index = get_asic_index_from_namespace(asic_id)
+    logger.info(f"Testing with downstream T1 neighbor: {target_t1} on {asic_id} (ns_arg='{ns_arg}', index={asic_index})")
+
+    # Step 0: Check for Dynamic Port Breakout (DPB) requirements
+    # -------------------------------------------------------------------------
+    # If any ports connected to the target neighbor are in breakout configuration,
+    # removing the neighbor and reloading minigraph will revert those ports to their
+    # native lane configuration. The GCU patch cannot restore breakout configurations
+    # because it only handles CONFIG_DB changes, not hardware lane remapping.
+    #
+    # Skip the test if DPB would be required to restore the configuration.
+    # -------------------------------------------------------------------------
+    neighbor_interfaces = get_interfaces_for_neighbor(duthost, target_t1)
+    logger.info(f"Interfaces connected to {target_t1}: {neighbor_interfaces}")
+
+    requires_dpb, breakout_ports = check_ports_require_dpb(duthost, neighbor_interfaces, asic_id)
+    if requires_dpb:
+        # Build detailed skip message with detection reasons
+        port_details = []
+        for port, info in breakout_ports.items():
+            reasons = info.get('reasons', [])
+            reason_str = "; ".join(reasons) if reasons else "low lane count"
+            port_details.append(f"{port} ({info['lane_count']} lanes, {info.get('speed', 'unknown')} speed): {reason_str}")
+        breakout_info = "\n  - ".join(port_details)
+        pytest.skip(
+            f"Test requires Dynamic Port Breakout (DPB) which is not supported. "
+            f"Ports detected as breakout configuration:\n  - {breakout_info}\n"
+            f"These ports would revert to native lane config after minigraph reload."
+        )
+
+    # Initialize config capture directory (if enabled)
+    capture_dir = None
+    if CAPTURE_CONFIGS:
+        capture_dir = get_capture_dir(duthost.hostname)
+        logger.info(f"Config capture enabled. Saving snapshots to: {capture_dir}")
+
+        # Capture initial CONFIG_DB state (before any test modifications)
+        capture_config_db(duthost, asic_id, capture_dir,
+                          "01_initial_config_db.json",
+                          "Initial CONFIG_DB state before test modifications")
+
     # Step 1: Backup minigraph
     logger.info(f"Backing up current minigraph from {MINIGRAPH} to {MINIGRAPH_BACKUP}")
     if not duthost.stat(path=MINIGRAPH)["stat"]["exists"]:
@@ -90,15 +574,15 @@ def test_addcluster_workflow(duthost):
     logger.info(f"Saved full configuration backup to {full_config_path}")
     duthost.shell(f"rm -f {dut_config_path}")
 
-    # Step 3: Modify minigraph to remove TARGET_LEAF
-    logger.info(f"Modifying minigraph to remove {TARGET_LEAF}")
+    # Step 3: Modify minigraph to remove target_t1
+    logger.info(f"Modifying minigraph to remove {target_t1}")
     local_dir = "/tmp/minigraph_modified"
     local_minigraph = os.path.join(local_dir, f"{duthost.hostname}-minigraph.xml")
     duthost.fetch(src=MINIGRAPH, dest=local_minigraph, flat=True)
-    refactor = MinigraphRefactor(TARGET_LEAF)
+    refactor = MinigraphRefactor(target_t1)
     if not refactor.process_minigraph(local_minigraph, local_minigraph):
-        logger.info(f"Skipping test - testbed topology does not match required conditions for {TARGET_LEAF}")
-        pytest.skip(f"Testbed topology does not match required conditions for {TARGET_LEAF}")
+        logger.info(f"Skipping test - testbed topology does not match required conditions for {target_t1}")
+        pytest.skip(f"Testbed topology does not match required conditions for {target_t1}")
     duthost.copy(src=local_minigraph, dest=MINIGRAPH)
 
     # Step 4: Reload minigraph
@@ -108,223 +592,253 @@ def test_addcluster_workflow(duthost):
         logger.error("Not all critical services fully started!")
         pytest.fail("Critical services not fully started after minigraph reload")
 
-    # Step 5: Capture full running configuration without TARGET_LEAF
-    logger.info("Capturing full running configuration without TARGET_LEAF")
-    dut_config_path = "/tmp/all-no-leaf.json"
-    no_leaf_config_path = os.path.join(THIS_DIR, "backup", f"{duthost.hostname}-all-no-leaf.json")
-    os.makedirs(os.path.dirname(no_leaf_config_path), exist_ok=True)
+    # Capture pre-patch CONFIG_DB state (neighbor removed via minigraph)
+    if CAPTURE_CONFIGS and capture_dir:
+        capture_config_db(duthost, asic_id, capture_dir,
+                          "02_pre_patch_config_db.json",
+                          f"CONFIG_DB after minigraph reload without {target_t1}")
+
+    # Step 5: Capture full running configuration without target_t1
+    logger.info(f"Capturing full running configuration without {target_t1}")
+    dut_config_path = "/tmp/all-without-t1.json"
+    no_t1_config_path = os.path.join(THIS_DIR, "backup", f"{duthost.hostname}-all-without-t1.json")
+    os.makedirs(os.path.dirname(no_t1_config_path), exist_ok=True)
     duthost.shell(f"show runningconfiguration all > {dut_config_path}")
 
-    duthost.fetch(src=dut_config_path, dest=no_leaf_config_path, flat=True)
-    logger.info(f"Saved full configuration without TARGET_LEAF backup to {no_leaf_config_path}")
+    duthost.fetch(src=dut_config_path, dest=no_t1_config_path, flat=True)
+    logger.info(f"Saved full configuration without {target_t1} backup to {no_t1_config_path}")
     duthost.shell(f"rm -f {dut_config_path}")
 
-    # step 6: Generate patch file
-    logger.info("Generating patch file")
-    patch_file = generate_config_patch(full_config_path, no_leaf_config_path)
+    # step 6: Generate patch files
+    # NOTE: Patches are split into two phases due to a GCU sorter limitation/bug.
+    # The GCU patch sorter fails with "'PortX' is not in list" when a PORT is being
+    # added in the same batch as an ACL_TABLE that references that PORT.
+    # Phase 1: Core config (PORT, INTERFACE, BGP_NEIGHBOR, etc.)
+    # Phase 2: ACL_TABLE entries (applied after ports exist)
+    logger.info("Generating patch files (two phases)")
+    phase1_file, phase2_file = generate_config_patch(full_config_path, no_t1_config_path)
 
-    # Step 7 check corresponding tables in CONFIG_DB, if not, create them by mini patch.
-    check_tables = ["BGP_NEIGHBOR", "CABLE_LENGTH", "BUFFER_PG", "PORT_QOS_MAP", "DEVICE_NEIGHBOR_METADATA"]
-    logger.info(f"Checking and creating tables: {check_tables}")
-    create_table_if_not_exist(duthost, check_tables)
+    # Capture the generated patch files
+    if CAPTURE_CONFIGS and capture_dir:
+        capture_file(phase1_file, capture_dir,
+                     "03a_generated_patch_phase1.json",
+                     f"Phase 1 GCU patch (core config) for {target_t1}")
+        capture_file(phase2_file, capture_dir,
+                     "03b_generated_patch_phase2.json",
+                     f"Phase 2 GCU patch (ACL bindings) for {target_t1}")
 
-    # Step 8: Apply addcluster.json
-    logger.info("Applying addcluster.json patch")
-    with open(patch_file) as file:
-        json_patch = json.load(file)
-    tmpfile = generate_tmpfile(duthost)
+    # Note: We don't need to pre-create tables - the main patch will create them
+    # with actual data. ConfigDb doesn't allow empty tables anyway.
 
-    # Extract information to check from patch
+    # Step 7: Apply patches in two phases
+    # Phase 1: Core configuration (PORT, INTERFACE, BGP_NEIGHBOR, etc.)
+    logger.info("Applying Phase 1 patch (core configuration)")
+    with open(phase1_file) as file:
+        phase1_patch = json.load(file)
+
+    # Extract information to check from phase 1 patch
     ports_to_check = set()
     portchannels_to_check = set()
     bgp_neighbors_to_check = set()
+    # NOTE: BUFFER_PG is excluded because on dynamic buffer model platforms (like Cisco-8000),
+    # buffer profiles are auto-generated by the buffer manager once PORT and CABLE_LENGTH are set.
     config_entries_to_check = {
         'DEVICE_NEIGHBOR_METADATA': set(),
         'CABLE_LENGTH': set(),
-        'BUFFER_PG': set(),
         'PORT_QOS_MAP': set(),
         'PFC_WD': set(),
         'PORTCHANNEL_MEMBER': set(),
         'DEVICE_NEIGHBOR': set()
     }
-    for patch_entry in json_patch:
+    for patch_entry in phase1_patch:
         path = patch_entry.get('path', '')
-        if path.startswith(f'/{ASICID}/PORT/'):
+        if path.startswith(f'/{asic_id}/PORT/'):
             port = path.split('/')[-1]
             ports_to_check.add(port)
-        elif path.startswith(f'/{ASICID}/PORTCHANNEL/'):
+        elif path.startswith(f'/{asic_id}/PORTCHANNEL/'):
             portchannel = path.split('/')[-1]
             portchannels_to_check.add(portchannel)
-        elif path.startswith(f'/{ASICID}/PORTCHANNEL_MEMBER/'):
+        elif path.startswith(f'/{asic_id}/PORTCHANNEL_MEMBER/'):
             entry = path.split('/')[-1]
             config_entries_to_check['PORTCHANNEL_MEMBER'].add(f"PORTCHANNEL_MEMBER|{entry}")
-        elif path.startswith(f'/{ASICID}/BGP_NEIGHBOR/'):
+        elif path.startswith(f'/{asic_id}/BGP_NEIGHBOR/'):
             neighbor = path.split('/')[-1]
             bgp_neighbors_to_check.add(neighbor)
-        elif path.startswith(f'/{ASICID}/DEVICE_NEIGHBOR_METADATA/'):
+        elif path.startswith(f'/{asic_id}/DEVICE_NEIGHBOR_METADATA/'):
             entry = path.split('/')[-1]
             config_entries_to_check['DEVICE_NEIGHBOR_METADATA'].add(f"DEVICE_NEIGHBOR_METADATA|{entry}")
-        elif path.startswith(f'/{ASICID}/DEVICE_NEIGHBOR/'):
+        elif path.startswith(f'/{asic_id}/DEVICE_NEIGHBOR/'):
             entry = path.split('/')[-1]
             config_entries_to_check['DEVICE_NEIGHBOR'].add(f"DEVICE_NEIGHBOR|{entry}")
-        elif path.startswith(f'/{ASICID}/CABLE_LENGTH/AZURE/'):
+        elif path.startswith(f'/{asic_id}/CABLE_LENGTH/AZURE/'):
             entry = path.split('/')[-1]
             config_entries_to_check['CABLE_LENGTH'].add(f"{entry}")
-        elif path.startswith(f'/{ASICID}/BUFFER_PG/'):
-            entry = '|'.join(path.split('/')[-2:])
-            config_entries_to_check['BUFFER_PG'].add(f"{entry}")
-        elif path.startswith(f'/{ASICID}/PORT_QOS_MAP/'):
+        elif path.startswith(f'/{asic_id}/PORT_QOS_MAP/'):
             entry = path.split('/')[-1]
             config_entries_to_check['PORT_QOS_MAP'].add(f"PORT_QOS_MAP|{entry}")
-        elif path.startswith(f'/{ASICID}/PFC_WD/'):
+        elif path.startswith(f'/{asic_id}/PFC_WD/'):
             entry = path.split('/')[-1]
             config_entries_to_check['PFC_WD'].add(f"PFC_WD|{entry}")
 
+    # Apply Phase 1 patch (core configuration)
+    tmpfile = generate_tmpfile(duthost)
     try:
-        apply_patch_result = apply_patch(duthost, json_data=json_patch, dest_file=tmpfile)
+        apply_patch_result = apply_patch(duthost, json_data=phase1_patch, dest_file=tmpfile)
         if apply_patch_result['rc'] != 0 or "Patch applied successfully" not in apply_patch_result['stdout']:
-            pytest.fail(f"Failed to apply patch: {apply_patch_result['stdout']}")
+            pytest.fail(f"Failed to apply Phase 1 patch: {apply_patch_result['stdout']}")
+        logger.info("Phase 1 patch applied successfully")
     finally:
         delete_tmpfile(duthost, tmpfile)
 
-    # Step 9: Check port status dynamically
+    # Step 7.1: Apply Phase 2 patch (ACL bindings)
+    # This is done separately due to GCU sorter limitation - it cannot handle
+    # PORT additions and ACL_TABLE updates referencing those ports in the same batch.
+    logger.info("Applying Phase 2 patch (ACL bindings)")
+    with open(phase2_file) as file:
+        phase2_patch = json.load(file)
+
+    # Extract ACL-bound ports from phase 2 patch for verification
+    acl_bound_ports = set()
+    for patch_entry in phase2_patch:
+        path = patch_entry.get('path', '')
+        if path.startswith(f'/{asic_id}/ACL_TABLE/'):
+            value = patch_entry.get('value', {})
+            if isinstance(value, dict):
+                acl_type = value.get('type', '')
+                if acl_type in ('MIRROR', 'MIRRORV6'):
+                    ports_list = value.get('ports', [])
+                    if isinstance(ports_list, list):
+                        for port in ports_list:
+                            if is_front_panel_port(port):
+                                acl_bound_ports.add(port)
+
+    if phase2_patch:
+        tmpfile = generate_tmpfile(duthost)
+        try:
+            apply_patch_result = apply_patch(duthost, json_data=phase2_patch, dest_file=tmpfile)
+            if apply_patch_result['rc'] != 0 or "Patch applied successfully" not in apply_patch_result['stdout']:
+                pytest.fail(f"Failed to apply Phase 2 patch: {apply_patch_result['stdout']}")
+            logger.info("Phase 2 patch applied successfully")
+        finally:
+            delete_tmpfile(duthost, tmpfile)
+    else:
+        logger.info("Phase 2 patch is empty (no ACL changes) - skipping")
+
+    # Capture post-patch CONFIG_DB state
+    if CAPTURE_CONFIGS and capture_dir:
+        capture_config_db(duthost, asic_id, capture_dir,
+                          "04_post_patch_config_db.json",
+                          f"CONFIG_DB after GCU patches applied for {target_t1}")
+        logger.info(f"Config capture complete. All snapshots saved to: {capture_dir}")
+
+    # Step 9: Verify port configuration restoration
+    # -------------------------------------------------------------------------
+    # IMPORTANT: This test validates CONFIGURATION RESTORATION, not operational status.
+    # We verify that ports which existed in the original configuration are correctly
+    # restored by the GCU patch, with all configurable attributes matching the patch.
+    #
+    # What we check:
+    # - Port exists in CONFIG_DB with correct attributes (admin_status, speed, etc.)
+    # - Port is bound to appropriate ACL tables as specified in the patch
+    # - Only front-panel ports are validated (internal/backplane ports are excluded)
+    #
+    # What we do NOT check:
+    # - Operational status (link up/down) - this depends on cable/peer availability
+    # - Traffic forwarding - out of scope for configuration validation
+    # -------------------------------------------------------------------------
     if not ports_to_check:
         pytest.fail("No ports found in patch to verify")
 
-    for port in ports_to_check:
-        logger.info(f"Checking status for port {port}")
-        result = duthost.shell(f"show interface status {port}", module_ignore_errors=False)["stdout"]
-        pytest_assert("up" in result, f"{port} is not up")
+    # Filter to only front-panel ports - internal ports (Ethernet-BP*, Ethernet-Rec*, etc.)
+    # are not configurable via GCU patches and should not be validated
+    front_panel_ports = {p for p in ports_to_check if is_front_panel_port(p)}
+    skipped_ports = ports_to_check - front_panel_ports
+    if skipped_ports:
+        logger.info(f"Skipping internal/backplane ports (not configurable via patch): {sorted(skipped_ports)}")
+
+    if not front_panel_ports:
+        pytest.fail("No front-panel ports found in patch to verify")
+
+    # Verify each port exists in CONFIG_DB with admin_status as specified in patch
+    for port in front_panel_ports:
+        logger.info(f"Verifying configuration restoration for port {port}")
+        # Check port exists in CONFIG_DB
+        redis_cmd = f'sonic-db-cli {ns_arg} CONFIG_DB hgetall "PORT|{port}"'
+        redis_output = duthost.shell(redis_cmd, module_ignore_errors=False)['stdout']
+        pytest_assert(redis_output.strip(), f"Port {port} not found in CONFIG_DB after patch")
+
+        # Verify admin_status is 'up' (as expected from original config restoration)
+        pytest_assert("'admin_status'" in redis_output and "'up'" in redis_output,
+                      f"Port {port} admin_status is not 'up' in CONFIG_DB. Got: {redis_output}")
+        logger.info(f"Verified port {port} exists in CONFIG_DB with admin_status=up")
 
     # Step 9.1: Check ports are bound to MIRROR ACL tables
-    logger.info("Checking ports binding in MIRROR ACL tables")
-    result = duthost.shell("show acl table", module_ignore_errors=False)["stdout"]
+    # Only verify ports that were explicitly added to MIRROR ACL tables in the patch.
+    # Not all ports in the patch are necessarily MIRROR-bound.
+    if acl_bound_ports:
+        logger.info(f"Checking MIRROR ACL bindings for {len(acl_bound_ports)} ports from patch")
+        result = duthost.shell("show acl table", module_ignore_errors=False)["stdout"]
+        mirror_bindings = parse_mirror_acl_bindings(result)
 
-    # Parse ACL table output to get MIRROR type tables and their bindings
-    current_table = None
-    mirror_bindings = set()
-    """ Example output:
-    admin@bjw-can-7250-lc2-1:~$ show acl table
-    Name        Type       Binding         Description    Stage    Status
-    ----------  ---------  --------------  -------------  -------  --------------------------------------
-    NTP_ACL     CTRLPLANE  NTP             NTP_ACL        ingress  {'asic0': 'Active', 'asic1': 'Active'}
-    SNMP_ACL    CTRLPLANE  SNMP            SNMP_ACL       ingress  {'asic0': 'Active', 'asic1': 'Active'}
-    SSH_ONLY    CTRLPLANE  SSH             SSH_ONLY       ingress  {'asic0': 'Active', 'asic1': 'Active'}
-    DATAACL     L3         Ethernet48      DATAACL        ingress  {'asic0': 'Active', 'asic1': 'Active'}
-                        Ethernet208
-                        PortChannel101
-                        PortChannel105
-    EVERFLOW    MIRROR     Ethernet48      EVERFLOW       ingress  {'asic0': 'Active', 'asic1': 'Active'}
-                        Ethernet208
-                        PortChannel101
-                        PortChannel105
-    EVERFLOWV6  MIRRORV6   Ethernet48      EVERFLOWV6     ingress  {'asic0': 'Active', 'asic1': 'Active'}
-                        Ethernet208
-                        PortChannel101
-                        PortChannel105
-    """
-    for line in result.splitlines():
-        if not line.strip() or '----' in line:
-            continue
-
-        # If line starts with name, it's a new table entry
-        if not line.startswith(' '):
-            fields = [f for f in line.split() if f]
-            if len(fields) >= 2 and fields[1] in ('MIRROR', 'MIRRORV6'):
-                current_table = fields[0]
-        # If line starts with space and we're in a MIRROR table, it's a binding
-        elif current_table:
-            port = line.strip()
-            if port:
-                mirror_bindings.add(port)
-
-        # Check if all ports_to_check are in mirror_bindings
-        for port in ports_to_check:
+        # Check ports that should be MIRROR-bound per the patch
+        for port in acl_bound_ports:
             pytest_assert(port in mirror_bindings,
                           f"Port {port} is not bound to any MIRROR ACL table. "
                           f"Current bindings: {sorted(mirror_bindings)}")
             logger.info(f"Verified port {port} is bound to MIRROR ACL table")
+    else:
+        logger.info("No MIRROR ACL table entries in patch - skipping ACL binding verification")
 
-    # Step 10: Check PortChannel exists
+    # Step 10: Verify PortChannel configuration restoration
+    # We verify the PortChannel exists in CONFIG_DB with correct attributes.
+    # Operational LACP status depends on peer availability and is not validated here.
     if portchannels_to_check:
-        result = duthost.shell(f"show interfaces portchannel -n {ASICID}", module_ignore_errors=False)["stdout"]
         for portchannel in portchannels_to_check:
-            logger.info(f"Checking portchannel {portchannel}")
+            logger.info(f"Verifying configuration restoration for PortChannel {portchannel}")
 
-            # First check if portchannel exists
-            pytest_assert(portchannel in result, f"{portchannel} not found in portchannel list")
+            # Verify PortChannel exists in CONFIG_DB
+            redis_cmd = f'sonic-db-cli {ns_arg} CONFIG_DB hgetall "PORTCHANNEL|{portchannel}"'
+            redis_output = duthost.shell(redis_cmd, module_ignore_errors=False)['stdout']
+            pytest_assert(redis_output.strip(),
+                          f"PortChannel {portchannel} not found in CONFIG_DB after patch")
 
-            # Parse the output to check status
-            for line in result.splitlines():
-                if portchannel in line:
-                    # Check if status is LACP(A)(Up)
-                    pytest_assert("LACP(A)(Up)" in line,
-                                  f"{portchannel} is not up. Current status: {line}")
-                    break
+            # Verify admin_status is 'up'
+            pytest_assert("'admin_status'" in redis_output and "'up'" in redis_output,
+                          f"PortChannel {portchannel} admin_status is not 'up' in CONFIG_DB. Got: {redis_output}")
+            logger.info(f"Verified PortChannel {portchannel} exists in CONFIG_DB with admin_status=up")
 
-    # Step 11: Check BGP sessions
+    # Step 11: Verify BGP neighbor configuration restoration
+    # We verify BGP neighbors exist in CONFIG_DB with correct attributes.
+    # Session establishment depends on peer availability and is not validated here.
     if bgp_neighbors_to_check:
-        # Check IPv4 BGP sessions
-        result_v4 = duthost.shell(f"show ip bgp summary -n {ASICID}", module_ignore_errors=False)["stdout"]
-        # Check IPv6 BGP sessions
-        result_v6 = duthost.shell(f"show ipv6 bgp summary -n {ASICID}", module_ignore_errors=False)["stdout"]
-
-        def check_bgp_status(output, neighbor):
-            """Helper function to check BGP neighbor status.
-
-            Example output format:
-            admin@bjw-can-7250-lc2-1:~$ show ip bgp sum -n asic0
-
-            IPv4 Unicast Summary:
-            asic0: BGP router identifier 192.0.0.6, local AS number 65100 vrf-id 0
-            BGP table version 26
-            RIB entries 27, using 6048 bytes of memory
-            Peers 5, using 3709880 KiB of memory
-            Peer groups 4, using 256 bytes of memory
-
-            Neighbhor   V   AS  MsgRcvd  MsgSent  TblVer  InQ  OutQ  Up/Down  State/PfxRcd Neightbor
-            --------- --- ---- -------- -------- ------- ---- ----- -------- ------------- ---------
-            10.0.0.13   4  65000   0        0        0     0     0   never    Idle (Admin) ARISTA01T1
-            10.0.0.17   4  65001   0        0        0     0     0   never    Idle (Admin) ARISTA03T1
-
-            Total number of neighbors 2
-            """
-            for line in output.splitlines():
-                if neighbor in line:
-                    # Split line into fields
-                    fields = line.strip().split()
-                    if len(fields) >= 10:
-                        state = fields[9]  # State/PfxRcd field
-                        # Check if state is a number (indicating received prefixes)
-                        if state.isdigit() and int(state) > 0:
-                            logger.info(f"BGP neighbor {neighbor} is established with {state} prefixes")
-                            return True
-                    logger.error(f"BGP neighbor {neighbor} not established. Status line: {line}")
-                    return False
-            logger.error(f"BGP neighbor {neighbor} not found in output")
-            return False
-
         for neighbor in bgp_neighbors_to_check:
-            logger.info(f"Checking BGP neighbor {neighbor}")
-            if ':' in neighbor:  # IPv6 address
-                pytest_assert(check_bgp_status(result_v6, neighbor),
-                              f"IPv6 BGP session with {neighbor} not established")
-            else:  # IPv4 address
-                pytest_assert(check_bgp_status(result_v4, neighbor),
-                              f"IPv4 BGP session with {neighbor} not established")
+            logger.info(f"Verifying configuration restoration for BGP neighbor {neighbor}")
+
+            # Verify BGP neighbor exists in CONFIG_DB
+            redis_cmd = f'sonic-db-cli {ns_arg} CONFIG_DB hgetall "BGP_NEIGHBOR|{neighbor}"'
+            redis_output = duthost.shell(redis_cmd, module_ignore_errors=False)['stdout']
+            pytest_assert(redis_output.strip(),
+                          f"BGP neighbor {neighbor} not found in CONFIG_DB after patch")
+
+            # Verify admin_status is 'up' (not shutdown)
+            # Note: BGP neighbors use 'admin_status': 'up' when not shutdown
+            if "'admin_status'" in redis_output:
+                pytest_assert("'up'" in redis_output,
+                              f"BGP neighbor {neighbor} admin_status is not 'up' in CONFIG_DB. Got: {redis_output}")
+            logger.info(f"Verified BGP neighbor {neighbor} exists in CONFIG_DB")
 
     # Step 12: Verify all addcluster.json changes are reflected in CONFIG_DB
     for table, entries in config_entries_to_check.items():
         for entry in entries:
             if table == 'CABLE_LENGTH':
-                redis_cmd = f'sonic-db-cli -n {ASICID} CONFIG_DB hgetall "CABLE_LENGTH|AZURE"'
+                redis_cmd = f'sonic-db-cli {ns_arg} CONFIG_DB hgetall "CABLE_LENGTH|AZURE"'
                 redis_output = duthost.shell(redis_cmd, module_ignore_errors=False)['stdout']
                 cable_lengths = json.loads(redis_output.replace("'", '"'))
 
                 if entry not in cable_lengths:
                     pytest.fail(f"Key {entry} missing in CONFIG_DB. Got: {cable_lengths}")
             else:
-                redis_key = f'sonic-db-cli -n {ASICID} CONFIG_DB keys "{entry}"'
+                redis_key = f'sonic-db-cli {ns_arg} CONFIG_DB keys "{entry}"'
                 redis_value = duthost.shell(redis_key, module_ignore_errors=False)['stdout'].strip()
                 pytest_assert(redis_value == entry,
                               f"Key {entry} missing or incorrect in CONFIG_DB. Got: {redis_value}")
@@ -341,20 +855,72 @@ def test_addcluster_workflow(duthost):
     logger.info(f"Saved applied full configuration backup to {applied_config_path}")
     duthost.shell(f"rm -f {dut_config_path}")
 
+    # -------------------------------------------------------------------------
     # Step 14: Compare full configuration before and after applying addcluster.json
-    logger.info("Comparing specific tables before and after applying addcluster.json")
+    # -------------------------------------------------------------------------
+    # COMPARISON STRATEGY:
+    # We compare only the specific entries modified by the patch, not entire tables.
+    # This avoids false-positive failures from unrelated differences in:
+    # - Entries not touched by the patch
+    # - Default values regenerated differently by minigraph reload
+    #
+    # NORMALIZATION:
+    # The normalize_entry() function handles semantically equivalent values:
+    # - admin_status='up' is equivalent to no admin_status field (implicit default)
+    # - The GCU patch generator injects admin_status='up' to ensure resources come up,
+    #   but minigraph-generated configs typically don't have this field explicitly set
+    # - Without normalization, {'admin_status': 'up', 'asn': '65025', ...} would not
+    #   match {'asn': '65025', ...} even though they're functionally identical
+    # -------------------------------------------------------------------------
+    logger.info("Comparing specific entries before and after applying addcluster.json")
 
     def get_table_data(config, table):
         """Extract table data from config."""
-        return config.get(ASICID, {}).get(table, {})
+        return config.get(asic_id, {}).get(table, {})
 
-    # Get list of tables to compare from the patch
-    tables_to_compare = set()
-    for patch_entry in json_patch:
+    def normalize_entry(entry, table):
+        """Normalize entry for comparison by handling semantically equivalent values.
+
+        For BGP_NEIGHBOR, PORT, and PORTCHANNEL tables:
+        - admin_status='up' is semantically equivalent to no admin_status field
+        - The patch generator adds admin_status='up' to ensure resources come up,
+          but minigraph-generated configs may not have this field explicitly set
+
+        Args:
+            entry: Configuration entry dict to normalize
+            table: Table name (used to determine which normalizations apply)
+
+        Returns:
+            Normalized copy of the entry dict
+        """
+        if not isinstance(entry, dict):
+            return entry
+
+        normalized = dict(entry)
+
+        # Tables where admin_status='up' is the implicit default
+        admin_status_tables = ['BGP_NEIGHBOR', 'PORT', 'PORTCHANNEL']
+        if table in admin_status_tables:
+            # Remove admin_status if it's 'up' (the default) for comparison purposes
+            if normalized.get('admin_status') == 'up':
+                del normalized['admin_status']
+
+        return normalized
+
+    # Build a mapping of (table, key) -> expected value from the patches
+    # This allows us to verify only the entries that were actually patched
+    patched_entries = {}  # {(table, key): expected_value}
+    for patch_entry in phase1_patch + phase2_patch:
         path = patch_entry.get('path', '')
         parts = path.split('/')
-        if len(parts) > 2:
-            tables_to_compare.add(parts[2])
+        # Path format: /asic_id/TABLE/key or /asic_id/TABLE/key/property
+        if len(parts) >= 4:
+            patch_asic = parts[1]
+            table = parts[2]
+            key = parts[3]
+            # Only track entries for our target ASIC
+            if patch_asic == asic_id:
+                patched_entries[(table, key)] = True
 
     # Load configurations
     with open(full_config_path, 'r') as file:
@@ -362,16 +928,37 @@ def test_addcluster_workflow(duthost):
     with open(applied_config_path, 'r') as file:
         applied_config = json.load(file)
 
-    # Compare only modified tables
-    for table in tables_to_compare:
-        logger.info(f"Comparing table: {table}")
+    # Group patched entries by table for organized logging
+    tables_with_entries = {}
+    for (table, key) in patched_entries:
+        if table not in tables_with_entries:
+            tables_with_entries[table] = []
+        tables_with_entries[table].append(key)
+
+    # Compare only the specific entries that were patched
+    for table, keys in tables_with_entries.items():
+        logger.info(f"Comparing table: {table} ({len(keys)} entries)")
         original_table = get_table_data(full_config, table)
         applied_table = get_table_data(applied_config, table)
 
-        if original_table != applied_table:
-            logger.error(f"Table {table} mismatch:")
-            logger.error(f"Original: {original_table}")
-            logger.error(f"Applied:  {applied_table}")
-            pytest.fail(f"Configuration mismatch in table {table}")
+        mismatches = []
+        for key in keys:
+            original_entry = normalize_entry(original_table.get(key, {}), table)
+            applied_entry = normalize_entry(applied_table.get(key, {}), table)
+
+            if original_entry != applied_entry:
+                mismatches.append({
+                    'key': key,
+                    'original': original_entry,
+                    'applied': applied_entry
+                })
+
+        if mismatches:
+            logger.error(f"Table {table} has {len(mismatches)} entry mismatches:")
+            for m in mismatches:
+                logger.error(f"  Entry '{m['key']}':")
+                logger.error(f"    Original: {m['original']}")
+                logger.error(f"    Applied:  {m['applied']}")
+            pytest.fail(f"Configuration mismatch in table {table}: {len(mismatches)} entries differ")
         else:
             logger.info(f"Table {table} matches between configurations")

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -65,6 +65,8 @@ ADDCLUSTER_FILE = os.path.join(TEMPLATES_DIR, "addcluster.json")
 
 # Loganalyzer ignore patterns for expected TRANSIENT errors during port reconfiguration.
 #
+# See also: https://github.com/sonic-net/sonic-buildimage/issues/24577
+#
 # These errors occur during a brief race window when GCU patches transition ports from
 # admin_status='down' to 'up'. Orchagent attempts to apply speed/PFC config before the
 # admin_status change fully propagates, causing temporary failures:

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -193,7 +193,7 @@ def get_downstream_t1_neighbor(duthost, mg_facts):
 
         # Check if neighbor is a T1 device in T2 topology
         device_info = minigraph_devices.get(neighbor_name, {})
-        # "LeafRouter" is an ambiguous term among vendors, but we use it here to 
+        # "LeafRouter" is an ambiguous term among vendors, but we use it here to
         # identify T1 devices. Do we need something more robust here?
         if device_info.get('type') == 'LeafRouter':
             # Determine the ASIC namespace for this neighbor
@@ -385,12 +385,14 @@ def check_ports_require_dpb(duthost, interfaces, namespace):
                 # Unusual ratios may indicate breakout
                 # Standard ratios: 25, 50, 100 Gbps per lane
                 if gbps_per_lane not in [10, 25, 50, 100]:
-                    reasons.append(f"unusual speed/lane ratio: {speed_gbps}G / {lane_count} lanes = {gbps_per_lane}G/lane")
+                    reasons.append(
+                        f"unusual speed/lane ratio: {speed_gbps}G / {lane_count} lanes = {gbps_per_lane}G/lane")
 
         # Heuristic 4: Low lane count with high speed (likely PAM4 breakout)
         # 2-lane 100G is often from 4x100G breakout of 400G port
         if lane_count == 2 and speed and int(speed) >= 100000:
-            reasons.append(f"{lane_count} lanes at {int(speed)//1000}G suggests breakout configuration")
+            reasons.append(
+                f"{lane_count} lanes at {int(speed)//1000}G suggests breakout configuration")
 
         # Heuristic 5: Lane count less than 4 is almost always breakout on modern platforms
         # (except for some 25G/10G single-lane ports which are typically native)
@@ -874,7 +876,7 @@ def collect_oper_status_from_patches(duthost, phase1_patch, phase2_patch, asic_i
                      (info['type'] == 'bgp_neighbor' and info['oper_status'] not in (None, 'Established')))
     unknown_count = sum(1 for info in items_to_check.values() if info['oper_status'] is None)
     logger.info(f"Pre-patch oper status summary: {up_count} up/Established/Active, "
-               f"{down_count} down/not-established/Inactive, {unknown_count} unknown")
+                f"{down_count} down/not-established/Inactive, {unknown_count} unknown")
 
     return items_to_check
 
@@ -967,10 +969,11 @@ def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout
 
     logger.info(f"Waiting up to {timeout}s for operational status to converge...")
     logger.info(f"  - {len(must_be_up)} items must be operationally up/Established/Active "
-               f"(ports: {port_must_up}, portchannels: {pc_must_up}, BGP: {bgp_must_up}, ACL: {acl_must_up})")
+                f"(ports: {port_must_up}, portchannels: {pc_must_up}, BGP: {bgp_must_up}, ACL: {acl_must_up})")
     logger.info(f"  - {len(must_be_down)} items must be operationally down (admin_status='down') "
-               f"(ports: {port_must_down}, portchannels: {pc_must_down})")
-    logger.info(f"  - {len(was_down)} items were down/Inactive before with admin_status='up' (will check but only warn)")
+                f"(ports: {port_must_down}, portchannels: {pc_must_down})")
+    logger.info(f"  - {len(was_down)} items were down/Inactive before with admin_status='up' "
+                "(will check but only warn)")
 
     # Build items_by_type for status queries - include all items we need to check
     all_items_to_check = set(must_be_up.keys()) | set(must_be_down.keys()) | set(was_down.keys())
@@ -1029,7 +1032,7 @@ def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout
             logger.error(f"Operational status did not converge within {timeout}s")
     else:
         # If nothing must be up or down, just wait a bit for stability
-        logger.info(f"No items required to be up or down - waiting 60s for stability")
+        logger.info("No items required to be up or down - waiting 60s for stability")
         time.sleep(60)
         converged = True
 
@@ -1052,7 +1055,7 @@ def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout
             })
             admin_info = f"admin_status='{info['admin_status']}', " if info.get('admin_status') else ""
             logger.error(f"FAIL: {name} ({info['type']}) was operationally '{info['oper_status']}' before patch, "
-                        f"{admin_info}but is now '{current}'")
+                         f"{admin_info}but is now '{current}'")
         else:
             logger.info(f"PASS: {name} ({info['type']}) is operationally '{expected}' as expected")
 
@@ -1069,7 +1072,7 @@ def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout
                 'admin_status': 'down'
             })
             logger.error(f"FAIL: {name} ({info['type']}) has admin_status='down' in patch, "
-                        f"but oper_status is '{current}' (expected 'down')")
+                         f"but oper_status is '{current}' (expected 'down')")
         else:
             logger.info(f"PASS: {name} ({info['type']}) is operationally 'down' as expected (admin_status='down')")
 
@@ -1088,15 +1091,15 @@ def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout
                 'admin_status': info.get('admin_status')  # ACL tables don't have admin_status
             })
             logger.warning(f"INFO: {name} ({info['type']}) was operationally '{was_state}' before patch and "
-                          f"is now '{current}'. This may be due to external factors.")
+                           f"is now '{current}'. This may be due to external factors.")
         else:
             logger.info(f"IMPROVED: {name} ({info['type']}) was '{was_state}' before but is now '{expected}'")
 
     success = len(failures) == 0
     total_checked = len(must_be_up) + len(must_be_down)
     logger.info(f"Oper status verification complete: {total_checked - len(failures)}/{total_checked} passed "
-               f"({len(must_be_up)} must-be-up, {len(must_be_down)} must-be-down), "
-               f"{len(warnings)} warnings for previously-down items")
+                f"({len(must_be_up)} must-be-up, {len(must_be_down)} must-be-down), "
+                f"{len(warnings)} warnings for previously-down items")
 
     return success, failures, warnings
 
@@ -1203,7 +1206,8 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
     # Build namespace argument for CLI commands (handles single-ASIC vs multi-ASIC)
     ns_arg = get_namespace_arg(duthost, asic_id)
     asic_index = get_asic_index_from_namespace(asic_id)
-    logger.info(f"Testing with downstream T1 neighbor: {target_t1} on {asic_id} (ns_arg='{ns_arg}', index={asic_index})")
+    logger.info(
+        f"Testing with downstream T1 neighbor: {target_t1} on {asic_id} (ns_arg='{ns_arg}', index={asic_index})")
 
     # Step 0: Check for Dynamic Port Breakout (DPB) requirements
     # -------------------------------------------------------------------------
@@ -1224,7 +1228,8 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
         for port, info in breakout_ports.items():
             reasons = info.get('reasons', [])
             reason_str = "; ".join(reasons) if reasons else "low lane count"
-            port_details.append(f"{port} ({info['lane_count']} lanes, {info.get('speed', 'unknown')} speed): {reason_str}")
+            speed_info = info.get('speed', 'unknown')
+            port_details.append(f"{port} ({info['lane_count']} lanes, {speed_info} speed): {reason_str}")
         breakout_info = "\n  - ".join(port_details)
         pytest.skip(
             f"Test requires Dynamic Port Breakout (DPB) which is not supported. "
@@ -1400,7 +1405,7 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
             config_entries_to_check['DEVICE_NEIGHBOR'].add(f"DEVICE_NEIGHBOR|{entry}")
         elif path.startswith(f'/{asic_id}/CABLE_LENGTH/AZURE/'):
             entry = path.split('/')[-1]
-            config_entries_to_check['CABLE_LENGTH'].add(f"{entry}")
+            config_entries_to_check['CABLE_LENGTH'].add(entry)
         elif path.startswith(f'/{asic_id}/PORT_QOS_MAP/'):
             entry = path.split('/')[-1]
             config_entries_to_check['PORT_QOS_MAP'].add(f"PORT_QOS_MAP|{entry}")
@@ -1481,7 +1486,7 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
 
         if oper_warnings:
             logger.warning(f"{len(oper_warnings)} item(s) were down before and remain down - "
-                          f"this may be due to external factors")
+                           "this may be due to external factors")
     else:
         logger.info("No pre-patch operational status recorded - skipping oper status verification")
 

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -1100,11 +1100,11 @@ def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout
 
 
 @pytest.fixture(autouse=True)
-def setup_env(duthosts, rand_one_dut_front_end_hostname):
-    """Setup and teardown fixture using a frontend (linecard) DUT.
+def setup_env(duthosts, enum_downstream_dut_hostname):
+    """Setup and teardown fixture using a downstream-connected linecard DUT.
 
-    Uses rand_one_dut_front_end_hostname to ensure we get a linecard in T2 topology,
-    which is where downstream T1 neighbors are connected.
+    Uses enum_downstream_dut_hostname to ensure we get a linecard that has downstream
+    T1 neighbors connected, which is required for this test.
 
     Teardown Strategy:
     ------------------
@@ -1127,7 +1127,7 @@ def setup_env(duthosts, rand_one_dut_front_end_hostname):
     Note: This test validates GCU apply_patch functionality, not rollback. Rollback
     is tested separately in other GCU test modules.
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_downstream_dut_hostname]
     create_checkpoint(duthost)
     yield
     try:
@@ -1147,7 +1147,7 @@ def setup_env(duthosts, rand_one_dut_front_end_hostname):
         delete_checkpoint(duthost)
 
 
-def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
+def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
     """Test adding a downstream T1 neighbor cluster via GCU.
 
     This test validates that a T1 neighbor can be added to a multi-ASIC
@@ -1179,15 +1179,15 @@ def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
     test design and DPB-capable platforms.
 
     The test:
-    1. Uses a frontend/linecard DUT (rand_one_dut_front_end_hostname)
+    1. Uses a downstream-connected linecard DUT (enum_downstream_dut_hostname)
     2. Dynamically discovers a T1 neighbor from minigraph facts
     3. Tests on the specific ASIC where the T1 neighbor is connected
 
     Args:
         duthosts: DUT hosts fixture
-        rand_one_dut_front_end_hostname: Fixture that provides a frontend DUT hostname
+        enum_downstream_dut_hostname: Fixture providing a linecard with downstream neighbors
     """
-    duthost = duthosts[rand_one_dut_front_end_hostname]
+    duthost = duthosts[enum_downstream_dut_hostname]
 
     # Dynamically discover a downstream T1 neighbor
     asic_id, target_t1 = get_downstream_t1_neighbor(duthost)

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -25,6 +25,7 @@ Key Design Notes:
 See test_addcluster_workflow() docstring for detailed explanation.
 """
 
+import ast
 import json
 import logging
 import os
@@ -63,9 +64,11 @@ TEMPLATES_DIR = os.path.join(THIS_DIR, "templates")
 ADDCLUSTER_FILE = os.path.join(TEMPLATES_DIR, "addcluster.json")
 
 # Configuration capture settings
-# Set to True to save config_db.json files and generated patches for debugging/analysis.
+# If the environment variable GCU_CAPTURE_CONFIGS is set to 'true', '1', 'y', or 'yes'
+# regardless of case, the test will capture pre- and post-patch configuration files for
+# debugging and analysis.
 # Captured files are saved to: tests/generic_config_updater/captures/<hostname>/<timestamp>/
-CAPTURE_CONFIGS = True
+CAPTURE_CONFIGS = os.environ.get('GCU_CAPTURE_CONFIGS', '').lower() in ('true', '1', 'y', 'yes')
 
 
 def get_capture_dir(hostname):
@@ -164,7 +167,7 @@ def capture_file(src_path, capture_dir, filename, description):
         return None
 
 
-def get_downstream_t1_neighbor(duthost):
+def get_downstream_t1_neighbor(duthost, mg_facts):
     """Get a downstream T1 neighbor from minigraph facts.
 
     In T2 topology, T1 neighbors are downstream devices connected to linecards.
@@ -173,14 +176,13 @@ def get_downstream_t1_neighbor(duthost):
 
     Args:
         duthost: DUT host object (should be a frontend/linecard node)
-
+        mg_facts: Minigraph facts dictionary
     Returns:
         tuple: (asic_namespace, neighbor_name) where:
                - asic_namespace is the ASIC namespace (e.g., 'asic0')
                - neighbor_name is the T1 device name (e.g., 'ARISTA01T1')
                Returns (None, None) if no T1 neighbor found.
     """
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     minigraph_devices = mg_facts.get('minigraph_devices', {})
     minigraph_neighbors = mg_facts.get('minigraph_neighbors', {})
 
@@ -240,17 +242,17 @@ def get_asic_index_from_namespace(namespace):
     return 0
 
 
-def get_interfaces_for_neighbor(duthost, neighbor_name):
+def get_interfaces_for_neighbor(duthost, mg_facts, neighbor_name):
     """Get the list of interfaces connected to a specific neighbor.
 
     Args:
         duthost: DUT host object
+        mg_facts: Minigraph facts dictionary
         neighbor_name: Name of the neighbor device (e.g., 'ARISTA01T1')
 
     Returns:
         list: List of interface names connected to the neighbor
     """
-    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
     minigraph_neighbors = mg_facts.get('minigraph_neighbors', {})
 
     interfaces = []
@@ -310,7 +312,7 @@ def check_ports_require_dpb(duthost, interfaces, namespace):
         config_str = result['stdout'].strip()
         try:
             # Handle Python dict string format from redis
-            config = eval(config_str)  # Safe here as we control the source
+            config = ast.literal_eval(config_str)  # Safe here as we control the source
         except (SyntaxError, ValueError):
             logger.warning(f"Could not parse config for {interface}: {config_str}")
             continue
@@ -1189,8 +1191,12 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
     """
     duthost = duthosts[enum_downstream_dut_hostname]
 
+    # Cache minigraph facts for the DUT (used to find downstream T1 neighbor)
+    # to avoid lengthy CLI calls during test execution. This is especially important for multi-ASIC DUTs.
+    mg_facts = duthost.minigraph_facts(host=duthost.hostname)['ansible_facts']
+
     # Dynamically discover a downstream T1 neighbor
-    asic_id, target_t1 = get_downstream_t1_neighbor(duthost)
+    asic_id, target_t1 = get_downstream_t1_neighbor(duthost, mg_facts)
     if not target_t1:
         pytest.skip("No downstream T1 neighbor found in minigraph")
 
@@ -1208,7 +1214,7 @@ def test_addcluster_workflow(duthosts, enum_downstream_dut_hostname):
     #
     # Skip the test if DPB would be required to restore the configuration.
     # -------------------------------------------------------------------------
-    neighbor_interfaces = get_interfaces_for_neighbor(duthost, target_t1)
+    neighbor_interfaces = get_interfaces_for_neighbor(duthost, mg_facts, target_t1)
     logger.info(f"Interfaces connected to {target_t1}: {neighbor_interfaces}")
 
     requires_dpb, breakout_ports = check_ports_require_dpb(duthost, neighbor_interfaces, asic_id)

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import time
 import pytest
 
 from datetime import datetime
@@ -437,6 +438,640 @@ def parse_mirror_acl_bindings(acl_table_output):
     return mirror_bindings
 
 
+# Timeout for waiting for operational status to converge after applying patches
+OPER_STATUS_CONVERGENCE_TIMEOUT = 300
+
+
+def parse_interface_status_output(output, interfaces_to_check=None):
+    """Parse 'show interfaces status' output and extract operational status.
+
+    Extracts the Oper (operational) status column from SONiC's interface status table.
+    The Oper column indicates whether the interface is physically up or down,
+    independent of the Admin (administrative) status configuration.
+
+    Command: show interfaces status [-n <namespace>]
+
+    Example output:
+        Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type
+        Ethernet0    0,1,2,3  100G     9100   rs     Eth1/1   routed  up      up       QSFP28
+        Ethernet4    4,5,6,7  100G     9100   rs     Eth1/2   routed  down    up       QSFP28
+
+    Args:
+        output: Raw stdout from 'show interfaces status' command.
+        interfaces_to_check: Optional set/list of interface names to filter.
+                             If None, parses all interfaces found.
+
+    Returns:
+        dict: Mapping of interface name to operational status ('up' or 'down').
+              Returns empty dict if parsing fails or no interfaces match.
+
+    Note:
+        Field positions can vary based on SONiC version and enabled features.
+        This parser looks for 'up'/'down' keywords at index >= 7 to avoid
+        matching non-status fields that might contain these strings.
+    """
+    status = {}
+    # Example format:
+    #   Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
+    #   Ethernet0    0,1,2,3  100G     9100   rs     Eth1/1   routed  up      up       QSFP28  off
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) < 9:
+            continue
+
+        interface = fields[0]
+        if interfaces_to_check is not None and interface not in interfaces_to_check:
+            continue
+
+        # Oper status is typically at index 7, but field positions can vary
+        # Look for 'up'/'down' pattern starting from field index 7
+        for i, field in enumerate(fields):
+            if field.lower() in ('up', 'down') and i >= 7:
+                status[interface] = field.lower()
+                break
+
+    return status
+
+
+def parse_portchannel_status_output(output, portchannels_to_check=None):
+    """Parse 'show interfaces portchannel' output and extract LACP operational status.
+
+    Extracts the operational status of port channels by looking for LACP state
+    indicators. Port channels use LACP (Link Aggregation Control Protocol) to
+    manage member port bundling.
+
+    Command: show interfaces portchannel [-n <namespace>]
+
+    Example output:
+        Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available
+        No.  Team Dev       Protocol    Ports
+        101  PortChannel101 LACP(A)(Up) Ethernet32(S) Ethernet36(S)
+        102  PortChannel102 LACP(A)(Dw) Ethernet40(D)
+
+    Args:
+        output: Raw stdout from 'show interfaces portchannel' command.
+        portchannels_to_check: Optional set/list of portchannel names to filter.
+                               If None, parses all portchannels found.
+
+    Returns:
+        dict: Mapping of portchannel name to operational status ('up' or 'down').
+              Returns empty dict if parsing fails or no portchannels match.
+
+    Note:
+        Status is determined by LACP state indicators:
+        - 'LACP(A)(Up)' or 'Up' in fields -> 'up'
+        - 'LACP(A)(Dw)' or 'Down' in fields -> 'down'
+    """
+    status = {}
+    for line in output.splitlines():
+        # Find portchannel names in the line
+        for word in line.split():
+            if word.startswith('PortChannel'):
+                pc_name = word
+                if portchannels_to_check is not None and pc_name not in portchannels_to_check:
+                    continue
+                # Look for LACP status indicators
+                if 'LACP(A)(Up)' in line or 'Up' in line.split():
+                    status[pc_name] = 'up'
+                elif 'Down' in line.split() or 'LACP(A)(Dw)' in line:
+                    status[pc_name] = 'down'
+                break
+    return status
+
+
+def parse_bgp_summary_json(output, neighbors_to_check=None):
+    """Parse BGP summary JSON output and extract session states for neighbors.
+
+    Extracts BGP session states from FRRouting's JSON-formatted BGP summary.
+    Session states indicate the current phase of the BGP finite state machine.
+
+    Command: vtysh -c 'show bgp summary json' (or vtysh -n <asic> for multi-ASIC)
+
+    Common BGP session states:
+        - 'Established': Session is up and exchanging routes (operational)
+        - 'Idle': Not attempting to connect
+        - 'Connect': TCP connection in progress
+        - 'Active': Actively trying to establish TCP connection
+        - 'OpenSent': TCP connected, BGP OPEN message sent
+        - 'OpenConfirm': Waiting for KEEPALIVE or NOTIFICATION
+
+    Args:
+        output: Raw stdout from vtysh BGP summary JSON command.
+        neighbors_to_check: Optional set/list of neighbor IPs to filter.
+                            If None, parses all neighbors found.
+
+    Returns:
+        dict: Mapping of neighbor IP to session state string.
+              Returns empty dict if JSON parsing fails or output is empty.
+
+    Note:
+        Parses both ipv4Unicast and ipv6Unicast address families.
+        Only 'Established' state indicates a fully operational BGP session.
+    """
+    states = {}
+    if not output or not output.strip():
+        return states
+
+    try:
+        bgp_summary = json.loads(output)
+        # BGP summary JSON has different structures for IPv4/IPv6
+        for af_key in ['ipv4Unicast', 'ipv6Unicast']:
+            if af_key in bgp_summary:
+                peers = bgp_summary[af_key].get('peers', {})
+                for neighbor_ip, peer_info in peers.items():
+                    if neighbors_to_check is not None and neighbor_ip not in neighbors_to_check:
+                        continue
+                    states[neighbor_ip] = peer_info.get('state', 'Unknown')
+    except json.JSONDecodeError:
+        pass
+
+    return states
+
+
+def parse_acl_table_output(output, acl_tables_to_check=None):
+    """Parse 'show acl table' output and extract ACL table operational status.
+
+    Extracts the Status column from SONiC's ACL table listing. ACL tables can be
+    Active (rules are being enforced) or Inactive (table exists but not applied).
+
+    Command: show acl table [-n <namespace>]
+
+    Example output:
+        Name        Type        Binding          Description    Stage    Status
+        ----------  ----------  ---------------  -------------  -------  --------
+        DATAACL     L3          Ethernet0        Data ACL       ingress  Active
+        EVERFLOW    MIRROR      Ethernet0,Eth4   Everflow       ingress  Active
+        SNMP_ACL    CTRLPLANE   None             SNMP Control   ingress  Inactive
+
+    Args:
+        output: Raw stdout from 'show acl table' command.
+        acl_tables_to_check: Optional set/list of ACL table names to filter.
+                             If None, parses all ACL tables found.
+
+    Returns:
+        dict: Mapping of ACL table name to status ('Active' or 'Inactive').
+              Returns empty dict if parsing fails or no tables match.
+
+    Note:
+        Skips header lines (containing dashes) and empty lines.
+        ACL table names are expected to be the first field in each data row.
+    """
+    status = {}
+    # Example format:
+    #   Name        Type        Binding          Description    Stage    Status
+    #   ----------  ----------  ---------------  -------------  -------  --------
+    #   DATAACL     L3          Ethernet0        Data ACL       ingress  Active
+    #   EVERFLOW    MIRROR      Ethernet0        Everflow       ingress  Active
+    for line in output.splitlines():
+        line_stripped = line.strip()
+        if not line_stripped or line_stripped.startswith('-'):
+            continue
+
+        fields = line.split()
+        if len(fields) < 2:
+            continue
+
+        acl_name = fields[0]
+        if acl_tables_to_check is not None and acl_name not in acl_tables_to_check:
+            continue
+
+        # Status is typically the last field
+        if 'Active' in fields:
+            status[acl_name] = 'Active'
+        elif 'Inactive' in fields:
+            status[acl_name] = 'Inactive'
+
+    return status
+
+
+def get_all_oper_status(duthost, asic_id, items_by_type):
+    """Query operational status for multiple item types from DUT in one call.
+
+    Consolidates status queries for ports, portchannels, BGP neighbors, and ACL
+    tables into a single function. This reduces code duplication and provides
+    a consistent interface for status collection used by both pre-patch snapshot
+    and post-patch verification.
+
+    Supported item types and their operational states:
+        - 'port': 'up' or 'down' (from show interfaces status)
+        - 'portchannel': 'up' or 'down' (from show interfaces portchannel)
+        - 'bgp_neighbor': 'Established', 'Idle', etc. (from vtysh BGP summary)
+        - 'acl_table': 'Active' or 'Inactive' (from show acl table)
+
+    Args:
+        duthost: DUT host object (ansible host connection).
+        asic_id: ASIC namespace identifier (e.g., 'asic0', 'asic1').
+                 Used for multi-ASIC DUTs to query the correct namespace.
+        items_by_type: Dict mapping item type to set of names to query.
+                       Only queries are made for non-empty sets.
+                       Example: {
+                           'port': {'Ethernet0', 'Ethernet4'},
+                           'portchannel': {'PortChannel101'},
+                           'bgp_neighbor': {'10.0.0.1', 'fc00::1'},
+                           'acl_table': {'EVERFLOW', 'DATAACL'}
+                       }
+
+    Returns:
+        dict: Flat mapping of item name to its operational status.
+              Status values vary by type (see supported types above).
+              Items not found in command output will not appear in result.
+
+    Note:
+        Errors during individual queries are logged but do not raise exceptions.
+        Partial results are returned if some queries succeed and others fail.
+    """
+    all_status = {}
+    ns_arg = get_namespace_arg(duthost, asic_id)
+    asic_index = get_asic_index_from_namespace(asic_id)
+
+    # Query interface status for ports (and portchannels may also appear here)
+    ports = items_by_type.get('port', set())
+    if ports:
+        try:
+            result = duthost.shell(f"show interfaces status {ns_arg}", module_ignore_errors=True)
+            if result['rc'] == 0:
+                all_status.update(parse_interface_status_output(result['stdout'], ports))
+        except Exception as e:
+            logger.warning(f"Error querying interface status: {e}")
+
+    # Query portchannel status
+    portchannels = items_by_type.get('portchannel', set())
+    if portchannels:
+        try:
+            result = duthost.shell(f"show interfaces portchannel {ns_arg}", module_ignore_errors=True)
+            if result['rc'] == 0:
+                all_status.update(parse_portchannel_status_output(result['stdout'], portchannels))
+        except Exception as e:
+            logger.warning(f"Error querying portchannel status: {e}")
+
+    # Query BGP neighbor session states
+    bgp_neighbors = items_by_type.get('bgp_neighbor', set())
+    if bgp_neighbors:
+        try:
+            if duthost.is_multi_asic:
+                vtysh_cmd = f"sudo vtysh -n {asic_index} -c 'show bgp summary json'"
+            else:
+                vtysh_cmd = "sudo vtysh -c 'show bgp summary json'"
+
+            result = duthost.shell(vtysh_cmd, module_ignore_errors=True)
+            if result['rc'] == 0:
+                all_status.update(parse_bgp_summary_json(result['stdout'], bgp_neighbors))
+        except Exception as e:
+            logger.warning(f"Error querying BGP status: {e}")
+
+    # Query ACL table status
+    acl_tables = items_by_type.get('acl_table', set())
+    if acl_tables:
+        try:
+            result = duthost.shell(f"show acl table {ns_arg}", module_ignore_errors=True)
+            if result['rc'] == 0:
+                all_status.update(parse_acl_table_output(result['stdout'], acl_tables))
+        except Exception as e:
+            logger.warning(f"Error querying ACL table status: {e}")
+
+    return all_status
+
+
+def collect_oper_status_from_patches(duthost, phase1_patch, phase2_patch, asic_id):
+    """Collect operational status for items referenced in patches that have admin_status.
+
+    This function queries the current operational status of ports, portchannels, and
+    BGP neighbors that are mentioned in the patch files and have admin_status configured.
+    This pre-patch snapshot is used to verify operational status convergence after patches
+    are applied.
+
+    Args:
+        duthost: DUT host object
+        phase1_patch: List of patch operations for phase 1
+        phase2_patch: List of patch operations for phase 2
+        asic_id: ASIC namespace (e.g., 'asic0')
+
+    Returns:
+        dict: Dictionary mapping item names to their pre-patch operational status
+              Format: {
+                  'Ethernet32': {'oper_status': 'up', 'admin_status': 'up', 'type': 'port'},
+                  'PortChannel101': {'oper_status': 'down', 'admin_status': 'up', 'type': 'portchannel'},
+                  '10.0.0.1': {'oper_status': 'Established', 'admin_status': 'up', 'type': 'bgp_neighbor'},
+                  'EVERFLOW': {'oper_status': 'Active', 'admin_status': None, 'type': 'acl_table'},
+              }
+    """
+    items_to_check = {}
+
+    # Extract ports, portchannels, BGP neighbors, and ACL tables from patches
+    for patch in phase1_patch + phase2_patch:
+        path = patch.get('path', '')
+        value = patch.get('value', {})
+
+        if not isinstance(value, dict):
+            continue
+
+        # Extract PORT entries (require admin_status)
+        if f'/{asic_id}/PORT/' in path:
+            admin_status = value.get('admin_status')
+            if admin_status:
+                port = path.split('/')[-1]
+                if is_front_panel_port(port):
+                    items_to_check[port] = {
+                        'admin_status': admin_status,
+                        'type': 'port',
+                        'oper_status': None
+                    }
+
+        # Extract PORTCHANNEL entries (require admin_status)
+        elif f'/{asic_id}/PORTCHANNEL/' in path:
+            admin_status = value.get('admin_status')
+            if admin_status:
+                portchannel = path.split('/')[-1]
+                items_to_check[portchannel] = {
+                    'admin_status': admin_status,
+                    'type': 'portchannel',
+                    'oper_status': None
+                }
+
+        # Extract BGP_NEIGHBOR entries (require admin_status)
+        elif f'/{asic_id}/BGP_NEIGHBOR/' in path:
+            admin_status = value.get('admin_status')
+            if admin_status:
+                neighbor_ip = path.split('/')[-1]
+                items_to_check[neighbor_ip] = {
+                    'admin_status': admin_status,
+                    'type': 'bgp_neighbor',
+                    'oper_status': None  # Will be BGP session state: Established, Idle, Active, etc.
+                }
+
+        # Extract ACL_TABLE entries (no admin_status, but has 'type' field)
+        # ACL tables have operational status (Active/Inactive)
+        elif f'/{asic_id}/ACL_TABLE/' in path or '/ACL_TABLE/' in path:
+            acl_type = value.get('type')
+            if acl_type:  # Valid ACL table entry has a 'type' field
+                acl_name = path.split('/')[-1]
+                # Handle paths like /asic0/ACL_TABLE/EVERFLOW/ports - skip sub-paths
+                if acl_name != 'ports' and not acl_name.startswith('policy'):
+                    items_to_check[acl_name] = {
+                        'admin_status': None,  # ACL tables don't have admin_status
+                        'type': 'acl_table',
+                        'acl_type': acl_type,  # Store ACL type (MIRROR, L3, etc.)
+                        'oper_status': None  # Will be Active/Inactive
+                    }
+
+    if not items_to_check:
+        logger.info("No items found in patches - skipping oper status collection")
+        return {}
+
+    logger.info(f"Collecting pre-patch operational status for {len(items_to_check)} items")
+
+    # Build items_by_type dict for get_all_oper_status
+    items_by_type = {}
+    for name, info in items_to_check.items():
+        item_type = info['type']
+        if item_type not in items_by_type:
+            items_by_type[item_type] = set()
+        items_by_type[item_type].add(name)
+
+    # Query all operational statuses using consolidated helper
+    oper_statuses = get_all_oper_status(duthost, asic_id, items_by_type)
+
+    # Update items_to_check with the retrieved operational statuses
+    for name, status in oper_statuses.items():
+        if name in items_to_check:
+            items_to_check[name]['oper_status'] = status
+            logger.debug(f"Pre-patch oper status for {name}: {status}")
+
+    # Log summary
+    up_count = sum(1 for info in items_to_check.values()
+                   if info['oper_status'] in ('up', 'Established', 'Active'))
+    down_count = sum(1 for info in items_to_check.values()
+                     if info['oper_status'] in ('down', 'Inactive') or
+                     (info['type'] == 'bgp_neighbor' and info['oper_status'] not in (None, 'Established')))
+    unknown_count = sum(1 for info in items_to_check.values() if info['oper_status'] is None)
+    logger.info(f"Pre-patch oper status summary: {up_count} up/Established/Active, "
+               f"{down_count} down/not-established/Inactive, {unknown_count} unknown")
+
+    return items_to_check
+
+
+def verify_oper_status_after_patches(duthost, pre_patch_status, asic_id, timeout=OPER_STATUS_CONVERGENCE_TIMEOUT):
+    """Verify operational status converges correctly after patches are applied.
+
+    This function waits for operational status to stabilize and then verifies:
+    1. Items that were operationally 'up'/'Established' before AND have admin_status='up' should be up after
+    2. Items that were operationally 'down'/not-Established before are checked but only logged (not failed)
+       since external factors (e.g., far-end link down, peer not ready) may prevent them from coming up
+
+    Args:
+        duthost: DUT host object
+        pre_patch_status: Dictionary from collect_oper_status_from_patches()
+        asic_id: ASIC namespace (e.g., 'asic0')
+        timeout: Seconds to wait for status convergence (default: 300)
+
+    Returns:
+        tuple: (success, failures, warnings) where:
+               - success: True if all required items are operationally up/Established
+               - failures: List of items that failed verification
+               - warnings: List of items that were down before and still down
+    """
+    if not pre_patch_status:
+        logger.info("No pre-patch status recorded - skipping oper status verification")
+        return True, [], []
+
+    failures = []
+    warnings = []
+
+    # Helper to check if an item was "up" (handles ports, BGP, and ACL tables)
+    def was_operationally_up(info):
+        if info['type'] == 'bgp_neighbor':
+            return info['oper_status'] == 'Established'
+        elif info['type'] == 'acl_table':
+            return info['oper_status'] == 'Active'
+        else:
+            return info['oper_status'] == 'up'
+
+    # Helper to check if an item was "down" (handles ports, BGP, and ACL tables)
+    def was_operationally_down(info):
+        if info['type'] == 'bgp_neighbor':
+            # BGP states other than Established are considered "down"
+            return info['oper_status'] is not None and info['oper_status'] != 'Established'
+        elif info['type'] == 'acl_table':
+            return info['oper_status'] == 'Inactive'
+        else:
+            return info['oper_status'] == 'down'
+
+    # Items that MUST come up: were 'up'/'Established'/'Active' before
+    # For ports/portchannels: also need admin_status='up'
+    # For ACL tables: no admin_status, just check if was Active
+    # For BGP: need admin_status='up' (from config)
+    must_be_up = {
+        name: info for name, info in pre_patch_status.items()
+        if was_operationally_up(info) and (
+            info['type'] == 'acl_table' or  # ACL tables don't have admin_status
+            info['admin_status'] == 'up'
+        )
+    }
+
+    # Items that MUST be down: configured with admin_status='down' in the patch
+    # These items should be operationally down after patches are applied
+    must_be_down = {
+        name: info for name, info in pre_patch_status.items()
+        if info.get('admin_status') == 'down' and info['type'] != 'acl_table'
+    }
+
+    # Items that were down before - we'll check but only warn
+    # For ACL tables: was Inactive
+    # For ports/portchannels: was down with admin_status='up'
+    # For BGP: was not Established with admin_status='up'
+    was_down = {
+        name: info for name, info in pre_patch_status.items()
+        if was_operationally_down(info) and (
+            info['type'] == 'acl_table' or
+            info['admin_status'] == 'up'
+        )
+    }
+
+    # Categorize by type for logging
+    port_must_up = sum(1 for info in must_be_up.values() if info['type'] == 'port')
+    pc_must_up = sum(1 for info in must_be_up.values() if info['type'] == 'portchannel')
+    bgp_must_up = sum(1 for info in must_be_up.values() if info['type'] == 'bgp_neighbor')
+    acl_must_up = sum(1 for info in must_be_up.values() if info['type'] == 'acl_table')
+
+    port_must_down = sum(1 for info in must_be_down.values() if info['type'] == 'port')
+    pc_must_down = sum(1 for info in must_be_down.values() if info['type'] == 'portchannel')
+
+    logger.info(f"Waiting up to {timeout}s for operational status to converge...")
+    logger.info(f"  - {len(must_be_up)} items must be operationally up/Established/Active "
+               f"(ports: {port_must_up}, portchannels: {pc_must_up}, BGP: {bgp_must_up}, ACL: {acl_must_up})")
+    logger.info(f"  - {len(must_be_down)} items must be operationally down (admin_status='down') "
+               f"(ports: {port_must_down}, portchannels: {pc_must_down})")
+    logger.info(f"  - {len(was_down)} items were down/Inactive before with admin_status='up' (will check but only warn)")
+
+    # Build items_by_type for status queries - include all items we need to check
+    all_items_to_check = set(must_be_up.keys()) | set(must_be_down.keys()) | set(was_down.keys())
+    items_by_type = {}
+    for name in all_items_to_check:
+        info = pre_patch_status.get(name, {})
+        item_type = info.get('type')
+        if item_type:
+            if item_type not in items_by_type:
+                items_by_type[item_type] = set()
+            items_by_type[item_type].add(name)
+
+    # Helper to get expected operational state based on item type
+    def get_expected_state(info):
+        if info['type'] == 'bgp_neighbor':
+            return 'Established'
+        elif info['type'] == 'acl_table':
+            return 'Active'
+        else:
+            return 'up'
+
+    def check_oper_status():
+        """Check if all must_be_up items are up and must_be_down items are down."""
+        current_status = get_all_oper_status(duthost, asic_id, items_by_type)
+
+        # Check if all must_be_up items are up/Established/Active
+        all_up = True
+        for name, info in must_be_up.items():
+            current = current_status.get(name)
+            expected = get_expected_state(info)
+            if current != expected:
+                all_up = False
+
+        # Check if all must_be_down items are down
+        all_down = True
+        for name in must_be_down.keys():
+            if current_status.get(name) != 'down':
+                all_down = False
+
+        if not all_up:
+            not_up = [name for name, info in must_be_up.items()
+                      if current_status.get(name) != get_expected_state(info)]
+            logger.debug(f"Still waiting for {len(not_up)} items to come up: {not_up[:5]}...")
+
+        if not all_down:
+            not_down = [name for name in must_be_down.keys() if current_status.get(name) != 'down']
+            logger.debug(f"Still waiting for {len(not_down)} items to go down: {not_down[:5]}...")
+
+        return all_up and all_down
+
+    # Wait for convergence
+    if must_be_up or must_be_down:
+        converged = wait_until(timeout, 10, 30, check_oper_status)  # Check every 10s, initial delay 30s
+
+        if not converged:
+            logger.error(f"Operational status did not converge within {timeout}s")
+    else:
+        # If nothing must be up or down, just wait a bit for stability
+        logger.info(f"No items required to be up or down - waiting 60s for stability")
+        time.sleep(60)
+        converged = True
+
+    # Final status check and collect results
+    logger.info("Performing final operational status verification...")
+    final_status = get_all_oper_status(duthost, asic_id, items_by_type)
+
+    # Verify must_be_up items
+    for name, info in must_be_up.items():
+        current = final_status.get(name)
+        expected = get_expected_state(info)
+
+        if current != expected:
+            failures.append({
+                'name': name,
+                'type': info['type'],
+                'pre_patch_oper': info['oper_status'],
+                'post_patch_oper': current,
+                'admin_status': info.get('admin_status')  # ACL tables don't have admin_status
+            })
+            admin_info = f"admin_status='{info['admin_status']}', " if info.get('admin_status') else ""
+            logger.error(f"FAIL: {name} ({info['type']}) was operationally '{info['oper_status']}' before patch, "
+                        f"{admin_info}but is now '{current}'")
+        else:
+            logger.info(f"PASS: {name} ({info['type']}) is operationally '{expected}' as expected")
+
+    # Verify must_be_down items (configured with admin_status='down')
+    for name, info in must_be_down.items():
+        current = final_status.get(name)
+
+        if current != 'down':
+            failures.append({
+                'name': name,
+                'type': info['type'],
+                'pre_patch_oper': info['oper_status'],
+                'post_patch_oper': current,
+                'admin_status': 'down'
+            })
+            logger.error(f"FAIL: {name} ({info['type']}) has admin_status='down' in patch, "
+                        f"but oper_status is '{current}' (expected 'down')")
+        else:
+            logger.info(f"PASS: {name} ({info['type']}) is operationally 'down' as expected (admin_status='down')")
+
+    # Check was_down items (warn only)
+    for name, info in was_down.items():
+        current = final_status.get(name)
+        expected = get_expected_state(info)
+        was_state = info['oper_status']
+
+        if current != expected:
+            warnings.append({
+                'name': name,
+                'type': info['type'],
+                'pre_patch_oper': was_state,
+                'post_patch_oper': current,
+                'admin_status': info.get('admin_status')  # ACL tables don't have admin_status
+            })
+            logger.warning(f"INFO: {name} ({info['type']}) was operationally '{was_state}' before patch and "
+                          f"is now '{current}'. This may be due to external factors.")
+        else:
+            logger.info(f"IMPROVED: {name} ({info['type']}) was '{was_state}' before but is now '{expected}'")
+
+    success = len(failures) == 0
+    total_checked = len(must_be_up) + len(must_be_down)
+    logger.info(f"Oper status verification complete: {total_checked - len(failures)}/{total_checked} passed "
+               f"({len(must_be_up)} must-be-up, {len(must_be_down)} must-be-down), "
+               f"{len(warnings)} warnings for previously-down items")
+
+    return success, failures, warnings
+
+
 @pytest.fixture(autouse=True)
 def setup_env(duthosts, rand_one_dut_front_end_hostname):
     """Setup and teardown fixture using a frontend (linecard) DUT.
@@ -636,6 +1271,21 @@ def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
     with open(phase1_file) as file:
         phase1_patch = json.load(file)
 
+    # Load Phase 2 patch now as well so we can collect pre-patch operational status
+    with open(phase2_file) as file:
+        phase2_patch = json.load(file)
+
+    # Step 7a: Collect pre-patch operational status for items with admin_status
+    # -------------------------------------------------------------------------
+    # Before applying any patches, record the operational status of ports/portchannels
+    # that have admin_status configured. This allows us to verify that items that
+    # were operationally 'up' before remain 'up' after patches are applied.
+    # -------------------------------------------------------------------------
+    logger.info("Collecting pre-patch operational status for items in patches")
+    pre_patch_oper_status = collect_oper_status_from_patches(
+        duthost, phase1_patch, phase2_patch, asic_id
+    )
+
     # Extract information to check from phase 1 patch
     ports_to_check = set()
     portchannels_to_check = set()
@@ -694,8 +1344,7 @@ def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
     # This is done separately due to GCU sorter limitation - it cannot handle
     # PORT additions and ACL_TABLE updates referencing those ports in the same batch.
     logger.info("Applying Phase 2 patch (ACL bindings)")
-    with open(phase2_file) as file:
-        phase2_patch = json.load(file)
+    # Note: phase2_patch was already loaded earlier for pre-patch oper status collection
 
     # Extract ACL-bound ports from phase 2 patch for verification
     acl_bound_ports = set()
@@ -723,6 +1372,40 @@ def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
             delete_tmpfile(duthost, tmpfile)
     else:
         logger.info("Phase 2 patch is empty (no ACL changes) - skipping")
+
+    # Step 8: Verify operational status convergence
+    # -------------------------------------------------------------------------
+    # Wait for operational status to converge and verify that items which were
+    # operationally 'up' before the patches AND have admin_status='up' in config
+    # are also operationally 'up' after the patches are applied.
+    #
+    # For items that were operationally 'down' before patches:
+    # - Only log a warning if still down (don't fail)
+    # - External factors (e.g., far-end link down) may prevent them from coming up
+    # -------------------------------------------------------------------------
+    if pre_patch_oper_status:
+        logger.info("Verifying operational status convergence after patches")
+        oper_success, oper_failures, oper_warnings = verify_oper_status_after_patches(
+            duthost, pre_patch_oper_status, asic_id, timeout=OPER_STATUS_CONVERGENCE_TIMEOUT
+        )
+
+        if not oper_success:
+            failure_details = "\n".join([
+                f"  - {f['name']} ({f['type']}): was '{f['pre_patch_oper']}' -> now '{f['post_patch_oper']}' "
+                f"(admin_status={f['admin_status']})"
+                for f in oper_failures
+            ])
+            pytest.fail(
+                f"Operational status verification failed for {len(oper_failures)} item(s):\n{failure_details}\n"
+                f"These items were operationally 'up' before patches and have admin_status='up', "
+                f"but are not operationally 'up' after patches were applied."
+            )
+
+        if oper_warnings:
+            logger.warning(f"{len(oper_warnings)} item(s) were down before and remain down - "
+                          f"this may be due to external factors")
+    else:
+        logger.info("No pre-patch operational status recorded - skipping oper status verification")
 
     # Capture post-patch CONFIG_DB state
     if CAPTURE_CONFIGS and capture_dir:

--- a/tests/generic_config_updater/test_multiasic_addcluster.py
+++ b/tests/generic_config_updater/test_multiasic_addcluster.py
@@ -1,3 +1,25 @@
+"""Test adding a T1 neighbor cluster to multi-ASIC SONiC via Generic Config Updater (GCU).
+
+This module tests the ability to add/configure a downstream T1 neighbor cluster on a
+multi-ASIC chassis using GCU JSON patches. The test simulates a scenario where a T1
+neighbor needs to be (re)configured on existing physical ports.
+
+Key Design Notes:
+-----------------
+1. PORT ENTRIES ALWAYS EXIST: After `config load_minigraph`, all physical ports defined
+   in platform.json exist in CONFIG_DB, regardless of device links. The test reconfigures
+   these existing ports rather than creating them from nothing.
+
+2. RFC 6902 "add" SEMANTICS: The generated patches use "add" operations which per RFC 6902
+   mean "add or replace". For existing PORT entries, this replaces the platform-default
+   config (e.g., 400G) with neighbor-specific config (e.g., 100G with FEC).
+
+3. VALID PRODUCTION SCENARIO: This test validates a realistic datacenter expansion use
+   case where physical ports exist but need to be configured for a new neighbor.
+
+See test_addcluster_workflow() docstring for detailed explanation.
+"""
+
 import json
 import logging
 import os
@@ -1123,8 +1145,33 @@ def setup_env(duthosts, rand_one_dut_front_end_hostname):
 def test_addcluster_workflow(duthosts, rand_one_dut_front_end_hostname):
     """Test adding a downstream T1 neighbor cluster via GCU.
 
-    This test validates that a T1 neighbor can be added to a multi-ASIC 
+    This test validates that a T1 neighbor can be added to a multi-ASIC
     SONiC device using GCU JSON patches.
+
+    Test Approach - Port Configuration vs Port Creation
+    ---------------------------------------------------
+    This test validates RECONFIGURING existing ports, not creating ports from nothing.
+    After `config load_minigraph`, physical ports ALWAYS exist in CONFIG_DB because
+    the minigraph parser generates PORT entries from platform.json/hwsku.json for ALL
+    physical ports, regardless of whether they have device links defined.
+
+    When the target neighbor is removed from the minigraph:
+    - PORT entries remain (at platform defaults: e.g., 400G, 8-lane, admin_status=up)
+    - DEVICE_NEIGHBOR entries are removed
+    - BGP_NEIGHBOR entries are removed
+    - PORT_QOS_MAP, PFC_WD entries are removed
+
+    The generated patch uses RFC 6902 "add" operations which means "add or replace":
+    - For PORT: Replaces existing 400G/8-lane config with neighbor-specific config (e.g., 100G/4-lane)
+    - For other tables: Creates new entries that didn't exist
+
+    This represents a valid production scenario: "Configuring existing but unused ports
+    for a new T1 neighbor" - typical for datacenter expansion where physical ports exist
+    but aren't yet configured for any neighbor.
+
+    Note: True "add ports from nothing" would only apply to Dynamic Port Breakout (DPB)
+    scenarios where ports are dynamically created/deleted, which requires different
+    test design and DPB-capable platforms.
 
     The test:
     1. Uses a frontend/linecard DUT (rand_one_dut_front_end_hostname)

--- a/tests/generic_config_updater/util/generate_patch.py
+++ b/tests/generic_config_updater/util/generate_patch.py
@@ -1,16 +1,406 @@
+"""Generate JSON patches for SONiC Generic Config Updater (GCU).
+
+This module generates JSON patches (RFC 6902) to transform a "no-leaf" configuration
+(without a specific T1 neighbor) into a "full" configuration (with the T1 neighbor).
+
+Key Design Considerations:
+--------------------------
+1. YANG Validation: SONiC uses YANG models to validate configuration changes.
+   Some tables have required fields (e.g., PORT requires 'lanes', ACL_TABLE requires 'type').
+   Property-level patches like {"op": "add", "path": "/asic0/PORT/Ethernet168/fec"}
+   fail YANG validation because the entry doesn't have all required fields.
+   Solution: Coalesce property-level patches into complete entry-level patches.
+
+2. Dependency Ordering: Some tables depend on others being configured first.
+   - PORT must exist before INTERFACE entries referencing that port
+   - INTERFACE base entries (Ethernet168) must exist before IP entries (Ethernet168|10.0.0.1/31)
+   - BGP_NEIGHBOR entries require their associated INTERFACE to exist
+   - ACL_TABLE binding updates must come last (they reference existing tables)
+
+3. ACL_TABLE Bindings: When adding new ports, existing ACL_TABLE entries need their
+   'ports' field updated to include the new ports. These patches must come last.
+"""
+
 import json
 import jsonpatch
+import logging
 import os
 
-ASICID = "asic0"
+logger = logging.getLogger(__name__)
+
+
+def escape_json_pointer(s):
+    """Escape special characters for JSON Pointer (RFC 6901).
+
+    In JSON Pointer, '~' must be escaped as '~0' and '/' must be escaped as '~1'.
+    """
+    return s.replace('~', '~0').replace('/', '~1')
+
+
+# Required fields for YANG validation by table type.
+# When these tables are modified, YANG validation requires these fields to be present.
+# If jsonpatch generates property-level patches for these tables, we must coalesce them
+# into entry-level patches that include these required fields.
+REQUIRED_FIELDS = {
+    'PORT': ['lanes'],      # PORT entries must have 'lanes' field
+    'ACL_TABLE': ['type'],  # ACL_TABLE entries must have 'type' field (e.g., 'MIRROR', 'L3')
+}
+
+# Patterns for non-front-panel ports that should be excluded from patches.
+# These are internal ports (backplane, recycle, etc.) that should not be modified.
+# - Ethernet-BPxx: Cisco backplane ports connecting ASICs
+# - Ethernet-Rec: Recycle ports
+# - EthernetBPxx: Alternative backplane port naming
+NON_FRONT_PANEL_PORT_PATTERNS = [
+    'Ethernet-BP',    # Cisco backplane ports (e.g., Ethernet-BP0, Ethernet-BP256)
+    'EthernetBP',     # Alternative backplane naming
+    'Ethernet-Rec',   # Recycle ports
+    'Ethernet-IB',    # Inband ports
+]
+
+
+def is_front_panel_port(port_name):
+    """Check if a port is a front panel port (not backplane/internal).
+
+    Args:
+        port_name: Port name string (e.g., 'Ethernet0', 'Ethernet-BP0')
+
+    Returns:
+        bool: True if this is a front panel port, False if it's a backplane/internal port
+    """
+    if not port_name:
+        return False
+    for pattern in NON_FRONT_PANEL_PORT_PATTERNS:
+        if port_name.startswith(pattern):
+            return False
+    return True
+
+
+def filter_non_front_panel_ports(ports):
+    """Filter a collection of ports to only include front panel ports.
+
+    Args:
+        ports: Collection of port names (set, list, etc.)
+
+    Returns:
+        set: Set containing only front panel ports
+    """
+    return {p for p in ports if is_front_panel_port(p)}
+
+# Known table names for detecting single-ASIC config structure
+KNOWN_TABLES = {
+    'ACL_TABLE', 'ACL_RULE', 'BGP_NEIGHBOR', 'BUFFER_PG', 'CABLE_LENGTH',
+    'DEVICE_NEIGHBOR', 'DEVICE_NEIGHBOR_METADATA', 'INTERFACE', 'PFC_WD',
+    'PORT', 'PORTCHANNEL', 'PORTCHANNEL_INTERFACE', 'PORTCHANNEL_MEMBER',
+    'PORT_QOS_MAP', 'LOOPBACK_INTERFACE', 'VLAN', 'VLAN_MEMBER',
+}
+
+
+def is_multi_asic_config(config):
+    """Detect if config is multi-ASIC (has asicN namespaces) or single-ASIC.
+
+    Multi-ASIC config structure:
+        {"localhost": {...}, "asic0": {"PORT": {...}}, "asic1": {...}}
+
+    Single-ASIC config structure:
+        {"localhost": {...}, "PORT": {...}, "ACL_TABLE": {...}}
+
+    Returns:
+        bool: True if multi-ASIC, False if single-ASIC
+    """
+    for key in config.keys():
+        if key.startswith('asic'):
+            return True
+    # Also check if top-level keys are table names (single-ASIC)
+    for key in config.keys():
+        if key in KNOWN_TABLES:
+            return False
+    # Default to multi-ASIC if unclear
+    return True
+
+
+def parse_patch_path(path, is_multi_asic):
+    """Parse a JSON patch path into components.
+
+    For multi-ASIC: /asic0/PORT/Ethernet0/fec -> (asic0, PORT, Ethernet0, fec)
+    For single-ASIC: /PORT/Ethernet0/fec -> (None, PORT, Ethernet0, fec)
+
+    Args:
+        path: JSON pointer path string
+        is_multi_asic: Whether the config is multi-ASIC
+
+    Returns:
+        tuple: (namespace, table_name, key, property) - any can be None if not present
+    """
+    parts = path.split('/')
+    # parts[0] is always '' (empty string before leading /)
+
+    if is_multi_asic:
+        # Multi-ASIC: /namespace/TABLE/key/property
+        namespace = parts[1] if len(parts) > 1 else None
+        table_name = parts[2] if len(parts) > 2 else None
+        key = parts[3] if len(parts) > 3 else None
+        prop = parts[4] if len(parts) > 4 else None
+    else:
+        # Single-ASIC: /TABLE/key/property (no namespace)
+        namespace = None
+        table_name = parts[1] if len(parts) > 1 else None
+        key = parts[2] if len(parts) > 2 else None
+        prop = parts[3] if len(parts) > 3 else None
+
+    return (namespace, table_name, key, prop)
+
+
+def build_patch_path(namespace, table_name, key, is_multi_asic):
+    """Build a JSON patch path from components.
+
+    Args:
+        namespace: ASIC namespace (e.g., 'asic0') or None for single-ASIC
+        table_name: Table name (e.g., 'PORT')
+        key: Entry key (e.g., 'Ethernet0')
+        is_multi_asic: Whether to include namespace in path
+
+    Returns:
+        str: JSON pointer path
+    """
+    escaped_key = escape_json_pointer(key)
+    if is_multi_asic and namespace:
+        return "/{}/{}/{}".format(namespace, table_name, escaped_key)
+    else:
+        return "/{}/{}".format(table_name, escaped_key)
+
+
+def get_table_from_config(config, namespace, table_name, is_multi_asic):
+    """Get a table from config, handling single vs multi-ASIC structure.
+
+    Args:
+        config: The configuration dictionary
+        namespace: ASIC namespace or None
+        table_name: Table name to retrieve
+        is_multi_asic: Whether config is multi-ASIC
+
+    Returns:
+        dict: The table contents or empty dict
+    """
+    if is_multi_asic and namespace:
+        return config.get(namespace, {}).get(table_name, {})
+    else:
+        return config.get(table_name, {})
+
+
+def get_entry_from_config(config, namespace, table_name, key, is_multi_asic):
+    """Get a specific entry from config table.
+
+    Args:
+        config: The configuration dictionary
+        namespace: ASIC namespace or None
+        table_name: Table name
+        key: Entry key
+        is_multi_asic: Whether config is multi-ASIC
+
+    Returns:
+        dict: The entry value or empty dict
+    """
+    table = get_table_from_config(config, namespace, table_name, is_multi_asic)
+    return table.get(key, {})
+
+
+def coalesce_property_patches(patches, full_config, no_leaf_config, tables_to_coalesce):
+    """Coalesce property-level patches into entry-level patches.
+
+    When jsonpatch generates patches like:
+        {"op": "add", "path": "/asic1/PORT/Ethernet168/fec", "value": "rs"}
+        {"op": "replace", "path": "/asic1/PORT/Ethernet168/lanes", "value": "..."}
+
+    This function coalesces them into a single entry-level patch:
+        {"op": "replace", "path": "/asic1/PORT/Ethernet168", "value": {...full entry...}}
+
+    This is ALWAYS required for tables with YANG-required fields (PORT, ACL_TABLE)
+    because the patch sorter on the DUT tries many different orderings and intermediate
+    states may be missing required fields.
+
+    Args:
+        patches: List of patch operations from jsonpatch
+        full_config: The full configuration dictionary (target state)
+        no_leaf_config: The configuration without leaf (current state)
+        tables_to_coalesce: List of table names to coalesce (e.g., ['PORT', 'INTERFACE'])
+
+    Returns:
+        tuple: (coalesced_patches, remaining_patches, is_multi_asic)
+    """
+    # Detect if this is multi-ASIC or single-ASIC config
+    multi_asic = is_multi_asic_config(full_config)
+
+    # Track entries that need coalescing: {(namespace, table, key): True}
+    entries_to_coalesce = {}
+    # Track property-level patches to remove
+    patches_to_remove = set()
+
+    # Determine minimum path components for property-level patch
+    # Multi-ASIC: /asic0/TABLE/key/property = 5 components
+    # Single-ASIC: /TABLE/key/property = 4 components
+    min_property_components = 5 if multi_asic else 4
+
+    for i, patch in enumerate(patches):
+        path_components = patch['path'].split('/')
+
+        if len(path_components) < min_property_components:
+            continue
+
+        namespace, table_name, key, prop = parse_patch_path(patch['path'], multi_asic)
+
+        # Skip if no property (this is entry-level, not property-level)
+        if prop is None:
+            continue
+
+        if table_name not in tables_to_coalesce:
+            continue
+
+        # ALWAYS coalesce property-level patches for tables with required YANG fields.
+        if table_name in REQUIRED_FIELDS:
+            entries_to_coalesce[(namespace, table_name, key)] = True
+            patches_to_remove.add(i)
+        else:
+            # For other tables (INTERFACE, BGP_NEIGHBOR), only coalesce if entry is new
+            no_leaf_table = get_table_from_config(no_leaf_config, namespace, table_name, multi_asic)
+            if key not in no_leaf_table:
+                entries_to_coalesce[(namespace, table_name, key)] = True
+                patches_to_remove.add(i)
+
+    # Build coalesced patches
+    coalesced_patches = []
+
+    for (namespace, table_name, key) in entries_to_coalesce:
+        full_value = get_entry_from_config(full_config, namespace, table_name, key, multi_asic)
+        if full_value:
+            # Use "replace" if entry exists in no_leaf_config, "add" if it's new
+            no_leaf_table = get_table_from_config(no_leaf_config, namespace, table_name, multi_asic)
+            op = "replace" if key in no_leaf_table else "add"
+
+            coalesced_patches.append({
+                "op": op,
+                "path": build_patch_path(namespace, table_name, key, multi_asic),
+                "value": full_value
+            })
+
+    # Remove the property-level patches that were coalesced
+    remaining_patches = [p for i, p in enumerate(patches) if i not in patches_to_remove]
+
+    return coalesced_patches, remaining_patches, multi_asic
+
+
+def find_interface_entries_for_bgp(full_config, namespace, local_addr, is_multi_asic):
+    """Find INTERFACE entries that match a BGP neighbor's local_addr.
+
+    Args:
+        full_config: The full configuration dictionary
+        namespace: The ASIC namespace (e.g., 'asic0') or None for single-ASIC
+        local_addr: The local IP address from BGP_NEIGHBOR entry
+        is_multi_asic: Whether config uses multi-ASIC structure
+
+    Returns:
+        list: List of (interface_key, value) tuples for matching INTERFACE entries
+    """
+    interface_entries = []
+    interface_table = get_table_from_config(full_config, namespace, "INTERFACE", is_multi_asic)
+
+    base_interface = None
+    for interface_key, value in interface_table.items():
+        # Check if this interface key contains the local_addr
+        # Keys are like "Ethernet96" or "Ethernet96|10.0.0.160/31"
+        if '|' in interface_key and local_addr in interface_key:
+            interface_entries.append((interface_key, value))
+            # Extract base interface name
+            base_interface = interface_key.split('|')[0]
+
+    # Also add the base interface entry if found
+    if base_interface and base_interface in interface_table:
+        # Insert at beginning so base interface comes before IP entries
+        interface_entries.insert(0, (base_interface, interface_table[base_interface]))
+
+    return interface_entries
+
+
+def find_acl_table_bindings_for_ports(full_config, no_leaf_config, namespace, ports, is_multi_asic):
+    """Find ACL_TABLE entries that need port bindings updated.
+
+    When ports are added, we need to update ACL_TABLE entries to include them
+    in the 'ports' field if they were bound in the original config.
+
+    Args:
+        full_config: The full configuration dictionary (with all ports)
+        no_leaf_config: The config without the leaf (missing ports)
+        namespace: The ASIC namespace (e.g., 'asic0') or None for single-ASIC
+        ports: Set of port names being added
+        is_multi_asic: Whether config uses multi-ASIC structure
+
+    Returns:
+        list: List of patch operations to update ACL_TABLE bindings
+    """
+    patches = []
+    full_acl_table = get_table_from_config(full_config, namespace, "ACL_TABLE", is_multi_asic)
+    no_leaf_acl_table = get_table_from_config(no_leaf_config, namespace, "ACL_TABLE", is_multi_asic)
+
+    for acl_name, full_acl_entry in full_acl_table.items():
+        full_ports = full_acl_entry.get("ports", [])
+        if not full_ports:
+            continue
+
+        # Get current ports in no_leaf config (may be empty or missing some ports)
+        no_leaf_acl_entry = no_leaf_acl_table.get(acl_name, {})
+        no_leaf_ports = no_leaf_acl_entry.get("ports", [])
+
+        # Find ports that need to be added (in full but not in no_leaf)
+        ports_to_add = []
+        for port in full_ports:
+            if port in ports and port not in no_leaf_ports:
+                ports_to_add.append(port)
+
+        # Generate patches to add each missing port to the ACL_TABLE binding
+        for port in ports_to_add:
+            escaped_acl_name = escape_json_pointer(acl_name)
+            new_ports_list = list(no_leaf_ports) + [port]
+
+            # Build path based on single-ASIC vs multi-ASIC
+            if is_multi_asic:
+                ports_path = "/{}/ACL_TABLE/{}/ports".format(namespace, escaped_acl_name)
+            else:
+                ports_path = "/ACL_TABLE/{}/ports".format(escaped_acl_name)
+
+            # Check if we already have a patch for this ACL_TABLE's ports
+            existing_patch = None
+            for p in patches:
+                if p['path'] == ports_path:
+                    existing_patch = p
+                    break
+
+            if existing_patch:
+                # Add to existing patch's value
+                if port not in existing_patch['value']:
+                    existing_patch['value'].append(port)
+            else:
+                patches.append({
+                    "op": "replace",
+                    "path": ports_path,
+                    "value": new_ports_list
+                })
+
+    return patches
 
 
 def generate_config_patch(full_config_path, no_leaf_config_path):
     """
     Generate a JSON patch file by comparing two configuration files.
+
+    This function:
+    1. Coalesces property-level patches into entry-level patches for YANG validation
+    2. Orders patches by dependency (PORT -> INTERFACE -> BGP_NEIGHBOR -> others)
+    3. Generates ACL_TABLE binding updates for new ports
+
     Args:
         full_config_path (str): Path to the full configuration JSON file
         no_leaf_config_path (str): Path to the configuration JSON file without leaf
+
     Returns:
         str: Path to the generated patch file
     """
@@ -25,37 +415,276 @@ def generate_config_patch(full_config_path, no_leaf_config_path):
     # Generate patches
     patches = jsonpatch.make_patch(no_leaf_config, full_config)
 
-    # Add Cluster supported Tables
+    # Add Cluster supported Tables (INTERFACE added for BGP_NEIGHBOR dependencies)
+    # NOTE: BUFFER_PG and BUFFER_QUEUE are intentionally excluded because:
+    # - On dynamic buffer model platforms (like Cisco-8000), buffer profiles are auto-generated
+    # - Profiles like "pg_lossless_<speed>_<cable>_profile" are created by buffer manager
+    # - YANG validation fails if we reference profiles that don't exist yet
+    # - The buffer manager will auto-configure these once PORT and CABLE_LENGTH are set
     filtered_tables = [
-        "ACL_TABLE", "BGP_NEIGHBOR", "BUFFER_PG", "CABLE_LENGTH", "DEVICE_NEIGHBOR",
-        "DEVICE_NEIGHBOR_METADATA", "PFC_WD", "PORT", "PORTCHANNEL",
+        "ACL_TABLE", "BGP_NEIGHBOR", "CABLE_LENGTH", "DEVICE_NEIGHBOR",
+        "DEVICE_NEIGHBOR_METADATA", "INTERFACE", "PFC_WD", "PORT", "PORTCHANNEL",
         "PORTCHANNEL_INTERFACE", "PORTCHANNEL_MEMBER", "PORT_QOS_MAP"
     ]
     admin_status_tables = ["BGP_NEIGHBOR", "PORT", "PORTCHANNEL"]
 
+    # Coalesce property-level patches into entry-level patches for tables that need it.
+    # Why each table is coalesced:
+    # - PORT: Requires 'lanes' field for YANG validation ("Missing required element 'lanes'")
+    # - INTERFACE: Needs proper ordering (base entry before IP entry)
+    # - ACL_TABLE: Requires 'type' field for YANG validation ("Missing required element 'type'")
+    # - BGP_NEIGHBOR: Needs complete entry to avoid "All Keys are not parsed in BGP_NEIGHBOR" error
+    tables_to_coalesce = ["PORT", "INTERFACE", "ACL_TABLE", "BGP_NEIGHBOR"]
+    coalesced_port_patches, remaining_patches, is_multi_asic = coalesce_property_patches(
+        patches.patch, full_config, no_leaf_config, tables_to_coalesce
+    )
+    logger.info("Coalesced %d property-level patches into %d entry-level patches (multi_asic=%s)",
+                len(patches.patch) - len(remaining_patches), len(coalesced_port_patches), is_multi_asic)
+
+    # First pass: collect BGP_NEIGHBOR local_addr values and PORT entries being added
+    bgp_local_addrs = {}  # {namespace: set of local_addr values}
+    ports_being_added = {}  # {namespace: set of port names}
+
+    # Check coalesced patches for ports being added (exclude backplane ports)
+    for patch in coalesced_port_patches:
+        namespace, table_name, key, _ = parse_patch_path(patch['path'], is_multi_asic)
+        if table_name == 'PORT' and key and key.startswith('Ethernet'):
+            # Skip backplane and other non-front-panel ports
+            if not is_front_panel_port(key):
+                continue
+            if namespace not in ports_being_added:
+                ports_being_added[namespace] = set()
+            ports_being_added[namespace].add(key)
+
+    for patch in remaining_patches:
+        namespace, table_name, key, _ = parse_patch_path(patch['path'], is_multi_asic)
+
+        if table_name is None or key is None:
+            continue
+        if namespace == "localhost":
+            continue
+
+        if patch['op'] == 'add' and table_name == 'BGP_NEIGHBOR':
+            value = patch.get('value', {})
+            if isinstance(value, dict):
+                local_addr = value.get('local_addr')
+                if local_addr:
+                    if namespace not in bgp_local_addrs:
+                        bgp_local_addrs[namespace] = set()
+                    bgp_local_addrs[namespace].add(local_addr)
+
+        # Track ports being added for ACL_TABLE binding updates (exclude backplane ports)
+        if patch['op'] == 'add' and table_name == 'PORT' and key.startswith('Ethernet'):
+            # Skip backplane and other non-front-panel ports
+            if not is_front_panel_port(key):
+                continue
+            if namespace not in ports_being_added:
+                ports_being_added[namespace] = set()
+            ports_being_added[namespace].add(key)
+
+    # Build set of required INTERFACE entries based on BGP_NEIGHBOR local_addr values
+    required_interface_patches = []
+    added_interface_keys = set()
+
+    for namespace, local_addrs in bgp_local_addrs.items():
+        for local_addr in local_addrs:
+            interface_entries = find_interface_entries_for_bgp(full_config, namespace, local_addr, is_multi_asic)
+            for interface_key, value in interface_entries:
+                no_leaf_interface = get_table_from_config(no_leaf_config, namespace, "INTERFACE", is_multi_asic)
+                patch_key = (namespace, interface_key)
+                if interface_key not in no_leaf_interface and patch_key not in added_interface_keys:
+                    escaped_key = escape_json_pointer(interface_key)
+                    required_interface_patches.append({
+                        "op": "add",
+                        "path": build_patch_path(namespace, "INTERFACE", escaped_key, is_multi_asic),
+                        "value": value
+                    })
+                    added_interface_keys.add(patch_key)
+
+    # Track coalesced entry paths to avoid duplicate admin_status patches
+    coalesced_entry_paths = set()
+    for patch in coalesced_port_patches:
+        namespace, table_name, key, _ = parse_patch_path(patch['path'], is_multi_asic)
+        if table_name and key:
+            entry_path = build_patch_path(namespace, table_name, key, is_multi_asic)
+            coalesced_entry_paths.add(entry_path)
+
     filtered_patch_list = []
-    for patch in patches.patch:
-        # Get table name from path: /asic0/TABLE_NAME/...
-        table_name = patch['path'].split('/')[2] if len(patch['path'].split('/')) > 2 else None
+    for patch in remaining_patches:
+        namespace, table_name, key, prop = parse_patch_path(patch['path'], is_multi_asic)
+
+        if namespace == "localhost":  # internal to SONiC, do not update
+            continue
 
         # Skip if table not supported
         if table_name not in filtered_tables:
             continue
 
-        # Add admin_status for specific tables
-        if patch['op'] == 'add' and table_name in admin_status_tables:
-            if 'admin_status' not in patch.get('value', {}):
-                patch['value']['admin_status'] = 'up'
+        # Skip patches for backplane and other non-front-panel ports
+        if key and not is_front_panel_port(key):
+            logger.debug("Skipping non-front-panel port patch: %s", patch['path'])
+            continue
+        # Also skip patches that reference non-front-panel ports (e.g., INTERFACE entries)
+        if key and '|' in key:
+            base_port = key.split('|')[0]
+            if not is_front_panel_port(base_port):
+                logger.debug("Skipping non-front-panel port interface patch: %s", patch['path'])
+                continue
+
+        # Skip ACL_TABLE/ports patches - we generate our own complete replacement patches
+        if table_name == 'ACL_TABLE' and prop == 'ports':
+            continue
+        # Also skip array index patches for ports (e.g., /ACL_TABLE/EVERFLOW/ports/0)
+        path_components = patch['path'].split('/')
+        if table_name == 'ACL_TABLE':
+            if 'ports' in path_components:
+                continue
+
+        # For entry-level "add" patches, inject admin_status directly into the value
+        if patch['op'] == 'add' and table_name in admin_status_tables and key:
+            if prop is None and isinstance(patch.get('value'), dict):
+                if 'admin_status' not in patch['value']:
+                    new_value = dict(patch['value'])
+                    new_value['admin_status'] = 'up'
+                    patch = dict(patch)
+                    patch['value'] = new_value
 
         filtered_patch_list.append(patch)
-    filtered_patch = jsonpatch.JsonPatch(filtered_patch_list)
 
-    # Generate output path in same directory as full config
+    # Build the final patch list with correct dependency order:
+    # 1. PORT entries (coalesced) - must come first
+    # 2. ACL_TABLE entries (coalesced) - need complete entries with "type" field
+    # 3. INTERFACE base entries (e.g., Ethernet168) - before IP entries
+    # 4. INTERFACE IP entries (e.g., Ethernet168|10.0.0.170/31)
+    # 5. BGP_NEIGHBOR entries (coalesced) - need complete entries for YANG validation
+    # 6. Other table entries
+    # 7. ACL_TABLE binding updates - last
+
+    def is_front_panel_patch(patch):
+        """Check if a patch is for a front panel port (not backplane)."""
+        _, table_name, key, _ = parse_patch_path(patch['path'], is_multi_asic)
+        if not key:
+            return True  # Not a port-related patch
+        # Check the key directly for PORT table
+        if table_name == 'PORT':
+            return is_front_panel_port(key)
+        # Check for INTERFACE entries like "Ethernet-BP0|10.0.0.1/31"
+        if '|' in key:
+            base_port = key.split('|')[0]
+            return is_front_panel_port(base_port)
+        # Check if key itself is a port name
+        if key.startswith('Ethernet'):
+            return is_front_panel_port(key)
+        return True
+
+    # Filter out backplane ports from coalesced patches
+    coalesced_port_only = [p for p in coalesced_port_patches if '/PORT/' in p['path'] and is_front_panel_patch(p)]
+    coalesced_acl_table = [p for p in coalesced_port_patches if '/ACL_TABLE/' in p['path']]
+    coalesced_interface = [p for p in coalesced_port_patches if '/INTERFACE/' in p['path'] and is_front_panel_patch(p)]
+    coalesced_bgp_neighbor = [p for p in coalesced_port_patches if '/BGP_NEIGHBOR/' in p['path']]
+
+    # Log filtered backplane ports
+    backplane_port_count = sum(1 for p in coalesced_port_patches if '/PORT/' in p['path'] and not is_front_panel_patch(p))
+    if backplane_port_count > 0:
+        logger.info("Filtered out %d backplane/non-front-panel PORT patches", backplane_port_count)
+
+    # Sort INTERFACE patches: base entries before IP entries
+    required_interface_patches.sort(key=lambda p: (p['path'].count('|'), p['path']))
+    coalesced_interface.sort(key=lambda p: (p['path'].count('|'), p['path']))
+
+    # Combine all INTERFACE patches and dedupe
+    all_interface_patches = []
+    seen_interface_paths = set()
+    for p in required_interface_patches + coalesced_interface:
+        if p['path'] not in seen_interface_paths:
+            all_interface_patches.append(p)
+            seen_interface_paths.add(p['path'])
+
+    # Build final ordered list respecting all dependencies
+    # NOTE: We split into two phases due to a GCU sorter limitation/bug.
+    # The GCU patch sorter fails with "'PortX' is not in list" when:
+    # - A PORT is being added/modified in the same batch as
+    # - An ACL_TABLE that references that PORT in its 'ports' field
+    # The sorter tries to analyze dependencies but doesn't understand that
+    # the PORT will exist by the time the ACL_TABLE patch is applied.
+    #
+    # Phase 1: Core configuration (PORT, INTERFACE, BGP_NEIGHBOR, etc.)
+    # Phase 2: ACL_TABLE entries (applied after ports exist)
+
+    # Track coalesced ACL_TABLE entries
+    coalesced_acl_tables = set()
+    for patch in coalesced_acl_table:
+        namespace, table_name, key, _ = parse_patch_path(patch['path'], is_multi_asic)
+        if table_name == 'ACL_TABLE' and key:
+            coalesced_acl_tables.add((namespace, key))
+
+    # Generate ACL_TABLE binding patches for ports being added
+    acl_binding_patches = []
+    for namespace, ports in ports_being_added.items():
+        acl_patches = find_acl_table_bindings_for_ports(
+            full_config, no_leaf_config, namespace, ports, is_multi_asic
+        )
+        for patch in acl_patches:
+            patch_namespace, patch_table, patch_acl_name, _ = parse_patch_path(patch['path'], is_multi_asic)
+            if (patch_namespace, patch_acl_name) not in coalesced_acl_tables:
+                acl_binding_patches.append(patch)
+
+    # Phase 1: All non-ACL patches
+    phase1_patch_list = (coalesced_port_only + all_interface_patches +
+                         coalesced_bgp_neighbor + filtered_patch_list)
+
+    # Phase 2: All ACL_TABLE patches (coalesced + binding updates)
+    phase2_patch_list = coalesced_acl_table + acl_binding_patches
+
+    # Combined list for metadata (but we write separate files)
+    final_patch_list = phase1_patch_list + phase2_patch_list
+
+    phase1_patch = jsonpatch.JsonPatch(phase1_patch_list)
+    phase2_patch = jsonpatch.JsonPatch(phase2_patch_list)
+
+    # Log the complete patch for diagnostic purposes
+    logger.info("Generated patches with %d total operations (Phase 1: %d, Phase 2: %d):",
+                len(final_patch_list), len(phase1_patch_list), len(phase2_patch_list))
+    logger.info("  Phase 1 (core config):")
+    logger.info("    - PORT entries: %d", len(coalesced_port_only))
+    logger.info("    - INTERFACE entries: %d", len(all_interface_patches))
+    logger.info("    - BGP_NEIGHBOR entries: %d", len(coalesced_bgp_neighbor))
+    logger.info("    - Other entries: %d", len(filtered_patch_list))
+    logger.info("  Phase 2 (ACL bindings):")
+    logger.info("    - ACL_TABLE entries: %d", len(coalesced_acl_table))
+    logger.info("    - ACL binding updates: %d", len(acl_binding_patches))
+
+    logger.debug("Phase 1 patch content:\n%s", json.dumps(phase1_patch.patch, indent=2))
+    logger.debug("Phase 2 patch content:\n%s", json.dumps(phase2_patch.patch, indent=2))
+
+    # Generate output paths in same directory as full config
     output_dir = os.path.dirname(full_config_path)
-    output_file = os.path.join(output_dir, 'generated_patch.json')
+    phase1_file = os.path.join(output_dir, 'generated_patch_phase1.json')
+    phase2_file = os.path.join(output_dir, 'generated_patch_phase2.json')
 
-    # Write patch to file
-    with open(output_file, 'w') as file:
-        json.dump(filtered_patch.patch, file, indent=4)
+    # Write phase 1 patch (core config)
+    with open(phase1_file, 'w') as file:
+        json.dump(phase1_patch.patch, file, indent=4)
 
-    return output_file
+    # Write phase 2 patch (ACL bindings)
+    with open(phase2_file, 'w') as file:
+        json.dump(phase2_patch.patch, file, indent=4)
+
+    # Also write metadata file with information about patch generation
+    metadata = {
+        'total_patches': len(final_patch_list),
+        'phase1_patches': len(phase1_patch_list),
+        'phase2_patches': len(phase2_patch_list),
+        'port_patches': len(coalesced_port_only),
+        'acl_table_patches': len(coalesced_acl_table),
+        'interface_patches': len(all_interface_patches),
+        'bgp_neighbor_patches': len(coalesced_bgp_neighbor),
+        'acl_binding_patches': len(acl_binding_patches),
+        'is_multi_asic': is_multi_asic
+    }
+    metadata_file = os.path.join(output_dir, 'generated_patch_metadata.json')
+    with open(metadata_file, 'w') as file:
+        json.dump(metadata, file, indent=4)
+
+    # Return tuple of (phase1_file, phase2_file)
+    return phase1_file, phase2_file

--- a/tests/generic_config_updater/util/generate_patch.py
+++ b/tests/generic_config_updater/util/generate_patch.py
@@ -601,7 +601,15 @@ def generate_config_patch(full_config_path, no_leaf_config_path):
 
     # Filter out backplane ports from coalesced patches
     coalesced_port_only = [p for p in coalesced_port_patches if '/PORT/' in p['path'] and is_front_panel_patch(p)]
-    coalesced_acl_table = [p for p in coalesced_port_patches if '/ACL_TABLE/' in p['path']]
+    # Filter ACL_TABLE patches, excluding localhost namespace (multi-ASIC cross-namespace issue)
+    # On multi-ASIC chassis, localhost ACL_TABLE entries reference ports only in ASIC namespaces
+    coalesced_acl_table = [p for p in coalesced_port_patches
+                          if '/ACL_TABLE/' in p['path'] and not p['path'].startswith('/localhost/')]
+    localhost_acl_count = sum(1 for p in coalesced_port_patches
+                              if '/ACL_TABLE/' in p['path'] and p['path'].startswith('/localhost/'))
+    if localhost_acl_count > 0:
+        logger.info("Filtered out %d localhost ACL_TABLE patches (multi-ASIC cross-namespace issue)",
+                    localhost_acl_count)
     coalesced_interface = [p for p in coalesced_port_patches if '/INTERFACE/' in p['path'] and is_front_panel_patch(p)]
     coalesced_bgp_neighbor = [p for p in coalesced_port_patches if '/BGP_NEIGHBOR/' in p['path']]
 
@@ -643,6 +651,9 @@ def generate_config_patch(full_config_path, no_leaf_config_path):
     # Generate ACL_TABLE binding patches for ports being added
     acl_binding_patches = []
     for namespace, ports in ports_being_added.items():
+        # Skip localhost namespace - ACL bindings should be per-ASIC namespace
+        if namespace == 'localhost':
+            continue
         acl_patches = find_acl_table_bindings_for_ports(
             full_config, no_leaf_config, namespace, ports, is_multi_asic
         )

--- a/tests/generic_config_updater/util/generate_patch.py
+++ b/tests/generic_config_updater/util/generate_patch.py
@@ -87,6 +87,7 @@ def filter_non_front_panel_ports(ports):
     """
     return {p for p in ports if is_front_panel_port(p)}
 
+
 # Known table names for detecting single-ASIC config structure
 KNOWN_TABLES = {
     'ACL_TABLE', 'ACL_RULE', 'BGP_NEIGHBOR', 'BUFFER_PG', 'CABLE_LENGTH',
@@ -604,7 +605,7 @@ def generate_config_patch(full_config_path, no_leaf_config_path):
     # Filter ACL_TABLE patches, excluding localhost namespace (multi-ASIC cross-namespace issue)
     # On multi-ASIC chassis, localhost ACL_TABLE entries reference ports only in ASIC namespaces
     coalesced_acl_table = [p for p in coalesced_port_patches
-                          if '/ACL_TABLE/' in p['path'] and not p['path'].startswith('/localhost/')]
+                           if '/ACL_TABLE/' in p['path'] and not p['path'].startswith('/localhost/')]
     localhost_acl_count = sum(1 for p in coalesced_port_patches
                               if '/ACL_TABLE/' in p['path'] and p['path'].startswith('/localhost/'))
     if localhost_acl_count > 0:
@@ -614,7 +615,8 @@ def generate_config_patch(full_config_path, no_leaf_config_path):
     coalesced_bgp_neighbor = [p for p in coalesced_port_patches if '/BGP_NEIGHBOR/' in p['path']]
 
     # Log filtered backplane ports
-    backplane_port_count = sum(1 for p in coalesced_port_patches if '/PORT/' in p['path'] and not is_front_panel_patch(p))
+    backplane_port_count = sum(
+        1 for p in coalesced_port_patches if '/PORT/' in p['path'] and not is_front_panel_patch(p))
     if backplane_port_count > 0:
         logger.info("Filtered out %d backplane/non-front-panel PORT patches", backplane_port_count)
 

--- a/tests/generic_config_updater/util/generate_patch.py
+++ b/tests/generic_config_updater/util/generate_patch.py
@@ -273,9 +273,27 @@ def coalesce_property_patches(patches, full_config, no_leaf_config, tables_to_co
     for (namespace, table_name, key) in entries_to_coalesce:
         full_value = get_entry_from_config(full_config, namespace, table_name, key, multi_asic)
         if full_value:
-            # Use "replace" if entry exists in no_leaf_config, "add" if it's new
-            no_leaf_table = get_table_from_config(no_leaf_config, namespace, table_name, multi_asic)
-            op = "replace" if key in no_leaf_table else "add"
+            # Always use "add" operation for maximum compatibility.
+            #
+            # NOTE: We intentionally use "add" instead of "replace" even for existing entries.
+            # Per RFC 6902, "add" will update if exists or create if not, while "replace" fails
+            # if the target doesn't exist. Using "add" universally loses the following capabilities:
+            #
+            # 1. VALIDATION: "replace" would fail fast if an entry we expected to exist is missing,
+            #    catching bugs where assumptions about the base config are incorrect.
+            #
+            # 2. DEBUGGING: The patch file becomes less self-documenting - we can no longer
+            #    distinguish which entries were updates to existing config vs. new additions
+            #    by inspecting the operation type.
+            #
+            # 3. ERROR LOCALIZATION: When "replace" fails, it points to the exact entry that
+            #    violated assumptions. With "add", silent overwrites may mask configuration
+            #    drift issues that only manifest later as test failures.
+            #
+            # This trade-off was made to avoid GCU patch application failures when the base
+            # configuration state differs slightly from expectations (e.g., after partial
+            # rollbacks or manual interventions).
+            op = "add"
 
             coalesced_patches.append({
                 "op": op,
@@ -379,8 +397,12 @@ def find_acl_table_bindings_for_ports(full_config, no_leaf_config, namespace, po
                 if port not in existing_patch['value']:
                     existing_patch['value'].append(port)
             else:
+                # Use "add" instead of "replace" for ACL_TABLE port bindings.
+                # This field should always exist in a valid ACL_TABLE entry, but using "add"
+                # avoids failures if the 'ports' field is unexpectedly missing. See the
+                # detailed comment in coalesce_property_patches() for trade-offs of this approach.
                 patches.append({
-                    "op": "replace",
+                    "op": "add",
                     "path": ports_path,
                     "value": new_ports_list
                 })

--- a/tests/generic_config_updater/util/process_minigraph.py
+++ b/tests/generic_config_updater/util/process_minigraph.py
@@ -11,8 +11,29 @@ NS_A = "{" + NS_A_VAL + "}"
 
 
 class MinigraphRefactor:
+    """Refactors minigraph.xml to remove a T1 neighbor and its associated configuration.
+
+    This class removes a specified leaf router (T1 neighbor) from the minigraph,
+    including:
+    - BGP sessions
+    - BGP router declarations
+    - Device definitions
+    - Device interface links
+    - PortChannel interfaces that use the affected ports
+    - IP interfaces that reference those PortChannels
+    - Link metadata
+
+    After applying these changes and reloading the minigraph, the affected ports
+    will have admin_status=down (read from port_config.ini defaults) because they
+    are no longer referenced in the minigraph configuration.
+    """
+
     def __init__(self, leaf_router):
         self.leafrouter_name = leaf_router
+        # Ports connected to the target neighbor, collected during link removal
+        self.affected_ports = set()
+        # PortChannels that use the affected ports, collected during PortChannel removal
+        self.affected_portchannels = set()
 
     def remove_bgp_sessions(self, root):
         peering_sessions = root.find(f".//{NS}PeeringSessions")
@@ -59,6 +80,14 @@ class MinigraphRefactor:
         return removed_device
 
     def remove_device_interface_links(self, root):
+        """Remove DeviceLinkBase entries that connect to the target neighbor.
+
+        Also collects the local port names from these links for subsequent
+        PortChannel and IPInterface removal.
+
+        Returns:
+            int: Number of links removed
+        """
         device_links = root.find(f".//{NS}PngDec/{NS}DeviceInterfaceLinks")
         removed_links = 0
         if device_links:
@@ -66,10 +95,93 @@ class MinigraphRefactor:
                 start_device = link.find(f"{NS}StartDevice").text
                 end_device = link.find(f"{NS}EndDevice").text
                 if self.leafrouter_name in [start_device, end_device]:
+                    # Collect the local port (the one NOT on the target neighbor)
+                    if start_device == self.leafrouter_name:
+                        local_port = link.find(f"{NS}EndPort").text
+                    else:
+                        local_port = link.find(f"{NS}StartPort").text
+                    if local_port:
+                        self.affected_ports.add(local_port)
                     device_links.remove(link)
-                    # print(f"Removed device link: {ET.tostring(link, encoding='unicode')}")
                     removed_links += 1
         return removed_links
+
+    def remove_portchannel_interfaces(self, root):
+        """Remove PortChannel entries that use the affected ports.
+
+        Finds PortChannel elements under DeviceDataPlaneInfo/PortChannelInterfaces
+        where AttachTo contains any of the affected ports. The AttachTo field can
+        contain multiple ports separated by semicolons (e.g., "Ethernet48;Ethernet56").
+
+        Returns:
+            int: Number of PortChannel entries removed
+        """
+        if not self.affected_ports:
+            return 0
+
+        removed_portchannels = 0
+
+        # Find all DeviceDataPlaneInfo elements (there may be multiple for multi-ASIC)
+        for dpg_info in root.findall(f".//{NS}DeviceDataPlaneInfo"):
+            portchannel_interfaces = dpg_info.find(f"{NS}PortChannelInterfaces")
+            if portchannel_interfaces is None:
+                continue
+
+            for portchannel in list(portchannel_interfaces.findall(f"{NS}PortChannel")):
+                name_elem = portchannel.find(f"{NS}Name")
+                attach_to_elem = portchannel.find(f"{NS}AttachTo")
+
+                if attach_to_elem is None or attach_to_elem.text is None:
+                    continue
+
+                # AttachTo can contain multiple ports: "Ethernet48;Ethernet56"
+                attached_ports = set(attach_to_elem.text.split(';'))
+
+                # Check if any affected port is in this PortChannel
+                if attached_ports & self.affected_ports:
+                    pc_name = name_elem.text if name_elem is not None else "unknown"
+                    self.affected_portchannels.add(pc_name)
+                    portchannel_interfaces.remove(portchannel)
+                    print(f"Removed PortChannel: {pc_name} (AttachTo: {attach_to_elem.text})")
+                    removed_portchannels += 1
+
+        return removed_portchannels
+
+    def remove_ip_interfaces(self, root):
+        """Remove IPInterface entries that reference affected PortChannels or ports.
+
+        Finds IPInterface elements under DeviceDataPlaneInfo/IPInterfaces where
+        AttachTo matches any affected PortChannel or affected port.
+
+        Returns:
+            int: Number of IPInterface entries removed
+        """
+        # Combine affected ports and portchannels for lookup
+        affected_attachments = self.affected_ports | self.affected_portchannels
+        if not affected_attachments:
+            return 0
+
+        removed_interfaces = 0
+
+        for dpg_info in root.findall(f".//{NS}DeviceDataPlaneInfo"):
+            ip_interfaces = dpg_info.find(f"{NS}IPInterfaces")
+            if ip_interfaces is None:
+                continue
+
+            for ip_interface in list(ip_interfaces.findall(f"{NS}IPInterface")):
+                attach_to_elem = ip_interface.find(f"{NS}AttachTo")
+
+                if attach_to_elem is None or attach_to_elem.text is None:
+                    continue
+
+                if attach_to_elem.text in affected_attachments:
+                    prefix_elem = ip_interface.find(f"{NS}Prefix")
+                    prefix = prefix_elem.text if prefix_elem is not None else "unknown"
+                    ip_interfaces.remove(ip_interface)
+                    print(f"Removed IPInterface: AttachTo={attach_to_elem.text}, Prefix={prefix}")
+                    removed_interfaces += 1
+
+        return removed_interfaces
 
     def remove_link_metadata(self, root):
         metadata_declaration = root.find(f".//{NS}LinkMetadataDeclaration")
@@ -85,26 +197,54 @@ class MinigraphRefactor:
         return removed_metadata
 
     def process_minigraph(self, input_file, output_file):
+        """Process minigraph to remove target neighbor and associated config.
+
+        Removes the target leaf router and all associated configuration including:
+        - BGP sessions
+        - BGP router declaration
+        - Device definition
+        - Device interface links
+        - PortChannel interfaces using affected ports
+        - IP interfaces on affected PortChannels/ports
+        - Link metadata
+
+        Args:
+            input_file: Path to input minigraph XML
+            output_file: Path to write modified minigraph XML
+
+        Returns:
+            tuple: (success: bool, affected_ports: set)
+                   success is False if no BGP sessions were found for the target
+                   affected_ports contains the local port names that were connected
+                   to the target neighbor (for admin_status verification)
+        """
         ET.register_namespace('', NS_VAL)
         ET.register_namespace('a', NS_A_VAL)
 
         tree = ET.parse(input_file)
         root = tree.getroot()
 
+        # Order matters: remove links first to collect affected ports,
+        # then remove PortChannels that use those ports,
+        # then remove IPInterfaces that reference those PortChannels
         results = {
             "removed_sessions": self.remove_bgp_sessions(root),
             "removed_router": self.remove_bgp_router(root),
             "removed_device": self.remove_device(root),
             "removed_links": self.remove_device_interface_links(root),
-            "removed_metadata": self.remove_link_metadata(root)
+            "removed_portchannels": self.remove_portchannel_interfaces(root),
+            "removed_ip_interfaces": self.remove_ip_interfaces(root),
+            "removed_metadata": self.remove_link_metadata(root),
+            "affected_ports": list(self.affected_ports),
+            "affected_portchannels": list(self.affected_portchannels)
         }
 
         tree.write(output_file)
 
         print(json.dumps(results, indent=2))
         if results["removed_sessions"] == 0:
-            return False
-        return True
+            return False, set()
+        return True, self.affected_ports
 
 
 def main():
@@ -120,7 +260,9 @@ def main():
         # print(f"Backup created: {backup_file}")
 
     refactor = MinigraphRefactor("ARISTA01T1")
-    refactor.process_minigraph(input_file, output_file)
+    success, affected_ports = refactor.process_minigraph(input_file, output_file)
+    if affected_ports:
+        print(f"Affected ports (should become admin_status=down): {sorted(affected_ports)}")
 
 
 if __name__ == "__main__":

--- a/tests/generic_config_updater/util/process_minigraph.py
+++ b/tests/generic_config_updater/util/process_minigraph.py
@@ -3,12 +3,14 @@ import json
 import shutil
 import os
 import sys
+import logging
 
 NS_VAL = "Microsoft.Search.Autopilot.Evolution"
 NS_A_VAL = "http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"
 NS = "{" + NS_VAL + "}"
 NS_A = "{" + NS_A_VAL + "}"
 
+logger = logging.getLogger(__name__)
 
 class MinigraphRefactor:
     """Refactors minigraph.xml to remove a T1 neighbor and its associated configuration.
@@ -45,7 +47,7 @@ class MinigraphRefactor:
                 if start_router is not None and start_router.text == self.leafrouter_name or \
                    end_router is not None and end_router.text == self.leafrouter_name:
                     peering_sessions.remove(session)
-                    # print(f"Removed session: {ET.tostring(session, encoding='unicode')}")
+                    # logger.info(f"Removed session: {ET.tostring(session, encoding='unicode')}")
                     removed_sessions += 1
         return removed_sessions
 
@@ -57,7 +59,7 @@ class MinigraphRefactor:
                 hostname = router.find(f"{NS_A}Hostname")
                 if hostname is not None and hostname.text == self.leafrouter_name:
                     routers.remove(router)
-                    # print(f"Removed router: {ET.tostring(router, encoding='unicode')}")
+                    # logger.info(f"Removed router: {ET.tostring(router, encoding='unicode')}")
                     removed_router = True
         return removed_router
 
@@ -75,7 +77,7 @@ class MinigraphRefactor:
             hostname = self.parse_device(device)
             if hostname is not None and hostname == self.leafrouter_name:
                 devices.remove(device)
-                # print(f"Removed device: {ET.tostring(device, encoding='unicode')}")
+                # logger.info(f"Removed device: {ET.tostring(device, encoding='unicode')}")
                 removed_device = True
         return removed_device
 
@@ -142,7 +144,7 @@ class MinigraphRefactor:
                     pc_name = name_elem.text if name_elem is not None else "unknown"
                     self.affected_portchannels.add(pc_name)
                     portchannel_interfaces.remove(portchannel)
-                    print(f"Removed PortChannel: {pc_name} (AttachTo: {attach_to_elem.text})")
+                    logger.info("Removed PortChannel: %s (AttachTo: %s)", pc_name, attach_to_elem.text)
                     removed_portchannels += 1
 
         return removed_portchannels
@@ -178,7 +180,7 @@ class MinigraphRefactor:
                     prefix_elem = ip_interface.find(f"{NS}Prefix")
                     prefix = prefix_elem.text if prefix_elem is not None else "unknown"
                     ip_interfaces.remove(ip_interface)
-                    print(f"Removed IPInterface: AttachTo={attach_to_elem.text}, Prefix={prefix}")
+                    logger.info("Removed IPInterface: AttachTo=%s, Prefix=%s", attach_to_elem.text, prefix)
                     removed_interfaces += 1
 
         return removed_interfaces
@@ -192,7 +194,7 @@ class MinigraphRefactor:
                     key = link_metadata.find(f"{NS_A}Key")
                     if key is not None and self.leafrouter_name in key.text:
                         link.remove(link_metadata)
-                        print(f"Removed LinkMetadata with key: {key.text}")
+                        logger.info("Removed LinkMetadata with key: %s", key.text)
                         removed_metadata += 1
         return removed_metadata
 
@@ -241,7 +243,7 @@ class MinigraphRefactor:
 
         tree.write(output_file)
 
-        print(json.dumps(results, indent=2))
+        logger.info(json.dumps(results, indent=2))
         if results["removed_sessions"] == 0:
             return False, set()
         return True, self.affected_ports
@@ -249,7 +251,7 @@ class MinigraphRefactor:
 
 def main():
     if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <input_minigraph.xml> <output_minigraph.xml>")
+        logger.info("Usage: %s <input_minigraph.xml> <output_minigraph.xml>", sys.argv[0])
         sys.exit(1)
 
     input_file, output_file = sys.argv[1], sys.argv[2]
@@ -257,12 +259,12 @@ def main():
     backup_file = f"{input_file}.backup"
     if not os.path.exists(backup_file):
         shutil.copy2(input_file, backup_file)
-        # print(f"Backup created: {backup_file}")
+        # logger.info(f"Backup created: {backup_file}")
 
     refactor = MinigraphRefactor("ARISTA01T1")
     success, affected_ports = refactor.process_minigraph(input_file, output_file)
     if affected_ports:
-        print(f"Affected ports (should become admin_status=down): {sorted(affected_ports)}")
+        logger.info("Affected ports (should become admin_status=down): %s", sorted(affected_ports))
 
 
 if __name__ == "__main__":

--- a/tests/generic_config_updater/util/process_minigraph.py
+++ b/tests/generic_config_updater/util/process_minigraph.py
@@ -12,6 +12,7 @@ NS_A = "{" + NS_A_VAL + "}"
 
 logger = logging.getLogger(__name__)
 
+
 class MinigraphRefactor:
     """Refactors minigraph.xml to remove a T1 neighbor and its associated configuration.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR significantly enhances the `test_multiasic_addcluster` test for downstream multi-ASIC platforms (T2 topology). The test validates the Generic Config Updater (GCU) `apply_patch` functionality for adding a downstream T1 neighbor cluster to a multi-ASIC SONiC device.

**Background:**
The test validates a realistic datacenter expansion scenario where physical ports exist but need to be configured for a new T1 neighbor. The workflow:
1. Backs up the original minigraph
2. Modifies minigraph to remove a target T1 neighbor
3. Reloads config from modified minigraph (ports revert to defaults with admin_status=down)
4. Generates and applies two-phase GCU patches to restore the removed neighbor
5. Validates configuration restoration and operational status convergence

**Key Changes:**

1. **New `enum_downstream_dut_hostname` fixture:**
   - Added to `conftest.py` to ensure testing on a linecard with downstream T1 neighbors
   - Replaces `rand_one_dut_front_end_hostname` for proper DUT selection

2. **Two-phase patch generation:**
   - Phase 1: Core configuration (PORT, PORTCHANNEL, BGP_NEIGHBOR, etc.)
   - Phase 2: ACL_TABLE binding updates (must be applied after ports exist)
   - Fixes GCU sorter limitation that cannot handle PORT additions and ACL_TABLE updates referencing those ports in the same batch

3. **Localhost ACL_TABLE filtering for multi-ASIC:**
   - Filter out localhost ACL_TABLE patches that reference ASIC-specific ports
   - Fixes YANG validation errors on multi-ASIC chassis where localhost ACL entries reference ports like PortChannel152 that only exist in ASIC namespaces

4. **Dynamic Port Breakout (DPB) detection:**
   - Added `check_ports_require_dpb()` to detect breakout configurations
   - Skips test if ports are in breakout mode (GCU cannot restore lane remapping)
   - Uses multiple heuristics: port index alignment, sibling ports, speed-to-lane ratio

5. **MinigraphRefactor improvements:**
   - Properly removes PortChannel and IPInterface entries when removing T1 neighbor
   - Ensures affected ports have admin_status=down after minigraph reload

6. **Operational status verification framework:**
   - Collects pre-patch operational status for ports, portchannels, BGP neighbors, and ACL tables
   - Verifies status convergence after patches are applied
   - Items that were operationally up/Established/Active before must remain so after
   - Items that were down before are checked but only warned (external factors may prevent convergence)

7. **Configuration capture for debugging:**
   - Captures config_db.json snapshots at key points (initial, pre-patch, post-patch)
   - Saves generated patches for offline analysis
   - Files saved to `tests/generic_config_updater/captures/<hostname>/<timestamp>/`

8. **Configuration comparison improvements:**
   - Compare only specific entries modified by the patch, not entire tables
   - Added `normalize_entry()` to handle semantically equivalent values
   - `admin_status='up'` treated as equivalent to no `admin_status` field (implicit default)

9. **Reliable teardown using config_reload:**
   - Restores original minigraph from backup before cleanup
   - Uses `config_reload(duthost)` instead of GCU rollback
   - GCU rollback fails for this test's complex state (minigraph modification + GCU patches)

Fixes # MIGSMSFT-1322]


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `test_multiasic_addcluster` test was failing on multi-ASIC platforms due to multiple issues:

1. **DUT selection:** The test needs a linecard with downstream T1 neighbors, but `rand_one_dut_front_end_hostname` might select a linecard without downstream connections.

2. **Single-phase patch limitation:** GCU's patch sorter cannot handle PORT additions and ACL_TABLE updates that reference those ports in the same batch, causing YANG validation failures.

3. **Localhost ACL_TABLE on multi-ASIC:** On multi-ASIC chassis, localhost ACL_TABLE entries reference ports (e.g., PortChannel152) that only exist in ASIC namespaces, causing "Invalid value" YANG errors.

4. **BGP_NEIGHBOR mismatch false positives:** The patch generator injects `admin_status='up'` while minigraph configs don't have this field explicitly (it's an implicit default).

5. **Breakout port configurations:** If target ports are in breakout mode, the GCU patch cannot restore them after minigraph reload reverts to native lane configuration.

6. **Teardown rollback failures:** The complex config state (minigraph modification + GCU patches) causes GCU rollback to fail with YANG validation or dependency ordering errors.

#### How did you do it?

1. **Added `enum_downstream_dut_hostname` fixture** in `conftest.py` that explicitly selects a DUT with downstream T1 neighbors.

2. **Implemented two-phase patch generation** in `generate_patch.py`:
   - `generate_config_patch()` returns `(phase1_file, phase2_file)`
   - Phase 1: Everything except ACL_TABLE binding updates
   - Phase 2: ACL_TABLE entries with port bindings 

3. **Filter localhost ACL_TABLE patches** in `generate_patch.py`:
   - Skip localhost namespace when generating ACL binding patches
   - Filter out localhost entries from coalesced ACL_TABLE

4. **Added `check_ports_require_dpb()` function** with heuristics:
   - Port index alignment (breakout ports have non-standard indices)
   - Sibling port detection (multiple ports in same lane group)
   - Speed-to-lane ratio analysis
   - Skips test with detailed message if DPB would be required

5. **Built unified oper status verification framework**:
   - `collect_oper_status_from_patches()` - Extracts items from patches and queries current status
   - `get_all_oper_status()` - Queries ports, portchannels, BGP, ACL tables in one call
   - `verify_oper_status_after_patches()` - Waits for convergence and verifies

6. **Added config capture** with automatic timestamped directories and .gitignore

7. **Entry-level comparison** extracting specific `(table, key)` pairs from patch paths

8. **Replaced rollback with config_reload** in teardown fixture

#### How did you verify/test it?

- Ran the test on T2 multi-ASIC chassis 
- Verified DPB detection correctly identifies and skips breakout configurations
- Verified two-phase patch application works correctly
- Verified localhost ACL filtering prevents YANG validation errors
- Verified operational status convergence for ports, portchannels, and BGP neighbors
- Verified teardown completes successfully without ERROR status
- Confirmed GCU patches correctly restore PORT, PORTCHANNEL, PORTCHANNEL_MEMBER, PORTCHANNEL_INTERFACE, BGP_NEIGHBOR, DEVICE_NEIGHBOR, DEVICE_NEIGHBOR_METADATA, CABLE_LENGTH, PORT_QOS_MAP, and PFC_WD tables

#### Any platform specific information?

- This test is specific to **T2 topology** (multi-ASIC chassis with linecards)
- Uses new `enum_downstream_dut_hostname` fixture to target linecards with downstream neighbors
- The localhost ACL_TABLE filtering is specific to multi-ASIC chassis
- DPB detection works on platforms with breakout-capable ports
- **WARNING:** This test selects frontend ports based on role, then name (e.g. with regex "Ethernet[0-9]+"). We cannot control the adopted conventions of other vendors, but we did our best to avoid conflicts on other VoQ platforms. 

#### Supported testbed topology if it's a new test case?

Not a new test case - this is a major improvement to the existing `test_multiasic_addcluster` test.

Supported topology: **t2** (T2 multi-ASIC chassis)

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Documentation is included inline in the code:
- Module docstring explaining design notes and key concepts
- Extended fixture docstring with "Teardown Strategy" section
- Detailed docstrings for all helper functions (parsing, verification, DPB detection)
- Step-by-step comments in test workflow explaining each phase
- Comparison strategy documentation explaining normalization rationale

**Files Changed:**
- `tests/conftest.py` - Added `enum_downstream_dut_hostname` fixture
- `tests/generic_config_updater/test_multiasic_addcluster.py` - Major test rewrite with all improvements
- `tests/generic_config_updater/util/generate_patch.py` - Two-phase generation, localhost filtering
- `tests/generic_config_updater/util/process_minigraph.py` - PortChannel/IPInterface removal
