### PR TITLE
 xfail test_rendered_golden_config_override for t0-f2-d40u8

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2807,6 +2807,15 @@ gnmi/test_gnoi_system_reboot.py::test_gnoi_system_reboot_warm:
       - "release in ['202412']"
       - "'f2' in topo_name"
 
+###############################################
+#####       golden_config_infra           #####
+###############################################
+golden_config_infra/test_config_reload_with_rendered_golden_config.py::test_rendered_golden_config_override:
+  xfail:
+    reason: "Ports not operationally up after golden config override on t0-f2-d40u8"
+    conditions:
+      - "https://github.com/sonic-net/sonic-mgmt/issues/23198 and topo_name == 't0-f2-d40u8'"
+
 #######################################
 #####           ha              #####
 #######################################


### PR DESCRIPTION
### Description of PR

Summary:
Mark `test_rendered_golden_config_override` as xfail on `t0-f2-d40u8` topology using `tests_mark_conditions.yaml`.
As for `t0-f2-d40u8`  topo, the link between T0 and server have link-training enabled.  If golden config doesn't have these settings, links won't come up.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_rendered_golden_config_override` is not supported on `t0-f2-d40u8` topology and causes test failures.

#### How did you do it?
Added an xfail entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` with condition `topo_name == 't0-f2-d40u8'`. No changes to the test file itself.

#### How did you verify/test it?
Verified the conditional mark plugin picks up the xfail condition for t0-f2-d40u8 topology.

#### Any platform specific information?
Applies to t0-f2-d40u8 topology only.

#### Supported testbed topology if it is a new test case?
N/A

### Documentation
N/A
