### PR TITLE
[hft] Relax config transition Msg/s validation

### DIFF
--- a/tests/high_frequency_telemetry/utilities.py
+++ b/tests/high_frequency_telemetry/utilities.py
@@ -833,13 +833,19 @@ def validate_config_state_transitions(
             }
             continue
 
-        # Validate the output based on expected configuration state
+        # Validate the output based on expected configuration state.
+        # This helper is used for config state transition validation, not
+        # precise rate validation. For create/re-create phases, only verify
+        # that the stream becomes active again. Strict Msg/s checks are
+        # intentionally skipped because countersyncd reports a cumulative
+        # average rate and config application latency can skew the early
+        # samples within the same collection window.
         expect_disabled = (action == "delete")
         validation = validate_counter_output(
             output=output,
             expected_objects=validation_objects,
             min_counter_value=0,
-            expected_poll_interval=10000,
+            expected_poll_interval=None,
             expect_disabled=expect_disabled
         )
 


### PR DESCRIPTION
### Description of PR
Summary:
Relax `test_hft_config_deletion_stream` validation so config transition phases verify stream activation/deactivation without enforcing strict cumulative `Msg/s` range checks.
Fixes # (issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_hft_config_deletion_stream` is intended to validate config state transitions (`create -> delete -> create`).

After the HFT config setup path moved to SONiC CLI commands, config application can take longer before countersyncd starts producing telemetry data. The reported `Msg/s` is a cumulative average, so startup dead time in create/re-create phases can pull early samples below the expected range even when the stream is functioning correctly.

This makes the test unnecessarily sensitive to config-apply latency instead of validating the intended behavior: messages start flowing after create, stop after delete, and resume after re-create.

#### How did you do it?
- Updated `validate_config_state_transitions()` in `tests/high_frequency_telemetry/utilities.py`
- Removed strict `expected_poll_interval` / `Msg/s` validation from config transition validation
- Kept the existing active/inactive stream validation semantics for create/re-create and delete phases

#### How did you verify/test it?
- `python3 -m py_compile tests/high_frequency_telemetry/utilities.py`
- Reviewed the validation flow to confirm:
  - create/re-create phases still require active stream output
  - delete phase still validates disabled behavior with no active messages

#### Any platform specific information?
No platform-specific behavior is introduced. This change makes the transition test less sensitive to timing differences in HFT config application.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A
