### PR TITLE
vxlan: fix test_vxlan_vnet_bgp_subintf setup on dualtor and wait for ACL active

### DIFF
--- a/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
+++ b/tests/vxlan/test_vxlan_vnet_bgp_subintf.py
@@ -8,6 +8,7 @@ import pytest
 import time
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.config_reload import config_reload
+from tests.common.utilities import wait_until
 from tests.common.vxlan_ecmp_utils import Ecmp_Utils
 
 ecmp_utils = Ecmp_Utils()
@@ -349,7 +350,19 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
         pytest_assert(len(vnet_bgps) > 0 and vnet_bgps[0]["neighborname"] == "WLPARTNER_PASSIVE_V4"
                       and vnet_bgps[0]["state/pfxrcd"].isdigit(), f"BGP neighbor not found for vnet {VNET_NAME}.")
 
-        # Check acl table and rules are set
+        # Wait for ACL table and rule to become active (e.g. after config_reload on slower platforms)
+        def _acl_table_and_rule_active(duthost):
+            acl_table = duthost.shell(
+                f"sonic-db-cli STATE_DB HGET 'ACL_TABLE_TABLE|{ACL_TABLE_NAME}' 'status'",
+                module_ignore_errors=True)
+            if acl_table.get('stdout', '').strip().lower() != "active":
+                return False
+            acl_rule = duthost.shell(
+                f"sonic-db-cli STATE_DB HGET 'ACL_RULE_TABLE|{ACL_TABLE_NAME}|rule_1' 'status'",
+                module_ignore_errors=True)
+            return acl_rule.get('stdout', '').strip().lower() == "active"
+
+        wait_until(60, 2, 0, _acl_table_and_rule_active, duthost)
         acl_table = duthost.shell(f"sonic-db-cli STATE_DB HGET 'ACL_TABLE_TABLE|{ACL_TABLE_NAME}' 'status'")
         pytest_assert(acl_table['stdout'].strip().lower() == "active", f"ACL table {ACL_TABLE_NAME} not active.")
 
@@ -363,17 +376,24 @@ def common_setup_and_teardown(tbinfo, duthosts, rand_one_dut_hostname, ptfhost, 
         pytest_assert(route_tunnel['stdout'].strip().lower() == "active",
                       f"VNET route tunnel for {VNET_NAME} not active.")
 
-        # Get ptf eth of portchannels
+        # Get ptf eth of portchannels (only ports present in this DUT's ptf_map, e.g. dualtor)
         wl_ptf_port_num = []
         t1_ptf_port_num = []
         portchannel_members = config_facts.get("PORTCHANNEL_MEMBER", {})
         for key in portchannel_members:
             members = list(portchannel_members[key].keys())
             for intf in members:
+                dut_port_idx = port_indexes.get(intf)
+                if dut_port_idx is None:
+                    continue
+                ptf_port = ptf_ports_available_in_topo.get(dut_port_idx)
+                if ptf_port is None:
+                    # Port not in this DUT's ptf_map (e.g. dualtor: port on other ToR)
+                    continue
                 if key == wl_intf_info["wl_portchannel"]:
-                    wl_ptf_port_num.append(ptf_ports_available_in_topo[port_indexes[intf]])
+                    wl_ptf_port_num.append(ptf_port)
                 else:
-                    t1_ptf_port_num.append(ptf_ports_available_in_topo[port_indexes[intf]])
+                    t1_ptf_port_num.append(ptf_port)
 
         test_configs = {
             "wl_portchannel": wl_intf_info["wl_portchannel"],


### PR DESCRIPTION
### Description of PR
#### Summary:
Fix setup failure KeyError(28) in common_setup_and_teardown when running on dualtor (e.g. tor-dualtor3). Only use portchannel members that exist in this DUT's PTF map; skip ports that are on the other ToR or not in ptf_map for the selected DUT.

Wait for ACL table/rule active in test_vxlan_vnet_bgp_subintf setup

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

- `port_indexes` (from config_facts) has all DUT ports (e.g. Ethernet224 → 28).
- `ptf_ports_available_in_topo` is built from `tbinfo["topo"]["ptf_map"][str(dut_indx)]` and only contains ports for **this** ToR.
- In dualtor, a portchannel member (e.g. Ethernet224, DUT index 28) may not be in this DUT's ptf_map (e.g. it is on the other ToR).
- Code did `ptf_ports_available_in_topo[port_indexes[intf]]` → **KeyError(28)** when 28 was not a key.

- After config_reload, STATE_DB can show ACL table as "Inactive" for a while on some platforms.


#### How did you do it?
In dualtor, ptf_map per DUT only includes ports for that ToR. Portchannel members can have DUT port indices not in this DUT's ptf_map (e.g. port on other ToR). Use .get() and skip such ports instead of KeyError.

- Only append to wl_ptf_port_num/t1_ptf_port_num when port is in ptf_ports_available_in_topo for this DUT
- Skip port_indexes.get(intf) and ptf_ports_available_in_topo.get() when missing

- Resolve DUT port index with `port_indexes.get(intf)` and skip if missing.
- Resolve PTF port with `ptf_ports_available_in_topo.get(dut_port_idx)`; if `None`, skip that member (port not in this DUT's ptf_map).
- Only append to `wl_ptf_port_num` / `t1_ptf_port_num` when a valid PTF port is found.
- Existing assertions still require at least one WL and one T1 port in topo; if all members are skipped, test fails with a clear message.

- Add `wait_until(60, 2, 0, _acl_table_and_rule_active, duthost)` before asserting ACL table and rule status.
- Helper `_acl_table_and_rule_active` polls STATE_DB; existing assertions kept for clear failure messages.

#### How did you verify/test it?

- Lint: clean.
- Dualtor: setup no longer raises KeyError(28).
- Titan T0 / slower platforms: ACL check no longer fails when table becomes active shortly after 10s.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
