### PR TITLE
[ha] add ovs flow rule to match ports used for ha sync

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1307,7 +1307,7 @@ class VMTopology(object):
             # added ovs rules for HA
             # cp_data_channel_port: 11362, dp_channel_dst_port: 11364
             # Match dst and src ports, for both TCP and UDP
-            for ha_port in [11362, 11364]:
+            for ha_port in [11362, 11364, 11367, 11368]:
                 for proto in ['tcp', 'udp', 'tcp6', 'udp6']:
                     bind_helper("ovs-ofctl add-flow %s table=0,priority=10,%s,in_port=%s,tp_dst=%d,action=output:%s,%s" %  # noqa: E501
                                 (br_name, proto, dut_iface_id, ha_port, vm_iface_id, injected_iface_id))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

11367, 11368 are used ha sync and flow sync, without matching rules for these two ports, peer connection won't able to establish in lab. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Otherwise ha state will always be `connecting`, never will be the desired state.  

#### How did you do it?
Allowing packet mirroring for these two ports. 

#### How did you verify/test it?
1. re-deployed topology. OVS flow rules were added.
2. run PL steady state test cases, state machine was able to enter the desired state. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
