### PR TITLE
Add skip for `test_config_setup_boot.py `until PR25215 merges

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -675,6 +675,15 @@ clock/test_clock.py::test_config_clock_timezone:
       - "https://github.com/sonic-net/sonic-buildimage/issues/24562 and asic_type in ['mellanox', 'nvidia', 'vs']"
 
 #######################################
+#####          config_setup       #####
+#######################################
+config_setup/test_config_setup_boot.py:
+  skip:
+    reason: "Skip until https://github.com/sonic-net/sonic-buildimage/pull/25215 has merged and test updated"
+    conditions:
+      - "True"
+
+#######################################
 #####           configlet         #####
 #######################################
 configlet:


### PR DESCRIPTION
Temporary fix to get https://github.com/sonic-net/sonic-buildimage/pull/25215 merged then we can update the test and re-enable it.

https://github.com/sonic-net/sonic-buildimage/pull/25215 Changes the path for the 'pending_config*' flags so the test will need to be updated but because they are in different submodules we need to order the PRs:
1. disable the test (sonic-mgmt)
2. merge the PR to change the paths (sonic-buildimage)
3. enable the test and update the paths in the test (sonic-mgmt)


Background:
https://github.com/sonic-net/sonic-mgmt/pull/22377 merged while https://github.com/sonic-net/sonic-buildimage/pull/25215 was pending to fix https://github.com/sonic-net/sonic-buildimage/issues/25202.
Because https://github.com/sonic-net/sonic-mgmt/pull/22377 relies on `pending_config*` files being in `/tmp/` it conflicts with https://github.com/sonic-net/sonic-buildimage/pull/25215 which is moving the `pending_config*` files from `/tmp/` to `/etc/sonic/`
