### PR TITLE
Fix VxLAN ECMP test cleanup and loganalyzer

### DIFF
--- a/tests/vxlan/test_vxlan_ecmp.py
+++ b/tests/vxlan/test_vxlan_ecmp.py
@@ -113,6 +113,7 @@ def _ignore_route_sync_errlogs(rand_one_dut_hostname, loganalyzer):
                 ".*api SAI_COMMON_API_CREATE failed in syncd mode.*",
                 ".*ERR syncd.*SAI_BFD_SESSION_ATTR_.*",
                 ".*ERR swss.*SAI_STATUS_FAILURE.*",
+                ".*ERR syncd.*hwif_to_tap_name: failed to find hostif info entry for hwif device.*",
             ])
     return
 
@@ -351,6 +352,9 @@ def fixture_setUp(duthosts,
         data['duthost'].shell(
             "for i in `redis-cli -n 4 --scan --pattern \"NEIGH|{}|*\" `; "
             "do redis-cli -n 4 del $i ; done".format(intf))
+        # Restore interface to operational state after removing VNET association
+        data['duthost'].shell(
+            "sudo config interface startup {}".format(intf))
 
     # This script's setup code re-uses same vnets for v4inv4 and v6inv4.
     # There will be same vnet in multiple encap types.


### PR DESCRIPTION
### Description of PR

  Summary:
  Fix VxLAN ECMP test loganalyzer failure and interface state cleanup on VPP platform.

  ### Type of change

  - [x] Bug fix
  - [ ] Testbed and Framework(new/improvement)
  - [ ] New Test case
      - [ ] Skipped for non-supported platforms
  - [ ] Test case improvement

  ### Back port request
  - [ ] 202205
  - [ ] 202305
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511

  ### Approach
  #### What is the motivation for this PR?
  On VPP platforms, VxLAN ECMP tests fail due to loganalyzer catching `hwif_to_tap_name` ERR logs from syncd. These are harmless — VPP-internal interfaces (BVI, vxlan_tunnel) have no host
   TAP pair, so the lookup fails with an error that is expected and benign. Additionally, interfaces shut down during tests were not restored in teardown.

  #### How did you do it?
  - Added `hwif_to_tap_name: failed to find hostif info entry` to the loganalyzer ignore list in `_ignore_route_sync_errlogs`
  - Added `config interface startup` in test teardown to restore interface state

  #### How did you verify/test it?
  Ran full VxLAN ECMP test suite (64 tests across 4 encap types) on VPP t1-lag topology — all passed.

  #### Any platform specific information?
  The loganalyzer error (`hwif_to_tap_name`) only occurs on VPP — the ignore pattern is a no-op on hardware platforms.
 The interface startup in teardown is good cleanup practice for any platform.

  #### Supported testbed topology if it's a new test case?
  N/A — existing test fix.

  ### Documentation
  N/A
