### PR TITLE
Enable dynamic port selection from setup in snappi pfcwd test

### DIFF
--- a/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
+++ b/tests/snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py
@@ -9,7 +9,7 @@ from tests.common.fixtures.conn_graph_facts import conn_graph_facts, fanout_grap
     fanout_graph_facts_multidut     # noqa: F401
 from tests.common.snappi_tests.snappi_fixtures import snappi_api_serv_ip, snappi_api_serv_port, \
     get_snappi_ports_single_dut, snappi_testbed_config, \
-    get_snappi_ports_multi_dut, is_snappi_multidut, \
+    get_snappi_ports_multi_dut, is_snappi_multidut, snappi_port_selection, tgen_port_info, \
     snappi_api, snappi_dut_base_config, get_snappi_ports, get_snappi_ports_for_rdma, cleanup_config      # noqa: F401
 from tests.common.snappi_tests.qos_fixtures import prio_dscp_map, lossless_prio_list      # noqa: F401
 from tests.common.reboot import reboot                              # noqa: F401
@@ -18,7 +18,7 @@ from tests.common.config_reload import config_reload
 from tests.common.platform.interface_utils import check_interface_status_of_up_ports
 from tests.snappi_tests.pfcwd.files.pfcwd_basic_helper import run_pfcwd_basic_test
 from tests.common.snappi_tests.snappi_test_params import SnappiTestParams
-from tests.snappi_tests.files.helper import skip_pfcwd_test, reboot_duts, \
+from tests.snappi_tests.files.helper import reboot_duts, \
     setup_ports_and_dut, multidut_port_info   # noqa: F401
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.topology('multidut-tgen', 'tgen')]
@@ -27,14 +27,14 @@ WAIT_TIME = 600
 INTERVAL = 40
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope='module')
 def number_of_tx_rx_ports():
     yield (1, 1)
 
 
 @pytest.fixture(autouse=False)
-def save_restore_config(setup_ports_and_dut):          # noqa: F811
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+def save_restore_config(tgen_port_info):          # noqa: F811
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
     timestamp = time.time()
     dest = f'~/{timestamp}'
 
@@ -59,7 +59,7 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
                                           lossless_prio_list,    # noqa: F811
                                           tbinfo,                # noqa: F811
                                           prio_dscp_map,         # noqa: F811
-                                          setup_ports_and_dut,   # noqa: F811
+                                          tgen_port_info,        # noqa: F811
                                           trigger_pfcwd,         # noqa: F811
                                           ):
     """
@@ -76,7 +76,8 @@ def test_pfcwd_basic_single_lossless_prio(snappi_api,                   # noqa: 
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info('Peer Ports: {}'.format([port['peer_port'] for port in snappi_ports]))
 
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
@@ -104,7 +105,7 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa: F811
                                          lossless_prio_list,    # noqa: F811
                                          tbinfo,      # noqa: F811
                                          prio_dscp_map,             # noqa: F811
-                                         setup_ports_and_dut,       # noqa: F811
+                                         tgen_port_info,       # noqa: F811
                                          trigger_pfcwd):
     """
     Run PFC watchdog basic test on multiple lossless priorities
@@ -121,7 +122,8 @@ def test_pfcwd_basic_multi_lossless_prio(snappi_api,                # noqa: F811
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info('Ports:{}'.format(snappi_ports))
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -148,7 +150,7 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
                                                  enum_dut_lossless_prio_with_completeness_level,   # noqa: F811
                                                  get_snappi_ports,   # noqa: F811
                                                  prio_dscp_map,             # noqa: F811
-                                                 setup_ports_and_dut,    # noqa: F811
+                                                 tgen_port_info,    # noqa: F811
                                                  reboot_duts,               # noqa: F811
                                                  trigger_pfcwd):
     """
@@ -167,7 +169,8 @@ def test_pfcwd_basic_single_lossless_prio_reboot(snappi_api,                # no
         N/A
     """
 
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info('Ports:{}'.format(snappi_ports))
 
     _, lossless_prio = enum_dut_lossless_prio_with_completeness_level.split('|')
     lossless_prio = int(lossless_prio)
@@ -195,7 +198,7 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
                                                 lossless_prio_list,         # noqa: F811
                                                 tbinfo,      # noqa: F811
                                                 prio_dscp_map,              # noqa: F811
-                                                setup_ports_and_dut,        # noqa: F811
+                                                tgen_port_info,        # noqa: F811
                                                 reboot_duts,                # noqa: F811
                                                 trigger_pfcwd):
     """
@@ -214,7 +217,8 @@ def test_pfcwd_basic_multi_lossless_prio_reboot(snappi_api,                 # no
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info('Ports:{}'.format(snappi_ports))
 
     snappi_extra_params = SnappiTestParams()
     snappi_extra_params.multi_dut_params.multi_dut_ports = snappi_ports
@@ -243,7 +247,7 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
                                                           prio_dscp_map,            # noqa: F811
                                                           restart_service,
                                                           trigger_pfcwd,
-                                                          setup_ports_and_dut,      # noqa: F811
+                                                          tgen_port_info,      # noqa: F811
                                                           save_restore_config):
     """
     Verify PFC watchdog basic test works on a single lossless priority after various service restarts
