### PR TITLE
[BMC] Improve BMC validators to use testbed.yaml instead of naming convention

### DIFF
--- a/ansible/scripts/meta/validators/ip_address_validator.py
+++ b/ansible/scripts/meta/validators/ip_address_validator.py
@@ -66,6 +66,8 @@ class IpAddressValidator(GlobalValidator):
             context: ValidatorContext containing testbed and connection graph data
         """
         testbed_info = context.get_testbeds()
+        self._bmc_device_groups = self._build_bmc_device_groups(
+            testbed_info)
 
         # Collect all IP addresses from all groups
         ip_addresses, device_ips = self._collect_all_ip_addresses_globally(context, testbed_info)
@@ -344,24 +346,49 @@ class IpAddressValidator(GlobalValidator):
             device_ips[device_name][group_name][source_type] = {}
         device_ips[device_name][group_name][source_type][ip_type] = ip_addr
 
+    def _build_bmc_device_groups(self, testbed_info):
+        """
+        Build groups of devices that are the same BMC physical device
+        from testbed.yaml entries.
+
+        A BMC DUT and its console server counterpart (e.g., switch01-bmc
+        and switch01-bmc-con) share the same management IP. This method
+        reads the testbed entries to find BMC DUTs (those with bmc_host)
+        and their associated console server devices from devices.csv.
+
+        Returns:
+            list[set]: List of device name sets that share the same
+                physical BMC device and may legitimately share IPs.
+        """
+        groups = []
+        for tb in testbed_info:
+            if not isinstance(tb, dict):
+                continue
+            bmc_host = tb.get('bmc_host')
+            duts = tb.get('duts', tb.get('dut', []))
+            if not bmc_host or not duts:
+                continue
+            # The BMC DUT and its -con counterpart are the same device
+            for dut in duts:
+                groups.append({dut, dut + '-con'})
+        return groups
+
     def _is_bmc_con_pair(self, device1_name, device2_name):
         """
-        Check if two devices are a BMC device and its console server counterpart.
-
-        A BMC device (e.g., switch01-bmc) and its console server role (e.g., switch01-bmc-con)
-        are the same physical device and legitimately share the same management IP.
+        Check if two devices are a BMC device and its console server
+        counterpart based on testbed.yaml configuration.
 
         Args:
             device1_name: Name of the first device
             device2_name: Name of the second device
 
         Returns:
-            bool: True if one is a BMC device and the other is its console server role
+            bool: True if both devices belong to the same BMC device
+                group as defined in testbed.yaml.
         """
-        if device1_name + "-con" == device2_name:
-            return "-bmc" in device1_name
-        if device2_name + "-con" == device1_name:
-            return "-bmc" in device2_name
+        for group in self._bmc_device_groups:
+            if device1_name in group and device2_name in group:
+                return True
         return False
 
     def _should_allow_conflict(self, device1_name, device2_name):

--- a/ansible/scripts/meta/validators/pdu_validator.py
+++ b/ansible/scripts/meta/validators/pdu_validator.py
@@ -45,6 +45,9 @@ class PDUValidator(GlobalValidator):
         Args:
             context: ValidatorContext containing testbed and connection graph data
         """
+        testbed_info = context.get_testbeds()
+        self._bmc_host_pairs = self._build_bmc_host_pairs(
+            testbed_info)
 
         # Collect PDU connection data from all groups
         pdu_data = self._collect_pdu_data_globally(context)
@@ -352,10 +355,30 @@ class PDUValidator(GlobalValidator):
                 )
 
     @staticmethod
-    def _is_bmc_host_pair(device1, device2):
-        """Check if two devices are a BMC and its host sharing the same chassis."""
-        if device1 + "-bmc" == device2:
-            return True
-        if device2 + "-bmc" == device1:
-            return True
+    def _build_bmc_host_pairs(testbed_info):
+        """
+        Build pairs of (bmc_dut, host) from testbed.yaml bmc_host field.
+
+        Returns:
+            list[set]: List of device name sets where each set contains
+                a BMC DUT and its host that share the same chassis/PSU.
+        """
+        pairs = []
+        for tb in testbed_info:
+            if not isinstance(tb, dict):
+                continue
+            bmc_host = tb.get('bmc_host')
+            duts = tb.get('duts', tb.get('dut', []))
+            if not bmc_host or not duts:
+                continue
+            for dut in duts:
+                pairs.append({dut, bmc_host})
+        return pairs
+
+    def _is_bmc_host_pair(self, device1, device2):
+        """Check if two devices are a BMC and its host sharing the
+        same chassis, based on testbed.yaml bmc_host mapping."""
+        for pair in self._bmc_host_pairs:
+            if device1 in pair and device2 in pair:
+                return True
         return False


### PR DESCRIPTION
### Description of PR

Summary:
Replace hardcoded hostname pattern matching in BMC IP and PDU validators with testbed.yaml-driven lookups, addressing review comments from PR #23195.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request

### Approach
#### What is the motivation for this PR?
The BMC validators added in PR #23195 used hardcoded naming conventions (e.g., checking for `-bmc` suffix) to identify BMC device relationships. This is fragile and not portable. The information is already available in testbed.yaml via the `bmc_host` field.

#### How did you do it?
- **ip_address_validator**: Added `_build_bmc_device_groups()` that reads testbed entries with `bmc_host` field to build groups of devices (BMC DUT + its `-con` counterpart) that legitimately share IPs.
- **pdu_validator**: Added `_build_bmc_host_pairs()` that reads the `bmc_host` mapping to build pairs of devices (BMC DUT + host CPU) that share the same chassis and PDU ports.
- Both use `context.get_testbeds()` which is already available in the `ValidatorContext`.

#### How did you verify/test it?
- Verified flake8 passes with `--max-line-length=120`
- Logic is equivalent to the previous naming-based approach but driven by testbed configuration

#### Any platform specific information?
N/A

#### Supported testbed topology if it is a new test case?
N/A

### Documentation
- Addresses review comments from [PR #23195](https://github.com/sonic-net/sonic-mgmt/pull/23195).
