### PR TITLE
test_po_cleanup: fix loganalyzer marker loss under CPU stress

### DIFF
--- a/tests/common/plugins/loganalyzer/loganalyzer.py
+++ b/tests/common/plugins/loganalyzer/loganalyzer.py
@@ -67,6 +67,87 @@ class DisableLogrotateCronContext:
         self.ansible_host.command("systemctl start logrotate.timer", module_ignore_errors=True)
 
 
+class DisableLogrotateAndWaitSyslogContext:
+    """
+    Context class to disable logrotate and wait for syslog backlog to drain on exit.
+    """
+
+    def __init__(self, ansible_host, cleanup=None, syslog_path="/var/log/syslog",
+                 timeout=300, interval=10, stable_iterations=2):
+        """
+        Constructor of DisableLogrotateAndWaitSyslogContext.
+        :param ansible_host: DUT object representing a SONiC switch under test.
+        :param cleanup: Optional callable executed before waiting for syslog to stabilize.
+        :param syslog_path: Path to the syslog file on the DUT.
+        :param timeout: Maximum time to wait for syslog to stabilize.
+        :param interval: Poll interval when checking syslog size.
+        :param stable_iterations: Number of consecutive identical size checks required.
+        """
+        self.ansible_host = ansible_host
+        self.cleanup = cleanup
+        self.syslog_path = syslog_path
+        self.timeout = timeout
+        self.interval = interval
+        self.stable_iterations = stable_iterations
+        self.disable_logrotate_context = DisableLogrotateCronContext(ansible_host)
+
+    def __enter__(self):
+        self.disable_logrotate_context.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            if self.cleanup is not None:
+                self.cleanup()
+            self._wait_for_file_size_to_stabilize()
+        finally:
+            self.disable_logrotate_context.__exit__(exc_type, exc_val, exc_tb)
+
+    def _wait_for_file_size_to_stabilize(self):
+        if self.stable_iterations < 1:
+            raise ValueError("stable_iterations must be at least 1")
+
+        stable_count = 0
+        previous_size = None
+        quoted_file_path = "'{}'".format(self.syslog_path.replace("'", "'\"'\"'"))
+        end = time.time() + self.timeout
+
+        while time.time() < end:
+            result = self.ansible_host.shell(
+                "stat -c %s {}".format(quoted_file_path),
+                module_ignore_errors=True
+            )
+            if result.get("failed") or result.get("rc", 0) != 0:
+                stable_count = 0
+                previous_size = None
+                logging.debug("Failed to stat file %s: %s", self.syslog_path, result)
+            else:
+                current_size = result.get("stdout", "").strip()
+                if current_size == previous_size:
+                    stable_count += 1
+                else:
+                    stable_count = 0
+                    previous_size = current_size
+
+                logging.debug(
+                    "File size check for %s: current=%s previous=%s stable_count=%s/%s",
+                    self.syslog_path,
+                    current_size,
+                    previous_size,
+                    stable_count,
+                    self.stable_iterations,
+                )
+
+                if stable_count >= self.stable_iterations:
+                    logging.info("File %s size stabilized", self.syslog_path)
+                    return True
+
+            time.sleep(self.interval)
+
+        logging.warning("File %s size did not stabilize within %s seconds", self.syslog_path, self.timeout)
+        return False
+
+
 class LogAnalyzerError(Exception):
     """Raised when loganalyzer found matches during analysis phase."""
     def __repr__(self):

--- a/tests/pc/test_po_cleanup.py
+++ b/tests/pc/test_po_cleanup.py
@@ -5,7 +5,7 @@ from tests.common.fixtures.duthost_utils import stop_route_checker_on_duthost
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
 from tests.common.utilities import wait_until
 from tests.common import config_reload
-from tests.common.plugins.loganalyzer.loganalyzer import LogAnalyzer
+from tests.common.plugins.loganalyzer.loganalyzer import DisableLogrotateAndWaitSyslogContext, LogAnalyzer
 
 pytestmark = [
     pytest.mark.disable_route_check,
@@ -138,15 +138,17 @@ def test_po_cleanup_after_reload(duthosts, enum_rand_one_per_hwsku_frontend_host
             duthost.command("docker exec swss{} supervisorctl stop rsyslogd".format(asic_id))
 
         with loganalyzer:
-            logging.info("Reloading config..")
-            config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
-
-        duthost.shell("killall yes")
+            with DisableLogrotateAndWaitSyslogContext(
+                duthost,
+                cleanup=lambda: duthost.shell("killall yes", module_ignore_errors=True),
+            ):
+                logging.info("Reloading config..")
+                config_reload(duthost, wait=240, safe_reload=True, wait_for_bgp=True)
         # Cancel the watchdog so it doesn't fire during later tests
         if watchdog_pid:
             duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
     except Exception:
-        duthost.shell("killall yes")
+        duthost.shell("killall yes", module_ignore_errors=True)
         if watchdog_pid:
             duthost.shell("kill {} 2>/dev/null || true".format(watchdog_pid), module_ignore_errors=True)
         raise


### PR DESCRIPTION
### Description of PR

Fix `test_po_cleanup_after_reload` failure caused by LogAnalyzer end marker being lost under heavy CPU stress and syslog load.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_po_cleanup_after_reload` fails consistently with:
```
RuntimeError: cannot find marker end-LogAnalyzer-port_channel_cleanup.xxx in /var/log/syslog
```

Two issues combine to lose the loganalyzer end marker:

1. **Logrotate fires mid-test**: The system logrotate timer can trigger during `config_reload` under CPU stress, rotating `/var/log/syslog`. Markers get pushed beyond `syslog.1` into compressed archives (`syslog.2.gz`) that loganalyzer does not search.

2. **Syslog UDP buffer overflow**: Under heavy CPU load (all cores running `yes`), rsyslogd cannot keep up with syslog traffic and its UDP receive buffer overflows, silently dropping the end marker written via `/dev/log`.

This supersedes PR #22776 which attempted to fix this by writing markers directly to `/var/log/syslog`, but that approach causes log timestamp ordering issues.

#### How did you do it?

Three changes to `test_po_cleanup_after_reload`:

1. **Wrap with `DisableLogrotateCronContext`** — stops the logrotate timer and cron job for the duration of the test, preventing mid-test syslog rotation.

2. **Move CPU stress cleanup into a `try/finally` block inside `with loganalyzer:`** — `killall yes` runs before loganalyzer `__exit__` places the end marker, so rsyslogd is no longer competing for CPU.

3. **Poll `/var/log/syslog` file size until stable** — after stopping CPU stress, wait for two consecutive 10-second intervals with no file growth before allowing the end marker to be placed. This ensures rsyslogd has drained any remaining socket buffer backlog.

#### How did you verify/test it?

1. **Without fix:** Test fails consistently with `RuntimeError: cannot find marker end-LogAnalyzer-...`
2. **With fix:** PASSED (1 passed in 1153s / 19:13)

Intermediate approaches that did NOT work:
- `DisableLogrotateCronContext` alone: logrotate is only one of two root causes; the syslog buffer overflow also drops the marker
- `killall yes` + no drain wait: rsyslogd buffer backlog can take minutes to drain after CPU stress ends

#### Any platform specific information?

Not platform-specific. Applies to any setup with enough port channels to generate heavy syslog traffic during config_reload under CPU stress.

### Documentation

N/A