### PR TITLE
tests/common/platform: Improve wait_critical_processes failure message with unhealthy container/process details

### DIFF
--- a/tests/common/platform/processes_utils.py
+++ b/tests/common/platform/processes_utils.py
@@ -97,5 +97,14 @@ def wait_critical_processes(dut, timeout=None):
             timeout = 900
     logging.info("Wait until all critical processes are healthy in {} sec"
                  .format(timeout))
-    pytest_assert(wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut),
-                  "Not all critical processes are healthy")
+    passed = wait_until(timeout, 20, 0, _all_critical_processes_healthy, dut)
+    if not passed:
+        _, details = get_critical_processes_status(dut)
+        failed = [
+            "{}: status={}, exited_critical_process={}".format(
+                name, info.get("status"), info.get("exited_critical_process", [])
+            )
+            for name, info in details.items()
+            if not info.get("status") or info.get("exited_critical_process")
+        ]
+        pytest_assert(False, "Not all critical processes are healthy: {}".format(failed))


### PR DESCRIPTION
### Description of PR

When wait_critical_processes times out, include which container(s) and exited_critical_process list in the assertion message so failures show e.g. ['pmon: status=False, exited_critical_process=[psud]'] instead of generic 'Not all critical processes are healthy'.

Summary: Fixes #
When wait_critical_processes() times out, the assertion no longer only says "Not all critical processes are healthy". It now includes which container(s) failed and their exited_critical_process list so failures can be diagnosed without digging through logs.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Test failures during BGP setup (e.g. after config_reload in bgp/conftest.py) were hard to debug because the generic message did not identify which container or process was not up. Correlating with show tech dumps is easier when the failure output names the failing container and process(es).

#### How did you do it?
After wait_until() returns False, call get_critical_processes_status(dut) once and build a list of unhealthy entries (container name, status, exited_critical_process).
Assert with that list in the message, e.g. Not all critical processes are healthy: ['pmon: status=False, exited_critical_process=[psud]', ...].

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
