### PR TITLE
Remove stale 10.2.0.1/32 static route from SmartSwitch golden config

### DIFF
--- a/ansible/golden_config_db/smartswitch_t1.json
+++ b/ansible/golden_config_db/smartswitch_t1.json
@@ -10,15 +10,6 @@
             "log_level": "2",
             "port": "50052"
         }
-    },
-    "STATIC_ROUTE": {
-        "default|10.2.0.1/32": {
-            "blackhole": "false",
-            "distance": "0",
-            "ifname": "",
-            "nexthop": "18.0.202.1",
-            "nexthop-vrf": "default"
-        }
     }
 
 }


### PR DESCRIPTION
The STATIC_ROUTE for 10.2.0.1/32 was a leftover from the old per-port DPU dataplane setup (nexthop 18.0.202.1). No test or functionality depends on this route — tests add their own routes dynamically via fixtures. Removing it fixes the routeCheck failure on SmartSwitch testbeds.




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove the hardcoded STATIC_ROUTE entry for 10.2.0.1/32 (nexthop 18.0.202.1) from smartswitch_t1.json
This route was a leftover from the old per-port DPU dataplane setup (18.x.202.x INTERFACE entries), which was replaced by VLAN-based connectivity (20.0.200.x / 20.0.201.x) in #22839
The nexthop 18.0.202.1 is no longer reachable, causing routeCheck monit failures on SmartSwitch testbeds: missed_ROUTE_TABLE_routes: ["10.2.0.1/32"]
No test or feature depends on this route -- HA/DASH tests add their own static routes dynamically via pytest fixtures (add_npu_static_routes)
Root Cause
After the VLAN dataplane migration, the NPU golden config still contained:

"STATIC_ROUTE": {
    "default|10.2.0.1/32": {
        "nexthop": "18.0.202.1"
    }
}
Since 18.0.202.1 no longer exists as a DPU interface, the route cannot be resolved and is never programmed into the ASIC. The routeCheck script detects the mismatch between CONFIG_DB and ASIC_DB and raises a monit alert.


Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ X] 202511

### Approach

#### What is the motivation for this PR?
fter the VLAN-based DPU dataplane migration (#22839), the SmartSwitch golden config (smartswitch_t1.json) still contained a hardcoded STATIC_ROUTE for 10.2.0.1/32 with nexthop 18.0.202.1. This was the old per-port DPU dataplane address which no longer exists. Since the nexthop is unreachable, the route never gets programmed into the ASIC, causing routeCheck monit failures on every SmartSwitch testbed:

'routeCheck' status failed (255) -- Failure results: {
    "": {
        "missed_ROUTE_TABLE_routes": [
            "10.2.0.1/32"
        ]
    }
}
No test or feature depends on this route -- HA/DASH PrivateLink tests add their own static routes dynamically via pytest fixtures (add_npu_static_routes).
#### How did you do it?

#### How did you verify/test it?
Removed the STATIC_ROUTE section from ansible/golden_config_db/smartswitch_t1.json. This is the only change 
#### Any platform specific information?
Applies to SmartSwitch platforms only (e.g., Cisco-8102-28FH-DPU-O). No impact on other platforms.
#### Supported testbed topology if it's a new test case?
N/A -- this is a config fix, not a new test case. Affects t1-smartswitch and t1-smartswitch-ha topologies
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
