### PR TITLE
Refine detection of Marvell ASICs

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1908,6 +1908,18 @@ Totals               6450                 6449
                     return asic
         return UNKNOWN_ASIC
 
+    def _try_get_mrvl_asic_name(self, output):
+        prestera_devices = {
+            "Device 8400",  # Falcon
+            "Device 9400",  # AlleyCat5P
+        }
+
+        for search_term in prestera_devices:
+            if search_term in output:
+                return "marvell-prestera"
+
+        return "marvell-teralynx"
+
     def get_asic_name(self):
         asic = UNKNOWN_ASIC
         output = self.shell("lspci", module_ignore_errors=True)["stdout"]
@@ -1918,7 +1930,7 @@ Totals               6450                 6449
         elif "Mellanox Technologies" in output:
             asic = "spc"
         elif "Marvell Technology" in output:
-            asic = "marvell-teralynx"
+            asic = self._try_get_mrvl_asic_name(output)
 
         logger.info("asic: {}".format(asic))
 


### PR DESCRIPTION
Distinguish between "marvell-teralynx" and "marvell-prestera" ASICs.

### Description of PR

This allows sonic-mgmt to differentiate "marvell-teralynx" and "marvell-prestera" ASICs.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Allow testing of marvell-prestera based switches

#### How did you do it?
Use the PCI device ID to distinguish between "marvell-prestera" and the rest. For now "the rest" assumes any Marvell ASIC that is not one of the explicitly listed IDs is "marvell-teralynx".

#### How did you verify/test it?
Run tests locally with a marvell-prestera switch.