### PR TITLE
System health fix

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -41,6 +41,8 @@ DEFAULT_INTERVAL = 62
 FAST_INTERVAL = 10
 THERMAL_CHECK_INTERVAL = 70
 PSU_CHECK_INTERVAL = FAST_INTERVAL + 5
+LED_CHECK_INTERVAL = 5
+LED_WAIT_TIMEOUT = 60
 WAIT_TIMEOUT = 180
 STATE_DB = 6
 
@@ -161,11 +163,26 @@ def test_service_checker_with_process_exit(duthosts, enum_rand_one_per_hwsku_hos
 
                 assert result is True, '{} is not recorded'.format(
                     critical_process)
+                summary_result = wait_until(
+                    WAIT_TIMEOUT, 10, 2, check_system_health_info, duthost, 'summary', SUMMARY_NOT_OK)
                 summary = redis_get_field_value(
                     duthost, STATE_DB, HEALTH_TABLE_NAME, 'summary')
-                assert summary == SUMMARY_NOT_OK, 'Expect summary {}, got {}'.format(
+                assert summary_result is True, 'Expect summary {}, got {}'.format(
                     SUMMARY_NOT_OK, summary)
-                check_system_health_led_info(duthost)
+                led_result = wait_until(
+                    LED_WAIT_TIMEOUT, LED_CHECK_INTERVAL, 0,
+                    check_system_health_led_info, duthost
+                )
+                if not led_result:
+                    system_health_summary = duthost.shell(
+                        'show system-health summary'
+                    )['stdout']
+                    pytest.fail(
+                        'System status LED did not converge to expected fault '
+                        'color in {} seconds. Latest summary:\n{}'.format(
+                            LED_WAIT_TIMEOUT, system_health_summary
+                        )
+                    )
             break
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The killed process fault can appear before the summary field or the LED state can update. This can result in the test failing with the result; 

```
System status LED is not yellow, amber, or red, but it is green
```

This diff adds an LED time constraint to wait for SYSTEM_HEALTH_INFO.summary to become `Not OK`, instead of an immediate read. The LED state is then polled for 60s, every 5 seconds. 

If the LED state hasn't converged after the poll, the test fails

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511

### Approach
#### What is the motivation for this PR?
`test_service_checker_with_process_exit` would intermittently fail when the process failure is detected before the CLI and the LED had converged. 

#### How did you do it?
Changed the test to wait for `SYSTEM_HEALTH_INFO.summary` to become `Not OK` and then poll LED state.

#### How did you verify/test it?
Manually ran the tests.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
