### PR TITLE
[202511][DASH] Improve FNIC test case for Privatelink (#22288)

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -104,10 +104,6 @@ class MultiAsicSonicHost(object):
 
         # Update the asic service based on feature table state and asic flag
         for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
-            if service == 'teamd' and is_dpu:
-                logger.info("Removing teamd from default services for switch_type DPU")
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
-                continue
             if service not in config_facts['FEATURE']:
                 self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                 continue

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -87,8 +87,15 @@ class SonicHost(AnsibleHostBase):
         self._os_version = self._get_os_version()
 
         device_metadata = self.get_running_config_facts().get('DEVICE_METADATA', {}).get('localhost', {})
+        switch_type = device_metadata.get('switch_type', '')
         device_type = device_metadata.get('type')
         device_subtype = device_metadata.get('subtype')
+
+        if switch_type == "dpu":
+            logger.info("Removing teamd and lldp from default services for switch_type DPU")
+            self.DEFAULT_ASIC_SERVICES.remove("lldp")
+            self.DEFAULT_ASIC_SERVICES.remove("teamd")
+
         if (device_type == 'UpperSpineRouter') or (device_subtype in ['UpstreamLC', 'DownstreamLC']):
             self.DEFAULT_ASIC_SERVICES.append("macsec")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3810,7 +3810,9 @@ def yang_validation_check(request, duthosts):
     skip_yang = request.config.getoption("--skip_yang")
 
     if skip_yang:
-        logger.info("Skipping YANG validation check due to --skip_yang flag")
+        logger.info("Skipping YANG validation pre-check due to --skip_yang flag")
+        yield
+        logger.info("Skipping YANG validation post-check due to --skip_yang flag")
         return
 
     def run_yang_validation(stage):

--- a/tests/dash/configs/privatelink_config.py
+++ b/tests/dash/configs/privatelink_config.py
@@ -74,7 +74,7 @@ APPLIANCE_CONFIG = {
         "sip": APPLIANCE_VIP,
         "vm_vni": VM_VNI,
         "local_region_id": LOCAL_REGION_ID,
-        "trusted_vnis": [ENCAP_VNI, NSG_OUTBOUND_VNI],
+        "trusted_vnis_list": [ENCAP_VNI, NSG_OUTBOUND_VNI],
     }
 }
 
@@ -84,7 +84,7 @@ APPLIANCE_FNIC_CONFIG = {
         "vm_vni": VM_VNI,
         "outbound_direction_lookup": OUTBOUND_DIR_LOOKUP,
         "local_region_id": LOCAL_REGION_ID,
-        "trusted_vnis": ENCAP_VNI
+        "trusted_vnis_list": [ENCAP_VNI]
     }
 }
 
@@ -113,7 +113,21 @@ ENI_FNIC_CONFIG = {
         "pl_sip_encoding": f"{PL_ENCODING_IP}/{PL_ENCODING_MASK}",
         "eni_mode": EniMode.MODE_FNIC,
         "v4_meter_policy_id": METER_POLICY_V4,
-        "trusted_vnis": ENI_TRUSTED_VNI,
+        "trusted_vnis_list": [ENI_TRUSTED_VNI],
+    }
+}
+
+ENI_FNIC_PL_CONFIG = {
+    f"DASH_ENI_TABLE:{ENI_ID}": {
+        "vnet": VNET1,
+        "underlay_ip": VM1_PA,
+        "mac_address": ENI_MAC,
+        "eni_id": ENI_ID2,
+        "admin_state": State.STATE_ENABLED,
+        "pl_underlay_sip": APPLIANCE_VIP,
+        "pl_sip_encoding": f"{PL_ENCODING_IP}/{PL_ENCODING_MASK}",
+        "eni_mode": EniMode.MODE_FNIC,
+        "trusted_vnis_list": [VNET1_VNI],
     }
 }
 
