### PR TITLE
[xfail][test_sflow]: Mark reboot tests xfail on sn5640 SP5 platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4515,7 +4515,7 @@ sflow/test_sflow.py::TestReboot::testFastreboot:
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
   xfail:
-    reason: "Test case has issue on sn5640 platform."
+    reason: "Test case has issue on sn5640 SP5 platform."
     conditions:
       - "platform in ['x86_64-nvidia_sn5640-r0']"
 
@@ -4525,7 +4525,7 @@ sflow/test_sflow.py::TestReboot::testWarmreboot:
     conditions:
       - "topo_name in ['dualtor', 'dualtor-56', 'dualtor-120', 'dualtor-aa', 'dualtor-aa-56', 'dualtor-aa-64-breakout']"
   xfail:
-    reason: "Test case has issue on sn5640 platform."
+    reason: "Test case has issue on sn5640 SP5 platform."
     conditions:
       - "platform in ['x86_64-nvidia_sn5640-r0']"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Add xfail conditions for sFlow reboot test cases on SN5640 (SP5) platform.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
These test cases are currently failing on SN5640 SP5 platform due to a known issue.
- sflow/test_sflow.py::TestReboot::testReboot
- sflow/test_sflow.py::TestReboot::testWarmreboot

#### How did you do it?
Add xfail conditions for sFlow reboot test cases on SN5640 (SP5) platform.
#### How did you verify/test it?
Verified it in internal setup.
#### Any platform specific information?
SN5640
#### Supported testbed topology if it's a new test case?
t0-isolated-d32u32s2
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
