### PR TITLE
[cherry-pick] Issue 20728: Enhance configlet/test_add_rack.py for ipv6-only topos (#21591)

### DIFF
--- a/tests/common/configlet/utils.py
+++ b/tests/common/configlet/utils.py
@@ -403,6 +403,17 @@ def chk_bgp_session(duthost, ip, msg):
         "{}: BGP session for {} = {}; expect established".format(msg, ip, bgp_state)
 
 
+def chk_any_bgp_session(duthost, msg):
+    v4_remote = tor_data.get("ip", {}).get("remote")
+    v6_remote = tor_data.get("ipv6", {}).get("remote")
+    if v4_remote:
+        chk_bgp_session(duthost, v4_remote, msg)
+    elif v6_remote:
+        chk_bgp_session(duthost, v6_remote.lower(), msg)
+    else:
+        report_error("{}: No neighbors detected".format(msg))
+
+
 def main():
     set_print()
     print("Calling compare dumps")

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -628,10 +628,6 @@ configlet/test_add_rack.py:
     reason: "AddRack is not yet supported on multi-ASIC platform"
     conditions:
       - "is_multi_asic==True"
-  xfail:
-    reason: "xfail for IPv6-only topologies, need to add support for IPv6-only - https://github.com/sonic-net/sonic-mgmt/issues/20728"
-    conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/20728 and '-v6-' in topo_name"
 
 container_hardening/test_container_hardening.py::test_container_privileged:
   skip:

--- a/tests/configlet/util/base_test.py
+++ b/tests/configlet/util/base_test.py
@@ -11,7 +11,7 @@ from tests.common.configlet.helpers import set_log_prefix_msg, get_prefix_lvl, s
 from tests.common.configlet.utils import base_dir, data_dir, orig_db_dir, no_t0_db_dir, clet_db_dir, managed_files,\
                    patch_add_t0_dir, patch_rm_t0_dir, files_dir, tor_data, init_data, \
                    RELOAD_WAIT_TIME, PAUSE_INTF_DOWN, PAUSE_INTF_UP, PAUSE_CLET_APPLY, DB_COMP_WAIT_TIME,\
-                   do_pause, db_comp, chk_bgp_session, chk_for_pfc_wd, report_error, take_DB_dumps, init_global_data
+                   do_pause, db_comp, chk_any_bgp_session, chk_for_pfc_wd, report_error, take_DB_dumps, init_global_data
 
 
 if os.path.exists("/etc/sonic/sonic-environment"):
@@ -204,8 +204,7 @@ def apply_clet(duthost, skip_test=False):
         "DB compare failed after apply-clet"
 
     # Ensure BGP session is up
-    chk_bgp_session(duthost, tor_data["ip"]["remote"], "post-clet test")
-    chk_bgp_session(duthost, tor_data["ipv6"]["remote"].lower(), "post-clet test")
+    chk_any_bgp_session(duthost, "post-clet test")
 
     log_info("AddRack by template succeeded")
 
@@ -265,8 +264,7 @@ def do_test_add_rack(duthost, is_storage_backend=False, skip_load=False,
                      is_storage_backend=is_storage_backend)
 
         # Ensure BGP session is up before we apply stripped minigraph
-        chk_bgp_session(duthost, tor_data["ip"]["remote"], "pre-clet test")
-        chk_bgp_session(duthost, tor_data["ipv6"]["remote"].lower(), "pre-clet test")
+        chk_any_bgp_session(duthost, "pre-clet test")
 
         set_log_prefix_msg("test prepare")
         prepare_for_test(duthost)


### PR DESCRIPTION
### Description of PR

Cherry-pick of #21591 to 202511.

Summary:
Currently, the test checks for both ipv4 and ipv6 neighbors unconditionally, and will fail if either is missing. Change that behavior to instead check to see if neighbors exist before running the bgp checks. Add a failure case if no neighbors are found in either AF. This way the test is AF-agnostic.

Fixes #20728

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Cherry-pick of #21591 as requested by @weiguo-nvidia.

#### How did you do it?
`git cherry-pick 331f5944` applied cleanly with no conflicts.

#### How did you verify/test it?
Verified in master via #21591.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

*— anders-bot (AI-assisted, on behalf of @anders-nexthop)*