### PR TITLE
skip test chassis reboot test on disaggregated chassis

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -1271,15 +1271,27 @@ platform_tests/test_advanced_reboot.py::test_warm_reboot_sad:
       - "is_smartswitch==True"
 
 #######################################
-#####   test_cont_warm_reboot.py  #####
+#####   test_auto_negotiation.py  #####
 #######################################
-
 
 platform_tests/test_auto_negotiation.py:
   skip:
     reason: 'Auto negotiation tests require physical port interfaces, not available on BMC'
     conditions:
       - "'bmc' in topo_type"
+
+#######################################
+#####   test_chassis_reboot.py  #####
+#######################################
+platform_tests/test_chassis_reboot.py:
+  skip:
+    reason: "Chassis reboot test is not supported on T2 single node topology"
+    conditions:
+      - "'t2_single_node' in topo_name"
+
+#######################################
+#####   test_cont_warm_reboot.py  #####
+#######################################
 
 platform_tests/test_cont_warm_reboot.py:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Skip `platform_tests/test_chassis_reboot.py` test on for disaggregated chassis as it is not applicable. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`platform_tests/test_chassis_reboot.py` test is specific for modular chassis are not applicable for disaggregated chassis. 

#### How did you do it?

Add a conditional mark to skip it on disaggregated topologies.

#### How did you verify/test it?

Applies specifically to t2_single_node (disaggregated/fixed) topologies.
Modular chassis t2 topologies are unaffected and continue to run the test.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
