### PR TITLE
[Test Gap][decap][t0] Add test_decap_warmboot to verify decap rules persist after warm-reboot

### DIFF
--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -18,6 +18,7 @@ from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
 from tests.common.reboot import reboot                                      # noqa: F401
+from tests.common.helpers.assertions import pytest_assert
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa: F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
@@ -353,25 +354,62 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
             apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'DEL')
 
 
+# ---------------------------------------------------------------------------
+# Warm-reboot decap test (Test Gap #16480)
+# ---------------------------------------------------------------------------
+
+TUNNEL_TABLE_KEY = "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL"
+DECAP_RULE_FIELDS = ["dscp_mode", "ecn_mode", "ttl_mode", "tunnel_type"]
+
+
+def _read_decap_rules(duthost):
+    """Return default IPINIP_TUNNEL configuration from APP_DB as a dict."""
+    rules = {}
+    for field in DECAP_RULE_FIELDS:
+        cmd = "redis-cli -n 0 hget '{}' '{}'".format(TUNNEL_TABLE_KEY, field)
+        res = duthost.shell(cmd, module_ignore_errors=True)
+        value = (res.get("stdout") or "").strip()
+        if value:
+            rules[field] = value
+    return rules
+
+
+def _verify_decap_rules(duthost, context=""):
+    """Assert that default IPINIP_TUNNEL decap rules are present in APP_DB."""
+    rules = _read_decap_rules(duthost)
+    pytest_assert(
+        rules.get("tunnel_type") == "IPINIP",
+        "IPINIP_TUNNEL not found on {} {}".format(duthost.hostname, context)
+    )
+    pytest_assert(
+        "dscp_mode" in rules and "ecn_mode" in rules and "ttl_mode" in rules,
+        "Incomplete decap rules on {}: {} {}".format(duthost.hostname, rules, context)
+    )
+    logger.info("Decap rules verified on %s: %s %s", duthost.hostname, rules, context)
+    return rules
+
+
 @pytest.mark.disable_loganalyzer
-def test_decap_warmboot(tbinfo, duthosts, localhost, ptfhost, setup_teardown, mux_server_url,           # noqa: F811
-                        toggle_all_simulator_ports_to_random_side, supported_ttl_dscp_params,           # noqa: F811
-                        ip_ver, loopback_ips, duts_running_config_facts, duts_minigraph_facts,
-                        mux_status_from_nic_simulator):                                                 # noqa: F811
-    """
-    Test that IPinIP decap rules are present and functional after warm-reboot.
+def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfhost,
+                        setup_teardown, mux_server_url,                                 # noqa: F811
+                        toggle_all_simulator_ports_to_random_side,                      # noqa: F811
+                        supported_ttl_dscp_params, ip_ver, loopback_ips,
+                        duts_running_config_facts, duts_minigraph_facts,
+                        mux_status_from_nic_simulator):                                 # noqa: F811
+    """Verify IPinIP decap rules and traffic survive warm-reboot.
+
+    Test Gap: https://github.com/sonic-net/sonic-mgmt/issues/16480
 
     Test steps:
