### PR TITLE
[smartswitch] Remove acms from smartswitch DPU config

### DIFF
--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -9,9 +9,6 @@
         }
     },
     "FEATURE": {
-        "acms": {
-            "state": "disabled"
-        },
         "lldp": {
             "state": "disabled"
         },


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Remove the hardcoded `"acms": {"state": "disabled"}` entry from the smartswitch DPU golden config (`ansible/golden_config_db/smartswitch_dpu_extra.json`). Removing this entry allows the `acms` feature's default state to apply naturally, rather than forcing it to disabled via the golden config.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The golden config was explicitly disabling `acms` on DPUs. This is not needed — the feature should use its default state. Keeping this explicit `disabled` entry can mask issues and prevents `acms` from starting even when it should.

#### How did you do it?
Removed the 3-line `"acms": {"state": "disabled"}` block from `ansible/golden_config_db/smartswitch_dpu_extra.json`.

#### How did you verify/test it?
Verified on a smartswitch testbed that the DPU comes up correctly and that the `acms` feature uses its default state after the golden config is applied.

#### Any platform specific information?
Applies to smartswitch platforms using the DPU golden config.

#### Supported testbed topology if it's a new test case?
N/A — not a new test case.

### Documentation
N/A

Signed-off-by: Vasundhara Volam <vvolam@microsoft.com>