@@ -127,7 +141,7 @@ ENI_CONFIG = {
         "pl_underlay_sip": APPLIANCE_VIP,
         "pl_sip_encoding": f"{PL_ENCODING_IP}/{PL_ENCODING_MASK}",
         "v4_meter_policy_id": METER_POLICY_V4,
-        "trusted_vnis": VM_VNI
+        "trusted_vnis_list": [VM_VNI]
     }
 }
 
@@ -137,6 +151,14 @@ PE_VNET_MAPPING_CONFIG = {
         "underlay_ip": PE_PA,
         "overlay_sip_prefix": f"{PL_OVERLAY_SIP}/{PL_OVERLAY_SIP_MASK}",
         "overlay_dip_prefix": f"{PL_OVERLAY_DIP}/{PL_OVERLAY_DIP_MASK}",
+    }
+}
+
+VM_VNET_MAPPING_CONFIG = {
+    f"DASH_VNET_MAPPING_TABLE:{VNET1}:{VM1_CA}": {
+        "routing_type": RoutingType.ROUTING_TYPE_VNET,
+        "underlay_ip": VM1_PA,
+        "mac_address": VM_MAC,
     }
 }
 
@@ -301,7 +323,8 @@ ROUTING_TYPE_VNET_CONFIG = {
         "items": [
             {
                 "action_name": "action1",
-                "action_type": ActionType.ACTION_TYPE_MAPROUTING,
+                "action_type": ActionType.ACTION_TYPE_STATICENCAP,
+                "encap_type": EncapType.ENCAP_TYPE_VXLAN,
             },
         ]
     }

--- a/tests/dash/conftest.py
+++ b/tests/dash/conftest.py
@@ -151,20 +151,35 @@ def dash_pl_config(duthost, dpuhosts, dpu_index, config_facts, minigraph_facts):
     for neigh_ip, config in list(config_facts["BGP_NEIGHBOR"].items()):
         if ip_interface(neigh_ip).version == 4:
             if LOCAL_PTF_INTF not in dash_info and config["name"].endswith("T0"):
-                intf, _ = get_intf_from_ip(config['local_addr'], config_facts)
-                dash_info[LOCAL_PTF_INTF] = minigraph_facts["minigraph_ptf_indices"][intf]
-                dash_info[LOCAL_DUT_INTF] = intf
-                dash_info[LOCAL_PTF_MAC] = neigh_table["v4"][neigh_ip]["macaddress"]
+                try:
+                    intf, _ = get_intf_from_ip(config['local_addr'], config_facts)
+                    dash_info[LOCAL_PTF_INTF] = minigraph_facts["minigraph_ptf_indices"][intf]
+                    dash_info[LOCAL_DUT_INTF] = intf
+                    dash_info[LOCAL_PTF_MAC] = neigh_table["v4"][neigh_ip]["macaddress"]
+                except KeyError:
+                    logger.warning("Could not find PTF interface mapping for neighbor %s, skipping", neigh_ip)
+                    dash_info.pop(LOCAL_PTF_INTF, None)
+                    dash_info.pop(LOCAL_DUT_INTF, None)
+                    dash_info.pop(LOCAL_PTF_MAC, None)
+                    continue
             if REMOTE_PTF_SEND_INTF not in dash_info and config["name"].endswith("T2"):
