### PR TITLE
Fix BGP scale test reliability: route validation, pipeline drain, and…

### DIFF
--- a/ansible/library/announce_routes.py
+++ b/ansible/library/announce_routes.py
@@ -739,7 +739,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v4:
                     filterout_subnet_ipv4(aggregate_routes, routes_v4)
                     routes_v4.extend(aggregate_routes_v4)
-                topo_routes[k][IPV4] = routes_v4
+                topo_routes[k][IPV4] = topo_routes[k].get(IPV4, []) + routes_v4
                 routes_to_change[port] += routes_v4
             if enable_ipv6_routes_generation:
                 routes_v6, _ = generate_routes("v6", podset_number, tor_number, tor_subnet_number,
@@ -752,7 +752,7 @@ def fib_t1_lag(topo, ptf_ip, topo_name, no_default_route=False, action="announce
                 if aggregate_routes_v6:
                     filterout_subnet_ipv6(aggregate_routes, routes_v6)
                     routes_v6.extend(aggregate_routes_v6)
-                topo_routes[k][IPV6] = routes_v6
+                topo_routes[k][IPV6] = topo_routes[k].get(IPV6, []) + routes_v6
                 routes_to_change[port6] += routes_v6
 
         if 'vips' in v:

--- a/tests/bgp/test_ipv6_bgp_scale.py
+++ b/tests/bgp/test_ipv6_bgp_scale.py
@@ -286,9 +286,30 @@ def _get_backplane_ports():
     return {k for k, v in ptf.config.get('port_map', {}).items() if v == 'backplane'}
 
 
+def wait_for_rx_quiescence(pdp, exp_mask, stable_secs=10, poll_interval=1, max_timeout=120):
+    """Wait until mask_rx_cnt stops incrementing for stable_secs seconds.
+
+    After stopping the traffic thread, packets remain in transit through the
+    nn_agent pipeline (DUT -> veth -> AF_PACKET -> nn_agent -> nanomsg -> PTF).
+    This can take 12-17 seconds to drain. Polling until counters stabilize
+    avoids the false packet loss caused by a fixed-duration sleep.
+    """
+    start = time.time()
+    prev_rx = sum(pdp.mask_rx_cnt[exp_mask].values())
+    stable_since = start
+    while time.time() - stable_since < stable_secs:
+        if time.time() - start > max_timeout:
+            logger.warning("rx quiescence max timeout (%ds) exceeded; proceeding with current counters", max_timeout)
+            break
+        time.sleep(poll_interval)
+        curr_rx = sum(pdp.mask_rx_cnt[exp_mask].values())
+        if curr_rx != prev_rx:
+            prev_rx = curr_rx
+            stable_since = time.time()
+
+
 def calculate_downtime(ptf_dp, end_time, start_time, masked_exp_pkt):
-    logger.warning("Waiting %d seconds for mask counters to be updated", MASK_COUNTER_WAIT_TIME)
-    time.sleep(MASK_COUNTER_WAIT_TIME)
+    wait_for_rx_quiescence(ptf_dp, masked_exp_pkt)
     backplane_ports = _get_backplane_ports()
     rx_total = sum(
         cnt for port_key, cnt in ptf_dp.mask_rx_cnt[masked_exp_pkt].items()
@@ -342,6 +363,19 @@ def flush_counters(ptf_dp, masked_exp_pkt):
                 ptf_dp.mask_rx_cnt[masked_exp_pkt], ptf_dp.mask_tx_cnt[masked_exp_pkt])
 
 
+def _send_with_retry(ptf_dataplane, device_num, port_num, pkt, max_retries=10, base_backoff=0.1):
+    """Send a single packet, retrying on nanomsg timeout (nn_agent CPU starvation)."""
+    for attempt in range(max_retries):
+        try:
+            ptf_dataplane.send(device_num, port_num, pkt)
+            return True
+        except Exception as e:
+            if "timed out" not in str(e).lower():
+                raise
+            time.sleep(base_backoff * (2 ** min(attempt, 4)))
+    return False
+
+
 def send_packets(
     terminated,
     ptf_dataplane,
@@ -355,14 +389,16 @@ def send_packets(
     pkts_len = len(pkts)
     rounds_per_timeslot = 1 + (pkt_cnt_per_timeslot // pkts_len)
     rounds_cnt = 0
+    retry_failures = 0
     while True:
         if terminated.is_set():
-            logger.info("%d packets are sent", rounds_cnt * pkts_len)
+            logger.info("%d packets are sent (%d retry failures)", rounds_cnt * pkts_len, retry_failures)
             break
         logger.info("round %d, sending %d packets", rounds_cnt, rounds_cnt * pkts_len)
         for _ in range(rounds_per_timeslot):
             for pkt in pkts:
-                ptf_dataplane.send(device_num, port_num, pkt)
+                if not _send_with_retry(ptf_dataplane, device_num, port_num, pkt):
+                    retry_failures += 1
 
         while datetime.datetime.now() - last_round_time < datetime.timedelta(seconds=sending_timeslot):
             time.sleep(sending_timeslot / 10.0)


### PR DESCRIPTION
### Description of PR

  Summary:
  Fix three reliability issues in test_ipv6_bgp_scale and announce_routes that cause false failures on large-scale topologies.

  ### Type of change

  - [x] Bug fix
  - [ ] Testbed and Framework(new/improvement)
  - [ ] New Test case
      - [ ] Skipped for non-supported platforms
  - [ ] Test case improvement

  ### Back port request
  - [ ] 202205
  - [ ] 202305
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511

  ### Approach
  #### What is the motivation for this PR?
  BGP scale tests fail intermittently on large topologies due to three independent issues:

  1. **Route count mismatch**: `fib_t1_lag()` overwrites `topo_routes[k]` using `=` for BGP_SCALE_T1S topologies, discarding shared ECMP routes from the earlier block
  2. **False packet loss**: `calculate_downtime()` uses a fixed 10s sleep before reading rx counters, but the nn_agent pipeline can take 12-17s to drain on loaded systems
  3. **Silent traffic thread crash**: `send_packets()` doesn't handle nanomsg timeout exceptions — under CPU starvation (50+ load on 12 cores with 1024 exaBGP processes), `nn_agent` can't
   drain its socket fast enough

  #### How did you do it?
  1. Changed `topo_routes[k][IPV4] = routes_v4` to `topo_routes[k].get(IPV4, []) + routes_v4` to append instead of overwrite (same for IPv6)
  2. Replaced fixed `time.sleep(MASK_COUNTER_WAIT_TIME)` with `wait_for_rx_quiescence()` that polls until rx counters stabilize for 10 consecutive seconds
  3. Added `_send_with_retry()` wrapper that catches nanomsg timeout and retries up to 10 times with exponential backoff (0.1s base, capped at 1.6s). Also logs retry failure count.

  #### How did you verify/test it?
  Ran BGP scale tests on VPP t1-lag topology (32 peers, 512 ports). Without fixes: intermittent failures with truncated TX counts and incorrect downtime calculations. With fixes:
  consistent pass.

  #### Any platform specific information?
  Issue 1 (route overwrite) affects any platform using BGP_SCALE_T1S topologies. Issues 2 and 3 are more pronounced on VPP and other platforms with slower route programming or high CPU
  load.

  #### Supported testbed topology if it's a new test case?
  N/A — existing test fixes. Tested on t1-lag.

  ### Documentation
  N/A