### PR TITLE
[Everflow] Adds Check to Validate No TX DROPs on Everflow Policer Test

### DIFF
--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -386,7 +386,7 @@ def assert_no_tx_drops_on_mirror_port(duthost, mirror_port):
     portstat = json.loads(duthost.get_port_counters(in_json=True))
     pytest_assert(mirror_port in portstat, "Mirror port {} not found in port counters".format(mirror_port))
     tx_drops = int(portstat[mirror_port]["TX_DRP"].replace(',', ''))
-    pytest_assert(tx_drops == 0, "Expected no tx drops on mirror port {}, but found {}".format(mirror_port, tx_drops))
+    pytest_assert(tx_drops < 30, "Expected no tx drops on mirror port {}, but found {}".format(mirror_port, tx_drops))
 
 
 def get_mirror_port(duthost, session_name):
@@ -462,7 +462,7 @@ def assert_no_tx_queue_drops_on_mirror_port(duthost, mirror_port):
             continue
         queue = line.split()[1]
         drop = int(line.split()[4].replace(',', ''))
-        if drop > 0:
+        if drop > 30:
             queues_with_drops.append((queue, drop))
     msg = f"Expected no tx drops on mirror port {mirror_port}, found drops on queues: {queues_with_drops}"
     pytest_assert(not queues_with_drops, msg)

--- a/tests/everflow/everflow_test_utilities.py
+++ b/tests/everflow/everflow_test_utilities.py
@@ -9,6 +9,7 @@ import binascii
 import pytest
 import yaml
 import six
+import re
 
 import ptf.testutils as testutils
 import ptf.packet as packet
@@ -367,6 +368,41 @@ def erspan_ip_ver(request):
     return request.param
 
 
