### PR TITLE
Scope Ansible connection vars per host

### DIFF
--- a/tests/common/devices/aos.py
+++ b/tests/common/devices/aos.py
@@ -103,7 +103,7 @@ class AosHost(AnsibleHostBase):
     def __getattr__(self, module_name):
         if not module_name.startswith('aos_'):
             return None
-        self.host.options['variable_manager'].extra_vars.update(self.admin_conn_props)
+        self._update_host_variables(self.admin_conn_props)
         return super(AosHost, self).__getattr__(module_name)
 
     def _has_cli_cmd_failed(self, cmd_output_obj):

--- a/tests/common/devices/arista.py
+++ b/tests/common/devices/arista.py
@@ -63,7 +63,7 @@ class AristaHost(AnsibleHostBase):
             }
         else:
             raise Exception("Does not have module: {}".format(module_name))
-        self.host.options["variable_manager"].extra_vars.update(evars)
+        self._update_host_variables(evars)
         return super(AristaHost, self).__getattr__(module_name)
 
     def __str__(self):

--- a/tests/common/devices/base.py
+++ b/tests/common/devices/base.py
@@ -53,6 +53,25 @@ class AnsibleHostBase(object):
                 self.mgmt_ipv6 = None
         self.hostname = hostname
 
+    def _get_inventory_host(self):
+        return self.host.options["inventory_manager"].get_host(self.hostname)
+
+    def _set_host_variable(self, name, value):
+        vm = self.host.options["variable_manager"]
+        inventory_host = self._get_inventory_host()
+
+        if hasattr(vm, "set_host_variable"):
+            vm.set_host_variable(inventory_host, name, value)
+            return
+
+        inventory_host.vars[name] = value
+        if hasattr(vm, "_hostvars"):
+            vm._hostvars.setdefault(self.hostname, {})[name] = value
+
+    def _update_host_variables(self, variables):
+        for name, value in variables.items():
+            self._set_host_variable(name, value)
+
     def __getattr__(self, module_name):
         if self.host.has_module(module_name):
             self.module_name = module_name

--- a/tests/common/devices/cisco.py
+++ b/tests/common/devices/cisco.py
@@ -102,7 +102,7 @@ class CiscoHost(AnsibleHostBase):
             }
         else:
             raise Exception("Does not have module: {}".format(module_name))
-        self.host.options['variable_manager'].extra_vars.update(evars)
+        self._update_host_variables(evars)
         return super(CiscoHost, self).__getattr__(module_name)
 
     def __str__(self):

--- a/tests/common/devices/eos.py
+++ b/tests/common/devices/eos.py
@@ -74,7 +74,7 @@ class EosHost(AnsibleHostBase):
                 'ansible_ssh_pass': self.shell_passwd,
                 'ansible_become_method': 'sudo'
             }
-        self.host.options['variable_manager'].extra_vars.update(evars)
+        self._update_host_variables(evars)
         return super(EosHost, self).__getattr__(module_name)
 
     def __str__(self):

--- a/tests/common/devices/fanout.py
+++ b/tests/common/devices/fanout.py
@@ -39,6 +39,7 @@ class FanoutHost(object):
             self.os = os
             self.fanout_port_alias_to_name = {}
             self.host = SonicHost(ansible_adhoc, hostname,
+                                  ansible_connection='multi_passwd_ssh',
                                   ssh_user=user,
                                   ssh_passwd=passwd)
         elif os == 'onyx':

--- a/tests/common/devices/juniper.py
+++ b/tests/common/devices/juniper.py
@@ -40,7 +40,7 @@ class JuniperHost(AnsibleHostBase):
             }
         else:
             raise Exception("Does not have module: {}".format(module_name))
-        self.host.options["variable_manager"].extra_vars.update(evars)
+        self._update_host_variables(evars)
         return super(JuniperHost, self).__getattr__(module_name)
 
     def __str__(self):

--- a/tests/common/devices/k8s.py
+++ b/tests/common/devices/k8s.py
@@ -28,7 +28,7 @@ class K8sMasterHost(AnsibleHostBase):
         evars = {
             'ansible_become_method': 'enable'
         }
