### PR TITLE
Fix interface range shutdown/startup not supported on multi-asic

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -451,9 +451,10 @@ def test_lldp_entry_table_after_all_batched_flap(
     asic_interface_map = group_interfaces_by_asic(duthost, testable_interfaces)
     lldpctl_lookup_map = _build_lldpctl_lookup_map(lldpctl_interfaces)
     for asic_str, asic_interfaces in asic_interface_map.items():
-        interface_list = ",".join(asic_interfaces)
-        logger.info("Flapping interfaces: {}".format(interface_list))
-        _shutdown_startup_interface(duthost, interface_list, asic_str)
+        logger.info("Flapping interfaces: {}".format(asic_interfaces))
+        # Interface range shutdown/startup is not supported in multi-asic platforms.
+        for interface in asic_interfaces:
+            _shutdown_startup_interface(duthost, interface, asic_str)
     # Single wait_until call checking all interfaces together
     _verify_interface_lldp_recovery(db_instance, testable_interfaces, lldpctl_lookup_map, delay=10)
 


### PR DESCRIPTION
### Description of PR
test_lldp_entry_table_after_all_batched_flap fails on multi-asic platform. 
Error: Interface range not supported in multi-asic platforms !!

The command running at the moment which introduced the error: sudo config interface -n asic0 shutdown Ethernet40,Ethernet136,Ethernet104,Ethernet24,Ethernet48,Ethernet120,Ethernet112,Ethernet128,Ethernet0,Ethernet16,Ethernet96,Ethernet72,Ethernet8,Ethernet64,Ethernet32,Ethernet80,Ethernet88,Ethernet56

In multi-asic scenario, port range shutdown/restarted is not supported by CLI. There's check to prevent this from sonic-buildimage/src/sonic-utilities/config/main.py
   intf_fs = parse_interface_in_filter(interface_name)
    if len(intf_fs) > 1 and multi_asic.is_multi_asic():
        ctx.fail("Interface range not supported in multi-asic platforms !!")

Solution: Always shutdown/start ports one by one from the list. Then no need to distinguish if it's multi-asic or not.

### Type of change

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Fix OC test failure
#### How did you do it?

#### How did you verify/test it?
After fix this test passes. 