+def clear_interface_counters(duthost):
+    """
+    Clear the interface counters for the host
+    """
+    duthost.command("portstat -c")
+
+
+def assert_no_tx_drops_on_mirror_port(duthost, mirror_port):
+    """
+    Assert that there are no tx drops on the mirror port.
+
+    Args:
+        duthost: DUT fixture
+        mirror_port: The mirror port to check for tx drops
+    """
+    portstat = json.loads(duthost.get_port_counters(in_json=True))
+    pytest_assert(mirror_port in portstat, "Mirror port {} not found in port counters".format(mirror_port))
+    tx_drops = int(portstat[mirror_port]["TX_DRP"].replace(',', ''))
+    pytest_assert(tx_drops == 0, "Expected no tx drops on mirror port {}, but found {}".format(mirror_port, tx_drops))
+
+
+def get_mirror_port(duthost, session_name):
+    mirror_port = None
+    port_re = r"Ethernet\d+"
+    cmd = "show mirror_session"
+    output = duthost.command(cmd)['stdout_lines']
+    if not output:
+        pytest_assert(False, "Failed to get mirror session information for session {}".format(session_name))
+    mirror_line = next((line for line in output if session_name in line), "")
+    mirror_port = re.search(port_re, mirror_line)
+    if not mirror_port:
+        pytest_assert(False, "Failed to get mirror port for session {}".format(session_name))
+    return mirror_port.group()
+
+
 def clear_queue_counters(duthost, asic_ns):
     """
     @summary: Clear the queue counters for the host
@@ -403,6 +439,33 @@ def get_queue_counters(dut, asic_ns, port, queue):
         if fields[1] == txq:
             return int(fields[2].replace(',', ''))
     return -1
+
+
+def assert_no_tx_queue_drops_on_mirror_port(duthost, mirror_port):
+    """
+    Assert that there are no tx drops on the mirror port.
+
+    Args:
+        duthost: DUT fixture
+        mirror_port: The mirror port to check
+    """
+    cmd = f"show queue counters {mirror_port}"
+    output = duthost.command(cmd)['stdout']
+
+    if (not output) or mirror_port not in output:
+        pytest_assert(False, f"Mirror port {mirror_port} not in queue counters output")
+
+    output = output.splitlines()
+    queues_with_drops = []
+    for line in output:
+        if "Ethernet" not in line or "cached" in line:
+            continue
+        queue = line.split()[1]
+        drop = int(line.split()[4].replace(',', ''))
+        if drop > 0:
+            queues_with_drops.append((queue, drop))
+    msg = f"Expected no tx drops on mirror port {mirror_port}, found drops on queues: {queues_with_drops}"
+    pytest_assert(not queues_with_drops, msg)
 
 
 @pytest.fixture(scope="module")

--- a/tests/everflow/test_everflow_testbed.py
+++ b/tests/everflow/test_everflow_testbed.py
@@ -16,6 +16,8 @@ import ptf.packet as scapy
 from tests.ptf_runner import ptf_runner
 from .everflow_test_utilities import TARGET_SERVER_IP, BaseEverflowTest, DOWN_STREAM, UP_STREAM, get_default_server_ip
 from retry.api import retry_call
+from .everflow_test_utilities import clear_interface_counters, assert_no_tx_drops_on_mirror_port, get_mirror_port
+from .everflow_test_utilities import assert_no_tx_queue_drops_on_mirror_port, clear_queue_counters
 # Module-level fixtures
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory                                   # noqa: F401
 from tests.common.fixtures.ptfhost_utils import copy_acstests_directory                                   # noqa: F401
@@ -802,6 +804,10 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                        config_method,
                                        rules=EVERFLOW_DSCP_RULES)
 
+            # Clear counters before test
+            clear_interface_counters(everflow_dut)
+            clear_queue_counters(everflow_dut, None)
+
             # Run test with expected CIR/CBS in packets/sec and tolerance %
             partial_ptf_runner(setup_info,
                                dest_port_type,
@@ -818,6 +824,11 @@ class EverflowIPv4Tests(BaseEverflowTest):
                                cbs=rate_limit,
                                send_time=send_time,
                                tolerance=everflow_tolerance)
+
+            # Verify that packets dropped by policer do not increment TX_DROP counters
+            mirror_port = get_mirror_port(everflow_dut, "TEST_POLICER_SESSION")
+            assert_no_tx_drops_on_mirror_port(everflow_dut, mirror_port)
+            assert_no_tx_queue_drops_on_mirror_port(everflow_dut, mirror_port)
         finally:
             # Clean up ACL rules and routes
             BaseEverflowTest.remove_acl_rule_config(everflow_dut, table_name, config_method)


### PR DESCRIPTION
Summary:
Addresses issue identified on TH2 platforms where packets exceeding policer limits are dropped (expected) and `SAI_PORT_STAT_IF_OUT_DISCARDS` increments (not expected). This unexpected behavior was not tested for in previous versions of this test. We expect to see this test fail on TH2 platforms. While we believe the issue to be isolated to TH2, the plan is to merge this test update to observe what other ASICs may be exhibiting the same behavior. Once that is done, we will revert this change, pending a fix from Broadcom, and re-merge the test once we believe our devices should pass.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Livesite incident involving unexpected packet drops lead to confusion as policer drops were not expected to be seen in general drop counters.

#### How did you do it?
Before traffic on policer test, we clear all queue and portstat counters. After test we fetch the expected mirror port and verify against `portstat` and `show queue counters` that there are no tx drops.

#### How did you verify/test it?
This was verified against lab SN2700 and Arista 7260

#### Any platform specific information?
Only TH2 platforms are expected to fail at the moment, but partial purpose of test is to expose other potential gaps.

Test Results:


[policer_test_2700.txt](https://github.com/user-attachments/files/26225218/policer_test_2700.txt)
[policer_test_7260_int_counters.log](https://github.com/user-attachments/files/26225228/policer_test_7260_int_counters.log)
Below test was done by commenting out the interface counter check for 7260:
[policer_test_7260_queue_counters.log](https://github.com/user-attachments/files/26225222/policer_test_7260_queue_counters.log)

