### PR TITLE
[testbed_health_check] Move is_snappi_testbed detection to __init__

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -97,7 +97,7 @@ class TestbedHealthChecker:
         self.testbed_file = testbed_file
         self.log_verbosity = log_verbosity
         self.output_file = output_file
-        self.is_snappi_testbed = False
+        self.is_snappi_testbed = 'rdma' in testbed_name or 'ixia' in testbed_name
 
         # DPU-related state
         self.dpu_hosts = []
@@ -195,9 +195,6 @@ class TestbedHealthChecker:
         )
         if not self.sonichosts:
             raise HostInitFailed("sonichosts is None. Please check testbed name/file/inventory.")
-
-        if 'rdma' in self.testbed_name or 'ixia' in self.testbed_name:
-            self.is_snappi_testbed = True
 
         logger.info("======================= init_hosts ends =======================")
 


### PR DESCRIPTION
### Description of PR
[agent]
Move the `is_snappi_testbed` flag assignment from `init_hosts()` to `__init__()` so the flag is available immediately after construction.

Previously, any code calling `check_bgp_session_state()` or `check_interface_status_of_up_ports()` before `init_hosts()` would silently get `False` for `is_snappi_testbed`, potentially running incorrect checks on Snappi testbeds.

The detection logic (`'rdma' in testbed_name or 'ixia' in testbed_name`) only depends on `testbed_name`, which is already available in `__init__`.

Fixes: #22765

### Type of change
- [x] Bug fix

### How did you test it?
1. AST parse verification: OK
2. Confirmed `is_snappi_testbed` assignment is in `__init__` (line 100) and removed from `init_hosts()`
3. Behavioral verification:
```
PASS: testbed=rdma-testbed is_snappi=True
PASS: testbed=ixia-testbed is_snappi=True
PASS: testbed=vms6-1 is_snappi=False
PASS: testbed=t0-rdma is_snappi=True
```