### PR TITLE
Ignore transient monit errors during stress ARP on dualtor testbeds

### DIFF
--- a/tests/arp/test_stress_arp.py
+++ b/tests/arp/test_stress_arp.py
@@ -46,13 +46,25 @@ def ignore_errors_for_non_selected_dualtor_hosts(
         # There is a known issue which causes redundant route entry delete and reports an ERR log.
         # FYI, https://github.com/sonic-net/sonic-swss/issues/2579
         # This error can be safely ignored on standby
-        error_patterns = [
+        standby_error_patterns = [
             ".*ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\".*\",\"switch_id\":\"oid:.*\",\"vr\":\"oid:.*\"} doesn't exist",  # noqa: E501
         ]
         for duthost in duthosts:
             if duthost.hostname != enum_rand_one_per_hwsku_frontend_hostname:
                 if loganalyzer and duthost.hostname in loganalyzer:
-                    loganalyzer[duthost.hostname].ignore_regex.extend(error_patterns)
+                    loganalyzer[duthost.hostname].ignore_regex.extend(standby_error_patterns)
+
+        # The stress ARP flood overwhelms orchagent/muxorch on dualtor testbeds, causing transient
+        # monit check failures while orchagent processes the neighbor/route churn (~18 min recovery).
+        # These are expected during stress testing and not indicative of a real problem.
+        # Tracked: ADO 37245786
+        monit_error_patterns = [
+            r".*ERR monit\[\d+\]: 'dualtorNeighborCheck' status failed.*",
+            r".*ERR monit\[\d+\]: 'routeCheck' status failed.*",
+        ]
+        for duthost in duthosts:
+            if loganalyzer and duthost.hostname in loganalyzer:
+                loganalyzer[duthost.hostname].ignore_regex.extend(monit_error_patterns)
     yield
 
 


### PR DESCRIPTION
## Description
The stress ARP flood overwhelms orchagent/muxorch on dualtor testbeds, causing transient `dualtorNeighborCheck` and `routeCheck` monit failures while orchagent processes the neighbor/route churn (~18 min recovery). These are expected during stress testing and orchagent fully catches up — no permanent route leaks.

### Changes
Add loganalyzer ignore patterns for `dualtorNeighborCheck` and `routeCheck` monit ERR logs on all dualtor hosts during `test_stress_arp` tests.

### Evidence
- **Feb 28 run:** 5,149 addNeighbor burst, only 1,619 (31%) got mux processing before neighborCheck fired ~90s later
- **Mar 24 run:** 7,846 addNeighbor burst, only 372 (4.7%) got mux processing. 34,621 tunnel routes removed over ~18 minutes. Both routeCheck and dualtorNeighborCheck failed simultaneously.
- 7 confirmed dualtor neighborCheck failures (Dec 2025 – Feb 2026), 3 routeCheck failures on dualtor testbeds. Non-dualtor testbeds unaffected.

### Tracking
- **ADO 37245786** — Investigate orchagent processing performance under dualtor neighbor/route churn (follow-up work)
- **ADO 35637971** — Original nightly test failure where this was discovered