### PR TITLE
Add test_default_route to prevent phantom CI runner failure

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -157,6 +157,18 @@ def verify_default_route_in_app_db(duthost, tbinfo, af, uplink_ns, device_neigh_
                   "Default route nexthops doesn't match the testbed topology")
 
 
+def test_default_route(duthosts, tbinfo):
+    """
+    Verify default route set_src and nexthop global address.
+
+    This test exists to prevent the CI runner from creating a phantom failure
+    entry for the module name 'test_default_route'. See:
+    https://github.com/sonic-net/sonic-mgmt/issues/23040
+    """
+    test_default_route_set_src(duthosts, tbinfo)
+    test_default_ipv6_route_next_hop_global_address(duthosts, tbinfo)
+
+
 def test_default_route_set_src(duthosts, tbinfo):
     """
     check if ipv4 and ipv6 default src address match Loopback0 address


### PR DESCRIPTION
### Description
Add a `test_default_route` function to `tests/route/test_default_route.py` to prevent the CI runner from creating phantom failure entries.

### Root Cause
The CI/elastictest runner creates a phantom test failure entry when no test function matches the module name. Since `test_default_route.py` has no function named `test_default_route`, the runner records a failure with:
- **Summary**: "Test failed and no xml file created"
- **Runtime**: null
- **Result**: failure

This has been happening for **120+ days**, recording **878+ phantom failures** across all branches with a reported **0% pass rate** — while all actual test functions in the module pass normally.

### Evidence
In a single test plan run, the Kusto data shows:

| TestCase | Result | Runtime |
|----------|--------|---------|
| `test_default_route_set_src` | ✅ success | 89.6s |
| `test_default_ipv6_route_next_hop_global_address` | ✅ success | 18.1s |
| `test_default_route_with_bgp_flap` | ✅ success | 35.8s |
| `test_ipv6_default_route_table_enabled_for_mgmt_interface` | ✅ success | 30.1s |
| `test_default_route` (phantom) | ❌ failure | null |

### Fix
Add a thin `test_default_route()` function that delegates to the existing `test_default_route_set_src` and `test_default_ipv6_route_next_hop_global_address` tests. This satisfies the CI runner's expectation without adding redundant test logic.

The underlying CI runner bug is tracked in #23040.

### Impact
- Eliminates 878+ phantom failures per 90 days across all branches
- Removes false nightly PBI triggers (e.g., ADO #37049752)
- Reduces triage noise for the SONiC test team