### PR TITLE
Temporarily skip some t0 tests covered by t1-lag to save CPU

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_skip_for_quota_shortage.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_vs_skip_for_quota_shortage.yaml
@@ -1,0 +1,85 @@
+# This file contains conditional marks to skip test cases on t0 topology in PR testing.
+# These tests are also covered by t1-lag topology, so skipping them on t0 saves CPU quota.
+# Only applies to VS (virtual switch) platform.
+# Generated based on Kusto analysis of PR test results from the last 7 days.
+
+bgp/test_bgp_update_replication.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+copp/test_copp.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+drop_packets/drop_packets.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+everflow/test_everflow_ipv6.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+everflow/test_everflow_testbed.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+ip/test_mgmt_ipv6_only.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+ntp/test_ntp.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+pfcwd/test_pfcwd_function.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+pfcwd/test_pfcwd_timer_accuracy.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+route/test_route_consistency.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+sub_port_interfaces/test_sub_port_interfaces.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"
+
+
+tacacs/test_accounting.py:
+  skip:
+    reason: "All tests covered by t1-lag topology, skip on t0 to save PR testing CPU quota"
+    conditions:
+      - "topo_type == 't0' and asic_type in ['vs']"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Due to recent CPU quota shortage in PR test, we decide to skip some tests on t0 which covered by t1-lag to save some CPU quotas.
#### How did you do it?
Query which tests files running on t0 are fully covered by t1-lag, then skip 12 longest execution test files.
#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
