### PR TITLE
feat: add cancel_pr for testplan.py

### DIFF
--- a/.azure-pipelines/test_plan.py
+++ b/.azure-pipelines/test_plan.py
@@ -447,6 +447,31 @@ class TestPlanManager(object):
         print(f"Result of cancelling test plan at {tp_url}:")
         print(str(resp["data"]))
 
+    def cancel_pr(self, pr_id):
+        tp_url = f"{self.scheduler_url}/test_plan/pr/{pr_id}"
+        cancel_url = f"{tp_url}/cancel"
+
+        print(f"Cancelling old PR testplans at {cancel_url}")
+
+        payload = json.dumps({})
+        headers = {
+            "Authorization": f"Bearer {self.get_token()}",
+            "Content-Type": "application/json"
+        }
+
+        raw_resp = {}
+        try:
+            raw_resp = requests.post(cancel_url, headers=headers, data=payload, timeout=10)
+            resp = raw_resp.json()
+        except Exception as exception:
+            raise Exception(f"HTTP execute failure, url: {cancel_url}, raw_resp: {str(raw_resp)}, "
+                            f"exception: {str(exception)}")
+        if not resp["success"]:
+            raise Exception(f"Cancel test PR failed with error: {resp['errmsg']}")
+
+        print(f"Result of cancelling PR testplans at {tp_url}:")
+        print(str(resp["data"]))
+
     def poll(self, test_plan_id, interval=60, timeout=-1, expected_state="", expected_result=None):
         print(f"Polling progress and status of test plan at {self.frontend_url}/scheduler/testplan/{test_plan_id}")
         print(f"Polling interval: {interval} seconds")
@@ -461,6 +486,7 @@ class TestPlanManager(object):
         start_time = time.time()
         poll_retry_times = 0
         while timeout < 0 or (time.time() - start_time) < timeout:
+
             resp = None
             try:
                 resp = requests.get(poll_url, headers=headers, timeout=10).json()
@@ -1038,6 +1064,7 @@ if __name__ == "__main__":
 
     parser_poll = subparsers.add_parser("poll", help="Poll test plan status.")
     parser_cancel = subparsers.add_parser("cancel", help="Cancel running test plan.")
+    parser_cancel_pr = subparsers.add_parser("cancel_pr", help="Cancel test plans for a PR.")
 
     for p in [parser_cancel, parser_poll]:
         p.add_argument(
@@ -1118,9 +1145,10 @@ if __name__ == "__main__":
             env["SONIC_AUTOMATION_UMI"]
         )
 
+        pr_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER") or os.environ.get(
+            "SYSTEM_PULLREQUEST_PULLREQUESTID")
+
         if args.action == "create":
-            pr_id = os.environ.get("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER") or os.environ.get(
-                "SYSTEM_PULLREQUEST_PULLREQUESTID")
             build_repo_provider = os.environ.get("BUILD_REPOSITORY_PROVIDER")
             build_reason = args.build_reason if args.build_reason else os.environ.get("BUILD_REASON")
             build_id = os.environ.get("BUILD_BUILDID")
@@ -1208,6 +1236,8 @@ if __name__ == "__main__":
             tp.poll(args.test_plan_id, args.interval, args.timeout, args.expected_state, args.expected_result)
         elif args.action == "cancel":
             tp.cancel(args.test_plan_id)
+        elif args.action == "cancel_pr":
+            tp.cancel_pr(pr_id=pr_id)
         sys.exit(0)
     except PollTimeoutException as e:
         print(f"Polling test plan failed with exception: {repr(e)}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Adding the ability to cancel previous PR to integrate with https://github.com/sonic-net/sonic-mgmt/pull/22861
Fixes # (issue) 37065882

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Currently, when running a new testplan, there is no safety check to cancel all the previous dangling job.

This add the ability to test_plan.py to cancel all related job with PR number using cancel_pr. However this PR does not add the call, only the implementation. The real call will be implemented in https://github.com/sonic-net/sonic-mgmt/pull/22861

#### How did you do it?

Added a cancel_pr method that hits Elastictest endpoint API to cancel all previous job for the same PR

#### How did you verify/test it?

Verified locally and manually using CI

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
