### PR TITLE
[SmartSwitch] [HA] disable northbound route zmq flag for ha topology 

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -601,7 +601,10 @@ class GenerateGoldenConfigDBModule(object):
         # Older version image may not support ZMQ feature flag
         rc, out, err = self.module.run_command("sudo cat /usr/local/yang-models/sonic-device_metadata.yang")
         if "orch_northbond_route_zmq_enabled" in out:
-            ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
+            if self.topo_name == "t1-smartswitch-ha":
+                ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "false"
+            else:
+                ori_config_db["DEVICE_METADATA"]["localhost"]["orch_northbond_route_zmq_enabled"] = "true"
 
         return json.dumps(ori_config_db, indent=4)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

In smartswitch ha topology, noticed peer loopback0 (npu pa ip) is not pingable if orch_northbond_route_zmq_enabled is set to true - the route failed to install. 

This is not a ha specific problem, but it's impacting HA tests as NPU-DPU BFD probing requires loopback reachability. Also, we don't need to enable northbond_route_zmq on NPU config. Hence, adding this change to explicitly disable. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To make sure npu - dpu works (BFD), so HA tests can pass. 

#### How did you do it?
In golden config gen, check the topo name, if matching ha, set the flag to false. 

#### How did you verify/test it?
Once the flag is set to false, loopback became reachable. 

#### Any platform specific information?
NA. 

#### Supported testbed topology if it's a new test case?
Na. 

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
