### PR TITLE
[generic_config_updater] Add SONiC version precheck for test_buffer_profile_create_remove_rollback

### DIFF
--- a/tests/generic_config_updater/test_incremental_qos.py
+++ b/tests/generic_config_updater/test_incremental_qos.py
@@ -273,7 +273,7 @@ def test_buffer_profile_create_remove_rollback(duthost, ensure_dut_readiness, cl
     if "master" not in os_version and "internal" not in os_version:
         is_chassis = duthost.get_facts().get("modular_chassis")
         min_version = "202405" if is_chassis else "202605"
-        if os_version.split('.')[0][:6] <= min_version:
+        if os_version.split('.')[0][:6] < min_version:
             pytest.skip("Test requires SONiC version >= {} (chassis: {}), current version: {}"
                         .format(min_version, bool(is_chassis), os_version))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Summary:
Add a SONiC version precheck at the start of `test_buffer_profile_create_remove_rollback`
to skip the test on images that do not yet contain the required GCU buffer profile
create/remove support.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

### Approach
#### What is the motivation for this PR?
`test_buffer_profile_create_remove_rollback` exercises GCU buffer profile
create/remove/rollback functionality that is only present in SONiC 202605+
(or 202405+ on modular-chassis platforms). Without the precheck, the test
fails spuriously on older images instead of being skipped cleanly.

#### How did you do it?
Read `duthost.os_version` at the start of the test and compare the first
6 characters (YYYYMM) against the minimum required branch string. Modular-
chassis DUTs (detected via `duthost.get_facts().get("modular_chassis")`)
use a lower minimum of `202405`; all other platforms require `202605`.
`master` and `internal` builds always bypass the check.

#### How did you verify/test it?
Manually verified version string parsing logic against both version formats
(`YYYYMM.DD` and `YYYYMMDD.N`) used in the SONiC ecosystem.

#### Any platform specific information?
Modular-chassis DUTs require SONiC >= 202405; non-chassis DUTs require >= 202605.

#### Supported testbed topology if it's a new test case?
t0

### Documentation
N/A

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
