### PR TITLE
Removed DPU critical process check and re-enable CLI-based reboot test

### DIFF
--- a/tests/smartswitch/common/device_utils_dpu.py
+++ b/tests/smartswitch/common/device_utils_dpu.py
@@ -33,17 +33,6 @@ REBOOT_CAUSE_INT = 10
 PING_TIMEOUT = 30
 PING_TIME_INT = 10
 
-# Items to skip in DPU critical process check (non-critical or often Not OK on DPUs)
-# - container_checker: container health; may not apply or differ on DPU
-# - snmp: optional, often not enabled on DPUs
-# - acms:acms: optional; also in system_health services_to_ignore
-# - routeCheck: route check; may not apply or differ on DPU
-# - PSU0, PSU1, ...: PSU check; may not apply or differ on DPU
-DPU_CRITICAL_PROCESS_SKIP = frozenset({
-    "container_checker", "snmp", "acms:acms", "routeCheck",
-    "PSU0", "PSU1", "PSU2", "PSU3",
-})
-
 
 @pytest.fixture(scope='function')
 def num_dpu_modules(platform_api_conn):   # noqa F811
@@ -481,7 +470,6 @@ def check_dpu_critical_processes(dpuhosts, dpu_id):
             dpu_id, len(dpuhosts)
         )
         return True
-
     cmd = "sudo show system-health detail"
     output_dpu_process = dpuhost.show_and_parse(cmd)
 
@@ -490,14 +478,14 @@ def check_dpu_critical_processes(dpuhosts, dpu_id):
         if parse_output['status'].lower() == 'ok':
             continue
         name = parse_output.get("name", "")
-        if name in DPU_CRITICAL_PROCESS_SKIP:
-            logging.debug(
-                "Skipping non-critical '%s' (Not OK) in DPU%d critical process check",
-                name, dpu_id
-            )
-            continue
-        logging.error("'{}' has failed in DPU{}"
-                      .format(name, dpu_id))
+        logging.error(
+            "DPU%d critical process not OK: name=%r status=%r state-detail=%r state-value=%r",
+            dpu_id,
+            name,
+            parse_output.get("status"),
+            parse_output.get("state-detail"),
+            parse_output.get("state-value"),
+        )
         return False
     return True
 

--- a/tests/smartswitch/platform_tests/test_reload_dpu.py
+++ b/tests/smartswitch/platform_tests/test_reload_dpu.py
@@ -32,8 +32,7 @@ MAX_COOL_OFF_TIME = 300
 EXTRA_DPU_ONLINE_TIMEOUT_FOR_WATCHDOG = 40
 
 
-# @pytest.fixture(params=["gnoi_based", "cli_based"])
-@pytest.fixture(params=["gnoi_based"])
+@pytest.fixture(params=["gnoi_based", "cli_based"])
 def invocation_type(request):
     """Parametrize reboot tests to run with both gNOI and CLI reboot paths."""
     return request.param


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
- Removed DPU_CRITICAL_PROCESS_SKIP as it was ignoring non-OK processes.
- Re-enabled cli_based invocation type in test_reload_dpu.py so reboot tests run with both gNOI and CLI paths

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
  The DPU critical process check was silently ignoring failures for a hardcoded list of processes (DPU_CRITICAL_PROCESS_SKIP). This masked real issues during reboot/reload tests. Additionally, CLI-based reboot testing was disabled, leaving test coverage incomplete.
#### How did you do it?

  - Removed the DPU_CRITICAL_PROCESS_SKIP allowlist from device_utils_dpu.py so all non-OK processes are now treated as failures
  - Re-enabled cli_based in the invocation_type fixture in test_reload_dpu.py so reboot tests run against both gNOI and CLI paths

#### How did you verify/test it?
v-cshekar@sonic-mgmt-v-cshekar:/var/src/sonic-mgmt-int/tests$ sudo ./run_tests.sh -n vms69-t1-smartswitch-4280-22 -i ../ansible/veos,../ansible/str3 -d str3-nvidia-4280-E04-U22 -H "str3-nvidia-4280-E04-U22-dpu-0" -u -m individual -c smartswitch/platform_tests/test_reload_dpu.py::test_cold_reboot_dpus -e "--skip_sanity" -l info

ERROR    root:device_utils_dpu.py:480 DPU0 critical process not OK: name='monit' status='Not OK' state-detail=None state-value=None
ERROR    root:device_utils_dpu.py:480 DPU0 critical process not OK: name='monit' status='Not OK' state-detail=None state-value=None
ERROR    root:device_utils_dpu.py:480 DPU0 critical process not OK: name='diskCheck' status='Not OK' state-detail=None state-value=None
ERROR    root:device_utils_dpu.py:480 DPU0 critical process not OK: name='diskCheck' status='Not OK' state-detail=None state-value=None
ERROR    root:device_utils_dpu.py:480 DPU0 critical process not OK: name='syncd' status='Not OK' state-detail=None state-value=None
ERROR    root:device_utils_dpu.py:480 DPU0 critical process not OK: name='syncd' status='Not OK' state-detail=None state-value=None
ERROR    root:__init__.py:40 Traceback (most recent call last):

INFO     conftest:conftest.py:92 Removed client cert directory /tmp/ss_gnoi_certs
 tests/smartswitch/platform_tests/test_reload_dpu.py::test_cold_reboot_dpus[gnoi_based-str3-nvidia-4280-E04-U22] ⨯                                                                                                                                50% █████     

INFO     tests.conftest:conftest.py:3190 Core dump and config check passed for test_reload_dpu.py
 tests/smartswitch/platform_tests/test_reload_dpu.py::test_cold_reboot_dpus[cli_based-str3-nvidia-4280-E04-U22] ⨯                                                                                                                                100% ██████████

<frozen importlib._bootstrap>:488

#### Any platform specific information?
SmartSwitch only 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
