### PR TITLE
Increase pcied wait_data timeout

### DIFF
--- a/tests/platform_tests/daemon/test_pcied.py
+++ b/tests/platform_tests/daemon/test_pcied.py
@@ -116,8 +116,8 @@ def wait_data(duthost, expected_key_count):
             logger.info("Expected PCIE device keys :{}, Current device key count {}".format(
                 expected_key_count, device_keys_found))
         return device_keys_found == expected_key_count
-    pcied_pooling_interval = 60
-    wait_until(pcied_pooling_interval, 6, 0, _collect_data)
+    pcied_polling_timeout = 80
+    wait_until(pcied_polling_timeout, 6, 0, _collect_data)
     return shared_scope.data_after_restart
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

On platforms with large numbers of PCIe devices, pcied needs ~60s after restart to scan and begin writing to STATE_DB. The previous 60s timeout left insufficient time for the actual DB population

Also fix variable naming: pooling_interval -> polling_timeout to accurately reflect the parameter semantics (wait_until timeout, not polling interval).

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
On platforms with large numbers of PCIe devices, pcied needs
~60s after restart to scan and begin writing to STATE_DB. The previous
60s timeout left insufficient time for the actual DB population
#### How did you do it?

#### How did you verify/test it?

verfied on sn4700 platforms with 70 pcie devices

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
