### PR TITLE
[202511][PR:22862] [cisco platform] Fix route add fixture in snappi tests

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -1531,12 +1531,12 @@ def gen_data_flow_dest_ip(addr, dut=None, intf=None, namespace=None, setup=True)
             dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
             dut.shell(
                 f"{asic_arg} config route {cmd} prefix {DEST_TO_GATEWAY_MAP[addr]['dest']}/32 nexthop "
-                f"{addr} {DEST_TO_GATEWAY_MAP[addr]['intf']}"
+                f"{addr} dev {DEST_TO_GATEWAY_MAP[addr]['intf']}"
             )
         else:
             dut.shell(
                 f"{asic_arg} config route {cmd} prefix {DEST_TO_GATEWAY_MAP[addr]['dest']}/32 nexthop "
-                f"{addr} {DEST_TO_GATEWAY_MAP[addr]['intf']}"
+                f"{addr} dev {DEST_TO_GATEWAY_MAP[addr]['intf']}"
             )
             dut.shell(f"sudo {asic_arg} arp {int_arg} {arp_opt}")
     except RunAnsibleModuleFail:


### PR DESCRIPTION
### Description of PR

Cherry-pick of #22862 to the 202511 branch.

Add `dev` option to `config route add/remove` commands in snappi test fixtures, as required by sonic-utilities changes (sonic-net/sonic-utilities#3836).

Without this fix, the route add/remove commands fail with a TypeError:
```
Usage: config route add [OPTIONS] prefix [vrf <vrf_name>] nexthop <nh_ip> dev <dev_name>
Try 'config route add -h' for help.

Error: Got unexpected extra argument (Ethernet188)
```

### Type of change

- [x] Bug fix

### Back port request
- [x] 202511
