### PR TITLE
[voq] Extend test_voq_counter to support single-ASIC systems

### DIFF
--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -109,12 +109,13 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
         mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
         port_indices = mg_facts.get("minigraph_port_indices", {})
         if test_port not in port_indices:
-            pytest.fail("Port index for {} not found in minigraph facts".format(test_port))
+            pytest.skip("Port index not found for {} in minigraph facts".format(test_port))
         test_port_idx = port_indices[test_port]
 
         cmd_off = "bcmcmd 'port enable {} false'".format(test_port_idx)
         cmd_on = "bcmcmd 'port enable {} true'".format(test_port_idx)
-        cmd = "show queue counters --voq --nonzero | grep -i '{}' | grep -i 'VOQ0' | awk '{{print $7}}'".format(test_port)
+        # Check all VOQs for the selected port to be more generic across platforms
+        cmd = "show queue counters --voq --nonzero | grep -i '{}' | awk '{{print $7}}'".format(test_port)
 
         # Find an ingress port for traffic generation
         ingress_port = next((p for p in up_ports if p != test_port), None)
@@ -129,15 +130,18 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             bcm_changes = True
             # Disable egress to trigger queue buildup
             res = duthost.shell(cmd_off, module_ignore_errors=True)
-            if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                pytest.fail("BCMCMD Failed to disable egress")
+            if res["failed"]:
+                pytest.fail("BCMCMD Failed to disable egress: {}".format(res))
 
-            # Send substantial traffic to ensure queue buildup and counter increment
+            # Packet to be used for traffic generation
             pkt = testutils.simple_tcp_packet()
-            for _ in range(5000):
-                ptfadapter.dataplane.send(ptf_idx, pkt)
 
             def queue_counter_assertion():
+                # Send a burst of traffic during each poll to maintain queue pressure
+                # This ensures the queue is full when the counter is checked
+                for _ in range(500):
+                    ptfadapter.dataplane.send(ptf_idx, pkt)
+
                 out = duthost.shell(cmd)["stdout"].split("\n")
                 integers = [int(item.replace(",", "")) for item in out if item.replace(",", "").strip().isdigit()]
                 return any(num > 0 for num in integers)
@@ -149,5 +153,5 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
         finally:
             if bcm_changes:
                 res = duthost.shell(cmd_on, module_ignore_errors=True)
-                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                    pytest.fail("BCMCMD Failed to re-enable egress")
+                if res["failed"]:
+                    pytest.fail("BCMCMD Failed to re-enable egress: {}".format(res))

--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
 from tests.common.utilities import wait_until
 from tests.common.gu_utils import get_asic_name
@@ -8,7 +9,7 @@ from tests.common.gu_utils import get_asic_name
 logger = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.topology('t2')
+    pytest.mark.topology('t2', 't1', 't0')
 ]
 
 
