### PR TITLE
Fix AutoMergeScan: use squash merge instead of rebase

### DIFF
--- a/.github/workflows/automerge_scan.yml
+++ b/.github/workflows/automerge_scan.yml
@@ -69,6 +69,6 @@ jobs:
           done
           # merge the PR
           echo ========Merging  PR========
-          gh pr merge --rebase --delete-branch --admin -R sonic-net/sonic-mgmt $url || true
+          gh pr merge --squash --delete-branch --admin -R sonic-net/sonic-mgmt $url || true
           echo ========Finished PR========
         done


### PR DESCRIPTION
### Description of PR

Summary:
Change `gh pr merge --rebase` to `gh pr merge --squash` in the AutoMergeScan workflow.

Cherry-pick PRs (created by mssonicbld) may contain merge commits (e.g. `Merge branch '202511' into cherry/202511/xxxxx`). Git rebase cannot handle merge commits, causing the error:

> GraphQL: This branch can't be rebased (mergePullRequest)

Example: https://github.com/sonic-net/sonic-mgmt/pull/22779

Squash merge produces the same linear history (satisfying the `required_linear_history` branch protection) but works regardless of whether the PR branch contains merge commits.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The AutoMergeScan workflow uses `gh pr merge --rebase` to merge PRs. However, cherry-pick PRs often contain merge commits in their branch history. GitHub cannot rebase branches that contain merge commits, causing the merge to fail silently (due to `|| true`).

#### How did you do it?

Changed `--rebase` to `--squash` in the `gh pr merge` command. Squash merge collapses all commits into one, avoiding the merge commit issue while still producing linear history.

#### How did you verify/test it?

- Verified `sonic-net/sonic-mgmt` repo settings: `allow_squash_merge: true`
- Verified squash merge satisfies the `required_linear_history` branch protection rule on the `202511` branch
- Confirmed PR #22779 has `rebaseable: false` due to a merge commit in the branch (`Merge branch '202511' into cherry/202511/20379`)

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
