### PR TITLE
[HA ]configure vlan port on both dpus and perform cleanup

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -338,12 +338,11 @@ def vxlan_udp_dport(request, duthost):
 
 
 @pytest.fixture(scope="module")
-def set_vxlan_udp_sport_range(dpuhosts, dpu_index):
+def set_vxlan_udp_sport_range(dpuhosts):
     """
     Configure VXLAN UDP source port range in dpu configuration.
 
     """
-    dpuhost = dpuhosts[dpu_index]
     vxlan_sport_config = [
         {
             "SWITCH_TABLE:switch": {
@@ -356,15 +355,17 @@ def set_vxlan_udp_sport_range(dpuhosts, dpu_index):
 
     logger.info(f"Setting VXLAN source port config: {vxlan_sport_config}")
     config_path = "/tmp/vxlan_sport_config.json"
-    dpuhost.copy(content=json.dumps(vxlan_sport_config, indent=4), dest=config_path, verbose=False)
-    apply_swssconfig_file(dpuhost, config_path)
-    if 'pensando' in dpuhost.facts['asic_type']:
-        logger.warning("Applying Pensando DPU VXLAN sport workaround")
-        dpuhost.shell("pdsctl debug update device --vxlan-port 4789 --vxlan-src-ports 5120-5247")
+    for dpuhost in dpuhosts:
+        dpuhost.copy(content=json.dumps(vxlan_sport_config, indent=4), dest=config_path, verbose=False)
+        apply_swssconfig_file(dpuhost, config_path)
+        if 'pensando' in dpuhost.facts['asic_type']:
+            logger.warning("Applying Pensando DPU VXLAN sport workaround")
+            dpuhost.shell("pdsctl debug update device --vxlan-port 4789 --vxlan-src-ports 5120-5247")
     yield
-
-    if str(VXLAN_UDP_BASE_SRC_PORT) in dpuhost.shell("redis-cli -n 0 hget SWITCH_TABLE:switch vxlan_sport")['stdout']:
-        config_reload(dpuhost, safe_reload=True, yang_validate=False)
+    for dpuhost in dpuhosts:
+        if str(VXLAN_UDP_BASE_SRC_PORT) in dpuhost.shell("redis-cli -n 0"
+                                                         " hget SWITCH_TABLE:switch vxlan_sport")['stdout']:
+            config_reload(dpuhost, safe_reload=True, yang_validate=False)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Description of PR
Summary:
Need to perform vxlan setup on both primary and standby DPUs and also do a config reload during the cleanup. This is required to generate the PL packets by the DPU with a certain VxLAN range.It is the same as the one used in the DASH tests: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/dash/conftest.py#L421

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
VXLAN config is needed on both DPUs

#### How did you do it?
Added the code to config VxLAN on standby DPU

#### How did you verify/test it?
Run the HA steady traffic test

#### Any platform specific information?
HA smartswitch

#### Supported testbed topology if it's a new test case?
HA topology

### Documentation
N/A
