### PR TITLE
Enable test_qos_sai for q3d

### DIFF
--- a/tests/common/plugins/conditional_mark/__init__.py
+++ b/tests/common/plugins/conditional_mark/__init__.py
@@ -28,7 +28,7 @@ MARK_CONDITIONS_CONSTANTS = {
                      't1-lag', 't1-28-lag', 't1-48-lag', 't1-64-lag', 't1-56-lag',
                      't1-backend', 't1-isolated-d128', 't1-isolated-d32',
                      't2', 't2_2lc_36p-masic', 't2_2lc_min_ports-masic',
-                     'lt2-p32o64', 'lt2-o128', 'ft2-64']
+                     'lt2-p32o64', 'lt2-o128', 'ft2-64', 't2-single-node-min']
 }
 
 

--- a/tests/qos/files/qos_params.q3d.yaml
+++ b/tests/qos/files/qos_params.q3d.yaml
@@ -1,0 +1,363 @@
+qos_params:
+    q3d:
+        topo-t2-single-node-min:
+            400000_2000m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 50
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 2
+                    packet_size: 1500
+                    cell_size: 1500 # No concept of cell, keep it equal to packet size.
+                    pkts_num_hdrm_full: 880 # current max headroom size 1384448
+                    pkts_num_hdrm_partial: 850
+                    pkts_num_trig_pfc: 25280
+                    pkts_num_trig_pfc_multi:
+                    - 25280
+                    - 25220 # Dynamic th is -6 leading to very less difference in trigerring pfc for subsequent queues.
+                    src_port_ids:
+                    - 0
+                pkts_num_leak_out: 140
+                internal_hdr_size: 48
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 100
+                    pkts_num_trig_egr_drp: 38400
+                    packet_size: 1500
+                    cell_size: 1500 # No concept of cell, keep it equal to packet size.
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 25700
+                    pkts_num_trig_ingr_drp: 26515
+                    pkts_num_margin: 50
+                    packet_size: 1500
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 25700
+                    pkts_num_trig_ingr_drp: 26515
+                    pkts_num_margin: 50
+                    packet_size: 1500
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 100
+                    pkts_num_margin: 1000
+                    pkts_num_trig_pfc: 25000
+                    packet_size: 1500
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 100
+                    pkts_num_margin: 1000
+                    pkts_num_trig_pfc: 25000
+                    packet_size: 1500
+            400000_120000m:
+                hdrm_pool_size:
+                    dscps:
+                    - 3
+                    - 4
+                    dst_port_id: 0
+                    ecn: 1
+                    margin: 100
+                    pgs:
+                    - 3
+                    - 4
+                    pgs_num: 2
+                    packet_size: 1500
+                    cell_size: 1500 # No concept of cell, keep it equal to packet size.
+                    pkts_num_hdrm_full: 53900 # Current max headroom size 82837504
+                    pkts_num_hdrm_partial: 53800
+                    pkts_num_trig_pfc: 25280
+                    pkts_num_trig_pfc_multi:
+                    - 25280
+                    - 25220 # Dynamic th is -6 leading to very less difference in trigerring pfc for subsequent queues.
+                    src_port_ids:
+                    - 0
+                pkts_num_leak_out: 140
+                internal_hdr_size: 48
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_margin: 100
+                    pkts_num_trig_egr_drp: 38400
+                    packet_size: 1500
+                    cell_size: 1500 # No concept of cell, keep it equal to packet size.
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 25700
+                    pkts_num_trig_ingr_drp: 79550
+                    pkts_num_margin: 100
+                    packet_size: 1500
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 25700
+                    pkts_num_trig_ingr_drp: 79550
+                    pkts_num_margin: 100
+                    packet_size: 1500
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_dismiss_pfc: 100
+                    pkts_num_margin: 1000
+                    pkts_num_trig_pfc: 25000
+                    packet_size: 1500
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_dismiss_pfc: 100
+                    pkts_num_margin: 1000
+                    pkts_num_trig_pfc: 25000
+                    packet_size: 1500
+            100000_120000m:
+                pkts_num_leak_out: 5
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_trig_ingr_drp: 566603
+                    pkts_num_margin: 100
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_trig_ingr_drp: 566603
+                    pkts_num_margin: 100
+                hdrm_pool_size:
+                    dscps: [ 3, 4 ]
+                    ecn: 1
+                    pgs: [ 3, 4 ]
+                    src_port_ids: [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ]
+                    dst_port_id: 18
+                    pgs_num: 18
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_hdrm_full: 178614
+                    pkts_num_hdrm_partial: 178514
+                    margin: 100
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_trig_ingr_drp: 566603
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_dismiss_pfc: 3245
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 387989
+                    pkts_num_dismiss_pfc: 3245
+                    pkts_num_margin: 150
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_margin: 200
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 387989
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 566603
+                    cell_size: 4096
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_pfc: 28160
+                    pkts_num_trig_ingr_drp: 566603
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    cell_size: 4096
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 2179900
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 4096
+            400000_30m:
+                pkts_num_leak_out: 140
+                internal_hdr_size: 48
+                xoff_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
+                    pkts_num_margin: 100
+                xoff_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
+                    pkts_num_margin: 100
+                hdrm_pool_size:
+                    dscps: [3, 4]
+                    ecn: 1
+                    pgs: [3, 4]
+                    src_port_ids: [0, 2, 4, 6, 8, 10, 12, 14, 16]
+                    dst_port_id: 18
+                    pgs_num: 18
+                    packet_size: 1246
+                    cell_size: 4096
+                    pkts_num_trig_pfc: 60391
+                    pkts_num_hdrm_full: 1153
+                    pkts_num_hdrm_partial: 1143
+                    margin: 30
+                wm_pg_headroom:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_trig_ingr_drp: 775751
+                    cell_size: 4096
+                    pkts_num_margin: 30
+                xon_1:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_dismiss_pfc: 12985
+                    pkts_num_margin: 150
+                xon_2:
+                    dscp: 4
+                    ecn: 1
+                    pg: 4
+                    pkts_num_trig_pfc: 762403
+                    pkts_num_dismiss_pfc: 12985
+                    pkts_num_margin: 150
+                lossy_queue_1:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_trig_egr_drp: 2179770
+                    pkts_num_margin: 100
+                wm_pg_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_pfc: 762403
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_pg_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2179770
+                    packet_size: 64
+                    cell_size: 4096
+                    pkts_num_margin: 40
+                wm_q_shared_lossless:
+                    dscp: 3
+                    ecn: 1
+                    queue: 3
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_ingr_drp: 775751
+                    cell_size: 4096
+                wm_buf_pool_lossless:
+                    dscp: 3
+                    ecn: 1
+                    pg: 3
+                    queue: 3
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_pfc: 28160
+                    pkts_num_trig_ingr_drp: 775751
+                    pkts_num_fill_egr_min: 8
+                    cell_size: 4096
+                wm_q_shared_lossy:
+                    dscp: 8
+                    ecn: 1
+                    queue: 0
+                    pkts_num_fill_min: 0
+                    pkts_num_trig_egr_drp: 2179770
+                    cell_size: 4096
+                wm_buf_pool_lossy:
+                    dscp: 8
+                    ecn: 1
+                    pg: 0
+                    queue: 0
+                    pkts_num_fill_ingr_min: 0
+                    pkts_num_trig_egr_drp: 2179770
+                    pkts_num_fill_egr_min: 0
+                    cell_size: 4096
+            wrr:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [50, 50, 100, 50, 50, 350]
+            wrr_chg:
+                dscp_list: [0, 47, 3, 4, 46, 44]
+                ecn: 1
+                limit: 80
+                lossless_weight: 30
+                lossy_weight: 8
+                q_list: [0, 1, 3, 4, 5, 6]
+                q_pkt_cnt: [80, 100, 300, 100, 100, 700]
+        topo-any:
+            cell_size: 4096

