### PR TITLE
Fix lossless_prio_list on single-ASIC devices

### DIFF
--- a/tests/qos/qos_fixtures.py
+++ b/tests/qos/qos_fixtures.py
@@ -75,7 +75,8 @@ def lossless_prio_list(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum
         Lossless priorities (list)
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    config_facts = duthost.config_facts(host=duthost.hostname, asic_index=enum_rand_one_frontend_asic_index,
+    asichost = duthost.asic_instance(enum_rand_one_frontend_asic_index)
+    config_facts = duthost.config_facts(host=duthost.hostname, asic_index=asichost.asic_index,
                                         source="running")['ansible_facts']
 
     if "PORT_QOS_MAP" not in list(config_facts.keys()):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Fixes a ValueError that occurs when the lossless_prio_list fixture is used with single-ASIC devices. 
The issue arises because enum_rand_one_frontend_asic_index returns None for single-ASIC devices, 
which causes config_facts() to fail.

The fix uses the duthost.asic_instance() pattern to properly handle None values, 
converting them to valid ASIC index 0 for single-ASIC devices.

Summary:
Fixes #23029 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The `lossless_prio_list` fixture in `tests/qos/qos_fixtures.py` fails with a `ValueError` 
on single-ASIC devices because `enum_rand_one_frontend_asic_index` returns `None` for single-ASIC devices,
 but the Ansible `config_facts` module expects an integer or the string `'all'`, not `None`.
This blocks QoS tests (e.g., `test_ecn_config_utility`) from running on single-ASIC topologies.

#### How did you do it?
Use `MultiAsicSonicHost.asic_instance()` method (defined in `tests/common/devices/multi_asic.py:239-248`) 
to handle `None` correctly by returning `self.asics[0]` with `asic_index=0` for single-ASIC devices.

#### How did you verify/test it?
Ran qos/test_ecn_config.py::test_ecn_config_utility[ldp205-None] 

#### Any platform specific information?
Single-ASIC devices are affected 

#### Supported testbed topology if it's a new test case?
N/A
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
N/A
