### PR TITLE
Ipv6 handling for PFC watchdog background traffic 

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
+++ b/ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py
@@ -1,9 +1,10 @@
+import ipaddress
 import ptf
 import logging
 import random
 from ptf.base_tests import BaseTest
 import time
-from ptf.testutils import test_params_get, simple_udp_packet, send_packet
+from ptf.testutils import test_params_get, simple_udp_packet, simple_udpv6_packet, send_packet
 import macsec  # noqa F401
 
 
@@ -23,6 +24,37 @@ class PfcWdBackgroundTrafficTest(BaseTest):
         self.queues = self.test_params['queues'] if 'queues' in self.test_params else [3, 4]
         self.bidirection = self.test_params['bidirection'] if 'bidirection' in self.test_params else True
 
+    @staticmethod
+    def _is_ipv6(addr):
+        """Return True if addr is an IPv6 address string."""
+        try:
+            return ipaddress.ip_address(str(addr)).version == 6
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _build_udp_pkt(eth_src, eth_dst, ip_src, ip_dst, dscp, ttl, is_ipv6, ip_ecn=0):
+        """Build a UDP packet, choosing IPv4 or IPv6 based on is_ipv6 flag."""
+        if is_ipv6:
+            return simple_udpv6_packet(
+                eth_src=eth_src,
+                eth_dst=eth_dst,
+                ipv6_src=ip_src,
+                ipv6_dst=ip_dst,
+                ipv6_tc=dscp << 2,
+                ipv6_hlim=ttl
+            )
+        else:
+            return simple_udp_packet(
+                eth_src=eth_src,
+                eth_dst=eth_dst,
+                ip_src=ip_src,
+                ip_dst=ip_dst,
+                ip_dscp=dscp,
+                ip_ecn=ip_ecn,
+                ip_ttl=ttl
+            )
+
     def runTest(self):
         ttl = 64
         pkts_dict = {}
@@ -38,30 +70,23 @@ class PfcWdBackgroundTrafficTest(BaseTest):
                 pkts_dict[dst_port] = []
             src_mac = self.dataplane.get_mac(0, src_port)
             dst_mac = self.dataplane.get_mac(0, dst_port)
+            is_ipv6 = self._is_ipv6(self.src_ips[i]) or self._is_ipv6(self.dst_ips[i])
             for queue in self.queues:
                 print(f"traffic from {src_port} to {dst_port}: {queue} ")
                 logging.info(f"traffic from {src_port} to {dst_port}: {queue} ")
-                pkt = simple_udp_packet(
-                    eth_src=src_mac,
-                    eth_dst=self.router_mac,
-                    ip_src=self.src_ips[i],
-                    ip_dst=self.dst_ips[i],
-                    ip_dscp=queue,
-                    ip_ecn=0,
-                    ip_ttl=ttl
+                pkt = self._build_udp_pkt(
+                    eth_src=src_mac, eth_dst=self.router_mac,
+                    ip_src=self.src_ips[i], ip_dst=self.dst_ips[i],
+                    dscp=queue, ttl=ttl, is_ipv6=is_ipv6
                 )
                 pkts_dict[src_port].append(pkt)
                 if self.bidirection:
                     print(f"traffic from {dst_port} to {src_port}: {queue} ")
                     logging.info(f"traffic from {dst_port} to {src_port}: {queue} ")
-                    pkt = simple_udp_packet(
-                        eth_src=dst_mac,
-                        eth_dst=self.router_mac,
-                        ip_src=self.dst_ips[i],
-                        ip_dst=self.src_ips[i],
-                        ip_dscp=queue,
-                        ip_ecn=0,
-                        ip_ttl=ttl
+                    pkt = self._build_udp_pkt(
+                        eth_src=dst_mac, eth_dst=self.router_mac,
+                        ip_src=self.dst_ips[i], ip_dst=self.src_ips[i],
+                        dscp=queue, ttl=ttl, is_ipv6=is_ipv6
                     )
                     pkts_dict[dst_port].append(pkt)
 

--- a/tests/common/helpers/pfcwd_helper.py
+++ b/tests/common/helpers/pfcwd_helper.py
@@ -600,6 +600,9 @@ def verify_pfc_storm_in_expected_state(dut, port, queue, expected_state):
     pfcwd_stat = parser_show_pfcwd_stat(dut, port, queue)
     if dut.facts['asic_type'] == 'vs':
         return True
+    if not pfcwd_stat:
+        logger.info(f'Port {port} Storm verification : no watchdog stats')
+        return False
     if expected_state == "storm":
         if ("storm" in pfcwd_stat[0]['status']) and \
                 int(pfcwd_stat[0]['storm_detect_count']) > int(pfcwd_stat[0]['restored_count']):


### PR DESCRIPTION
### Description of PR

Summary:
The PFC watchdog test cases are invoked for v4 and v6. The PTF background traffic test (`pfc_wd_background_traffic.py`) only used `simple_udp_packet()` (IPv4). When the test framework passed IPv6 addresses (`src_ips`, `dst_ips`), these were stuffed into IPv4 header fields, producing malformed packets that the DUT dropped silently. This meant zero valid traffic reached the stormed queue during IPv6 test variants  and no storm detection.

**Fix:** Added `_is_ipv6()` and `_build_udp_pkt()` helper methods. The PTF test now auto-detects address family and uses `simple_udpv6_packet()` for IPv6, correctly setting `ipv6_src`, `ipv6_dst`, `ipv6_tc` (`DSCP << 2`), and `ipv6_hlim`.

Additionally, `verify_pfc_storm_in_expected_state()` in `pfcwd_helper.py` now guards against empty `pfcwd_stat` — previously it would crash with an `IndexError` when the watchdog had no stats for the given port/queue.

**Files changed:**
- `ansible/roles/test/files/ptftests/py3/pfc_wd_background_traffic.py` — IPv6 packet generation support
- `tests/common/helpers/pfcwd_helper.py` — empty stats guard


### Type of change


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### How did you verify/test it?
Ran PFCwd test suite on hardware testbed:
- **Without patch:** 2 failed, 21 passed, 9 skipped, 6 xfailed, 2 xpassed
- **With patch:** 2 failed, 21 passed, 9 skipped, 4 xfailed, 6 xpassed
- The 4 additional xpassed tests are all IPv6 background traffic variants that now generate valid packets

The 2 remaining failures (`test_pfcwd_show_stat`, `test_pfcwd_timer_accuracy`) are separate issues.

#### Any platform specific information?
The fix is platform-agnostic — it corrects PTF packet construction which applies to all platforms.

#### Supported testbed topology if it's a new test case?
N/A — bug fix to existing tests.

### Documentation

N/A — bug fix, no new documentation required.