-        self.host.options['variable_manager'].extra_vars.update(evars)
+        self._update_host_variables(evars)
 
     def check_k8s_master_ready(self):
         """

--- a/tests/common/devices/onyx.py
+++ b/tests/common/devices/onyx.py
@@ -24,7 +24,7 @@ class OnyxHost(AnsibleHostBase):
                  'ansible_become_method': 'enable'
                  }
 
-        self.host.options['variable_manager'].extra_vars.update(evars)
+        self._update_host_variables(evars)
         self.localhost = ansible_adhoc(inventory='localhost', connection='local', host_pattern="localhost")["localhost"]
         self.fanout_helper = FanoutOnyxDropCounter(self)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -62,6 +62,9 @@ class SonicHost(AnsibleHostBase):
                  shell_user=None, shell_passwd=None,
                  ssh_user=None, ssh_passwd=None,
                  ansible_connection=None):
+        def _is_template_value(value):
+            return isinstance(value, str) and "{{" in value and "}}" in value
+
         init_kwargs = {}
         if ansible_connection:
             init_kwargs["connection"] = ansible_connection
@@ -72,6 +75,11 @@ class SonicHost(AnsibleHostBase):
         if ansible_connection:
             self._set_host_variable('ansible_connection', ansible_connection)
 
+        visible_vars = None
+        if any(_is_template_value(value) for value in (shell_user, shell_passwd, ssh_user, ssh_passwd)):
+            im = self.host.options['inventory_manager']
+            visible_vars = get_host_visible_vars(im._sources, self.hostname) or {}
+
         if shell_user and shell_passwd:
             im = self.host.options['inventory_manager']
             vm = self.host.options['variable_manager']
@@ -79,6 +87,8 @@ class SonicHost(AnsibleHostBase):
                 host=im.get_hosts(pattern='sonic')[0]
             )['ansible_connection']
             hostvars = vm.get_vars(host=im.get_host(hostname=self.hostname))
+            resolved_shell_user = visible_vars.get('ansible_ssh_user', shell_user) if visible_vars else shell_user
+            resolved_shell_passwd = visible_vars.get('ansible_ssh_pass', shell_passwd) if visible_vars else shell_passwd
             # parse connection options and reset those options with
             # passed credentials
             connection_loader.get(sonic_conn, class_only=True)
@@ -90,15 +100,17 @@ class SonicHost(AnsibleHostBase):
             )
             for user_var in (_['name'] for _ in user_def['vars']):
                 if user_var in hostvars:
-                    self._set_host_variable(user_var, shell_user)
+                    self._set_host_variable(user_var, resolved_shell_user)
             for pass_var in (_['name'] for _ in pass_def['vars']):
                 if pass_var in hostvars:
-                    self._set_host_variable(pass_var, shell_passwd)
+                    self._set_host_variable(pass_var, resolved_shell_passwd)
 
         if ssh_user and ssh_passwd:
+            resolved_ssh_user = visible_vars.get('ansible_ssh_user', ssh_user) if visible_vars else ssh_user
+            resolved_ssh_passwd = visible_vars.get('ansible_ssh_pass', ssh_passwd) if visible_vars else ssh_passwd
             evars = {
-                'ansible_ssh_user': ssh_user,
-                'ansible_ssh_pass': ssh_passwd,
+                'ansible_ssh_user': resolved_ssh_user,
+                'ansible_ssh_pass': resolved_ssh_passwd,
             }
             self._update_host_variables(evars)
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -83,17 +83,17 @@ class SonicHost(AnsibleHostBase):
             )
             for user_var in (_['name'] for _ in user_def['vars']):
                 if user_var in hostvars:
-                    vm.extra_vars.update({user_var: shell_user})
+                    self._set_host_variable(user_var, shell_user)
             for pass_var in (_['name'] for _ in pass_def['vars']):
                 if pass_var in hostvars:
-                    vm.extra_vars.update({pass_var: shell_passwd})
+                    self._set_host_variable(pass_var, shell_passwd)
 
         if ssh_user and ssh_passwd:
             evars = {
                 'ansible_ssh_user': ssh_user,
                 'ansible_ssh_pass': ssh_passwd,
             }
-            self.host.options['variable_manager'].extra_vars.update(evars)
+            self._update_host_variables(evars)
 
         self._facts = self._gather_facts()
         self._os_version = self._get_os_version()

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -60,15 +60,22 @@ class SonicHost(AnsibleHostBase):
     """
     def __init__(self, ansible_adhoc, hostname,
                  shell_user=None, shell_passwd=None,
-                 ssh_user=None, ssh_passwd=None):
-        AnsibleHostBase.__init__(self, ansible_adhoc, hostname)
+                 ssh_user=None, ssh_passwd=None,
+                 ansible_connection=None):
+        init_kwargs = {}
+        if ansible_connection:
+            init_kwargs["connection"] = ansible_connection
+        AnsibleHostBase.__init__(self, ansible_adhoc, hostname, **init_kwargs)
 
         self.DEFAULT_ASIC_SERVICES = ["bgp", "database", "lldp", "swss", "syncd", "teamd"]
+
+        if ansible_connection:
+            self._set_host_variable('ansible_connection', ansible_connection)
 
         if shell_user and shell_passwd:
             im = self.host.options['inventory_manager']
             vm = self.host.options['variable_manager']
-            sonic_conn = vm.get_vars(
+            sonic_conn = ansible_connection or vm.get_vars(
                 host=im.get_hosts(pattern='sonic')[0]
             )['ansible_connection']
             hostvars = vm.get_vars(host=im.get_host(hostname=self.hostname))


### PR DESCRIPTION
### Description of PR

Summary:
Prevent host-specific Ansible connection and credential overrides from leaking through shared variable-manager state and affecting later DUT operations in mixed topologies.

Fixes # N/A

### Type of change

- [x] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Mixed fanout environments can exercise different device wrappers in the same run. Some wrappers were storing host-specific values such as `ansible_connection`, credentials, and become settings in shared `variable_manager.extra_vars`. That allowed one host's connection mode, for example `network_cli`, to leak into later DUT operations and caused commands such as `duthost.command()` and `duthost.shell()` to run with the wrong connection context.

#### How did you do it?
Added host-scoped variable helpers in `AnsibleHostBase` and updated the affected device wrappers to set connection and authentication overrides on the target inventory host instead of writing them into shared extra vars.

#### How did you verify/test it?
Ran:
`python -m py_compile tests/common/devices/base.py tests/common/devices/sonic.py tests/common/devices/aos.py tests/common/devices/arista.py tests/common/devices/cisco.py tests/common/devices/eos.py tests/common/devices/juniper.py tests/common/devices/k8s.py tests/common/devices/onyx.py`

#### Any platform specific information?
No platform-specific behavior is intended. The fix is framework-side and applies to mixed topologies where multiple host wrappers are used in the same run.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
No documentation update is required for this framework fix.