### PR TITLE
[Snappi] Fix vlan IP assignment

### DIFF
--- a/tests/common/snappi_tests/common_helpers.py
+++ b/tests/common/snappi_tests/common_helpers.py
@@ -891,12 +891,13 @@ def enable_packet_aging(duthost, asic_value=None):
                     duthost.shell('bcmcmd -n {} "BCMSAI credit-watchdog enable"'.format(asic_value[-1]))
 
 
-def get_ipv6_addrs_in_subnet(subnet, number_of_ip):
+def get_ipv6_addrs_in_subnet(subnet, number_of_ip, exclude_ips=None):
     """
     Get N IPv6 addresses in a subnet.
     Args:
         subnet (str): IPv6 subnet, e.g., '2001::1/64'
         number_of_ip (int): Number of IP addresses to get
+        exclude_ips (list): Optional list of IPs to exclude
     Return:
         Return n IPv6 addresses in this subnet in a list.
     """
@@ -904,12 +905,16 @@ def get_ipv6_addrs_in_subnet(subnet, number_of_ip):
     subnet = str(IPNetwork(subnet).network) + "/" + str(subnet.split("/")[1])
     subnet = subnet.encode().decode("utf-8")
     ipv6_list = []
-    for i in range(number_of_ip):
+    exclude_set = set(exclude_ips) if exclude_ips else set()
+    while len(ipv6_list) < number_of_ip:
         network = IPv6Network(subnet)
         address = IPv6Address(
             network.network_address + getrandbits(
                 network.max_prefixlen - network.prefixlen))
-        ipv6_list.append(str(address))
+        addr_str = str(address)
+        if addr_str in exclude_set or addr_str in ipv6_list:
+            continue
+        ipv6_list.append(addr_str)
 
     return ipv6_list
 

--- a/tests/common/snappi_tests/snappi_fixtures.py
+++ b/tests/common/snappi_tests/snappi_fixtures.py
@@ -247,7 +247,8 @@ def __vlan_intf_config(config, port_config_list, duthost, snappi_ports):
             gw4 = v4_entry['addr']
             pfx4 = v4_entry['prefixlen']
             subnet4 = f"{gw4}/{pfx4}"
-            member_ipv4s = get_addrs_in_subnet(subnet4, len(members))
+            # Do not assign the VLAN gateway IP to a TGEN interface.
+            member_ipv4s = get_addrs_in_subnet(subnet4, len(members), exclude_ips=[gw4])
         else:
             gw4 = pfx4 = None
             member_ipv4s = [None] * len(members)
@@ -256,7 +257,8 @@ def __vlan_intf_config(config, port_config_list, duthost, snappi_ports):
             gw6 = v6_entry['addr']
             pfx6 = v6_entry['prefixlen']
             subnet6 = f"{gw6}/{pfx6}"
-            member_ipv6s = get_ipv6_addrs_in_subnet(subnet6, len(members))
+            # Do not assign the VLAN gateway IP to a TGEN interface.
+            member_ipv6s = get_ipv6_addrs_in_subnet(subnet6, len(members), exclude_ips=[gw6])
         else:
             gw6 = pfx6 = None
             member_ipv6s = [None] * len(members)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes the following error:
```
15/03/2026 15:59:42 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/opt/venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/src/sonic-mgmt_vms20-rdma-t0-7050cx3/tests/snappi_tests/pfc/test_pfc_pause_lossless_with_snappi.py", line 76, in test_pfc_pause_single_lossless_prio
    run_pfc_test(api=snappi_api,
  File "/var/src/sonic-mgmt_vms20-rdma-t0-7050cx3/tests/snappi_tests/pfc/files/helper.py", line 255, in run_pfc_test
    tgen_flow_stats, switch_flow_stats, in_flight_flow_metrics = run_traffic(duthost=duthost,
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/src/sonic-mgmt_vms20-rdma-t0-7050cx3/tests/common/snappi_tests/traffic_generation.py", line 615, in run_traffic
    api.set_config(config)
  File "/opt/venv/lib/python3.12/site-packages/snappi_ixnetwork/snappi_api.py", line 338, in set_config
    return self._request_detail()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/snappi_ixnetwork/snappi_api.py", line 273, in _request_detail
    raise SnappiIxnException(500, errors)
snappi_ixnetwork.exceptions.SnappiIxnException: IxNet - Ipv4 Port 0 Start: Ipv4 Port 0: Gateway Address=192.168.0.1 is Same As Interface Address=192.168.0.1
 -> x.x.x.x;1;6IxNet - Error in Action Starting Ipv4 Port 0.
Port x.x.x.x1;6: Ipv4 Port 0: Gateway Address=192.168.0.1 is Same As Interface Address=192.168.0.1
```

Current VLAN IP assignment in snappi may assign gateway IP to the port. Needs to exclude them from the list.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix nightly failure on T0 snappi.

#### How did you do it?
exclude the gateway IPs.

#### How did you verify/test it?
Local testbed.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
