### PR TITLE
vpp: Enable test_arpall for vpp

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/arptest.py
+++ b/ansible/roles/test/files/ptftests/py3/arptest.py
@@ -44,6 +44,8 @@ class ExpectReply(ACSDataplaneTest):
 
     def runTest(self):
         acs_mac = self.test_params['acs_mac']
+        no_padding = self.test_params.get('no_padding', False)
+        exp_pktlen = 42 if no_padding else 60
         pkt = simple_arp_packet(pktlen=60,
                                 eth_dst='ff:ff:ff:ff:ff:ff',
                                 eth_src='00:06:07:08:09:0a',
@@ -55,7 +57,8 @@ class ExpectReply(ACSDataplaneTest):
                                 hw_snd='00:06:07:08:09:0a',
                                 hw_tgt='ff:ff:ff:ff:ff:ff',
                                 )
-        exp_pkt = simple_arp_packet(eth_dst='00:06:07:08:09:0a',
+        exp_pkt = simple_arp_packet(pktlen=exp_pktlen,
+                                    eth_dst='00:06:07:08:09:0a',
                                     eth_src=acs_mac,
                                     arp_op=2,
                                     ip_snd='10.10.1.2',
@@ -75,6 +78,8 @@ class VerifyUnicastARPReply(ACSDataplaneTest):
 
     def runTest(self):
         acs_mac = self.test_params['acs_mac']
+        no_padding = self.test_params.get('no_padding', False)
+        exp_pktlen = 42 if no_padding else 60
         pkt = simple_arp_packet(pktlen=60,
                                 eth_dst=acs_mac,
                                 eth_src='00:06:07:08:09:00',
@@ -86,7 +91,8 @@ class VerifyUnicastARPReply(ACSDataplaneTest):
                                 hw_snd='00:06:07:08:09:00',
                                 hw_tgt=acs_mac,
                                 )
-        exp_pkt = simple_arp_packet(eth_dst='00:06:07:08:09:00',
+        exp_pkt = simple_arp_packet(pktlen=exp_pktlen,
+                                    eth_dst='00:06:07:08:09:00',
                                     eth_src=acs_mac,
                                     arp_op=2,
                                     ip_snd='10.10.1.2',

--- a/tests/arp/test_arpall.py
+++ b/tests/arp/test_arpall.py
@@ -29,6 +29,9 @@ def test_arp_unicast_reply(common_setup_teardown, intfs_for_test, enum_frontend_
         'port': intf1_indice,
         'kvm_support': True
     }
+    # VPP software dataplane does not pad ARP replies to Ethernet minimum frame size
+    if duthost.facts['asic_type'] == 'vpp' and duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        params['no_padding'] = True
     log_file = "/tmp/arptest.VerifyUnicastARPReply.{0}.log".format(datetime.now().strftime("%Y-%m-%d-%H:%M:%S"))
     ptf_runner(ptfhost, 'ptftests', "arptest.VerifyUnicastARPReply", '/root/ptftests',
                params=params, log_file=log_file, is_python3=True)
@@ -49,6 +52,9 @@ def test_arp_expect_reply(common_setup_teardown, intfs_for_test, enum_frontend_a
         'port': intf1_indice,
         'kvm_support': True
     }
+    # VPP software dataplane does not pad ARP replies to Ethernet minimum frame size
+    if duthost.facts['asic_type'] == 'vpp' and duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        params['no_padding'] = True
 
     # Start PTF runner and send correct arp packets
     clear_dut_arp_cache(duthost, asichost.cli_ns_option)
@@ -115,6 +121,9 @@ def test_arp_garp_no_update(common_setup_teardown, intfs_for_test, enum_frontend
         'port': intf1_indice,
         'kvm_support': True
     }
+    # VPP software dataplane does not pad ARP replies to Ethernet minimum frame size
+    if duthost.facts['asic_type'] == 'vpp' and duthost.facts['platform'] == 'x86_64-kvm_x86_64-r0':
+        params['no_padding'] = True
 
     # Test Gratuitous ARP behavior, no Gratuitous ARP installed when arp was not resolved before
     clear_dut_arp_cache(duthost, asichost.cli_ns_option)

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -16,49 +16,6 @@ acl/test_stress_acl.py::test_acl_add_del_stress:
       - "asic_type in ['vpp']"
 
 #######################################
-#####           ARP               #####
-#######################################
-arp/test_arpall.py::test_arp_expect_reply:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-arp/test_arpall.py::test_arp_garp_no_update:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-arp/test_arpall.py::test_arp_unicast_reply:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-arp/test_neighbor_mac.py:
-  skip:
-    reason: >
-            Failed/Errored: https://github.com/sonic-net/sonic-sairedis/issues/1662 / Race condition between setting ip on Ethernet0 and remove Ethernet0 from portchannel
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp'] and https://github.com/sonic-net/sonic-sairedis/issues/1662"
-
-arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-#######################################
 #####           BFD               #####
 #######################################
 bfd/test_bfd.py:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enable test_arpall for vpp
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
1. A lot of test cases in test_arpall.py are skipped due to failure. The main reason is vpp handles arp request internally and not punting to control plane. The test expects a neighbour is created after arp request sent from PTF. Because it is not punted, SONiC doesn't see and it won't create the neighbour. This doesn't affect forwarding because the neighbour is created internally in vpp. If SONiC needs to send a packet to the neighbour, it will send arp first to resolve the neighbour.
PR https://github.com/sonic-net/sonic-sairedis/pull/1792 is created to change the vpp behaviour. With the PR, vpp behaves the same way as other ASICs.
2. vpp doesn't pad arp packet. If the packet is sent through wire, NIC will pad it. But if the packet is between VMs, padding is not needed. The test case needs to match ARP packets without padding for x86_64-kvm_x86_64-r0 platform and with vpp asic.
#### How did you do it?

#### How did you verify/test it?
Run sonic-mgmt test
#### Any platform specific information?
vpp
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
