### PR TITLE
[ha] enable software bfd on dpu

### DIFF
--- a/ansible/golden_config_db/smartswitch_dpu_extra.json
+++ b/ansible/golden_config_db/smartswitch_dpu_extra.json
@@ -24,5 +24,10 @@
             "log_level": "2",
             "port": "50052"
         }
+    },
+    "SYSTEM_DEFAULTS": {
+        "software_bfd": {
+            "status": "enabled"
+        }
     }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

If not enabled, bfdmgr won't be started and  software bfd session won't be created. 
https://github.com/sonic-net/sonic-buildimage/blob/86942115b28069715c146a8dc3bd0310a4ec201b/src/sonic-bgpcfgd/bgpcfgd/main.py#L118

sign-off: Jing Zhang zhangjing@microsoft.com


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [X] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To enable software BFD on DPU. Otherwise bfd sessions on NPU will always be down and there won't be any active nexthop for vnet route. 

#### How did you do it?
Add the config db table entry to DPU extra config json file. 

#### How did you verify/test it?
Added the config manually, config reload DPU, added software bfd session in DPU state db, confirmed the BFD sessions are up on NPU. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
