### PR TITLE
Ignore expected error from DPU conosle minicom session disconnection.

### DIFF
--- a/tests/smartswitch/platform_tests/test_platform_dpu.py
+++ b/tests/smartswitch/platform_tests/test_platform_dpu.py
@@ -194,6 +194,11 @@ def test_dpu_console(duthosts, enum_rand_one_per_hwsku_hostname,
     @summary: To Verify `DPU console access`
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+    ignore_regex = [
+        r".*ERR kernel:.*cp210x ttyUSB\d+: failed set request 0x12 status: -110.*",
+    ]
+    if duthost.loganalyzer:
+        duthost.loganalyzer.ignore_regex.extend(ignore_regex)
 
     for index in range(num_dpu_modules):
         dpu_name = module.get_name(platform_api_conn, index)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
When the DPU serial console is accessed with ‘minicom -D /dev/ttyUSB0’ for DPU-1, while disconnecting from minicom session (most of the times), seeing the following driver error

ERR kernel: [82343.867625] cp210x ttyUSB0: failed set request 0x12 status: -110

This is a non functional error log. Visible only when you connect to the DPU serial console with minicom. Hence, we decided to add it to skip list.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
