### PR TITLE
Fix test_dhcp_server_config_vlan_intf_change for multi-IPv4 VLANs

### DIFF
--- a/tests/dhcp_server/test_dhcp_server.py
+++ b/tests/dhcp_server/test_dhcp_server.py
@@ -673,7 +673,8 @@ def test_dhcp_server_config_vlan_member_change(
     """
         Test if config change on dhcp interface status can take effect
     """
-    loganalyzer[duthost.hostname].ignore_regex.append(".*Failed to get port by bridge port.*")
+    if loganalyzer and loganalyzer[duthost.hostname]:
+        loganalyzer[duthost.hostname].ignore_regex.append(".*Failed to get port by bridge port.*")
     test_xid = 11
     vlan_name, gateway, net_mask, vlan_hosts, vlan_members_with_ptf_idx = parse_vlan_setting_from_running_config
     expected_assigned_ip = random.choice(vlan_hosts)
@@ -807,10 +808,46 @@ def test_dhcp_server_config_vlan_intf_change(
     )
     apply_dhcp_server_config_gcu(duthost, config_to_apply)
 
-    # When the subnet not match to VLAN, client won't get IP
-    duthost.add_ip_addr_to_vlan(vlan_name_1, vlan_ipv4_2)
-    duthost.remove_ip_addr_from_vlan(vlan_name_1, vlan_ipv4_1)
+    # When the VLAN has multiple IPv4 addresses, extra IPs on different subnets
+    # can interfere with the DHCP server's subnet matching after IP swap/restore.
+    # Temporarily remove them so the test operates with a single unambiguous subnet.
+    vlan_brief = duthost.get_vlan_brief()
+    all_vlan_ipv4_prefixes = vlan_brief[vlan_name_1].get('interface_ipv4', [])
+    extra_ipv4_prefixes = [prefix for prefix in all_vlan_ipv4_prefixes if prefix != vlan_ipv4_1]
+    if extra_ipv4_prefixes:
+        logging.info("Temporarily removing extra IPv4 prefixes from %s: %s" %
+                     (vlan_name_1, extra_ipv4_prefixes))
+        for extra_ip in extra_ipv4_prefixes:
+            duthost.remove_ip_addr_from_vlan(vlan_name_1, extra_ip)
+
     try:
+        # When the subnet not match to VLAN, client won't get IP
+        duthost.add_ip_addr_to_vlan(vlan_name_1, vlan_ipv4_2)
+        duthost.remove_ip_addr_from_vlan(vlan_name_1, vlan_ipv4_1)
+        try:
+            verify_discover_and_request_then_release(
+                duthost=duthost,
+                ptfhost=ptfhost,
+                ptfadapter=ptfadapter,
+                dut_port_to_capture_pkt=dut_port_1,
+                ptf_port_index=ptf_port_index_1,
+                ptf_mac_port_index=ptf_port_index_1,
+                test_xid=test_xid_1,
+                dhcp_interface=None,
+                expected_assigned_ip=None,
+                exp_gateway=None,
+                server_id=None,
+                net_mask=None
+            )
+        except Exception as e:
+            duthost.add_ip_addr_to_vlan(vlan_name_1, vlan_ipv4_1)
+            duthost.remove_ip_addr_from_vlan(vlan_name_1, vlan_ipv4_2)
+            raise e
+
+        # When the subnet is changed to match VLAN, client can get IP
+        duthost.add_ip_addr_to_vlan(vlan_name_1, vlan_ipv4_1)
+        duthost.remove_ip_addr_from_vlan(vlan_name_1, vlan_ipv4_2)
+        time.sleep(5)
         verify_discover_and_request_then_release(
             duthost=duthost,
             ptfhost=ptfhost,
@@ -819,31 +856,12 @@ def test_dhcp_server_config_vlan_intf_change(
             ptf_port_index=ptf_port_index_1,
             ptf_mac_port_index=ptf_port_index_1,
             test_xid=test_xid_1,
-            dhcp_interface=None,
-            expected_assigned_ip=None,
-            exp_gateway=None,
-            server_id=None,
-            net_mask=None
+            dhcp_interface=vlan_name_1,
+            expected_assigned_ip=expected_assigned_ip_1,
+            exp_gateway=gateway_1,
+            server_id=gateway_1,
+            net_mask=net_mask_1
         )
-    except Exception as e:
-        duthost.add_ip_addr_to_vlan(vlan_name_1, vlan_ipv4_1)
-        duthost.remove_ip_addr_from_vlan(vlan_name_1, vlan_ipv4_2)
-        raise e
-
-    # When the subnet is changed to match VLAN, client can get IP
-    duthost.add_ip_addr_to_vlan(vlan_name_1, vlan_ipv4_1)
-    duthost.remove_ip_addr_from_vlan(vlan_name_1, vlan_ipv4_2)
-    verify_discover_and_request_then_release(
-        duthost=duthost,
-        ptfhost=ptfhost,
-        ptfadapter=ptfadapter,
-        dut_port_to_capture_pkt=dut_port_1,
-        ptf_port_index=ptf_port_index_1,
-        ptf_mac_port_index=ptf_port_index_1,
-        test_xid=test_xid_1,
-        dhcp_interface=vlan_name_1,
-        expected_assigned_ip=expected_assigned_ip_1,
-        exp_gateway=gateway_1,
-        server_id=gateway_1,
-        net_mask=net_mask_1
-    )
+    finally:
+        for extra_ip in extra_ipv4_prefixes:
+            duthost.add_ip_addr_to_vlan(vlan_name_1, extra_ip)


### PR DESCRIPTION
### Description of PR

Summary:

Fix `test_dhcp_server_config_vlan_intf_change` failing when the VLAN interface has multiple IPv4 addresses on different subnets.

#### Root Cause

The VLAN interface can have multiple IPv4 addresses on different subnets:

```
VLAN_INTERFACE|Vlan1000|192.168.0.1/21
VLAN_INTERFACE|Vlan1000|192.169.0.1/22
```

The test only manipulates the primary IP (`192.168.0.1/21`). When it removes and restores that IP during the subnet mismatch test, the extra IP (`192.169.0.1/22`) remains on the VLAN and interferes with Kea's subnet matching logic. After the swap/restore cycle, Kea fails to detect the restored subnet and produces zero DHCP response packets.

#### Fix

Before performing the IP swap, the test now:

1. Queries `duthost.get_vlan_brief()` to discover all IPv4 addresses on the VLAN
2. Temporarily removes extra IPv4 addresses so the test operates with a single unambiguous subnet
3. Restores the extra IPs in a `finally` block regardless of test outcome

Additional improvements:
- Add a guard on `loganalyzer` access in `test_dhcp_server_config_vlan_member_change` to prevent `NoneType` errors
- Add a short sleep after IP restore to let Kea settle before verification

#### Files Changed

- `tests/dhcp_server/test_dhcp_server.py`

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach

#### What is the motivation for this PR?

The test `test_dhcp_server_config_vlan_intf_change` fails on testbeds where the VLAN interface has multiple IPv4 addresses on different subnets. The test assumes a single IPv4 address on the VLAN, so when it swaps and restores the primary IP, the remaining extra IP interferes with Kea's subnet matching logic, causing zero DHCP response packets and a test failure.

#### How did you do it?

1. Before the IP swap/restore cycle, the test now calls `duthost.get_vlan_brief()` to discover all IPv4 addresses configured on the target VLAN.
2. Any extra IPv4 addresses beyond the primary one are temporarily removed so the test operates with a single, unambiguous subnet.
3. A `finally` block guarantees the extra IPs are restored regardless of test outcome.
4. Added a guard on `loganalyzer` access in `test_dhcp_server_config_vlan_member_change` to prevent `NoneType` errors when the analyzer is not initialized.
5. Added a short `time.sleep(5)` after IP restore to allow Kea to settle before verification.

#### How did you verify/test it?

Ran `test_dhcp_server_config_vlan_intf_change` on a testbed where the VLAN interface has multiple IPv4 addresses on different subnets. Before this fix the test consistently failed with zero DHCP response packets after the IP restore step; after this fix the test passes reliably. Also verified that single-IP VLAN configurations are unaffected.

#### Any platform specific information?

N/A. The fix is test-side only and applies to any platform running the DHCP server test suite.

#### Supported testbed topology if it's a new test case?

N/A. This is a fix for an existing test case, not a new one.

### Documentation

N/A. No new features or test cases introduced; this is a bug fix for an existing test.