@@ -260,7 +264,9 @@ def test_pfcwd_basic_single_lossless_prio_service_restart(snappi_api,           
     Returns:
         N/A
     """
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info('Ports:{}'.format(snappi_ports))
+
     lossless_prio = random.sample(lossless_prio_list, 1)
     lossless_prio = int(lossless_prio[0])
 
@@ -328,7 +334,7 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
                                                          tbinfo,      # noqa: F811
                                                          prio_dscp_map,             # noqa: F811
                                                          restart_service,
-                                                         setup_ports_and_dut,       # noqa: F811
+                                                         tgen_port_info,       # noqa: F811
                                                          trigger_pfcwd,
                                                          save_restore_config):
     """
@@ -348,7 +354,8 @@ def test_pfcwd_basic_multi_lossless_prio_restart_service(snappi_api,            
         N/A
     """
 
-    testbed_config, port_config_list, snappi_ports = setup_ports_and_dut
+    testbed_config, port_config_list, snappi_ports = tgen_port_info
+    logger.info('Ports:{}'.format(snappi_ports))
 
     if (snappi_ports[0]['duthost'].is_multi_asic):
         ports_dict = defaultdict(list)


### PR DESCRIPTION
### Description of PR

Summary:
Adapt the PFC watchdog basic snappi test to use the `tgen_port_info` fixture for dynamic port selection, aligning with the refactoring introduced in PR #18067. Also fix a fixture scope mismatch and improve reboot test reliability.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #18067 refactored snappi port selection by introducing `tgen_port_info` and `snappi_port_selection` fixtures. The pfcwd basic test needed to be updated to consume these new fixtures instead of directly calling `setup_ports_and_dut` in each test body.

#### How did you do it?
- Replace inline `setup_ports_and_dut` usage in all 6 test function bodies with the `tgen_port_info` fixture parameter
- Remove redundant `setup_ports_and_dut` from test function signatures where it was no longer used in the body
- Change `number_of_tx_rx_ports` fixture scope from `function` (default) to `module` to match the module-scoped `snappi_port_selection` dependency
- Add `snappi_port_selection` to imports (was missing)
- Update `save_restore_config` to use `tgen_port_info` fixture parameter. `save_restore_config` needs `tgen_port_info` to get the `snappi_ports` list, which contains `duthost` handles for each port. It uses those to identify which DUTs to back up and restore config on.

#### How did you verify/test it?
Validated on a T0/T1 and T2 chassis testbed (Cisco 8800) with IXIA traffic generator:
- `test_pfcwd_basic_single_lossless_prio` — PASSED
- `test_pfcwd_basic_multi_lossless_prio` — PASSED
- `test_pfcwd_basic_single_lossless_prio_reboot` (cold reboot) — PASSED
- `test_pfcwd_basic_multi_lossless_prio_reboot` (cold reboot) — PASSED
- `test_pfcwd_basic_single_lossless_prio_service_restart` — PASSED
- `test_pfcwd_basic_multi_lossless_prio_restart_service` — PASSED

```
T0/T1:
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-tgen_port_info0-True-swss] PASSED [ 82%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-tgen_port_info0-True-swss] PASSED [ 92%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-cold-NOTSET-tgen_port_info0-False] SKIPPED [ 30%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-warm-tgen_port_info0-True] SKIPPED [ 52%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-tgen_port_info0-True-swss] PASSED [ 82%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-tgen_port_info0-True-swss] PASSED [ 92%]

T2:
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-tgen_port_info1-False] PASSED [  5%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio[multidut_port_info0-tgen_port_info0-True] SKIPPED [ 11%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_reboot[multidut_port_info0-warm-NOTSET-tgen_port_info0-True] SKIPPED [ 21%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_reboot[multidut_port_info0-warm-tgen_port_info0-True] SKIPPED [ 51%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio_service_restart[multidut_port_info0-tgen_port_info0-True-swss] SKIPPED [ 81%]

Individual tests on T2:
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-tgen_port_info0-True-swss] 
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-tgen_port_info0-False-swss] SKIPPED [ 25%]
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-tgen_port_info1-True-swss] 
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_multi_lossless_prio_restart_service[multidut_port_info0-tgen_port_info1-False-swss] PASSED [ 50%]
````

#### Any platform specific information?
T0/T1: Tested on Arista 8102 (single-ASIC per linecard)
T2: Tested on Cisco 8800 modular chassis (multi-ASIC, 3 ASICs per linecard).

#### Supported testbed topology if it's a new test case?
N/A — existing test, supports `multidut-tgen` and `tgen` topologies.

### Documentation
N/A