### PR TITLE
Fix more tests on VOQ systems without chassis_app_db

### DIFF
--- a/tests/bgp/bgp_helpers.py
+++ b/tests/bgp/bgp_helpers.py
@@ -995,7 +995,9 @@ def initial_tsa_check_before_and_after_test(duthosts):
                               "Supervisor {} tsa_enabled config is enabled".format(duthost.hostname))
 
     def run_tsb_on_linecard_and_verify(lc):
-        if verify_dut_configdb_tsa_value(lc) is not False or get_tsa_chassisdb_config(lc) != 'false' or \
+        is_chassis = not lc.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_chassis_config_absent")
+        if verify_dut_configdb_tsa_value(lc) is not False or \
+                (is_chassis and get_tsa_chassisdb_config(lc) != 'false') or \
                 get_traffic_shift_state(lc, cmd='TSC no-stats') != TS_NORMAL:
             lc.shell('TSB')
             lc.shell('sudo config save -y')

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_voq.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_voq.yaml
@@ -46,6 +46,15 @@ voq/test_voq_init.py::test_voq_neighbor_create:
     conditions:
       - "is_chassis_config_absent==True"
 
+#######################################
+#####test_voq_intfs.py #####
+#######################################
+voq/test_voq_intfs.py::test_cycle_voq_intf:
+  skip:
+    reason: "Skipped as the test applies to chassis only"
+    conditions:
+      - "is_chassis_config_absent==True"
+
 #################################################
 #####test_voq_ipfwd.py #####
 #################################################


### PR DESCRIPTION
Should skip/fix:
bgp/test_traffic_shift_lc.py
bgp/test_startup_tsa_tsb_service.py
voq/test_voq_intfs.py

Failures seen:
bgp/test_traffic_shift_lc.py:
```
bgp/bgp_helpers.py:989: in run_tsb_on_linecard_and_verify
    if verify_dut_configdb_tsa_value(lc) is not False or get_tsa_chassisdb_config(lc) != 'false' or \
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        lc         = &lt;MultiAsicSonicHost ctn101&gt;
bgp/bgp_helpers.py:946: in get_tsa_chassisdb_config
    tsa_conf = duthost.shell('sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout']
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        duthost    = &lt;MultiAsicSonicHost ctn101&gt;
```

bgp/test_startup_tsa_tsb_service.py:
```
bgp/bgp_helpers.py:989: in run_tsb_on_linecard_and_verify
    if verify_dut_configdb_tsa_value(lc) is not False or get_tsa_chassisdb_config(lc) != 'false' or \
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        lc         = &lt;MultiAsicSonicHost ctn101&gt;
bgp/bgp_helpers.py:946: in get_tsa_chassisdb_config
    tsa_conf = duthost.shell('sonic-db-cli CHASSIS_APP_DB HGET \'BGP_DEVICE_GLOBAL|STATE\' tsa_enabled')['stdout']
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        duthost    = &lt;MultiAsicSonicHost ctn101&gt;
```

voq/test_voq_intfs.py:
```
voq/test_voq_init.py:219: in check_voq_interfaces
    voqdb = VoqDbCli(per_host)
            ^^^^^^^^^^^^^^^^^^
        <trim>
common/helpers/sonic_db.py:503: in __init__
    output = host.command("grep chassis_db_address /etc/sonic/chassisdb.conf")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        __class__  = &lt;class 'tests.common.helpers.sonic_db.VoqDbCli'&gt;
        host       = &lt;MultiAsicSonicHost ctn101&gt;
        self       = &lt;tests.common.helpers.sonic_db.VoqDbCli object at 0x7f96ea1591f0&gt;
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511