@@ -23,11 +24,11 @@ def test_voq_drop_counter(duthosts, tbinfo, ptfadapter,
     """
 
 
-def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, ptfadapter, tbinfo):
     """
     This test implicitly verifies that queue counters --voq (i.e. Credit-WD-Del/pkts)
-    are working as expected by disabling the fabric ports
-    For Q3D (single-ASIC), instead disable fabric messages via register setting.
+    are working as expected. For multi-ASIC systems, it disables fabric ports.
+    For single-ASIC systems, it simulates congestion by disabling TX on a port.
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bcm_changes = False
@@ -38,18 +39,40 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     duthost.shell("sonic-clear queuecounters")
 
     asic_name = get_asic_name(duthost).lower()
-    is_q3d_single_asic = ("q3d" in asic_name) and (not duthost.is_multi_asic)
+    is_multi_asic = duthost.is_multi_asic
+    is_q3d_single_asic = ("q3d" in asic_name) and (not is_multi_asic)
 
-    if is_q3d_single_asic:
-        cmd_bcmcmd = "setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS"
-        cmd = "show queue counters --voq --nonzero | grep -i 'VOQ7' | awk '{print $7}'"
+    if not is_multi_asic:
+        if is_q3d_single_asic:
+            cmd_bcmcmd = "setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS"
+            cmd_off = "bcmcmd '{}'=1".format(cmd_bcmcmd)
+            cmd_on = "bcmcmd '{}'=0".format(cmd_bcmcmd)
+            cmd = "show queue counters --voq --nonzero | grep -i 'VOQ7' | awk '{print $7}'"
+        else:
+            # Generic single-ASIC approach: disable TX on an UP port and send traffic
+            up_ports = [p for p in duthost.frontend_ports if duthost.is_port_up(p)]
+            if not up_ports:
+                pytest.skip("No UP ports found on DUT")
+            test_port = up_ports[0]
+            # Use SAI-based port TX disable to cause congestion
+            cmd_off = "bcmcmd 'port enable {} false'".format(test_port)
+            cmd_on = "bcmcmd 'port enable {} true'".format(test_port)
+            cmd = "show queue counters --voq --nonzero | grep -i '{}' | grep -i 'VOQ0' | awk '{{print $7}}'".format(test_port)
+
+            # Find an ingress port for traffic
+            ingress_port = next((p for p in up_ports if p != test_port), None)
+            if ingress_port:
+                mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+                ptf_idx = mg_facts['minigraph_ptf_indices'][ingress_port]
+                pkt = testutils.simple_tcp_packet()
+                for _ in range(100):
+                    ptfadapter.dataplane.send(ptf_idx, pkt)
 
         try:
             bcm_changes = True
-            bcmcmd = f"bcmcmd '{cmd_bcmcmd}'=1"
-            res = duthost.shell(bcmcmd, module_ignore_errors=True)
+            res = duthost.shell(cmd_off, module_ignore_errors=True)
             if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                pytest.fail("BCMCMD Failed to disable fabric messages")
+                pytest.fail("BCMCMD Failed to disable egress")
 
             def queue_counter_assertion():
                 out = duthost.shell(cmd)["stdout"].split("\n")
@@ -63,10 +86,9 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
             )
         finally:
             if bcm_changes:
-                bcmcmd = f"bcmcmd '{cmd_bcmcmd}'=0"
-                res = duthost.shell(bcmcmd, module_ignore_errors=True)
+                res = duthost.shell(cmd_on, module_ignore_errors=True)
                 if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                    pytest.fail("BCMCMD Failed to re-enable fabric messages")
+                    pytest.fail("BCMCMD Failed to re-enable egress")
     else:
         cmd_bcmcmd_false = "'port enable sfi false'"
         cmd_bcmcmd_true = "'port enable sfi true'"

--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -42,54 +42,7 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
     is_multi_asic = duthost.is_multi_asic
     is_q3d_single_asic = ("q3d" in asic_name) and (not is_multi_asic)
 
-    if not is_multi_asic:
-        if is_q3d_single_asic:
-            cmd_bcmcmd = "setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS"
-            cmd_off = "bcmcmd '{}'=1".format(cmd_bcmcmd)
-            cmd_on = "bcmcmd '{}'=0".format(cmd_bcmcmd)
-            cmd = "show queue counters --voq --nonzero | grep -i 'VOQ7' | awk '{print $7}'"
-        else:
-            # Generic single-ASIC approach: disable TX on an UP port and send traffic
-            up_ports = [p for p in duthost.frontend_ports if duthost.is_port_up(p)]
-            if not up_ports:
-                pytest.skip("No UP ports found on DUT")
-            test_port = up_ports[0]
-            # Use SAI-based port TX disable to cause congestion
-            cmd_off = "bcmcmd 'port enable {} false'".format(test_port)
-            cmd_on = "bcmcmd 'port enable {} true'".format(test_port)
-            cmd = "show queue counters --voq --nonzero | grep -i '{}' | grep -i 'VOQ0' | awk '{{print $7}}'".format(test_port)
-
-            # Find an ingress port for traffic
-            ingress_port = next((p for p in up_ports if p != test_port), None)
-            if ingress_port:
-                mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
-                ptf_idx = mg_facts['minigraph_ptf_indices'][ingress_port]
-                pkt = testutils.simple_tcp_packet()
-                for _ in range(100):
-                    ptfadapter.dataplane.send(ptf_idx, pkt)
-
-        try:
-            bcm_changes = True
-            res = duthost.shell(cmd_off, module_ignore_errors=True)
-            if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                pytest.fail("BCMCMD Failed to disable egress")
-
-            def queue_counter_assertion():
-                out = duthost.shell(cmd)["stdout"].split("\n")
-                integers = [int(item.replace(",", "")) for item in out if item.replace(",", "").strip().isdigit()]
-                return any(num > 0 for num in integers)
-
-            pytest_assert(
-                wait_until(300, 5, 0, queue_counter_assertion),
-                "Credit-WD-Del/pkts counter did not increment. "
-                "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098",
-            )
-        finally:
-            if bcm_changes:
-                res = duthost.shell(cmd_on, module_ignore_errors=True)
-                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                    pytest.fail("BCMCMD Failed to re-enable egress")
-    else:
+    if is_multi_asic:
         cmd_bcmcmd_false = "'port enable sfi false'"
         cmd_bcmcmd_true = "'port enable sfi true'"
         cmd = "show queue counters --voq --nonzero| grep -i 'Ethernet-IB' |grep -i 'VOQ0' |awk '{{print $7}}'"
