### PR TITLE
Fix system_health: accept similar fault LED colors using color groups

### DIFF
--- a/tests/system_health/test_system_health.py
+++ b/tests/system_health/test_system_health.py
@@ -70,6 +70,21 @@ DEFAULT_LED_CONFIG = {
 }
 
 
+# Similar colors treated as equivalent fault indicators (e.g. red/orange/amber).
+FAULT_COLOR_GROUPS = [
+    {'red', 'orange', 'amber'},
+    {'red_blink', 'orange_blink', 'amber_blink'},
+]
+
+
+def _get_color_group(color):
+    """Return the color group for the given color, or None."""
+    for group in FAULT_COLOR_GROUPS:
+        if color in group:
+            return group
+    return None
+
+
 @pytest.fixture(autouse=True, scope="module")
 def check_image_version(duthost):
     """Skip the test for unsupported images."""
@@ -520,8 +535,12 @@ def check_system_health_led_info(duthost):
         assert system_status_lower == expected_normal, \
             f"System status LED is not the configured 'normal' color ({expected_normal}), but it is {system_led_status}"
     else:
-        # Logic for faulted system: Iterate through led_cfg to find a match among non-normal keys
+        # Faulted system: LED must match a configured non-normal color or similar equivalent.
         not_normal = {color for key, color in led_cfg.items() if key != "normal"}
+        for color in list(not_normal):
+            color_group = _get_color_group(color)
+            if color_group:
+                not_normal.update(color_group)
         assert system_status_lower in not_normal, \
             f"System status LED '{system_led_status}' does not match any colors defined in config: {not_normal}"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:

Some platforms (Mellanox) configure 'orange' as the fault LED color but the platform api reports 'red' on read (e.g. via _get_primary_color()). The previous exact match caused false failures on those platforms.

Original PR for the test: https://github.com/sonic-net/sonic-mgmt/pull/20716
- This PR hard coded the fault colors as red, orange, or yellow.

PR that introduced the bug we are fixing: https://github.com/sonic-net/sonic-mgmt/pull/22675
- Only accepts "red" as a fault color while Mellanox uses "orange"

Fixes #23055:

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Bug https://github.com/sonic-net/sonic-mgmt/issues/23055 filed - `Bug: inconsistent system status LED color on mlnx sn2700`

#### How did you do it?

Introduce FAULT_COLOR_GROUPS to treat similar colors (red/orange/amber) as equivalent fault indicators. Also fix a latent UnboundLocalError when the LED line is absent from CLI output.

#### How did you verify/test it?

Ran on 202511 sonic-mgmt T0 topology.

#### Any platform specific information?

Issue is seen on Mellanox, but test case updates should not effect other platforms.

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
