### PR TITLE
Fix test_show_queue_counters for T2 topo VOQ devices

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -758,10 +758,13 @@ class TestShowQueue():
                         if hostname != duthost.hostname:
                             continue
                     # The interface name is always the last but one field in the BUFFER_QUEUE entry key
-                    t2_multi_asic_match = duthost.is_multi_asic and fields[-3] == asic.namespace and \
-                        tbinfo['topo']['type'] == 't2'
-                    if tbinfo['topo']['type'] not in ['t2'] or t2_multi_asic_match:
-                        interfaces.add(fields[-2])
+                    # Note that on multi-asic T2, filter interfaces by asic namespace since
+                    # queue counters are queried per-asic. On single-asic T2 or
+                    # non-T2 topologies, include all local interfaces.
+                    if (duthost.is_multi_asic and tbinfo['topo']['type'] == 't2' and
+                            fields[-3] != asic.namespace):
+                        continue
+                    interfaces.add(fields[-2])
                 except IndexError:
                     pass
 


### PR DESCRIPTION
### Description of PR

Fix interfaces filtering by asic namespace since queue counters are queried per-asic on multi-ASIC T2 (VOQ) devices. On single-asic T2 or non-T2 topologies, include all local interfaces.

Summary:
Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Manually created a backport PR to 202511 : https://github.com/sonic-net/sonic-mgmt/pull/23357

### Approach
#### What is the motivation for this PR?

- On multi-ASIC T2 topology, show queue counters is queried per ASIC namespace, not globally across all ASICs.
- The test was collecting interfaces from all ASICs regardless of namespace, causing a mismatch between expected and actual interface names   during the naming mode check.
- Currently there is a  filtering logic, but it was inverted — it excluded T2 topologies by default and only re-included them under a narrow multi-ASIC match condition.
- This accidentally broke single-ASIC T2 devices, where the multi-ASIC condition is never true, so their interfaces were never collected at all.

#### How did you do it?

- Removed the t2_multi_asic_match variable check and its positive-include condition.
- Replaced it with a simple early-skip: when on a multi-ASIC T2 device, skip any interface whose ASIC namespace does not match the current namespace being iterated.
- All other cases — single-ASIC T2 and non-T2 topologies — fall through without skipping, so all local interfaces are collected as expected.

#### How did you verify/test it?

- Verified on multi-ASIC T2 (VOQ) devices that only interfaces belonging to the current ASIC namespace are collected.
- Verified on single-ASIC T2 devices that all local interfaces are included.
- Verified on non-T2 topologies that behavior is unchanged.

Test passes on mutli-asic and single-asic systems

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