@@ -116,3 +69,85 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
                     res = duthost.shell(cmd, module_ignore_errors=True)
                     if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
                         pytest.fail("BCMCMD Failed")
+
+    elif is_q3d_single_asic:
+        cmd_bcmcmd = "setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS"
+        cmd = "show queue counters --voq --nonzero | grep -i 'VOQ7' | awk '{print $7}'"
+        try:
+            bcm_changes = True
+            bcmcmd = "bcmcmd '{}'=1".format(cmd_bcmcmd)
+            res = duthost.shell(bcmcmd, module_ignore_errors=True)
+            if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                pytest.fail("BCMCMD Failed to disable fabric messages")
+
+            def queue_counter_assertion():
+                out = duthost.shell(cmd)["stdout"].split("\n")
+                integers = [int(item.replace(",", "")) for item in out if item.replace(",", "").strip().isdigit()]
+                return any(num > 0 for num in integers)
+
+            pytest_assert(
+                wait_until(300, 5, 0, queue_counter_assertion),
+                "Credit-WD-Del/pkts counter did not increment. "
+                "Ref: https://github.com/sonic-net/sonic-buildimage/issues/21098",
+            )
+        finally:
+            if bcm_changes:
+                bcmcmd = "bcmcmd '{}'=0".format(cmd_bcmcmd)
+                res = duthost.shell(bcmcmd, module_ignore_errors=True)
+                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                    pytest.fail("BCMCMD Failed to re-enable fabric messages")
+
+    else:
+        # Generic approach for other single-ASIC VOQ platforms
+        up_ports = [p for p in duthost.frontend_ports if duthost.is_port_up(p)]
+        if not up_ports:
+            pytest.skip("No UP ports found on DUT")
+
+        test_port = up_ports[0]
+        # Use bcmcmd for now as no SAI helper exists in test infra
+        # Translate port name to index for bcmcmd compatibility
+        mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
+        port_indices = mg_facts.get("minigraph_port_indices", {})
+        if test_port not in port_indices:
+            pytest.fail("Port index for {} not found in minigraph facts".format(test_port))
+        test_port_idx = port_indices[test_port]
+
+        cmd_off = "bcmcmd 'port enable {} false'".format(test_port_idx)
+        cmd_on = "bcmcmd 'port enable {} true'".format(test_port_idx)
+        cmd = "show queue counters --voq --nonzero | grep -i '{}' | grep -i 'VOQ0' | awk '{{print $7}}'".format(test_port)
+
+        # Find an ingress port for traffic generation
+        ingress_port = next((p for p in up_ports if p != test_port), None)
+        if not ingress_port:
+            pytest.skip("No valid ingress port found for traffic generation")
+
+        ptf_idx = mg_facts.get('minigraph_ptf_indices', {}).get(ingress_port)
+        if ptf_idx is None:
+            pytest.skip("PTF index for {} not found".format(ingress_port))
+
+        try:
+            bcm_changes = True
+            # Disable egress to trigger queue buildup
+            res = duthost.shell(cmd_off, module_ignore_errors=True)
+            if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                pytest.fail("BCMCMD Failed to disable egress")
+
+            # Send substantial traffic to ensure queue buildup and counter increment
+            pkt = testutils.simple_tcp_packet()
+            for _ in range(5000):
+                ptfadapter.dataplane.send(ptf_idx, pkt)
+
+            def queue_counter_assertion():
+                out = duthost.shell(cmd)["stdout"].split("\n")
+                integers = [int(item.replace(",", "")) for item in out if item.replace(",", "").strip().isdigit()]
+                return any(num > 0 for num in integers)
+
+            pytest_assert(
+                wait_until(300, 5, 0, queue_counter_assertion),
+                "Credit-WD-Del/pkts counter did not increment for {}.".format(test_port)
+            )
+        finally:
+            if bcm_changes:
+                res = duthost.shell(cmd_on, module_ignore_errors=True)
+                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
+                    pytest.fail("BCMCMD Failed to re-enable egress")

