### PR TITLE
voq/test_voq_counter: fix Credit-WD-Del counter verification

### DIFF
--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
+from tests.common.gu_utils import get_asic_name
 
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     """
     This test implicitly verifies that queue counters --voq (i.e. Credit-WD-Del/pkts)
     are working as expected by disabling the fabric ports
+    For Q3D (single-ASIC), instead disable fabric messages via register setting.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bcm_changes = False
@@ -33,30 +35,62 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     pytest_require((duthost.facts.get('platform_asic') == "broadcom-dnx"),
                    "The Test Case is only supported on Broadcom-dnx ASIC")
 
-    cmd_bcmcmd_false = "'port enable sfi false'"
-    cmd_bcmcmd_true = "'port enable sfi true'"
-    cmd = "show queue counters --voq --nonzero| grep -i '{}' |grep -i '{}' |awk '{{print $7}}'".format("Ethernet-IB",
-                                                                                                       "VOQ0")
-    try:
-        bcm_changes = True
-        for asic in duthost.asics:
-            bcmcmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_false
+    duthost.shell("sonic-clear queuecounters")
+
+    asic_name = get_asic_name(duthost).lower()
+    is_q3d_single_asic = ("q3d" in asic_name) and (not duthost.is_multi_asic)
+
+    if is_q3d_single_asic:
+        cmd_bcmcmd = "setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS"
+        cmd = "show queue counters --voq --nonzero | grep -i 'VOQ7' | awk '{print $7}'"
+
+        try:
+            bcm_changes = True
+            bcmcmd = f"bcmcmd '{cmd_bcmcmd}'=1"
             res = duthost.shell(bcmcmd, module_ignore_errors=True)
             if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                pytest.fail("BCMCMD Failed")
+                pytest.fail("BCMCMD Failed to disable fabric messages")
 
-        def queue_counter_assertion():
-            out = duthost.shell(cmd)['stdout'].split('\n')
-            integers = [int(item.replace(',', '')) for item in out if item.replace(',', '').strip().isdigit()]
-            return any(num > 0 for num in integers)
+            def queue_counter_assertion():
+                out = duthost.shell(cmd)["stdout"].split("\n")
+                integers = [int(item.replace(",", "")) for item in out if item.replace(",", "").strip().isdigit()]
+                return any(num > 0 for num in integers)
 
-        pytest_assert(wait_until(300, 0, 0, queue_counter_assertion),
-                      "Credit-WD-Del/pkts is not increasing "
-                      "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098")
-    finally:
-        if bcm_changes:
+            pytest_assert(
+                wait_until(300, 5, 0, queue_counter_assertion),
+                "Credit-WD-Del/pkts counter did not increment. "
+                "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098",
+            )
+        finally:
+            if bcm_changes:
+                bcmcmd = f"bcmcmd '{cmd_bcmcmd}'=0"
+                res = duthost.shell(bcmcmd, module_ignore_errors=True)
+                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                    pytest.fail("BCMCMD Failed to re-enable fabric messages")
+    else:
+        cmd_bcmcmd_false = "'port enable sfi false'"
+        cmd_bcmcmd_true = "'port enable sfi true'"
+        cmd = "show queue counters --voq --nonzero| grep -i 'Ethernet-IB' |grep -i 'VOQ0' |awk '{{print $7}}'"
+        try:
+            bcm_changes = True
             for asic in duthost.asics:
-                cmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_true
-                res = duthost.shell(cmd, module_ignore_errors=True)
+                bcmcmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_false
+                res = duthost.shell(bcmcmd, module_ignore_errors=True)
                 if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
                     pytest.fail("BCMCMD Failed")
+
+            def queue_counter_assertion():
+                out = duthost.shell(cmd)['stdout'].split('\n')
+                integers = [int(item.replace(',', '')) for item in out if item.replace(',', '').strip().isdigit()]
+                return any(num > 0 for num in integers)
+
+            pytest_assert(wait_until(300, 0, 0, queue_counter_assertion),
+                          "Credit-WD-Del/pkts is not increasing "
+                          "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098")
+        finally:
+            if bcm_changes:
+                for asic in duthost.asics:
+                    cmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_true
+                    res = duthost.shell(cmd, module_ignore_errors=True)
+                    if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                        pytest.fail("BCMCMD Failed")


### PR DESCRIPTION

### Description of PR

Summary:
Fix verification of the Credit-WD-Del counter in `tests/voq/test_voq_counter.py` on DNX/Q3D single-ASIC systems.

Fixes #23049

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework (new/improvement)
- [ ] New test case
  - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Approach

#### What is the motivation for this PR?

The test `tests/voq/test_voq_counter.py::test_voq_drop_counter` checks the Credit-WD-Del counter but shows no increments on DNX/Q3D single-ASIC platforms, even when the Credit Watchdog feature is working. This is due to assumptions in the test about fabric ports, specific VOQ indices, and the availability of `bcmcmd -n` that do not hold on these systems.

#### How did you do it?

This change updates the test logic to better match DNX/Q3D single-ASIC behavior while preserving existing multi-ASIC behavior:

1. On platforms without fabric ports, `port enable sfi [true/false]` does not apply and cannot be used to trigger Credit Watchdog deletes. Instead, the test now uses:
   ```text
   setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS
   ```
   to induce credit starvation on the central scheduler, causing VOQs that are holding traffic to be cleared by the Credit Watchdog.

2. The original test parsed Credit-WD-Del counters from VOQ0 for Ethernet-IB links. On DNX/Q3D single-ASIC systems, traffic accumulates in a different VOQ index (e.g. VOQ7), and there may be no Ethernet-IB links. The test is updated to check the appropriate VOQ’s Credit-WD-Del counters for the platform under test instead of assuming VOQ0 on Ethernet-IB.

3. The `bcmcmd -n` flag is only applicable on multi-ASIC systems. The test now has separate paths:
   - multi-ASIC: continue using `bcmcmd -n` as before,
   - single-ASIC: avoid `-n` and use a single-ASIC-safe command sequence.

#### How did you verify/test it?

The updated test was run on a DNX/Q3D single-ASIC platform and now passes: the Credit-WD-Del counter increments as expected when Credit Watchdog deletes occur, and the test completes successfully.

Existing multi-ASIC logic is preserved and continues to be exercised via the multi-ASIC path in the test.

### Any platform specific information?

The changes primarily affect DNX/Q3D single-ASIC platforms and are gated so that existing multi-ASIC and chassis behavior remains unchanged.

### Supported testbed topology if it's a new test case?

Not applicable; this is a change to an existing test case.

### Documentation

Not applicable; this is a test bug fix and does not introduce a new feature or test case.
