### PR TITLE
Allow skipped PR test topologies to run in baseline test

### DIFF
--- a/.azure-pipelines/pr_test_template.yml
+++ b/.azure-pipelines/pr_test_template.yml
@@ -119,48 +119,50 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_t0_2vlans_elastictest
-  #   displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  - ${{ if ne(parameters.BUILD_REASON, 'PullRequest') }}:
+    - job: impacted_area_t0_2vlans_elastictest
+      displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
+      dependsOn:
+      - get_impacted_area
+      condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-2vlans_checker')
+      variables:
+        TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+      continueOnError: false
+      pool: ${{ parameters.AGENT_POOL }}
+      steps:
+        - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+          - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+            displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: t0-2vlans
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+        - template: impacted_area_testing/calculate-instance-numbers.yml
+          parameters:
+            TOPOLOGY: t0-2vlans
+            BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: t0
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+        - template: run-test-elastictest-template.yml
+          parameters:
+            BUILD_REASON: ${{ parameters.BUILD_REASON }}
+            RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+            STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+            TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+            MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+            MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+            PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+            EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+            TOPOLOGY: t0
+            SCRIPTS: $(SCRIPTS)
+            MIN_WORKER: $(INSTANCE_NUMBER)
+            MAX_WORKER: $(INSTANCE_NUMBER)
+            DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
+            KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            MGMT_BRANCH: $(BUILD_BRANCH)
+            COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+            ${{ each param in parameters.OVERRIDE_PARAMS }}:
+              ${{ param.key }}: ${{ param.value }}
+
 
   - job: impacted_area_t1_lag_elastictest
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
@@ -203,183 +205,191 @@ jobs:
           ${{ each param in parameters.OVERRIDE_PARAMS }}:
             ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_dualtor_elastictest
-  #   displayName: "impacted-area-kvmtest-dualtor by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+  - ${{ if ne(parameters.BUILD_REASON, 'PullRequest') }}:
+    - job: impacted_area_dualtor_elastictest
+      displayName: "impacted-area-kvmtest-dualtor by Elastictest"
+      dependsOn:
+      - get_impacted_area
+      condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dualtor_checker')
+      variables:
+        TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+      continueOnError: false
+      pool: ${{ parameters.AGENT_POOL }}
+      steps:
+        - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+          - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+            displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: dualtor
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+        - template: impacted_area_testing/calculate-instance-numbers.yml
+          parameters:
+            TOPOLOGY: dualtor
+            BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: dualtor
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+        - template: run-test-elastictest-template.yml
+          parameters:
+            BUILD_REASON: ${{ parameters.BUILD_REASON }}
+            RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+            STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+            TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+            MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+            MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+            PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+            EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+            TOPOLOGY: dualtor
+            SCRIPTS: $(SCRIPTS)
+            MIN_WORKER: $(INSTANCE_NUMBER)
+            MAX_WORKER: $(INSTANCE_NUMBER)
+            COMMON_EXTRA_PARAMS: "--disable_loganalyzer --disable_sai_validation "
+            KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            MGMT_BRANCH: $(BUILD_BRANCH)
+            ${{ each param in parameters.OVERRIDE_PARAMS }}:
+              ${{ param.key }}: ${{ param.value }}
 
-  # - job: impacted_area_t0_sonic_elastictest
-  #   displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: t0-sonic
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+  - ${{ if ne(parameters.BUILD_REASON, 'PullRequest') }}:
+    - job: impacted_area_t0_sonic_elastictest
+      displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
+      dependsOn:
+      - get_impacted_area
+      condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't0-sonic_checker')
+      variables:
+        TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+      continueOnError: false
+      pool: ${{ parameters.AGENT_POOL }}
+      steps:
+        - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+          - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+            displayName: "Checkout sonic-mgmt repository"
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: t0-64-32
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
-  #         VM_TYPE: vsonic
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         SPECIFIC_PARAM: '[
-  #             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
-  #             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
-  #           ]'
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+        - template: impacted_area_testing/calculate-instance-numbers.yml
+          parameters:
+            TOPOLOGY: t0-sonic
+            BUILD_BRANCH: $(BUILD_BRANCH)
 
