### PR TITLE
[smartswitch] Skip temperature sensor test for unsupported DPU platforms

### DIFF
--- a/tests/smartswitch/platform_tests/test_dpu_show_platform_temperature.py
+++ b/tests/smartswitch/platform_tests/test_dpu_show_platform_temperature.py
@@ -75,6 +75,8 @@ def test_dpu_show_platform_temperature(duthosts, rand_one_dut_hostname):
     platform_temp_parsed = duthost.show_and_parse(cmd)
 
     platform = duthost.facts['platform']
+    if platform not in SENSORS:
+        pytest.skip("Platform '{}' not supported in temperature sensor test".format(platform))
     expected_sensors = SENSORS[platform]
     expected_sensor_values = EXPECTED_SENSOR_VALUES[platform]
 


### PR DESCRIPTION
## Description

Skip `test_dpu_show_platform_temperature` gracefully for platforms not yet defined in the `SENSORS` dictionary, instead of crashing with a `KeyError`.

Fixes #23016

## Changes

**`tests/smartswitch/platform_tests/test_dpu_show_platform_temperature.py`**

Added a guard before the `SENSORS[platform]` lookup that calls `pytest.skip()` when the platform is not in the dictionary. This prevents `KeyError` on platforms like Cisco 8102-28FH-DPU-O (`x86_64-8102_28fh_dpu_o-r0`) where sensor definitions have not yet been added.

## Root Cause

The `SENSORS` dictionary only contains entries for NVIDIA DPU platforms (`arm64-nvda_bf-bf3comdpu`, `arm64-nvda_bf-9009d3b600cvaa`). When the test runs on any other SmartSwitch platform, `SENSORS[platform]` raises `KeyError`.

## How it was tested

- Verified the fix logic against test logs from a Cisco 8102-28FH-DPU-O SmartSwitch running SONiC 202511
- The test now skips with a clear message instead of failing with `KeyError`
