### PR TITLE
MVRF: Fix TACACS+ connection failure logs resulting in teardown errors

### DIFF
--- a/tests/mvrf/test_mgmtvrf.py
+++ b/tests/mvrf/test_mgmtvrf.py
@@ -110,19 +110,19 @@ def setup_mvrf(duthosts, rand_one_dut_hostname, localhost, check_ntp_sync,
         duthost.command("sudo config snmpagentaddress add %s -p 161 -v mgmt" % duthost.mgmt_ip, module_async=True)
         time.sleep(15)
         verify_show_command(duthost, mvrf=True)
+
+        # After mgmt VRF is enabled, eth0 moves into the mgmt VRF.
+        # Existing TACACS+ servers in config_db were added without vrf=mgmt,
+        # so tacplus will try to reach them via the default
+        # VRF where no route exists anymore.  Re-add each server with -m so
+        # that the vrf=mgmt is added to tacplus config files and TACACS+
+        # auth works over the management VRF.
+        configure_tacacs_for_mgmt_vrf(duthost)
     except Exception as e:
         logger.error("Exception raised in setup, exception: {}".format(repr(e)))
         restore_config_db(duthost)
         pytest.fail("Configure mgmt vrf failed, no test case will be executed. "
                     "Code after 'yield' will not be executed either.")
-
-    # After mgmt VRF is enabled, eth0 moves into the mgmt VRF.
-    # Existing TACACS+ servers in config_db were added without vrf=mgmt,
-    # so tacplus will try to reach them via the default
-    # VRF where no route exists anymore.  Re-add each server with -m so
-    # that the vrf=mgmt is added to tacplus config files and TACACS+
-    # auth works over the management VRF.
-    configure_tacacs_for_mgmt_vrf(duthost)
 
     yield
 


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
TACACS+ connection failure syslog observed causing test failures

Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
After mgmt VRF is enabled, eth0 moves into the mgmt VRF. Existing TACACS+ servers in config_db were added without vrf=mgmt, so tacplus will try to reach them via the default VRF where no route exists anymore.  Re-add each server with -m so that the vrf=mgmt is added to tacplus config files and TACACS+ auth works over the management VRF.

#### What is the motivation for this PR?
To fix TACACS+ syslog errors in mvrf tests

#### How did you do it?
Re-adding each server with -m so that the vrf=mgmt is added to tacplus config files and TACACS+ auth works over the management VRF.

#### How did you verify/test it?
Run mvrf test compoent
```bash
./run_tests.sh -n  ptf2-m -d str-marvell-tl10-01 -c mvrf -i ../ansible/lab,../ansible/veos -t t0,any -u
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
