### PR TITLE
tests_mark_conditions: xfail test_decap and test_vnet_decap on SN5640

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -873,9 +873,11 @@ decap/test_decap.py:
     conditions:
       - "topo_name in ['t1-isolated-d128', 't1-isolated-d32']"
   xfail:
-    reason: "Xfail due to github issue 20982"
+    reason: "Xfail due to github issue 20982. Or decap is not supported on x86_64-nvidia_sn5640-r0."
+    conditions_logical_operator: or
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/20982 and asic_type in ['mellanox', 'nvidia']"
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 decap/test_decap.py::test_decap[ttl=pipe, dscp=pipe, vxlan=disable]:
   skip:
@@ -5327,6 +5329,12 @@ vxlan/test_vnet_bgp_route_precedence.py:
     conditions:
       - "https://github.com/sonic-net/sonic-buildimage/issues/23824"
       - "https://github.com/sonic-net/sonic-mgmt/issues/21895 and '-v6-' in topo_name and asic_type in ['mellanox']"
+
+vxlan/test_vnet_decap.py::test_vnet_decap:
+  xfail:
+    reason: "Decap is not supported on x86_64-nvidia_sn5640-r0."
+    conditions:
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 vxlan/test_vnet_decap.py::test_vnet_decap[inner_ipv4-outer_ipv4]:
   xfail:


### PR DESCRIPTION
### Description of PR

Add xfail mark for `decap/test_decap.py::test_decap` and `vxlan/test_vnet_decap.py::test_vnet_decap` on `x86_64-nvidia_sn5640-r0` platform because decap is not supported on this platform.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_decap` and `test_vnet_decap` consistently fail on `x86_64-nvidia_sn5640-r0` because decap is not supported on this platform.

#### How did you do it?

Added xfail entries in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for platform `x86_64-nvidia_sn5640-r0` with reason explaining decap is not supported.

#### How did you verify/test it?

Verified the YAML syntax and confirmed the conditional mark system picks up the new entries.

#### Any platform specific information?

Applies to `x86_64-nvidia_sn5640-r0` platform only.

### Documentation

N/A