### PR TITLE
[Everflow] Use `shutdown_ebgp` to fix interlocking

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -26,7 +26,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 from tests.common.macsec.macsec_helper import MACSEC_INFO
 from tests.common.dualtor.dual_tor_common import mux_config              # noqa: F401
 from tests.common.helpers.sonic_db import AsicDbCli
-from tests.common.fixtures.duthost_utils import shutdown_ebgp # noqa: F401
+from tests.common.fixtures.duthost_utils import shutdown_ebgp          # noqa: F401
 import json
 
 logger = logging.getLogger(__name__)
@@ -407,7 +407,8 @@ def get_queue_counters(dut, asic_ns, port, queue):
 
 
 @pytest.fixture(scope="module")
-def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario, shutdown_ebgp):
+def setup_info(duthosts, rand_one_dut_hostname, tbinfo, request, topo_scenario,
+               shutdown_ebgp):  # noqa: F811
     """
     Gather all required test information.
 


### PR DESCRIPTION
Details in: https://github.com/sonic-net/sonic-mgmt/issues/22947

On high scale systems (ports & routes) `test_everflow_ipv6.py` would see initial testlets failing because the `config shutdown bgp all` command hasn't completed removing all it's routes before the test went ahead with injecting packets.
The `shutdown_ebgp` function already has interlocks to wait for the routes to be removed from all neighbors and the OA process to complete it's transactions before completing.

Summary:
Fixes #22947 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511