### PR TITLE
[loganalyzer] Ignore link-training status query errors

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -453,3 +453,7 @@ r, ".*ERR telemetry#.*getDbInfo: Failed to find CHASSIS_STATE_DB.*"
 
 # Ignore SAI_STATUS_INVALID_PARAMETER error for SAI_API_QUEUE get stats until it's resolved
 r, ".*ERR swss#orchagent:.*SAI_API_QUEUE, status: SAI_STATUS_INVALID_PARAMETER.*"
+
+# Ignore link-training failure status query errors during port state transitions
+# SAI cannot read LT registers while the port serdes is mid-transition
+r, ".* ERR swss\d*#orchagent:.*getPortLinkTrainingFailure: Failed to get LT failure status for .*"


### PR DESCRIPTION
**What I did**

Added an ignore pattern to `loganalyzer_common_ignore.txt` for link-training failure status query errors:

The failure was seen in the following case:
```
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] PASSED [ 16%]
drop_packets/test_configurable_drop_counters.py::test_neighbor_link_down[PORT_INGRESS_DROPS-L3_EGRESS_LINK_DOWN] ERROR [ 16%]
......
>               pt_assert(False, failure_message)
E               Failed: Got matched syslog in processes "analyze_logs--<MultiAsicSonicHost str4-7060x6-512-12>" exit code:"1"
E               match: 3
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2026 Mar 20 15:56:58.589769 xxxx ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet482
E               
E               2026 Mar 20 15:57:00.467465 xxxx  ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet482
E               
E               2026 Mar 20 15:57:05.467153 xxxx ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet482

```

**Why I did it**

When toggling interfaces with link-training configured, orchagent may report the following error. This happens mostly when port is transitioning up->down or down->up:
```
ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496
ERR swss#orchagent: message repeated 6 times: [ :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496]
```

**How to reproduce**

1. Toggle link-training config on fanout:
```
sudo config interface link-training Ethernet496 off
sudo config interface link-training Ethernet496 on
sudo config interface link-training Ethernet496 off
```

2.  On the DUT, you will see the following logs:
```
$ sudo tail -f /var/log/syslog | grep ERR

ERR swss#orchagent: message repeated 6 times: [ :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496]
ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496
ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496
ERR swss#orchagent: message repeated 2 times: [ :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496]
ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496
ERR swss#orchagent: :- getPortLinkTrainingFailure: Failed to get LT failure status for Ethernet496
```

**How I verified it**

Confirmed that the regex pattern matches all observed syslog error formats using Python `re.match()`.