### PR TITLE
Ensure DUT is in TSB mode before running BGP tests

### DIFF
--- a/tests/bgp/conftest.py
+++ b/tests/bgp/conftest.py
@@ -743,6 +743,54 @@ def bgpmon_setup_teardown(ptfhost, duthosts, enum_rand_one_per_hwsku_frontend_ho
     ptfhost.shell("ip neigh flush to %s nud permanent" % dut_lo_addr)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def ensure_tsb(duthosts, rand_one_dut_hostname):
+    """Ensure the DUT is in TSB (normal) mode before running BGP tests.
+
+    startup_tsa_tsb.service puts the switch into TSA on boot/config_reload
+    to prevent attracting traffic before it's ready, then transitions to TSB
+    after a delay. This fixture ensures TSB is complete and routes are being
+    advertised before tests run.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    tsa_enabled = duthost.shell(
+        'sonic-db-cli CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled"',
+        module_ignore_errors=True
+    )["stdout"].strip()
+
+    if tsa_enabled == "true":
+        result = duthost.shell("TSB", module_ignore_errors=True)
+        if result["rc"] != 0:
+            logger.warning("TSB command failed with rc=%d: %s", result["rc"], result.get("stderr", ""))
+
+        def _bgp_advertising():
+            try:
+                result = duthost.shell(
+                    "vtysh -c 'show bgp summary json'",
+                    module_ignore_errors=True
+                )
+                summary = json.loads(result["stdout"])
+                peers = (
+                    summary.get("ipv4Unicast", {}).get("peers", {}) or
+                    summary.get("ipv6Unicast", {}).get("peers", {})
+                )
+                # pfxSnt == 1 means only the loopback is advertised, which indicates TSA is still active
+                return any(
+                    p.get("pfxSnt", 0) > 1
+                    for p in peers.values()
+                    if p.get("state") == "Established"
+                )
+            except Exception:
+                return False
+
+        pt_assert(
+            wait_until(300, 10, 0, _bgp_advertising),
+            "BGP is not advertising routes after TSB within 300 seconds"
+        )
+
+    yield
+
+
 def pytest_addoption(parser):
     """
     Adds options to pytest that are used by bgp suppress fib pending test


### PR DESCRIPTION
### Description of PR

This PR adds a fixture to ensure the DUT is in TSB (Traffic Shift Back) mode before running BGP tests. The `startup_tsa_tsb.service` puts switches into TSA (Traffic Shift Away) mode on config reload to prevent attracting traffic before the system is fully ready. After a delay, it transitions to TSB mode and begins advertising routes normally. BGP tests can fail if they run while the DUT is still in TSA mode or during the TSA->TSB transition, as routes are not yet being advertised to peers. This issue was seen when trying to run test_bgp_update_timer.py, the first run is successful and each subsequent run of the test fails.

Summary:
Fixes # (issue) https://github.com/sonic-net/sonic-mgmt/issues/23336

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

BGP tests can fail intermittently when run while the DUT is transitioning from TSA to TSB mode after a config reload. This was discovered when running test_bgp_update_timer.py - the first run would succeed, but subsequent runs would fail because the DUT was still in TSA mode or transitioning to TSB, preventing routes from being advertised to peers. This fixture ensures all BGP tests start with the DUT in Normal mode.

#### How did you do it?

Added an autouse module-scoped fixture `ensure_tsb()` to `tests/bgp/conftest.py` that:
1. Checks CONFIG_DB to see if TSA is currently enabled
2. If TSA is enabled, executes the `TSB` command to transition back to normal mode
3. Waits up to 300 seconds for BGP to start advertising routes
4. Runs automatically before all BGP tests in the module

#### How did you verify/test it?

Verified that test_bgp_update_timer.py now runs successfully on consecutive executions. Previously, the first run would pass but subsequent runs would fail due to the DUT being in TSA mode after config reload. With this fixture, the test now waits for TSB completion and route advertisement before proceeding, eliminating the intermittent failures.