### PR TITLE
[bgp] Support BGP confederation in update replication test

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -154,11 +154,16 @@ def setup_bgp_peers(
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     dut_asn = mg_facts["minigraph_bgp_asn"]
+    confed_asn = duthost.get_bgp_confed_asn()
+    use_vtysh = False
     dut_type = mg_facts["minigraph_devices"][duthost.hostname]["type"]
     if dut_type in ["ToRRouter", "SpineRouter", "BackEndToRRouter", "LowerSpineRouter"]:
         neigh_type = "LeafRouter"
-    elif dut_type == "UpperSpineRouter":
+    elif dut_type in ["UpperSpineRouter", "FabricSpineRouter"]:
         neigh_type = "LowerSpineRouter"
+        if dut_type == "FabricSpineRouter" and confed_asn is not None:
+            # For FT2, we need to use vtysh to configure BGP neigh if BGP confed is enabled
+            use_vtysh = True
     else:
         neigh_type = "ToRRouter"
 
@@ -197,7 +202,9 @@ def setup_bgp_peers(
             is_ipv6_only=is_ipv6_only_topology(tbinfo),
             namespace=connection_namespace,
             is_multihop=is_quagga or is_dualtor,
-            is_passive=False
+            is_passive=False,
+            confed_asn=confed_asn,
+            use_vtysh=use_vtysh,
         )
 
         bgp_peers.append(peer)


### PR DESCRIPTION
### Description of PR
Summary:
Improve `tests/bgp/test_bgp_update_replication.py` so the test can establish ExaBGP neighbors correctly on BGP confederation topologies.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
`test_bgp_update_replication.py` currently brings up BGP peers by using only `minigraph_bgp_asn` as the DUT-facing ASN. That works for regular topologies, but it does not work correctly when the DUT is running BGP confederation.

#### How did you do it?
- read the confederation ASN from the DUT with `get_bgp_confed_asn()`
- pass `confed_asn` into each `BGPNeighbor`
- enable `use_vtysh` for `FabricSpineRouter` when confederation is enabled, matching the existing confed-aware pattern already used by nearby BGP tests
- keep existing behavior unchanged for non-confederation topologies

#### How did you verify/test it?
- `python -m flake8 --max-line-length=120 tests\\bgp\\test_bgp_update_replication.py`
- `python -m py_compile tests\\bgp\\test_bgp_update_replication.py`
- attempted `python -m pytest --collect-only tests\\bgp\\test_bgp_update_replication.py -q`, but collection is blocked in this Windows environment because repo test helpers import Linux-only `fcntl`

The change is also validated on a physical testbed

<img width="658" height="167" alt="image" src="https://github.com/user-attachments/assets/2631ee9e-628a-4c59-84fb-941cc29d423b" />

#### Any platform specific information?
This change is only relevant for confederation-enabled topologies, especially FT2 `FabricSpineRouter` cases that require the existing `vtysh` configuration path.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
No documentation update is needed because this changes existing test setup logic only.