### PR TITLE
Fix BGPNeighbor router_id for IPv6-only topologies

### DIFF
--- a/tests/common/helpers/bgp.py
+++ b/tests/common/helpers/bgp.py
@@ -146,7 +146,7 @@ class BGPNeighbor(object):
         self.is_passive = is_passive
         self.is_multihop = not is_passive and is_multihop
         self.debug = debug
-        self.is_ipv6_neighbor = is_ipv6_only
+        self.is_ipv6_neighbor = is_ipv6_only or ipaddress.ip_address(self.ip).version == 6
         if not self.is_ipv6_neighbor:
             self.router_id = router_id or self.ip
         else:


### PR DESCRIPTION
Summary: Fix BGPNeighbor router_id for IPv6-only topologies
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
BGPNeighbor fails to start exabgp on IPv6-only topologies because the router_id is set to an IPv6 address, which is invalid (BGP router ID must be a 32-bit IPv4 address).

Root cause: PR #21863 moved the router_id auto-detection logic from start_session() (introduced by PR #21577) into __init__(), but made it depend on an explicit is_ipv6_only flag. Callers that do not pass is_ipv6_only=True (e.g. test_bgp_update_timer.py) fall through to the default path which assigns the raw IPv6 address as router_id, causing exabgp to crash with "Exited too quickly".

#### How did you do it?
Fix: auto-detect IPv6 neighbors by checking the IP version of the neighbor address, so that all callers get correct router_id handling regardless of whether they pass the is_ipv6_only flag.

#### How did you verify/test it?
Regression test pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
