### PR TITLE
Add OVERRIDE_PARAMS passthrough in pre_defined_pr_test pipeline

### DIFF
--- a/.azure-pipelines/pre_defined_pr_test.yml
+++ b/.azure-pipelines/pre_defined_pr_test.yml
@@ -42,6 +42,10 @@ parameters:
   type: string
   default: "all"
 
+- name: OVERRIDE_PARAMS
+  type: object
+  default: {}
+
 stages:
 - stage: Test
   variables:
@@ -64,3 +68,4 @@ stages:
         MGMT_COMMIT_HASH: ${{ parameters.MGMT_COMMIT_HASH }}
         KVM_BUILD_ID: ${{ parameters.KVM_BUILD_ID }}
         INCLUDE_JOBS: ${{ parameters.INCLUDE_JOBS }}
+        OVERRIDE_PARAMS: ${{ parameters.OVERRIDE_PARAMS }}


### PR DESCRIPTION
## Summary

The `pr_test_template.yml` already supports `OVERRIDE_PARAMS` for passing extra elastictest arguments (e.g. `KVM_IMAGE_BUILD_PIPELINE_ID`). However, `pre_defined_pr_test.yml` (pipeline 3320) does not expose or forward this parameter, so callers using pipeline 3320 via API cannot pass `OVERRIDE_PARAMS` through to the template.

## Changes

Add the `OVERRIDE_PARAMS` parameter (`type: object`, `default: {}`) to `pre_defined_pr_test.yml` and forward it to the `pr_test_template.yml` template call.

## Motivation

The PR binary search system (and other automation tools) trigger pipeline 3320 via the Azure DevOps Pipelines API and pass `OVERRIDE_PARAMS` in `templateParameters`. Without this change, `OVERRIDE_PARAMS` is silently dropped because `pre_defined_pr_test.yml` doesn't declare or forward it.

## Testing

- No functional change to existing callers (default is `{}` which is equivalent to not passing it)
- Verified that `pr_test_template.yml` already handles `OVERRIDE_PARAMS` correctly via `each param in parameters.OVERRIDE_PARAMS`