### PR TITLE
Fix extra loganalyzer argument passed to _setup_test_params in test_qos_dscp_mapping

### DIFF
--- a/tests/qos/test_qos_dscp_mapping.py
+++ b/tests/qos/test_qos_dscp_mapping.py
@@ -504,7 +504,7 @@ class TestQoSSaiDSCPQueueMapping_IPIP_Base():
         inner_dst_ip_list = route_config
 
         with allure.step("Prepare test parameter"):
-            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links, loganalyzer)
+            test_params = self._setup_test_params(duthost, tbinfo, downstream_links, upstream_links)
 
         with allure.step("Run test"):
             self._run_test(ptfadapter, duthost, tbinfo, test_params, inner_dst_ip_list, dut_qos_maps_module, dscp_mode)


### PR DESCRIPTION
### Description of PR

Summary:
Fix a bug in \	est_dscp_to_queue_mapping\ where \_setup_test_params()\ is called with an extra \loganalyzer\ argument that the method does not accept, which would cause \TypeError\ at runtime.

\_setup_test_params(self, duthost, tbinfo, downstream_links, upstream_links)\ only accepts 4 positional arguments, but was called with 5 (the extra \loganalyzer\).

Found during review of #23267.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
During review of #23267 (Disable loganalyzer in test_qos_dscp_mapping), discovered that \_setup_test_params()\ is called with an extra \loganalyzer\ argument on line 507 that does not match the method signature (line 242-247). This would cause a \TypeError: _setup_test_params() takes 5 positional arguments but 6 were given\ at runtime.

#### How did you do it?
Removed the extra \loganalyzer\ argument from the \_setup_test_params()\ call.

#### How did you verify/test it?
Code inspection — the method definition confirms it does not use \loganalyzer\.

#### Any platform specific information?
N/A — affects all platforms.

### Documentation
N/A