### PR TITLE
vpp: restrict platform_tests skip marker to kvm platform

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -77,14 +77,6 @@ bfd/test_bfd_traffic.py:
 #######################################
 #####           BGP               #####
 #######################################
-bgp/test_bgp_allow_list.py:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 bgp/test_bgp_bbr.py::test_bbr_enabled_dut_asn_in_aspath:
   skip:
     reason: >
@@ -110,14 +102,6 @@ bgp/test_bgp_gr_helper.py::test_bgp_gr_helper_routes_perserved:
       - "asic_type in ['vpp']"
 
 bgp/test_bgp_multipath_relax.py::test_bgp_multipath_relax:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-bgp/test_bgp_peer_shutdown.py::test_bgp_peer_shutdown:
   skip:
     reason: >
             Failed/Errored: To be included


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
restrict platform_tests skip marker to kvm platform
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
1. sonic-vpp skips platform_tests by checking asic-type == vpp. This is not correct anymore because there is hardware platform using vpp dataplane but it supports the platform_tests.
2. remove additional skip markers because they pass on arctos platform

#### How did you do it?
Add platform in ['x86_64-kvm_x86_64-r0'] additional condition to limit the skip to kvm based vpp platform.

#### How did you verify/test it?
Run sonic-mgmt tests
#### Any platform specific information?
vpp
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
