### PR TITLE
[202305] Handle neigh flush failure in test_stress_arp

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -5,6 +5,7 @@ from .arp_utils import MacToInt, IntToMac, get_crm_resources, fdb_cleanup, \
                       clear_dut_arp_cache, increment_ipv6_addr, get_fdb_dynamic_mac_count
 import ptf.testutils as testutils
 from tests.common.helpers.assertions import pytest_assert, pytest_require
+from tests.common.errors import RunAnsibleModuleFail
 from scapy.all import Ether, IPv6, ICMPv6ND_NS, ICMPv6NDOptSrcLLAddr, in6_getnsmac, \
                       in6_getnsma, inet_pton, inet_ntop, socket
 from ipaddress import ip_address, ip_network
@@ -88,7 +89,13 @@ def test_ipv4_arp(duthost, garp_enabled, ip_and_intf_info, intfs_for_test,
         pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= arp_avaliable),
                       "ARP Table Add failed")
 
-        clear_dut_arp_cache(duthost)
+        try:
+            clear_dut_arp_cache(duthost)
+        except RunAnsibleModuleFail as e:
+            if 'Failed to send flush request: No such file or directory' in str(e):
+                logger.warning("Failed to flush ARP cache, skipping: {}".format(e))
+            else:
+                raise
         fdb_cleanup(duthost)
 
         time.sleep(5)
@@ -156,7 +163,13 @@ def test_ipv6_nd(duthost, ptfhost, config_facts, tbinfo, ip_and_intf_info,
         pytest_assert(wait_until(20, 1, 0, lambda: get_fdb_dynamic_mac_count(duthost) >= nd_avaliable),
                       "Neighbor Table Add failed")
 
-        clear_dut_arp_cache(duthost)
+        try:
+            clear_dut_arp_cache(duthost)
+        except RunAnsibleModuleFail as e:
+            if 'Failed to send flush request: No such file or directory' in str(e):
+                logger.warning("Failed to flush ARP cache, skipping: {}".format(e))
+            else:
+                raise
         fdb_cleanup(duthost)
         # Wait for 10 seconds before starting next loop
         time.sleep(10)


### PR DESCRIPTION
### Description of PR

Summary:
Fix `test_stress_arp.py::test_ipv4_arp` failure on S6100/202305 where `ip -stats neigh flush all` fails with `Failed to send flush request: No such file or directory`.

Partial backport of #20932 (error handling only, without ipv6-only topology changes which don't apply to 202305).

Fixes ADO: https://msazure.visualstudio.com/One/_workitems/edit/37053289

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request
- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_ipv4_arp` consistently fails on S6100/202305 because `clear_dut_arp_cache()` calls `ip -stats neigh flush all` which fails with `No such file or directory` on this platform. The error is not handled, causing `RunAnsibleModuleFail` to propagate and fail the test.

#### How did you do it?
Wrapped `clear_dut_arp_cache()` calls in `try/except RunAnsibleModuleFail` to handle the `No such file or directory` error gracefully (log warning and continue), matching the approach used in PR #20932 on master.

#### How did you verify/test it?
Tested on S6100 (tbtk5-t0-s6100-4, 202305 image SONiC.20230531.46):
- Before: FAILED with `RunAnsibleModuleFail` on neigh flush
- After: **PASSED** (1 passed in 434.67s / 0:07:14)

#### Any platform specific information?
Observed on Dell S6100 (Force10-S6100) with 202305 image.

### Documentation
N/A