### PR TITLE
[dut_console] Fix fixture conflict in test_idle_timeout

### DIFF
--- a/tests/dut_console/test_idle_timeout.py
+++ b/tests/dut_console/test_idle_timeout.py
@@ -14,8 +14,8 @@ pytestmark = [
 ]
 
 
-def test_timeout(duthost_console, duthosts, enum_supervisor_dut_hostname):
-    duthost = duthosts[enum_supervisor_dut_hostname]
+def test_timeout(duthost_console, duthosts, enum_rand_one_per_hwsku_hostname):
+    duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     logger.info("Get default session idle timeout")
     default_tmout = duthost_console.send_command('echo $TMOUT')
     pytest_assert(default_tmout == DEFAULT_TMOUT, "default timeout on dut is not {} seconds".format(DEFAULT_TMOUT))


### PR DESCRIPTION
### Description of PR

Summary:
Fix fixture conflict in `test_idle_timeout.py` that causes `AttributeError: 'SubRequest' object has no attribute 'param'`.

The `test_timeout` function uses the `duthost_console` fixture (which depends on `enum_rand_one_per_hwsku_hostname`), but the test also declares `enum_supervisor_dut_hostname` as a parameter. These two enum fixtures are mutually exclusive in `pytest_generate_tests` (`elif` chain in `conftest.py`), so only `enum_supervisor_dut_hostname` gets parameterized while `enum_rand_one_per_hwsku_hostname` does not — causing the fixture to fail when accessing `request.param`.



### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
`test_timeout` in `tests/dut_console/test_idle_timeout.py` always fails with:
```
AttributeError: 'SubRequest' object has no attribute 'param'
```
at `conftest.py:2421` in `enum_rand_one_per_hwsku_hostname` fixture, because the fixture is never parameterized by `pytest_generate_tests`.

#### How did you do it?
Changed `enum_supervisor_dut_hostname` to `enum_rand_one_per_hwsku_hostname` in the `test_timeout` function signature and body. This aligns the test with the `duthost_console` fixture's dependency, ensuring both use the same parameterization path in `pytest_generate_tests`.

#### How did you verify/test it?
Ran the test on testbed `testbed-bjw2-can-t1-7260-12` (Arista 7260CX3-64) with SONiC master image (`SONiC.master.1067794-cee76d55f`):
- **Before fix**: `AttributeError: 'SubRequest' object has no attribute 'param'` (ERROR)
- **After fix**: `1 passed, 35 warnings in 91.80s` (PASSED)

#### Any platform specific information?
N/A — this is a test framework fixture issue affecting all platforms.

#### Supported testbed topology if it's a new test case?
N/A — existing test case, topology `any`.

### Documentation
N/A