### PR TITLE
[snmp][pc] Add watchdog for CPU stress cleanup on test abort

### DIFF
--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -112,8 +112,8 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         # where the test may be killed before reaching the finally block.
         # See: https://github.com/sonic-net/sonic-mgmt/issues/21517
         watchdog_timeout = 600  # 10 minutes — well beyond config_reload's 240s wait
-        duthost.shell(
-            "nohup sh -c 'sleep {}; pkill -9 yes' >/dev/null 2>&1 &".format(watchdog_timeout))
+        watchdog_pid = duthost.shell(
+            "nohup sh -c 'sleep {}; pkill -x -9 yes' >/dev/null 2>&1 & echo $!".format(watchdog_timeout))['stdout'].strip()
 
         # Make CPU high
         for i in range(host_vcpus):
@@ -140,6 +140,9 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
             config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
 
         duthost.shell("killall yes")
+        # Cancel the watchdog so it doesn't fire during later tests
+        duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
     except Exception:
         duthost.shell("killall yes")
+        duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
         raise

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -106,6 +106,7 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
     for pc in port_channel_intfs:
         loganalyzer.expect_regex.append(LOG_EXPECT_PO_CLEANUP_RE.format(pc))
 
+    watchdog_pid = None
     try:
         # Start a watchdog that guarantees cleanup even if the test times out or aborts.
         # Without this, 'yes' processes can leak on weak-per-core platforms (e.g. armhf)
@@ -141,8 +142,10 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
 
         duthost.shell("killall yes")
         # Cancel the watchdog so it doesn't fire during later tests
-        duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
+        if watchdog_pid:
+            duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
     except Exception:
         duthost.shell("killall yes")
-        duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
+        if watchdog_pid:
+            duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
         raise

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -113,8 +113,9 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         # where the test may be killed before reaching the finally block.
         # See: https://github.com/sonic-net/sonic-mgmt/issues/21517
         watchdog_timeout = 600  # 10 minutes — well beyond config_reload's 240s wait
-        watchdog_pid = duthost.shell(
-            "nohup sh -c 'sleep {}; pkill -x -9 yes' >/dev/null 2>&1 & echo $!".format(watchdog_timeout))['stdout'].strip()
+        watchdog_cmd = "nohup sh -c 'sleep {}; pkill -x -9 yes' >/dev/null 2>&1 & echo $!".format(
+            watchdog_timeout)
+        watchdog_pid = duthost.shell(watchdog_cmd)['stdout'].strip()
 
         # Make CPU high
         for i in range(host_vcpus):

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -107,6 +107,14 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
         loganalyzer.expect_regex.append(LOG_EXPECT_PO_CLEANUP_RE.format(pc))
 
     try:
+        # Start a watchdog that guarantees cleanup even if the test times out or aborts.
+        # Without this, 'yes' processes can leak on weak-per-core platforms (e.g. armhf)
+        # where the test may be killed before reaching the finally block.
+        # See: https://github.com/sonic-net/sonic-mgmt/issues/21517
+        watchdog_timeout = 600  # 10 minutes — well beyond config_reload's 240s wait
+        duthost.shell(
+            "nohup sh -c 'sleep {}; pkill -9 yes' >/dev/null 2>&1 &".format(watchdog_timeout))
+
         # Make CPU high
         for i in range(host_vcpus):
             duthost.shell("nohup yes > /dev/null 2>&1 & sleep 1")

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -45,6 +45,14 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
     assert int(snmp_facts['ansible_ChStackUnitCpuUtil5sec'])
 
     try:
