### PR TITLE
[202511] Fix test_decap.py for v6 topos

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -786,11 +786,9 @@ db_migrator/test_migrate_dns.py::test_migrate_dns_03:
 #######################################
 decap/test_decap.py:
   skip:
-    reason: 'Skip on t1-isolated-d32/128 and v6 topos'
-    conditions_logical_operator: or
+    reason: 'Skip on t1-isolated-d32/128 topos'
     conditions:
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
-      - "'-v6-' in topo_name"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
   skip:

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -27,6 +27,7 @@ from tests.common.fixtures.fib_utils import single_fib_for_duts             # no
 from tests.ptf_runner import ptf_runner
 from tests.common.dualtor.mux_simulator_control import mux_server_url       # noqa: F401
 from tests.common.utilities import wait, setup_ferret
+from tests.common.utilities import is_ipv6_only_topology
 from tests.common.dualtor.dual_tor_common import active_active_ports                                # noqa: F401
 from tests.common.dualtor.dual_tor_common import active_standby_ports                               # noqa: F401
 from tests.common.dualtor.dual_tor_common import mux_config                                         # noqa: F401
@@ -81,13 +82,21 @@ def restore_default_decap_cfg(duthosts):
 
 
 @pytest.fixture(scope='module')
-def ip_ver(request):
-    return {
-        "outer_ipv4": to_bool(request.config.getoption("outer_ipv4")),
-        "outer_ipv6": to_bool(request.config.getoption("outer_ipv6")),
-        "inner_ipv4": to_bool(request.config.getoption("inner_ipv4")),
-        "inner_ipv6": to_bool(request.config.getoption("inner_ipv6")),
-    }
+def ip_ver(request, tbinfo):
+    if is_ipv6_only_topology(tbinfo):
+        return {
+            "outer_ipv4": False,
+            "outer_ipv6": to_bool(request.config.getoption("outer_ipv6")),
+            "inner_ipv4": False,
+            "inner_ipv6": to_bool(request.config.getoption("inner_ipv6")),
+        }
+    else:
+        return {
+            "outer_ipv4": to_bool(request.config.getoption("outer_ipv4")),
+            "outer_ipv6": to_bool(request.config.getoption("outer_ipv6")),
+            "inner_ipv4": to_bool(request.config.getoption("inner_ipv4")),
+            "inner_ipv6": to_bool(request.config.getoption("inner_ipv6")),
+        }
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix decap tests for v6 topos by setting IPv4 flags to false
Remove test_decap.py skip condition for v6 topos in tests_mark_conditions.yaml
Manual cherry-pick of #21761
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [x] 202412
- [x] 202505

### Approach
#### What is the motivation for this PR?
test_decap.py failed on v6 topos

#### How did you do it?
Set IPv4 flags to false

#### How did you verify/test it?
The test passed on V6 topos

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
