### PR TITLE
[cherry-pick] Fix duthost fixture mismatch in test_bgp_update_replica…

### DIFF
--- a/tests/bgp/test_bgp_update_replication.py
+++ b/tests/bgp/test_bgp_update_replication.py
@@ -109,13 +109,14 @@ def measure_stats(dut):
 
 
 @pytest.fixture
-def setup_duthost_intervals(duthost):
+def setup_duthost_intervals(duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     '''
     Fixture to allow for dynamic interval definitions for each interval, based on duthost facts.
     The default is left relatively long to ensure that it passes on all platforms.
 
     Returns a list of float values.
     '''
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     DEFAULT_INTERVALS = [10.0, 9.0, 8.0]
     PLATFORM_INTERVALS = {
         'mellanox': [4.0, 3.5, 3.0],
@@ -135,7 +136,8 @@ def setup_duthost_intervals(duthost):
 
 @pytest.fixture
 def setup_bgp_peers(
-    duthost,
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
     tbinfo,
     ptfhost,
     setup_interfaces,
@@ -144,6 +146,7 @@ def setup_bgp_peers(
 ):
     ASN_BASE = 61000
     PORT_BASE = 11000
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     mg_facts = duthost.get_extended_minigraph_facts(tbinfo)
 
     dut_asn = mg_facts["minigraph_bgp_asn"]
@@ -211,11 +214,13 @@ def setup_bgp_peers(
 
 
 def test_bgp_update_replication(
-    duthost,
+    duthosts,
+    enum_rand_one_per_hwsku_frontend_hostname,
     setup_bgp_peers,
     setup_duthost_intervals,
 ):
     NUM_ROUTES = 10_000
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     bgp_peers: list[BGPNeighbor] = setup_bgp_peers
     duthost_intervals: list[float] = setup_duthost_intervals
 


### PR DESCRIPTION
Use enum_rand_one_per_hwsku_frontend_hostname consistently across setup_duthost_intervals, setup_bgp_peers, and test_bgp_update_replication to match the duthost selection in setup_interfaces fixture. Previously, setup_interfaces selected one device while, setup_bgp_peers and the test used a different device causing BGP commands to run with the wrong Loopback3 IP address leading to failures

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/aristanetworks/sonic-qual.msft/issues/1158)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
