### PR TITLE
Fix PTF/DUT subnet mismatch when VLAN has multiple IPv4 addresses

### DIFF
--- a/tests/arp/arp_utils.py
+++ b/tests/arp/arp_utils.py
@@ -2,7 +2,7 @@ import re
 import logging
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.utilities import wait_until
-from ipaddress import ip_interface
+from ipaddress import ip_interface, ip_network, IPv4Network
 
 
 logger = logging.getLogger(__name__)
@@ -95,14 +95,21 @@ def fdb_has_mac(duthost, mac):
     return any(mac in line.lower() for line in duthost.command("show mac")["stdout_lines"])
 
 
-def get_first_vlan_ipv4(config_facts):
+def get_vlan_last_ipv4(config_facts):
     """
-    Get first VLAN interface and its IPv4 address
+    Return (vlan_intf_name, ipv4) for the first VLAN_INTERFACE with IPv4,
+    using the last IPv4 in that interface's address list.
     """
     vlan_intfs = config_facts.get("VLAN_INTERFACE", {})
     for intf, addrs in vlan_intfs.items():
+        intf_ipv4 = None
         for addr in addrs:
-            if ":" in addr:
+            try:
+                if type(ip_network(addr, strict=False)) is IPv4Network:
+                    iface = ip_interface(addr)
+                    intf_ipv4 = (intf, iface.ip)
+            except ValueError:
                 continue
-            return intf, ip_interface(addr).ip
+        if intf_ipv4 is not None:
+            return intf_ipv4
     return None, None

--- a/tests/arp/test_arp_update.py
+++ b/tests/arp/test_arp_update.py
@@ -5,7 +5,7 @@ import ptf.testutils as testutils
 import pytest
 import random
 
-from tests.arp.arp_utils import clear_dut_arp_cache, fdb_cleanup, get_dut_mac, fdb_has_mac, get_first_vlan_ipv4
+from tests.arp.arp_utils import clear_dut_arp_cache, fdb_cleanup, get_dut_mac, fdb_has_mac, get_vlan_last_ipv4
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor  # noqa: F401
 from tests.common.fixtures.ptfhost_utils import setup_vlan_arp_responder, run_icmp_responder  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert as pt_assert
@@ -61,7 +61,7 @@ def dut_interface_info(rand_selected_dut, config_facts, tbinfo):
     """
     duthost = rand_selected_dut
     dut_mac = get_dut_mac(duthost, config_facts, tbinfo)
-    vlan_name, dut_ipv4 = get_first_vlan_ipv4(config_facts)
+    vlan_name, dut_ipv4 = get_vlan_last_ipv4(config_facts)
 
     return {
         'host': duthost,


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 

Fix PTF/DUT subnet mismatch in ARP tests when a VLAN interface has multiple IPv4 addresses.


#### Root Cause

After the community added a second VLAN IP (`192.169.0.1`), two APIs used by the ARP tests diverged in which IPv4 they selected:

| API | Behavior | Selected IP |
|-----|----------|-------------|
| `get_first_vlan_ipv4` | Returns the **first** IPv4 in the VLAN | `192.168.0.1` (DUT) |
| `ip_and_intf_info` (conftest) | Uses the **last** IPv4 network and assigns PTF an IP in that subnet | `192.169.x.x` (PTF) |

This put PTF and DUT in **different subnets**, causing ping failures and MAC learning tests to break.

#### Fix

Rename `get_first_vlan_ipv4` to `get_vlan_last_ipv4` so it returns the **last** IPv4 in the VLAN, matching the behavior of `ip_and_intf_info`. Both APIs now consistently use `192.169.0.1`, keeping PTF and DUT in the same subnet.

Additionally, improve robustness:
- Use `ip_network`/`IPv4Network` type checking for IPv4 detection instead of the `":" in addr` heuristic
- Add `try`/`except` for `ValueError` on malformed addresses

#### Files Changed

- `tests/arp/arp_utils.py` — renamed function, updated import, new selection logic
- `tests/arp/test_arp_update.py` — updated import and call site
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
