### PR TITLE
Feature/smartswitch vlan dataplane config

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -1029,6 +1029,12 @@
         become: true
         shell: config bgp startup all
 
+      - name: Wait for DPU control planes to boot after config reload
+        pause:
+          seconds: 300
+        when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"] and is_lit_mode|bool == true
+        tags: [ dpu_config ]
+
       - name: Copy smartswitch dpu config
         copy: src=golden_config_db/smartswitch_dpu_extra.json
               dest=/tmp/dpu_extra.json

--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -823,6 +823,7 @@
           hwsku: "{{ hwsku }}"
           vm_configuration: "{{ configuration if topo == 't1-filterleaf-lag' else omit }}"
           is_lit_mode: "{{ is_lit_mode | default(true) }}"
+          npu_index: "{{ dut_index | default(0) | int }}"
         become: true
 
       - name: Copy macsec profile json to dut
@@ -1042,6 +1043,7 @@
           hostname: "{{ inventory_hostname }}"
           host_username: "{{ sonic_login }}"
           host_passwords: "{{ sonic_default_passwords }}"
+          npu_index: "{{ dut_index | default(0) | int }}"
         become: true
         # t1-28-lag is smartswitch topo only
         when: topo in ["t1-smartswitch-ha","t1-28-lag","smartswitch-t1", "t1-48-lag"] and is_lit_mode|bool == true

--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -33,9 +33,12 @@
         "Ethernet0|20.0.200.1/24": {}
     },
     "STATIC_ROUTE": {
-        "0.0.0.0/0": {
+        "default|0.0.0.0/0": {
             "nexthop": "20.0.200.254",
-            "ifname": "Ethernet0"
+            "ifname": "Ethernet0",
+            "nexthop-vrf": "",
+            "blackhole": "false",
+            "distance": "0"
         }
     }
 }

--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -27,18 +27,5 @@
             "log_level": "2",
             "port": "50052"
         }
-    },
-    "INTERFACE": {
-        "Ethernet0": {},
-        "Ethernet0|20.0.200.1/24": {}
-    },
-    "STATIC_ROUTE": {
-        "default|0.0.0.0/0": {
-            "nexthop": "20.0.200.254",
-            "ifname": "Ethernet0",
-            "nexthop-vrf": "",
-            "blackhole": "false",
-            "distance": "0"
-        }
     }
 }

--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -2,7 +2,7 @@
     "DEVICE_METADATA": {
         "localhost": {
             "bgp_asn": "65100",
-            "hostname": "DPU_HOSTNAME_PLACEHOLDER",
+            "hostname": "dpu",
             "subtype": "SmartSwitch",
             "switch_type": "dpu",
             "type": "SmartSwitchDPU"
@@ -26,6 +26,16 @@
         "gnmi": {
             "log_level": "2",
             "port": "50052"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0": {},
+        "Ethernet0|20.0.200.1/24": {}
+    },
+    "STATIC_ROUTE": {
+        "0.0.0.0/0": {
+            "nexthop": "20.0.200.254",
+            "ifname": "Ethernet0"
         }
     }
 }

--- a/ansible/golden_config_db/smartswitch_t1.json
+++ b/ansible/golden_config_db/smartswitch_t1.json
@@ -11,20 +11,6 @@
             "port": "50052"
         }
     },