+        # Start a watchdog that guarantees cleanup even if the test times out or aborts.
+        # Without this, 'yes' processes can leak on weak-per-core platforms (e.g. armhf)
+        # where the test may be killed before reaching the finally block.
+        # See: https://github.com/sonic-net/sonic-mgmt/issues/21517
+        watchdog_timeout = 300  # 5 minutes — well beyond the test's expected duration
+        duthost.shell(
+            "nohup sh -c 'sleep {}; pkill -9 yes' >/dev/null 2>&1 &".format(watchdog_timeout))
+
         for i in range(host_vcpus):
             duthost.shell("nohup yes > /dev/null 2>&1 & sleep 1")
 

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -44,6 +44,7 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
 
     assert int(snmp_facts['ansible_ChStackUnitCpuUtil5sec'])
 
+    watchdog_pid = None
     try:
         # Start a watchdog that guarantees cleanup even if the test times out or aborts.
         # Without this, 'yes' processes can leak on weak-per-core platforms (e.g. armhf)
@@ -88,4 +89,5 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
     finally:
         duthost.shell("killall yes")
         # Cancel the watchdog so it doesn't fire during later tests
-        duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
+        if watchdog_pid:
+            duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -51,8 +51,9 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
         # where the test may be killed before reaching the finally block.
         # See: https://github.com/sonic-net/sonic-mgmt/issues/21517
         watchdog_timeout = 300  # 5 minutes — well beyond the test's expected duration
-        watchdog_pid = duthost.shell(
-            "nohup sh -c 'sleep {}; pkill -x -9 yes' >/dev/null 2>&1 & echo $!".format(watchdog_timeout))['stdout'].strip()
+        watchdog_cmd = "nohup sh -c 'sleep {}; pkill -x -9 yes' >/dev/null 2>&1 & echo $!".format(
+            watchdog_timeout)
+        watchdog_pid = duthost.shell(watchdog_cmd)['stdout'].strip()
 
         for i in range(host_vcpus):
             duthost.shell("nohup yes > /dev/null 2>&1 & sleep 1")

--- a/tests/snmp/test_snmp_cpu.py
+++ b/tests/snmp/test_snmp_cpu.py
@@ -50,8 +50,8 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
         # where the test may be killed before reaching the finally block.
         # See: https://github.com/sonic-net/sonic-mgmt/issues/21517
         watchdog_timeout = 300  # 5 minutes — well beyond the test's expected duration
-        duthost.shell(
-            "nohup sh -c 'sleep {}; pkill -9 yes' >/dev/null 2>&1 &".format(watchdog_timeout))
+        watchdog_pid = duthost.shell(
+            "nohup sh -c 'sleep {}; pkill -x -9 yes' >/dev/null 2>&1 & echo $!".format(watchdog_timeout))['stdout'].strip()
 
         for i in range(host_vcpus):
             duthost.shell("nohup yes > /dev/null 2>&1 & sleep 1")
@@ -87,3 +87,5 @@ def test_snmp_cpu(duthosts, enum_rand_one_per_hwsku_hostname, localhost, creds_a
         raise
     finally:
         duthost.shell("killall yes")
+        # Cancel the watchdog so it doesn't fire during later tests
+        duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)


### PR DESCRIPTION
### Description of PR
[agent]
Add a background watchdog process that kills `yes` CPU hogs after a timeout, even if the test is aborted before reaching the `finally` block.

On weak-per-core platforms (e.g. Nokia-7215/armhf), PTF tests using `yes` for CPU stress can be killed by pytest timeout before cleanup runs, leaving `yes` processes running forever and making the platform unusable for subsequent tests.

**Affected tests:**
- `tests/snmp/test_snmp_cpu.py` — watchdog timeout: 300s (5 min)
- `tests/pc/test_po_cleanup.py` — watchdog timeout: 600s (10 min, accounts for config_reload wait)

The watchdog uses `nohup sh -c 'sleep N; pkill -9 yes'` to guarantee cleanup regardless of test outcome. The existing `finally` block still handles normal cleanup; the watchdog is a safety net for abnormal termination.

Fixes: #21517

### Type of change
- [x] Bug fix

### How did you test it?
```
AST parse verification: OK (both files)
Verified watchdog command spawns before CPU hog processes
Verified existing finally blocks are preserved unchanged
```