### PR TITLE
[acl] Replace time.sleep with wait_until in test_acl_outer_vlan

### DIFF
--- a/tests/acl/test_acl_outer_vlan.py
+++ b/tests/acl/test_acl_outer_vlan.py
@@ -296,12 +296,20 @@ def get_acl_counter(duthost, table_name, rule_name, timeout=ACL_COUNTERS_UPDATE_
     Returns:
         Acl counter value for packets
     """
-    # Wait for orchagent to update the ACL counters
-    time.sleep(timeout)
-    result = duthost.show_and_parse('aclshow -a')
+    def _check_acl_counter():
+        result = duthost.show_and_parse('aclshow -a')
+        if len(result) == 0:
+            return False
+        for rule in result:
+            if table_name == rule['table name'] and rule_name == rule['rule name']:
+                return True
+        return False
 
-    if len(result) == 0:
+    # Wait for orchagent to update the ACL counters
+    if not wait_until(timeout, 2, 0, _check_acl_counter):
         pytest.fail("Failed to retrieve acl counter for {}|{}".format(table_name, rule_name))
+
+    result = duthost.show_and_parse('aclshow -a')
     for rule in result:
         if table_name == rule['table name'] and rule_name == rule['rule name']:
             return int(rule['packets count'])


### PR DESCRIPTION
### Description
Replace fixed sleep in `get_acl_counter()` with polling `wait_until()` that checks for ACL counter availability every 2 seconds, avoiding unnecessary fixed delays while remaining robust.

### Motivation
Addresses #20256 — replace `time.sleep` with `wait_until` for more resilient test timing.

### Changes
- `get_acl_counter()`: Replaced `time.sleep(timeout)` with `wait_until(timeout, 2, 0, _check_acl_counter)` that polls `aclshow -a` for the target rule
- Remaining 7 `time.sleep` calls are pure config delays (vlan setup, portchannel, arp_responder) with no condition to poll — left as-is

Fixes: #20256