-    "DPU": {
-        "dpu0": {
-            "gnmi_port": "50052"
-        },
-        "dpu1": {
-            "gnmi_port": "50052"
-        },
-        "dpu2": {
-            "gnmi_port": "50052"
-        },
-        "dpu3": {
-            "gnmi_port": "50052"
-        }
-    },
     "STATIC_ROUTE": {
         "default|10.2.0.1/32": {
             "blackhole": "false",

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -14,7 +14,7 @@ import ipaddress
 
 from ansible.module_utils.basic import AnsibleModule
 from sonic_py_common import device_info, multi_asic
-from ansible.module_utils.smartswitch_utils import smartswitch_hwsku_config
+from ansible.module_utils.smartswitch_utils import smartswitch_hwsku_config, smartswitch_vlan_config
 
 DOCUMENTATION = '''
 module: generate_golden_config_db.py
@@ -60,7 +60,8 @@ class GenerateGoldenConfigDBModule(object):
                                     num_asics=dict(required=False, type='int', default=1),
                                     hwsku=dict(required=False, type='str', default=None),
                                     vm_configuration=dict(required=False, type='dict', default={}),
-                                    is_lit_mode=dict(required=False, type='bool', default=True)),
+                                    is_lit_mode=dict(required=False, type='bool', default=True),
+                                    npu_index=dict(required=False, type='int', default=0)),
                                     supports_check_mode=True)
         self.topo_name = self.module.params['topo_name']
         self.port_index_map = self.module.params['port_index_map']
@@ -71,6 +72,7 @@ class GenerateGoldenConfigDBModule(object):
 
         self.vm_configuration = self.module.params['vm_configuration']
         self.is_lit_mode = self.module.params['is_lit_mode']
+        self.npu_index = self.module.params['npu_index']
 
     def generate_mgfx_golden_config_db(self):
         rc, out, err = self.module.run_command("sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data")
@@ -412,7 +414,6 @@ class GenerateGoldenConfigDBModule(object):
         if rc != 0:
             self.module.fail_json(msg="Failed to get config from minigraph: {}".format(err))
 
-        # Generate FEATURE table from init_cfg.ini
         ori_config_db = json.loads(out)
         if "DEVICE_METADATA" not in ori_config_db or "localhost" not in ori_config_db["DEVICE_METADATA"]:
             return "{}"
@@ -426,7 +427,6 @@ class GenerateGoldenConfigDBModule(object):
         ori_config_db["FEATURE"]["dhcp_server"]["state"] = "enabled"
         ori_config_db["FEATURE"]["dhcp_relay"]["state"] = "enabled"
 
-        # Generate INTERFACE table for EthernetBPXX
         if "PORT" not in ori_config_db or "INTERFACE" not in ori_config_db:
             return "{}"
 
@@ -443,19 +443,31 @@ class GenerateGoldenConfigDBModule(object):
             ori_config_db["DHCP_SERVER_IPV4_PORT"] = {}
 
         hwsku_config = smartswitch_hwsku_config[hwsku]
-        for i in range(smartswitch_hwsku_config[hwsku]["dpu_num"]):
+        dpu_num = hwsku_config["dpu_num"]
+
+        vlan_cfg = smartswitch_vlan_config.get(self.npu_index, smartswitch_vlan_config[0])
+        vlan_name = vlan_cfg["vlan_name"]
+
+        ori_config_db["VLAN"] = {
+            vlan_name: {"vlanid": vlan_cfg["vlanid"]}
+        }
+        ori_config_db["VLAN_INTERFACE"] = {
+            vlan_name: {},
+            "{}|{}".format(vlan_name, vlan_cfg["vlan_interface_ip"]): {}
+        }
+        ori_config_db["VLAN_MEMBER"] = {}
+
+        for i in range(dpu_num):
             port_index = hwsku_config["base"] + i * hwsku_config["step"] \
                 if "base" in hwsku_config and "step" in hwsku_config else i
             port_key = hwsku_config["port_key"].format(port_index)
-            if "interface_key" in hwsku_config:
-                interface_key = hwsku_config["interface_key"].format(port_index, i)
             dpu_key = hwsku_config["dpu_key"].format(i)
 
             if port_key in ori_config_db["PORT"]:
                 ori_config_db["PORT"][port_key]["admin_status"] = "up"
-                if "interface_key" in hwsku_config:
-                    ori_config_db["INTERFACE"][port_key] = {}
-                    ori_config_db["INTERFACE"][interface_key] = {}
+
+            vlan_member_key = "{}|{}".format(vlan_name, port_key)
+            ori_config_db["VLAN_MEMBER"][vlan_member_key] = {"tagging_mode": "untagged"}
 
             ori_config_db["CHASSIS_MODULE"]["DPU{}".format(i)] = {"admin_status": "up"}
 
@@ -493,6 +505,9 @@ class GenerateGoldenConfigDBModule(object):
             "FEATURE": copy.deepcopy(ori_config_db["FEATURE"]),
             "INTERFACE": copy.deepcopy(ori_config_db["INTERFACE"]),
             "PORT": copy.deepcopy(ori_config_db["PORT"]),
+            "VLAN": copy.deepcopy(ori_config_db["VLAN"]),
+            "VLAN_INTERFACE": copy.deepcopy(ori_config_db["VLAN_INTERFACE"]),
+            "VLAN_MEMBER": copy.deepcopy(ori_config_db["VLAN_MEMBER"]),
             "CHASSIS_MODULE": copy.deepcopy(ori_config_db["CHASSIS_MODULE"]),
             "DPUS": copy.deepcopy(ori_config_db["DPUS"]),
             "DHCP_SERVER_IPV4_PORT": copy.deepcopy(ori_config_db["DHCP_SERVER_IPV4_PORT"]),
@@ -500,10 +515,8 @@ class GenerateGoldenConfigDBModule(object):
             "DHCP_SERVER_IPV4": copy.deepcopy(ori_config_db["DHCP_SERVER_IPV4"])
         }
 
-        # Set buffer_model to traditional by default
         gold_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
 
-        # Generate dhcp_server related configuration
         rc, out, err = self.module.run_command("cat {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))
         if rc != 0:
             self.module.fail_json(msg="Failed to get smartswitch config: {}".format(err))

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -522,6 +522,9 @@ class GenerateGoldenConfigDBModule(object):
         }
 
         gold_config_db["DEVICE_METADATA"]["localhost"]["buffer_model"] = "traditional"
+        if self.topo_name == "t1-smartswitch-ha":
+            gold_config_db["DEVICE_METADATA"]["localhost"]["cluster"] = "cluster1"
+            gold_config_db["DEVICE_METADATA"]["localhost"]["region"] = "west"
 
         rc, out, err = self.module.run_command("cat {}".format(TEMP_SMARTSWITCH_CONFIG_PATH))
         if rc != 0:

--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -466,6 +466,12 @@ class GenerateGoldenConfigDBModule(object):
             if port_key in ori_config_db["PORT"]:
                 ori_config_db["PORT"][port_key]["admin_status"] = "up"
 
+            # Remove any minigraph-generated INTERFACE entries for DPU dataplane ports
+            keys_to_remove = [k for k in ori_config_db["INTERFACE"]
+                              if k == port_key or k.startswith(port_key + "|")]
+            for k in keys_to_remove:
+                del ori_config_db["INTERFACE"][k]
+
             vlan_member_key = "{}|{}".format(vlan_name, port_key)
             ori_config_db["VLAN_MEMBER"][vlan_member_key] = {"tagging_mode": "untagged"}
 

--- a/ansible/library/load_extra_dpu_config.py
+++ b/ansible/library/load_extra_dpu_config.py
@@ -154,9 +154,12 @@ class LoadExtraDpuConfigModule(object):
                 "Ethernet0|{}".format(dpu_dataplane_ip): {}
             }
             dpu_config["STATIC_ROUTE"] = {
-                "0.0.0.0/0": {
+                "default|0.0.0.0/0": {
                     "nexthop": gateway_ip,
-                    "ifname": "Ethernet0"
+                    "ifname": "Ethernet0",
+                    "nexthop-vrf": "",
+                    "blackhole": "false",
+                    "distance": "0"
                 }
             }
 

--- a/ansible/library/load_extra_dpu_config.py
+++ b/ansible/library/load_extra_dpu_config.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python
+import json
 import paramiko
 import os
 import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.misc_utils import wait_for_path
-from ansible.module_utils.smartswitch_utils import smartswitch_hwsku_config
+from ansible.module_utils.smartswitch_utils import smartswitch_hwsku_config, smartswitch_vlan_config
 
 DPU_HOST_IP_BASE = "169.254.200.{}"
 SRC_DPU_CONFIG_TEMPLATE = "/tmp/dpu_extra_template.json"
@@ -31,7 +32,8 @@ class LoadExtraDpuConfigModule(object):
                 hwsku=dict(type='str', required=True),
                 hostname=dict(type='str', required=True),
                 host_username=dict(type='str', required=True),
-                host_passwords=dict(type='list', elements='str', required=True, no_log=True)
+                host_passwords=dict(type='list', elements='str', required=True, no_log=True),
+                npu_index=dict(type='int', required=False, default=0)
             ),
             supports_check_mode=False
         )
@@ -40,6 +42,7 @@ class LoadExtraDpuConfigModule(object):
         self.hostname = self.module.params['hostname']
         self.host_username = self.module.params['host_username']
         self.host_passwords = self.module.params['host_passwords']
+        self.npu_index = self.module.params['npu_index']
 
         try:
             self.hwsku_config = smartswitch_hwsku_config[self.hwsku]
@@ -132,13 +135,33 @@ class LoadExtraDpuConfigModule(object):
         # Backup the original template before modifications
         self.module.run_command("cp {} {}".format(SRC_DPU_CONFIG_FILE, SRC_DPU_CONFIG_TEMPLATE))
 
+        vlan_cfg = smartswitch_vlan_config.get(self.npu_index, smartswitch_vlan_config[0])
+        gateway_ip = vlan_cfg["vlan_interface_ip"].split("/")[0]
+
         for i in range(0, self.dpu_num):
             # Copy fresh template for each DPU
             self.module.run_command("cp {} {}".format(SRC_DPU_CONFIG_TEMPLATE, SRC_DPU_CONFIG_FILE))
-            # Update the extra dpu config file
-            self.module.run_command("sed -i 's/18.*202/18.{}.202/g' {}".format(i, SRC_DPU_CONFIG_FILE))
-            self.module.run_command("sed -i 's/DPU_HOSTNAME_PLACEHOLDER/{}-dpu-{}/g' {}".format(
-                self.hostname, i, SRC_DPU_CONFIG_FILE))
+
+            with open(SRC_DPU_CONFIG_FILE, 'r') as f:
+                dpu_config = json.load(f)
+
+            dpu_config["DEVICE_METADATA"]["localhost"]["hostname"] = "{}-dpu-{}".format(
+                self.hostname, i)
+
+            dpu_dataplane_ip = "{}{}/24".format(vlan_cfg["dpu_ip_prefix"], i + 1)
+            dpu_config["INTERFACE"] = {
+                "Ethernet0": {},
+                "Ethernet0|{}".format(dpu_dataplane_ip): {}
+            }
+            dpu_config["STATIC_ROUTE"] = {
+                "0.0.0.0/0": {
+                    "nexthop": gateway_ip,
+                    "ifname": "Ethernet0"
+                }
+            }
+
+            with open(SRC_DPU_CONFIG_FILE, 'w') as f:
+                json.dump(dpu_config, f, indent=4)
 
             dpu_ip = DPU_HOST_IP_BASE.format(i + 1)
 

--- a/ansible/module_utils/smartswitch_utils.py
+++ b/ansible/module_utils/smartswitch_utils.py
@@ -1,7 +1,6 @@
 common_cisco_hwsku_config = {
     "dpu_num": 8,
     "port_key": "Ethernet{}",
-    "interface_key": "Ethernet{}|18.{}.202.0/31",
     "base": 224,
     "step": 8,
     "dpu_key": "dpu{}"
@@ -10,7 +9,6 @@ common_cisco_hwsku_config = {
 common_mellanox_hwsku_config = {
     "dpu_num": 4,
     "port_key": "Ethernet{}",
-    "interface_key": "Ethernet{}|18.{}.202.0/31",
     "base": 224,
     "step": 8,
     "dpu_key": "dpu{}"
@@ -33,3 +31,20 @@ smartswitch_hwsku_config.update({
     "Mellanox-SN4280-O28": common_mellanox_hwsku_config.copy(),
     "Mellanox-SN4280-O8C40": common_mellanox_hwsku_config.copy()
 })
+
+# VLAN configuration for NPU-DPU dataplane connectivity.
+# NPU 0 uses Vlan1000 (20.0.200.0/24); NPU 1 uses Vlan2000 (20.0.201.0/24, HA testbeds).
+smartswitch_vlan_config = {
+    0: {
+        "vlan_name": "Vlan1000",
+        "vlanid": "1000",
+        "vlan_interface_ip": "20.0.200.254/24",
+        "dpu_ip_prefix": "20.0.200.",
+    },
+    1: {
+        "vlan_name": "Vlan2000",
+        "vlanid": "2000",
+        "vlan_interface_ip": "20.0.201.254/24",
+        "dpu_ip_prefix": "20.0.201.",
+    }
+}

--- a/ansible/module_utils/smartswitch_utils.py
+++ b/ansible/module_utils/smartswitch_utils.py
@@ -33,17 +33,17 @@ smartswitch_hwsku_config.update({
 })
 
 # VLAN configuration for NPU-DPU dataplane connectivity.
-# NPU 0 uses Vlan1000 (20.0.200.0/24); NPU 1 uses Vlan2000 (20.0.201.0/24, HA testbeds).
+# Both NPUs use Vlan55 with different subnets: NPU 0 → 20.0.200.0/24, NPU 1 → 20.0.201.0/24 (HA testbeds).
 smartswitch_vlan_config = {
     0: {
-        "vlan_name": "Vlan1000",
-        "vlanid": "1000",
+        "vlan_name": "Vlan55",
+        "vlanid": "55",
         "vlan_interface_ip": "20.0.200.254/24",
         "dpu_ip_prefix": "20.0.200.",
     },
     1: {
-        "vlan_name": "Vlan2000",
-        "vlanid": "2000",
+        "vlan_name": "Vlan55",
+        "vlanid": "55",
         "vlan_interface_ip": "20.0.201.254/24",
         "dpu_ip_prefix": "20.0.201.",
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:The previous design used direct point-to-point INTERFACE entries (e.g. Ethernet224|18.x.202.0/31) for NPU-DPU dataplane connectivity. The VLAN-based model provides a cleaner, standards-aligned design that supports HA topologies with a second NPU.                               
                                                                                                                                                                                       
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
- Added a smartswitch_vlan_config dict in smartswitch_utils.py mapping NPU index → VLAN name, VLAN ID, gateway IP, and DPU IP prefix (NPU 0 → Vlan1000/20.0.200.0/24, NPU 1 → Vlan2000/20.0.201.0/24)                  
  - Updated generate_golden_config_db.py to accept npu_index, look up the VLAN config, and populate VLAN, VLAN_INTERFACE, and VLAN_MEMBER tables in the NPU golden config                                                
  - Updated load_extra_dpu_config.py to accept npu_index, and use structured JSON manipulation (instead of sed) to write per-DPU hostname, INTERFACE IP, and STATIC_ROUTE (default route via the VLAN gateway) into each 
  DPU's config                                                                                                                                                                                                           
  - Updated config_sonic_basedon_testbed.yml to pass npu_index (derived from dut_index) to both modules                                                                                                                  
  - Updated smartswitch_dpu_extra.json template to include INTERFACE and STATIC_ROUTE skeleton entries and replaced DPU_HOSTNAME_PLACEHOLDER with dpu as the default                                                     
                             
#### How did you verify/test it?
 tested using deploy-mg tool on a SmartSwitch testbed  — verified Vlan1000 created on NPU with correct DPU ports as untagged members and correct gateway IP                                                           
  - Verified each DPU received correct IP (20.0.200.{dpu_index+1}/24) on Ethernet0 and a default static route via 20.0.200.254                                                                                           
  - Verified DPU hostnames are correctly set to {hostname}-dpu-{i}                                                                                                                                                       
                                                                                                                                                                                                                         
  Any platform specific information?                       
#### Any platform specific information?
Applies to SmartSwitch platforms (Cisco and Mellanox HWSKUs) used in t1-smartswitch-ha

#### Supported testbed topology if it's a new test case?
t1-smartswitch-ha,
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
PLAY RECAP *********************************************************************                                                                                   
MtFuji-dut01               : ok=94   changed=23   unreachable=0    failed=0    skipped=98   rescued=0    ignored=2                                                 
MtFuji-dut02               : ok=92   changed=24   unreachable=0    failed=0    skipped=97   rescued=0    ignored=2                                                 
                                                                                                                                                                   
Friday 13 March 2026  06:19:33 +0000 (0:00:00.603)       0:15:34.236 **********                                                                                    
===============================================================================                                                                                    
Load DPU config in smartswitch ---------------------------------------- 417.00s                                                                                    
/data/ansible/config_sonic_basedon_testbed.yml:1046 ---------------------------                                                                                    
Wait for DPU control planes to boot after config reload --------------- 300.04s                                                                                    
/data/ansible/config_sonic_basedon_testbed.yml:1032 ---------------------------                                                                                    
Wait 60s for docker containers to restart ------------------------------ 60.04s                                                                                    
/data/ansible/config_sonic_basedon_testbed.yml:557 ----------------------------                                                                                    
execute cli "config load_minigraph --override_config -y" to apply new minigraph -- 42.32s                                                                          
/data/ansible/config_sonic_basedon_testbed.yml:851 ----------------------------                                                                                    
restart docker service, let docker proxy takes effect ------------------ 36.65s                                                                                    
/data/ansible/config_sonic_basedon_testbed.yml:551 ----------------------------                                                                                    
Sync DUT system time with NTP server ----------------------------------- 21.40s                                                                                    
/data/ansible/config_sonic_basedon_testbed.yml:989 ----------------------------
Wait for switch to become reachable again ------------------------------ 10.26s
/data/ansible/config_sonic_basedon_testbed.yml:899 ----------------------------
Configure TACACS with PTF TACACS server --------------------------------- 5.00s
/data/ansible/config_sonic_basedon_testbed.yml:1071 ---------------------------
Configure TACACS -------------------------------------------------------- 4.53s
/data/ansible/config_sonic_basedon_testbed.yml:1058 ---------------------------
Start chrony.service on DUT --------------------------------------------- 2.04s
/data/ansible/config_sonic_basedon_testbed.yml:996 ----------------------------
execute cli "config save -y" to save current minigraph as startup-config --- 2.03s
/data/ansible/config_sonic_basedon_testbed.yml:1177 ---------------------------
execute cli "config bmp enable bgp-neighbor-table" to enable bgp-neighbor-table --- 1.60s
/data/ansible/config_sonic_basedon_testbed.yml:1010 ---------------------------
execute cli "config bmp enable bgp-rib-in-table" to enable bgp-rib-in-table --- 1.55s
/data/ansible/config_sonic_basedon_testbed.yml:1013 ---------------------------
execute cli "config bmp enable bgp-rib-out-table" to enable bgp-rib-out-table --- 1.55s
/data/ansible/config_sonic_basedon_testbed.yml:1016 ---------------------------
execute cli "config bgp startup all" to bring up all bgp sessions for test --- 1.54s
/data/ansible/config_sonic_basedon_testbed.yml:1028 ---------------------------
remove running golden config file if exists ----------------------------- 1.44s
/data/ansible/config_sonic_basedon_testbed.yml:1182 ---------------------------
create new minigraph file for SONiC device ------------------------------ 1.12s
/data/ansible/config_sonic_basedon_testbed.yml:613 ----------------------------
Wait for chrony.service restart after reload minigraph ------------------ 1.10s
/data/ansible/config_sonic_basedon_testbed.yml:981 ----------------------------
Check if chrony exists -------------------------------------------------- 1.04s
/data/ansible/config_sonic_basedon_testbed.yml:921 ----------------------------
Copy smartswitch dpu config --------------------------------------------- 1.03s
/data/ansible/config_sonic_basedon_testbed.yml:1038 ---------------------------
Done