-                intf, _ = get_intf_from_ip(config['local_addr'], config_facts)
-                intfs = list(config_facts["PORTCHANNEL_MEMBER"][intf].keys())
-                dash_info[REMOTE_PTF_SEND_INTF] = minigraph_facts["minigraph_ptf_indices"][intfs[0]]
-                dash_info[REMOTE_PTF_RECV_INTF] = [minigraph_facts["minigraph_ptf_indices"][i] for i in intfs]
-                dash_info[REMOTE_DUT_INTF] = intf
-                dash_info[REMOTE_PTF_MAC] = neigh_table["v4"][neigh_ip]["macaddress"]
-
+                try:
+                    intf, _ = get_intf_from_ip(config['local_addr'], config_facts)
+                    intfs = list(config_facts["PORTCHANNEL_MEMBER"][intf].keys())
+                    dash_info[REMOTE_PTF_SEND_INTF] = minigraph_facts["minigraph_ptf_indices"][intfs[0]]
+                    dash_info[REMOTE_PTF_RECV_INTF] = [minigraph_facts["minigraph_ptf_indices"][i] for i in intfs]
+                    dash_info[REMOTE_DUT_INTF] = intf
+                    dash_info[REMOTE_PTF_MAC] = neigh_table["v4"][neigh_ip]["macaddress"]
+                except KeyError:
+                    logger.warning("Could not find PTF interface mapping for neighbor %s, skipping", neigh_ip)
+                    dash_info.pop(REMOTE_PTF_SEND_INTF, None)
+                    dash_info.pop(REMOTE_PTF_RECV_INTF, None)
+                    dash_info.pop(REMOTE_DUT_INTF, None)
+                    dash_info.pop(REMOTE_PTF_MAC, None)
+                    continue
             if REMOTE_PTF_INTF in dash_info and LOCAL_PTF_INTF in dash_info:
                 break
+
     dpuhost = dpuhosts[dpu_index]
     dash_info[DPU_DATAPLANE_PORT] = dpuhost.dpu_dataplane_port
     dash_info[DPU_DATAPLANE_IP] = dpuhost.dpu_data_port_ip
@@ -524,6 +539,7 @@ def add_npu_static_routes(
     duthost, dash_pl_config, skip_config, skip_cleanup, dpu_index, dpuhosts
 ):
     dpuhost = dpuhosts[dpu_index]
+    cleanup_cmds = []
     if not skip_config:
         cmds = []
         vm_nexthop_ip = get_interface_ip(duthost, dash_pl_config[LOCAL_DUT_INTF]).ip + 1
