### PR TITLE
Fix test_masked_services.py test when golden config is presented

### DIFF
--- a/tests/minigraph/test_masked_services.py
+++ b/tests/minigraph/test_masked_services.py
@@ -69,8 +69,10 @@ def test_masked_services(duthosts, rand_one_dut_hostname):
 
     logging.info("Starting load_minigraph")
     try:
-        # if golden config exists, call with override. Otherwise, call without override to avoid failure due to missing golden config.
-        if duthost.stat(path="/etc/sonic/golden_config_db.json").get('stat', {}).get('exists', False):
+        # If golden config exists, call with override. Otherwise, call without
+        # override to avoid failure due to missing golden config.
+        golden_cfg = duthost.stat(path="/etc/sonic/golden_config_db.json")
+        if golden_cfg.get('stat', {}).get('exists', False):
             config_reload(duthost, config_source='minigraph', override_config=True)
         else:
             config_reload(duthost, config_source='minigraph')


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_masked_services.py` to apply golden config during minigraph load when `golden_config_db.json` is present, so physical interface settings like link-training are preserved.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Some interfaces depend on physical-layer attributes in `golden_config_db.json` (e.g., link-training) to come up. Previously `config_reload` was called without `override_config=True`, so these settings were lost during minigraph load. This worked before but breaks on newer platforms that require these settings.

#### How did you do it?
Check if `/etc/sonic/golden_config_db.json` exists on the DUT. If yes, call `config_reload` with `override_config=True`; otherwise call without override to avoid failure.

#### How did you verify/test it?
Verified on physical testbed. Interfaces requiring link-training come up correctly when golden config is present.

#### Any platform specific information?
N/A

#### Supported testbed topology if it is a new test case?
N/A

### Documentation
N/A