--- a/tests/qos/qos_sai_base.py
+++ b/tests/qos/qos_sai_base.py
@@ -59,7 +59,7 @@ class QosBase:
                           "t1-isolated-d448u15-lag", "t1-isolated-v6-d448u15-lag"]
     SUPPORTED_PTF_TOPOS = ['ptf32', 'ptf64']
     SUPPORTED_ASIC_LIST = ["pac", "gr", "gr2", "gb", "td2", "th", "th2", "spc1", "spc2", "spc3", "spc4", "spc5",
-                           "td3", "th3", "j2c+", "jr2", "th5"]
+                           "td3", "th3", "j2c+", "jr2", "th5", "q3d"]
 
     BREAKOUT_SKUS = ['Arista-7050-QX-32S']
     LOW_SPEED_PORT_SKUS = ['Arista-7050CX3-32S-C28S4', 'Arista-7050CX3-32C-C28S4']

--- a/tests/qos/test_pfc_counters.py
+++ b/tests/qos/test_pfc_counters.py
@@ -85,11 +85,12 @@ def run_test(fanouthosts, duthost, conn_graph_facts, enum_fanout_graph_facts, le
     onyx_pfc_container_name = 'storm'
     int_status = asic.show_interface(command="status")[
         'ansible_facts']['int_status']
-    """ We only test active physical interfaces """
+    """ We only test active physical interfaces that have connection graph entries """
     active_phy_intfs = [intf for intf in int_status if
                         intf.startswith('Ethernet') and
                         int_status[intf]['admin_state'] == 'up' and
-                        int_status[intf]['oper_state'] == 'up']
+                        int_status[intf]['oper_state'] == 'up' and
+                        intf in conn_facts]
     only_lossless_rx_counters = "Cisco-8122" in asic.sonichost.facts["hwsku"]
     no_xon_counters = "Cisco-8122" in asic.sonichost.facts["hwsku"]
     if only_lossless_rx_counters and asic_type != 'vs':

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -468,6 +468,7 @@ class TestQosSai(QosSaiBase):
         testParams.update(dutTestParams["basicParams"])
         testParams.update({"test_port_ids": dutConfig["testPortIds"]})
         testParams.update({
+            "dut_asic": dutConfig["dutAsic"],
             "dscp": qosConfig[xoffProfile]["dscp"],
             "ecn": qosConfig[xoffProfile]["ecn"],
             "pg": qosConfig[xoffProfile]["pg"],
@@ -928,7 +929,7 @@ class TestQosSai(QosSaiBase):
         dst_asic_index = get_src_dst_asic_and_duts['dst_asic_index']
 
         if ('platform_asic' in dutTestParams["basicParams"] and
-                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx"):
+                dutTestParams["basicParams"]["platform_asic"] == "broadcom-dnx") and (dutConfig["dutAsic"] != 'q3d'):
             # for 100G port speed the number of ports required to fill headroom is huge,
             # hence skipping the test with speed 100G or cable length of 2k
             if portSpeedCableLength not in ['400000_120000m']:
@@ -954,9 +955,12 @@ class TestQosSai(QosSaiBase):
             else:
                 qosConfig["hdrm_pool_size"]["dst_port_id"] = dutConfig['testPortIds'][dst_dut_index][dst_asic_index][0]
 
-            src_port_vlans = [testPortIps[src_dut_index][src_asic_index][port]['vlan_id']
-                              if 'vlan_id' in testPortIps[src_dut_index][src_asic_index][port]
-                              else None for port in qosConfig["hdrm_pool_size"]["src_port_ids"]]
+        src_port_vlans = [
+            testPortIps[src_dut_index][src_asic_index][port]['vlan_id']
+            if port in testPortIps[src_dut_index][src_asic_index] and
+            'vlan_id' in testPortIps[src_dut_index][src_asic_index][port]
+            else None for port in qosConfig["hdrm_pool_size"]["src_port_ids"]]
+
         self.updateTestPortIdIp(dutConfig, get_src_dst_asic_and_duts, qosConfig["hdrm_pool_size"])
 
         testParams = dict()
@@ -1344,7 +1348,8 @@ class TestQosSai(QosSaiBase):
             "pkts_num_leak_out": dutQosConfig["param"][portSpeedCableLength]["pkts_num_leak_out"],
             "pkts_num_trig_egr_drp": qosConfig["lossy_queue_1"]["pkts_num_trig_egr_drp"],
             "hwsku": dutTestParams['hwsku'],
-            "ip_type": dutConfig["ip_type"]
+            "ip_type": dutConfig["ip_type"],
+            "dut_asic": dutConfig["dutAsic"],
         })
 
         if "platform_asic" in dutTestParams["basicParams"]:

