### PR TITLE
[qos] Fix broken S6100 T1 headroom pool skip condition

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4072,9 +4072,8 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
     reason: "Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100']
-       and topo_type in ['t1-64-lag'] and hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox']
-       and asic_type in ['cisco-8000']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
+      - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Arista-7260CX3-D108C10', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32S-D48C8', 'Arista-7060CX-32S-D48C8'] and asic_type not in ['mellanox'] and asic_type in ['cisco-8000']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in (constants['QOS_SAI_TOPO'] + ['t2_single_node_max', 't2_single_node_min']) and asic_type not in ['mellanox','marvell-teralynx']"
       - "asic_type in ['vs']"
@@ -4084,9 +4083,8 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
     reason: "Unsupported testbed type."
     conditions_logical_operator: or
     conditions:
-      - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc', 'x86_64-arista_7800r3ak_36dm2_lc'] or asic_type in ['mellanox']
-         and asic_type in ['cisco-8000']
-         and https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
+      - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc', 'x86_64-arista_7800r3ak_36dm2_lc'] or asic_type in ['mellanox'] and asic_type in ['cisco-8000']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "topo_name not in constants['QOS_SAI_TOPO'] and asic_type not in ['mellanox']"
       - "asic_type in ['marvell-teralynx']"


### PR DESCRIPTION
### Description of PR

Summary:
Fix broken S6100 T1 headroom pool skip condition in tests_mark_conditions.yaml. PR #14912 (Oct 2024) incorrectly merged separate OR conditions into a single AND condition, creating a logical contradiction that prevented the skip from ever triggering. This caused S6100 T1 headroom pool tests to run and fail consistently.

Fixes https://github.com/sonic-net/sonic-mgmt/issues/12292

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202503

### Approach

#### What is the motivation for this PR?

PR #14912 ("Adding conditions to longer matching entries") incorrectly merged three separate OR conditions into one AND condition for testQosSaiHeadroomPoolSize and testQosSaiHeadroomPoolWatermark:

\`\`\`
hwsku in ['Force10-S6100'] AND hwsku not in [..., 'Force10-S6100', ...] AND asic_type in ['cisco-8000']
\`\`\`

This is logically always FALSE (S6100 is in both include and exclude lists), so the skip never triggered. Since Oct 2024, S6100 T1 headroom tests have been running and failing, when they should have been skipped per issue #12292.

The original skip was added in PR #12266 (Apr 2024) because S6100 T1 headroom pool tests fail due to LAG keepalive packets consuming shared buffer. S6100 T0 and T1 share the same buffer configuration, and T0 tests pass reliably, so skipping T1 does not reduce MMU quality coverage.

#### How did you do it?

Restored the original separate OR conditions from PR #12266:
1. S6100 T1 skip: \`hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']\`
2. General unsupported SKU: \`hwsku not in [...] and asic_type not in ['mellanox']\`
3. Cisco-8000 skip: \`asic_type in ['cisco-8000']\`

Applied same fix to both testQosSaiHeadroomPoolSize and testQosSaiHeadroomPoolWatermark.

#### How did you verify/test it?

Verified by inspecting the YAML conditions. The conditions now match the original intent from PR #12266.

#### Any platform specific information?

Affects Force10-S6100 on T1 (t1-64-lag) topology only.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A