### PR TITLE
[smartswitch] fix the errors from command execution on DPU

### DIFF
--- a/tests/dash/test_dash_privatelink_redirect.py
+++ b/tests/dash/test_dash_privatelink_redirect.py
@@ -362,11 +362,12 @@ def dpu_setup(duthost, dpuhosts, dpu_index, skip_config):
             dpu_cmds.append(
                 f"config int ip add Ethernet0 {dpuhost.dpu_data_port_ip}/31"
             )
-    pt_require(dpuhost.npu_data_port_ip, "DPU data port IP is not set")
-    dpu_cmds.append(
-        f"ip route replace default via {dpuhost.npu_data_port_ip}"
-    )
-    dpuhost.shell_cmds(cmds=dpu_cmds)
+    if dpuhost.npu_data_port_ip:
+        dpu_cmds.append(
+            f"ip route replace default via {dpuhost.npu_data_port_ip}"
+        )
+    if len(dpu_cmds) > 0:
+        dpuhost.shell_cmds(cmds=dpu_cmds)
 
 
 @pytest.fixture(scope="class", autouse=True)

--- a/tests/dash/test_dash_smartswitch_vnet.py
+++ b/tests/dash/test_dash_smartswitch_vnet.py
@@ -43,8 +43,10 @@ def dpu_setup_vnet(duthost, dpuhosts, dpu_index, skip_config):
         dpu_cmds.append("config loopback add Loopback0")
         dpu_cmds.append(f"config int ip add Loopback0 {APPLIANCE_VIP}/32")
 
-    dpu_cmds.append(f"ip route replace default via {dpuhost.npu_data_port_ip}")
-    dpuhost.shell_cmds(cmds=dpu_cmds)
+    if dpuhost.npu_data_port_ip:
+        dpu_cmds.append(f"ip route replace default via {dpuhost.npu_data_port_ip}")
+    if len(dpu_cmds) > 0:
+        dpuhost.shell_cmds(cmds=dpu_cmds)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -54,7 +56,8 @@ def add_npu_static_routes_vnet(duthost, dash_smartswitch_vnet_config, skip_confi
         cmds = []
         pe_nexthop_ip = get_interface_ip(duthost, dash_smartswitch_vnet_config[REMOTE_DUT_INTF]).ip + 1
         cmds.append(f"ip route replace {dash_smartswitch_vnet_config[REMOTE_PA_IP]}/32 via {pe_nexthop_ip}")
-        cmds.append(f"ip route replace {APPLIANCE_VIP}/32 via {dpuhost.dpu_data_port_ip}")
+        if dpuhost.dpu_data_port_ip:
+            cmds.append(f"ip route replace {APPLIANCE_VIP}/32 via {dpuhost.dpu_data_port_ip}")
         logger.info(f"Adding static routes: {cmds}")
         duthost.shell_cmds(cmds=cmds)
 
@@ -63,7 +66,8 @@ def add_npu_static_routes_vnet(duthost, dash_smartswitch_vnet_config, skip_confi
     if not skip_config and not skip_cleanup:
         dpuhost = dpuhosts[dpu_index]
         cmds = []
-        cmds.append(f"ip route del {dash_smartswitch_vnet_config[REMOTE_PA_IP]}/32 via {pe_nexthop_ip}")
+        if dpuhost.dpu_data_port_ip:
+            cmds.append(f"ip route del {dash_smartswitch_vnet_config[REMOTE_PA_IP]}/32 via {pe_nexthop_ip}")
         cmds.append(f"ip route del {APPLIANCE_VIP}/32 via {dpuhost.dpu_data_port_ip}")
         logger.info(f"Removing static routes: {cmds}")
         duthost.shell_cmds(cmds=cmds)


### PR DESCRIPTION
### Description of PR
Summary:
Fixes #23311
Fixes this issue:
vnet and PL redirect DASH Tests are failing because this command failure: config loopback add Loopback0', 'config int ip add Loopback0 10.1.0.5/32', 'ip route replace default via '


### Type of change
- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Need a fix for vnet and PL redirect DASH tests that are failing because this command failure: config loopback add Loopback0', 'config int ip add Loopback0 10.1.0.5/32', 'ip route replace default via '
This is because after topology changes introduced in PR 22902, npu_data_port_ip is not set. 

#### How did you do it?
Skipped the command execution when those fields are empty

#### How did you verify/test it?
Run on MtFuji topology

#### Any platform specific information?
MtFuji

#### Supported testbed topology if it's a new test case?
cmono_t1

### Documentation
N/A