### PR TITLE
[GIT_PR20544][Qos]Update conditionalmark to platform specific for DscpEcntest

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4077,7 +4077,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpEcn:
     reason: "Unsupported testbed type or test fails on all topologies. https://github.com/sonic-net/sonic-mgmt/issues/23059"
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['broadcom'] and asic_subtype not in ['broadcom-dnx']"
+      - "platform not in ['x86_64-nokia_ixr7250e_36x400g-r0']"
       - "https://github.com/sonic-net/sonic-mgmt/issues/23059"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4075,7 +4075,6 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpEcn:
   skip:
     reason: "Unsupported testbed type"
-    conditions_logical_operator: or
     conditions:
       - "platform not in ['x86_64-nokia_ixr7250e_36x400g-r0']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -4074,11 +4074,10 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDot1pQueueMapping:
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpEcn:
   skip:
-    reason: "Unsupported testbed type or test fails on all topologies. https://github.com/sonic-net/sonic-mgmt/issues/23059"
+    reason: "Unsupported testbed type"
     conditions_logical_operator: or
     conditions:
       - "platform not in ['x86_64-nokia_ixr7250e_36x400g-r0']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/23059"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
As part of PR# https://github.com/sonic-net/sonic-mgmt/pull/20544. The DscpEcnTest are enabled for 'broadcom' asic_type with sub-type as "broadcom-dnx".
This test is tested on t2 - broadcom-dnx devices in Nokia platform.

Making the conditional mark platform specific & skipping the test for all other platforms.
The test is currently skipped on all platforms with PR -https://github.com/sonic-net/sonic-mgmt/pull/23060.
related issue #https://github.com/sonic-net/sonic-mgmt/issues/23059
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
