### PR TITLE
[testQosSaiDscpEcn] [test_ecn_config.py] Skip QoS ECN tests on non-j2c platforms

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3925,7 +3925,7 @@ qos/test_ecn_config.py:
   skip:
     reason: "This test only support on cisco device"
     conditions:
-      - "asic_type not in ['cisco-8000', 'broadcom']"
+      - "asic_type not in ['cisco-8000', 'broadcom'] or asic_subtype not in ['broadcom-dnx']"
 
 qos/test_oq_watchdog.py:
   skip:
@@ -4077,7 +4077,7 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDscpEcn:
     reason: "Unsupported testbed type or test fails on all topologies. https://github.com/sonic-net/sonic-mgmt/issues/23059"
     conditions_logical_operator: or
     conditions:
-      - "asic_type not in ['broadcom'] and asic_subtype not in ['broadcom-dnx']"
+      - "asic_type not in ['broadcom'] or asic_subtype not in ['broadcom-dnx']"
       - "https://github.com/sonic-net/sonic-mgmt/issues/23059"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiDscpQueueMapping:


### PR DESCRIPTION
PR #20544 introduced the testQosSaiDscpEcn test and updated configurations exclusively for Jericho2 (j2c) platforms. Because equivalent configurations were not added for other platform yaml files (like td3, th2), these tests fail on non-j2c platforms.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
1. The PR #20544 added a new test testQosSaiDscpEcn parametrized with ["ecn_1", "ecn_2", "ecn_3", "ecn_4", "ecn_5"]

2. Changed ecn_1 - ecn_4 configuration and added new ecn_5 configuration to sonic-mgmt/tests/qos/files/qos_params.j2c.yaml (Jericho2)

3. Did NOT make configuration changes to other platform yaml files such as td3, th2, etc.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
PR #20544 introduced the testQosSaiDscpEcn test and updated QoS ECN configurations exclusively for Jericho2 (j2c) platforms. Because equivalent configurations were not added for other platform yaml files (like td3, th2), these tests fail on non-j2c platforms. This PR prevents those false-positive failures.

#### How did you do it?
Updated the skip conditions in tests/common/plugins/conditional_mark/tests_mark_conditions.yaml so that the tests only run on the supported Jericho2 platform.

Changes made:
* For qos/test_ecn_config.py: Changed the condition to asic_type not in ['cisco-8000', 'broadcom'] or asic_subtype not in ['broadcom-dnx'].
* For testQosSaiDscpEcn: Changed the condition to asic_type not in ['broadcom'] or asic_subtype not in ['broadcom-dnx'].
* This consolidated logic ensures that even if the asic_type is Broadcom, the tests will be skipped unless the asic_subtype is explicitly broadcom-dnx (Jericho2).

#### How did you verify/test it?
Manually tested on testbed running dualtor-AA56 topology — verified that tests are skipped appropriately on non-j2c hardware without failing the test run.

#### Any platform specific information?
These tests will now be explicitly skipped on non-j2c ASICs (such as Tomahawk, Trident3, etc.) and will only execute on broadcom-dnx platforms.

#### Supported testbed topology if it's a new test case?
N/A — Skipped for non-supported platforms, , not a new test case.

### Documentation
N/A — test skip condition update.
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
