### PR TITLE
[HA][smartswitch] ha test workaround for the neigh resolve issue

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -734,7 +734,8 @@ def setup_dash_ha_from_json(duthosts):
     for i in range(len(duthosts)):
         logger.info(f"Sending ping to DPU0 for {duthosts[i].hostname}")
         ip_part = 200 + i
-        duthosts[i].shell(f"ping -c 3 20.0.{ip_part}.1")
+        ping_result = duthosts[i].shell(f"ping -c 3 20.0.{ip_part}.1", module_ignore_errors=True)["stdout"]
+        logger.info(f"{duthosts[i].hostname} ping_result [{ping_result}]")
 
     with open(ha_set_file) as f:
         ha_set_data = json.load(f)["DASH_HA_SET_CONFIG_TABLE"]


### PR DESCRIPTION
### Description of PR
Summary:
neigh resolve is not working without interface name with VLAN interface so the ha traffic tests will fail.
Need to introduce a ping before HA configuration

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
neigh resolve is not working without interface name with VLAN interface so the ha traffic tests will fail.
#### How did you do it?
Added ping for the DUT1 and DUT2 in HA topology

#### How did you verify/test it?
Run the steady traffic test
#### Any platform specific information?
MtFuji HA
#### Supported testbed topology if it's a new test case?
HA 
### Documentation
N/A
