### PR TITLE
[ 202511, Backport PR23358 ] Fix test_show_queue_counters for T2 topo VOQ devices

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -726,7 +726,8 @@ class TestShowPriorityGroup():
 
 class TestShowQueue():
 
-    def test_show_queue_counters(self, setup, setup_config_mode, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+    def test_show_queue_counters(self, setup, setup_config_mode, duthosts, enum_rand_one_per_hwsku_frontend_hostname,
+                                 tbinfo):
         """
         Checks whether 'show queue counters' lists the interface names as
         per the configured naming mode
@@ -757,6 +758,12 @@ class TestShowQueue():
                         if hostname != duthost.hostname:
                             continue
                     # The interface name is always the last but one field in the BUFFER_QUEUE entry key
+                    # Note that on multi-asic T2, filter interfaces by asic namespace since
+                    # queue counters are queried per-asic. On single-asic T2 or
+                    # non-T2 topologies, include all local interfaces.
+                    if (duthost.is_multi_asic and tbinfo['topo']['type'] == 't2' and
+                            fields[-3] != asic.namespace):
+                        continue
                     interfaces.add(fields[-2])
                 except IndexError:
                     pass


### PR DESCRIPTION
### Description of PR

Add filter interfaces condition by asic namespace since queue counters are queried per-asic on multi-ASIC T2 (VOQ) devices. On single-asic T2 or non-T2 topologies, include all local interfaces

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Created another PR for this change in master :  https://github.com/sonic-net/sonic-mgmt/pull/23358

### Approach
#### What is the motivation for this PR?

- On multi-ASIC T2 topology, show queue counters is queried per ASIC namespace, not globally across all ASICs.
- The test was collecting interfaces from all ASICs regardless of namespace, causing a mismatch between expected and actual interface names during the naming mode check.

Currently, the test simply accumulated every interface it encountered without any namespace awareness.

#### How did you do it?

 - Added tbinfo as a fixture parameter to the test function, which provides topology information needed to identify the T2 topology type.
 - Added an early-skip inside the interface collection loop: when on a multi-ASIC T2 device, skip any interface whose ASIC namespace does not match the current namespace being iterated.
 - Single-ASIC T2 devices and non-T2 topologies are unaffected — they fall through without skipping, so all local interfaces continue to be collected.
 - The change is purely additive — no existing logic was removed or restructured, only new filtering was inserted.

#### How did you verify/test it?

- Verified on multi-ASIC T2 (VOQ) devices that only interfaces belonging to the current ASIC namespace are collected
- Verified on single-ASIC T2 devices that all local interfaces are included
- Verified on non-T2 topologies that behavior is unchanged.

Test passes on mutli-asic and single-asic systems

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
