### PR TITLE
Update cEOS template t0-leaf to add next-hop-self

### DIFF
--- a/ansible/roles/eos/templates/t0-leaf.j2
+++ b/ansible/roles/eos/templates/t0-leaf.j2
@@ -236,6 +236,7 @@ router bgp {{ host['bgp']['asn'] }}
         {% for remote_ip in remote_ips %}
  neighbor {{ remote_ip }} remote-as {{ asn }}
  neighbor {{ remote_ip }} description {{ asn }}
+ neighbor {{ remote_ip }} next-hop-self
 {# set LT2/FT2 as reflector to advertise route to DUT #}
             {% if props.swrole is defined and props.swrole in ("lowerspine", "fabricspine") %}
  neighbor {{ remote_ip }} route-reflector-client


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
This line was added by PR https://github.com/sonic-net/sonic-mgmt/pull/18659.
But it was removed unexpectedly recently.
This PR is too add the line back
```
neighbor {{ remote_ip }} next-hop-self
```
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR is to update `ansible/roles/eos/templates/t0-leaf.j2` to add `neighbor {{ remote_ip }} next-hop-self`

#### How did you do it?
Update `ansible/roles/eos/templates/t0-leaf.j2` 

#### How did you verify/test it?
The change is verified by deploying a testbed with the new template. 
<img width="779" height="643" alt="image" src="https://github.com/user-attachments/assets/8ad0ed84-ce6b-4226-b73d-26f7d75c3145" />
#### Any platform specific information?
No.
#### Supported testbed topology if it's a new test case?
Not a new test.
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
