### PR TITLE
[BMC] Add bmc-dual-mgmt testbed entry to testbed.yaml

### DIFF
--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -267,3 +267,19 @@
   inv_name: lab
   auto_recover: 'True'
   comment: Multi servers testbed demo
+
+- conf-name: bmc-dual-mgmt-01
+  group-name: bmc-dual-mgmt
+  topo: bmc-dual-mgmt
+  ptf_image_name: docker-ptf
+  ptf: ptf_bmc01
+  ptf_ip: 10.255.0.200/24
+  ptf_ipv6: 2001:db8:1::10/64
+  server: server_1
+  vm_base:
+  dut:
+    - switch01-bmc
+  bmc_host: switch01
+  inv_name: lab
+  auto_recover: 'False'
+  comment: BMC dual-mgmt testbed


### PR DESCRIPTION
### Description of PR

Summary:
Add example `bmc-dual-mgmt-01` testbed entry to `testbed.yaml` with the new `bmc_host` field for BMC-to-host CPU mapping.

This is part of the SONiC BMC test framework as described in the [BMC High-Level Test Plan](https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/bmc/BMC-high-level-test-plan.md), Section 3.1.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request

### Approach
#### What is the motivation for this PR?
BMC testbeds need a testbed.yaml entry that defines the BMC as DUT and maps it to the associated host (CPU) device via the `bmc_host` field. This field is consumed by `get_bmc_host()` to create a SonicHost instance for the host side during cross-device BMC tests (e.g., power cycle verification).

#### How did you do it?
Added a `bmc-dual-mgmt-01` entry to `ansible/testbed.yaml` with:
- `topo: bmc-dual-mgmt` — references the BMC dual-mgmt topology file
- `dut: [switch01-bmc]` — the BMC device as DUT
- `bmc_host: switch01` — new field mapping BMC to its host CPU
- `vm_base:` empty — no VMs needed for BMC topology
- `auto_recover: 'False'` — BMC recovery requires special handling

#### How did you verify/test it?
- Validated YAML parsing with `yaml.safe_load()` — all fields parse correctly
- Verified `bmc_host` field is preserved in the parsed dict (it flows through to `tbinfo` automatically since `_read_regular_testbed_topo_from_yaml` preserves all fields)

#### Any platform specific information?
Applies to BMC testbeds using the bmc-dual-mgmt topology.

#### Supported testbed topology if it is a new test case?
N/A — this PR adds testbed configuration only.

### Documentation
- Aligns with the [BMC High-Level Test Plan](https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/bmc/BMC-high-level-test-plan.md), Section 3.1.
