### PR TITLE
Adding loganalyzer ignore for SAI Port Phy Serdes Attrs during buffer overflow error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -149,6 +149,8 @@ r, ".* ERR syncd\d*#syncd.*getSupportedBufferPoolCounters.*is not supported on b
 # https://dev.azure.com/msazure/One/_workitems/edit/14233570
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_stats_ext.*Ext Stat Get failed.*"
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_stats.*Multi stats get failed with error.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_serdes_attribute_cmn:\d+ RX VGA get failed with error -8.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_serdes_attribute_cmn:\d+ Port.*TX_FIR_TAPS_LIST get failed with error -8.*"
 
 # https://dev.azure.com/msazure/One/_workitems/edit/14233568
 r, ".* ERR syncd\d*#syncd.*SAI_API_BUFFER.*Unknown or unsupported stat type.*"


### PR DESCRIPTION
### Description of PR
With SAI 14.3, we observed the following errors when querying port serdes attributes with a null buffer (expecting SAI_STATUS_BUFFER_OVERFLOW): (this is the standard way of checking sai attribute support in prod code)

```
ERR syncd#syncd: [none] SAI_API_PORT:brcm_sai_get_port_serdes_attribute_cmn:18718 RX VGA get failed with error -8.
ERR syncd#syncd: [none] SAI_API_PORT:brcm_sai_get_port_serdes_attribute_cmn:18705 Port 68: TX_FIR_TAPS_LIST get failed with error -8

```
As error -8 corresponds to SAI_STATUS_BUFFER_OVERFLOW, it appears the log severity may need to be adjusted within the SAI implementation. 
Until it is fixed we are adding this ignore for the port phy serdes attrs so that we may not fall into mgmt regressions.


Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
With the latest brcm SAI 14.3 we are seeing these errors which can cause regression in mgmt tests.

#### How did you do it?
Added ignore logs for logre.

#### How did you verify/test it?
mgmt tests, and python scripts to match regex.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
NA