-    1. Apply decap configuration and verify IPinIP traffic is decapsulated correctly before warm-reboot
-    2. Save config and perform warm-reboot
-    3. Verify decap rules are still present in APP_DB/ASIC_DB after warm-reboot
-    4. Verify IPinIP traffic is decapsulated correctly after warm-reboot
-
-    Addresses issue: https://github.com/sonic-net/sonic-mgmt/issues/16480
+        1. Verify default IPINIP_TUNNEL decap rules exist in APP_DB before warm-reboot
+        2. Run IPv4-in-IPv4 traffic test to confirm decap works before warm-reboot
+        3. Perform warm-reboot on the DUT
+        4. Verify decap rules are unchanged in APP_DB after warm-reboot
+        5. Run IPv4-in-IPv4 traffic test again to confirm decap still works
     """
+    duthost = duthosts[rand_one_dut_hostname]
     setup_info = setup_teardown
-    asic_type = duthosts[0].facts["asic_type"]
-    ecn_mode = "copy_from_outer"
+    asic_type = duthost.facts["asic_type"]
     ttl_mode = supported_ttl_dscp_params['ttl']
     dscp_mode = supported_ttl_dscp_params['dscp']
     vxlan = supported_ttl_dscp_params['vxlan']
@@ -380,81 +418,59 @@ def test_decap_warmboot(tbinfo, duthosts, localhost, ptfhost, setup_teardown, mu
     if vxlan == "set_unset":
         pytest.skip("Skipping warmboot test for vxlan set_unset variant")
 
-    try:
-        # Step 1: Apply decap config and verify traffic before warm-reboot
-        apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'SET')
+    # Step 1: Verify default decap rules before warm-reboot
+    logger.info("Step 1: Verifying default decap rules before warm-reboot on %s", duthost.hostname)
+    pre_reboot_rules = _verify_decap_rules(duthost, context="(before warm-reboot)")
 
-        if 'dualtor' in tbinfo['topo']['name']:
-            wait(30, 'Wait for mux active/standby state to stabilize')
+    # Step 2: Verify decap traffic before warm-reboot
+    logger.info("Step 2: Running decap traffic test before warm-reboot")
+    if 'dualtor' in tbinfo['topo']['name']:
+        wait(30, 'Wait for mux active/standby state to stabilize')
 
-        logger.info("Verifying decap traffic BEFORE warm-reboot")
-        launch_ptf_runner(
-            ptfhost=ptfhost,
-            tbinfo=tbinfo,
-            duthosts=duthosts,
-            mux_server_url=mux_server_url,
-            duts_running_config_facts=duts_running_config_facts,
-            duts_minigraph_facts=duts_minigraph_facts,
-            mux_status_from_nic_simulator=mux_status_from_nic_simulator,
-            setup_info=setup_info,
-            outer_ipv4=setup_info["outer_ipv4"],
-            outer_ipv6=setup_info["outer_ipv6"],
-            inner_ipv4=setup_info["inner_ipv4"],
-            inner_ipv6=setup_info["inner_ipv6"],
-            ttl_mode=ttl_mode,
-            dscp_mode=dscp_mode,
-            asic_type=asic_type,
-        )
+    launch_ptf_runner(
+        ptfhost=ptfhost, tbinfo=tbinfo, duthosts=duthosts,
+        mux_server_url=mux_server_url,
+        duts_running_config_facts=duts_running_config_facts,
+        duts_minigraph_facts=duts_minigraph_facts,
+        mux_status_from_nic_simulator=mux_status_from_nic_simulator,
+        setup_info=setup_info,
+        outer_ipv4=True, outer_ipv6=False,
+        inner_ipv4=True, inner_ipv6=False,
+        ttl_mode=ttl_mode, dscp_mode=dscp_mode, asic_type=asic_type,
+    )
 
-        # Step 2: Save config and perform warm-reboot
-        for duthost in duthosts:
-            if not duthost.is_supervisor_node():
-                duthost.shell('config save -y')
+    # Step 3: Save config and perform warm-reboot
+    logger.info("Step 3: Performing warm-reboot on %s", duthost.hostname)
+    duthost.shell('config save -y')
+    reboot(duthost, localhost, reboot_type='warm', wait_warmboot_finalizer=True,
+           safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
+    logger.info("Warm-reboot completed on %s", duthost.hostname)
 
-        logger.info("Performing warm-reboot")
-        reboot(duthosts[0], localhost, reboot_type='warm', wait_warmboot_finalizer=True, safe_reboot=True)
+    # Step 4: Verify decap rules are unchanged after warm-reboot
+    logger.info("Step 4: Verifying decap rules after warm-reboot on %s", duthost.hostname)
+    post_reboot_rules = _verify_decap_rules(duthost, context="(after warm-reboot)")
+    pytest_assert(
+        pre_reboot_rules == post_reboot_rules,
+        "Decap rules changed after warm-reboot on {}: before={}, after={}".format(
+            duthost.hostname, pre_reboot_rules, post_reboot_rules)
+    )
+    logger.info("Decap rules match before and after warm-reboot on %s", duthost.hostname)
 
-        # Step 3: Verify decap rules are present in APP_DB after warm-reboot
-        logger.info("Verifying decap rules in APP_DB after warm-reboot")
-        for duthost in duthosts:
-            if duthost.is_supervisor_node():
-                continue
-            for asic_id in duthost.get_frontend_asic_ids():
-                result = duthost.shell(
-                    'sonic-db-cli{} APP_DB keys "TUNNEL_DECAP_TABLE:*"'.format(
-                        " -n {}".format(asic_id) if asic_id is not None else ""
-                    )
-                )
-                assert result['stdout'].strip(), \
-                    "No decap tunnel entries found in APP_DB on {} asic {} after warm-reboot".format(
-                        duthost.hostname, asic_id
-                    )
-                logger.info("Decap rules present on {} asic {}: {}".format(
-                    duthost.hostname, asic_id, result['stdout'].strip()
-                ))
+    # Step 5: Verify decap traffic after warm-reboot
+    logger.info("Step 5: Running decap traffic test after warm-reboot")
+    if 'dualtor' in tbinfo['topo']['name']:
+        wait(30, 'Wait for mux active/standby state to stabilize after warm-reboot')
 
-        # Step 4: Verify traffic is decapsulated correctly after warm-reboot
-        if 'dualtor' in tbinfo['topo']['name']:
-            wait(30, 'Wait for mux active/standby state to stabilize after warm-reboot')
+    launch_ptf_runner(
+        ptfhost=ptfhost, tbinfo=tbinfo, duthosts=duthosts,
+        mux_server_url=mux_server_url,
+        duts_running_config_facts=duts_running_config_facts,
+        duts_minigraph_facts=duts_minigraph_facts,
+        mux_status_from_nic_simulator=mux_status_from_nic_simulator,
+        setup_info=setup_info,
+        outer_ipv4=True, outer_ipv6=False,
+        inner_ipv4=True, inner_ipv6=False,
+        ttl_mode=ttl_mode, dscp_mode=dscp_mode, asic_type=asic_type,
+    )
 
-        logger.info("Verifying decap traffic AFTER warm-reboot")
-        launch_ptf_runner(
-            ptfhost=ptfhost,
-            tbinfo=tbinfo,
-            duthosts=duthosts,
-            mux_server_url=mux_server_url,
-            duts_running_config_facts=duts_running_config_facts,
-            duts_minigraph_facts=duts_minigraph_facts,
-            mux_status_from_nic_simulator=mux_status_from_nic_simulator,
-            setup_info=setup_info,
-            outer_ipv4=setup_info["outer_ipv4"],
-            outer_ipv6=setup_info["outer_ipv6"],
-            inner_ipv4=setup_info["inner_ipv4"],
-            inner_ipv6=setup_info["inner_ipv6"],
-            ttl_mode=ttl_mode,
-            dscp_mode=dscp_mode,
-            asic_type=asic_type,
-        )
-
-    finally:
-        apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'DEL')
+    logger.info("test_decap_warmboot PASSED on %s", duthost.hostname)

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -17,6 +17,7 @@ from jinja2 import Template
 from netaddr import IPNetwork
 from ansible.plugins.filter.core import to_bool
 
+from tests.common.reboot import reboot                                      # noqa: F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses        # noqa: F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses         # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory     # noqa: F401
@@ -350,3 +351,110 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
         if vxlan != "set_unset" or asic_type in ["cisco-8000"]:
             # in vxlan setunset case the config was not applied, hence DEL is also not required
             apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'DEL')
+
+
+@pytest.mark.disable_loganalyzer
+def test_decap_warmboot(tbinfo, duthosts, localhost, ptfhost, setup_teardown, mux_server_url,           # noqa: F811
+                        toggle_all_simulator_ports_to_random_side, supported_ttl_dscp_params,           # noqa: F811
+                        ip_ver, loopback_ips, duts_running_config_facts, duts_minigraph_facts,
+                        mux_status_from_nic_simulator):                                                 # noqa: F811
+    """
+    Test that IPinIP decap rules are present and functional after warm-reboot.
+
+    Test steps:
+    1. Apply decap configuration and verify IPinIP traffic is decapsulated correctly before warm-reboot
+    2. Save config and perform warm-reboot
+    3. Verify decap rules are still present in APP_DB/ASIC_DB after warm-reboot
+    4. Verify IPinIP traffic is decapsulated correctly after warm-reboot
+
+    Addresses issue: https://github.com/sonic-net/sonic-mgmt/issues/16480
+    """
+    setup_info = setup_teardown
+    asic_type = duthosts[0].facts["asic_type"]
+    ecn_mode = "copy_from_outer"
+    ttl_mode = supported_ttl_dscp_params['ttl']
+    dscp_mode = supported_ttl_dscp_params['dscp']
+    vxlan = supported_ttl_dscp_params['vxlan']
+
+    # Skip vxlan set_unset variant — not relevant for warmboot persistence test
+    if vxlan == "set_unset":
+        pytest.skip("Skipping warmboot test for vxlan set_unset variant")
+
+    try:
+        # Step 1: Apply decap config and verify traffic before warm-reboot
+        apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'SET')
+
+        if 'dualtor' in tbinfo['topo']['name']:
+            wait(30, 'Wait for mux active/standby state to stabilize')
+
+        logger.info("Verifying decap traffic BEFORE warm-reboot")
+        launch_ptf_runner(
+            ptfhost=ptfhost,
+            tbinfo=tbinfo,
+            duthosts=duthosts,
+            mux_server_url=mux_server_url,
+            duts_running_config_facts=duts_running_config_facts,
+            duts_minigraph_facts=duts_minigraph_facts,
+            mux_status_from_nic_simulator=mux_status_from_nic_simulator,
+            setup_info=setup_info,
+            outer_ipv4=setup_info["outer_ipv4"],
+            outer_ipv6=setup_info["outer_ipv6"],
+            inner_ipv4=setup_info["inner_ipv4"],
+            inner_ipv6=setup_info["inner_ipv6"],
+            ttl_mode=ttl_mode,
+            dscp_mode=dscp_mode,
+            asic_type=asic_type,
+        )
+
+        # Step 2: Save config and perform warm-reboot
+        for duthost in duthosts:
+            if not duthost.is_supervisor_node():
+                duthost.shell('config save -y')
+
+        logger.info("Performing warm-reboot")
+        reboot(duthosts[0], localhost, reboot_type='warm', wait_warmboot_finalizer=True, safe_reboot=True)
+
+        # Step 3: Verify decap rules are present in APP_DB after warm-reboot
+        logger.info("Verifying decap rules in APP_DB after warm-reboot")
+        for duthost in duthosts:
+            if duthost.is_supervisor_node():
+                continue
+            for asic_id in duthost.get_frontend_asic_ids():
+                result = duthost.shell(
+                    'sonic-db-cli{} APP_DB keys "TUNNEL_DECAP_TABLE:*"'.format(
+                        " -n {}".format(asic_id) if asic_id is not None else ""
+                    )
+                )
+                assert result['stdout'].strip(), \
+                    "No decap tunnel entries found in APP_DB on {} asic {} after warm-reboot".format(
+                        duthost.hostname, asic_id
+                    )
+                logger.info("Decap rules present on {} asic {}: {}".format(
+                    duthost.hostname, asic_id, result['stdout'].strip()
+                ))
+
+        # Step 4: Verify traffic is decapsulated correctly after warm-reboot
+        if 'dualtor' in tbinfo['topo']['name']:
+            wait(30, 'Wait for mux active/standby state to stabilize after warm-reboot')
+
+        logger.info("Verifying decap traffic AFTER warm-reboot")
+        launch_ptf_runner(
+            ptfhost=ptfhost,
+            tbinfo=tbinfo,
+            duthosts=duthosts,
+            mux_server_url=mux_server_url,
+            duts_running_config_facts=duts_running_config_facts,
+            duts_minigraph_facts=duts_minigraph_facts,
+            mux_status_from_nic_simulator=mux_status_from_nic_simulator,
+            setup_info=setup_info,
+            outer_ipv4=setup_info["outer_ipv4"],
+            outer_ipv6=setup_info["outer_ipv6"],
+            inner_ipv4=setup_info["inner_ipv4"],
+            inner_ipv6=setup_info["inner_ipv6"],
+            ttl_mode=ttl_mode,
+            dscp_mode=dscp_mode,
+            asic_type=asic_type,
+        )
+
+    finally:
+        apply_decap_cfg(duthosts, ip_ver, loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'DEL')

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -394,6 +394,7 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
                         mux_server_url,                                                 # noqa: F811
                         toggle_all_simulator_ports_to_random_side,                      # noqa: F811
                         supported_ttl_dscp_params, ip_ver, loopback_ips,
+                        fib_info_files, single_fib_for_duts,                            # noqa: F811
                         duts_running_config_facts, duts_minigraph_facts,
                         mux_status_from_nic_simulator):                                 # noqa: F811
     """Verify IPinIP decap rules and traffic survive warm-reboot.
