### PR TITLE
Fix: Skip DPU tests when --dpu-pattern is not specified instead of failing : test_gnoi_system_reboot_halt_dpus

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -488,6 +488,9 @@ def get_specified_device_info(request, device_pattern):
         return [get_target_hostname(request)]
 
     host_pattern = request.config.getoption(device_pattern)
+    # When no DPUs specified (None/"None"/empty), return [] so DPU tests skip instead of fail
+    if device_pattern == '--dpu-pattern' and (host_pattern is None or host_pattern == 'None' or host_pattern == ''):
+        return []
     if host_pattern == 'all':
         if device_pattern == '--dpu-pattern':
             testbed_duts = [dut for dut in testbed_duts if 'dpu' in dut]


### PR DESCRIPTION
Summary:
```
  def test_gnoi_system_reboot_halt_dpus(duthosts, rand_one_dut_hostname, localhost, request):
        """
        Test gNOI System.Reboot API with HALT method.
        Verifies that the reboot is triggered, RebootStatus is correct before reboot,
        and the system recovers with all critical processes running.
        """
        duthost = duthosts[rand_one_dut_hostname]
    
>       dpuhost_names = get_specified_dpus(request)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^

duthost    = <MultiAsicSonicHost MtFuji-dut>
duthosts   = [<MultiAsicSonicHost MtFuji-dut>]
localhost  = <tests.common.devices.local.Localhost object at 0x7f9cf2fea4e0>
rand_one_dut_hostname = 'MtFuji-dut'
request    = <FixtureRequest for <Function test_gnoi_system_reboot_halt_dpus>>

gnmi/test_gnoi_system_reboot.py:166: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
conftest.py:472: in get_specified_dpus
    return get_specified_device_info(request, "--dpu-pattern")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        request    = <FixtureRequest for <Function test_gnoi_system_reboot_halt_dpus>>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

request = <FixtureRequest for <Function test_gnoi_system_reboot_halt_dpus>>, device_pattern = '--dpu-pattern'

    def get_specified_device_info(request, device_pattern):
        """
        Get a list of device hostnames specified with the --host-pattern or --dpu-pattern CLI option
        """
        tbname, tbinfo = get_tbinfo(request)
        testbed_duts = tbinfo['duts']
    
        if is_parallel_run(request):
            return [get_target_hostname(request)]
    
        host_pattern = request.config.getoption(device_pattern)
        if host_pattern == 'all':
            if device_pattern == '--dpu-pattern':
                testbed_duts = [dut for dut in testbed_duts if 'dpu' in dut]
                logger.info(f"dpu duts: {testbed_duts}")
            return testbed_duts
        else:
            specified_duts = get_duts_from_host_pattern(host_pattern)
    
        if any([dut not in testbed_duts for dut in specified_duts]):
>           pytest.fail("One of the specified DUTs {} does not belong to the testbed {}".format(specified_duts, tbname))
E           Failed: One of the specified DUTs ['None'] does not belong to the testbed cmono_t1

device_pattern = '--dpu-pattern'
host_pattern = 'None'
request    = <FixtureRequest for <Function test_gnoi_system_reboot_halt_dpus>>
specified_duts = ['None']
tbinfo     = {'auto_recover': 'True', 'comment': 'Churchill_Mono(8101-32FH-O) T1 topology', 'conf-name': 'cmono_t1', 'duts': ['MtFuji-dut'], ...}
tbname     = 'cmono_t1'
testbed_duts = ['MtFuji-dut']

conftest.py:450: Failed
```

**Summary:**
When --dpu-pattern (or -H in run_tests.sh) is not provided, run_tests.sh passes --dpu-pattern None to pytest. The code treated the string "None" as a real host pattern, which led to a test failure instead of skipping DPU tests.

This change makes get_specified_device_info() return an empty list when --dpu-pattern is None, the string "None", or empty, so tests that depend on DPUs skip with "No DPUs specified" instead of failing.

**Problem:**
Without -H, DPU_NAME defaults to "None" and pytest is invoked with --dpu-pattern None.
get_specified_device_info() only handled host_pattern == 'all'; any other value (including "None") went to get_duts_from_host_pattern(host_pattern).
get_duts_from_host_pattern('None') returns ['None'], and the check that all specified DUTs are in the testbed fails because 'None' is not in tbinfo['duts'].
Result: pytest.fail("One of the specified DUTs ['None'] does not belong to the testbed ...") for tests like test_gnoi_system_reboot_halt_dpus.

**Solution**
In get_specified_device_info() (in tests/conftest.py), add an early return for the “no DPU specified” case when using --dpu-pattern:

If device_pattern == '--dpu-pattern' and host_pattern is None, the string 'None', or '', return [] immediately.
Callers such as test_gnoi_system_reboot_halt_dpus then get an empty list from get_specified_dpus(request) and skip with "No DPUs specified, skipping HALT reboot test."

**Change**
File: tests/conftest.py
Update: In get_specified_device_info(), after reading host_pattern, return [] when --dpu-pattern is used and host_pattern is None, 'None', or empty.

**Testing**
Without -H: Run the same command that previously failed (e.g. ./run_tests.sh -n cmono_t1 -d MtFuji-dut ... with no -H). test_gnoi_system_reboot_halt_dpus should skip with "No DPUs specified, skipping HALT reboot test." and the run should complete without that failure.
With -H: On a SmartSwitch testbed, run with -H "<dpu-hostname>". DPU tests should run as before and pass when the DPU reboots correctly.

**Logs**
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated xml file: /run_logs/anukverm/gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_halt_dpus_2026-03-16-11-54-42.xml -
INFO:root:Can not get Allure report URL. Please check logs
----------------------------------------- live log sessionfinish ------------------------------------------
16/03/2026 12:02:09 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs
========================================= short test summary info =========================================
SKIPPED [1] gnmi/test_gnoi_system_reboot.py:170: No DPUs specified, skipping HALT reboot test.

Results (444.91s (0:07:24)):
       1 skipped
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

Signed-off-by: Anukul Verma <anukverm@cisco.com>