### PR TITLE
Enable test_ecmp_balance on dualtor topologies

### DIFF
--- a/tests/ecmp/test_ecmp_balance.py
+++ b/tests/ecmp/test_ecmp_balance.py
@@ -64,12 +64,12 @@ def validate_testbed_for_ecmp_test(duthost, tbinfo):
 
 
 @pytest.fixture(scope="module")
-def setup(duthosts, rand_selected_dut, tbinfo):
+def setup(duthosts, duthost, tbinfo):
     """Gather all required test information from DUT and tbinfo.
 
     Args:
         duthosts: All DUTs belong to the testbed.
-        rand_one_dut_hostname: hostname of a random chosen dut to run test.
+        duthost: The DUT host running the test.
         tbinfo: A fixture to gather information about the testbed.
 
     Yields:
@@ -78,12 +78,26 @@ def setup(duthosts, rand_selected_dut, tbinfo):
     """
     # Validate testbed configuration for ECMP hash testing
     # This replaces the original hardcoded ASIC and topology checks
-    validate_testbed_for_ecmp_test(rand_selected_dut, tbinfo)
+    validate_testbed_for_ecmp_test(duthost, tbinfo)
 
-    mg_facts = rand_selected_dut.get_extended_minigraph_facts(tbinfo)
+    mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
     topo = tbinfo["topo"]["type"]
 
     vlan_mac = None
+
+    # Get VLAN MAC for dual-ToR topologies
+    vlan_intf = mg_facts.get("minigraph_vlan_interfaces", [])
+    if vlan_intf:
+        vlan_name = list(mg_facts.get("minigraph_vlans", {}).keys())[0] if mg_facts.get("minigraph_vlans") else None
+        if vlan_name:
+            # Fetch VLAN MAC from the switch
+            vlan_mac_result = duthost.shell(
+                f"ip link show {vlan_name} | grep -o 'link/ether [^ ]*' | awk '{{print $2}}'",
+                module_ignore_errors=True
+            )
+            if vlan_mac_result["rc"] == 0 and vlan_mac_result["stdout"].strip():
+                vlan_mac = vlan_mac_result["stdout"].strip()
+                logger.info(f"Using VLAN MAC: {vlan_mac} for downstream traffic on {vlan_name}")
 
     # Get the list of upstream/downstream ports
     downstream_ports = defaultdict(list)
@@ -98,7 +112,7 @@ def setup(duthosts, rand_selected_dut, tbinfo):
     # For M0_VLAN/MX/T0/dual ToR scenario, we need to use the VLAN MAC to interact with downstream ports
     # For T1/M0_L3 scenario, no VLANs are present so using the router MAC is acceptable
     downlink_dst_mac = (
-        vlan_mac if vlan_mac is not None else rand_selected_dut.facts["router_mac"]
+        vlan_mac if vlan_mac is not None else duthost.facts["router_mac"]
     )
 
     upstream_neigh_type = get_upstream_neigh_type(tbinfo)
@@ -108,6 +122,7 @@ def setup(duthosts, rand_selected_dut, tbinfo):
         "Cannot get neighbor type for unsupported topo: {}".format(topo),
     )
 
+    # Gather downstream ports from current DUT only
     for interface, neighbor in list(mg_facts["minigraph_neighbors"].items()):
         port_id = mg_facts["minigraph_ptf_indices"][interface]
         if downstream_neigh_type in neighbor["name"].upper():
@@ -115,13 +130,18 @@ def setup(duthosts, rand_selected_dut, tbinfo):
             downstream_port_ids.append(port_id)
             downstream_port_id_to_router_mac_map[port_id] = downlink_dst_mac
             downstream_port_id_to_interface_map[port_id] = interface
