### PR TITLE
[TH6-128] Update FRR bgp memory due to higher bgp sessions count for TH6-128 Nokia HWSKU

### DIFF
--- a/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
+++ b/tests/common/plugins/memory_utilization/memory_utilization_dependence.json
@@ -5,7 +5,8 @@
     "Arista-7060X6": ["Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-16PE-384C-B-O128S2", "Arista-7060X6-64PE-B-O128"],
     "Mellanox-SN5640": ["Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512S2"],
     "Arista-7060CX": ["Arista-7060CX-32S-C32", "Arista-7060CX-32S-D48C8"],
-    "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"]
+    "Arista-7260CX3": ["Arista-7260CX3-C64", "Arista-7260CX3-D108C8", "Arista-7260CX3-D108C10"],
+    "Nokia-IXR7220": ["Nokia-IXR7220-H6-O256"]
   },
   "COMMON": [
     {
@@ -357,6 +358,26 @@
         }
       },
       "memory_check": "parse_docker_stats_output"
+    }
+  ],
+  "Nokia-IXR7220": [
+    {
+      "name": "frr_bgp",
+      "cmd": "vtysh -c \"show memory bgp\"",
+      "memory_params": {
+        "used": {
+          "memory_increase_threshold": [
+            {"type": "percentage", "value": "50%"},
+            {"type": "value", "value": 64},
+            {"type": "comparison", "value": "max"}
+          ],
+          "memory_high_threshold": {
+            "type": "value",
+            "value": 384
+          }
+        }
+      },
+      "memory_check": "parse_frr_memory_output"
     }
   ]
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

- This PR fixes fixes _frr_bgp_ _memory_utilization_ issue where all the pretest tests fail at teardown for TH6-128 Nokia HWSKU.

```
            if errors:
                failure_message = "\n".join(errors)
                logger.error(f"Memory errors detected in fixture teardown: {failure_message}")
>               pytest.fail(failure_message)
E               Failed: [ALARM]: frr_bgp:used, Previous memory usage 298.0 MB exceeds high threshold 256.0 MB (previous: 298.0 MB, current: 298.0 MB)
E               [ALARM]: frr_bgp:used, Current memory usage 298.0 MB exceeds high threshold 256.0 MB (previous: 298.0 MB, current: 298.0 MB)
``` 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

- For TH6 new HWSKUs with breakout config, the number of neighbors is **_doubled_** than the actual 800G config HWSKU. Due to this, frr_bgp memory utilization threshold needs to be modified accordingly.

#### How did you do it?

- Add the new HWSKU to 'Nokia-IXR7220' bucket and increase the threshold value.

#### How did you verify/test it?

- Ran pretests with the fix and made sure all the pretests are running fine without any memory related issues.

#### Any platform specific information?

- LT2 topo

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
