### PR TITLE
Add wait_until before reading trim counters to avoid timing related failures

### DIFF
--- a/tests/packet_trimming/base_packet_trimming.py
+++ b/tests/packet_trimming/base_packet_trimming.py
@@ -7,14 +7,15 @@ from tests.common.utilities import wait_until, configure_packet_aging
 from tests.common.mellanox_data import is_mellanox_device
 from tests.packet_trimming.constants import (
     DEFAULT_PACKET_SIZE, DEFAULT_DSCP, MIN_PACKET_SIZE, CONFIG_TOGGLE_COUNT,
-    JUMBO_PACKET_SIZE, PORT_TOGGLE_COUNT)
+    JUMBO_PACKET_SIZE, PORT_TOGGLE_COUNT, TRIMMING_COUNTER_INTERVAL)
 from tests.packet_trimming.packet_trimming_config import PacketTrimmingConfig
 from tests.packet_trimming.packet_trimming_helper import (
     configure_trimming_action, configure_trimming_acl, verify_srv6_packet_with_trimming, cleanup_trimming_acl,
     verify_trimmed_packet, reboot_dut, check_connected_route_ready, get_switch_trim_counters_json,
     get_port_trim_counters_json, disable_egress_data_plane, enable_egress_data_plane,
     verify_queue_and_port_trim_counter_consistency, get_queue_trim_counters_json, compare_counters,
-    configure_port_mirror_session, remove_port_mirror_session, check_trim_drop_counter_zero)
+    has_non_zero_trim_counters, configure_port_mirror_session, remove_port_mirror_session,
+    check_trim_drop_counter_zero)
 
 logger = logging.getLogger(__name__)
 
@@ -359,6 +360,9 @@ class BasePacketTrimming:
             # Verify the consistency of the trim counter on the queue and the port level
             for egress_port in test_params['egress_ports']:
                 for port in egress_port['dut_members']:
+                    pytest_assert(wait_until(5 * TRIMMING_COUNTER_INTERVAL, TRIMMING_COUNTER_INTERVAL, 0,
+                                             has_non_zero_trim_counters, duthost, port),
+                                  f"port level trim counters are zero for {port}")
                     verify_queue_and_port_trim_counter_consistency(duthost, port)
 
         with allure.step("Verify TrimSent counters on switch level"):

--- a/tests/packet_trimming/packet_trimming_helper.py
+++ b/tests/packet_trimming/packet_trimming_helper.py
@@ -2894,6 +2894,23 @@ def check_trim_drop_counter_zero(duthost, port):
     return trim_drop == 0
 
 
+def has_non_zero_trim_counters(duthost, port):
+    """
+    Checks if port level trim counters are non-zero.
+
+    Args:
+        duthost: DUT host object
+        port (str): port name, e.g. "Ethernet96"
+
+    Returns:
+        True if the counters are non-zero, otherwise False
+    """
+    port_trim_packets = get_port_trim_counters_json(duthost, port)
+    if 'TRIM_PKTS' not in port_trim_packets:
+        return False
+    return int(port_trim_packets['TRIM_PKTS']) > 0
+
+
 def verify_queue_and_port_trim_counter_consistency(duthost, port):
     """
     Verify the consistency of the trim counter on the queue and the port level.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
We were seeing failures in the `base_packet_trimming.py::test_trimming_counters` testcase related to trim counters being zero.

#### How did you do it?
We could not reproduce the issue while using a debugger, leading us to believe it was timing related. After adding a sleep before reading the counters, we did not see the issue. We opted to implement logic that uses `wait_for` instead of sleeping.

#### How did you verify/test it?
Verified the failures were no longer happening with this change.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
