### PR TITLE
GCU: skip ECN test for certain Cisco platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2507,12 +2507,10 @@ generic_config_updater/test_dynamic_acl.py::test_gcu_acl_forward_rule_replacemen
 
 generic_config_updater/test_ecn_config_update.py::test_ecn_config_updates:
   skip:
-    # Cisco-8800-LC-48H-C48 (PAC ASIC) and Cisco-8122 (GR2 ASIC) platforms are skipped because
-    # dynamic WRED configuration updates are not yet implemented in the SAI layer for these ASICs.
     reason: "WRED dynamic config updates not implemented in SAI for PAC/GR2 ASICs"
     conditions_logical_operator: "OR"
     conditions:
-      - "hwsku in ['Cisco-8800-LC-48H-C48', 'Cisco-8122-O128S2'] or hwsku.startswith('Cisco-8122-O64')"
+      - "hwsku in ['Cisco-8800-LC-48H-C48', 'Cisco-8122-O128S2', 'Cisco-8122-O64']"
       - "topo_type in ['m0', 'mx', 'm1']"
       - "release in ['202211']"
       - "https://github.com/sonic-net/sonic-buildimage/issues/22295 and platform in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0']"

--- a/tests/generic_config_updater/test_ecn_config_update.py
+++ b/tests/generic_config_updater/test_ecn_config_update.py
@@ -1,17 +1,4 @@
 """Tests for ECN/WRED configuration updates via Generic Config Updater.
-
-Note on Platform Support:
-    This test validates that WRED profile changes in CONFIG_DB propagate correctly
-    to ASIC_DB. The following Cisco 8000 platforms are skipped:
-
-    - Cisco-8800-LC-48H-C48 (PAC ASIC): WRED dynamic updates not implemented in SAI
-    - Cisco-8122-O128S2, Cisco-8122-O64 (GR2 ASIC): WRED dynamic updates not implemented in SAI
-
-    The GR2 SAI layer (sai_wred_manager_gr2.cpp) has stub implementations for WRED
-    configuration functions. CONFIG_DB changes are accepted but don't propagate to
-    hardware or ASIC_DB.
-
-    Other Cisco 8000 platforms (GB/GR ASICs like 8101, 8102, 8111) are supported.
 """
 import ast
 from functools import cmp_to_key


### PR DESCRIPTION
### Description of PR

Summary:
Add skip conditions for Cisco 8000 GR2 ASIC platforms (Cisco-8122) to `test_ecn_config_updates`. These platforms do not support dynamic WRED configuration updates in the SAI layer.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?

The `test_ecn_config_updates` test validates that WRED profile changes in CONFIG_DB propagate correctly to ASIC_DB. On Cisco-8122 platforms (GR2 ASIC), dynamic WRED configuration updates are not implemented in the SAI layer. CONFIG_DB changes are accepted but don't propagate to ASIC_DB, causing the test to fail.

The existing skip for Cisco-8800-LC-48H-C48 (PAC ASIC) has the same root cause.

#### How did you do it?

- Added Cisco-8122-O128S2 and Cisco-8122-O64 hwskus to the existing skip conditions
- Updated the skip reason to clarify it applies to PAC and GR2 ASICs

#### How did you verify/test it?

Verified test fails on Cisco-8122 platforms without this skip, and is correctly skipped after the change.

#### Any platform specific information?

Affects Cisco 8000 platforms with PAC or GR2 ASICs:
- Cisco-8800-LC-48H-C48 (PAC ASIC) - already skipped
- Cisco-8122-O128S2, Cisco-8122-O64 (GR2 ASIC) - newly added

Other Cisco 8000 platforms (GB/GR ASICs like 8101, 8102, 8111) are supported.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation
