### PR TITLE
[bgp] Fix confed ASN lookup in route checker

### DIFF
--- a/tests/bgp/route_checker.py
+++ b/tests/bgp/route_checker.py
@@ -63,7 +63,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
     """
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
-    asn = mg_facts['minigraph_bgp_asn']
+    confed_asn = dut_host.get_bgp_confed_asn()
     all_routes = {}
     BGP_ENTRY_HEADING = r"BGP routing table entry for "
     BGP_COMMUNITY_HEADING = r"Community: "
@@ -87,6 +87,10 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
             # get hostname('ARISTA11T0') by VM name('VM0122')
             hostname = host_name_map[node['host'].hostname]
         host = node['host']
+        peer_in_bgp_confed = node['conf']['bgp'].get('peer_in_bgp_confed', False)
+        asn = mg_facts['minigraph_bgp_asn']
+        if peer_in_bgp_confed:
+            asn = int(confed_asn)
         peer_ips = node['conf']['bgp']['peers'][asn]
         for ip in peer_ips:
             if ipaddress.IPNetwork(ip).version == 4:
@@ -165,7 +169,7 @@ def parse_routes_on_eos(dut_host, neigh_hosts, ip_ver, exp_community=[]):
 def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     mg_facts = dut_host.minigraph_facts(
         host=dut_host.hostname)['ansible_facts']
-    asn = mg_facts['minigraph_bgp_asn']
+    confed_asn = dut_host.get_bgp_confed_asn()
     all_routes = {}
 
     host_name_map = {}
@@ -175,6 +179,10 @@ def parse_routes_on_vsonic(dut_host, neigh_hosts, ip_ver):
     def parse_routes_process_vsonic(node=None, results=None):
         hostname = host_name_map[node['host'].hostname]
         host = node['host']
+        peer_in_bgp_confed = node['conf']['bgp'].get('peer_in_bgp_confed', False)
+        asn = mg_facts['minigraph_bgp_asn']
+        if peer_in_bgp_confed:
+            asn = int(confed_asn)
         peer_ips = node['conf']['bgp']['peers'][asn]
 
         for ip in peer_ips:


### PR DESCRIPTION
### Description of PR
Summary:
Port the `tests/bgp/route_checker.py` confederation fix from PR #22417 to `master`, including converting `confed_asn` to `int` before indexing the BGP peer map.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
On confederation topologies, `route_checker.py` can look up neighbor peers using a string confederation ASN such as `'4200100000'`, but the peer map is keyed by integers. That causes a `KeyError` when parsing routes.

#### How did you do it?
- ported the confederation-aware route checker logic from PR #22417 to `master`
- added `get_bgp_confed_asn()` handling in both `parse_routes_on_eos()` and `parse_routes_on_vsonic()`
- when `peer_in_bgp_confed` is set, convert `confed_asn` with `int(confed_asn)` before indexing `node['conf']['bgp']['peers']`
- preserved the existing non-confederation path by continuing to use `minigraph_bgp_asn`

#### How did you verify/test it?
- `python -m flake8 --max-line-length=120 tests\\bgp\\route_checker.py`
- `python -m py_compile tests\\bgp\\route_checker.py`
- inspected the focused diff against `upstream/master`
- Verified on a physical LT2 testbed



#### Any platform specific information?
This affects confederation-enabled BGP topologies where `peer_in_bgp_confed` is used and the confederation ASN may be stored as a string.

#### Supported testbed topology if it's a new test case?
Not a new test case.

### Documentation
No documentation update is needed.