### PR TITLE
iface_namingmode: add topology marker to test_show_acl_table

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -1401,13 +1401,12 @@ class TestConfigInterface():
         _verify_speed(native_speed)
 
 
+@pytest.mark.topology('t1', 't2', 'lt2', 'ft2')
 def test_show_acl_table(setup, setup_config_mode, tbinfo):
     """
     Checks whether 'show acl table DATAACL' lists the interface names
     as per the configured naming mode
     """
-    if tbinfo['topo']['type'] not in ['t1', 't2', 'lt2', 'ft2']:
-        pytest.skip('Unsupported topology')
 
     if not setup['physical_interfaces']:
         pytest.skip('No non-portchannel member interface present')


### PR DESCRIPTION
### Description of PR

Summary:
`test_show_acl_table` was using a runtime `pytest.skip()` check to filter unsupported topologies. Since this check runs **after** fixture setup, `setup_config_mode` gets executed on unsupported topologies, causing errors instead of clean skips.

Replace the manual topology check with `@pytest.mark.topology('t1', 't2', 'lt2', 'ft2')` decorator, which is evaluated before any fixtures are instantiated, ensuring the test is properly skipped on non-t1/t2/lt2/ft2 topologies.

This matches the pattern already used by `TestNeighbors` and other test classes in the same file.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
On unsupported topologies, `setup_config_mode` fixture runs and fails before the skip check is reached, resulting in an error instead of a clean skip.

#### How did you do it?
Added `@pytest.mark.topology('t1', 't2', 'lt2', 'ft2')` decorator to the test function and removed the now-redundant manual `pytest.skip()` check.

#### How did you verify/test it?
Code inspection — the fix aligns with the established pattern used throughout the same file (e.g. `TestNeighbors`, `test_show_interfaces_neighbor_expected`).

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
t1, t2, lt2, ft2

### Documentation
N/A