### PR TITLE
iface_namemode: add new port role of Dpc

### DIFF
--- a/ansible/library/port_alias.py
+++ b/ansible/library/port_alias.py
@@ -180,7 +180,7 @@ class SonicPortAliasMap():
                     if role == "Inb":
                         inband_aliases.append(alias)
 
-                    if role in {"Ext"} or (role in ["Int", "Inb", "Rec"] and include_internal):
+                    if role in {"Ext"} or (role in ["Int", "Inb", "Rec", "Dpc"] and include_internal):
                         add_port = True
                         aliases.append(
                             (alias, -1 if port_index == -1 or len(mapping) <= port_index else mapping[port_index]))


### PR DESCRIPTION
### Description of PR
this testcase (iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters) is 
to compare below 2 fields matching when alias mode is enabled.
 
(From DUT) 
admin@MtFuji-dut:/etc/sonic$ grep -A 200 "BUFFER_QUEUE" config_db.json | grep -E "Ethernet240"

"Ethernet240|0-2": {
"Ethernet240|3-4": {
"Ethernet240|5-7": {

(TestCase gets from port_config.ini)
admin@MtFuji-dut:~$ cat /usr/share/sonic/device/x86_64-8102_28fh_dpu_o-r0/Cisco-8102-28FH-DPU-O/port_config.ini
# name          lanes                                         alias   index speed   subport role
Ethernet0       2304,2305,2306,2307,2308,2309,2310,2311       etp0      0    400000    0     
......
...
Ethernet208     512,513,514,515,516,517,518,519               etp26    26    400000    0     
Ethernet216     528,529,530,531,532,533,534,535               etp27    27    400000    0     
Ethernet224     2828,2829,2830,2831                           etp28    28    200000    0     Dpc
Ethernet232     2816,2817,2818,2819                           etp29    29    200000    0     Dpc
Ethernet240     2824,2825,2826,2827                           etp30    30    200000    0     Dpc
Ethernet248     2820,2821,2822,2823                           etp31    31    200000    0     Dpc
Ethernet256     0,1,2,3                                       etp32    32    200000    0     Dpc
Ethernet264     12,13,14,15                                   etp33    33    200000    0     Dpc
Ethernet272     4,5,6,7                                       etp34    34    200000    0     Dpc
Ethernet280     8,9,10,11                                     etp35    35    200000    0     Dpc


admin@MtFuji-dut:/usr/share/sonic/device/x86_64-8102_28fh_dpu_o-r0/Cisco-8102-28FH-DPU-O$ vi port_config.ini
   admin@MtFuji-dut:/etc/sonic$ grep "Ethernet240" /usr/share/sonic/device/x86_64-8102_28fh_dpu_o-r0/Cisco-8102-28FH-DPU-O/port_config.ini
   Ethernet240 2824,2825,2826,2827 etp30 30 200000 0 Dpc **<- due to this, alias map wont have this key.**

### ISSUE
iface_namingmode/test_iface_namingmode.py::test_show_queue_counters KeyError: 'Ethernet240'

def test_show_queue_counters(self, setup, setup_config_mode, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
        """
            intfsChecked = 0
            if mode == 'alias':
                for intf in interfaces:
>                   alias = setup['port_name_map'][intf]
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                   KeyError: 'Ethernet240'
asic       = 
buffer_queue_keys = ['BUFFER_QUEUE|Ethernet232|0-2', 'BUFFER_QUEUE|Ethernet200|3-4', 'BUFFER_QUEUE|Ethernet24|0-2', 'BUFFER_QUEUE|Ethernet192|5-7', 'BUFFER_QUEUE|Ethernet216|0-2', 'BUFFER_QUEUE|Ethernet32|0-2', ...]
configDbCli = 
dutHostGuest = 
duthost    = 
duthosts   = []
enum_rand_one_per_hwsku_frontend_hostname = 'MtFuji-dut'
fields     = ['BUFFER_QUEUE', 'Ethernet88', '3-4']
ifmode     = 'alias'
interfaces = {'Ethernet104', 'Ethernet112', 'Ethernet120', 'Ethernet128', 'Ethernet136', 'Ethernet144', ...}
intf       = 'Ethernet240'
intfsChecked = 0
key        = 'BUFFER_QUEUE|Ethernet88|3-4'
mode       = 'alias'
queue_counter = ' TestAlias0    UC0               0                0            0             0\n TestAlias0    UC1               0   ...          0            0             0\n      etp35   MC15               0                0            0             0'
self       = 
setup      = {'default_interfaces': ['Ethernet0', 'Ethernet8', 'Ethernet16', 'Ethernet24', 'Ethernet32', 'Ethernet40', ...], 'minig..., 'physical_interfaces': ['Ethernet8', 'Ethernet16', 'Ethernet24', 'Ethernet32', 'Ethernet40', 'Ethernet48', ...], ...}
setup_config_mode = (, 'alias', 'alias')
iface_namingmode/test_iface_namingmode.py:774: KeyError

### TESTFLOW
show int status
   Ethernet224                      2828,2829,2830,2831     200G   9100    N/A  TestAlias28          routed    down     down                                DPU-NPU Data Port         off
   Ethernet232                      2816,2817,2818,2819     200G   9100    N/A  TestAlias29          routed    down     down                                DPU-NPU Data Port         off
   Ethernet240                      2824,2825,2826,2827     200G   9100    N/A  TestAlias30          routed    down     down                                DPU-NPU Data Port         off

===> ISSUE
   Ethernet240                      2824,2825,2826,2827     200G   9100    N/A  N/A          routed    down     down                                DPU-NPU Data Port         off


testflow:
Results (84.62s (0:01:24)):
       1 passed

sonic@sonic-ucs-m6-16:/data/tests$ time ./run_tests.sh -n cmono_t1 -d MtFuji-dut -l debug -e -s -m individual -u -e --skip_sanity -t t0,any -p /run_logs/iface_name -c "iface_namingmode/test_iface_namingmode.py::TestShowQueue::test_show_queue_counters[alias-MtFuji-dut]"

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [] 202505
- [x] 202511

### Approach
Test Case: add this solution and rerun
also, u can refer to yang module

Found the yang https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-port.yang#L184

#### What is the motivation for this PR?
testcase failing
#### How did you do it?
testcase failing
#### How did you verify/test it?
rerun this testcase and add current solution
#### Any platform specific information?
cisco T0
#### Supported testbed topology if it's a new test case?
