### PR TITLE
Add port alias mapping for Cisco-C8220TG-48A-O hwsku

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -72,7 +72,7 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
             for i in range(256, 258):
                 alias = "etp{}".format(33 if i == 256 else 34)
                 port_alias_to_name_map[alias] = "Ethernet{}".format(i)
-        elif hwsku == "Cisco-C8220TG-48A-O":
+        elif hwsku == "Cisco-C8220TG-48A-O" or hwsku == "Cisco-C8220TG-G1S2":
             for i in range(1, 4):
                 port_alias_to_name_map["etp%d" % i] = "Ethernet%d" % i
         elif hwsku == "Arista-7050-QX32":


### PR DESCRIPTION
### Description of PR

Add `etp{N}` → `Ethernet{N}` port alias to name mapping for hwsku `Cisco-C8220TG-48A-O` (Cisco 8220 platform) in the `ImportError` fallback path of `get_port_alias_to_name_map()`.

Without this mapping, `remove-topo` and `add-topo` fail with:
```
Did not find port for 'etp1' in the ports based on hwsku 'Cisco-C8220TG-48A-O'
```

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The Cisco-C8220TG-48A-O hwsku is not in the hardcoded port alias mapping in `port_utils.py`. When the `sonic_py_common` import is not available (e.g. running from the test container rather than the DUT), the fallback path has no mapping for this hwsku, causing `remove-topo` and `add-topo` to fail.

#### How did you do it?
Added an `elif` block for `Cisco-C8220TG-48A-O` that maps `etp1`–`etp3` to `Ethernet1`–`Ethernet3`, matching the DUT's actual `port_config.ini`.

#### How did you verify/test it?
Verified by running `remove-topo` and `add-topo` on a physical `testbed-bjw3-can-8220-1` testbed with topology `c0`. Both completed successfully after the fix.

#### Any platform specific information?
Cisco-C8220TG-48A-O (Cisco 8220 platform, 3 ports: etp1, etp2, etp3)

#### Supported testbed topology if it's a new test case?
N/A — this is a framework fix, not a new test case.

### Documentation
N/A