### PR TITLE
[loganalyzer] Ignore mgmtd backend commit timeout error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -428,6 +428,9 @@ r, ".*ERR bgp\#bgpmon:\s+\*ERROR\*\s+Failed\s+with\s+rc:\d+\s+when\s+execute:\s+
 # https://github.com/sonic-net/sonic-buildimage/issues/24966
 r, ".* ERR bgp#mgmtd.*mgmt_ds_lock: ERROR: lock already taken on DS:running by session-id.*"
 
+# https://github.com/sonic-net/sonic-mgmt/issues/16794
+r, ".* ERR bgp\d*#mgmtd.*mgmt_txn_cfg_commit_timedout.*"
+
 # This is an info log which matches the regex "kernel:.*\serr", not an err
 r, ".*ACPI.*System may be unstable or behave erratically.*"
 


### PR DESCRIPTION
### Description of PR
[agent]
Add `mgmt_txn_cfg_commit_timedout` ERR pattern to the common loganalyzer ignore list.

This error occurs when FRR's mgmtd backend times out during configuration commits (e.g. during stress ACL tests) and causes loganalyzer teardown failures even though the test itself passed.

The pattern `ERR bgp\d*#mgmtd.*mgmt_txn_cfg_commit_timedout` matches both single-asic (`bgp#mgmtd`) and multi-asic (`bgp0#mgmtd`, `bgp2#mgmtd`) variants.

Fixes: #16794

### Type of change
- [x] Bug fix

### How did you test it?
Verified the regex pattern matches the exact error messages reported in the issue:
```
PASS: match=True  | 2025 Feb  3 13:34:49 dut ERR bgp#mgmtd[45]: [H7JX4-WT6FK] mgmt_txn_cfg_commit_timedout: ERROR: Backend timeout txn-id: 4 aborting commit
PASS: match=True  | 2025 Feb  3 13:34:49 dut ERR bgp2#mgmtd[45]: mgmt_txn_cfg_commit_timedout: ERROR: timeout
PASS: match=False | 2025 Feb  3 13:34:49 dut ERR bgp#frrctl[123]: some other error (should NOT match)
PASS: match=False | 2025 Feb  3 13:34:49 dut INFO bgp#mgmtd[45]: normal operation (should NOT match)
```