### PR TITLE
[SmartSwitch] Fix test issues in dash smartswitch vnet test

### DIFF
--- a/tests/dash/packets.py
+++ b/tests/dash/packets.py
@@ -351,10 +351,10 @@ def inbound_vnet_packets(dash_config_info, inner_extra_conf={}, inner_packet_typ
     pa_mismatch_vxlan_packet["IP"].src = str(remote_pa_ip + 1)
 
     masked_exp_packet = Mask(expected_packet)
-    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "id")
-    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "chksum")
-    masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "sport")
-    masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "chksum")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "id")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "chksum")
+    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "sport")
+    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "chksum")
 
     return inner_packet, pa_match_vxlan_packet, pa_mismatch_vxlan_packet, masked_exp_packet
 
@@ -402,10 +402,10 @@ def outbound_vnet_packets(dash_config_info, inner_extra_conf={}, inner_packet_ty
     )
 
     masked_exp_packet = Mask(expected_packet)
-    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "id")
-    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "chksum")
-    masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "sport")
-    masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "chksum")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "id")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "chksum")
+    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "sport")
+    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "chksum")
     return inner_packet, vxlan_packet, masked_exp_packet
 
 
@@ -519,7 +519,7 @@ def outbound_smartswitch_vnet_packets(
         udp_dport=vxlan_udp_dport,
         udp_sport=VXLAN_UDP_BASE_SRC_PORT,
         with_udp_chksum=False,
-        vxlan_vni=dash_config_info[VNET1_VNI],
+        vxlan_vni=dash_config_info[VM_VNI],
         ip_ttl=64,
         inner_frame=inner_packet,
     )
@@ -536,10 +536,11 @@ def outbound_smartswitch_vnet_packets(
     )
 
     masked_exp_packet = Mask(expected_packet)
-    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "id")
-    masked_exp_packet.set_do_not_care_scapy(scapy.IP, "chksum")
-    masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "sport")
-    masked_exp_packet.set_do_not_care_scapy(scapy.UDP, "chksum")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "id")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "chksum")
+    masked_exp_packet.set_do_not_care_packet(scapy.IP, "ttl")
+    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "sport")
+    masked_exp_packet.set_do_not_care_packet(scapy.UDP, "chksum")
     return inner_packet, vxlan_packet, masked_exp_packet
 
 

--- a/tests/dash/templates/dash_smartswitch_vnet_0.j2
+++ b/tests/dash/templates/dash_smartswitch_vnet_0.j2
@@ -4,7 +4,7 @@
                         "sip":"{{ loopback_ip }}",
                         "vm_vni":"{{ vm_vni }}",
                         "local_region_id":"{{ local_region_id }}",
-			"trusted_vnis": "100"
+			"trusted_vnis_list":["{{ vm_vni }}"]
                 },
                 "OP": "{{ op }}"
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The dash smartswitch vnet test has some issues.
Update the dash smartswitch vnet test according to the conclusion in https://github.com/sonic-net/sonic-buildimage/issues/25147

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix test issues in dash smartswitch vnet test
#### How did you do it?
1. Update "trusted_vnis" to "trusted_vnis_list" in the template.
2. Use VM_VNI for the outbound packet and configure it as trusted VNI.
3. Set TTL as a 'do not care' field for VNET tests
#### How did you verify/test it?
Run the tests/dash/test_dash_smartswitch_vnet.py test with SN4280 testbed.
#### Any platform specific information?
Only for smartswitch.
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
