### PR TITLE
Use linux "ip route show" cmd on ptf container

### DIFF
--- a/tests/dualtor/conftest.py
+++ b/tests/dualtor/conftest.py
@@ -273,7 +273,7 @@ def setup_interfaces(ptfhost, upper_tor_host, lower_tor_host, tbinfo, test_devic
     finally:
         upper_tor_host.shell("show arp")
         lower_tor_host.shell("show arp")
-        ptfhost.shell("show ip route")
+        ptfhost.shell("ip route show")
         for conn in list(connections.values()):
             ptfhost.shell("ifconfig %s 0.0.0.0" % conn["neighbor_intf"], module_ignore_errors=True)
             ptfhost.shell("ip route del %s" % conn["local_addr"], module_ignore_errors=True)


### PR DESCRIPTION
PR https://github.com/sonic-net/sonic-mgmt/pull/22956 adjusted the PTF test libs to use the command 'show ip route' for IP route table verification.  This change was made in order to bypass a known scaling restriction in the Linux kernel when dumping full-scale routing tables via netlink.  However, this does not work as the 'show ip route' command does not exist on the PTF container.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #23091

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Remove test regression as a result of #22956

#### How did you do it?
Revert #22956 in sonic-mgmt/tests/dualtor/conftest.py to the previous command, `ip route show`.

#### How did you verify/test it?
Verified that all dualtor tests indicated in the linked issue now pass.
