### PR TITLE
Fix double-removal bug in DEFAULT_ASIC_SERVICES filtering

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -103,14 +103,16 @@ class MultiAsicSonicHost(object):
             service_list.remove('snmp')
 
         # Update the asic service based on feature table state and asic flag
-        for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
+        filtered_asic_services = []
+        for service in self.sonichost.DEFAULT_ASIC_SERVICES:
             if service not in config_facts['FEATURE']:
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                 continue
             if config_facts['FEATURE'][service]['has_per_asic_scope'] == "False":
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
+                continue
             if config_facts['FEATURE'][service]['state'] == "disabled":
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
+                continue
+            filtered_asic_services.append(service)
+        self.sonichost.DEFAULT_ASIC_SERVICES = filtered_asic_services
         if not self.get_facts().get("modular_chassis") and not is_dpu:
             service_list.append("lldp")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
When determining critical services for a MultiAsicSonicHost, sometimes we attempt to remove a service from the critical services list that has already been removed elsewhere.

#### How did you do it?
Replace in-place list removal during iteration with building a new filtered list. This prevents double-removing entries like lldp/teamd that were already removed in sonic.py for DPU.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
