### PR TITLE
[SmartSwitch] Update the dash PL test for "turn on/off VxLAN SRC_PORT Range filtering"

### DIFF
--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -413,7 +413,8 @@ def set_vxlan_udp_sport_range(dpuhosts, dpu_index):
         {
             "SWITCH_TABLE:switch": {
                 "vxlan_sport": VXLAN_UDP_BASE_SRC_PORT,
-                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK
+                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK,
+                "vxlan_security": "true"
             },
             "OP": "SET"
         }
@@ -429,6 +430,28 @@ def set_vxlan_udp_sport_range(dpuhosts, dpu_index):
     yield
     if str(VXLAN_UDP_BASE_SRC_PORT) in dpuhost.shell("redis-cli -n 0 hget SWITCH_TABLE:switch vxlan_sport")['stdout']:
         config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+@pytest.fixture(scope="function")
+def disable_vxlan_security(dpuhosts, dpu_index):
+    """
+    Disable VXLAN security in dpu configuration.
+    Configuration is applied by swssconfig..
+    """
+    dpuhost = dpuhosts[dpu_index]
+    vxlan_security_config = [
+        {
+            "SWITCH_TABLE:switch": {
+                "vxlan_security": "false"
+            },
+            "OP": "SET"
+        }
+    ]
+    logger.info(f"Disabling VXLAN security: {vxlan_security_config}")
+    config_path = "/tmp/vxlan_security_config.json"
+    dpuhost.copy(content=json.dumps(vxlan_security_config, indent=4),
+                 dest=config_path, verbose=False)
+    apply_swssconfig_file(dpuhost, config_path)
 
 
 @pytest.fixture(scope="function")

--- a/tests/dash/test_dash_privatelink.py
+++ b/tests/dash/test_dash_privatelink.py
@@ -98,14 +98,22 @@ def test_privatelink_basic_transform(
     testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[LOCAL_PTF_INTF])
 
 
+@pytest.mark.parametrize("vxlan_security", ["true", "false"])
 def test_privatelink_udp_sport_range_negative(
     ptfadapter,
-    dash_pl_config
+    dash_pl_config,
+    vxlan_security,
+    request
 ):
     """
     Validate that when the VXLAN UDP source port is not in the configured
-    range, the packet is dropped by the DPU.
+    range, the packet is dropped by the DPU when vxlan_security is true.
+    When vxlan_security is false, the packet is not dropped.
     """
+    # vxlan_security is enabled by default, disable it when vxlan_security is false
+    if vxlan_security == "false":
+        request.getfixturevalue("disable_vxlan_security")
+
     vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(dash_pl_config, "vxlan")
     min_valid_sport = VXLAN_UDP_BASE_SRC_PORT
     max_valid_sport = VXLAN_UDP_BASE_SRC_PORT + 2**VXLAN_UDP_SRC_PORT_MASK - 1
@@ -117,10 +125,16 @@ def test_privatelink_udp_sport_range_negative(
                           65535]
     logger.info(f"Send the vxlan encaped outbound packets with invalid sport: \
         {invalid_sport_list}")
-    logger.info("Check the packets are all dropped.")
+
+    logger.info(f"Validate the traffic when vxlan_security is {vxlan_security}.")
     for invalid_sport in invalid_sport_list:
         vm_to_dpu_pkt[scapy.UDP].sport = invalid_sport
         ptfadapter.dataplane.flush()
         logger.info(f"Sending packet with sport: {invalid_sport}")
         testutils.send(ptfadapter, dash_pl_config[LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
-        testutils.verify_no_packet_any(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[REMOTE_PTF_RECV_INTF])
+        if vxlan_security == "true":
+            logger.info("Check the packet is dropped.")
+            testutils.verify_no_packet_any(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[REMOTE_PTF_RECV_INTF])
+        else:
+            logger.info("Check the packet is not dropped.")
+            testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[REMOTE_PTF_RECV_INTF])

--- a/tests/dash/test_dash_smartswitch_vnet.py
+++ b/tests/dash/test_dash_smartswitch_vnet.py
@@ -79,7 +79,8 @@ def set_vxlan_udp_sport_range(dpuhosts, dpu_index):
         {
             "SWITCH_TABLE:switch": {
                 "vxlan_sport": VXLAN_UDP_BASE_SRC_PORT,
-                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK
+                "vxlan_mask": VXLAN_UDP_SRC_PORT_MASK,
+                "vxlan_security": "true"
             },
             "OP": "SET"
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add a test for the security feature "turn on/off  VxLAN SRC_PORT Range filtering".
Before this feature, the VxLAN SRC_PORT Range filtering was always enabled in the DPU and could not be disabled.
With this feature, we can disable it in Sonic by setting a new attribute in config_db.

For the dash PL test, we enable the filtering by default, and we have the negative test test_privatelink_udp_sport_range_negative to cover the validation for packet drop when the VxLAN port is out of range. Now we need extend this test case to also cover the scenario that when the filtering is disabled, the out of range packets can still be forwarded.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Add a test for the security feature "turn on/off  VxLAN SRC_PORT Range filtering".
#### How did you do it?
1. set the new attribute in fixture set_vxlan_udp_sport_range
2. parameterize the test test_privatelink_udp_sport_range_negative to cover both the filtering is on/off
#### How did you verify/test it?
Run the dash PL test on SN4280 testbed, all passed.
#### Any platform specific information?
Only for smartswitch.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
