### PR TITLE
[test_critical_process_monitoring][otel]: Fix otel process monitoring test failure due to auto-restart behavior

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -325,6 +325,9 @@ def get_expected_alerting_messages_supervisor(duthost, containers_in_namespaces)
                 # TODO: Should remove the following two lines once the issue was solved in the image.
                 if "syncd" in container_name_in_namespace and critical_process == "dsserve":
                     continue
+                # Skip 'otel' process since it would autorestart
+                if "otel" in container_name_in_namespace and critical_process == "otel":
+                    continue
                 logger.info("Generating the regex of expected alerting message for process '{}' in container '{}'"
                             .format(critical_process, container_name_in_namespace))
                 expected_alerting_messages.append(".*Process '{}' is not running in namespace '{}'.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: The test was failing with the error:
```
Expected Messages that are missing:
.*Process 'otel' is not running in namespace 'host'.*
```
The 'otel' process in the 'otel' container has auto-restart configured. When the test kills this process, it restarts too quickly for the monitoring system (Supervisord) to log the expected alerting message to syslog.
Fixes # (issue)
Added skip logic in the get_expected_alerting_messages_supervisor function to exclude the 'otel' process from the expected alerting messages.
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The test expected to find an alerting message about the 'otel' process not running in the syslog, but it was missing.
#### How did you do it?
Added skip logic in the get_expected_alerting_messages_supervisor function to exclude the 'otel' process from the expected alerting messages.
#### How did you verify/test it?
Verified it in the internal test setup:
```
------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
================================================================================ 2 passed, 244 warnings in 1409.85s (0:23:29) ================================================================================
DEBUG:tests.conftest:[log_custom_msg] item: <Function test_orchagent_heartbeat>
```
#### Any platform specific information?
SN5640
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
