### PR TITLE
Fix announce_routes port mismatch in multi-server deployments

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -1734,7 +1734,13 @@ def main():
     if not topo:
         module.fail_json(msg='Unable to load topology "{}"'.format(topo_name))
     if dut_interfaces:
+        # Save original vm_offsets before filtering, because get_vms_by_dut_interfaces()
+        # remaps offsets starting from 0. The original offsets must be preserved to match
+        # the exabgp ports assigned by the Ansible playbook (which uses the full topology).
+        original_vm_offsets = {vm: attr['vm_offset'] for vm, attr in topo['topology']['VMs'].items()}
         topo['topology']['VMs'] = MultiServersUtils.get_vms_by_dut_interfaces(topo['topology']['VMs'], dut_interfaces)
+        for vm_name in topo['topology']['VMs']:
+            topo['topology']['VMs'][vm_name]['vm_offset'] = original_vm_offsets[vm_name]
         for vm_name in list(topo['configuration'].keys()):
             if vm_name not in topo['topology']['VMs']:
                 topo['configuration'].pop(vm_name)


### PR DESCRIPTION
Summary: Fix announce_routes port mismatch in multi-server deployments
Fixes # 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #22395 changed the announce_routes.yml to calculate exabgp ports using the full topology's original vm_offsets (e.g., ARISTA129T1 gets offset 16, port 6016). However, the announce_routes.py module internally calls get_vms_by_dut_interfaces() which remaps vm_offsets starting from 0 (e.g., ARISTA129T1 gets offset 0, port 6000). This mismatch causes the module to connect to port 6000 while exabgp is actually listening on port 6016.

#### How did you do it?
Save original `vm_offsets` before filtering, because `get_vms_by_dut_interfaces()` remaps offsets starting from 0. The original offsets must be preserved to match the exabgp ports assigned by the Ansible playbook (which uses the full topology).

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
