### PR TITLE
[cherry-pick/202511] Fix double-removal bug in DEFAULT_ASIC_SERVICES filtering

### DIFF
--- a/tests/common/devices/multi_asic.py
+++ b/tests/common/devices/multi_asic.py
@@ -103,18 +103,19 @@ class MultiAsicSonicHost(object):
             service_list.remove('snmp')
 
         # Update the asic service based on feature table state and asic flag
-        for service in list(self.sonichost.DEFAULT_ASIC_SERVICES):
+        filtered_asic_services = []
+        for service in self.sonichost.DEFAULT_ASIC_SERVICES:
             if service == 'teamd' and is_dpu:
                 logger.info("Removing teamd from default services for switch_type DPU")
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                 continue
             if service not in config_facts['FEATURE']:
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
                 continue
             if config_facts['FEATURE'][service]['has_per_asic_scope'] == "False":
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
+                continue
             if config_facts['FEATURE'][service]['state'] == "disabled":
-                self.sonichost.DEFAULT_ASIC_SERVICES.remove(service)
+                continue
+            filtered_asic_services.append(service)
+        self.sonichost.DEFAULT_ASIC_SERVICES = filtered_asic_services
         if not self.get_facts().get("modular_chassis") and not is_dpu:
             service_list.append("lldp")
 


### PR DESCRIPTION
Cherry-pick of commit 5dfac6fe01 (#23014) to the 202511 branch.

The original fix replaces in-place mutation of `DEFAULT_ASIC_SERVICES` during filtering with a non-mutating pattern that builds a new list, preventing a double-removal bug where services could be skipped during iteration.

Conflict resolution: preserved the existing DPU `teamd` skip logic from the 202511 branch while applying the new filter pattern.

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>