### PR TITLE
[loganalyzer] Wait for rsyslog readiness before placing markers

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer.py
@@ -184,11 +184,69 @@ class AnsibleLogAnalyzer:
             file.write('\n')
             file.flush()
 
+    def wait_for_rsyslog_ready(self, timeout=120):
+        '''
+        @summary: Wait until rsyslog is accepting and flushing messages.
+
+        Writes a probe message via /dev/log and polls /var/log/syslog until the
+        probe appears, confirming that rsyslogd is running and able to flush to
+        disk.  This prevents marker loss when rsyslog was recently restarted
+        (e.g. after config_reload).
+
+        @param timeout: Maximum seconds to wait for rsyslog readiness.
+        @return: True if rsyslog confirmed ready, False on timeout.
+        '''
+        probe = 'rsyslog-ready-probe-{}'.format(time.time())
+        syslog_file = '/var/log/syslog'
+        prev_syslog_file = '/var/log/syslog.1'
+        end_time = time.time() + timeout
+
+        while time.time() < end_time:
+            # Check /dev/log socket exists before attempting to write
+            if not os.path.exists('/dev/log'):
+                time.sleep(2)
+                continue
+
+            try:
+                logger = self.init_sys_logger()
+                logger.info(probe)
+                logger.info('\n')
+                self.flush_rsyslogd()
+            except Exception:
+                time.sleep(2)
+                continue
+
+            # Poll for the probe in syslog (may have been rotated)
+            poll_end = time.time() + 10
+            while time.time() < poll_end:
+                for path in (syslog_file, prev_syslog_file):
+                    if os.path.exists(path):
+                        try:
+                            with open(path, 'r') as fp:
+                                for line in fp:
+                                    if probe in line:
+                                        return True
+                        except Exception:
+                            pass
+                time.sleep(1)
+
+            # Probe not found yet — retry with a new probe
+            probe = 'rsyslog-ready-probe-{}'.format(time.time())
+
+        return False
+
     def place_marker_to_syslog(self, marker):
         '''
         @summary: Place marker into '/dev/log'.
         @param marker: Marker to be placed into syslog.
+
+        Before writing the marker, ensures rsyslog is ready to accept and
+        persist messages.  This avoids silent marker loss during periods
+        when rsyslog is restarting (e.g. after config_reload).
         '''
+        if not self.wait_for_rsyslog_ready():
+            print('WARNING: rsyslog did not become ready within timeout; '
+                  'marker {} may be lost'.format(marker))
 
         syslogger = self.init_sys_logger()
         syslogger.info(marker)


### PR DESCRIPTION
### Description of PR
When `config_reload` restarts rsyslog, the `/dev/log` socket may briefly disappear. Markers written via `place_marker_to_syslog()` during this window are silently lost, causing `"cannot find marker end-LogAnalyzer-..."` failures in tests such as `port_channel_cleanup`.

This PR adds a `wait_for_rsyslog_ready()` method that writes a probe message through `/dev/log` and polls `/var/log/syslog` until the probe appears, confirming rsyslog is running and flushing to disk. `place_marker_to_syslog()` now calls this before writing the actual marker.

### Motivation
Observed in CI: after `config_reload` with CPU stress (`nohup yes > /dev/null` on all cores), the end marker was lost because rsyslog had not yet recovered when the marker was written. The test waited 120s and timed out.

### Approach
- **Probe-then-write**: a lightweight probe message is sent through the same `/dev/log` → rsyslogd → `/var/log/syslog` pipeline. Once the probe appears on disk, we know rsyslog is ready.
- **No ordering change**: both probe and marker travel the same rsyslog path, so no new timing issues are introduced relative to container logs (which arrive via RELP or UDP to the same rsyslogd instance).
- **Graceful degradation**: if rsyslog does not recover within the timeout (default 120s), a warning is printed and the marker is written anyway (preserving current behavior).

### Files changed
- `ansible/roles/test/files/tools/loganalyzer/loganalyzer.py`
  - Added `wait_for_rsyslog_ready(timeout=120)` method
  - Modified `place_marker_to_syslog()` to call `wait_for_rsyslog_ready()` before writing

Signed-off-by: 50n1c-rnsft <50n1c-rnsft@users.noreply.github.com>