-        elif upstream_neigh_type in neighbor["name"].upper():
-            upstream_ports[neighbor["namespace"]].append(interface)
-            upstream_port_ids.append(port_id)
-            upstream_port_id_to_router_mac_map[port_id] = rand_selected_dut.facts[
-                "router_mac"
-            ]
-            upstream_port_id_to_interface_map[port_id] = interface
+
+    # For dual-ToR active-active, gather upstream ports from BOTH ToRs
+    # This allows test to accept packets exiting via either ToR
+    for dut in duthosts:
+        dut_mg_facts = dut.get_extended_minigraph_facts(tbinfo)
+        for interface, neighbor in list(dut_mg_facts["minigraph_neighbors"].items()):
+            port_id = dut_mg_facts["minigraph_ptf_indices"][interface]
+            if upstream_neigh_type in neighbor["name"].upper():
+                upstream_ports[neighbor["namespace"]].append(interface)
+                upstream_port_ids.append(port_id)
+                upstream_port_id_to_router_mac_map[port_id] = dut.facts["router_mac"]
+                upstream_port_id_to_interface_map[port_id] = interface
 
     setup_information = {
         "destination_mac": downstream_port_id_to_router_mac_map,
@@ -143,34 +163,37 @@ def setup(duthosts, rand_selected_dut, tbinfo):
 
 
 @pytest.fixture(scope="function")
-def set_ecmp_offset(duthost, tbinfo):
+def set_ecmp_offset(duthosts, duthost, tbinfo):
     """
     Change the ECMP hash offset temporarily for test, then restore it.
-    Platform-independent implementation using ECMPHashManager.
+    Sets offset on ALL ToRs in Active-Active to ensure consistent hashing.
 
     Args:
-        duthost: The DUT host object
+        duthosts: All DUT hosts in the testbed
+        duthost: The primary DUT host object
+        tbinfo: Testbed info
     """
-    # Create platform-specific ECMP hash manager
-    ecmp_manager = ECMPHashManager(duthost, tbinfo)
+    managers = []
+    original_values = {}
 
-    # Check if platform is supported
-    if not ecmp_manager.is_supported():
-        pytest.skip(f"ECMP hash offset test not supported for hardware SKU: {ecmp_manager.hwsku}")
+    for dut in duthosts:
+        ecmp_manager = ECMPHashManager(dut, tbinfo)
 
-    # Backup original value
-    original_value = ecmp_manager.backup_current_offset()
-    logger.info(f"Original ECMP hash offset value: {original_value}")
+        if not ecmp_manager.is_supported():
+            pytest.skip(f"ECMP hash offset test not supported for hardware SKU: {ecmp_manager.hwsku}")
+
+        original_value = ecmp_manager.backup_current_offset()
+        original_values[dut.hostname] = original_value
+        managers.append((dut, ecmp_manager))
 
     try:
-        # Set test offset value
-        ecmp_manager.set_test_offset()
+        for dut, ecmp_manager in managers:
+            ecmp_manager.set_test_offset()
 
-        # Yield control back to the test
         yield
     finally:
-        # Restore the original value
-        ecmp_manager.restore_original_offset()
+        for dut, ecmp_manager in managers:
+            ecmp_manager.restore_original_offset()
 
 
 @pytest.fixture(scope="module", params=["ipv4", "ipv6"])


### PR DESCRIPTION
### Description of PR

  This PR enables `test_ecmp_balance` on dualtor topologies by fixing two root causes that led to PR #22749 incorrectly skipping these tests.

  PR #22749 claimed "mux cable layer prevents packets from reaching DUT," but the actual issues were:
  1. VLAN MAC never populated (comment existed but no implementation)
  2. ECMP offset fixture only modified one ToR in multi-ToR setups

  **Changes:**
  1. Fetch VLAN MAC from DUT for dualtor topologies
  2. Change ECMP offset on ALL ToRs instead of single ToR
  3. Gather upstream ports from all ToRs

  Summary:
  Fixes # (issue)

  ### Type of change

  - [x] Bug fix
  - [ ] Testbed and Framework(new/improvement)
  - [ ] New Test case
      - [ ] Skipped for non-supported platforms
  - [ ] Test case improvement

  ### Back port request
  - [ ] 202205
  - [ ] 202305
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [x] 202511

  ### Approach

  #### What is the motivation for this PR?

  PR #22749 incorrectly skipped `test_ecmp_balance` on all dualtor topologies based on wrong root cause analysis. The actual issues were incomplete test infrastructure.

  #### How did you do it?

  **1. Populate VLAN MAC**
  - Get VLAN name from minigraph, fetch MAC from DUT via `ip link show`
  - Use VLAN MAC for downstream traffic

  **2. Change ECMP offset on ALL ToRs**
  - Modified `set_ecmp_offset` fixture to loop through `duthosts` instead of single `duthost`
  - In active-active, OVS uses hash-based ECMP to distribute packets across both ToRs
  - Changing offset on only one ToR causes packets via unchanged ToR to show identical flows

  **3. Gather upstream ports from all ToRs**
  - Collect upstream ports from all DUTs to accept packets from either ToR in active-active

  #### How did you verify/test it?

  Tested on dualtor-aa topology. Pass rate improved from ~30% to consistent passing.

  #### Any platform specific information?

  Works on dualtor-aa and dualtor-120. Backward compatible with t0/t1 topologies.

  #### Supported testbed topology if it's a new test case?

 

  ### Documentation

