### PR TITLE
Upgrade network container to Trixie

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -143,7 +143,7 @@
   become: yes
   docker_container:
     name: net_{{ vm_set_name }}_{{ vm_name }}
-    image: "{{ docker_registry_host }}/debian:bookworm"
+    image: "{{ debian_docker_registry_host }}/debian:trixie"
     pull: no
     state: started
     restart: no

--- a/ansible/vars/docker_registry.yml
+++ b/ansible/vars/docker_registry.yml
@@ -1,1 +1,2 @@
 docker_registry_host: sonicdev-microsoft.azurecr.io:443
+debian_docker_registry_host: publicmirror.azurecr.io:443


### PR DESCRIPTION
Cherry-pick of #22682 to 202511 branch.

## Description
Upgrades the net container image from Debian Bookworm to Trixie, and introduces a separate `debian_docker_registry_host` variable pointing to `publicmirror.azurecr.io:443`.