### PR TITLE
Ignore pmon DomInfoUpdateTask VDM basic real values error in loganalyzer

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -419,6 +419,8 @@ r, ".*ERR pmon.*Failed to freeze VDM stats in contextmanager for port.*"
 r, ".*ERR pmon.*Failed to freeze VDM stats for port.*"
 r, ".*ERR pmon.*Failed to confirm VDM unfreeze status for port.*"
 r, ".*ERR pmon.*Failed to unfreeze VDM stats in contextmanager for port.*"
+# https://github.com/aristanetworks/sonic-qual.msft/issues/1156
+r, ".*ERR pmon#DomInfoUpdateTask.*Failed to get VDM basic real values for port.*"
 
 # https://github.com/sonic-net/sonic-buildimage/issues/21186
 r, ".*ERR bgp\#bgpmon:\s+\*ERROR\*\s+Failed\s+with\s+rc:\d+\s+when\s+execute:\s+.*vtysh.*-c.*show\s+bgp\s+summary\s+json.*"


### PR DESCRIPTION
## Why I did it

`pmon#DomInfoUpdateTask` periodically logs ERR-level messages on some platforms when a port does not support VDM basic real values:

```
ERR pmon#DomInfoUpdateTask[43671]: Failed to get VDM basic real values for port 64
```

This causes LogAnalyzer to fail tests that are otherwise functionally passing.

Tracking issue: https://github.com/aristanetworks/sonic-qual.msft/issues/1156

## How I did it

Added an ignore pattern for `Failed to get VDM basic real values for port` in `loganalyzer_common_ignore.txt`.

Note: `tests/common/plugins/loganalyzer/loganalyzer_common_ignore.txt` is a symlink to `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt`, so only one file change is needed.

## How to verify it

Run any test that was previously failing due to this pmon error on a DUT with LogAnalyzer enabled  it should no longer be flagged as a failure.