### PR TITLE
[DASH] Use VLAN intf for DPU dataplane intf when available

### DIFF
--- a/tests/common/helpers/smartswitch_util.py
+++ b/tests/common/helpers/smartswitch_util.py
@@ -14,6 +14,11 @@ def get_dpu_dataplane_port(duthost, dpu_index):
         if_dpu_index = 224 + dpu_index*8
         interface = f"Ethernet{if_dpu_index}"
 
+    for vlan_interface, vlan_info in duthost.get_vlan_brief().items():
+        if interface in vlan_info.get("members", []):
+            logger.info(f"DPU dataplane interface {interface} is VLAN member, use VLAN interface: {vlan_interface}")
+            return vlan_interface
+
     logger.info(f"DPU dataplane interface: {interface}")
     return interface
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
#22902 changed the default smartswitch config to put all DPU dataplane interfaces on the NPU in a VLAN. When trying to reach the DPU dataplane, the appropriate interface is now the VLAN interface.

#### How did you do it?
Once the individual DPU-facing port is found on the NPU, check if it is a VLAN member. If so, us the VLAN interface instead.

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
