### PR TITLE
[202305] syslog rate limit hits race condition between log generate and new spawn rsyslogd

### DIFF
--- a/tests/syslog/test_syslog_rate_limit.py
+++ b/tests/syslog/test_syslog_rate_limit.py
@@ -289,14 +289,24 @@ def wait_rsyslogd_restart(duthost, service_name, old_pid):
     wait_time = 30
     while wait_time > 0:
         wait_time -= 1
-        if get_rsyslogd_pid(duthost, service_name) == old_pid:
+        # Check if new PID obtained (old process replaced)
+        new_pid = get_rsyslogd_pid(duthost, service_name)
+        if not new_pid or new_pid == old_pid:
             time.sleep(1)
             continue
 
         output = duthost.command(cmd, module_ignore_errors=True)['stdout'].strip()
         if 'RUNNING' in output:
-            logger.info('Rsyslogd restarted')
-            return True
+            logger.info('Rsyslogd restarted with new PID: {}'.format(new_pid))
+            # Test if rsyslog is actually ready by sending a test log message
+            test_cmd = "docker exec -i {} bash -c 'echo test | logger -t rate-limit-test'".format(service_name)
+            result = duthost.command(test_cmd, module_ignore_errors=True)
+            if result.get('rc', 1) == 0:
+                logger.info('Rsyslogd restarted and ready')
+                return True
+            else:
+                logger.info('Rsyslog not ready yet, test log failed')
+                continue
 
         time.sleep(1)
 


### PR DESCRIPTION
Cherry-pick of #21573 to 202305 branch.

### Description of PR
Backport of #21573 - Fix race condition in test_syslog_rate_limit between log_generate and newly spawned rsyslogd.

### Type of change
- [x] Bug fix
- [x] Test case improvement

### Original PR
https://github.com/sonic-net/sonic-mgmt/pull/21573