### PR TITLE
Add non-unicast noise filter to LossyQueueTest ingress drop checks

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -5057,25 +5057,33 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                if (platform_asic and
-                        platform_asic in ["broadcom-dnx", "marvell-teralynx"]):
-                    if cntr == 1:
-                        log_message("recv_counters_base: {}, recv_counters: {}".format(
-                            recv_counters_base[cntr], recv_counters[cntr]), to_stderr=True)
+                dnx_asics = ["broadcom-dnx", "marvell-teralynx"]
+                counter_margin = COUNTER_MARGIN if (
+                    platform_asic and platform_asic in dnx_asics) else 0
+                # Check if ingress drop is caused by environmental non-unicast noise
+                if not ignore_ingress_drop_caused_by_nonunicast_noise(
+                        self.src_client, port_list['src'][src_port_id],
+                        recv_counters, recv_counters_base, cntr,
+                        counter_margin=counter_margin):
+                    if (platform_asic and
+                            platform_asic in ["broadcom-dnx", "marvell-teralynx"]):
+                        if cntr == 1:
+                            log_message("recv_counters_base: {}, recv_counters: {}".format(
+                                recv_counters_base[cntr], recv_counters[cntr]), to_stderr=True)
+                            qos_test_assert(
+                                self,
+                                recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
+                                "Ingress drop encountered: {} packets dropped on "
+                                "counter {} ({})".format(
+                                    recv_counters[cntr] - recv_counters_base[cntr],
+                                    cntr, port_counter_fields[cntr]))
+                    else:
                         qos_test_assert(
-                            self,
-                            recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
+                            self, recv_counters[cntr] == recv_counters_base[cntr],
                             "Ingress drop encountered: {} packets dropped on "
                             "counter {} ({})".format(
                                 recv_counters[cntr] - recv_counters_base[cntr],
                                 cntr, port_counter_fields[cntr]))
-                else:
-                    qos_test_assert(
-                        self, recv_counters[cntr] == recv_counters_base[cntr],
-                        "Ingress drop encountered: {} packets dropped on "
-                        "counter {} ({})".format(
-                            recv_counters[cntr] - recv_counters_base[cntr],
-                            cntr, port_counter_fields[cntr]))
             # xmit port no egress drop
             for cntr in egress_counters:
                 qos_test_assert(
@@ -5126,12 +5134,16 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                                     recv_counters[cntr] - recv_counters_base[cntr],
                                     cntr, port_counter_fields[cntr]))
                 else:
-                    qos_test_assert(
-                        self, recv_counters[cntr] == recv_counters_base[cntr],
-                        "Ingress drop encountered: {} packets dropped on "
-                        "counter {} ({})".format(
-                            recv_counters[cntr] - recv_counters_base[cntr],
-                            cntr, port_counter_fields[cntr]))
+                    # Check if ingress drop is caused by environmental non-unicast noise
+                    if not ignore_ingress_drop_caused_by_nonunicast_noise(
+                            self.src_client, port_list['src'][src_port_id],
+                            recv_counters, recv_counters_base, cntr):
+                        qos_test_assert(
+                            self, recv_counters[cntr] == recv_counters_base[cntr],
+                            "Ingress drop encountered: {} packets dropped on "
+                            "counter {} ({})".format(
+                                recv_counters[cntr] - recv_counters_base[cntr],
+                                cntr, port_counter_fields[cntr]))
 
             # xmit port egress drop
             if platform_asic and platform_asic == "broadcom-dnx" and dut_asic != 'q3d':


### PR DESCRIPTION
### Description of PR

Extend the `ignore_ingress_drop_caused_by_nonunicast_noise()` function (introduced in PR #22871 for PFCtest/PFCXonTest) to also cover **LossyQueueTest**.

PR #22871 added non-unicast noise filtering to PFCtest and PFCXonTest, but missed LossyQueueTest. Environmental broadcast/multicast traffic causes false positive ingress drop failures in LossyQueueTest with the same root cause.

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
LossyQueueTest has the same false positive ingress drop issue as PFCtest/PFCXonTest. Environmental broadcast/multicast traffic (ARP, IPv6 NS/RA) arrives during testing and causes InDiscard counter increases unrelated to test traffic. PR #22871 fixed this for PFCtest/PFCXonTest but did not cover LossyQueueTest.

Kusto analysis shows LossyQueueTest still fails at 33% rate on SONiC.20251110.x across multiple platforms (Cisco-8101, Arista-7060X6, etc.) even after PR #22871.

#### How did you do it?
Applied the same `ignore_ingress_drop_caused_by_nonunicast_noise()` wrapper to both ingress drop check points in LossyQueueTest:
1. Short-of-drop phase (no ingress drop expected)
2. Post-excess-traffic phase (no ingress drop expected on non-DNX platforms)

#### How did you verify/test it?
Code review. Same pattern as PR #22871 which was verified on Cisco-8000 chassis topology.

#### Any platform specific information?
Counter margin (COUNTER_MARGIN) applied for broadcom-dnx, cisco-8000, and marvell-teralynx platforms.

ADO PBIs: #37142761