--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -139,6 +139,15 @@ SAI_LOG = "/var/log/sai.log"
 SDK_LOG = "/var/log/syslog"
 
 
+def update_COUNTER_MARGIN(dut_asic):
+    global COUNTER_MARGIN
+    # For q3d few extra ipv6 NS/RA pkt(6-9) received from VM, adding to counter value
+    # & may give inconsistent test results so changing margin to 10
+    if dut_asic == "q3d":
+        log_message("Overriding COUNTER_MARGIN to 10 for q3d", to_stderr=True)
+        COUNTER_MARGIN = 10
+
+
 def log_message(message, level='info', to_stderr=False):
     if to_stderr:
         sys.stderr.write(message + "\n")
@@ -571,6 +580,8 @@ def dynamically_compensate_leakout(
     while leakout_num > 0 and retry < max_retry:
         send_packet(ptf_test, compensate_port, compensate_pkt, leakout_num)
         num += leakout_num
+        # Wait for the packet to be leaked out
+        time.sleep(1)
         prev = curr
         curr, _ = counter_checker(thrift_client, asic_type, check_port)
         leakout_num = curr[check_field] - prev[check_field]
@@ -2156,6 +2167,7 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         initialize_diag_counter(self)
 
         # Parse input parameters
+        dut_asic = self.test_params['dut_asic']
         dscp = int(self.test_params['dscp'])
         ecn = int(self.test_params['ecn'])
         router_mac = self.test_params['router_mac']
@@ -2182,6 +2194,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
         pkt_dst_mac = router_mac if router_mac != '' else dst_port_mac
         # get counter names to query
         ingress_counters, egress_counters = get_counter_names(sonic_version)
+
+        update_COUNTER_MARGIN(dut_asic)
 
         # get a snapshot of PG drop packets counter
         if '201811' not in sonic_version and ('mellanox' in asic_type or 'cisco-8000' in asic_type):
@@ -2273,6 +2287,8 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                 send_packet(self, src_port_id, pkt, (pkts_num_egr_mem +
                                                      pkts_num_leak_out +
                                                      pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
+                pkt_count = (pkts_num_egr_mem + pkts_num_leak_out +
+                             pkts_num_trig_pfc) // cell_occupancy - 1 - margin
             elif 'cisco-8000' in asic_type:
                 fill_leakout_plus_one(
                     self, src_port_id, dst_port_id,
@@ -2281,10 +2297,16 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
                 # Send 1 less packet due to leakout filling
                 send_packet(self, src_port_id, pkt, (pkts_num_leak_out +
                                                      pkts_num_trig_pfc) // cell_occupancy - 2 - margin)
+                pkt_count = (pkts_num_leak_out +
+                             pkts_num_trig_pfc) // cell_occupancy - 2 - margin
             else:
                 # send packets short of triggering pfc
                 send_packet(self, src_port_id, pkt, (pkts_num_leak_out +
                                                      pkts_num_trig_pfc) // cell_occupancy - 1 - margin)
+                pkt_count = (pkts_num_leak_out +
+                             pkts_num_trig_pfc) // cell_occupancy - 1 - margin
+            log_message("Sending {} packets to port {} short of PFC trigger".format(
+                pkt_count, src_port_id), to_stderr=True)
             capture_diag_counter(self, 'ShortOfPfc')
 
             # allow enough time for the dut to sync up the counter values in counters_db
@@ -2343,6 +2365,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
             # send 1 packet to trigger pfc
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
+            log_message("Sending {} packets to port {} to trigger PFC".format(
+                1 + 2 * margin, src_port_id), to_stderr=True)
+
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             capture_diag_counter(self, 'TrigPfc')
@@ -2394,6 +2419,11 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # send packets short of ingress drop
             send_packet(self, src_port_id, pkt, (pkts_num_trig_ingr_drp -
                                                  pkts_num_trig_pfc) // cell_occupancy - 1 - 2 * margin)
+            pkt_count = ((pkts_num_trig_ingr_drp - pkts_num_trig_pfc) //
+                         cell_occupancy - 1 - 2 * margin)
+            log_message("Sending {} packets to port {} short of ingress drop".format(
+                pkt_count, src_port_id), to_stderr=True)
+
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             capture_diag_counter(self, 'ShortOfIngDrp')
@@ -2436,6 +2466,9 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
 
             # send 1 packet to trigger ingress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
+            log_message("Sending {} packets to port {} to trigger ingress drop".format(
+                1 + 2 * margin, src_port_id), to_stderr=True)
+
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
             capture_diag_counter(self, 'TrigIngDrp')
@@ -2892,6 +2925,8 @@ class PFCXonTest(sai_base_test.ThriftInterfaceDataPlane):
         hwsku = self.test_params['hwsku']
         src_dst_asic_diff = self.test_params['src_dst_asic_diff']
         dut_asic = self.test_params['dut_asic']
+
+        update_COUNTER_MARGIN(dut_asic)
 
         self.sai_thrift_port_tx_enable(self.dst_client, asic_type, [dst_port_id, dst_port_2_id, dst_port_3_id])
 
@@ -3660,7 +3695,7 @@ class HdrmPoolSizeTest_withDynamicBufferCacl(sai_base_test.ThriftInterfaceDataPl
             pkt_cnt = 1 + 2 * margin
             send_packet(self, self.src_port_ids[sidx_dscp_pg_tuples[i][0]], pkt, pkt_cnt)
             # allow enough time for the dut to sync up the counter values in counters_db
-            time.sleep(1.5)
+            time.sleep(5)
             self.show_port_counter(self.asic_type, recv_counters_bases, xmit_counters_bases,
                                    'To fill last PG and trigger ingress drop, send {} pkt with DSCP {} PG {}'
                                    ' from src_port{} to dst_port'.format(pkt_cnt, sidx_dscp_pg_tuples[i][1],
@@ -4843,6 +4878,9 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
         hwsku = self.test_params['hwsku']
         platform_asic = self.test_params['platform_asic']
         ip_type = self.test_params.get('ip_type', 'ipv4')
+        dut_asic = self.test_params["dut_asic"]
+
+        update_COUNTER_MARGIN(dut_asic)
 
         # get counter names to query
         ingress_counters, egress_counters = get_counter_names(sonic_version)
@@ -4932,21 +4970,16 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             # Since there is variability in packet leakout in hwsku Arista-7050CX3-32S-D48C8 and
             # Arista-7050CX3-32S-C32. Starting with zero pkts_num_leak_out and trying to find
             # actual leakout by sending packets and reading actual leakout from HW
-            if hwsku == 'DellEMC-Z9332f-O32' or hwsku == 'DellEMC-Z9332f-M-O16C64':
+            if (hwsku == 'DellEMC-Z9332f-O32' or
+                    hwsku == 'DellEMC-Z9332f-M-O16C64' or
+                    check_leackout_compensation_support(asic_type, hwsku)):
                 pkts_num_leak_out = 0
 
             if asic_type == 'cisco-8000':
-                qos_test_assert(self, fill_leakout_plus_one(self, src_port_id, dst_port_id,
-                                                            pkt, int(self.test_params['pg']), asic_type))
-
-            if platform_asic and platform_asic == "broadcom-dnx":
-                if check_leackout_compensation_support(asic_type, hwsku):
-                    send_packet(self, src_port_id, pkt, pkts_num_leak_out)
-                    time.sleep(5)
-                    dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
-                                                   port_list['dst'][dst_port_id], TRANSMITTED_PKTS,
-                                                   xmit_counters_base, self, src_port_id, pkt, 10)
-                    pkts_num_leak_out = 0
+                qos_test_assert(
+                    self, fill_leakout_plus_one(
+                        self, src_port_id, dst_port_id, pkt,
+                        int(self.test_params['pg']), asic_type))
 
             # send packets short of triggering egress drop
             if hwsku in ('DellEMC-Z9332f-M-O16C64', 'DellEMC-Z9332f-O32') or 'Arista-7060X6' in hwsku:
@@ -4959,6 +4992,12 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                 # send packets short of triggering egress drop
                 send_packet(self, src_port_id, pkt, pkts_num_leak_out +
                             pkts_num_trig_egr_drp - 1 - margin)
+                log_message(
+                    "Sending {}({} + {} - 1 - {}) packets short of "
+                    "triggering drop".format(
+                        pkts_num_leak_out + pkts_num_trig_egr_drp - 1 - margin,
+                        pkts_num_leak_out, pkts_num_trig_egr_drp, margin),
+                    to_stderr=True)
                 if check_leackout_compensation_support(asic_type, hwsku):
                     time.sleep(5)
                     dynamically_compensate_leakout(self.dst_client, asic_type, sai_thrift_read_port_counters,
@@ -4985,7 +5024,11 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             if platform_asic and platform_asic == "broadcom-dnx":
                 voq_queue_counters = sai_thrift_read_port_voq_counters(self.src_client, voq_list)
             # recv port no pfc
-            qos_test_assert(self, recv_counters[pg] == recv_counters_base[pg])
+            qos_test_assert(
+                self, recv_counters[pg] == recv_counters_base[pg],
+                "Unexpected PFC triggered: recv_counters[{}]={} != "
+                "recv_counters_base[{}]={}".format(
+                    pg, recv_counters[pg], pg, recv_counters_base[pg]))
             # recv port no ingress drop
             # For dnx few extra ipv6 NS/RA pkt received, adding to coutner value
             # & may give inconsistent test results
@@ -4996,15 +5039,34 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                     if cntr == 1:
                         log_message("recv_counters_base: {}, recv_counters: {}".format(
                             recv_counters_base[cntr], recv_counters[cntr]), to_stderr=True)
-                        qos_test_assert(self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN)
+                        qos_test_assert(
+                            self,
+                            recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
+                            "Ingress drop encountered: {} packets dropped on "
+                            "counter {} ({})".format(
+                                recv_counters[cntr] - recv_counters_base[cntr],
+                                cntr, port_counter_fields[cntr]))
                 else:
-                    qos_test_assert(self, recv_counters[cntr] == recv_counters_base[cntr])
+                    qos_test_assert(
+                        self, recv_counters[cntr] == recv_counters_base[cntr],
+                        "Ingress drop encountered: {} packets dropped on "
+                        "counter {} ({})".format(
+                            recv_counters[cntr] - recv_counters_base[cntr],
+                            cntr, port_counter_fields[cntr]))
             # xmit port no egress drop
             for cntr in egress_counters:
-                qos_test_assert(self, xmit_counters[cntr] == xmit_counters_base[cntr])
+                qos_test_assert(
+                    self, xmit_counters[cntr] == xmit_counters_base[cntr],
+                    "Egress drop encountered: {} packets dropped on "
+                    "counter {} ({})".format(
+                        xmit_counters[cntr] - xmit_counters_base[cntr],
+                        cntr, port_counter_fields[cntr]))
 
             # send 1 packet to trigger egress drop
             send_packet(self, src_port_id, pkt, 1 + 2 * margin)
+            log_message(
+                "Sending {}(1 + 2 *{}) packets short of triggering drop".format(
+                    1 + 2 * margin, margin), to_stderr=True)
             # allow enough time for the dut to sync up the counter values in counters_db
             time.sleep(8)
 
@@ -5017,21 +5079,57 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             xmit_counters, queue_counters = sai_thrift_read_port_counters(
                 self.dst_client, asic_type, port_list['dst'][dst_port_id])
             # recv port no pfc
-            qos_test_assert(self, recv_counters[pg] == recv_counters_base[pg])
+            qos_test_assert(
+                self, recv_counters[pg] == recv_counters_base[pg],
+                "Unexpected PFC triggered: recv_counters[{}]={} != "
+                "recv_counters_base[{}]={}".format(
+                    pg, recv_counters[pg], pg, recv_counters_base[pg]))
             # recv port no ingress drop
             for cntr in ingress_counters:
                 if platform_asic and platform_asic == "broadcom-dnx":
                     if cntr == 1:
-                        qos_test_assert(self, recv_counters[cntr] > recv_counters_base[cntr])
+                        if dut_asic == 'q3d':
+                            qos_test_assert(
+                                self, recv_counters[cntr] > recv_counters_base[cntr],
+                                "Expected ingress drop but counter {} ({}) did not "
+                                "increase: {} <= {}".format(
+                                    cntr, port_counter_fields[cntr],
+                                    recv_counters[cntr], recv_counters_base[cntr]))
+                        else:
+                            qos_test_assert(
+                                self, recv_counters[cntr] >= recv_counters_base[cntr],
+                                "Ingress drop encountered: {} packets dropped on "
+                                "counter {} ({})".format(
+                                    recv_counters[cntr] - recv_counters_base[cntr],
+                                    cntr, port_counter_fields[cntr]))
                 else:
-                    qos_test_assert(self, recv_counters[cntr] == recv_counters_base[cntr])
+                    qos_test_assert(
+                        self, recv_counters[cntr] == recv_counters_base[cntr],
+                        "Ingress drop encountered: {} packets dropped on "
+                        "counter {} ({})".format(
+                            recv_counters[cntr] - recv_counters_base[cntr],
+                            cntr, port_counter_fields[cntr]))
 
             # xmit port egress drop
-            if platform_asic and platform_asic == "broadcom-dnx":
+            if platform_asic and platform_asic == "broadcom-dnx" and dut_asic != 'q3d':
                 log_message("On J2C+ don't support egress drop stats - so ignoring this step for now", to_stderr=True)
+            elif dut_asic == 'q3d':
+                # No egress drop are expected
+                for cntr in egress_counters:
+                    qos_test_assert(
+                        self, xmit_counters[cntr] == xmit_counters_base[cntr],
+                        "Egress drop encountered {} (packets dropped on "
+                        "counter {} ({})".format(
+                            xmit_counters[cntr] - xmit_counters_base[cntr],
+                            cntr, port_counter_fields[cntr]))
             else:
                 for cntr in egress_counters:
-                    qos_test_assert(self, xmit_counters[cntr] > xmit_counters_base[cntr])
+                    qos_test_assert(
+                        self, xmit_counters[cntr] > xmit_counters_base[cntr],
+                        "Expected egress drop but counter {} ({}) did not "
+                        "increase: {} <= {}".format(
+                            cntr, port_counter_fields[cntr],
+                            xmit_counters[cntr], xmit_counters_base[cntr]))
 
             # voq ingress drop
             if platform_asic and platform_asic == "broadcom-dnx":


### PR DESCRIPTION
### Description of PR
Enable test_qos_sai for q3d. Backport of https://github.com/sonic-net/sonic-mgmt/pull/22156 to 202511

**Summary:**
This PR enables the following tests for Q3d platform.

1. testParameter
2. testQosSaiDscpQueueMapping
3. testQosSaiDwrr
4. testQosSaiDwrrWeightChange
5. testQosSaiHeadroomPoolSize
6. testQosSaiPfcXoffLimit
7. testQosSaiPfcXonLimit
8. testQosSaiLossyQueue


### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Run qos sanity test on q3d platform.

#### How did you do it?
Added q3d yaml file along with required changes in testcase.

Backport of PR #22156 to 202511 branch.

#### How did you verify/test it?
Ran on q3d platform.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A