### PR TITLE
Add topo_ptp-34 topology

### DIFF
--- a/ansible/vars/topo_ptp-34.yml
+++ b/ansible/vars/topo_ptp-34.yml
@@ -1,0 +1,48 @@
+topology:
+  host_interfaces:
+   - 0
+   - 1
+   - 2
+   - 3
+   - 4
+   - 5
+   - 6
+   - 7
+   - 8
+   - 9
+   - 10
+   - 11
+   - 12
+   - 13
+   - 14
+   - 15
+   - 16
+   - 17
+   - 18
+   - 19
+   - 20
+   - 21
+   - 22
+   - 23
+   - 24
+   - 25
+   - 26
+   - 27
+   - 28
+   - 29
+   - 30
+   - 31
+   - 32
+   - 33
+  VMs: {}
+  DUT:
+    vlan_configs:
+      default_vlan_config: one_vlan_a
+      one_vlan_a: {}
+
+configuration_properties:
+  common:
+    dut_asn: 0
+    dut_type: ToRRouter
+
+configuration: {}


### PR DESCRIPTION
### Description of PR

Summary:
Add a new PTP topology definition file for 34 host interfaces to support PTP-related testbed usage.

MSFT ADO - 37076229

Fixes # (N/A)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
A 34-port PTP topology variant is needed so testbed configuration can reference a dedicated `ptp-34` topology, aligned with existing `topo_ptp-*` definitions.

#### How did you do it?
Added a new topology file at [ansible/vars/topo_ptp-34.yml](ansible/vars/topo_ptp-34.yml), following the same schema used by existing PTP topology files:
- `topology.host_interfaces`: `0` through `33`
- `VMs: {}`
- `DUT.vlan_configs` with default `one_vlan_a`
- `configuration_properties.common` and empty `configuration`

#### How did you verify/test it?
- Verified file naming and location are consistent with existing topology files under [ansible/vars](ansible/vars).
- Verified YAML structure matches existing `topo_ptp-*` patterns and expected keys.

#### Any platform specific information?
No platform-specific behavior change. This is a topology-definition-only update.

#### Supported testbed topology if it's a new test case?
Not a new test case. This PR adds topology metadata (`ptp-34`) for testbed use.

### Documentation
No documentation update required for this change.