### PR TITLE
[bfd] Replace time.sleep with wait_until in test_bfd

### DIFF
--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -629,6 +629,7 @@ def test_bfd_multihop(request, rand_selected_dut, ptfhost, tbinfo,
 
         duthost.shell("sonic-clear queuecounters")
         # wait for queue counters to accumulate BFD traffic
+
         def _check_bfd_queue_nonzero():
             queue_pkt_count, _ = get_egress_queue_count(duthost, dut_intf, 7)
             return queue_pkt_count > 0


### PR DESCRIPTION
### Description
Replace fixed sleeps with polling `wait_until()` calls across multiple BFD test functions.

### Motivation
Addresses #20256 — replace `time.sleep` with `wait_until` for more resilient test timing.

### Changes
- `check_dut_bfd_status()`: Refactored manual retry loop to use `wait_until`
- `create_bfd_sessions_multihop()`: Poll for BFD sessions Up state instead of fixed 30s sleep
- `warm_up_ipv6_neighbors()`: Poll for NDP REACHABLE state instead of fixed 5s sleep
- `test_bfd_scale()`: Poll for BFD sessions in status output instead of fixed 10s sleep
- `test_bfd_multihop()`: Poll for queue counter accumulation instead of fixed 10s sleep
- Remaining 2 `time.sleep` calls are cleanup/IPv6 programming delays with no condition to poll — left as-is

Fixes: #20256