### PR TITLE
Increase pfcwd storm timeout for high-port-count platforms (7260)

### DIFF
--- a/tests/pfcwd/test_pfcwd_all_port_storm.py
+++ b/tests/pfcwd/test_pfcwd_all_port_storm.py
@@ -240,6 +240,12 @@ class TestPfcwdAllPortStorm(object):
             # longer time to generate storm on all ports
             if tbinfo and tbinfo['topo']['type'] in ["lt2", "ft2"]:
                 timeout = 120
+            # Increase timeout for high-port-count platforms (e.g., 7260 with
+            # 108+ ports) where storm generation/restoration takes longer
+            num_ports = len(selected_test_ports)
+            if num_ports > 64:
+                timeout = max(timeout, 120)
+            logger.info(f"Using timeout {timeout}s for {num_ports} ports")
             pytest_assert(
                 wait_until(timeout, 2, 5, verify_all_ports_pfc_storm_in_expected_state, duthost,
                            storm_hndle, action, selected_test_ports, baseline_counters, threshold,


### PR DESCRIPTION
### Description of PR

Summary:
Extend the PFC storm timeout increase from PR #23253 to also cover high-port-count platforms like Arista-7260CX3-D108C8/D108C10 (108+ ports). These platforms consistently fail `test_all_port_storm_restore` because PFC storm generation and restoration takes longer than 60s when operating on 100+ ports.

PR #23253 addressed this for LT2/FT2 topologies. This PR uses a port-count-based heuristic (>64 ports) so it automatically covers any high-density platform regardless of topology.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Kusto data shows **100% failure rate** for `test_all_port_storm_restore` on Arista-7260CX3-D108C8 across all 202511 images:

| Image | Platform | Topology | Failures | Passes |
|-------|----------|----------|----------|--------|
| .12 | 7260CX3-D108C8 | t0 | 48 | 0 |
| .16 | 7260CX3-D108C8 | t0 | 12 | 0 |
| .17 | 7260CX3-D108C8 | t0 | 6 | 0 |
| .17 | 7260CX3-D108C8 | dualtor | 4 | 0 |
| .16 | 7260CX3-D108C10 | t0 | 4 | 0 |

All failures show: `Failed: Not enough ports reached restore state (threshold: 100%)`

The root cause is that the 7260 has 108 ports and the pfc_gen script on the leaf-fanout needs more time to fully start/stop storm generation across all ports. The default 60s timeout is insufficient.

#### How did you do it?

Added a port-count check alongside the existing LT2/FT2 topology check:

`python
num_ports = len(selected_test_ports)
if num_ports > 64:
    timeout = max(timeout, 120)
`

This uses `max()` so it doesn't override the LT2/FT2 timeout if that's already set. The threshold of 64 ports covers:
- Arista-7260CX3-D108C8 (108 ports)
- Arista-7260CX3-D108C10 (108 ports) 
- Any future high-density platform

#### How did you verify/test it?

- Analyzed 30 days of Kusto data confirming the timeout is the root cause
- Verified the logic preserves the LT2/FT2 fix from PR #23253
- No functional change for platforms with <=64 ports

#### Any platform specific information?

Primarily affects Arista-7260CX3-D108C8 and D108C10 (TH2, 108 ports). The fix is generic and will help any high-port-count platform.

#### Supported testbed topology if it's a new test case?
N/A - bug fix

### Documentation
N/A