### PR TITLE
[Default Route] Replace ip route show with show ip route in default route verification tests

### DIFF
--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -198,8 +198,8 @@ def check_bgp(duthosts, tbinfo):
 
         def _check_default_route(version, dut):
             # Return True if successfully get default route
-            res = dut.shell("ip {} route show default".format("" if version == 4 else "-6"),
-                            module_ignore_errors=True)
+            res = dut.shell("show ip{} route {}/0".format("" if version == 4 else "v6",
+                            "0.0.0.0" if version == 4 else "::"), module_ignore_errors=True)
             return not res["rc"] and len(res["stdout"].strip()) != 0
 
         def _restart_bgp(dut):

--- a/tests/common/plugins/sanity_check/constants.py
+++ b/tests/common/plugins/sanity_check/constants.py
@@ -8,7 +8,7 @@ PRINT_LOGS = {
     "neigh": "ip neigh",
     "bgpv4": "show ip bgp summary",
     "bgpv6": "show ipv6 bgp summary",
-    "routes": "ip route | wc -l",
+    "routes": "show ip route | wc -l",
     "mux_status": "show mux status",
     "mux_config": "show mux config",
 }

--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -273,7 +273,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo, test_devic
     finally:
         upper_tor_host.shell("show arp")
         lower_tor_host.shell("show arp")
-        ptfhost.shell("ip route show")
+        ptfhost.shell("show ip route")
         for conn in list(connections.values()):
             ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"], module_ignore_errors=True)
             ptfhost.shell("ip route del %s" % conn["local_addr"], module_ignore_errors=True)

--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -189,9 +189,9 @@ def check_route_redistribution(duthost, prefix, ipv6, removed=False):
 #        nexthop via fc00::2e dev PortChannel104 weight 1 pref medium
 def check_static_route(duthost, prefix, nexthop_addrs, ipv6):
     if ipv6:
-        SHOW_STATIC_ROUTE_CMD = "ip -6 route show {}".format(prefix)
+        SHOW_STATIC_ROUTE_CMD = "show ipv6 route {}".format(prefix)
     else:
-        SHOW_STATIC_ROUTE_CMD = "ip route show {}".format(prefix)
+        SHOW_STATIC_ROUTE_CMD = "show ip route {}".format(prefix)
     output = duthost.shell(SHOW_STATIC_ROUTE_CMD, module_ignore_errors=True)["stdout"].split("\n")
 
     def _check_nh_in_output(nexthop):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This PR updates default-route verification to use `show ip route` instead of `ip route show`. We were previously hitting a "buffer too small" error when running `ip route show` on full topo, which started failing silently, so switching to the SONiC CLI command avoids that failure and makes the test more reliable at scale.

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`ip route show` fails with a "buffer too small" error in full topo previously started failing silently, which causes intermittent/consistent default-route verification failures during pre-sanity checks. We want a more reliable route query mechanism for large topologies.

#### How did you do it?
Replaced calls to `ip route show` with `show ip route` in the default route verification logic while keeping the expected behavior and parsing/verification intact.

#### How did you verify/test it?
- Ran the relevant default route verification test(s) locally / in CI.
- Verified route output is correctly retrieved and parsed using `show ip route`.
- Confirmed the "buffer too small" error falsely fails the pre-sanity checks

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A (existing test coverage)

### Documentation
N/A