### PR TITLE
[lldp] Fix LLDP_ENTRY_TABLE key comparison for dualtor topology

### DIFF
--- a/tests/lldp/test_lldp_syncd.py
+++ b/tests/lldp/test_lldp_syncd.py
@@ -108,7 +108,9 @@ def get_lldpctl_output(duthost):
 def get_show_lldp_table_output(duthost):
     lines = duthost.shell("show lldp table")["stdout"].split("\n")[3:-2]
     interface_list = [line.split()[0] for line in lines]
-    return interface_list
+    # Deduplicate: in dualtor topology, uplink ports may have multiple
+    # LLDP neighbors (T1 switch + fanout), causing duplicate interface entries
+    return list(dict.fromkeys(interface_list))
 
 
 def get_lldp_data(duthost, db_instance):
@@ -123,7 +125,7 @@ def check_lldp_table_keys(duthost, db_instance):
     # Check if LLDP_ENTRY_TABLE keys match show lldp table output
     lldp_entry_keys = get_lldp_entry_keys(db_instance)
     show_lldp_table_int_list = get_show_lldp_table_output(duthost)
-    return sorted(lldp_entry_keys) == sorted(show_lldp_table_int_list)
+    return set(lldp_entry_keys) == set(show_lldp_table_int_list)
 
 
 def _shutdown_startup_interface(duthost, interface, asic_str=""):
@@ -192,9 +194,14 @@ def assert_lldp_interfaces(
     """
     Assert that LLDP_ENTRY_TABLE keys match show lldp table output and lldpctl output
     """
+    db_set = set(lldp_entry_keys)
+    cli_set = set(show_lldp_table_int_list)
     pytest_assert(
-        sorted(lldp_entry_keys) == sorted(show_lldp_table_int_list),
-        "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output",
+        db_set == cli_set,
+        "LLDP_ENTRY_TABLE keys do not match 'show lldp table' output. "
+        "In DB but not in CLI: {}. In CLI but not in DB: {}".format(
+            db_set - cli_set, cli_set - db_set
+        ),
     )
 
     # Verify LLDP_ENTRY_TABLE keys match lldpctl interface indexes


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_lldp_entry_table_content` failure on dualtor-aa topology caused by duplicate LLDP neighbors from fanout switches.

In dualtor-aa topology, uplink ports (e.g., Ethernet224/232/240) receive LLDP PDUs from both the T1 ARISTA switch and the fanout switch. `show lldp table` lists multiple rows per port, but `LLDP_ENTRY_TABLE` in APPL_DB stores only one entry per interface. The sorted list comparison (29 DB keys vs 32 CLI rows) always fails.

Fixes https://msazure.visualstudio.com/One/_workitems/edit/36796797

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`test_lldp_entry_table_content` consistently fails on dualtor-aa topology testbeds (e.g., Arista-720DT-48CQ, Cisco-8101-C32) because `get_show_lldp_table_output()` returns duplicate interface entries when a port has multiple LLDP neighbors.

Example from `show lldp table` on dualtor-aa:
```
Ethernet224  ARISTA01T1           Ethernet2       BR       <- T1 neighbor
Ethernet224  str3-8101-fanout-10  etp28a          BR       <- fanout neighbor (duplicate!)
```

The comparison `sorted(lldp_entry_keys) == sorted(show_lldp_table_int_list)` fails because:
- `LLDP_ENTRY_TABLE` has 29 unique interface keys
- `show lldp table` parsed output has 32 entries (3 interfaces duplicated due to fanout)

#### How did you do it?

1. **Deduplicate in `get_show_lldp_table_output()`**: Use `dict.fromkeys()` to remove duplicate interface names while preserving order
2. **Use set comparison in `check_lldp_table_keys()`**: Replace `sorted()` list comparison with `set()` comparison for robustness
3. **Improve error message in `assert_lldp_interfaces()`**: Use set comparison and include diff details (which interfaces are in DB but not CLI, and vice versa) for easier debugging

#### How did you verify/test it?

- Analyzed actual failure logs from dualtor-aa testbed (str3-8101c1-08, Arista-720DT topology)
- Confirmed that Ethernet224, Ethernet232, Ethernet240 each appear twice in `show lldp table` (once for T1 neighbor ARISTA0xT1, once for fanout str3-8101-fanout-10)
- Verified that the fix correctly deduplicates and uses set comparison

#### Any platform specific information?

Affects dualtor-aa topology testbeds where uplink ports are connected through fanout switches that also advertise LLDP. Confirmed on:
- Arista-720DT-48CQ (dualtor-aa)
- Cisco-8101-C32 (dualtor-aa)

#### Supported testbed topology if it's a new test case?

N/A (bug fix for existing test)

### Documentation

N/A