### PR TITLE
Add ASIC-based skip condition for generic_config_updater/test_srv6

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2653,10 +2653,13 @@ generic_config_updater/test_pg_headroom_update.py:
 
 generic_config_updater/test_srv6:
   skip:
-    reason: "Unsupported topology."
+    reason: "SRv6 is not supported on older ASICs (TH/TH2/TD3, SPC1-3). Skip for unsupported topologies and platforms."
     conditions_logical_operator: "OR"
     conditions:
       - "topo_name in ['t0-isolated-d96u32s2']"
+      - "asic_type not in ['mellanox', 'broadcom', 'cisco', 'cisco-8000', 'vs'] or (release != 'master' and release < '202511')"
+      - "asic_type == 'mellanox' and asic_gen in ['spc1', 'spc2', 'spc3']"
+      - "asic_type == 'broadcom' and asic_gen not in ['th5']"
 
 generic_config_updater/test_vlan_interface.py::test_vlan_interface_tc1_suite:
   xfail:


### PR DESCRIPTION
### Description of PR

Summary:
Add ASIC-based skip conditions for `generic_config_updater/test_srv6` tests to prevent failures on platforms that do not support SRv6. The existing skip condition only covers topology (`t0-isolated-d96u32s2`), but SRv6 config updater tests also fail on older ASICs (Broadcom TH/TH2/TD3, Mellanox SPC1-3) because applying SRv6 CONFIG_DB entries triggers SAI errors caught by the loganalyzer during teardown.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Kusto data from 202511 .17 image (`20251110.17`) shows **122 out of 137** test runs of `generic_config_updater/test_srv6` failed. All failures occurred on non-SRv6-capable ASICs:



The regression grew across image versions: .15 had 0 failures, .16 had 4 failures, .17 had 122 failures due to broader platform test coverage.

PR #21713 adds similar ASIC-based skip conditions for `srv6/test_srv6_dataplane.py` but **misses** `generic_config_updater/test_srv6`. PR #23226 adds loganalyzer ignore for SRv6 SAI errors but doesn't address the root cause of running SRv6 config tests on unsupported platforms.

#### How did you do it?

Updated `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` to add ASIC-based skip conditions for `generic_config_updater/test_srv6`:

- Skip for unsupported ASIC types (not mellanox/broadcom/cisco/vs)
- Skip for Mellanox SPC1/SPC2/SPC3 (only SPC4+ supports SRv6)
- Skip for Broadcom non-TH5 (only TH5+ supports SRv6)
- Keep existing topology skip for `t0-isolated-d96u32s2`

The conditions use `OR` logic (skip if ANY condition matches) and follow the same pattern as `srv6/test_srv6_dataplane.py` skip conditions.

#### How did you verify/test it?

- Cross-referenced Kusto failure data across .15, .16, and .17 images
- Verified all 122 failures occur on ASICs that match the new skip conditions
- Confirmed passing platforms (TH5, SPC4+, Cisco Q200/Q201L) are NOT matched by skip conditions
- YAML syntax validated

#### Any platform specific information?

Platforms affected (will now be skipped):
- Broadcom TH, TH2, TD3 (all models)
- Mellanox SPC1, SPC2, SPC3 (all models)

Platforms NOT affected (will continue to run):
- Broadcom TH5+
- Mellanox SPC4+
- Cisco Q200, Q201L
- VS (virtual switch)

#### Supported testbed topology if it's a new test case?
N/A - bug fix for existing tests

### Documentation
N/A