### PR TITLE
Disable memory utilization check for test_rendered_golden_config_override

### DIFF
--- a/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
+++ b/tests/golden_config_infra/test_config_reload_with_rendered_golden_config.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.topology('any'),
     pytest.mark.disable_loganalyzer,
+    pytest.mark.disable_memory_utilization,
 ]
 
 GOLDEN_CONFIG = "/etc/sonic/golden_config_db.json"


### PR DESCRIPTION
Summary: Disable memory utilization check for test_rendered_golden_config_override
Fixes #

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The module setup fixture performs `config reload -y -f` which restarts
all containers and reinitializes monit. Monit captures its first data
point ~2 seconds after reload when containers are still initializing,
resulting in an artificially low memory baseline (~22%). After the test,
steady-state memory (~48%) is flagged as exceeding the 10% increase
threshold. This is a false positive — real-time metrics (free, docker
stats) confirm no actual memory growth.

#### How did you do it?
Disable memory utilization check for test_rendered_golden_config_override

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
