### PR TITLE
Fix merge conflict error in test_ipv6_bgp_scale.py

### DIFF
--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -53,7 +53,6 @@ ICMP_TYPE_MAX = 125
 _icmp_type_generator = itertools.cycle(range(ICMP_TYPE_MIN, ICMP_TYPE_MAX + 1))
 test_results = {}
 current_test = ""
-global_icmp_type = ICMP_TYPE_MIN
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -625,7 +624,7 @@ def flapper(duthost, ptfadapter, bgp_peers_info, transient_setup, flapping_count
         prefixes,
         duthost.facts['router_mac'],
         pdp.get_mac(pdp.port_to_device(injection_port), injection_port),
-        global_icmp_type
+        icmp_type
     )
     # Downtime ratio is calculated by dividing the number of flapping neighbors by 5, from test data
     downtime_ratio = len(flapping_connections) / 5


### PR DESCRIPTION
Summary: Fix issue during conflict resolution when merging PR #22419 and PR #22549
Fixes # 
PR https://github.com/sonic-net/sonic-mgmt/pull/22676 incorrect change `icmp_type` to `global_icmp_type`. Change it back

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
