### PR TITLE
[vxlan] Mark test_vxlan_ecmp as xfail on VPP platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -5435,6 +5435,10 @@ vxlan/test_vxlan_ecmp.py:
     reason: "VxLAN ECMP test is not yet supported on multi-ASIC platform. Also this test can only run on some platforms."
     conditions:
       - "(is_multi_asic == True) or (platform not in ['x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0', 'x86_64-kvm_x86_64-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
+  xfail:
+    reason: "xfail due to consistent VPP failures https://github.com/sonic-net/sonic-mgmt/issues/22659"
+    conditions:
+      - "asic_type == 'vpp'"
 
 vxlan/test_vxlan_ecmp_switchover.py:
   skip:


### PR DESCRIPTION
### Description of PR
[agent]
Mark `vxlan/test_vxlan_ecmp.py` as xfail on VPP platform (`asic_type == 'vpp'`).

This test consistently fails on the `kvmtest-t1-lag-vpp` CI pipeline across all PRs regardless of code changes. Evidence from 6+ consecutive PRs shows 2 test failures per run. While the VPP job is marked [OPTIONAL], its failure causes the overall `Azure.sonic-mgmt` check to show as FAILURE, causing confusion for PR authors.

| PR | Build | Result |
|---|---|---|
| #22589 | 1047276 | ❌ vxlan/test_vxlan_ecmp.py (2 failures) |
| #22591 | 1047540 | ❌ vxlan/test_vxlan_ecmp.py (2 failures) |
| #22592 | 1047541 | ❌ vxlan/test_vxlan_ecmp.py (2 failures) |
| #22594 | 1047367 | ❌ vxlan/test_vxlan_ecmp.py (2 failures) |
| #22650 | 1047563 | ❌ vxlan/test_vxlan_ecmp.py (2 failures) |

Fixes: #22659

### Type of change
- [x] Bug fix

### How did you test it?
Verified the xfail condition uses valid syntax matching other VPP-specific conditions in tests_mark_conditions.yaml (`asic_type == 'vpp'`).