### PR TITLE
Wait for route programming after stress link flap test

### DIFF
--- a/tests/bgp/test_bgp_stress_link_flap.py
+++ b/tests/bgp/test_bgp_stress_link_flap.py
@@ -431,6 +431,38 @@ def setup(duthosts, rand_one_dut_hostname, nbrhosts, fanouthosts, show_ip_interf
     pytest_assert(wait_until(600, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())),
                   "Not all BGP sessions are established on DUT")
 
+    # Wait for route programming to complete after link flap stress.
+    # After BGP sessions re-establish, routes are re-advertised but take
+    # time to be programmed to ASIC. Without this wait, the next test's
+    # sanity check sees routeCheck failing and reboots the DUT.
+    route_check = "sudo /usr/local/bin/route_check.py"
+    for attempt in range(20):
+        result = duthost.shell(
+            route_check, module_ignore_errors=True)
+        if result.get('rc', 1) == 0:
+            logger.info(
+                "routeCheck passed (attempt %d)",
+                attempt + 1)
+            for monit_wait in range(12):
+                monit_out = duthost.shell(
+                    "sudo monit status routeCheck",
+                    module_ignore_errors=True
+                ).get('stdout', '')
+                if 'status' in monit_out and 'OK' in monit_out:
+                    logger.info(
+                        "monit routeCheck OK (poll %d)",
+                        monit_wait + 1)
+                    break
+                logger.info(
+                    "monit routeCheck refresh (%d/12)",
+                    monit_wait + 1)
+                time.sleep(30)
+            break
+        logger.info(
+            "routeCheck not ready, 15s (%d/20)",
+            attempt + 1)
+        time.sleep(15)
+
 
 async def flap_dut_interface(duthost, port, sleep_duration, test_run_duration):
     logger.info("flap dut {} interface {} delay time {} timeout {}".format(


### PR DESCRIPTION
● ### Description of PR

  Summary:
  Wait for route programming to complete in BGP stress link flap test
  teardown to prevent unnecessary DUT reboot by next test's sanity check.

  ### Type of change

  - [x] Bug fix
  - [ ] Testbed and Framework(new/improvement)
  - [ ] New Test case
      - [ ] Skipped for non-supported platforms
  - [x] Test case improvement

  ### Back port request
  - [ ] 202205
  - [ ] 202305
  - [ ] 202311
  - [ ] 202405
  - [ ] 202411
  - [ ] 202505
  - [ ] 202511

  ### Approach
  #### What is the motivation for this PR?

  The BGP stress link flap test (`test_bgp_stress_link_flap.py`) flaps
  DUT interfaces repeatedly to stress BGP reconvergence. In the test's
  teardown (the yield fixture's cleanup section), it restores interfaces
  and waits for BGP sessions to re-establish (line 431, 600s timeout).

  However, BGP session establishment does not mean route programming is
  complete. After sessions come up, peers re-advertise routes, and
  these routes must be programmed to the ASIC via orchagent -> syncd.
  On platforms with synchronous route programming (e.g., VPP where
  each route requires an individual API call), this can take several
  minutes for hundreds of routes.

  The test teardown exits as soon as BGP sessions are up, but routes
  are still being programmed. The next test's pre-test sanity check
  runs `routeCheck` (via monit), sees a mismatch between APP_DB and
  ASIC_DB routes, and triggers a DUT reboot to recover. While the
  reboot restores a clean state, it wastes ~5 minutes and marks the
  sanity check as failed. The test that caused the stale state should
  clean up after itself rather than relying on the framework to reboot.

  #### How did you do it?

  Added a wait loop in the test's teardown section (after the existing
  `check_bgp_session_state` wait at line 431) that:

  1. Polls `route_check.py` every 15 seconds, up to 20 attempts (5 min
     window), until it reports no route mismatches
  2. Once route_check passes, polls `monit status routeCheck` every 30
     seconds until monit's cached status refreshes to OK — this is
     needed because monit caches routeCheck results and the pre-test
     sanity check reads monit's status, not route_check.py directly

  This way the test cleans up after itself rather than leaving stale
  route state for the next test to deal with.

  #### How did you verify/test it?

  Ran BGP stress link flap test followed by subsequent tests on VPP
  t1-lag topology (32 peers):
  - **Without fix**: next test's sanity check detects routeCheck failure,
    reboots DUT, wasting ~5 min
  - **With fix**: teardown waits ~2-3 min for routes to converge, next
    test proceeds normally with no reboot

  #### Any platform specific information?

  Most visible on VPP (synchronous route programming) but can affect
  any platform under heavy load where route programming lags behind
  BGP session establishment.

  #### Supported testbed topology if it's a new test case?
  N/A — existing test teardown fix. Tested on t1-lag.

  ### Documentation
  N/A