### PR TITLE
Fix infinite loop in monitor_memory causing pytest hang (#22993)

### DIFF
--- a/tests/route/test_default_route.py
+++ b/tests/route/test_default_route.py
@@ -234,8 +234,8 @@ def get_memory_usage(process_name):
     return total_memory_usage
 
 
-def monitor_memory(process_name, initial_memory, interval):
-    while True:
+def monitor_memory(process_name, initial_memory, interval, stop_event):
+    while not stop_event.is_set():
         memory_usage = get_memory_usage(process_name)
         logging.info("Monitor Memory usage for {}: {} bytes".format(process_name, memory_usage))
         if memory_usage >= 2 * initial_memory:
@@ -253,10 +253,16 @@ def test_default_route_with_bgp_flap(duthosts, tbinfo):
     for process_name in bmp_processes:
         initial_memory[process_name] = get_memory_usage(process_name)
 
+    # Create stop event for graceful thread termination
+    stop_event = threading.Event()
+
     # Create and start the memory monitoring threads
     bmp_monitor_threads = []
     for process_name in bmp_processes:
-        bmp_thread = threading.Thread(target=monitor_memory, args=(process_name, initial_memory[process_name], 30))
+        bmp_thread = threading.Thread(
+            target=monitor_memory,
+            args=(process_name, initial_memory[process_name], 30, stop_event)
+        )
         bmp_thread.start()
         bmp_monitor_threads.append(bmp_thread)
 
@@ -308,7 +314,8 @@ def test_default_route_with_bgp_flap(duthosts, tbinfo):
         if not wait_until(300, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())):
             pytest.fail("not all bgp sessions are up after config reload")
 
-        # Quit bmp memory monitor thread
+        # Signal threads to stop and wait for them to finish
+        stop_event.set()
         for bmp_thread in bmp_monitor_threads:
             bmp_thread.join()
 


### PR DESCRIPTION
### Description of PR

The `monitor_memory()` function had an infinite `while True` loop with no exit condition. When `test_default_route_with_bgp_flap()` tried to join the monitoring threads in the finally block, it would hang indefinitely because the threads never terminated.

This fix adds a `threading.Event` to signal when monitoring should stop:
- Added `stop_event` parameter to `monitor_memory()`
- Changed `while True` to `while not stop_event.is_set()`
- Create `stop_event` in `test_default_route_with_bgp_flap()`
- Pass `stop_event` to all monitoring threads
- Set `stop_event` before joining threads in finally block

This allows the threads to exit gracefully and prevents pytest from hanging.

Summary:
Fixes #22993

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

Pytest hangs indefinitely while running `test_default_route.py`. The test creates monitoring threads that run in an infinite loop with no exit condition. When the monitored processes (openbmpd, bgpd) are not running, their initial memory is 0 bytes, and the condition `memory_usage >= 2 * initial_memory` is never True, causing the threads to loop forever.

#### How did you do it?

Implemented a graceful thread termination mechanism using `threading.Event`:
1. Modified `monitor_memory()` to accept a `stop_event` parameter
2. Changed the infinite loop from `while True` to `while not stop_event.is_set()`
3. Created a `stop_event` in the test function
4. Passed the `stop_event` to all monitoring threads
5. Set the `stop_event` in the finally block before joining threads

#### How did you verify/test it?

- Verified the fix prevents infinite loops when processes have 0 initial memory
- Confirmed threads terminate gracefully when `stop_event` is set
- Test can now complete successfully without hanging

#### Any platform specific information?

Generic - affects all platforms

#### Supported testbed topology if it's a new test case?

N/A - This is a bug fix for existing test case

### Documentation

N/A - Bug fix only, no new features or test cases added