### PR TITLE
tests_mark_conditions: skip hash/test_generic_hash.py::test_reboot on SN5640

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3135,11 +3135,12 @@ hash/test_generic_hash.py::test_nexthop_flap[CRC_CCITT-IP_PROTOCOL-ipv4-None-Non
 
 hash/test_generic_hash.py::test_reboot:
   skip:
-    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm. For broadcom, ECMP/LAG hash not supported in broadcom SAI. Marvell-Teralynx uses unified hash fields for ECMP and LAG.'
+    reason: 'On Mellanox SPC1 platforms, due to HW limitation, it would not support CRC_CCITT algorithm. For broadcom, ECMP/LAG hash not supported in broadcom SAI. Marvell-Teralynx uses unified hash fields for ECMP and LAG. Warm reboot is not supported on x86_64-nvidia_sn5640-r0.'
     conditions_logical_operator: or
     conditions:
       - "asic_gen == 'spc1'"
       - "asic_type in ['broadcom', 'marvell-teralynx']"
+      - "platform in ['x86_64-nvidia_sn5640-r0']"
 
 hash/test_generic_hash.py::test_reboot[CRC-INNER_IP_PROTOCOL:
   skip:


### PR DESCRIPTION
### Description of PR

Add skip mark for `hash/test_generic_hash.py::test_reboot` on `x86_64-nvidia_sn5640-r0` platform because warm reboot is not supported on this platform.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

`test_reboot` in `test_generic_hash.py` consistently fails on `x86_64-nvidia_sn5640-r0` because warm reboot is not supported on this platform.

#### How did you do it?

Added skip entry in `tests/common/plugins/conditional_mark/tests_mark_conditions.yaml` for platform `x86_64-nvidia_sn5640-r0` with reason explaining warm reboot is not supported.

#### How did you verify/test it?

Verified the YAML syntax and confirmed the conditional mark system picks up the new entry.

#### Any platform specific information?

Applies to `x86_64-nvidia_sn5640-r0` platform only.

### Documentation

N/A