### PR TITLE
fix(pfcwd): use nohup for pfc_gen.py on EOS fanout to prevent SIGHUP termination

### DIFF
--- a/tests/common/templates/pfc_storm_eos.j2
+++ b/tests/common/templates/pfc_storm_eos.j2
@@ -1,9 +1,9 @@
 bash
 cd /mnt/flash
 {% if (pfc_asym  is defined) and (pfc_asym == True) %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} nohup sudo python {{pfc_gen_file}} -p {{pfc_queue_index}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} >/dev/null 2>&1 &
 {% else %}
-{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} sudo python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} &
+{% if pfc_storm_defer_time is defined %} sleep {{pfc_storm_defer_time}} &&{% endif %} nohup sudo python {{pfc_gen_file}} -p {{(1).__lshift__(pfc_queue_index)}} -t 65535 -n {{pfc_frames_number}} -i {{pfc_fanout_interface | replace("Ethernet", "et") | replace("/", "_")}} -r {{ansible_eth0_ipv4_addr}} >/dev/null 2>&1 &
 {% endif %}
 exit
 exit


### PR DESCRIPTION
On EOS-based fanouts, pfc_gen.py is launched in the background via exec_template (pexpect SSH session). When the bash subshell exits and then the EOS session exits, SIGHUP is sent to background processes. Without nohup, pfc_gen.py is killed before it can send PFC frames, causing pfcwd to never detect the storm — resulting in test_pfcwd_timer_accuracy failures on S6100.

### Description of PR

Summary:

Bug fix for `test_pfcwd_timer_accuracy` (and related pfcwd tests) consistently failing on Force10 S6100 with EOS fanouts, while passing on other platforms (e.g., Arista 7050QX).

**Root cause confirmed via manual testing on strtk5 testbed (S6100 acs-5 + fanout-10):**

| Mode | pfcwd detects storm? |
|---|---|
| Sync `pfc_gen.py` (foreground, no `&`) | ✅ Yes (3/3 runs) |
| Background `pfc_gen.py` (`&` + exit bash + exit EOS) | ❌ No |
| Background with `nohup` (`nohup ... &` + exit bash + exit EOS) | ✅ Yes |

When the EOS SSH session exits, it sends SIGHUP to all processes in the session. `pfc_gen.py` has no SIGHUP handler, so it is killed before sending any PFC frames. The fix uses `nohup` to protect the process from SIGHUP, and redirects output to `/dev/null` (previously stdout was connected to the EOS TTY which also gets closed on exit).

**Fix:** prefix `pfc_gen.py` invocation with `nohup` and add `>/dev/null 2>&1` in both branches of the EOS storm template.

### Type of change

- [x] Bug fix

### Back port request
- [x] 202511

### Approach

#### What is the motivation for this PR?
`test_pfcwd_timer_accuracy` fails on S6100 (EOS fanout) because pfc_gen.py is killed by SIGHUP before sending frames. The pfcwd watchdog never sees a storm, so the test assertion fails.

#### How did you do it?
Added `nohup` prefix and `>/dev/null 2>&1` to the pfc_gen.py background invocation in `tests/common/templates/pfc_storm_eos.j2`. Both the symmetric and asymmetric PFC paths are fixed.

#### How did you verify/test it?
Manual testing on strtk5-s6100-acs-5 (Force10 S6100) with strtk5-7260-fanout-10 (EOS/Arista):
- Confirmed 3x sync pfc_gen.py → pfcwd detection in DUT syslog ✅
- Confirmed background pfc_gen.py (no nohup) → no pfcwd detection ❌
- Confirmed nohup background pfc_gen.py → pfcwd detection in DUT syslog ✅

#### Any platform specific information?
EOS fanout platforms only. Other fanout types (SONiC, Linux) are not affected.

#### Supported testbed topology if it is a new test case?
N/A (bug fix)

### Documentation

N/A