### PR TITLE
test_qos_sai: prevent cascading failures after fixture error

### DIFF
--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -185,14 +185,16 @@ def pytest_sessionstart(session):
 
 
 def pytest_runtest_makereport(item, call):
-    """Record fixture failures during setup to skip subsequent tests in the same parameter set."""
+    """Record testParameter setup failures to cascade-skip subsequent tests in the same parameter set."""
     if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
+        return
+    if 'fixture_seed' not in item.keywords:
         return
 
     if call.when == "setup" and call.excinfo is not None:
-        test_name = item.name
-        if '[' in test_name:
-            param_set = test_name.split('[')[1].rstrip(']')
+        callspec = getattr(item, 'callspec', None)
+        if callspec and 'select_src_dst_dut_and_asic' in callspec.params:
+            param_set = callspec.params['select_src_dst_dut_and_asic']
         else:
             param_set = 'default'
 
@@ -208,9 +210,9 @@ def pytest_runtest_setup(item):
     if 'fixture_seed' in item.keywords:
         return
 
-    test_name = item.name
-    if '[' in test_name:
-        param_set = test_name.split('[')[1].rstrip(']')
+    callspec = getattr(item, 'callspec', None)
+    if callspec and 'select_src_dst_dut_and_asic' in callspec.params:
+        param_set = callspec.params['select_src_dst_dut_and_asic']
     else:
         param_set = 'default'
 

--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -175,49 +175,51 @@ def skip_lossy_buffer_only(is_lossy_only_pool):
         pytest.skip("Skip test for lossy only pool")
 
 
-# Global variable to track fixture failures per parameter set for TestQosSai
-_fixture_failures = {}
+# Maps a TestQosSai parameter set (select_src_dst_dut_and_asic value) to the
+# nodeid of a seed test whose fixture failed during setup, so downstream cases
+# in that set xfail instead of re-erroring on the same root cause. Per-worker
+# under xdist: only suppresses when seed and derivatives share a worker (serial
+# or --dist loadscope/loadgroup); plain --dist load falls back to per-case ERROR.
+_qos_sai_fixture_failures = {}
 
 
 def pytest_sessionstart(session):
-    """Clear fixture failure tracking to prevent stale state in pytest-xdist workers."""
-    _fixture_failures.clear()
+    """Reset tracking so stale entries can't leak across reused pytest-xdist workers."""
+    _qos_sai_fixture_failures.clear()
+
+
+def _is_qos_sai_item(item):
+    return bool(getattr(item, 'cls', None)) and item.cls.__name__ == 'TestQosSai'
+
+
+def _qos_sai_param_set(item):
+    """Return the select_src_dst_dut_and_asic parameter set for a TestQosSai item, or 'default'."""
+    callspec = getattr(item, 'callspec', None)
+    if callspec and 'select_src_dst_dut_and_asic' in callspec.params:
+        return callspec.params['select_src_dst_dut_and_asic']
+    return 'default'
 
 
 def pytest_runtest_makereport(item, call):
-    """Record testParameter setup failures to cascade-skip subsequent tests in the same parameter set."""
-    if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
+    """Record a seed (testParameter) setup failure to suppress cascades in the same parameter set."""
+    if not _is_qos_sai_item(item) or 'fixture_seed' not in item.keywords:
         return
-    if 'fixture_seed' not in item.keywords:
-        return
-
     if call.when == "setup" and call.excinfo is not None:
-        callspec = getattr(item, 'callspec', None)
-        if callspec and 'select_src_dst_dut_and_asic' in callspec.params:
-            param_set = callspec.params['select_src_dst_dut_and_asic']
-        else:
-            param_set = 'default'
-
-        _fixture_failures[param_set] = True
+        _qos_sai_fixture_failures[_qos_sai_param_set(item)] = item.nodeid
 
 
 def pytest_runtest_setup(item):
-    """Skip tests if fixtures failed for this parameter set."""
-    if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
+    """xfail downstream TestQosSai cases whose parameter set already failed its seed fixture."""
+    if not _is_qos_sai_item(item):
         return
 
-    # Don't skip seed tests - let them fail naturally to show the root cause
+    # Seed tests must fail naturally so the root cause surfaces as an ERROR.
     if 'fixture_seed' in item.keywords:
         return
 
-    callspec = getattr(item, 'callspec', None)
-    if callspec and 'select_src_dst_dut_and_asic' in callspec.params:
-        param_set = callspec.params['select_src_dst_dut_and_asic']
-    else:
-        param_set = 'default'
-
-    if param_set in _fixture_failures:
-        pytest.skip(f"Skipping because fixtures failed for parameter set [{param_set}]")
+    seed = _qos_sai_fixture_failures.get(_qos_sai_param_set(item))
+    if seed:
+        pytest.xfail(f"seed fixture failed for this parameter set; see {seed}")
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -175,6 +175,62 @@ def skip_lossy_buffer_only(is_lossy_only_pool):
         pytest.skip("Skip test for lossy only pool")
 
 
