### PR TITLE
Fix KeyError in QoS SAI tests for multi-VLAN topologies

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -1041,6 +1041,9 @@ class ARPpopulate(sai_base_test.ThriftInterfaceDataPlane):
             for dut_i in self.test_port_ids:
                 for asic_i in self.test_port_ids[dut_i]:
                     for dst_port_id in self.test_port_ids[dut_i][asic_i]:
+                        # Skip ports that don't have IP configuration (e.g., in multi-VLAN topologies like t0-118)
+                        if dst_port_id not in self.test_port_ips.get(dut_i, {}).get(asic_i, {}):
+                            continue
                         dst_port_ip = self.test_port_ips[dut_i][asic_i][dst_port_id]
                         dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
                         arpreq_pkt = construct_arp_pkt('ff:ff:ff:ff:ff:ff', dst_port_mac,
@@ -1077,6 +1080,9 @@ class ARPpopulateIPv6(ARPpopulate):
         for dut_i in self.test_port_ids:
             for asic_i in self.test_port_ids[dut_i]:
                 for dst_port_id in self.test_port_ids[dut_i][asic_i]:
+                    # Skip ports that don't have IP configuration (e.g., in multi-VLAN topologies like t0-118)
+                    if dst_port_id not in self.test_port_ips.get(dut_i, {}).get(asic_i, {}):
+                        continue
                     dst_port_ip = self.test_port_ips[dut_i][asic_i][dst_port_id]
                     dst_port_mac = self.dataplane.get_mac(0, dst_port_id)
                     arpreq_pkt = construct_ns_pkt(dst_port_mac, dst_port_ip['peer_addr'])


### PR DESCRIPTION
Fixes #17228

This PR fixes a KeyError: 63 crash in the QoS SAI test suite when running on multi-VLAN topologies like t0-118. The test was attempting to access port IP configurations that don't exist for all ports in multi-VLAN setups.

Type of change
- Bug fix
- Testbed and Framework(new/improvement)
- New Test case
- Skipped for non-supported platforms
- Test case improvement

Back port request
- 202205
- 202305
- 202311
- 202405
- 202411
- 202505
- 202511

Approach
What is the motivation for this PR?
The test qos/test_qos_sai.py::TestQosSai was failing on the t0-118 topology with the following error:
KeyError: 63
File "tests/saitests/py3/sai_qos_tests.py", line 1044, in runTest
    dst_port_ip = self.test_port_ips[dut_i][asic_i][dst_port_id]

Root Cause:
- The t0-118 topology uses 2 VLANs by default (unlike standard T0 topologies)
- The test iterates through all ports in self.test_port_ids (which contains 64 ports: 0-63)
- However, self.test_port_ips only contains entries for ports that have IP configurations
- In multi-VLAN topologies, some ports don't have IP configurations and are missing from test_port_ips
- When the test tries to access port 63 (or any other unconfigured port), it crashes with a KeyError

How did you do it?
Added defensive checks in both ARPpopulate (IPv4) and ARPpopulateIPv6 (IPv6) classes to skip ports that don't have IP configuration:

Before:
for dst_port_id in self.test_port_ids[dut_i][asic_i]:
    dst_port_ip = self.test_port_ips[dut_i][asic_i][dst_port_id]  # KeyError here!
    # ... send ARP/NS packets

After:
for dst_port_id in self.test_port_ids[dut_i][asic_i]:
    # Skip ports that don't have IP configuration (e.g., in multi-VLAN topologies like t0-118)
    if dst_port_id not in self.test_port_ips.get(dut_i, {}).get(asic_i, {}):
        continue
    dst_port_ip = self.test_port_ips[dut_i][asic_i][dst_port_id]
    # ... send ARP/NS packets

Changes:
1. Added port existence check in ARPpopulate.runTest() (line 1044) for IPv4 ARP population
2. Added port existence check in ARPpopulateIPv6.runTest() (line 1080) for IPv6 NS population

How did you verify/test it?
Testing Plan:
1. Existing topologies: The fix is backward compatible - it only skips ports that are missing from test_port_ips, so standard T0/T1/T2 topologies will continue to work as before
2. Multi-VLAN topologies: The test will now skip unconfigured ports instead of crashing, allowing QoS SAI tests to run successfully on t0-118 and similar multi-VLAN setups


Verification:
- The fix uses safe dictionary access with .get() to prevent KeyError at any nesting level
- Only ports that exist in both test_port_ids AND test_port_ips will have ARP/NS packets sent
- Ports without IP configuration are safely skipped

Any platform specific information?
Affected Topologies:

- ✅ t0-118: Primary affected topology (uses 2 VLANs)
- ✅ Any multi-VLAN topology: Where test_port_ids contains more ports than test_port_ips

Unaffected Topologies:
- ✅ Standard T0/T1/T2: These topologies have 1:1 mapping between test_port_ids and test_port_ips, so the check will always pass

Supported testbed topology if it's a new test case?
N/A - This is a bug fix for existing test cases, not a new test case.

Supported topologies after this fix:

- T0 (standard)
- T0-118 (multi-VLAN) ✅ Now supported
- T1
- T2
- Any other topology with proper port configuration

Documentation
No documentation changes required - this is an internal test fix that doesn't change any user-facing behavior or APIs.