@@ -532,31 +548,26 @@ def add_npu_static_routes(
         pt_require(vm_nexthop_ip, "VM nexthop interface does not have an IP address")
         pt_require(pe_nexthop_ip, "PE nexthop interface does not have an IP address")
 
-        cmds.append(f"ip route replace {pl.APPLIANCE_VIP}/32 via {dpuhost.dpu_data_port_ip}")
-        cmds.append(f"ip route replace {pl.VM1_PA}/32 via {vm_nexthop_ip}")
+        cmds.append(f"config route add prefix {pl.APPLIANCE_VIP}/32 nexthop {dpuhost.dpu_data_port_ip}")
+        cmds.append(f"config route add prefix {pl.VM1_PA}/32 nexthop {vm_nexthop_ip}")
 
         return_tunnel_endpoints = pl.TUNNEL1_ENDPOINT_IPS + pl.TUNNEL2_ENDPOINT_IPS
         for tunnel_ip in return_tunnel_endpoints:
-            cmds.append(f"ip route replace {tunnel_ip}/32 via {vm_nexthop_ip}")
+            cmds.append(f"config route add prefix {tunnel_ip}/32 nexthop {vm_nexthop_ip}")
         nsg_tunnel_endpoints = pl.TUNNEL3_ENDPOINT_IPS + pl.TUNNEL4_ENDPOINT_IPS
         for tunnel_ip in nsg_tunnel_endpoints:
-            cmds.append(f"ip route replace {tunnel_ip}/32 via {pe_nexthop_ip}")
+            cmds.append(f"config route add prefix {tunnel_ip}/32 nexthop {pe_nexthop_ip}")
 
-        cmds.append(f"ip route replace {pl.PE_PA}/32 via {pe_nexthop_ip}")
+        cmds.append(f"config route add prefix {pl.PE_PA}/32 nexthop {pe_nexthop_ip}")
         logger.info(f"Adding static routes: {cmds}")
         duthost.shell_cmds(cmds=cmds)
+
+        cleanup_cmds = [cmd.replace("add", "del") for cmd in cmds]
 
     yield
 
     if not skip_config and not skip_cleanup:
-        cmds = []
-        cmds.append(f"ip route del {pl.APPLIANCE_VIP}/32 via {dpuhost.dpu_data_port_ip}")
-        cmds.append(f"ip route del {pl.VM1_PA}/32 via {vm_nexthop_ip}")
-        for tunnel_ip in return_tunnel_endpoints:
-            cmds.append(f"ip route replace {tunnel_ip}/32 via {vm_nexthop_ip}")
-        cmds.append(f"ip route del {pl.PE_PA}/32 via {pe_nexthop_ip}")
-        logger.info(f"Removing static routes: {cmds}")
-        duthost.shell_cmds(cmds=cmds)
+        duthost.shell_cmds(cmds=cleanup_cmds, continue_on_fail=True, module_ignore_errors=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -70,7 +70,7 @@ def get_pl_overlay_dip(orig_dip, ol_dip, ol_mask):
     return str(ip_address(overlay_dip))
 
 
-def rand_udp_port_packets(config, floating_nic=True, outbound_vni=None):
+def rand_udp_port_packets(config, floating_nic=True, outbound_vni=None, outbound_encap="vxlan"):
     """
     Randomly generate the inner (overlay) UDP source and destination ports.
     Useful to ensure an even distribution of packets across multiple ECMP endpoints.
@@ -78,9 +78,11 @@ def rand_udp_port_packets(config, floating_nic=True, outbound_vni=None):
     sport = random.randint(49152, 65535)
     dport = random.randint(49152, 65535)
     vm_to_dpu_pkt, exp_dpu_to_pe_pkt = outbound_pl_packets(
-        config, "vxlan", floating_nic, inner_sport=sport, inner_dport=dport, vni=outbound_vni
+        config, outbound_encap, floating_nic, inner_sport=sport, inner_dport=dport, vni=outbound_vni
     )
-    pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(config, floating_nic, inner_sport=dport, inner_dport=sport)
+    pe_to_dpu_pkt, exp_dpu_to_vm_pkt = inbound_pl_packets(
+        config, floating_nic, inner_sport=dport, inner_dport=sport, exp_vni=outbound_vni
+    )
     return vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt
 
 
@@ -120,8 +122,13 @@ def set_do_not_care_layer(mask, layer, field_name, n=1):
 
 def inbound_pl_packets(
     config, floating_nic=False, inner_packet_type="udp", vxlan_udp_dport=4789, inner_sport=4567, inner_dport=6789,
-    vxlan_udp_base_src_port=VXLAN_UDP_BASE_SRC_PORT, vxlan_udp_src_port_mask=VXLAN_UDP_SRC_PORT_MASK
+    vxlan_udp_base_src_port=VXLAN_UDP_BASE_SRC_PORT, vxlan_udp_src_port_mask=VXLAN_UDP_SRC_PORT_MASK, exp_vni=None
 ):
+    if exp_vni is not None:
+        expected_vni = int(exp_vni)
+    else:
+        expected_vni = int(pl.ENCAP_VNI if floating_nic else pl.VM_VNI)
+
     inner_sip = get_pl_overlay_dip(  # not a typo, inner DIP/SIP are reversed for inbound direction
         pl.PE_CA, pl.PL_OVERLAY_DIP, pl.PL_OVERLAY_DIP_MASK
     )
@@ -170,7 +177,7 @@ def inbound_pl_packets(
         ip_id=0,
         udp_dport=vxlan_udp_dport,
         udp_sport=vxlan_udp_base_src_port,
-        vxlan_vni=pl.ENCAP_VNI if floating_nic else int(pl.VNET1_VNI),
+        vxlan_vni=expected_vni,
         inner_frame=exp_inner_packet,
     )
 
@@ -184,8 +191,7 @@ def inbound_pl_packets(
     if floating_nic:
         # As destination IP is not fixed in case of return path ECMP,
         # we need to mask the checksum and destination IP
-        masked_exp_packet.set_do_not_care_packet(scapy.IP, "dst")
-        masked_exp_packet.set_do_not_care(400, 48)  # Inner dst MAC
+        set_do_not_care_layer(masked_exp_packet, scapy.Ether, "dst", 2)
 
     return gre_packet, masked_exp_packet
 

--- a/tests/dash/proto_utils.py
+++ b/tests/dash/proto_utils.py
@@ -111,7 +111,10 @@ def parse_dash_proto(key: str, proto_dict: dict):
             elif field_map[key].message_type.name == "Guid":
                 new_dict[key] = parse_guid(value)
             elif field_map[key].message_type.name == "ValueOrRange":
-                new_dict[key] = parse_value_or_range(value)
+                if field_map[key].label == FieldDescriptor.LABEL_REPEATED:
+                    new_dict[key] = [parse_value_or_range(val) for val in value]
+                else:
+                    new_dict[key] = parse_value_or_range(value)
 
         elif field_map[key].type == field_map[key].TYPE_BYTES:
             new_dict[key] = parse_byte_field(value)

--- a/tests/dash/test_fnic.py
+++ b/tests/dash/test_fnic.py
@@ -6,10 +6,7 @@ import pytest
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
 from packets import rand_udp_port_packets
-from tests.common.helpers.assertions import pytest_assert
-from configs.privatelink_config import TUNNEL1_ENDPOINT_IPS, TUNNEL2_ENDPOINT_IPS
 from tests.common import config_reload
-from tests.dash.dash_utils import verify_tunnel_packets
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +39,6 @@ def common_setup_teardown(
     set_vxlan_udp_sport_range,
     # manually invoke setup_npu_dpu to ensure routes are added before DASH configs are programmed
     setup_npu_dpu,  # noqa: F811
-    single_endpoint
 ):
     if skip_config:
         yield
@@ -50,33 +46,23 @@ def common_setup_teardown(
     dpuhost = dpuhosts[dpu_index]
     logger.info(pl.ROUTING_TYPE_PL_CONFIG)
 
-    if single_endpoint:
-        tunnel_config = pl.TUNNEL1_CONFIG
-    else:
-        tunnel_config = pl.TUNNEL2_CONFIG
-
     base_config_messages = {
         **pl.APPLIANCE_FNIC_CONFIG,
         **pl.ROUTING_TYPE_PL_CONFIG,
         **pl.ROUTING_TYPE_VNET_CONFIG,
         **pl.VNET_CONFIG,
-        **pl.VNET2_CONFIG,
         **pl.ROUTE_GROUP1_CONFIG,
         **pl.METER_POLICY_V4_CONFIG,
-        **tunnel_config,
     }
     logger.info(base_config_messages)
 
     apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
 
-    if single_endpoint:
-        vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
-    else:
-        vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
     route_and_mapping_messages = {
         **pl.PE_VNET_MAPPING_CONFIG,
         **pl.PE_SUBNET_ROUTE_CONFIG,
-        **vm_subnet_route_config
+        **pl.VM_VNET_MAPPING_CONFIG,
+        **pl.VM_SUBNET_ROUTE_CONFIG
     }
     logger.info(route_and_mapping_messages)
     apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
@@ -91,15 +77,8 @@ def common_setup_teardown(
         logger.info(route_rule_messages)
         apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
 
-    meter_rule_messages = {
-        **pl.METER_RULE1_V4_CONFIG,
-        **pl.METER_RULE2_V4_CONFIG,
-    }
-    logger.info(meter_rule_messages)
-    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
-
     logger.info(pl.ENI_FNIC_CONFIG)
-    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
+    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_PL_CONFIG, dpuhost.dpu_index)
 
     logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
     apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
@@ -108,61 +87,29 @@ def common_setup_teardown(
 
     # Route rule removal is broken so config reload to cleanup for now
     # https://github.com/sonic-net/sonic-buildimage/issues/23590
-    config_reload(dpuhost, safe_reload=True, yang_validate=False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, pl.ENI_TRUSTED_VNI_CONFIG, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
-    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
-
-
-def test_fnic(ptfadapter, dash_pl_config, single_endpoint):
-    pkt_sets = list()
-
-    if single_endpoint:
-        num_packets = 5
+    if 'pensando' in dpuhost.facts['asic_type']:
+        apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
+        apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index, False)
+        apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
+        apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
     else:
-        # need a lot of packets to check ECMP distribution
-        num_packets = 1000
+        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+
+
+@pytest.mark.parametrize("encap_proto", ["vxlan", "gre"])
+def test_fnic(ptfadapter, dash_pl_config, encap_proto):
+    num_packets = 5
+    pkt_sets = list()
 
     for _ in range(num_packets):
         vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt = rand_udp_port_packets(
-            dash_pl_config, floating_nic=True, outbound_vni=pl.ENI_TRUSTED_VNI
+            dash_pl_config, floating_nic=True, outbound_vni=pl.VNET1_VNI, outbound_encap=encap_proto
         )
-        # Usually `testutils.send` automatically updates the packet payload to include the test nome
-        # and `testutils.verify_packet*` updates the expected packet payload to match. Since we are polling
-        # the dataplane directly for the DPU to VM packet, we need to manually update the payload
-        exp_dpu_to_vm_pkt = ptfadapter.update_payload(exp_dpu_to_vm_pkt)
         pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt))
-
-    if single_endpoint:
-        tunnel_endpoint_counts = {ip: 0 for ip in TUNNEL1_ENDPOINT_IPS}
-    else:
-        tunnel_endpoint_counts = {ip: 0 for ip in TUNNEL2_ENDPOINT_IPS}
 
     ptfadapter.dataplane.flush()
     for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
         testutils.send(ptfadapter, dash_pl_config[LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
         testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[REMOTE_PTF_RECV_INTF])
         testutils.send(ptfadapter, dash_pl_config[REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
-        verify_tunnel_packets(
-            ptfadapter,
-            dash_pl_config[LOCAL_PTF_INTF],
-            exp_dpu_to_vm_pkt,
-            tunnel_endpoint_counts
-        )
-
-    recvd_pkts = sum(tunnel_endpoint_counts.values())
-    logger.info(f"Received packets: {recvd_pkts}, Tunnel endpoint counts: {tunnel_endpoint_counts}")
-    pytest_assert(
-        recvd_pkts == num_packets,
-        f"Expected {num_packets} packets, but received {recvd_pkts} packets. " f"Counts: {tunnel_endpoint_counts}",
-    )
-
-    expected_pkt_per_endpoint = num_packets // len(tunnel_endpoint_counts)
-    pkt_count_low = expected_pkt_per_endpoint * 0.75
-    pkt_count_high = expected_pkt_per_endpoint * 1.25
-    for ip, count in tunnel_endpoint_counts.items():
-        pytest_assert(
-            pkt_count_low <= count <= pkt_count_high, f"Packet count for {ip} is out of expected range: {count}"
-        )
+        testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[LOCAL_PTF_INTF])

--- a/tests/dash/test_fnic_tunnel.py
+++ b/tests/dash/test_fnic_tunnel.py
@@ -1,0 +1,171 @@
+import logging
+
+import configs.privatelink_config as pl
+import ptf.testutils as testutils
+import ptf.packet as scapy
+import pytest
+from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
+from gnmi_utils import apply_messages
+from packets import rand_udp_port_packets
+from tests.common.helpers.assertions import pytest_assert
+from configs.privatelink_config import TUNNEL1_ENDPOINT_IPS, TUNNEL2_ENDPOINT_IPS
+from tests.common import config_reload
+from tests.common.dash_utils import verify_tunnel_packets
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("smartswitch"),
+    pytest.mark.skip_check_dut_health
+]
+
+
+"""
+Test prerequisites:
+- Assign IPs to DPU-NPU dataplane interfaces
+
+Note: It's also necessary for the DPU to learn the neighbor info of the dataplane port to the NPU before any
+DASH configs are programmed. This should be handled automatically by fixture ordering and does not require
+manual steps.
+
+The neighbor info is learned when applying the default route as orchagent will attempt to resolve the next hop IP.
+"""
+
+
+@pytest.fixture(autouse=True)
+def common_setup_teardown(
+    localhost,
+    duthost,
+    ptfhost,
+    dpu_index,
+    skip_config,
+    dpuhosts,
+    set_vxlan_udp_sport_range,
+    # manually invoke setup_npu_dpu to ensure routes are added before DASH configs are programmed
+    setup_npu_dpu,  # noqa: F811
+    single_endpoint
+):
+    if skip_config:
+        yield
+        return
+    dpuhost = dpuhosts[dpu_index]
+    logger.info(pl.ROUTING_TYPE_PL_CONFIG)
+
+    if single_endpoint:
+        tunnel_config = pl.TUNNEL1_CONFIG
+    else:
+        tunnel_config = pl.TUNNEL2_CONFIG
+
+    base_config_messages = {
+        **pl.APPLIANCE_FNIC_CONFIG,
+        **pl.ROUTING_TYPE_PL_CONFIG,
+        **pl.ROUTING_TYPE_VNET_CONFIG,
+        **pl.VNET_CONFIG,
+        **pl.VNET2_CONFIG,
+        **pl.ROUTE_GROUP1_CONFIG,
+        **pl.METER_POLICY_V4_CONFIG,
+        **tunnel_config,
+    }
+    logger.info(base_config_messages)
+
+    apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index)
+
+    if single_endpoint:
+        vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_SINGLE_ENDPOINT
+    else:
+        vm_subnet_route_config = pl.VM_SUBNET_ROUTE_WITH_TUNNEL_MULTI_ENDPOINT
+    route_and_mapping_messages = {
+        **pl.PE_VNET_MAPPING_CONFIG,
+        **pl.PE_SUBNET_ROUTE_CONFIG,
+        **pl.VM_VNET_MAPPING_CONFIG,
+        **vm_subnet_route_config
+    }
+    logger.info(route_and_mapping_messages)
+    apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index)
+
+    # inbound routing not implemented in Pensando SAI yet, so skip route rule programming
+    if 'pensando' not in dpuhost.facts['asic_type']:
+        route_rule_messages = {
+            **pl.VM_VNI_ROUTE_RULE_CONFIG,
+            **pl.INBOUND_VNI_ROUTE_RULE_CONFIG,
+            **pl.TRUSTED_VNI_ROUTE_RULE_CONFIG
+        }
+        logger.info(route_rule_messages)
+        apply_messages(localhost, duthost, ptfhost, route_rule_messages, dpuhost.dpu_index)
+
+    meter_rule_messages = {
+        **pl.METER_RULE1_V4_CONFIG,
+        **pl.METER_RULE2_V4_CONFIG,
+    }
+    logger.info(meter_rule_messages)
+    apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index)
+
+    logger.info(pl.ENI_FNIC_CONFIG)
+    apply_messages(localhost, duthost, ptfhost, pl.ENI_FNIC_CONFIG, dpuhost.dpu_index)
+
+    logger.info(pl.ENI_ROUTE_GROUP1_CONFIG)
+    apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index)
+
+    yield
+
+    # Route rule removal is broken so config reload to cleanup for now
+    # https://github.com/sonic-net/sonic-buildimage/issues/23590
+    config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    # apply_messages(localhost, duthost, ptfhost, pl.ENI_ROUTE_GROUP1_CONFIG, dpuhost.dpu_index, False)
+    # apply_messages(localhost, duthost, ptfhost, pl.ENI_TRUSTED_VNI_CONFIG, dpuhost.dpu_index, False)
+    # apply_messages(localhost, duthost, ptfhost, meter_rule_messages, dpuhost.dpu_index, False)
+    # apply_messages(localhost, duthost, ptfhost, route_and_mapping_messages, dpuhost.dpu_index, False)
+    # apply_messages(localhost, duthost, ptfhost, base_config_messages, dpuhost.dpu_index, False)
+
+
+def test_fnic_tunnel(ptfadapter, dash_pl_config, single_endpoint):
+    pkt_sets = list()
+
+    if single_endpoint:
+        num_packets = 5
+    else:
+        # need a lot of packets to check ECMP distribution
+        num_packets = 1000
+
+    for _ in range(num_packets):
+        vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt = rand_udp_port_packets(
+            dash_pl_config, floating_nic=True, outbound_vni=pl.ENCAP_VNI
+        )
+        exp_dpu_to_vm_pkt.set_do_not_care_packet(scapy.IP, "dst")
+        # Usually `testutils.send` automatically updates the packet payload to include the test name
+        # and `testutils.verify_packet*` updates the expected packet payload to match. Since we are polling
+        # the dataplane directly for the DPU to VM packet, we need to manually update the payload
+        exp_dpu_to_vm_pkt = ptfadapter.update_payload(exp_dpu_to_vm_pkt)
+        pkt_sets.append((vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt))
+
+    if single_endpoint:
+        tunnel_endpoint_counts = {ip: 0 for ip in TUNNEL1_ENDPOINT_IPS}
+    else:
+        tunnel_endpoint_counts = {ip: 0 for ip in TUNNEL2_ENDPOINT_IPS}
+
+    ptfadapter.dataplane.flush()
+    for vm_to_dpu_pkt, exp_dpu_to_pe_pkt, pe_to_dpu_pkt, exp_dpu_to_vm_pkt in pkt_sets:
+        testutils.send(ptfadapter, dash_pl_config[LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
+        testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[REMOTE_PTF_RECV_INTF])
+        testutils.send(ptfadapter, dash_pl_config[REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
+        verify_tunnel_packets(
+            ptfadapter,
+            dash_pl_config[LOCAL_PTF_INTF],
+            exp_dpu_to_vm_pkt,
+            tunnel_endpoint_counts
+        )
+
+    recvd_pkts = sum(tunnel_endpoint_counts.values())
+    logger.info(f"Received packets: {recvd_pkts}, Tunnel endpoint counts: {tunnel_endpoint_counts}")
+    pytest_assert(
+        recvd_pkts == num_packets,
+        f"Expected {num_packets} packets, but received {recvd_pkts} packets. " f"Counts: {tunnel_endpoint_counts}",
+    )
+
+    expected_pkt_per_endpoint = num_packets // len(tunnel_endpoint_counts)
+    pkt_count_low = expected_pkt_per_endpoint * 0.75
+    pkt_count_high = expected_pkt_per_endpoint * 1.25
+    for ip, count in tunnel_endpoint_counts.items():
+        pytest_assert(
+            pkt_count_low <= count <= pkt_count_high, f"Packet count for {ip} is out of expected range: {count}"
+        )

--- a/tests/dash/test_plnsg.py
+++ b/tests/dash/test_plnsg.py
@@ -12,7 +12,7 @@ from constants import (
 )
 from gnmi_utils import apply_messages
 from packets import inbound_pl_packets, plnsg_packets
-from test_fnic import verify_tunnel_packets
+from tests.common.dash_utils import verify_tunnel_packets
 from tests.common.helpers.assertions import pytest_assert as pt_assert
 import ptf.packet as scapy
 


### PR DESCRIPTION
What is the motivation for this PR?
Existing FNIC test case only covers the scenario where the DPU sends packets to a tunnel endpoint. Add a new test case to cover sending packets directly to the PL endpoint.

How did you do it?
Add a new test case using both NVGRE and VXLAN for the initial packet encap which sends traffic directly to PE endpoint IP instead of sending to a tunnel endpoint

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
