### PR TITLE
[202411] Fix check_other_vms in test_bgp_bbr.py

### DIFF
--- a/tests/bgp/test_bgp_bbr.py
+++ b/tests/bgp/test_bgp_bbr.py
@@ -23,6 +23,8 @@ from tests.common.utilities import wait_until, delete_running_config
 from tests.common.gu_utils import apply_patch, expect_op_success
 from tests.common.gu_utils import generate_tmpfile, delete_tmpfile
 from tests.common.gu_utils import format_json_patch_for_multiasic
+from tests.common.devices.sonic import SonicHost
+from tests.common.devices.eos import EosHost
 
 
 pytestmark = [
@@ -371,29 +373,62 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
 
         dut_asn = setup['dut_asn']
         tor1_asn = setup['tor1_asn']
+        vm_route = None
 
-        vm_route = nbrhosts[node]['host'].get_route(route.prefix)
-        if not isinstance(vm_route, dict):
-            logging.warning("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
-        vm_route['failed'] = False
-        vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
-        if accepted:
-            if route.prefix not in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
-                vm_route['failed'] = True
-                vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
-            else:
-                tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
-                    ['asPathEntry']['asPath']   # noqa E211
+        def _check_route():
+            nonlocal vm_route
+            vm_route = nbrhosts[node]['host'].get_route(route.prefix)
+            if not isinstance(vm_route, dict):
+                logging.warning("DEBUG: unexpected vm_route type {}, {}".format(type(vm_route), vm_route))
+            vm_route['failed'] = False
+            vm_route['message'] = 'Checking route {} on {} passed'.format(str(route), node)
+            if accepted:
+                tor_route_aspath = None
+                if isinstance(nbrhosts[node]['host'], EosHost):
+                    if route.prefix not in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
+                        vm_route['failed'] = True
+                        vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
+                        return False
+                    else:
+                        tor_route_aspath = vm_route['vrfs']['default']['bgpRouteEntries'][route.prefix]['bgpRoutePaths'][0]\
+                        ['asPathEntry']['asPath']   # noqa E211
+                elif isinstance(nbrhosts[node]['host'], SonicHost):
+                    if vm_route and 'paths' in vm_route:
+                        tor_route_aspath = vm_route['paths'][0]['aspath']['string']
+                    else:
+                        vm_route['failed'] = True
+                        vm_route['message'] = 'No route for {} found on {}'.format(route.prefix, node)
+                        return False
+                else:
+                    vm_route['failed'] = True
+                    vm_route['message'] = 'Unknown host type {} for {}'.format(type(nbrhosts[node]['host']), node)
+                    return False
+
                 # Route path from other VMs: -> DUT(T1) -> TOR1 -> aspath(other T1 -> DUMMY_ASN1)
                 tor_route_aspath_expected = '{} {} {}'.format(dut_asn, tor1_asn, route.aspath)
                 if tor_route_aspath != tor_route_aspath_expected:
                     vm_route['failed'] = True
                     vm_route['message'] = 'On {} expected aspath: {}, actual aspath: {}'\
                         .format(node, tor_route_aspath_expected, tor_route_aspath)
-        else:
-            if route.prefix in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
-                vm_route['failed'] = True
-                vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+                    return False
+            else:
+                if isinstance(nbrhosts[node]['host'], EosHost):
+                    if route.prefix in list(vm_route['vrfs']['default']['bgpRouteEntries'].keys()):
+                        vm_route['failed'] = True
+                        vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+                        return False
+                elif isinstance(nbrhosts[node]['host'], SonicHost):
+                    if vm_route and 'paths' in vm_route:
+                        vm_route['failed'] = True
+                        vm_route['message'] = 'No route {} expected on {}'.format(route.prefix, node)
+                        return False
+                else:
+                    vm_route['failed'] = True
+                    vm_route['message'] = 'Unknown host type {} for {}'.format(type(nbrhosts[node]['host']), node)
+                    return False
+            return True
+
+        wait_until(30, 2, 0, _check_route)
         results[node] = vm_route
 
     other_vms = setup['other_vms']
@@ -403,7 +438,7 @@ def check_bbr_route_propagation(duthost, nbrhosts, setup, route, accepted=True):
     pytest_assert(wait_until(5, 1, 0, check_tor1, nbrhosts, setup, route), 'tor1 check failed')
 
     # check DUT
-    pytest_assert(wait_until(5, 1, 0, check_dut, duthost, other_vms, bgp_neighbors,
+    pytest_assert(wait_until(30, 1, 0, check_dut, duthost, other_vms, bgp_neighbors,
                   setup, route, accepted=accepted), 'DUT check failed')
 
     results = parallel_run(check_other_vms, (nbrhosts, setup, route), {'accepted': accepted},


### PR DESCRIPTION
### Description of PR

Summary:
Cherry-pick of #22088 (and partial #20590) to the 202411 branch.

The `check_other_vms` function in `check_bbr_route_propagation` checks routes on neighbor VMs only **once** without any retry, causing flaky `test_bbr_enabled_dut_asn_in_aspath` failures when BGP route propagation takes longer than expected.

**Observed failure**: Route `172.16.10.0/24` not found on ANY neighbor VM (ARISTA02T0, ARISTA01T2, etc.) in KVM t1-lag topology on 202411 image.

Fixes the flaky BGP BBR test on the 202411 branch by cherry-picking the retry fix from master (#22088).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The `test_bbr_enabled_dut_asn_in_aspath` test in `bgp/test_bgp_bbr.py` is flaky on the 202411 branch. The root cause is a race condition: `check_other_vms` checks if the BBR route has propagated to neighbor VMs only **once** with no retry. On master, this was fixed in PR #22088 by wrapping the check in `wait_until(30, 2, 0)`, but the fix was never cherry-picked to 202411.

Additionally, the `check_dut` wait was only 5 seconds (increased to 30s on master in PR #20590), which is insufficient for BGP convergence on some topologies.

Link to failing test: https://elastictest.org/scheduler/testplan/69c3b4892878597161a7a207?searchTestCase=bgp&testcase=bgp%2Ftest_bgp_bbr.py&type=console

#### How did you do it?
- Wrapped the route check logic in `check_other_vms` inside an inner `_check_route()` function with `wait_until(30, 2, 0)` retry (up to 30 seconds, polling every 2 seconds)
- Added `SonicHost` support alongside `EosHost` for neighbor host type detection (from master PR #22088)
- Increased `check_dut` wait from 5s to 30s to allow sufficient BGP convergence time (from master PR #20590)
- Added proper `return False` / `return True` to support the `wait_until` retry pattern

#### How did you verify/test it?
- This is a direct cherry-pick of a fix already validated and merged on master (#22088, merged 2026-02-10)
- The same fix has been successfully included in the 202511 branch (label: `Included in 202511 branch`)
- CI Pre_test Static Analysis passed on this PR

#### Any platform specific information?
N/A — this is a test framework fix applicable to all platforms running the `bgp/test_bgp_bbr.py` test.

#### Supported testbed topology if it's a new test case?
N/A — bug fix for existing test, not a new test case. Affected topology: t1-lag (BGP BBR tests).

### Documentation
N/A