### PR TITLE
[202511] Fix test_bgp_suppress_fib.py for v6 topos

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -631,7 +631,10 @@ def get_eth_port(duthost, tbinfo):
     """
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     t0_vm = [vm_name for vm_name in mg_facts['minigraph_devices'].keys() if vm_name.endswith('T0')][0]
-    port = duthost.shell("show ip interface | grep -w {} | awk '{{print $1}}'".format(t0_vm))['stdout']
+    if is_ipv6_only_topology(tbinfo):
+        port = duthost.shell("show ipv6 interface | grep -w {} | awk '{{print $1}}'".format(t0_vm))['stdout']
+    else:
+        port = duthost.shell("show ip interface | grep -w {} | awk '{{print $1}}'".format(t0_vm))['stdout']
     return port
 
 

--- a/tests/bgp/test_bgp_suppress_fib.py
+++ b/tests/bgp/test_bgp_suppress_fib.py
@@ -18,6 +18,7 @@ from ptf.mask import Mask
 from natsort import natsorted
 from tests.common.reboot import reboot
 from tests.common.utilities import wait_until
+from tests.common.utilities import is_ipv6_only_topology
 from tests.common.config_reload import config_reload
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.tcpdump_sniff_helper import TcpdumpSniffHelper
@@ -56,6 +57,7 @@ DEFAULT = "default"
 VRF_TYPES = [DEFAULT, USER_DEFINED_VRF]
 BGP_FILTER = 'tcp port 179'
 STATIC_ROUTE_PREFIX = "1.1.1.0/24"
+STATIC_ROUTE_PREFIX_V6 = "2001:db8:1:1::/64"
 BASE_IP_ROUTE = '91.0.1.0/24'
 BASE_IPV6_ROUTE = '1000:1001::/64'
 BULK_ROUTE_COUNT = 512  # 512 ipv4 route and 512 ipv6 route
@@ -93,14 +95,18 @@ def topo_has_spine_layer(tbinfo):
 
 
 @pytest.fixture(scope="module")
-def generate_route_and_traffic_data():
+def generate_route_and_traffic_data(tbinfo):
     """
     Generate route and traffic data
     """
-    ip_routes_ipv4 = generate_routes(BASE_IP_ROUTE)
-    ip_routes_ipv6 = generate_routes(BASE_IPV6_ROUTE)
+    if is_ipv6_only_topology(tbinfo):
+        ip_routes_ipv4 = []
+        ipv4_routes_stress_and_perf = []
+    else:
+        ip_routes_ipv4 = generate_routes(BASE_IP_ROUTE)
+        ipv4_routes_stress_and_perf = generate_routes(BASE_IP_ROUTE, BULK_ROUTE_COUNT)
 
-    ipv4_routes_stress_and_perf = generate_routes(BASE_IP_ROUTE, BULK_ROUTE_COUNT)
+    ip_routes_ipv6 = generate_routes(BASE_IPV6_ROUTE)
     ipv6_routes_stress_and_perf = generate_routes(BASE_IPV6_ROUTE, BULK_ROUTE_COUNT)
 
     route_and_traffic_data = {
@@ -336,14 +342,17 @@ def check_interface_status(duthost, expected_oper='up'):
     return True
 
 
-def get_port_connected_with_vm(duthost, nbrhosts, vm_type='T0'):
+def get_port_connected_with_vm(duthost, tbinfo, nbrhosts, vm_type='T0'):
     """
     Get ports that connects with T0 VM
     """
     port_list = []
     vm_list = [vm_name for vm_name in nbrhosts.keys() if vm_name.endswith(vm_type)]
     for vm in vm_list:
-        port = duthost.shell("show ip interface | grep -w {} | awk '{{print $1}}'".format(vm))['stdout']
+        if is_ipv6_only_topology(tbinfo):
+            port = duthost.shell("show ipv6 interface | grep -w {} | awk '{{print $1}}'".format(vm))['stdout']
+        else:
+            port = duthost.shell("show ip interface | grep -w {} | awk '{{print $1}}'".format(vm))['stdout']
         port_list.append(port)
     logger.info("Ports connected with {} VMs: {}".format(vm_type, port_list))
     return port_list
@@ -371,12 +380,12 @@ def setup_vrf_cfg(duthost, cfg_facts, nbrhosts, tbinfo, loganalyzer):
     for bgp_neighbor in cfg_t1['BGP_NEIGHBOR']:
         cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('nhopself', None)
         cfg_t1['BGP_NEIGHBOR'][bgp_neighbor].pop('rrclient', None)
-    port_list = get_port_connected_with_vm(duthost, nbrhosts)
+    port_list = get_port_connected_with_vm(duthost, tbinfo, nbrhosts)
     vm_list = nbrhosts.keys()
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     port_channel_list = mg_facts['minigraph_portchannels'].keys()
     if len(port_channel_list) == 0:
-        upstream_port_list = get_port_connected_with_vm(duthost, nbrhosts, vm_type="T2")
+        upstream_port_list = get_port_connected_with_vm(duthost, tbinfo, nbrhosts, vm_type="T2")
         port_list.extend(upstream_port_list)
 
     extra_vars = {'cfg_t1': cfg_t1, 'port_list': port_list, 'vm_list': vm_list, 'pc_list': port_channel_list}
@@ -689,8 +698,10 @@ def announce_ipv4_ipv6_routes(ptf_ip, ipv4_route_list, exabgp_port, ipv6_route_l
     """
     Announce or withdraw ipv4 and ipv6 routes by exabgp
     """
-    announce_route(ptf_ip, ipv4_route_list, exabgp_port, action)
-    announce_route(ptf_ip, ipv6_route_list, exabgp_port_v6, action)
+    if ipv4_route_list:
+        announce_route(ptf_ip, ipv4_route_list, exabgp_port, action)
+    if ipv6_route_list:
+        announce_route(ptf_ip, ipv6_route_list, exabgp_port_v6, action)
 
 
 def config_bgp_suppress_fib(duthost, enable=True, validate_result=False):
@@ -782,35 +793,43 @@ def validate_route_propagate(duthost, nbrhosts, tbinfo, ipv4_route_list, ipv6_ro
     t2_vm_list = get_vm_name_list(tbinfo)
     for t2_vm in t2_vm_list:
         bgp_neighbor_v4, bgp_neighbor_v6 = get_bgp_neighbor_ip(duthost, t2_vm, vrf)
-        validate_route_propagate_status(nbrhosts[t2_vm], ipv4_route_list, bgp_neighbor_v4, vrf, exist=exist)
+        if not is_ipv6_only_topology:
+            validate_route_propagate_status(nbrhosts[t2_vm], ipv4_route_list, bgp_neighbor_v4, vrf, exist=exist)
         validate_route_propagate_status(nbrhosts[t2_vm], ipv6_route_list, bgp_neighbor_v6, vrf, ip_ver=IPV6_VER,
                                         exist=exist)
 
 
-def redistribute_static_route_to_bgp(duthost, redistribute=True):
+def redistribute_static_route_to_bgp(duthost, is_v6_topo, redistribute=True):
     """
     Enable or disable redistribute static route to BGP
     """
     vtysh_cmd = "sudo vtysh"
     config_terminal = " -c 'config'"
     enter_bgp_mode = " -c 'router bgp'"
-    enter_address_family_ipv4 = " -c 'address-family ipv4'"
+    if is_v6_topo:
+        enter_address_family = " -c 'address-family ipv6'"
+    else:
+        enter_address_family = " -c 'address-family ipv4'"
     redistribute_static = " -c 'redistribute static'"
     no_redistribute_static = " -c 'no redistribute static'"
     if redistribute:
-        duthost.shell(vtysh_cmd + config_terminal + enter_bgp_mode + enter_address_family_ipv4 + redistribute_static)
+        duthost.shell(vtysh_cmd + config_terminal + enter_bgp_mode + enter_address_family + redistribute_static)
     else:
-        duthost.shell(vtysh_cmd + config_terminal + enter_bgp_mode + enter_address_family_ipv4 + no_redistribute_static)
+        duthost.shell(vtysh_cmd + config_terminal + enter_bgp_mode + enter_address_family + no_redistribute_static)
 
 
-def remove_static_route_and_redistribute(duthost):
+def remove_static_route_and_redistribute(duthost, is_v6_topo):
     """
     Remove static route and stop redistribute it to BGP
     """
-    out = duthost.shell("show ip route {}".format(STATIC_ROUTE_PREFIX), verbose=False)['stdout']
+    if is_v6_topo:
+        out = duthost.shell("show ipv6 route {}".format(STATIC_ROUTE_PREFIX_V6), verbose=False)['stdout']
+    else:
+        out = duthost.shell("show ip route {}".format(STATIC_ROUTE_PREFIX), verbose=False)['stdout']
     if STATIC_ROUTE_PREFIX in out:
-        duthost.shell("sudo config route del prefix {}".format(STATIC_ROUTE_PREFIX))
-        redistribute_static_route_to_bgp(duthost, redistribute=False)
+        duthost.shell("sudo config route del prefix {}".
+                      format(STATIC_ROUTE_PREFIX_V6 if is_v6_topo else STATIC_ROUTE_PREFIX))
+        redistribute_static_route_to_bgp(duthost, is_v6_topo, redistribute=False)
 
 
 def bgp_route_flap_with_stress(duthost, tbinfo, nbrhosts, ptf_ip, ipv4_route_list, exabgp_port, ipv6_route_list,
@@ -833,8 +852,8 @@ def bgp_route_flap_with_stress(duthost, tbinfo, nbrhosts, ptf_ip, ipv4_route_lis
             check_bgp_neighbor(duthost)
 
 
-def perf_sniffer_prepare(tcpdump_sniffer, duthost, nbrhosts, mg_facts, recv_port):
-    eths_to_t2_vm = get_port_connected_with_vm(duthost, nbrhosts, vm_type='T2')
+def perf_sniffer_prepare(tcpdump_sniffer, duthost, tbinfo, nbrhosts, mg_facts, recv_port):
+    eths_to_t2_vm = get_port_connected_with_vm(duthost, tbinfo, nbrhosts, vm_type='T2')
     eths_to_t0_vm = get_eth_name_from_ptf_port(mg_facts, [port for port in recv_port.values()])
     tcpdump_sniffer.out_direct_ifaces = [random.choice(eths_to_t2_vm)]
     tcpdump_sniffer.in_direct_ifaces = eths_to_t0_vm
@@ -980,6 +999,7 @@ def test_bgp_route_without_suppress(duthost, tbinfo, nbrhosts, ptfadapter, prepa
 def test_bgp_route_with_suppress_negative_operation(duthost, tbinfo, nbrhosts, ptfadapter, localhost, prepare_param,
                                                     restore_bgp_suppress_fib, generate_route_and_traffic_data,
                                                     loganalyzer):
+    is_v6_topo = is_ipv6_only_topology(tbinfo)
     try:
         with allure.step("Prepare needed parameters"):
             router_mac, mg_facts, ptf_ip, exabgp_port_list, exabgp_port_list_v6, recv_port_list = prepare_param
@@ -1015,12 +1035,16 @@ def test_bgp_route_with_suppress_negative_operation(duthost, tbinfo, nbrhosts, p
                 with allure.step("Config static route and redistribute to BGP"):
                     port = get_eth_port(duthost, tbinfo)
                     logger.info("Config static route - sudo config route add prefix {} nexthop dev {}".
-                                format(STATIC_ROUTE_PREFIX, port))
-                    duthost.shell("sudo config route add prefix {} nexthop dev {}".format(STATIC_ROUTE_PREFIX, port))
-                    redistribute_static_route_to_bgp(duthost)
+                                format(STATIC_ROUTE_PREFIX_V6 if is_v6_topo else STATIC_ROUTE_PREFIX, port))
+                    duthost.shell("sudo config route add prefix {} nexthop dev {}".
+                                  format(STATIC_ROUTE_PREFIX_V6 if is_v6_topo else STATIC_ROUTE_PREFIX, port))
+                    redistribute_static_route_to_bgp(duthost, is_v6_topo)
 
                 with allure.step("Validate redistributed static route is propagate to T2 VM peer"):
-                    validate_route_propagate(duthost, nbrhosts, tbinfo, [STATIC_ROUTE_PREFIX], [])
+                    if is_v6_topo:
+                        validate_route_propagate(duthost, nbrhosts, tbinfo, [], [STATIC_ROUTE_PREFIX_V6])
+                    else:
+                        validate_route_propagate(duthost, nbrhosts, tbinfo, [STATIC_ROUTE_PREFIX], [])
 
                 with allure.step("Validate traffic could not be forwarded to T0 VM"):
                     ptf_interfaces = get_t2_ptf_intfs(mg_facts)
@@ -1050,7 +1074,7 @@ def test_bgp_route_with_suppress_negative_operation(duthost, tbinfo, nbrhosts, p
                                               action=WITHDRAW)
     finally:
         with allure.step("Delete static route and remove redistribute to BGP"):
-            remove_static_route_and_redistribute(duthost)
+            remove_static_route_and_redistribute(duthost, is_v6_topo)
 
 
 def test_credit_loop(duthost, tbinfo, nbrhosts, ptfadapter, prepare_param, generate_route_and_traffic_data,
@@ -1200,7 +1224,7 @@ def test_suppress_fib_performance(tcpdump_helper, duthost, tbinfo, nbrhosts, ptf
 
             with allure.step("Start sniffer"):
                 tcpdump_sniffer = tcpdump_helper
-                perf_sniffer_prepare(tcpdump_sniffer, duthost, nbrhosts, mg_facts, recv_port)
+                perf_sniffer_prepare(tcpdump_sniffer, duthost, tbinfo, nbrhosts, mg_facts, recv_port)
                 tcpdump_sniffer.start_sniffer(host='dut')
 
             with allure.step(f"Announce BGP ipv4 and ipv6 routes to DUT from T0 VM by ExaBGP - "


### PR DESCRIPTION
Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/21772

---

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip v4 route checks and add v6 version of commands for v6 topos
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_bgp_suppress_fib.py failed on v6 topos

#### How did you do it?
Modify the test to only do v6 checks

#### How did you verify/test it?
The test passed on v6 topos

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->