### PR TITLE
Treating the return values separately from log perform reboot

### DIFF
--- a/tests/smartswitch/common/reboot.py
+++ b/tests/smartswitch/common/reboot.py
@@ -138,7 +138,6 @@ def perform_reboot(duthost, reboot_type=REBOOT_TYPE_COLD, dpu_name=None,
 
     # cli_based path
     res = log_and_perform_reboot(duthost, reboot_type, dpu_name)
-    if res.get('failed', res.get('rc', 0) != 0):
     if dpu_name is None:
         if res.get('failed', res.get('rc', 0) != 0):
             pytest.fail("Failed to reboot the {} with type {}".format(duthost.hostname, reboot_type))


### PR DESCRIPTION
### Description of PR

This PR is to fix and strengthen few of the dpu sonic mgmt test cases.

Summary:
Fixes # (issue)

    Smartswitch sonic-mgmt reboot cases.

### Type of change

- [ X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X ] 202511


Approach

What is the motivation for this PR? 
        When rebooting a DPU (Data Processing Unit) on a SmartSwitch platform, the SSH session disconnects during the reboot sequence, causing the underlying shell command to return rc=255. The existing reboot test logic treated any non-zero rc as a failure, incorrectly flagging valid DPU reboots as test failures.

How did you do it? 

       Split the reboot result check into two paths based on whether the target is a DPU or a regular DUT:

       For regular DUT (dpu_name is None): fail if failed=True or rc != 0 (original behaviour)
        For DPU (dpu_name is set): fail if failed=True or rc not in (0, 255) — allows rc=255 since SSH disconnect during DPU reboot is expected
        
How did you verify/test it? 
              Tested on a SmartSwitch platform with a DPU reboot via reboot_type — confirmed the test no longer falsely fails on rc=255 while still catching genuine failures (rc other than 0 or 255).

Any platform specific information? 

     SmartSwitch platforms only (DPU reboot path). No impact on non-SmartSwitch DUT reboot behaviour.

Supported testbed topology if it's a new test case? 
            N/A — existing test case fix. Applies to SmartSwitch testbed topology with DPU.

Documentation 

PR that caused this issue: https://github.com/sonic-net/sonic-mgmt/pull/22514