### PR TITLE
[Ondatra] Fix for #71291 build break

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - 'master'
       - '202[0-9][0-9][0-9]'
-  pull_request_target:
+  pull_request:
     branches:
       - 'master'
       - '202[0-9][0-9][0-9]'

--- a/.github/workflows/sdn.yml
+++ b/.github/workflows/sdn.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
     paths:
       - 'sdn_tests/**'
-  pull_request_target:
+  pull_request:
     branches: [ master ]
     paths:
       - 'sdn_tests/**'

--- a/sdn_tests/pins_ondatra/infrastructure/testhelper/config_restorer.go
+++ b/sdn_tests/pins_ondatra/infrastructure/testhelper/config_restorer.go
@@ -26,13 +26,6 @@ var (
 	waitForSwitchStateTimeout       = 5 * time.Minute
 )
 
-var (
-	configChangedTimeout = 2 * time.Minute
-	// Using 4 minutes as the upper limit.
-	configPushAndConvergenceTimeout = 4 * time.Minute
-	waitForSwitchStateTimeout       = 5 * time.Minute
-)
-
 // DUT and CONTROL are the only restorable IDs.
 var restorableDUTIDs = map[string]bool{
 	"dut":     true,
@@ -249,7 +242,8 @@ func (cr *ConfigRestorer) restoreConfigOnDiff(ctx context.Context, t *testing.T,
 	log.InfoContextf(ctx, "Trying to restore config for device: %v by pushing default config\n", dutName)
 	configPushAndConvergenceCtx, configPushAndConvergenceCancel := context.WithTimeout(ctx, configPushAndConvergenceTimeout)
 	defer configPushAndConvergenceCancel()
-	if err := ConfigPushAndWaitForConvergence(configPushAndConvergenceCtx, t, device, nil /*(config)*/); err != nil {
+	if err := ConfigPushAndWaitForConvergence(configPushAndConvergenceCtx, t, device,
+ 			nil /*(config)*/, nil /*(ignorePathsWithPrefix)*/); err != nil {
 		log.InfoContextf(ctx, "ConfigPushAndWaitForConvergence(dut=%v) failed, err: %v", dutName, err)
 		return cr.reboot(ctx, t, device)
 	}


### PR DESCRIPTION

The changes address 2 things : 

1. A couple of build errors went in [21970](https://github.com/sonic-net/sonic-mgmt/pull/21790/changes) and [21971](https://github.com/sonic-net/sonic-mgmt/pull/21791/changes) . 

2. The attempt to fix it in [22847](https://github.com/sonic-net/sonic-mgmt/pull/22847) failed because in the github workflow file sdn.yml, the trigger is set as pull_request_target rather than pull_request. For the build to merge and build, pull_request is required. With pull_request_target, it will always builds from the base code because of which 22847 always fails. 

In this PR, the diff from 22847 is included and the pull_request_target is changed to pull_request.

One of the [checks](https://github.com/sonic-net/sonic-mgmt/pull/23136/checks) fails because the build is run twice - 

(1) for the pull_request_target that runs from the base code. This fails because the build errors are still present in the repo

(2) for the pull_request that is updated in the diff. This passes because the build is done after the fix is added. 

Once the code is merged, from the next PR onwards, the pull_request trigger will be run. In this PR though, the checks will have one failure for the pull_request_target.