-  # - job: impacted_area_dpu_elastictest
-  #   displayName: "impacted-area-kvmtest-dpu by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+        - template: run-test-elastictest-template.yml
+          parameters:
+            BUILD_REASON: ${{ parameters.BUILD_REASON }}
+            RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+            STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+            TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+            MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+            MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+            PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+            EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+            TOPOLOGY: t0-64-32
+            SCRIPTS: $(SCRIPTS)
+            MIN_WORKER: $(INSTANCE_NUMBER)
+            MAX_WORKER: $(INSTANCE_NUMBER)
+            KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            COMMON_EXTRA_PARAMS: "--neighbor_type=sonic --disable_sai_validation "
+            VM_TYPE: vsonic
+            MGMT_BRANCH: $(BUILD_BRANCH)
+            SPECIFIC_PARAM: '[
+                {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
+                {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
+              ]'
+            ${{ each param in parameters.OVERRIDE_PARAMS }}:
+              ${{ param.key }}: ${{ param.value }}
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: dpu
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: dpu
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-  #         SPECIFIC_PARAM: '[
-  #             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
-  #           ]'
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+  - ${{ if ne(parameters.BUILD_REASON, 'PullRequest') }}:
+    - job: impacted_area_dpu_elastictest
+      displayName: "impacted-area-kvmtest-dpu by Elastictest"
+      dependsOn:
+      - get_impacted_area
+      condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 'dpu_checker')
+      variables:
+        TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+      continueOnError: false
+      pool: ${{ parameters.AGENT_POOL }}
+      steps:
+        - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+          - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+            displayName: "Checkout sonic-mgmt repository"
 
-  # # This PR checker aims to run all t1 test scripts on multi-asic topology.
-  # - job: impacted_area_multi_asic_t1_elastictest
-  #   displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
-  #   dependsOn:
-  #   - get_impacted_area
-  #   condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
-  #   variables:
-  #     TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
-  #   timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
-  #   continueOnError: false
-  #   pool: ${{ parameters.AGENT_POOL }}
-  #   steps:
-  #     - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
-  #       - checkout: ${{ parameters.SONIC_MGMT_NAME }}
-  #         displayName: "Checkout sonic-mgmt repository"
+        - template: impacted_area_testing/calculate-instance-numbers.yml
+          parameters:
+            TOPOLOGY: dpu
+            BUILD_BRANCH: $(BUILD_BRANCH)
 
-  #     - template: impacted_area_testing/calculate-instance-numbers.yml
-  #       parameters:
-  #         TOPOLOGY: t1
-  #         BUILD_BRANCH: $(BUILD_BRANCH)
+        - template: run-test-elastictest-template.yml
+          parameters:
+            BUILD_REASON: ${{ parameters.BUILD_REASON }}
+            RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+            STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+            TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+            MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+            MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+            PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+            EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+            TOPOLOGY: dpu
+            SCRIPTS: $(SCRIPTS)
+            MIN_WORKER: $(INSTANCE_NUMBER)
+            MAX_WORKER: $(INSTANCE_NUMBER)
+            KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            MGMT_BRANCH: $(BUILD_BRANCH)
+            COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+            SPECIFIC_PARAM: '[
+                {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
+              ]'
+            ${{ each param in parameters.OVERRIDE_PARAMS }}:
+              ${{ param.key }}: ${{ param.value }}
 
