### PR TITLE
[container_upgrade] Convert parameters.json from string to list format

### DIFF
--- a/tests/container_upgrade/container_upgrade_helper.py
+++ b/tests/container_upgrade/container_upgrade_helper.py
@@ -93,7 +93,7 @@ def create_testcase_mapping(testcase_file):
 def create_parameters_mapping(containers, parameters_file):
     with open(parameters_file, 'r') as file:
         data = json.load(file)
-    container_parameters = {container: details['parameters'] for container, details in data.items()}
+    container_parameters = {container: ' '.join(details['parameters']) for container, details in data.items()}
 
     return container_parameters
 

--- a/tests/container_upgrade/parameters.json
+++ b/tests/container_upgrade/parameters.json
@@ -1,26 +1,90 @@
 {
     "docker-sonic-telemetry": {
-        "parameters": ""
+        "parameters": []
     },
     "docker-sonic-gnmi": {
-        "parameters": "--net=host --pid=host --userns=host --uts=host --cap-add=SYS_ADMIN --cap-add=SYS_BOOT --cap-add=SYS_PTRACE --cap-add=NET_ADMIN --cap-add=DAC_OVERRIDE --security-opt apparmor=unconfined --security-opt seccomp=unconfined -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /etc/fips/fips_enable:/etc/fips/fips_enable:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/dbus:/var/run/dbus:rw -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-chassis:/var/run/redis-chassis:ro --env RUNTIME_OWNER=local"
+        "parameters": [
+            "--net=host",
+            "--pid=host",
+            "--userns=host",
+            "--uts=host",
+            "--cap-add=SYS_ADMIN",
+            "--cap-add=SYS_BOOT",
+            "--cap-add=SYS_PTRACE",
+            "--cap-add=NET_ADMIN",
+            "--cap-add=DAC_OVERRIDE",
+            "--security-opt apparmor=unconfined",
+            "--security-opt seccomp=unconfined",
+            "-v /etc/sonic:/etc/sonic:ro",
+            "-v /etc/localtime:/etc/localtime:ro",
+            "-v /etc/fips/fips_enable:/etc/fips/fips_enable:ro",
+            "-v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro",
+            "-v /var/run/dbus:/var/run/dbus:rw",
+            "-v /var/run/redis:/var/run/redis:rw",
+            "-v /var/run/redis-chassis:/var/run/redis-chassis:ro",
+            "--env RUNTIME_OWNER=local"
+        ]
     },
     "docker-gnmi-watchdog": {
-        "parameters": "--pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"
+        "parameters": [
+            "--pid=host",
+            "--net=host",
+            "-v /etc/localtime:/etc/localtime:ro",
+            "-v /etc/sonic:/etc/sonic:ro"
+        ]
     },
     "docker-sonic-bmp": {
-        "parameters": "--net=host -v /etc/sonic:/etc/sonic:ro -v /etc/localtime:/etc/localtime:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-bmp:/var/run/redis-bmp:ro"
+        "parameters": [
+            "--net=host",
+            "-v /etc/sonic:/etc/sonic:ro",
+            "-v /etc/localtime:/etc/localtime:ro",
+            "-v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro",
+            "-v /var/run/redis:/var/run/redis:rw",
+            "-v /var/run/redis-bmp:/var/run/redis-bmp:ro"
+        ]
     },
     "docker-bmp-watchdog": {
-        "parameters": "--pid=host --net=host -v /etc/localtime:/etc/localtime:ro -v /etc/sonic:/etc/sonic:ro"
+        "parameters": [
+            "--pid=host",
+            "--net=host",
+            "-v /etc/localtime:/etc/localtime:ro",
+            "-v /etc/sonic:/etc/sonic:ro"
+        ]
     },
     "docker-sonic-restapi": {
-        "parameters": "--net=host -v /var/run/redis/redis.sock:/var/run/redis/redis.sock -v /etc/sonic/credentials:/etc/sonic/credentials:ro -v /etc/localtime:/etc/localtime:ro -v /var/run/redis:/var/run/redis:rw -v /var/run/redis-chassis:/var/run/redis-chassis:ro -v /etc/fips/fips_enable:/etc/fips/fips_enable:ro -v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro -e RUNTIME_OWNER=local -e NAMESPACE_PREFIX=asic -e CONTAINER_NAME=restapi -e SYSLOG_TARGET_IP=127.0.0.1"
+        "parameters": [
+            "--net=host",
+            "-v /var/run/redis/redis.sock:/var/run/redis/redis.sock",
+            "-v /etc/sonic/credentials:/etc/sonic/credentials:ro",
+            "-v /etc/localtime:/etc/localtime:ro",
+            "-v /var/run/redis:/var/run/redis:rw",
+            "-v /var/run/redis-chassis:/var/run/redis-chassis:ro",
+            "-v /etc/fips/fips_enable:/etc/fips/fips_enable:ro",
+            "-v /usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro",
+            "-e RUNTIME_OWNER=local",
+            "-e NAMESPACE_PREFIX=asic",
+            "-e CONTAINER_NAME=restapi",
+            "-e SYSLOG_TARGET_IP=127.0.0.1"
+        ]
     },
     "docker-restapi-watchdog": {
-        "parameters": "--net=host -v /etc/localtime:/etc/localtime:ro"
+        "parameters": [
+            "--net=host",
+            "-v /etc/localtime:/etc/localtime:ro"
+        ]
     },
     "docker-restapi-sidecar": {
-        "parameters": "--privileged --pid=host --net=host --uts=host --ipc=host -v /etc/sonic:/etc/sonic:ro -v /usr/bin/docker:/usr/bin/docker:ro -v /var/run/docker.sock:/var/run/docker.sock -v /:/hostroot:ro -e DOCKER_BIN=/usr/bin/docker"
+        "parameters": [
+            "--privileged",
+            "--pid=host",
+            "--net=host",
+            "--uts=host",
+            "--ipc=host",
+            "-v /etc/sonic:/etc/sonic:ro",
+            "-v /usr/bin/docker:/usr/bin/docker:ro",
+            "-v /var/run/docker.sock:/var/run/docker.sock",
+            "-v /:/hostroot:ro",
+            "-e DOCKER_BIN=/usr/bin/docker"
+        ]
     }
 }


### PR DESCRIPTION
### Description of PR

Summary:
Convert docker parameters in `parameters.json` from single string format to list format for better readability and to align with the internal repo format, reducing merge conflicts during public-to-internal sync.

Update `create_parameters_mapping()` to join the list with spaces, producing the same runtime result as before.

### Type of change
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The internal repo uses list format for docker parameters in `parameters.json`, while the public repo uses string format. This difference causes merge conflicts every time we sync public to internal. By aligning the format, future syncs will be clean.

#### How did you do it?
1. Converted `parameters.json` entries from strings (e.g., `"param1 param2"`) to lists (e.g., `["param1", "param2"]`)
2. Updated `create_parameters_mapping()` in `container_upgrade_helper.py` to use `' '.join(details['parameters'])` to reconstruct the string at runtime

#### How did you verify/test it?
The `create_parameters_mapping()` function joins the list back into a space-separated string, producing identical output to the previous string format. The docker run commands are unchanged.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A - existing test improvement

### Documentation
N/A
