### PR TITLE
Skip buffer configurations on NH-5010 fanout

### DIFF
--- a/ansible/roles/fanout/templates/sonic_deploy_202505.j2
+++ b/ansible/roles/fanout/templates/sonic_deploy_202505.j2
@@ -208,7 +208,7 @@
 {% endif %}
 {% set no_buffer_hwsku = (
     "Nokia-7215", "Nokia-7215-A1", "Nokia-7215-A1-G48S4", "Nokia-7215-A1-MGX-G48S4",
-    "Arista-720DT-G48S4",
+    "NH-5010-F-O64", "Arista-720DT-G48S4",
     "Arista-7050CX3-32S-S128", "Arista-7050CX3-32S-C6S104", "Arista-7050CX3-32S-C28S16"
 ) %}
 {% if 'marvell-teralynx' not in fanout_sonic_version["asic_type"] and not (fanout_hwsku in no_buffer_hwsku or "Arista-7060X6" in fanout_hwsku) %}
@@ -227,7 +227,7 @@
     {% endfor %}
     },
 {% endif %}
-{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] or fanout_hwsku == "Arista-720DT-G48S4" or "Nokia-7215" in fanout_hwsku %}
+{% if 'marvell-teralynx' in fanout_sonic_version["asic_type"] or fanout_hwsku == "Arista-720DT-G48S4" or "Nokia-7215" in fanout_hwsku or fanout_hwsku == "NH-5010-F-O64" %}
 
     "FLEX_COUNTER_TABLE": {
         "ACL": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip configuring buffer setting on NH-5010 fanout device

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Interfaces do not come up with the default buffer settings.

#### How did you do it?
Updated template file to skip generating buffer config on the device

#### How did you verify/test it?
Validated that interfaces come up after NH-5010 fanout prepare

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
