### PR TITLE
[ha] get remote npu pa ip (loopback0 ip) from topo definition instead of hard coding 

### DIFF
--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -526,6 +526,7 @@ def generate_vdpu_config(dpu_count=8):
 
 def generate_remote_dpu_config_for_dut(
     switch_id: int,
+    tbinfo,
     dpu_count=8,
     swbus_start=23606
 ):
@@ -538,7 +539,9 @@ def generate_remote_dpu_config_for_dut(
 
     remote_switch_id = 1 - switch_id
 
-    remote_npu_ip = f"10.1.{remote_switch_id}.32"
+    topo_dut = tbinfo["topo"]["properties"]["topology"]["DUT"]
+    remote_loopback = topo_dut["loopback"]["ipv4"][remote_switch_id]
+    remote_npu_ip = remote_loopback.split("/")[0]
     pa_prefix = f"20.0.20{remote_switch_id}."
 
     remote = {}
@@ -583,7 +586,7 @@ def generate_ha_config_for_dut(switch_id: int, duthost, tbinfo):
 
     return {
         "DPU": generate_local_dpu_config(switch_id),
-        "REMOTE_DPU": generate_remote_dpu_config_for_dut(switch_id),
+        "REMOTE_DPU": generate_remote_dpu_config_for_dut(switch_id, tbinfo),
         "VDPU": generate_vdpu_config(),
         "DASH_HA_GLOBAL_CONFIG": {
             "GLOBAL": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Currently the remote npu pa ip is harded in the config, which doesn't match the loopback of remote npu's loopback. Submitting this PR to fix that.

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To removed hard coded IP addresses. 

#### How did you do it?
Get the remote npu's PA IP from tbinfo (topology file).

#### How did you verify/test it?
Ran ha test to trigger the configuring fixture. Confirmed the IP matches in config_db afterwards. 

#### Any platform specific information?
NO. 

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