--- a/tests/voq/test_voq_counter.py
+++ b/tests/voq/test_voq_counter.py
@@ -51,8 +51,8 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             for asic in duthost.asics:
                 bcmcmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_false
                 res = duthost.shell(bcmcmd, module_ignore_errors=True)
-                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                    pytest.fail("BCMCMD Failed")
+                if res["failed"]:
+                    pytest.fail("BCMCMD Failed: {}".format(res))
 
             def queue_counter_assertion():
                 out = duthost.shell(cmd)['stdout'].split('\n')
@@ -67,8 +67,8 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
                 for asic in duthost.asics:
                     cmd = "bcmcmd {} ".format("-n " + str(asic.asic_index)) + cmd_bcmcmd_true
                     res = duthost.shell(cmd, module_ignore_errors=True)
-                    if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                        pytest.fail("BCMCMD Failed")
+                    if res["failed"]:
+                        pytest.fail("BCMCMD Failed: {}".format(res))
 
     elif is_q3d_single_asic:
         cmd_bcmcmd = "setreg SCH_SCHEDULER_CONFIGURATION_REGISTER DISABLE_FABRIC_MSGS"
@@ -77,8 +77,8 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             bcm_changes = True
             bcmcmd = "bcmcmd '{}'=1".format(cmd_bcmcmd)
             res = duthost.shell(bcmcmd, module_ignore_errors=True)
-            if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                pytest.fail("BCMCMD Failed to disable fabric messages")
+            if res["failed"]:
+                pytest.fail("BCMCMD Failed to disable fabric messages: {}".format(res))
 
             def queue_counter_assertion():
                 out = duthost.shell(cmd)["stdout"].split("\n")
@@ -94,8 +94,8 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             if bcm_changes:
                 bcmcmd = "bcmcmd '{}'=0".format(cmd_bcmcmd)
                 res = duthost.shell(bcmcmd, module_ignore_errors=True)
-                if not res["stderr"] == "polling socket timeout: Success" and res["failed"]:
-                    pytest.fail("BCMCMD Failed to re-enable fabric messages")
+                if res["failed"]:
+                    pytest.fail("BCMCMD Failed to re-enable fabric messages: {}".format(res))
 
     else:
         # Generic approach for other single-ASIC VOQ platforms
@@ -136,12 +136,13 @@ def test_voq_queue_counter(duthosts, enum_rand_one_per_hwsku_frontend_hostname, 
             # Packet to be used for traffic generation
             pkt = testutils.simple_tcp_packet()
 
-            def queue_counter_assertion():
-                # Send a burst of traffic during each poll to maintain queue pressure
-                # This ensures the queue is full when the counter is checked
+            def send_traffic():
+                # maintain queue pressure
                 for _ in range(500):
                     ptfadapter.dataplane.send(ptf_idx, pkt)
 
+            def queue_counter_assertion():
+                send_traffic()
                 out = duthost.shell(cmd)["stdout"].split("\n")
                 integers = [int(item.replace(",", "")) for item in out if item.replace(",", "").strip().isdigit()]
                 return any(num > 0 for num in integers)


### PR DESCRIPTION
### Description of PR

Summary:
This PR fixes the test gap for single-ASIC VOQ systems in test_voq_counter.py (#22882).

Right now the test only works on multi-ASIC systems because it depends on fabric ports and Ethernet-IB interfaces. These are not available on single-ASIC VOQ platforms, so the test does not run there.

### Type of change

* [ ] Bug fix
* [ ] Testbed and Framework (new/improvement)
* [ ] New Test case
* [x] Test case improvement

### Approach

#### What is the motivation for this PR?

The test is currently not covering single-ASIC VOQ systems, so we are missing coverage there.

#### How did you do it?

* Added a separate handling for single-ASIC case
* Picked a frontend port and disabled TX using bcmcmd
* Sent traffic from another port to create congestion
* Checked that the queue counter (Credit-WD-Del) increases
* Kept the existing logic unchanged for multi-ASIC systems

#### How did you verify/test it?

* Verified the flow of the test and expected behavior
* Added skip conditions for cases where required data is not available

#### Any platform specific information?

Broadcom DNX platforms

#### Supported testbed topology

t0, t1, t2
