### PR TITLE
[loganalyzer] Fix sshd-session auth fail ignore pattern

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -318,7 +318,7 @@ r, ".* NOTICE kernel:.*Kernel command line:.*Aboot=.*"
 r, ".* ERR syncd\d*#syncd.*SAI_API_BUFFER.*Unsupported buffer pool.*"
 
 # ignore TACACS login failure, which will happen when other user trying login device when running test
-r, ".* ERR sshd\[\d*\]: auth fail.*"
+r, ".* ERR sshd(-session)?\[\d*\]: auth fail.*"
 
 # ignore NTP nss_tacplus error, which will happen when reload config, because ntpd and chrony will invoke getpwnap API but nss_tacplus will re-render during reload config
 r, ".* ERR ntpd\[\d*\]: nss_tacplus: .*"


### PR DESCRIPTION
### Description of PR

Summary:
Newer versions of OpenSSH use `sshd-session` as the process name instead of `sshd`. The existing loganalyzer ignore pattern only matches `sshd[PID]`, causing false teardown failures across many test cases when the syslog contains:

```
ERR sshd-session[139646]: auth fail: Password incorrect. user: nsroot
```

This PR updates the regex to also match `sshd-session`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Many test cases fail during teardown because loganalyzer flags `ERR sshd-session[PID]: auth fail: Password incorrect` as an unexpected syslog message. This happens on systems running newer OpenSSH versions where the process name changed from `sshd` to `sshd-session`.

#### How did you do it?
Updated the existing ignore pattern in `ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt` from:
```
r, ".* ERR sshd\[\d*\]: auth fail.*"
```
to:
```
r, ".* ERR sshd(-session)?\[\d*\]: auth fail.*"
```

The `(-session)?` makes the `-session` part optional, so it matches both `sshd` and `sshd-session`.

#### How did you verify/test it?
- Verified the regex matches all three variants:
  - `ERR sshd-session[141172]: auth fail: Password incorrect. user: readonly` ✅
  - `ERR sshd-session[139646]: auth fail: Password incorrect. user: nsroot` ✅
  - `ERR sshd[12345]: auth fail: Password incorrect. user: admin` ✅ (backward compatible)
- Searched all SSH and TACACS test cases — no tests use loganalyzer `expect_regex` for sshd auth fail patterns. SSH tests (`test_ssh_default_password.py`, `test_ssh_limit.py`, `test_ssh_stress.py`) all have loganalyzer disabled entirely. This change is safe.

#### Any platform specific information?
No. Applies to all platforms running newer OpenSSH versions.

#### Supported testbed topology if it's a new test case?
N/A — bug fix only.

### Documentation
N/A — no new feature or test case.
