### PR TITLE
[202511 cherry pick] disable ipv6 RA for DUT facing interfaces. (#21811)

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -13,6 +13,7 @@ for INTF in ${INTF_LIST}; do
 
     echo "Update ${INTF} MAC address: ${ADDR}->$MAC"
     # bringing the device down/up to trigger ipv6 link local address change
+    sysctl -w net.ipv6.conf.${INTF}.accept_ra_defrtr=0
     ip link set dev ${INTF} down
     ip link set dev ${INTF} address ${MAC}
     ip link set dev ${INTF} up


### PR DESCRIPTION
Manual cherry pick: https://github.com/sonic-net/sonic-mgmt/pull/21811

Summary:
PTF may see multiple default IPv6 routes coming from DUT due to RA packets. which will cause a routing issue on the PTF for IPv6 packets as the traffic may be sent to DUT unexpectedly.

One example is that the ipv6 traffic coming in via mgmt interface, may choose one of the interfaces towards DUT to send the traffic back which is not intended.

This PR fix this routing behavior so that PTF doesn't rely on default routes learned via RA from DUT interfaces.

following is the output in PTF when RA routes are accepted on eth interfaces.

root@41d9f9447440:~# ip -6 route
......
default via fe80::a67a:72ff:fe55:1efc dev eth113 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth129 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth144 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth64 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth101 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth121 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth80 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth124 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth104 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth72 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth112 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth97 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth89 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth128 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth36 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth81 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth120 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth69 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth100 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth32 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth109 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth76 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth85 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth84 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth125 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth61 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth116 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth108 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth92 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth88 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth148 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth68 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth105 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth77 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth73 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth117 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth96 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth65 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth93 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium default via fe80::a67a:72ff:fe55:1efc dev eth60 proto ra metric 1024 expires 530sec mtu 9100 hoplimit 64 pref medium root@41d9f9447440:~#

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
