### PR TITLE
Add INCLUDE_JOBS parameter to pre_defined_pr_test pipeline

### DIFF
--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -38,6 +38,10 @@ parameters:
   type: string
   default: ""
 
+- name: INCLUDE_JOBS
+  type: string
+  default: "all"
+
 stages:
 - stage: Test
   variables:
@@ -59,3 +63,4 @@ stages:
         TEST_PLAN_NUM: ${{ parameters.TEST_PLAN_NUM }}
         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
+        INCLUDE_JOBS: ${{ parameters.INCLUDE_JOBS }}


### PR DESCRIPTION
### Description of PR

Summary:
Pass the `INCLUDE_JOBS` parameter through `pre_defined_pr_test.yml` so that pre-defined PR test runs can execute the full job set (default `"all"`), complementing the change introduced in #23123.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
#23123 added `INCLUDE_JOBS` to `pr_test_template.yml` with a default of `t0_job,t1_job,t2_job` so that regular PR tests stay scoped to t0/t1/t2, while baseline tests pass `INCLUDE_JOBS: all` to run every job. However, `pre_defined_pr_test.yml` was not updated and therefore could not pass `INCLUDE_JOBS` through to the shared template. Pre-defined PR tests should be able to run all tests, so this parameter needs to be plumbed through.

#### How did you do it?
- Added a new `INCLUDE_JOBS` parameter (type: string, default: `"all"`) to `pre_defined_pr_test.yml`.
- Passed `INCLUDE_JOBS` into the stage template variables so the downstream `pr_test_template.yml` receives it and enables all jobs by default.

#### How did you verify/test it?
Verified the pipeline YAML syntax is valid and the parameter is correctly forwarded to the stage template variables.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A