### PR TITLE
Fix ipfwd/test_dip_sip.py for v6 topo

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3335,6 +3335,12 @@ ipfwd/test_dip_sip.py::test_dip_sip:
     conditions:
       - "https://github.com/sonic-net/sonic-mgmt/issues/21571 and 't0-isolated-d256u256s2' in topo_name"
 
+ipfwd/test_dip_sip.py::test_ipv4_forwarding:
+  skip:
+    reason: "Skip for IPv6-only topologies"
+    conditions:
+      - "'-v6-' in topo_name"
+
 ipfwd/test_dir_bcast.py:
   skip:
     reason: "Unsupported topology."

--- a/tests/ipfwd/conftest.py
+++ b/tests/ipfwd/conftest.py
@@ -99,6 +99,8 @@ def get_port_facts(dut, mg_facts, port_status, switch_arptable, ignore_intfs,
                     elif addr.version == 6:
                         selected_port_facts[key + '_router_ipv6'] = intf['addr']
                         selected_port_facts[key + '_host_ipv6'] = intf['peer_addr']
+                        selected_port_facts[key + '_host_mac'] = \
+                            switch_arptable['arptable']['v6'][intf['peer_addr']]['macaddress']
             if up_port:
                 logger.info("{} port is {}".format(key, up_port))
                 break

--- a/tests/ipfwd/test_dip_sip.py
+++ b/tests/ipfwd/test_dip_sip.py
@@ -4,7 +4,7 @@ import logging
 
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa: F401
 from tests.common.fixtures.ptfhost_utils import remove_ip_addresses       # noqa: F401
-from tests.common.utilities import wait_until
+from tests.common.utilities import wait_until, is_ipv6_only_topology
 
 DEFAULT_HLIM_TTL = 64
 WAIT_EXPECTED_PACKET_TIMEOUT = 5
@@ -60,7 +60,7 @@ def delete_static_route(duthost, static_route, nexthop_ip, asic_id):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+def setup_static_route(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
                        enum_rand_one_frontend_asic_index, gather_facts, request):
 
     """
@@ -86,18 +86,27 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
         None
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
-    nexthop_ipv4 = gather_facts['dst_host_ipv4']
+    is_v6_topo = is_ipv6_only_topology(tbinfo)
+
+    if not is_v6_topo:
+        nexthop_ipv4 = gather_facts['dst_host_ipv4']
+        # Configure IPv4 static route
+        try:
+            result = add_static_route(duthost, STATIC_ROUTE, nexthop_ipv4, enum_rand_one_frontend_asic_index)
+            if result['rc'] != 0:
+                raise Exception("Failed to add IPv4 static route: {}".format(result['stderr']))
+        except Exception as e:
+            logger.error("Error occurred while adding IPv4 static route: %s", str(e))
+            pytest.fail("IPv4 static route addition failed")
+        # Verify IPv4 route is in the routing table
+        try:
+            assert wait_until(60, 5, 0, check_route, duthost, STATIC_ROUTE, nexthop_ipv4,
+                              enum_rand_one_frontend_asic_index, 4, True), "IPv4 static route verification failed"
+        except Exception as e:
+            logger.error("Error occurred while verifying IPv4 static route: %s", str(e))
+            pytest.fail("IPv4 static route verification failed")
+
     nexthop_ipv6 = gather_facts['dst_host_ipv6']
-
-    # Configure IPv4 static route
-    try:
-        result = add_static_route(duthost, STATIC_ROUTE, nexthop_ipv4, enum_rand_one_frontend_asic_index)
-        if result['rc'] != 0:
-            raise Exception("Failed to add IPv4 static route: {}".format(result['stderr']))
-    except Exception as e:
-        logger.error("Error occurred while adding IPv4 static route: %s", str(e))
-        pytest.fail("IPv4 static route addition failed")
-
     # Configure IPv6 static route
     try:
         result = add_static_route(duthost, STATIC_ROUTE_IPV6, nexthop_ipv6, enum_rand_one_frontend_asic_index)
@@ -106,16 +115,6 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     except Exception as e:
         logger.error("Error occurred while adding IPv6 static route: %s", str(e))
         pytest.fail("IPv6 static route addition failed")
-
-    # Verify IPv4 route is in the routing table
-
-    try:
-        assert wait_until(60, 5, 0, check_route, duthost, STATIC_ROUTE, nexthop_ipv4,
-                          enum_rand_one_frontend_asic_index, 4, True), "IPv4 static route verification failed"
-    except Exception as e:
-        logger.error("Error occurred while verifying IPv4 static route: %s", str(e))
-        pytest.fail("IPv4 static route verification failed")
-
     # # Verify IPv6 route is in the routing table
     try:
         assert wait_until(60, 5, 0, check_route, duthost, STATIC_ROUTE_IPV6, nexthop_ipv6,
@@ -128,8 +127,9 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
     yield
 
     # Use either individual functions
-    delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                             enum_rand_one_frontend_asic_index, gather_facts)
+    if not is_v6_topo:
+        delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                 enum_rand_one_frontend_asic_index, gather_facts)
     delete_ipv6_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                              enum_rand_one_frontend_asic_index, gather_facts)
 
@@ -138,12 +138,13 @@ def setup_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
 
 
 @pytest.fixture(autouse=True)
-def setup_teardown(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+def setup_teardown(duthosts, tbinfo, enum_rand_one_per_hwsku_frontend_hostname,
                    enum_rand_one_frontend_asic_index, gather_facts):
     yield
     # Teardown - delete the static routes
-    delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
-                             enum_rand_one_frontend_asic_index, gather_facts)
+    if not is_ipv6_only_topology(tbinfo):
+        delete_ipv4_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                 enum_rand_one_frontend_asic_index, gather_facts)
     delete_ipv6_static_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                              enum_rand_one_frontend_asic_index, gather_facts)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Skip test_ipv4_forwarding for v6 topo
Fix test_ipv6_forwarding by skipping IPv4 operations in setup and teardown fixtures
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
