### PR TITLE
[nat] Replace time.sleep with wait_until in test_static_nat and nat_helpers

### DIFF
--- a/tests/nat/nat_helpers.py
+++ b/tests/nat/nat_helpers.py
@@ -10,6 +10,7 @@ from netaddr import IPAddress
 import ptf.mask as mask
 import ptf.packet as packet
 import ptf.testutils as testutils
+from tests.common.utilities import wait_until
 from tests.common.errors import RunAnsibleModuleFail
 from tests.common.helpers.assertions import pytest_assert
 from jinja2 import Environment, FileSystemLoader
@@ -189,15 +190,12 @@ def dut_interface_control(duthost, action, interface_name, ip_addr=""):
     output_cli = exec_command(duthost, ["sudo config interface {}".format(interface_actions[action])])
     if output_cli["rc"]:
         raise Exception('Return code is {} not 0'.format(output_cli["rc"]))
-    attempts = 3
-    current_operstatus = dut_interface_status(duthost, interface_name)
-    while current_operstatus != expected_operstatus[action]:
-        if attempts == 0:
-            break
-        time.sleep(15)
-        current_operstatus = dut_interface_status(duthost, interface_name)
-        attempts -= 1
-    return current_operstatus
+
+    def _check_oper_status():
+        return dut_interface_status(duthost, interface_name) == expected_operstatus[action]
+
+    wait_until(60, 15, 0, _check_oper_status)
+    return dut_interface_status(duthost, interface_name)
 
 
 def nat_translations(duthost, show=False, clear=False):
@@ -961,7 +959,12 @@ def get_dynamic_l4_ports(duthost, proto, direction, public_ip):
     :param direction: string with current flow direction
     :return named tuple with values src_port, dst_port, exp_src_port, exp_dst_por
     """
-    time.sleep(5)
+    def _translation_exists():
+        output = exec_command(duthost, ["show nat translation"])['stdout']
+        pattern = r"{}.+{}:(\d+)".format(proto.lower(), public_ip)
+        return bool(re.findall(pattern, output))
+
+    wait_until(30, 5, 0, _translation_exists)
     # Get expected source port
     output = exec_command(duthost, ["show nat translation"])['stdout']
     # Find expected source port

--- a/tests/nat/test_static_nat.py
+++ b/tests/nat/test_static_nat.py
@@ -40,7 +40,24 @@ from .nat_helpers import dut_interface_control
 from .nat_helpers import get_public_ip
 import tests.common.reboot as common_reboot
 from tests.common.helpers.assertions import pytest_assert
+from tests.common.utilities import wait_until
 from tests.nat.conftest import nat_global_config
+
+
+def _nat_counters_incremented(duthost):
+    """Return True when NAT counters are non-empty and have incremented."""
+    nat_counters = nat_statistics(duthost, show=True)
+    if not nat_counters:
+        return False
+    return all(
+        int(nat_counters[e]["Packets"]) > 0 and int(nat_counters[e]["Bytes"]) > 0
+        for e in nat_counters
+    )
+
+
+def _iptables_match(duthost, expected_rules):
+    """Return True when iptables NAT rules match expected."""
+    return dut_nat_iptables_status(duthost) == expected_rules
 
 
 pytestmark = [
@@ -132,7 +149,7 @@ class TestStaticNat(object):
             generate_and_verify_traffic(duthost, ptfadapter, setup_data, interface_type, path,
                                         protocol_type, nat_type=nat_type)
         # wait for counters update
-        time.sleep(5)
+        wait_until(30, 5, 0, _nat_counters_incremented, duthost)
         # make sure NAT counters have incremented
         nat_counters = nat_statistics(duthost, show=True)
         pytest_assert(nat_counters,
@@ -176,7 +193,7 @@ class TestStaticNat(object):
             generate_and_verify_traffic(duthost, ptfadapter, setup_data, interface_type, path,
                                         protocol_type, nat_type=nat_type)
         # wait for counters update
-        time.sleep(5)
+        wait_until(30, 5, 0, _nat_counters_incremented, duthost)
         # make sure NAT counters have incremented
         nat_counters = nat_statistics(duthost, show=True)
         pytest_assert(nat_counters,
@@ -252,7 +269,7 @@ class TestStaticNat(object):
                 pytest_assert(nat_destination == cleared_translations[entry]["Destination"],
                               "Unexpected destination translation rule for {}".format(entry))
         # wait for counters update
-        time.sleep(5)
+        wait_until(30, 5, 0, _nat_counters_incremented, duthost)
         # make sure NAT counters exist and have incremented
         nat_counters = nat_statistics(duthost, show=True)
         pytest_assert(nat_counters,
@@ -318,7 +335,7 @@ class TestStaticNat(object):
                 pytest_assert(nat_destination == cleared_translations[entry]["Destination"],
                               "Unexpected source translation rule for {}".format(entry))
         # wait for counters update
-        time.sleep(5)
+        wait_until(30, 5, 0, _nat_counters_incremented, duthost)
         # make sure NAT counters exist and have incremented
         nat_counters = nat_statistics(duthost, show=True)
         pytest_assert(nat_counters,
@@ -849,8 +866,6 @@ class TestStaticNat(object):
             dut_interface_control(duthost, "ip add",
                                   setup_data["config_portchannels"][ifname_to_disable]['members'][0], interface_ip)
             # Check that NAT entries are present in iptables after readding interface IP
-            time.sleep(90)
-            iptables_output = dut_nat_iptables_status(duthost)
             iptables_rules = {
                 "prerouting": [
                     "DNAT all -- 0.0.0.0/0 {} mark match {} to:{}".format(network_data.public_ip,
@@ -862,6 +877,8 @@ class TestStaticNat(object):
                                                                           tested_zones[zone]["exp_zone"],
                                                                           network_data.public_ip)]
                 }
+            wait_until(90, 10, 0, _iptables_match, duthost, iptables_rules)
+            iptables_output = dut_nat_iptables_status(duthost)
             pytest_assert(iptables_rules == iptables_output,
                           "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}"
                           .format(iptables_output, iptables_rules))
@@ -944,7 +961,7 @@ class TestStaticNat(object):
             dut_interface_control(duthost, "enable",
                                   setup_data["config_portchannels"][ifname_to_disable]['members'][0])
             # Check that NAT entries are present in iptables after enabling interface
-            time.sleep(90)
+            wait_until(90, 10, 0, _iptables_match, duthost, iptables_rules)
             iptables_output = dut_nat_iptables_status(duthost)
             pytest_assert(iptables_rules == iptables_output,
                           "Unexpected iptables output for nat table \n Got:\n{}\n Expected:\n{}"


### PR DESCRIPTION
### Description
Replace fixed sleeps with polling `wait_until()` calls in NAT static test and helper files.

### Motivation
Addresses #20256 — replace `time.sleep` with `wait_until` for more resilient test timing.

### Changes

**tests/nat/test_static_nat.py:**
- 4x `time.sleep(5)` for counter updates → `wait_until(30, 5, 0, _nat_counters_incremented, duthost)`
- 2x `time.sleep(90)` for iptables rules → `wait_until(90, 10, 0, _iptables_match, duthost, iptables_rules)`
- Added helper functions `_nat_counters_incremented()` and `_iptables_match()`

**tests/nat/nat_helpers.py:**
- `dut_interface_control()`: Refactored manual retry loop to use `wait_until(60, 15, 0, ...)`
- `get_dynamic_l4_ports()`: Replaced `time.sleep(5)` with polling for NAT translation entry

Fixes: #20256