### PR TITLE
manage counterpoll status during case

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ from tests.common.plugins.ptfadapter.dummy_testutils import DummyTestUtils
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.helpers.parallel import patch_ansible_worker_process
 from tests.common.helpers.parallel import fix_logging_handler_fork_lock
+from tests.common.helpers.counterpoll_helper import ConterpollHelper
 
 import tests.common.gnmi_setup as gnmi_setup
 
@@ -3963,3 +3964,17 @@ def yang_validation_check(request, duthosts):
             error_summary.append(f"{host}: {result['error']}")
 
         pt_assert(False, "post-test YANG validation failed:\n" + "\n".join(error_summary))
+
+
+@pytest.fixture(scope="function", autouse=False)
+def restore_counter_poll(rand_selected_dut):
+    counter_poll_show = ConterpollHelper.get_counterpoll_show_output(rand_selected_dut)
+    parsed_counterpoll_before = ConterpollHelper.get_parsed_counterpoll_show(counter_poll_show)
+    yield
+    counter_poll_show = ConterpollHelper.get_counterpoll_show_output(rand_selected_dut)
+    parsed_counterpoll_after = ConterpollHelper.get_parsed_counterpoll_show(counter_poll_show)
+    ConterpollHelper.restore_counterpoll_status(
+        rand_selected_dut,
+        parsed_counterpoll_before,
+        parsed_counterpoll_after
+    )

