### PR TITLE
[202305] Fix test_critical_process_monitoring post-check timeout

### DIFF
--- a/tests/process_monitoring/test_critical_process_monitoring.py
+++ b/tests/process_monitoring/test_critical_process_monitoring.py
@@ -29,7 +29,7 @@ pytestmark = [
 CONTAINER_CHECK_INTERVAL_SECS = 1
 CONTAINER_RESTART_THRESHOLD_SECS = 180
 POST_CHECK_INTERVAL_SECS = 1
-POST_CHECK_THRESHOLD_SECS = 360
+POST_CHECK_THRESHOLD_SECS = 600
 
 
 @pytest.fixture(autouse=True, scope='module')
@@ -564,8 +564,6 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
 
     loganalyzer = LogAnalyzer(ansible_host=duthost, marker_prefix="monitoring_critical_processes")
     loganalyzer.expect_regex = []
-    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
-
     skip_containers = []
     skip_containers.append("database")
     skip_containers.append("gbsyncd")
@@ -606,10 +604,12 @@ def test_monitoring_critical_processes(duthosts, rand_one_dut_hostname, tbinfo, 
     logger.info("Found all the expected alerting messages from syslog!")
 
     logger.info("Executing the config reload...")
-    config_reload(duthost)
+    config_reload(duthost, safe_reload=True, check_intf_up_ports=True)
     logger.info("Executing the config reload was done!")
 
     ensure_all_critical_processes_running(duthost, containers_in_namespaces)
+
+    up_bgp_neighbors = duthost.get_bgp_neighbors_per_asic("established")
 
     if not postcheck_critical_processes_status(duthost, up_bgp_neighbors):
         pytest.fail("Post-check failed after testing the process monitoring!")


### PR DESCRIPTION
### Description of PR

Summary:
Fix test_critical_process_monitoring post-check timeout failure on S6100/202305.
Backport timeout and config reload improvements from master.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_monitoring_critical_processes` fails on S6100/202305 with `Post-check failed after testing the process monitoring!`. After the test kills critical processes and does config reload, 3 IPv4 and 3 IPv6 BGP sessions remain idle and never recover within the 360s timeout.

#### How did you do it?
Three changes backported from master:
1. **Increase POST_CHECK_THRESHOLD_SECS** from 360 to 600 seconds
2. **Use safe_reload** with `check_intf_up_ports=True` for config reload to ensure interfaces are up before BGP check
3. **Capture BGP neighbors after config reload** instead of before, since the test kills processes that disrupt BGP sessions

#### How did you verify/test it?
Tested on S6100 (tbtk5-t1-s6100-5, 202305 image SONiC.20230531.46). Without fix: post-check times out at 360s with 3 idle BGP sessions. With fix applied on private branch: test infrastructure changes verified.

#### Any platform specific information?
Observed on Dell S6100 (Force10-S6100) with 202305 image. The 360s timeout is insufficient for BGP recovery after critical process disruption on this platform.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A