+# Global variable to track fixture failures per parameter set for TestQosSai
+_fixture_failures = {}
+
+
+def pytest_runtest_makereport(item, call):
+    """Pytest hook that runs after each test phase (setup/call/teardown).
+
+    This hook detects fixture failures during setup and records them so that
+    subsequent tests in the same parameter set can be skipped.
+    """
+    # Only track setup failures for TestQosSai tests
+    if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
+        return
+
+    # Check if setup phase failed
+    if call.when == "setup" and call.excinfo is not None:
+        # A fixture failed during setup - extract parameter set
+        test_name = item.name
+        if '[' in test_name:
+            params = test_name.split('[')[1].rstrip(']')
+            param_set = params.split('-')[0]
+        else:
+            param_set = 'default'
+
+        # Mark this parameter set as having fixture failures
+        _fixture_failures[param_set] = True
+
+
+def pytest_runtest_setup(item):
+    """Pytest hook that runs before any test setup (including fixtures).
+
+    This hook skips tests if fixtures failed for this parameter set.
+    """
+    # Only apply to tests in TestQosSai class
+    if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
+        return
+
+    # Don't skip testParameter itself - let it run and fail naturally
+    if 'testParameter' in item.name:
+        return
+
+    # Extract parameter set from test name
+    # Format: testName[param_set-other_params] or testName[param_set]
+    test_name = item.name
+    if '[' in test_name:
+        params = test_name.split('[')[1].rstrip(']')
+        # Get the first parameter (the fixture parameter set like 'single_asic')
+        param_set = params.split('-')[0]
+    else:
+        param_set = 'default'
+
+    # Skip if fixtures failed for this parameter set
+    if param_set in _fixture_failures:
+        pytest.skip(f"Skipping because fixtures failed for parameter set [{param_set}]")
+
+
 @pytest.fixture(scope="module", autouse=True)
 def enable_dscp_remapping_on_dualtor_flag(request, duthost):
     """

--- a/tests/qos/conftest.py
+++ b/tests/qos/conftest.py
@@ -179,54 +179,41 @@ def skip_lossy_buffer_only(is_lossy_only_pool):
 _fixture_failures = {}
 
 
-def pytest_runtest_makereport(item, call):
-    """Pytest hook that runs after each test phase (setup/call/teardown).
+def pytest_sessionstart(session):
+    """Clear fixture failure tracking to prevent stale state in pytest-xdist workers."""
+    _fixture_failures.clear()
 
-    This hook detects fixture failures during setup and records them so that
-    subsequent tests in the same parameter set can be skipped.
-    """
-    # Only track setup failures for TestQosSai tests
+
+def pytest_runtest_makereport(item, call):
+    """Record fixture failures during setup to skip subsequent tests in the same parameter set."""
     if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
         return
 
-    # Check if setup phase failed
     if call.when == "setup" and call.excinfo is not None:
-        # A fixture failed during setup - extract parameter set
         test_name = item.name
         if '[' in test_name:
-            params = test_name.split('[')[1].rstrip(']')
-            param_set = params.split('-')[0]
+            param_set = test_name.split('[')[1].rstrip(']')
         else:
             param_set = 'default'
 
-        # Mark this parameter set as having fixture failures
         _fixture_failures[param_set] = True
 
 
 def pytest_runtest_setup(item):
-    """Pytest hook that runs before any test setup (including fixtures).
-
-    This hook skips tests if fixtures failed for this parameter set.
-    """
-    # Only apply to tests in TestQosSai class
+    """Skip tests if fixtures failed for this parameter set."""
     if not (hasattr(item, 'cls') and item.cls and item.cls.__name__ == 'TestQosSai'):
         return
 
-    # Don't skip testParameter itself - let it run and fail naturally
-    if 'testParameter' in item.name:
+    # Don't skip seed tests - let them fail naturally to show the root cause
+    if 'fixture_seed' in item.keywords:
         return
 
-    # Extract parameter set from test name
-    # Format: testName[param_set-other_params] or testName[param_set]
     test_name = item.name
     if '[' in test_name:
-        params = test_name.split('[')[1].rstrip(']')
-        # Get the first parameter (the fixture parameter set like 'single_asic')
-        param_set = params.split('-')[0]
+        param_set = test_name.split('[')[1].rstrip(']')
     else:
         param_set = 'default'
 
-    # Skip if fixtures failed for this parameter set
     if param_set in _fixture_failures:
         pytest.skip(f"Skipping because fixtures failed for parameter set [{param_set}]")
 

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -413,6 +413,7 @@ class TestQosSai(QosSaiBase):
 
         return ecn_status
 
+    @pytest.mark.fixture_seed
     def testParameter(
         self, duthosts, get_src_dst_asic_and_duts, dutConfig, dutQosConfig, ingressLosslessProfile,
         ingressLossyProfile, egressLosslessProfile, dualtor_ports_for_duts


### PR DESCRIPTION
### Description of PR

Summary:
Prevent cascading `ERROR` statuses in `tests/qos/test_qos_sai.py` when the `testParameter` fixture setup fails, by skipping remaining tests in the affected parameter set.

Fixes #23282

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?

A single infrastructure/fixture failure in testParameter currently causes all subsequent tests in the same parameter set to report as ERROR, which obscures the true root cause and significantly inflates the reported failure count for QoS SAI runs.

#### How did you do it?

Added pytest hooks (`pytest_runtest_makereport` and `pytest_runtest_setup`) that detect fixture setup failures per parameter set and track them in a small global map; once a parameter set is known-bad, subsequent tests in that set are short-circuited and reported as SKIPPED instead of re-running the broken setup and cascading more ERRORs.

#### How did you verify/test it?

Ran `tests/qos/test_qos_sai.py` on a setup where `testParameter` reliably fails during fixture setup and confirmed that only the first `testParameter` for each parameter set reports `ERROR`, while all remaining tests in those parameter sets are reported as `SKIPPED`, reducing the output from ~130+ cascading `ERROR`s to a small, fixed set of `ERROR`s plus clean `SKIPPED` statuses.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

### Documentation
