### PR TITLE
Enhance the debuggability of pcied test case

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -187,6 +187,9 @@ def test_pmon_pcied_stop_and_start_status(check_daemon_status, duthosts, rand_on
 
     data_after_restart = wait_data(
         duthost, len(data_before_restart['devices']))
+    if data_after_restart != data_before_restart:
+        logger.info("data_before_restart: {}".format(data_before_restart))
+        logger.info("data_after_restart: {}".format(data_after_restart))
     pytest_assert(data_after_restart == data_before_restart,
                   'DB data present before and after restart does not match')
 
@@ -224,6 +227,9 @@ def test_pmon_pcied_term_and_start_status(check_daemon_status, duthosts,
                   .format(daemon_name, pre_daemon_pid, post_daemon_pid))
     data_after_restart = wait_data(
         duthost, len(data_before_restart['devices']))
+    if data_after_restart != data_before_restart:
+        logger.info("data_before_restart: {}".format(data_before_restart))
+        logger.info("data_after_restart: {}".format(data_after_restart))
     pytest_assert(data_after_restart == data_before_restart,
                   'DB data present before and after restart does not match')
 
@@ -255,5 +261,8 @@ def test_pmon_pcied_kill_and_start_status(check_daemon_status, duthosts, rand_on
                   "Restarted {} pid should be bigger than {} but it is {}"
                   .format(daemon_name, pre_daemon_pid, post_daemon_pid))
     data_after_restart = wait_data(duthost, len(data_before_restart['devices']))
+    if data_after_restart != data_before_restart:
+        logger.info("data_before_restart: {}".format(data_before_restart))
+        logger.info("data_after_restart: {}".format(data_after_restart))
     pytest_assert(data_after_restart == data_before_restart,
                   'DB data present before and after restart does not match')


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Print the value of data_before_restart and data_after_restart
It would provide visibility for the key values in the test, especially when there is failure.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
There is no full value printed during pcied case failure.
#### How did you do it?
Print the value of data_before_restart and data_after_restart
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
