### PR TITLE
[vm_set]: Add fallback default for VM_targets when VMs are not required

### DIFF
--- a/ansible/roles/vm_set/tasks/main.yml
+++ b/ansible/roles/vm_set/tasks/main.yml
@@ -434,6 +434,11 @@
 
   when: vm_required is defined and vm_required == True
 
+- name: Set fallback default value for VM_targets
+  set_fact:
+    VM_targets: []
+  when: VM_targets is not defined
+
 - name: Generate DPU list of target DPUs
   set_fact: dpu_targets={{ VM_hosts | filter_vm_targets(topology['DPUs'], VM_base) | sort }}
   when: topology['DPUs'] is defined and hostvars[duts_name]['type'] == 'kvm'


### PR DESCRIPTION
### Description of PR

Summary:
When `ptf_imagename` is `docker-keysight-api-server`, `vm_required` is set to `false`, which skips the block that defines `VM_targets`. However, `remove_topo.yml` and `add_topo.yml` reference `VM_targets` unconditionally, causing `VM_targets is undefined` errors during topology teardown.

This change adds a top-level fallback that sets `VM_targets` to an empty list when it is not defined.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Topology setup and teardown should not fail when VMs are intentionally not required. For the `docker-keysight-api-server` PTF image, VM creation is skipped by design, but downstream tasks still assume `VM_targets` exists. That leads to avoidable teardown failures caused by an undefined variable rather than a real topology issue.

#### How did you do it?

Added a top-level fallback in `ansible/roles/vm_set/tasks/main.yml` to initialize `VM_targets` to an empty list when it is not defined. This matches the existing defensive pattern already used for `dpu_targets` and allows `add_topo.yml` and `remove_topo.yml` to evaluate safely even when VM setup is skipped.

#### How did you verify/test it?

Verified the change by reviewing the execution flow for the case where `ptf_imagename == 'docker-keysight-api-server'` and confirming that:
- `vm_required` can be `false`
- the VM initialization block can be skipped
- `VM_targets` is still defined afterward
- downstream references in topology add/remove tasks can execute without `VM_targets is undefined`

#### Any platform specific information?

This change is primarily relevant to environments using `docker-keysight-api-server`, where VMs are not required. It is otherwise low risk because it only provides a default empty list when `VM_targets` was previously undefined.

#### Supported testbed topology if it's a new test case?

Not applicable. This is not a new test case.

### Documentation

No documentation update is required for this bug fix.