### PR TITLE
Fix IPv6-only topology support in generic_patch BGP convergence check

### DIFF
--- a/tests/configlet/util/generic_patch.py
+++ b/tests/configlet/util/generic_patch.py
@@ -172,12 +172,17 @@ def generic_patch_add_t0(duthost, skip_load=False, hack_apply=False):
     # Wait for BGP sessions to establish BEFORE DB comparison.
     # After adding T0 config, BGP needs to converge and populate app-db route entries.
     # Comparing DBs before BGP convergence causes spurious mismatches in app-db.
-    assert wait_until(DB_COMP_WAIT_TIME, 20, 0, is_bgp_session_established,
-                      duthost, tor_data["ip"]["remote"]), \
-        "BGP IPv4 session for {} not established before DB comparison".format(tor_data["ip"]["remote"])
-    assert wait_until(DB_COMP_WAIT_TIME, 20, 0, is_bgp_session_established,
-                      duthost, tor_data["ipv6"]["remote"].lower()), \
-        "BGP IPv6 session for {} not established before DB comparison".format(tor_data["ipv6"]["remote"].lower())
+    v4_remote = tor_data.get("ip", {}).get("remote")
+    v6_remote = tor_data.get("ipv6", {}).get("remote")
+    if v4_remote:
+        assert wait_until(DB_COMP_WAIT_TIME, 20, 0, is_bgp_session_established,
+                          duthost, v4_remote), \
+            "BGP IPv4 session for {} not established before DB comparison".format(v4_remote)
+    if v6_remote:
+        assert wait_until(DB_COMP_WAIT_TIME, 20, 0, is_bgp_session_established,
+                          duthost, v6_remote.lower()), \
+            "BGP IPv6 session for {} not established before DB comparison".format(v6_remote.lower())
+    assert v4_remote or v6_remote, "No BGP neighbors detected for convergence check"
 
     assert wait_until(DB_COMP_WAIT_TIME, 20, 0, db_comp, duthost, patch_add_t0_dir,
                       orig_db_dir, "generic_patch_add_t0"), \


### PR DESCRIPTION

Summary: Fix IPv6-only topology support in generic_patch BGP convergence check
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #22895 added BGP session convergence wait before DB comparison in `generic_patch_add_t0()`, but unconditionally checks both IPv4 and IPv6 BGP sessions. On IPv6-only topologies (e.g. `t1-isolated-v6-d56u1-lag`), `tor_data["ip"]["remote"]` is empty, causing is_bgp_session_established() to fail.


#### How did you do it?
Fix by checking whether each neighbor IP exists before waiting for the BGP session, consistent with the `chk_any_bgp_session()` approach from PR #21591.


#### How did you verify/test it?
Regression test pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
