### PR TITLE
[Mellanox] Remove mst dependency in mellanox devices 

### DIFF
--- a/tests/common/helpers/port_utils.py
+++ b/tests/common/helpers/port_utils.py
@@ -1,5 +1,4 @@
 from natsort import natsorted
-from tests.platform_tests.mellanox.software_control_helper import ASIC_DETECT_GET_DEVICE_PATH_CMD
 
 
 def get_common_supported_speeds(duthost, dut_port_name, fanout, fanout_port_name):
@@ -101,6 +100,8 @@ class MlnxCableSupportedSpeedsHelper(object):
         if (duthost, dut_port_name) in cls.supported_speeds:
             return cls.supported_speeds[duthost, dut_port_name]
 
+        # Command to get ASIC device (PCI) path on DUT
+        ASIC_DETECT_GET_DEVICE_PATH_CMD = '/usr/bin/asic_detect/asic_detect.sh -p'
         if duthost not in cls.sorted_ports:
             int_status = duthost.show_interface(command="status")["ansible_facts"]['int_status']
             ports = natsorted([port_name for port_name in list(int_status.keys())])

--- a/tests/platform_tests/mellanox/software_control_helper.py
+++ b/tests/platform_tests/mellanox/software_control_helper.py
@@ -4,8 +4,6 @@ import re
 from tests.platform_tests.mellanox.interface_utils import get_physical_index_to_interfaces_map
 
 SC_ENABLED = 1
-# Command to get ASIC device (PCI) path on DUT
-ASIC_DETECT_GET_DEVICE_PATH_CMD = '/usr/bin/asic_detect/asic_detect.sh -p'
 
 PLATFORM_FOLDER_PATH = "/usr/share/sonic/device/"
 SAI_PROFILE_FILE_NAME = "sai.profile"


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Remove MST driver dependency and use the asic_detect script to access the pci device for getting pci information

Summary:
Fixes # (issue)
This change is aligned to the change done in sonic-buildimage which removes start of mst driver: https://github.com/sonic-net/sonic-buildimage/pull/25575

### Type of change


<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
