### PR TITLE
Fixes for test_pfcwd_cli.py for Cisco-8000 asic

### DIFF
--- a/tests/pfcwd/test_pfcwd_cli.py
+++ b/tests/pfcwd/test_pfcwd_cli.py
@@ -139,6 +139,12 @@ class SetupPfcwdFunc(object):
             self.ptf.command("ip -6 neigh flush all")
             self.dut.command("ip neigh flush all")
             self.dut.command("ip -6 neigh flush all")
+            # Prevent ARP replies from PTF interfaces that don't own the target IP.
+            # All vlan member ports share the same neighbor IP (e.g. 192.168.0.2).
+            # Without arp_ignore=1, the PTF kernel responds to ARP on every interface
+            # (default arp_ignore=0), causing the DUT to associate the IP with whichever
+            # port's reply arrives last -- typically the wrong port.
+            self.ptf.command("sysctl -w net.ipv4.conf.all.arp_ignore=1")
             if ip_version == "IPv4":
                 self.ptf.command("ifconfig {} {}".format(ptf_port, self.pfc_wd['test_neighbor_addr']))
                 self.ptf.command("ping {} -c 10".format(vlan['addr']))
@@ -430,11 +436,13 @@ class TestPfcwdFunc(SetupPfcwdFunc):
 
             self.storm_hndle.start_storm()
 
-        logger.info("Verify if PFC storm is detected on port {}".format(port))
-        pytest_assert(
-            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, dut, port, self.storm_hndle.pfc_queue_idx, "storm"),  # noqa: E501
-            "PFC storm state did not change as expected"
-        )
+            # For devices that require traffic, the detection loop must be within the
+            # send_background_traffic context to continue sending traffic.
+            logger.info("Verify if PFC storm is detected on port {}".format(port))
+            pytest_assert(
+                wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, dut, port, self.storm_hndle.pfc_queue_idx, "storm"),  # noqa: E501
+                "PFC storm state did not change as expected"
+            )
 
     def storm_restore_path(self, dut, port):
         """


### PR DESCRIPTION



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Some fixes for `pfcwd/test_pfcwd_cli.py`:
- Add `arp_ignore=1` to avoid the wrong VLAN interface responding to the IPv4 arp, causing a race condition that results in background traffic being forwarded to the wrong interface, causing PFC-WD to not trigger. 
- Fix the background traffic loop context which needs the detection loop to still be sending background traffic. Results in the same failure message, "PFC storm state did not change", caused by background traffic immediately stopping. Since the WD didn't have enough time to fire before the background traffic stopped, test fails. 

Sample failure message that this fixes:
```
>       pytest_assert(
            wait_until(30, 2, 5, verify_pfc_storm_in_expected_state, dut, port, self.storm_hndle.pfc_queue_idx, "storm"),  # noqa: E501
            "PFC storm state did not change as expected"
        )
E       Failed: PFC storm state did not change as expected
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on T0 Cisco8102 confirmed to get past the WD-detection issue on the 202511 branch. 
There's some other issues needed to workaround to get a full pass:
- Open issue with the PFC-WD RX count for Cisco8000, causes an "RX OK count does not match" error. 
- "_lock" attribute issue in common infra
- IPv6 test has an issue that's xfailed due to another bug (#21082)

#### Any platform specific information?

ARP issue is specific to VLAN topos (T0 for example) with IPv4. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
