### PR TITLE
[202505] Add support to download docker-ptf.gz (#21107)

### DIFF
--- a/tests/scripts/getbuild.py
+++ b/tests/scripts/getbuild.py
@@ -104,6 +104,10 @@ def download_artifacts(url, content_type, platform, buildid, num_asic, access_to
                 filename = 'sonic-4asic-vs.img.gz'
             else:
                 filename = 'sonic-vs.img.gz'
+        elif platform == "vpp":
+            filename = 'sonic-vpp.img.gz'
+        elif platform == "ptf":
+            filename = 'docker-ptf.gz'
         else:
             filename = "sonic-{}.bin".format(platform)
 
@@ -186,7 +190,7 @@ def main():
     parser.add_argument('--branch', metavar='branch',
                         type=str, help='branch name')
     parser.add_argument('--platform', metavar='platform', type=str,
-                        choices=['broadcom', 'mellanox', 'vs'],
+                        choices=['broadcom', 'mellanox', 'vs', 'ptf'],
                         help='platform to download')
     parser.add_argument('--content', metavar='content', type=str,
                         choices=['all', 'image'], default='image',
@@ -216,7 +220,10 @@ def main():
     else:
         buildid = int(args.buildid)
 
-    artifact_name = "sonic-buildimage.{}".format(args.platform)
+    if args.platform == 'ptf':
+        artifact_name = "sonic-buildimage.vs"  # PTF images are typically built with VS platform
+    else:
+        artifact_name = "sonic-buildimage.{}".format(args.platform)
 
     (dl_url, artifact_size) = get_download_url(buildid, artifact_name,
                                                url_prefix=args.url_prefix,


### PR DESCRIPTION
Cherry-pick #21107 since we need to load custom docker-ptf image from build branch

What is the motivation for this PR?
For PR builds this will later be used to download, load and test docker-ptf from a PR build rather than the master/latest tag.

How did you do it?
When fixing vulnerability for 202505 docker-ptf image. I notice that my changes were not applied. This could be due to the option PTF_MODIFIED was not turned on during the test.

When trying to turn this option on, we see the issue:

```
sonic-mgmt/tests/scripts/getbuild.py --platform ptf --num_asic 1 --buildid 1067552 --url_prefix mssonic/build
usage: getbuild.py [-h] [--buildid buildid] [--branch branch]
                   [--platform platform] [--content content]
                   [--num_asic num_asic] [--url_prefix url_prefix]
                   [--access_token [access_token]] [--token [token]]
getbuild.py: error: argument --platform: invalid choice: 'ptf' (choose from 'broadcom', 'mellanox', 'vs')
```

This is because we missed cherry-pick from https://github.com/sonic-net/sonic-mgmt/commit/b5e2f54e39b6a9e89a6efec5f44cd13bb871ad42

`202511` and `master` already have this changes. And vulnerability fix has applied to those docker-ptf image. `202505` needs this change to apply the vulnerability


How did you verify/test it?
Manually

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
