### PR TITLE
[vrf] Replace time.sleep with wait_until in test_vrf

### DIFF
--- a/tests/vrf/test_vrf.py
+++ b/tests/vrf/test_vrf.py
@@ -1102,7 +1102,14 @@ class TestVrfLoopbackIntf:
         ptfhost.shell("pgrep exabgp")
 
         # make sure routes announced to bgp neighbors
-        time.sleep(10)
+        def _bgp_speaker_routes_announced():
+            bgp_facts = duthost.bgp_facts()['ansible_facts']
+            for nbr, info in bgp_facts['bgp_neighbors'].items():
+                if info.get('state') != 'established':
+                    return False
+            return True
+
+        wait_until(30, 2, 0, _bgp_speaker_routes_announced)
 
         # -------- Testing ----------
 
@@ -1492,7 +1499,12 @@ class TestVrfUnbindIntf:
         duthost.shell("config interface vrf unbind {}".format(PORTCHANNEL_TEMP_1))
 
         # wait for neigh/route flush
-        time.sleep(5)
+        def _pc1_ip_flushed():
+            output = duthost.shell("ip addr show {}".format(PORTCHANNEL_TEMP_1),
+                                   module_ignore_errors=True)['stdout']
+            return 'inet ' not in output
+
+        wait_until(30, 2, 0, _pc1_ip_flushed)
 
         # -------- Testing ----------
         yield
@@ -1656,7 +1668,12 @@ class TestVrfDeletion:
         gen_vrf_neigh_file("Vrf2", ptfhost, render_file="/tmp/vrf2_neigh.txt")
 
         duthost.shell("config vrf del Vrf1")
-        time.sleep(5)
+
+        def _vrf1_deleted():
+            output = duthost.shell("ip link show type vrf", module_ignore_errors=True)['stdout']
+            return 'Vrf1' not in output
+
+        wait_until(30, 2, 0, _vrf1_deleted)
 
         # -------- Testing ----------
         yield


### PR DESCRIPTION
### Description
Replace fixed sleeps with polling `wait_until()` calls in VRF tests.

### Motivation
Addresses #20256 — replace `time.sleep` with `wait_until` for more resilient test timing.

### Changes
- `setup_bgp_with_loopback`: Replace `time.sleep(10)` with `wait_until` polling for BGP neighbors established
- `setup_vrf_unbindintf`: Replace `time.sleep(5)` with `wait_until` polling for IP addresses flushed from interface
- `setup_vrf_deletion`: Replace `time.sleep(5)` with `wait_until` polling for Vrf1 removed from kernel VRF list
- Remaining 4 `time.sleep` calls are part of existing retry loops or parametric capacity test delays — left as-is

Fixes: #20256