@@ -424,8 +425,8 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
 
     is_multi_asic = duthost.sonichost.is_multi_asic
     setup_info = {
-        "fib_info_files": duts_running_config_facts,
-        "single_fib_for_duts": False,
+        "fib_info_files": fib_info_files[:3],  # Test at most 3 DUTs
+        "single_fib_for_duts": single_fib_for_duts,
         "ignore_ttl": True if is_multi_asic else False,
         "max_internal_hops": 3 if is_multi_asic else 0,
         "outer_ipv4": True,
@@ -434,22 +435,14 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
         "inner_ipv6": False,
     }
 
-    # Build loopback IPs for this DUT
-    lo_ips = []
-    lo_ipv6s = []
-    cfg_facts = duts_running_config_facts[duthost.hostname]
-    lo_ip = None
-    lo_ipv6 = None
-    for addr in cfg_facts[0][1]["LOOPBACK_INTERFACE"]["Loopback0"]:
-        ip = IPNetwork(addr).ip
-        if ip.version == 4 and not lo_ip:
-            lo_ip = str(ip)
-        elif ip.version == 6 and not lo_ipv6:
-            lo_ipv6 = str(ip)
-    lo_ips.append(lo_ip)
-    lo_ipv6s.append(lo_ipv6)
-    local_loopback_ips = {'lo_ips': lo_ips, 'lo_ipv6s': lo_ipv6s}
-    setup_info.update(local_loopback_ips)
+    setup_info.update(loopback_ips)
+
+    # Build single-DUT loopback dict for apply_decap_cfg (which indexes by position)
+    dut_index = [dh.hostname for dh in duthosts if not dh.is_supervisor_node()].index(duthost.hostname)
+    single_dut_loopback = {
+        'lo_ips': [loopback_ips['lo_ips'][dut_index]],
+        'lo_ipv6s': [loopback_ips['lo_ipv6s'][dut_index]],
+    }
 
     local_ip_ver = {"outer_ipv4": True, "outer_ipv6": False,
                     "inner_ipv4": True, "inner_ipv6": False}
