### PR TITLE
[test_container_autorestart][otel] Added otel to the skip condition list

### DIFF
--- a/tests/autorestart/test_container_autorestart.py
+++ b/tests/autorestart/test_container_autorestart.py
@@ -497,6 +497,7 @@ def run_test_on_single_container(duthost, container_name, service_name, tbinfo):
     skip_condition = disabled_containers[:]
     skip_condition.append("database")
     skip_condition.append("acms")
+    skip_condition.append("otel")
     if tbinfo["topo"]["type"] != "t0":
         skip_condition.append("radv")
     if "202412" in duthost.os_version:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
otel container is expected to always restart.
The test_containers_autorestart test consistently fails for the otel container. When the test kills the critical otel process, the container does not stop as expected because the otel program in the container's supervisord config has autorestart=true. This causes supervisord to immediately respawn the process before supervisor-proc-exit-listener can detect the exit and trigger a container-level stop — resulting in the assertion "Failed to stop container 'otel'".

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test_containers_autorestart test consistently fails for the otel container. When the test kills the critical otel process, the container does not stop as expected because the otel program in the container's supervisord config has autorestart=true. This causes supervisord to immediately respawn the process before supervisor-proc-exit-listener can detect the exit and trigger a container-level stop — resulting in the assertion "Failed to stop container 'otel'".
#### How did you do it?
Added otel to the skip_condition list in run_test_on_single_container()
#### How did you verify/test it?
In internal test setup.
#### Any platform specific information?
sn5640
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
