### PR TITLE
[xfail][gcu] xfail on 202412 release until GCU validator changes are applied

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2518,7 +2518,7 @@ generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
     reason: "This test will be reworked following changes to GCU validators"
     conditions_logical_operator: "OR"
     conditions:
-      - "release in ['master', '202511'] and https://github.com/sonic-net/sonic-mgmt/issues/22333"
+      - "release in ['master', '202412', '202511'] and https://github.com/sonic-net/sonic-mgmt/issues/22333"
 
 generic_config_updater/test_eth_interface.py::test_replace_fec:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
This is a known issue https://github.com/sonic-net/sonic-mgmt/issues/22333: the test config does not include the full GCU config (missing the WRED_PROFILE section). WRED_PROFILE was removed in the 202412 release https://github.com/Azure/sonic-utilities.msft/pull/276, and while the logic has been updated in the image, the test repository has not yet been updated.

#### How did you do it?
xfail on 202412 release until GCU validator changes are applied
#### How did you verify/test it?
Verified it on internal setup.
#### Any platform specific information?
SN5640
#### Supported testbed topology if it's a new test case?
to-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