@@ -458,7 +451,7 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
         # Step 1: Apply test decap config and verify rules before warm-reboot
         logger.info("Step 1: Applying decap config and verifying rules before warm-reboot on %s",
                     duthost.hostname)
-        apply_decap_cfg([duthost], local_ip_ver, local_loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'SET')
+        apply_decap_cfg([duthost], local_ip_ver, single_dut_loopback, ttl_mode, dscp_mode, ecn_mode, 'SET')
         pre_reboot_rules = _verify_decap_rules(duthost, context="(before warm-reboot)")
 
         # Step 2: Verify decap traffic before warm-reboot
@@ -515,4 +508,4 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
         logger.info("test_decap_warmboot PASSED on %s", duthost.hostname)
 
     finally:
-        apply_decap_cfg([duthost], local_ip_ver, local_loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'DEL')
+        apply_decap_cfg([duthost], local_ip_ver, single_dut_loopback, ttl_mode, dscp_mode, ecn_mode, 'DEL')

--- a/tests/decap/test_decap.py
+++ b/tests/decap/test_decap.py
@@ -358,7 +358,7 @@ def test_decap(tbinfo, duthosts, ptfhost, setup_teardown, mux_server_url,       
 # Warm-reboot decap test (Test Gap #16480)
 # ---------------------------------------------------------------------------
 
-TUNNEL_TABLE_KEY = "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL"
+TUNNEL_TABLE_KEY = "TUNNEL_DECAP_TABLE:TEST_IPINIP_V4_TUNNEL"
 DECAP_RULE_FIELDS = ["dscp_mode", "ecn_mode", "ttl_mode", "tunnel_type"]
 
 
@@ -375,11 +375,11 @@ def _read_decap_rules(duthost):
 
 
 def _verify_decap_rules(duthost, context=""):
-    """Assert that default IPINIP_TUNNEL decap rules are present in APP_DB."""
+    """Assert that TEST_IPINIP_V4_TUNNEL decap rules are present in APP_DB."""
     rules = _read_decap_rules(duthost)
     pytest_assert(
         rules.get("tunnel_type") == "IPINIP",
-        "IPINIP_TUNNEL not found on {} {}".format(duthost.hostname, context)
+        "TEST_IPINIP_V4_TUNNEL not found in APP_DB on {} {}".format(duthost.hostname, context)
     )
     pytest_assert(
         "dscp_mode" in rules and "ecn_mode" in rules and "ttl_mode" in rules,
@@ -391,7 +391,7 @@ def _verify_decap_rules(duthost, context=""):
 
 @pytest.mark.disable_loganalyzer
 def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfhost,
-                        setup_teardown, mux_server_url,                                 # noqa: F811
+                        mux_server_url,                                                 # noqa: F811
                         toggle_all_simulator_ports_to_random_side,                      # noqa: F811
                         supported_ttl_dscp_params, ip_ver, loopback_ips,
                         duts_running_config_facts, duts_minigraph_facts,
@@ -400,16 +400,20 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
 
     Test Gap: https://github.com/sonic-net/sonic-mgmt/issues/16480
 
+    Unlike test_decap, this test manages its own decap config independently
+    (does not use the setup_teardown fixture) to avoid interference with the
+    module-scoped fixture that removes the default tunnel.
+
     Test steps:
-        1. Verify default IPINIP_TUNNEL decap rules exist in APP_DB before warm-reboot
+        1. Apply test decap config and verify rules in APP_DB before warm-reboot
         2. Run IPv4-in-IPv4 traffic test to confirm decap works before warm-reboot
-        3. Perform warm-reboot on the DUT
+        3. Save config and perform warm-reboot
         4. Verify decap rules are unchanged in APP_DB after warm-reboot
         5. Run IPv4-in-IPv4 traffic test again to confirm decap still works
     """
     duthost = duthosts[rand_one_dut_hostname]
-    setup_info = setup_teardown
     asic_type = duthost.facts["asic_type"]
+    ecn_mode = "copy_from_outer"
     ttl_mode = supported_ttl_dscp_params['ttl']
     dscp_mode = supported_ttl_dscp_params['dscp']
     vxlan = supported_ttl_dscp_params['vxlan']
@@ -418,59 +422,97 @@ def test_decap_warmboot(tbinfo, duthosts, rand_one_dut_hostname, localhost, ptfh
     if vxlan == "set_unset":
         pytest.skip("Skipping warmboot test for vxlan set_unset variant")
 
-    # Step 1: Verify default decap rules before warm-reboot
-    logger.info("Step 1: Verifying default decap rules before warm-reboot on %s", duthost.hostname)
-    pre_reboot_rules = _verify_decap_rules(duthost, context="(before warm-reboot)")
+    is_multi_asic = duthost.sonichost.is_multi_asic
+    setup_info = {
+        "fib_info_files": duts_running_config_facts,
+        "single_fib_for_duts": False,
+        "ignore_ttl": True if is_multi_asic else False,
+        "max_internal_hops": 3 if is_multi_asic else 0,
+        "outer_ipv4": True,
+        "outer_ipv6": False,
+        "inner_ipv4": True,
+        "inner_ipv6": False,
+    }
 
-    # Step 2: Verify decap traffic before warm-reboot
-    logger.info("Step 2: Running decap traffic test before warm-reboot")
-    if 'dualtor' in tbinfo['topo']['name']:
-        wait(30, 'Wait for mux active/standby state to stabilize')
+    # Build loopback IPs for this DUT
+    lo_ips = []
+    lo_ipv6s = []
+    cfg_facts = duts_running_config_facts[duthost.hostname]
+    lo_ip = None
+    lo_ipv6 = None
+    for addr in cfg_facts[0][1]["LOOPBACK_INTERFACE"]["Loopback0"]:
+        ip = IPNetwork(addr).ip
+        if ip.version == 4 and not lo_ip:
+            lo_ip = str(ip)
+        elif ip.version == 6 and not lo_ipv6:
+            lo_ipv6 = str(ip)
+    lo_ips.append(lo_ip)
+    lo_ipv6s.append(lo_ipv6)
+    local_loopback_ips = {'lo_ips': lo_ips, 'lo_ipv6s': lo_ipv6s}
+    setup_info.update(local_loopback_ips)
 
-    launch_ptf_runner(
-        ptfhost=ptfhost, tbinfo=tbinfo, duthosts=duthosts,
-        mux_server_url=mux_server_url,
-        duts_running_config_facts=duts_running_config_facts,
-        duts_minigraph_facts=duts_minigraph_facts,
-        mux_status_from_nic_simulator=mux_status_from_nic_simulator,
-        setup_info=setup_info,
-        outer_ipv4=True, outer_ipv6=False,
-        inner_ipv4=True, inner_ipv6=False,
-        ttl_mode=ttl_mode, dscp_mode=dscp_mode, asic_type=asic_type,
-    )
+    local_ip_ver = {"outer_ipv4": True, "outer_ipv6": False,
+                    "inner_ipv4": True, "inner_ipv6": False}
 
-    # Step 3: Save config and perform warm-reboot
-    logger.info("Step 3: Performing warm-reboot on %s", duthost.hostname)
-    duthost.shell('config save -y')
-    reboot(duthost, localhost, reboot_type='warm', wait_warmboot_finalizer=True,
-           safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
-    logger.info("Warm-reboot completed on %s", duthost.hostname)
+    try:
+        # Step 1: Apply test decap config and verify rules before warm-reboot
+        logger.info("Step 1: Applying decap config and verifying rules before warm-reboot on %s",
+                    duthost.hostname)
+        apply_decap_cfg([duthost], local_ip_ver, local_loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'SET')
+        pre_reboot_rules = _verify_decap_rules(duthost, context="(before warm-reboot)")
 
-    # Step 4: Verify decap rules are unchanged after warm-reboot
-    logger.info("Step 4: Verifying decap rules after warm-reboot on %s", duthost.hostname)
-    post_reboot_rules = _verify_decap_rules(duthost, context="(after warm-reboot)")
-    pytest_assert(
-        pre_reboot_rules == post_reboot_rules,
-        "Decap rules changed after warm-reboot on {}: before={}, after={}".format(
-            duthost.hostname, pre_reboot_rules, post_reboot_rules)
-    )
-    logger.info("Decap rules match before and after warm-reboot on %s", duthost.hostname)
+        # Step 2: Verify decap traffic before warm-reboot
+        logger.info("Step 2: Running decap traffic test before warm-reboot")
+        if 'dualtor' in tbinfo['topo']['name']:
+            wait(30, 'Wait for mux active/standby state to stabilize')
 
-    # Step 5: Verify decap traffic after warm-reboot
-    logger.info("Step 5: Running decap traffic test after warm-reboot")
-    if 'dualtor' in tbinfo['topo']['name']:
-        wait(30, 'Wait for mux active/standby state to stabilize after warm-reboot')
+        launch_ptf_runner(
+            ptfhost=ptfhost, tbinfo=tbinfo, duthosts=[duthost],
+            mux_server_url=mux_server_url,
+            duts_running_config_facts=duts_running_config_facts,
+            duts_minigraph_facts=duts_minigraph_facts,
+            mux_status_from_nic_simulator=mux_status_from_nic_simulator,
+            setup_info=setup_info,
+            outer_ipv4=True, outer_ipv6=False,
+            inner_ipv4=True, inner_ipv6=False,
+            ttl_mode=ttl_mode, dscp_mode=dscp_mode, asic_type=asic_type,
+        )
 
-    launch_ptf_runner(
-        ptfhost=ptfhost, tbinfo=tbinfo, duthosts=duthosts,
-        mux_server_url=mux_server_url,
-        duts_running_config_facts=duts_running_config_facts,
-        duts_minigraph_facts=duts_minigraph_facts,
-        mux_status_from_nic_simulator=mux_status_from_nic_simulator,
-        setup_info=setup_info,
-        outer_ipv4=True, outer_ipv6=False,
-        inner_ipv4=True, inner_ipv6=False,
-        ttl_mode=ttl_mode, dscp_mode=dscp_mode, asic_type=asic_type,
-    )
+        # Step 3: Save config and perform warm-reboot
+        logger.info("Step 3: Performing warm-reboot on %s", duthost.hostname)
+        duthost.shell('config save -y')
+        reboot(duthost, localhost, reboot_type='warm', wait_warmboot_finalizer=True,
+               safe_reboot=True, check_intf_up_ports=True, wait_for_bgp=True)
+        logger.info("Warm-reboot completed on %s", duthost.hostname)
 
-    logger.info("test_decap_warmboot PASSED on %s", duthost.hostname)
+        # Step 4: Verify decap rules are unchanged after warm-reboot
+        logger.info("Step 4: Verifying decap rules after warm-reboot on %s", duthost.hostname)
+        post_reboot_rules = _verify_decap_rules(duthost, context="(after warm-reboot)")
+        pytest_assert(
+            pre_reboot_rules == post_reboot_rules,
+            "Decap rules changed after warm-reboot on {}: before={}, after={}".format(
+                duthost.hostname, pre_reboot_rules, post_reboot_rules)
+        )
+        logger.info("Decap rules match before and after warm-reboot on %s", duthost.hostname)
+
+        # Step 5: Verify decap traffic after warm-reboot
+        logger.info("Step 5: Running decap traffic test after warm-reboot")
+        if 'dualtor' in tbinfo['topo']['name']:
+            wait(30, 'Wait for mux active/standby state to stabilize after warm-reboot')
+
+        launch_ptf_runner(
+            ptfhost=ptfhost, tbinfo=tbinfo, duthosts=[duthost],
+            mux_server_url=mux_server_url,
+            duts_running_config_facts=duts_running_config_facts,
+            duts_minigraph_facts=duts_minigraph_facts,
+            mux_status_from_nic_simulator=mux_status_from_nic_simulator,
+            setup_info=setup_info,
+            outer_ipv4=True, outer_ipv6=False,
+            inner_ipv4=True, inner_ipv6=False,
+            ttl_mode=ttl_mode, dscp_mode=dscp_mode, asic_type=asic_type,
+        )
+
+        logger.info("test_decap_warmboot PASSED on %s", duthost.hostname)
+
+    finally:
+        apply_decap_cfg([duthost], local_ip_ver, local_loopback_ips, ttl_mode, dscp_mode, ecn_mode, 'DEL')


### PR DESCRIPTION
#### Why I did it

Close test gap: https://github.com/sonic-net/sonic-mgmt/issues/16480

No existing test validates that IPinIP decap rules are present and functional after warm-reboot. This PR adds `test_decap_warmboot` to cover this scenario.

#### How I did it

Added `test_decap_warmboot` in `tests/decap/test_decap.py` that:
1. Applies decap configuration and verifies IPinIP traffic is decapsulated correctly **before** warm-reboot
2. Saves config and performs warm-reboot
3. Verifies decap tunnel entries are present in `APP_DB` (`TUNNEL_DECAP_TABLE:*`) on all ASICs after warm-reboot
4. Verifies IPinIP traffic is decapsulated correctly **after** warm-reboot

#### How to verify it

```bash
cd tests
python -m pytest decap/test_decap.py::test_decap_warmboot -v --topology t0
```

#### Which release branch to backport

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch

- [ ] <!-- image version -->

#### Description for the changelog

Add test_decap_warmboot to verify IPinIP decap rules persist and work correctly after warm-reboot.

#### Link to config_db schema for YANG module changes

N/A