### PR TITLE
Skip testQosSaiDscpEcn on all topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4029,9 +4029,11 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpEcn:
   skip:
-    reason: "Unsupported testbed type."
+    reason: "Unsupported testbed type or test fails on all topologies. https://github.com/sonic-net/sonic-mgmt/issues/23059"
+    conditions_logical_operator: or
     conditions:
       - "asic_type not in ['broadcom'] and asic_subtype not in ['broadcom-dnx']"
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23059"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
   skip:


### PR DESCRIPTION
### Description of PR

Skip `testQosSaiDscpEcn` on all topologies due to consistent failures.

Related issue: https://github.com/sonic-net/sonic-mgmt/issues/23059

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`testQosSaiDscpEcn` (introduced in PR #20544) fails on **all topologies**. The test was recently added for ECN/DSCP configuration validation but is not working correctly.

#### How did you do it?
Added a new skip condition in `tests_mark_conditions.yaml` referencing issue #23059, using `conditions_logical_operator: or` to preserve the existing ASIC type condition.

#### How did you verify/test it?
The test consistently fails across all topologies (observed on Arista 7260 Broadcom). This skip prevents nightly test noise until root cause is resolved.

**Note:** This PR only adds a skip. The tracking issue #23059 should remain open until the root cause is fixed.

#### Any platform specific information?
Observed on Arista 7260 (Broadcom ASIC), failing across all topologies.

### Documentation
Tracking issue: https://github.com/sonic-net/sonic-mgmt/issues/23059
Original PR: #20544