### PR TITLE
Set autoneg off for t0-f2 server-facing ports in golden config

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -637,6 +637,7 @@ class GenerateGoldenConfigDBModule(object):
             # Enable link_training for server facing ports
             if "Server" in config.get("description", ""):
                 config["link_training"] = "on"
+                config["autoneg"] = "off"
 
         return json.dumps({'PORT': golden_config['PORT']}, indent=4)
 


### PR DESCRIPTION
### Description of PR

Summary:
Update golden config generation for `t0-f2-d40u8` topology to set `autoneg=off` on server-facing ports alongside the existing `link_training=on` setting.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Link training was enabled for t0-f2 server-facing ports in #23107, but `autoneg` was not explicitly set to `off`. On some branches which doesn't have the fix for https://github.com/sonic-net/sonic-mgmt/pull/20030, autoneg can defaults to 'on', causing interfaces to fail to establish links.

#### How did you do it?
Added `config["autoneg"] = "off"` for server-facing ports in `generate_t0_f2_golden_config_db()` in `ansible/library/generate_golden_config_db.py`.

#### How did you verify/test it?
Verified on physical testbed with t0-f2-d40u8 topology. Server-facing interfaces come up correctly with autoneg disabled.

#### Any platform specific information?
Applies to t0-f2-d40u8 topology only.

#### Supported testbed topology if it is a new test case?
N/A

### Documentation
N/A
