### PR TITLE
Fix bfd probe interval.

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -594,8 +594,8 @@ def generate_ha_config_for_dut(switch_id: int, duthost, tbinfo):
         "VDPU": generate_vdpu_config(),
         "DASH_HA_GLOBAL_CONFIG": {
             "GLOBAL": {
-                "dpu_bfd_probe_interval_in_ms": "1000",
-                "dpu_bfd_probe_multiplier": "3",
+                "dpu_bfd_probe_interval_in_ms": "200",
+                "dpu_bfd_probe_multiplier": "5",
                 "cp_data_channel_port": "11362",
                 "dp_channel_dst_port": "11368",
                 "dp_channel_src_port_min": "7001",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
BFD probe intervals to DPU should be shorter for DPU to reduce traffic lose during link failure switchover.
Signoff: dypeters@cisco.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
BFD probe interval is currently 1s, but should be reduced so traffic loss is minimized during DPU link failure switchover.

#### How did you do it?
Move the BFD probe interval to DPUs from 1s to 200ms.

#### How did you verify/test it?
Tested switchover on HA testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
