### PR TITLE
deploy-mg: Change chronyd NTP server sync method

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -989,7 +989,7 @@
           - name: Wait for chrony synchronization (remaining correction < 0.5s)
             become: true
             ignore_errors: true
-            command: chronyc waitsync 12 0.5 0.1 5
+            command: chronyc waitsync 12 0.5 10.0 5
 
           - name: Force immediate time step with chrony
             become: true


### PR DESCRIPTION
Summary:
Sync DUT system time with NTP server with chrony ansible task during deploy-mg causes intermittent failures


### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
**Previous Sync DUT system time with NTP server with chrony flow:**
1. Ensure chronyd is running
2. Stop chronyd
3. Start a one-shot chronyd instance (chronyd -q) to trigger immediate time synchronization
4. Restart chronyd

**New flow:**
1. Ensure chronyd is running
2. Trigger a burst of NTP measurements using chronyc burst 4/4
3. Wait up to 60 seconds for synchronization, i.e., until the remaining correction becomes < 0.5 seconds, using chronyc waitsync 12 0.5 10.0 5
4. Force an immediate clock step via chronyc makestep if the latest measurements indicate a large enough offset

This flow aligns with the recommended time-synchronization method from the Chrony community,

#### What is the motivation for this PR?
The current "Sync DUT system time with NTP server with chrony" ansible task involved stopping chronyd, running a one-shot instance, and restarting the service. This caused intermittent failures in deploy-mg runs because the restart occasionally conflicted with existing chronyd processes.

CRIT chronyd: Fatal error : Another chronyd may already be running (pid=3574826)

```bash
fatal: [str-marvell-tl7-01]: FAILED! =>

"msg": "Unable to start service chrony: Job for chrony.service failed because the control process exited with error code.\nSee \"systemctl status chrony.service\" and \"journalctl -xeu chrony.service\" for details.\n"
```

#### How did you do it?

#### How did you verify/test it?
By running deploy-mg before and after the change
```bash
./testbed-cli.sh deploy-mg ptf2-m lab password.txt
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
