### PR TITLE
ansible: enhance ceos image discovery to detect pre-pulled registry images

### DIFF
--- a/ansible/roles/eos/tasks/ceos.yml
+++ b/ansible/roles/eos/tasks/ceos.yml
@@ -32,16 +32,40 @@
   delegate_to: "{{ VM_host[0] }}"
   when: ceos_registry is defined
 
+- name: Discover ceos_image locally (plain or from any registry)
+  # Searches all local docker images for one matching ceos_image. This single grep covers:
+  # - Plain local image: ceosimage:4.32.5M-1
+  # - Image pre-pulled from any registry: soniccr1.azurecr.io/ceosimage:4.32.5M-1
+  # When ceos_registry is defined, this task is skipped — the explicit registry check above is used.
+  become: yes
+  shell: >-
+    docker images --format
+    '{% raw %}{{.Repository}}:{{.Tag}}{% endraw %}'
+    | grep -m1 '{{ ceos_image }}$'
+  register: ceos_image_discovery_result
+  delegate_to: "{{ VM_host[0] }}"
+  ignore_errors: yes
+  changed_when: no
+  when: ceos_registry is not defined
+
 - name: Set ceos_effective_image
   set_fact:
-    # Use registry-prefixed image name when the registry image is available locally (was pulled
-    # from registry). This avoids creating a local alias and ensures containers always reference
-    # the registry image, satisfying security requirements (e.g. Microsoft ACR/MCR policy).
-    # Fall back to the plain ceos_image name when no registry is configured or registry image
-    # is not available (e.g. pull failed and image was built from ceos_image_orig instead).
+    # Priority order for determining the effective ceos image:
+    # 1. When ceos_registry is defined and the registry image is available locally, use the
+    #    registry-prefixed image name. This ensures containers always reference the registry
+    #    image, satisfying security requirements (e.g. Microsoft ACR/MCR policy).
+    # 2. When ceos_registry is not defined, use whatever local image matches ceos_image
+    #    (plain or from any registry). Preferring a pre-pulled registry image avoids building
+    #    a local image and triggering S360 alerts.
+    # 3. Fall back to the plain ceos_image name when no image is discovered.
     ceos_effective_image: >-
       {{ ceos_registry + '/' + ceos_image
          if (ceos_registry is defined and ceos_registry_image_info.images | length > 0)
+         else (ceos_image_discovery_result.stdout | trim)
+              if (ceos_registry is not defined and
+                  ceos_image_discovery_result is not skipped and
+                  ceos_image_discovery_result.rc == 0 and
+                  ceos_image_discovery_result.stdout | trim != '')
          else ceos_image }}
 
 - name: Create cEOS container

--- a/ansible/roles/vm_set/tasks/add_ceos_list.yml
+++ b/ansible/roles/vm_set/tasks/add_ceos_list.yml
@@ -1,10 +1,3 @@
-- name: Check if cEOS docker image exists locally
-  docker_image_info:
-    name:
-      - "{{ ceos_image }}"
-  become: yes
-  register: ceos_local_image_stat
-
 - name: Check if cEOS docker image from registry is already cached locally
   docker_image_info:
     name:
@@ -13,15 +6,36 @@
   register: ceos_registry_cached_image_stat
   when: ceos_registry is defined
 
+- name: Discover cEOS docker image locally (plain or from any registry)
+  # Searches all local docker images for one matching ceos_image. This single grep covers:
+  # - Plain local image: ceosimage:4.32.5M-1
+  # - Image pre-pulled from any registry: soniccr1.azurecr.io/ceosimage:4.32.5M-1
+  # When ceos_registry is defined, this task is skipped — the explicit registry check above is used.
+  become: yes
+  shell: >-
+    docker images --format
+    '{% raw %}{{.Repository}}:{{.Tag}}{% endraw %}'
+    | grep -m1 '{{ ceos_image }}$'
+  register: ceos_image_discovery_result
+  ignore_errors: yes
+  changed_when: no
+  when: ceos_registry is not defined
+
 - name: Set fact for whether ceos_image is already available
   set_fact:
     # When registry is defined, only the registry-prefixed image is considered "found" - using
     # a local image in that case would bypass the registry requirement (e.g. Microsoft ACR/MCR).
-    # When registry is not defined, only the locally-named image is considered.
+    # When registry is not defined, the image is "found" if any local image (plain or from any
+    # registry) matches ceos_image. This covers images pre-pulled during infrastructure
+    # provisioning (e.g. VMSS setup) without exposing the registry URL in public code.
     # The | bool filter ensures this is stored as a Python boolean, not the string "True"/"False",
     # so that "when: not ceos_image_found" evaluates correctly.
-    ceos_image_found: "{{ ((ceos_registry is not defined and ceos_local_image_stat.images | length > 0) or
-                           (ceos_registry is defined and ceos_registry_cached_image_stat.images | length > 0)) | bool }}"
+    ceos_image_found: "{{ ((ceos_registry is not defined and
+                            ceos_image_discovery_result is not skipped and
+                            ceos_image_discovery_result.rc == 0 and
+                            ceos_image_discovery_result.stdout | trim != '') or
+                           (ceos_registry is defined and
+                            ceos_registry_cached_image_stat.images | length > 0)) | bool }}"
 
 - name: Prepare ceos_image if it does not exist
   block:


### PR DESCRIPTION
### Description of PR

Summary:
Enhance ceos image discovery logic so that pre-pulled registry images are detected even when `ceos_registry` is not defined. This prevents unnecessary local image builds that trigger S360 security alerts.

This is a follow-up improvement to PR #22794 which added registry support for ceos images.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

PR #22794 added support for pulling ceos images from a configured registry (`ceos_registry`). However, when `ceos_registry` is not defined (e.g. in public code where the registry URL should not be exposed), pre-pulled registry images are not discovered. The code falls through to the download-and-build path, creating a local image that triggers S360 security alerts.

This is problematic for PR testing where ceos images are pre-pulled from a registry during VMSS instance provisioning, but `ceos_registry` is not defined in public configuration.

#### How did you do it?

Added a consolidated `docker images | grep` discovery task that runs when `ceos_registry` is not defined. The grep matches `ceos_image` at the end of the image name, so it discovers both:
- Plain local images: `ceosimage:4.32.5M-1`
- Registry-prefixed images: `any-registry/ceosimage:4.32.5M-1`

Changes are made in two files:
- `ansible/roles/vm_set/tasks/add_ceos_list.yml` — controls whether to download/build the image
- `ansible/roles/eos/tasks/ceos.yml` — sets `ceos_effective_image` for container creation

When `ceos_registry` IS defined, the existing explicit registry check is preserved unchanged.

Used `{% raw %}...{% endraw %}` Jinja2 blocks for Go template syntax in docker format strings, improving readability over the previous `{{ '{{' }}` escaping.

#### How did you verify/test it?

Manually tested on testbed with:
1. Pre-pulled registry image present, `ceos_registry` undefined — image discovered correctly
2. Plain local image present, `ceos_registry` undefined — image discovered correctly
3. `ceos_registry` defined — existing behavior preserved

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A — this is an infrastructure/provisioning change, not a test case.

### Documentation
N/A — internal infrastructure improvement.