-  #     - template: run-test-elastictest-template.yml
-  #       parameters:
-  #         BUILD_REASON: ${{ parameters.BUILD_REASON }}
-  #         RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
-  #         STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
-  #         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
-  #         MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
-  #         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
-  #         PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
-  #         EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
-  #         TOPOLOGY: t1-8-lag
-  #         SCRIPTS: $(SCRIPTS)
-  #         MIN_WORKER: $(INSTANCE_NUMBER)
-  #         MAX_WORKER: $(INSTANCE_NUMBER)
-  #         NUM_ASIC: 4
-  #         KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
-  #         MGMT_BRANCH: $(BUILD_BRANCH)
-  #         COMMON_EXTRA_PARAMS: "--disable_sai_validation "
-  #         ${{ each param in parameters.OVERRIDE_PARAMS }}:
-  #           ${{ param.key }}: ${{ param.value }}
+
+  - ${{ if ne(parameters.BUILD_REASON, 'PullRequest') }}:
+    # This PR checker aims to run all t1 test scripts on multi-asic topology.
+    - job: impacted_area_multi_asic_t1_elastictest
+      displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
+      dependsOn:
+      - get_impacted_area
+      condition: contains(dependencies.get_impacted_area.outputs['SetVariableTask.PR_CHECKERS'], 't1_checker')
+      variables:
+        TEST_SCRIPTS: $[ dependencies.get_impacted_area.outputs['SetVariableTask.TEST_SCRIPTS'] ]
+      timeoutInMinutes: ${{ parameters.TIMEOUT_IN_MINUTES_PR_TEST }}
+      continueOnError: false
+      pool: ${{ parameters.AGENT_POOL }}
+      steps:
+        - ${{ if eq(parameters.CHECKOUT_SONIC_MGMT, true) }}:
+          - checkout: ${{ parameters.SONIC_MGMT_NAME }}
+            displayName: "Checkout sonic-mgmt repository"
+
+        - template: impacted_area_testing/calculate-instance-numbers.yml
+          parameters:
+            TOPOLOGY: t1
+            BUILD_BRANCH: $(BUILD_BRANCH)
+
+        - template: run-test-elastictest-template.yml
+          parameters:
+            BUILD_REASON: ${{ parameters.BUILD_REASON }}
+            RETRY_TIMES: ${{ parameters.RETRY_TIMES }}
+            STOP_ON_FAILURE: ${{ parameters.STOP_ON_FAILURE }}
+            TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
+            MAX_RUN_TEST_MINUTES: ${{ parameters.MAX_RUN_TEST_MINUTES }}
+            MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
+            PTF_MODIFIED: ${{ parameters.PTF_MODIFIED }}
+            EXPECTED_RESULT: ${{ parameters.EXPECTED_RESULT }}
+            TOPOLOGY: t1-8-lag
+            SCRIPTS: $(SCRIPTS)
+            MIN_WORKER: $(INSTANCE_NUMBER)
+            MAX_WORKER: $(INSTANCE_NUMBER)
+            NUM_ASIC: 4
+            KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+            MGMT_BRANCH: $(BUILD_BRANCH)
+            COMMON_EXTRA_PARAMS: "--disable_sai_validation "
+            ${{ each param in parameters.OVERRIDE_PARAMS }}:
+              ${{ param.key }}: ${{ param.value }}
+
 
   - job: impacted_area_t2_elastictest
     displayName: "impacted-area-kvmtest-t2 by Elastictest"
@@ -448,3 +458,4 @@ jobs:
 #           ASIC_TYPE: "vpp"
 #           KVM_IMAGE_BUILD_PIPELINE_ID: "2818"
 #           COMMON_EXTRA_PARAMS: "--disable_sai_validation --disable_loganalyzer"
+


### PR DESCRIPTION
### Description of PR

#### Summary
PR #22835 temporarily disabled non-t0/t1-lag/t2 topology jobs in `pr_test_template.yml` to reduce load on limited KVM testbed resources during PR testing. However, the same template is also used by baseline tests (`baseline.test.buildimage.yml` and `baseline.test.mgmt.public.yml`), which are scheduled nightly and should run ALL topology jobs for comprehensive coverage.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Approach
#### What is the motivation for this PR?
The baseline test pipeline calls `pr_test_template.yml` with `BUILD_REASON: BaselineTest` while PR test uses `BUILD_REASON: PullRequest` (the default). We can leverage this existing distinction to gate which jobs are included at compile time.

#### How did you do it?
Each commented-out topology job is wrapped with a compile-time `if` expression:

`yaml
- ${{ if ne(parameters.BUILD_REASON, 'PullRequest') }}:
  - job: impacted_area_t0_2vlans_elastictest
    ...
`

This means:
- **PR test** (`BUILD_REASON=PullRequest`): jobs are excluded at compile time — same as current commented-out behavior
- **Baseline test** (`BUILD_REASON=BaselineTest`): jobs are included and run normally

Affected topology jobs re-enabled for baseline:
- `impacted_area_t0_2vlans_elastictest` (t0-2vlans_checker)
- `impacted_area_dualtor_elastictest` (dualtor_checker)
- `impacted_area_t0_sonic_elastictest` (t0-sonic_checker)
- `impacted_area_dpu_elastictest` (dpu_checker)
- `impacted_area_multi_asic_t1_elastictest` (t1_checker)

#### How did you verify/test it?
- PR test: `BUILD_REASON` defaults to `"PullRequest"` → skipped topology jobs are excluded (no change to current PR test behavior)
- Baseline test: passes `BUILD_REASON: BaselineTest"` → all topology jobs are compiled in and eligible to run

#### References
- PR #22835: Temporarily skip PR test jobs for non-t0/t1-lag/t2 topologies
- Baseline test pipelines: `baseline.test.buildimage.yml` (sonic-buildimage), `baseline.test.mgmt.public.yml` (sonic-mgmt)