### PR TITLE
[BGP Scale] - Change dut_interfaces fallback value from None to empty string

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1262,7 +1262,7 @@ def topo_bgp_routes(localhost, ptfhosts, tbinfo):
             action='generate',
             path="../ansible/",
             log_path=log_path,
-            dut_interfaces=servers_dut_interfaces.get(ptf_ip) if servers_dut_interfaces else None,
+            dut_interfaces=servers_dut_interfaces.get(ptf_ip, '') if servers_dut_interfaces else '',
             verbose=False
         )
         if 'topo_routes' not in res:


### PR DESCRIPTION
### Description of PR
Summary: Change the fallback value of `dut_interfaces` being passed to `announce_routes` in `topo_bgp_routes` from None to an empty string.
Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Upgrading to Ubuntu 24.04/newer version of Ansible treats the parsing of `None` for ansible module args different from before. Previously `None` would be coerced to an empty string when passed as an arg where a string was expected, now the following error raises in `topo_bgp_routes` in conftest.py when trying to invoke `announce_routes`:
```
argument 'dut_interfaces' is of type <class 'NoneType'> and we were unable to
convert to str: 'None' is not a string and conversion is not allowed
```

The fix is to pass a value of `''` rather than `None`, now that stricter checking is in place.

#### How did you do it?
Changed the fallback value being passed into topo_bgp_routes from None to an empty string.

#### How did you verify/test it?
Tested on 7060X6 platform on 202511 branch by running test_ipv6_bgp_scale.py, confirming the issue no longer occurs.