--- a/tests/dualtor/test_switchover_failure.py
+++ b/tests/dualtor/test_switchover_failure.py
@@ -11,6 +11,7 @@ from tests.common.dualtor.mux_simulator_control import (  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import run_icmp_responder, run_garp_service  # noqa: F401
 from tests.common.utilities import wait_until
 from tests.common.dualtor.dual_tor_common import cable_type, CableType                                     # noqa: F401
+from tests.common.helpers.counterpoll_helper import ConterpollHelper
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,7 @@ def common_setup_teardown(
 def test_mac_move_during_switchover(
     common_setup_teardown,
     toggle_all_simulator_ports_to_rand_unselected_tor,  # noqa: F811
+    restore_counter_poll,
     rand_selected_dut,
     rand_unselected_dut,
     ptfadapter,
@@ -165,6 +167,11 @@ def test_mac_move_during_switchover(
     """
     Trigger a MAC move during a switchover and verify that the switchover still completes successfully
     """
+
+    # Disable all counterpolls during the switchover flow and let the fixture restore them.
+    available_types = ConterpollHelper.get_available_counterpoll_types(rand_selected_dut)
+    ConterpollHelper.disable_counterpoll(rand_selected_dut, available_types)
+
     # Learn the neighbor on the DUT
     testutils.send(ptfadapter, common_setup_teardown["ptf_intf1"], neigh_learn_pkt)
 

--- a/tests/platform_tests/counterpoll/cpu_memory_helper.py
+++ b/tests/platform_tests/counterpoll/cpu_memory_helper.py
@@ -1,23 +1,8 @@
 import pytest
 
 from tests.common.constants import CounterpollConstants
-from tests.common.helpers.counterpoll_helper import ConterpollHelper
-from tests.common.utilities import skip_release
 
 
 @pytest.fixture(params=[CounterpollConstants.PORT_BUFFER_DROP])
 def counterpoll_type(request):
     return request.param
-
-
-@pytest.fixture()
-def restore_counter_poll(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-    skip_release(duthost, ["201811", "201911", "202012"])
-
-    counter_poll_show = ConterpollHelper.get_counterpoll_show_output(duthost)
-    parsed_counterpoll_before = ConterpollHelper.get_parsed_counterpoll_show(counter_poll_show)
-    yield
-    counter_poll_show = ConterpollHelper.get_counterpoll_show_output(duthost)
-    parsed_counterpoll_after = ConterpollHelper.get_parsed_counterpoll_show(counter_poll_show)
-    ConterpollHelper.restore_counterpoll_status(duthost, parsed_counterpoll_before, parsed_counterpoll_after)

--- a/tests/platform_tests/test_cpu_memory_usage.py
+++ b/tests/platform_tests/test_cpu_memory_usage.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from collections import namedtuple, Counter
-from tests.platform_tests.counterpoll.cpu_memory_helper import restore_counter_poll     # noqa: F401
 from tests.platform_tests.counterpoll.cpu_memory_helper import counterpoll_type         # noqa: F401
 from tests.common.constants import CounterpollConstants
 from tests.common.helpers.counterpoll_helper import ConterpollHelper
@@ -16,8 +15,7 @@ pytestmark = [
 ]
 
 
-def is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+def is_asan_image(duthost):
     asan_val_from_sonic_ver_cmd = "sonic-cfggen -y /etc/sonic/sonic_version.yml -v asan"
     asan_val = duthost.command(asan_val_from_sonic_ver_cmd)['stdout']
     is_asan = False
@@ -28,13 +26,13 @@ def is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname):
 
 
 @pytest.fixture(scope='module')
-def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+def setup_thresholds(rand_selected_dut):
+    duthost = rand_selected_dut
     is_chassis = duthost.get_facts().get("modular_chassis")
     cpu_threshold = 70 if is_chassis else 50
     memory_threshold = 60
     high_cpu_consume_procs = {}
-    is_asan = is_asan_image(duthosts, enum_rand_one_per_hwsku_hostname)
+    is_asan = is_asan_image(duthost)
     if ('arista_7800' in duthost.facts['platform'].lower()) or duthost.facts['platform'] in ('x86_64-mlnx_msn4600c-r0'):
         memory_threshold = 75
     if duthost.facts['platform'] in ('x86_64-arista_7050_qx32', 'x86_64-kvm_x86_64-r0', 'x86_64-arista_7050_qx32s',
@@ -60,9 +58,9 @@ def setup_thresholds(duthosts, enum_rand_one_per_hwsku_hostname):
     return memory_threshold, cpu_threshold, high_cpu_consume_procs
 
 
-def test_cpu_memory_usage(duthosts, enum_rand_one_per_hwsku_hostname, setup_thresholds):
+def test_cpu_memory_usage(rand_selected_dut, setup_thresholds):
     """Check DUT memory usage and process cpu usage are within threshold."""
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = rand_selected_dut
     # Wait until all critical services is fully started
     pytest_assert(wait_until(360, 20, 0, duthost.critical_services_fully_started),
                   "All critical services must be fully started!{}".format(duthost.critical_services))
@@ -122,11 +120,11 @@ def counterpoll_cpu_threshold(duthosts, request):
 
 
 @pytest.fixture
-def disable_pfcwd(duthosts, enum_rand_one_per_hwsku_hostname):
+def disable_pfcwd(rand_selected_dut):
     """
     Disable PFCWD before testing, and start_default after testing
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = rand_selected_dut
     pfcwd_status = duthost.shell(
         "sonic-db-cli CONFIG_DB hget \'DEVICE_METADATA|localhost\' \'default_pfcwd_status\'")['stdout']
     if pfcwd_status != 'enable':
@@ -137,7 +135,7 @@ def disable_pfcwd(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost.shell('pfcwd start_default')
 
 
-def test_cpu_memory_usage_counterpoll(duthosts, enum_rand_one_per_hwsku_hostname,
+def test_cpu_memory_usage_counterpoll(rand_selected_dut,
                                       setup_thresholds, restore_counter_poll, counterpoll_type,     # noqa: F811
                                       counterpoll_cpu_threshold, disable_pfcwd):
     """Check DUT memory usage and process cpu usage are within threshold.
@@ -147,7 +145,7 @@ def test_cpu_memory_usage_counterpoll(duthosts, enum_rand_one_per_hwsku_hostname
     Compare the average cpu usage with the cpu threshold for the specified progress
     Restore counterpolls status
     """
-    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    duthost = rand_selected_dut
     program_to_check = get_manufacturer_program_to_check(duthost)
     if program_to_check is None:
         pytest.skip("Skip no program is offered to check")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

"counter polling timeout" related error message may be printed due to pause signal in test_mac_move_during_switchover(). this commit is to disable counterpolls during the test case, and the update has no impact on original test case.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
In test case test_mac_move_during_switchover(), the pause signal will cause counter timeout failures in following test case. And it is confirmed that in SIGSTOP/SIGCONT situation, SAI cannot behave properly.

#### How did you do it?
The couterpollls will be disabled during the test and recover afterwards.

#### How did you verify/test it?
After discussion with SAI design team, disable the counter poll should be a valid solution because it can avoid current issue, and the original test can still succeed after the update.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
