### PR TITLE
copp: fix leaf fanout platform check to cover Th5-320

### DIFF
--- a/tests/copp/test_copp.py
+++ b/tests/copp/test_copp.py
@@ -112,7 +112,7 @@ class TestCOPP(object):
         # UDLD packet will not be forwarded to DUT
         if 'UDLD' == protocol:
             for fanouthost in list(fanouthosts.values()):
-                if fanouthost.get_fanout_os() == 'sonic' and "arista_7060x6_64pe_b" in fanouthost.facts["platform"]:
+                if fanouthost.get_fanout_os() == 'sonic' and "arista_7060x6_64pe" in fanouthost.facts["platform"]:
                     pytest.skip("Skip UDLD test for Arista-7060x6 fanout without UDLD forward support")
 
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]


### PR DESCRIPTION
## Description
Fix the leaf fanout platform check in `test_copp.py` to use `arista_7060x6_64pe` instead of `arista_7060x6_64pe_b`, so the UDLD test skip covers both:
- Th5-512: `x86_64-arista_7060x6_64pe_b`
- Th5-320: `x86_64-arista_7060x6_64pe` (without the `_b` suffix)

Both platforms do not support UDLD forward on leaf fanout when running SONiC.

## Changes
- `tests/copp/test_copp.py`: Changed `"arista_7060x6_64pe_b" in fanouthost.facts["platform"]` to `"arista_7060x6_64pe" in fanouthost.facts["platform"]`