### PR TITLE
Use sfp.get_power_override_support instead of hardcoded checks

### DIFF
--- a/tests/common/helpers/platform_api/sfp.py
+++ b/tests/common/helpers/platform_api/sfp.py
@@ -106,6 +106,10 @@ def get_power_override(conn, index):
     return sfp_api(conn, index, 'get_power_override')
 
 
+def get_power_override_support(conn, index):
+    return sfp_api(conn, index, 'get_power_override_support')
+
+
 def get_temperature(conn, index):
     return sfp_api(conn, index, 'get_temperature')
 

--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -964,7 +964,15 @@ class TestSfpApi(PlatformApiTestBase):
             if not self.expect(info_dict is not None, "Unable to retrieve transceiver {} info".format(i)):
                 continue
 
-            if not self.is_xcvr_support_power_override(info_dict):
+            try:
+                power_override_support = sfp.get_power_override_support(platform_api_conn, i)
+            except NotImplementedError:
+                power_override_support = None
+
+            if power_override_support is None:
+                power_override_support = self.is_xcvr_support_power_override(info_dict)
+
+            if not power_override_support:
                 logger.warning(
                     "test_power_override: Skipping transceiver {} (not applicable for this transceiver type)"
                     .format(i))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Dependent on https://github.com/sonic-net/sonic-platform-common/pull/641

Summary:
Fixes https://github.com/sonic-net/sonic-buildimage/issues/26372

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR adds support for the get_power_override_support API within the platform API test helpers and updates existing SFP test logic.

Previously, the test suite relied on a local helper that used string matching on transceiver types (e.g., checking for "QSFP" but not "QSFP-DD") to guess support. By using the official API, the tests are now more accurate and platform-agnostic, relying on the actual hardware capabilities reported by the platform layer.

#### How did you do it?
tests/common/helpers/platform_api/sfp.py: Added a helper function to wrap the new get_power_override_support call.

tests/platform_tests/api/test_sfp.py: Refactored the test logic to remove the local, hardcoded is_xcvr_support_power_override check. It now queries the platform API directly to determine support.

#### How did you verify/test it?
Ran tests/platform_tests/api/test_sfp.py on an Arista platform. Verified that the test correctly skips or executes power override test cases based on the boolean returned by the platform's SFP implementation rather than the old string-matching logic.

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
NA
