### PR TITLE
[HA] revert PR 22920 to the original BFD values

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -587,8 +587,8 @@ def generate_ha_config_for_dut(switch_id: int, duthost, tbinfo):
         "VDPU": generate_vdpu_config(),
         "DASH_HA_GLOBAL_CONFIG": {
             "GLOBAL": {
-                "dpu_bfd_probe_interval_in_ms": "200",
-                "dpu_bfd_probe_multiplier": "5",
+                "dpu_bfd_probe_interval_in_ms": "1000",
+                "dpu_bfd_probe_multiplier": "3",
                 "cp_data_channel_port": "11362",
                 "dp_channel_dst_port": "11368",
                 "dp_channel_src_port_min": "7001",


### PR DESCRIPTION
### Description of PR
Summary:
Need to revert to the original BFD parameters
### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Need to use the original BFD parameters
#### How did you do it?
Reverted the diff from PR 22920

#### How did you verify/test it?
Run flake8 on it

#### Any platform specific information?
MtFuji 
#### Supported testbed topology if it's a new test case?
HA topology
### Documentation
N/A