### PR TITLE
[snappi] fixed the function name log and cleanup in setup_dut_ports function

### DIFF
--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -854,7 +854,7 @@ def setup_dut_ports(
                                port_config_list=port_config_list,
                                duthost=duthost,
                                snappi_ports=snappi_ports)
-            pytest_assert(config_result is True, 'Failed to configure via {fn.__name__}')
+            pytest_assert(config_result is True, 'Failed to configure ports via {}'.format(fn.__name__))
         return found_ports()
 
     def config_port_setup(fn):
@@ -864,7 +864,7 @@ def setup_dut_ports(
                                duthost=duthost,
                                snappi_ports=snappi_ports,
                                setup=setup)
-            pytest_assert(config_result is True, 'Failed to configure via {fn.__name__}')
+            pytest_assert(config_result is True, 'Failed to configure ports via {}'.format(fn.__name__))
 
     if setup:
         if config_port(__vlan_intf_config):
@@ -876,17 +876,23 @@ def setup_dut_ports(
 
         config_port_setup(__l3_intf_config)
         if found_ports():
+            logger.info('Found relevant DUT interfaces')
             return config, port_config_list, snappi_ports
 
+        port_config_list = []
         config_port_setup(__intf_config_multidut)
         pytest_assert(found_ports(), 'Failed to configure DUT ports')
         return config, port_config_list, snappi_ports
-    elif (str(port_config_list[-1].type) == 'SnappiPortType.RtrInterface'):
-        config_port_setup(__l3_intf_config)
-        return None
-    elif (str(port_config_list[-1].type) == 'SnappiPortType.IPInterface'):
-        config_port_setup(__intf_config_multidut)
-        return None
+    else:
+        for port_config in port_config_list:
+            if port_config.type == SnappiPortType.RtrInterface:
+                logger.info('Cleanup for router interfaces...')
+                config_port_setup(__l3_intf_config)
+                return None
+            if port_config.type == SnappiPortType.IPInterface:
+                logger.info('Cleanup for p2p ip interfaces...')
+                config_port_setup(__intf_config_multidut)
+                return None
 
 
 def get_tgen_peer_ports(snappi_ports, hostname):


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
The function setup_dut_ports prints log with the function name. The format of the log is incorrect. 

If setup=False, then test should iterate over the port_config_list ports to determine if any of the port is router or p2p interface. If such is found, then call the appropriate function with setup=False flag for clean-up.

Earlier, it would just iterate over the last port.

@sdszhang for viz.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

- Fix the log to print the correct function name. 
- Keep port_config_list = [] during the setup if appropriate number of ports (VLANs, port-channel or router interfaces) are not found in the minigraph. Attempt to use all the p2p interfaces in this case. 
- when setup=False, iterate over all the ports and find if the interface is router or p2p interface. Based on the port type, call appropriate cleanup with setup=False.


#### How did you do it?
- Correct the log to print function name with ".format(fn._name_)".
- Kept port_config_list = [] to ensure port_config_list does not have any existing config from vlans, port-channels or router interfaces.
- Check explicitly all ports for router/p2p interface to call appropriate function with setup=False.

#### How did you verify/test it?
Will upload logs with 202511.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
