### PR TITLE
Fix the fixture is_support_fan invoke issue in case test_device_fan_speed_checker

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -389,7 +389,8 @@ def test_system_health_config(duthosts, enum_rand_one_per_hwsku_hostname,
 
 @pytest.mark.disable_loganalyzer
 def test_device_fan_speed_checker(duthosts, enum_rand_one_per_hwsku_hostname,
-                                  device_mocker_factory, disable_thermal_policy, is_support_mock_asic):  # noqa F811
+                                  device_mocker_factory, disable_thermal_policy, is_support_mock_asic,  # noqa F811
+                                  is_support_fan):                                                      # noqa F811
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     device_mocker = device_mocker_factory(duthost)
     wait_system_health_boot_up(duthost)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Fix the fixture is_support_fan invoke issue in case test_device_fan_speed_checker

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix the fixture is_support_fan invoke issue in case test_device_fan_speed_checker

#### How did you do it?
Add fixture is_support_fan invoke 
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
