### PR TITLE
[hft] Verify countersyncd stays RUNNING after port counter capture

### DIFF
--- a/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
+++ b/tests/high_frequency_telemetry/test_high_frequency_telemetry.py
@@ -99,7 +99,9 @@ def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
                 logger.warning("Msg/s validation: "
                                "No Msg/s data found in stable output")
 
-        logger.info("Verifying supervisor restarted countersyncd in swss")
+        logger.info(
+            "Verifying countersyncd is still running in swss after HFT capture"
+        )
         countersyncd_running = wait_until(
             60,
             5,
@@ -108,19 +110,17 @@ def test_hft_port_counters(duthosts, enum_rand_one_per_hwsku_hostname,
             "countersyncd",
             "swss"
         )
-        countersyncd_status = duthost.shell(
-            "docker exec swss supervisorctl status countersyncd",
-            module_ignore_errors=True
-        )["stdout"].strip()
-        pytest_assert(
-            countersyncd_running,
-            "Expected swss:countersyncd to be RUNNING under supervisor after "
-            f"telemetry capture, but got: {countersyncd_status}"
-        )
-        logger.info(
-            "Verified swss:countersyncd is RUNNING under supervisor: %s",
-            countersyncd_status
-        )
+        if not countersyncd_running:
+            countersyncd_status = duthost.shell(
+                "docker exec swss supervisorctl status countersyncd",
+                module_ignore_errors=True
+            )["stdout"].strip()
+            pytest_assert(
+                countersyncd_running,
+                "Expected swss:countersyncd to be RUNNING under supervisor after "
+                f"telemetry capture, but got: {countersyncd_status}"
+            )
+        logger.info("Verified swss:countersyncd is RUNNING after HFT capture")
 
     finally:
         # Clean up: Remove high frequency telemetry configuration


### PR DESCRIPTION
### Description of PR

Summary:
Add a post-check to `test_hft_port_counters` so the test also verifies that `swss:countersyncd` is still `RUNNING` under supervisor after HFT telemetry capture. This turns the observed supervisor recovery regression into a direct test failure instead of relying on manual DUT inspection.

Fixes # (issue): N/A

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

Also requested for `msft-202412` via label.

### Approach
#### What is the motivation for this PR?

The existing HFT port counter test validates telemetry output, but it does not verify that the supervisor-managed `countersyncd` service remains healthy afterward. We observed a real failure mode where telemetry validation passed while `docker exec swss supervisorctl status countersyncd` still ended in `EXITED`.

#### How did you do it?

- import `wait_until`
- after `validate_counter_output(...)`, poll `duthost.is_service_running("countersyncd", "swss")` for up to 60 seconds
- if recovery does not happen, fail with the exact `supervisorctl status countersyncd` output

#### How did you verify/test it?

Validation was done on physical testbed `vms70-t0-sn5640-2` / DUT `str4-sn5640-2`.

1. With the existing DUT supervisor configuration, the updated test failed with:
   - `Expected swss:countersyncd to be RUNNING under supervisor after telemetry capture, but got: countersyncd EXITED ...`
2. After live-patching the DUT `swss` supervisor stanza to use:
   - `autorestart=unexpected`
   - `startsecs=1`
   - `startretries=3`
3. Reran:
   ```bash
   ./run_tests.sh -u -n vms70-t0-sn5640-2 -i ../ansible/str4,../ansible/veos -l info -m individual -e --skip_sanity -e --disable_loganalyzer -c "high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_port_counters"
   ```
4. Observed:
   - `1 passed`
   - `swss:countersyncd` stayed `RUNNING`

#### Any platform specific information?

- Platform: `x86_64-nvidia_sn5640-r0`
- HwSku: `Mellanox-SN5640-C512S2`
- Image: `20241212.54`

#### Supported testbed topology if it's a new test case?

Not a new test case. Validated on an existing physical `t0` testbed.

### Documentation
No documentation update required.
