### PR TITLE
Upgrade the net container from Bookworm to Trixie

### DIFF
--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -109,7 +109,7 @@
   become: yes
   docker_container:
     name: net_{{ vm_set_name }}_{{ vm_name }}
-    image: "{{ docker_registry_host }}/debian:bookworm"
+    image: "{{ debian_docker_registry_host }}/debian:trixie"
     pull: no
     state: started
     restart: no

--- a/ansible/vars/docker_registry.yml
+++ b/ansible/vars/docker_registry.yml
@@ -1,1 +1,2 @@
 docker_registry_host: sonicdev-microsoft.azurecr.io:443
+debian_docker_registry_host: publicmirror.azurecr.io:443


### PR DESCRIPTION
Also add a new variable for the Docker registry, since the containers for the newer Debian versions are mirrored in a different Docker registry.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Cherry-pick of https://github.com/sonic-net/sonic-mgmt/pull/22682
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
