### PR TITLE
[loganalyzer] Ignore syncd Lua redis script errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -377,6 +377,10 @@ r, ".* ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent s
 # https://github.com/sonic-net/sonic-mgmt/issues/19790
 r, ".* ERR syncd#syncd: .* SAI_API_SWITCH:sai_query_stats_capability:\d+ stats capablity not supported for object.*"
 
+# https://github.com/sonic-net/sonic-mgmt/issues/21329
+r, ".* ERR syncd\d*#syncd: :- guard: RedisReply catches system_error:.*ERR Lua redis lib command arguments must be strings or integers.*"
+r, ".* ERR syncd\d*#syncd: :- runRedisScript: Caught exception while running Redis lua script:.*ERR Lua redis lib command arguments must be strings or integers.*"
+
 # Ignore all audisp-tacplus Accounting logs
 r, ".* INFO audisp-tacplus: Audisp-tacplus: Accounting: user: .*, tty: .*, host: .*, command: .*, type: \d+, task ID: \d+"
 


### PR DESCRIPTION
### Description of PR
[agent]
Add ignore patterns for syncd Redis Lua script errors that cause loganalyzer teardown failures across multiple test cases.

The error occurs randomly during counter polling when Redis Lua script execution hits an I/O error:
```
ERR syncd#syncd: :- guard: RedisReply catches system_error: ... ERR Lua redis lib command arguments must be strings or integers
ERR syncd#syncd: :- runRedisScript: Caught exception while running Redis lua script: ... ERR Lua redis lib command arguments must be strings or integers
```

This is a transient syncd/Redis issue not caused by test code, and causes test failures across multiple unrelated test suites.

Patterns handle both single-asic (`syncd#syncd`) and multi-asic (`syncd0#syncd`) variants.

Fixes: #21329

### Type of change
- [x] Bug fix

### How did you test it?
```
MATCH: ERR syncd#syncd: :- guard: RedisReply catches system_error: ... ERR Lua redis lib command arguments
MATCH: ERR syncd#syncd: :- runRedisScript: Caught exception ... ERR Lua redis lib command arguments  
MATCH: ERR syncd0#syncd: :- guard: ... (multi-asic variant)
```