### PR TITLE
[platform] Add missing consistency_checker_provider fixture to test_fast_reboot_from_other_vendor

### DIFF
--- a/tests/platform_tests/test_advanced_reboot.py
+++ b/tests/platform_tests/test_advanced_reboot.py
@@ -102,7 +102,7 @@ def test_fast_reboot(request, get_advanced_reboot, verify_dut_health,           
 
 def test_fast_reboot_from_other_vendor(duthosts,  rand_one_dut_hostname, request,
                                        get_advanced_reboot, verify_dut_health,      # noqa: F811
-                                       advanceboot_loganalyzer,  # noqa: F811
+                                       advanceboot_loganalyzer,  consistency_checker_provider,  # noqa: F811
                                        capture_interface_counters):
     '''
     Fast reboot test from other vendor case is run using advanced reboot test fixture


### PR DESCRIPTION
### Description of PR
[agent]
Add the missing `consistency_checker_provider` fixture parameter to `test_fast_reboot_from_other_vendor`.

The test body passes `consistency_checker_provider` to `get_advanced_reboot()`, but the fixture was never declared as a test parameter, causing:
```
AttributeError: 'FixtureFunctionDefinition' object has no attribute 'is_consistency_check_supported'
```

All other reboot tests (`test_fast_reboot`, `test_warm_reboot`, etc.) already include this fixture in their signatures. This was introduced in PR #16877 which added the fixture to the function body but not the parameters.

Fixes: #22795

### Type of change
- [x] Bug fix

### How did you test it?
```
AST parse: OK
Verified consistency_checker_provider is now in function signature (line 105)
and matches the reference in get_advanced_reboot() call (line 116)
```