### PR TITLE
[202505] [docker-ptf] Modify docker container pull setting (#21560)

### DIFF
--- a/ansible/roles/vm_set/tasks/add_topo.yml
+++ b/ansible/roles/vm_set/tasks/add_topo.yml
@@ -167,7 +167,12 @@
     docker_container:
       name: ptf_{{ vm_set_name }}
       image: "{{ docker_registry_host }}/{{ ptf_imagename }}:{{ ptf_imagetag }}"
-      pull: yes
+      # Set pull to 'missing' when ptf_modified is True (PR test with preloaded image)
+      # to avoid pulling and overwriting the local image. For nightly tests where
+      # ptf_modified is False/undefined, use 'always' to always pull the latest image.
+      # The ptf_modified flag is passed from Azure Pipelines through Elastictest's
+      # add_topo_params as "-e ptf_modified=True" when testing PR built docker-ptf images.
+      pull: "{{ 'missing' if (ptf_modified | default(false) | bool) else 'always' }}"
       state: started
       restart: no
       network_mode: none


### PR DESCRIPTION
Set pull to 'missing' to avoid pulling and overwriting the local image if there is a preloaded image present. This is used for testing PR built image which is preloaded in elastic test when PTF_MODIFIED is True. This mechanism is used to test PR built docker-ptf image.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Cherry-pick https://github.com/sonic-net/sonic-mgmt/pull/21560. This will allow ptf_modified to be used during add-topo

Since we already have https://github.com/sonic-net/sonic-mgmt/pull/23188. We need to have this to allow test plan to apply custom ptf on add-topo.

Fixes # (issue) 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Motivation is test security changes on https://github.com/sonic-net/sonic-buildimage/pull/26265. I noticed my adjustment does not apply to sonic-mgmt test plan for 202505

#### How did you do it?

Cherry-pick the missing PR that allow testplan to pull from our build

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
