### PR TITLE
Allow SNMP interface error/discard test to tolerate some live traffic

### DIFF
--- a/tests/snmp/test_snmp_interfaces.py
+++ b/tests/snmp/test_snmp_interfaces.py
@@ -252,7 +252,7 @@ def verify_snmp_counter(duthost, localhost, creds_all_duts, hostip, mg_facts, ri
 
     Allows a small margin of error to account for live traffic that may cause
     additional discards/errors between when counters are set and when SNMP is queried.
-    The margin is the lesser of 10% of the expected value or 100 packets.
+    The margin is the lesser of 5% of the expected value or 100 packets.
 
     Returns False if:
     - Counter is below expected value (test counters not applied)


### PR DESCRIPTION
## Description of PR

Summary:
Fix flaky `test_snmp_interfaces_error_discard` test by using >= comparison instead of exact equality when verifying SNMP counters.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [ ] Skipped for non-supported platforms
- [ ] Test case improvement



### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?

The `test_snmp_interfaces_error_discard` test fails intermittently with errors like:
```
ifInDiscards value is 10018 but must be 10000
```

This occurs because live traffic on the test interface can cause additional discards between when the test sets counter values in Redis and when SNMP is queried. The test expects exact counter values, but real traffic on PortChannel member interfaces adds extra discards.

#### How did you do it?

Changed the counter verification from exact equality (`!=`) to minimum threshold (`<`) comparison. The test now passes if the SNMP counter value is **at least** the expected value, tolerating additional discards from live traffic. The amount of live traffic, however, is limited to 100 packets or 5% of the expected total count, whichever is less.

#### How did you verify/test it?

The fix addresses the root cause identified in test failure logs where `ifInDiscards` showed 10018 instead of 10000 due to 18 extra discards on a PortChannel member interface from live traffic.

#### Any platform specific information?

No platform-specific changes. The fix applies to all platforms.

#### Supported testbed topology if it's a new test case?

N/A - existing test case fix.