### PR TITLE
[master][sonic-mgmt]: Add LogAnalyzer ignore pattern for SAI FEC stat error

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -47,6 +47,9 @@ r, ".* ERR swss#orchagent: :- querySwitchEcmpHashAlgorithmEnumCapabilities: Fail
 r, ".* ERR swss#orchagent: :- querySwitchLagHashAlgorithmEnumCapabilities: Failed to get attribute.*"
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed with error Feature unavailable.*"
 
+# Errors for config reload on broadcom platform on 202511
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed - port: \d+, rc: -16.*"
+
 # White list below messages found on KVM for now. Need to address them later.
 r, ".* ERR macsec\d*#wpa_supplicant.*l2_packet_send.*Network is down.*"
 r, ".* ERR macsec\d*#wpa_supplicant.*could not process SIGINT or SIGTERM in two seconds.*"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
test_pfcwd_cli (and other tests using LogAnalyzer) began failing from the March 6, 2026 SAI upgrade (14.1.x → 14.3.x).  The upgrade promoted FEC stat failure log messages from INFO to ERROR level, making them visible to LogAnalyzer.

These ERR messages appear ~40 seconds after syncd starts, during FlexCounter's initial counter discovery poll.

Tests that run `config reload -y -f` as part of setup/teardown restart syncd, triggering a fresh poll cycle each time. Each reload produces a burst of FEC error messages, which LogAnalyzer flags as unexpected.

The existing ignore pattern targets the old message format (failed with error Feature unavailable) and does not match the current format (failed - port: <N>, rc: -16).

Fixes: [qual-issue](https://github.com/aristanetworks/sonic-qual.msft/issues/1159)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The SAI upgrade promoted FEC stat failure log messages from INFO to ERROR level, making them visible to LogAnalyzer. These messages appear ~40 seconds after syncd starts during FlexCounter's initial counter discovery poll. Tests that run config reload as part of setup/teardown restart syncd, triggering a fresh poll cycle each time and producing a burst of ERR messages that LogAnalyzer flags as unexpected. The existing ignore pattern no longer matches the current message format.

#### How did you do it?
 Added a LogAnalyzer ignore pattern matching the current message format:                                                                                             
  `r".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed - port: \d+, rc: -16.*"`

#### How did you verify/test it?
Confirmed the pattern matches the ERR messages observed in the failing test logs.

#### Any platform specific information?
Applies to broadcom-based platforms

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
