### PR TITLE
[master] pfcwd: refactor LAG config handling into complete resource manager fixture

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -54,7 +54,6 @@ def stop_pfcwd(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.command("pfcwd start_default")
 
 
-
 class SetupPfcwdFunc(object):
     def parse_test_port_info(self):
         """
@@ -590,7 +589,6 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
         # for idx, port in enumerate(self.ports):
         port = list(self.ports.keys())[0]
-
 
         logger.info("--- Testing various Pfcwd actions on {} ---".format(port))
         self.setup_test_params(port, setup_info['vlan'], init=True, ip_version=ip_version)


### PR DESCRIPTION
Refactor `test_pfcwd_show_stat` LAG config management to use a proper pytest fixture that owns the full backup-and-restore lifecycle, fixing a bug where config restoration was skipped on test failure.

### Description of PR

Summary:
Addresses review feedback on #22208.

The original code in `test_pfcwd_show_stat` called `__restore_original_config` inside the `for action in actions` loop's `finally` block, which meant:
1. Config restore ran on **every loop iteration** instead of once
2. If the test raised an exception **before** the loop, restore never ran

This PR refactors the LAG config management into a complete pytest resource manager fixture `manage_lag_config` that:
- **Setup (before test):** calls `_backup_original_config` + `_shutdown_lag_members` — explicit named backup
- **Teardown (after test):** calls `_restore_original_config` — guaranteed even on failure

The backup/restore logic is extracted into module-level functions (`_backup_original_config` / `_restore_original_config`) forming a clear named pair. The class methods `__shutdown_lag_members` and `__restore_original_config` become thin wrappers.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?
`__restore_original_config` was placed inside the loop's `finally` block, causing it to run on every action iteration and be skipped entirely if an exception occurred before the loop. A pytest fixture guarantees teardown runs exactly once regardless of test outcome.

#### How did you do it?
- Extracted `_backup_original_config(duthost)` and `_restore_original_config(...)` as module-level functions (clear backup/restore pair)
- Extracted `_shutdown_lag_members(...)` as a module-level function; class method becomes a thin wrapper
- Added `manage_lag_config` fixture that takes `duthosts`, `tbinfo`, `nbrhosts`, `setup_pfc_test` as parameters — runs backup+shutdown in setup phase, restore in teardown phase
- Removed all explicit backup/restore calls from `test_pfcwd_show_stat`

#### How did you verify/test it?
Code review and static analysis. Logic is identical to the original — only the execution lifecycle is corrected.
https://elastictest.org/scheduler/testplan/69b283c788eba34838db536b

#### Any platform specific information?
None — applies to all platforms using portchannel test port type.

#### Supported testbed topology if it's a new test case?
N/A (improvement to existing test)

### Documentation

N/A