### PR TITLE
[bgp/agg]: Aggregate Address Lifecycle Operations

### DIFF
--- a/tests/bgp/bgp_aggregate_helpers.py
+++ b/tests/bgp/bgp_aggregate_helpers.py
@@ -1,0 +1,319 @@
+"""
+Shared helpers for BGP aggregate-address tests.
+
+Provides:
+  - AggregateCfg named tuple
+  - GCU patch helpers (add / remove / update / batch / safe-remove)
+  - DB and running-config query helpers
+  - Consistency and cleanup validators
+"""
+
+import ast
+import logging
+from collections import namedtuple
+
+import pytest
+
+from tests.common.gcu_utils import (
+    apply_gcu_patch,
+    apply_patch,
+    generate_tmpfile,
+    delete_tmpfile,
+    create_checkpoint,
+    rollback_or_reload,
+    delete_checkpoint,
+)
+from tests.common.helpers.assertions import pytest_assert
+
+logger = logging.getLogger(__name__)
+
+# ---- Constants & helper structures ----
+BGP_AGGREGATE_ADDRESS = "BGP_AGGREGATE_ADDRESS"
+PLACEHOLDER_PREFIX = "192.0.2.0/32"  # RFC5737 TEST-NET-1
+
+AggregateCfg = namedtuple(
+    "AggregateCfg", ["prefix", "bbr_required", "summary_only", "as_set"]
+)
+
+
+# ---- DB & running-config helpers ----
+def dump_db(duthost, dbname, tablename):
+    """Return current DB content as dict."""
+    keys_out = duthost.shell(
+        "sonic-db-cli {} keys '{}*'".format(dbname, tablename),
+        module_ignore_errors=True,
+    )["stdout"]
+    logger.info(
+        "dump %s db, table %s, keys output: %s",
+        dbname, tablename, keys_out,
+    )
+    keys = keys_out.strip().splitlines() if keys_out.strip() else []
+    res = {}
+    for k in keys:
+        fields = duthost.shell(
+            "sonic-db-cli {} hgetall '{}'".format(dbname, k),
+            module_ignore_errors=True,
+        )["stdout"]
+        logger.info("all fields:%s for key: %s", fields, k)
+        prefix = k.removeprefix("{}|".format(tablename))
+        res[prefix] = ast.literal_eval(fields)
+        logger.info("dump config db result: %s", res)
+    return res
+
+
+def running_bgp_has_aggregate(duthost, prefix):
+    """Grep FRR running BGP config for aggregate-address lines."""
+    return duthost.shell(
+        "show runningconfiguration bgp"
+        " | grep -i 'aggregate-address {}'".format(prefix),
+        module_ignore_errors=True,
+    )["stdout"]
+
+
+# ---- GCU JSON patch helpers ----
+def gcu_add_placeholder_aggregate(duthost, prefix):
+    patch = [
+        {
+            "op": "add",
+            "path": "/BGP_AGGREGATE_ADDRESS/{}".format(
+                prefix.replace("/", "~1")
+            ),
+            "value": {"summary-only": "false", "as-set": "false"},
+        }
+    ]
+    logger.info(
+        "Adding placeholder BGP aggregate %s",
+        prefix.replace("/", "~1"),
+    )
+    return apply_gcu_patch(duthost, patch)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_teardown(duthost):
+    """Create checkpoint before tests, rollback after."""
+    create_checkpoint(duthost)
+
+    # add placeholder aggregate to avoid GCU removing empty table
+    default_aggregates = dump_db(
+        duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS
+    )
+    if not default_aggregates:
+        gcu_add_placeholder_aggregate(duthost, PLACEHOLDER_PREFIX)
+
+    yield
+
+    try:
+        rollback_or_reload(duthost, fail_on_rollback_error=False)
+    finally:
+        delete_checkpoint(duthost)
+
+
+def gcu_add_aggregate(duthost, aggregate_cfg):
+    logger.info("Add BGP_AGGREGATE_ADDRESS by GCU cmd")
+    patch = [
+        {
+            "op": "add",
+            "path": "/BGP_AGGREGATE_ADDRESS/{}".format(
+                aggregate_cfg.prefix.replace("/", "~1")
+            ),
+            "value": {
+                "bbr-required": (
+                    "true" if aggregate_cfg.bbr_required else "false"
+                ),
+                "summary-only": (
+                    "true" if aggregate_cfg.summary_only else "false"
+                ),
+                "as-set": (
+                    "true" if aggregate_cfg.as_set else "false"
+                ),
+            },
+        }
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+def gcu_remove_aggregate(duthost, prefix):
+    patch = [
+        {
+            "op": "remove",
+            "path": "/BGP_AGGREGATE_ADDRESS/{}".format(
+                prefix.replace("/", "~1")
+            ),
+        }
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+def safe_remove_aggregate(duthost, prefix):
+    """Best-effort removal for cleanup — never raises."""
+    try:
+        patch = [
+            {
+                "op": "remove",
+                "path": "/BGP_AGGREGATE_ADDRESS/{}".format(
+                    prefix.replace("/", "~1")
+                ),
+            }
+        ]
+        tmpfile = generate_tmpfile(duthost)
+        try:
+            apply_patch(duthost, json_data=patch, dest_file=tmpfile)
+        finally:
+            delete_tmpfile(duthost, tmpfile)
+    except Exception:
+        logger.debug(
+            "Cleanup: aggregate %s already absent "
+            "or will be recovered by rollback",
+            prefix,
+        )
+
+
+def gcu_add_multiple_aggregates(duthost, cfgs):
+    """Add several aggregate entries in a single GCU patch."""
+    patch = [
+        {
+            "op": "add",
+            "path": "/BGP_AGGREGATE_ADDRESS/{}".format(
+                c.prefix.replace("/", "~1")
+            ),
+            "value": {
+                "bbr-required": (
+                    "true" if c.bbr_required else "false"
+                ),
+                "summary-only": (
+                    "true" if c.summary_only else "false"
+                ),
+                "as-set": "true" if c.as_set else "false",
+            },
+        }
+        for c in cfgs
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+def gcu_remove_multiple_aggregates(duthost, prefixes):
+    """Remove several aggregate entries in a single GCU patch."""
+    patch = [
+        {
+            "op": "remove",
+            "path": "/BGP_AGGREGATE_ADDRESS/{}".format(
+                p.replace("/", "~1")
+            ),
+        }
+        for p in prefixes
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+def gcu_update_aggregate_field(duthost, prefix, field, value):
+    """Update a single field of an existing aggregate via GCU."""
+    patch = [
+        {
+            "op": "replace",
+            "path": "/BGP_AGGREGATE_ADDRESS/{}/{}".format(
+                prefix.replace("/", "~1"), field
+            ),
+            "value": value,
+        }
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+# ---- Common Validators ----
+def verify_bgp_aggregate_consistence(duthost, bbr_enabled, cfg):
+    """Validate CONFIG_DB, STATE_DB, and FRR running-config match."""
+    config_db = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
+    pytest_assert(
+        cfg.prefix in config_db,
+        "Aggregate row {} not found in CONFIG_DB".format(cfg.prefix),
+    )
+    pytest_assert(
+        config_db[cfg.prefix].get("bbr-required")
+        == ("true" if cfg.bbr_required else "false"),
+        "bbr-required flag mismatch",
+    )
+    pytest_assert(
+        config_db[cfg.prefix].get("summary-only")
+        == ("true" if cfg.summary_only else "false"),
+        "summary-only flag mismatch",
+    )
+    pytest_assert(
+        config_db[cfg.prefix].get("as-set")
+        == ("true" if cfg.as_set else "false"),
+        "as-set flag mismatch",
+    )
+
+    state_db = dump_db(duthost, "STATE_DB", BGP_AGGREGATE_ADDRESS)
+    pytest_assert(
+        cfg.prefix in state_db,
+        "Aggregate row {} not found in STATE_DB".format(cfg.prefix),
+    )
+
+    running_config = running_bgp_has_aggregate(duthost, cfg.prefix)
+
+    if cfg.bbr_required and not bbr_enabled:
+        pytest_assert(
+            state_db[cfg.prefix].get("state") == "inactive",
+            "state flag mismatch",
+        )
+        pytest_assert(
+            cfg.prefix not in running_config,
+            "aggregate-address {} should not present in FRR "
+            "running-config when bbr is disabled".format(cfg.prefix),
+        )
+    else:
+        pytest_assert(
+            state_db[cfg.prefix].get("state") == "active",
+            "state flag mismatch",
+        )
+        pytest_assert(
+            cfg.prefix in running_config,
+            "aggregate-address {} not present in FRR "
+            "running-config".format(cfg.prefix),
+        )
+        if cfg.summary_only:
+            pytest_assert(
+                "summary-only" in running_config,
+                "summary-only expected in running-config",
+            )
+        else:
+            pytest_assert(
+                "summary-only" not in running_config,
+                "summary-only should NOT be present for this scenario",
+            )
+        if cfg.as_set:
+            pytest_assert(
+                "as-set" in running_config,
+                "as_set expected in running-config",
+            )
+        else:
+            pytest_assert(
+                "as-set" not in running_config,
+                "as_set should NOT be present for this scenario",
+            )
+
+
+def verify_bgp_aggregate_cleanup(duthost, prefix):
+    """Validate aggregate is fully removed from DB and running-config."""
+    config_db = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
+    pytest_assert(
+        prefix not in config_db,
+        "Aggregate row {} should be clean up from CONFIG_DB".format(
+            prefix
+        ),
+    )
+
+    state_db = dump_db(duthost, "STATE_DB", BGP_AGGREGATE_ADDRESS)
+    pytest_assert(
+        prefix not in state_db,
+        "Aggregate row {} should be clean up from STATE_DB".format(
+            prefix
+        ),
+    )
+
+    running_config = running_bgp_has_aggregate(duthost, prefix)
+    pytest_assert(
+        prefix.split("/")[0] not in running_config,
+        "aggregate-address {} should not present in FRR "
+        "running-config".format(prefix),
+    )

--- a/tests/bgp/test_bgp_aggregate_address.py
+++ b/tests/bgp/test_bgp_aggregate_address.py
@@ -32,7 +32,7 @@ from bgp_aggregate_helpers import (  # noqa: F401
 logger = logging.getLogger(__name__)
 
 # ---- Topology & device-type markers (register in pytest.ini to avoid warnings) ----
-pytestmark = [pytest.mark.topology("t1", "m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
+pytestmark = [pytest.mark.topology("m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
 
 # ---- Constants ----
 CONSTANTS_FILE = "/etc/sonic/constants.yml"

--- a/tests/bgp/test_bgp_aggregate_address.py
+++ b/tests/bgp/test_bgp_aggregate_address.py
@@ -22,7 +22,7 @@ import pytest
 # Functions
 from bgp_bbr_helpers import config_bbr_by_gcu, get_bbr_default_state, is_bbr_enabled
 
-from tests.common.gcu_utils import apply_gcu_patch
+from tests.common.gcu_utils import apply_gcu_patch, apply_patch, generate_tmpfile, delete_tmpfile
 from tests.common.gcu_utils import create_checkpoint, rollback_or_reload, delete_checkpoint
 from tests.common.helpers.assertions import pytest_assert
 
@@ -121,6 +121,57 @@ def gcu_add_aggregate(duthost, aggregate_cfg: AggregateCfg):
 def gcu_remove_aggregate(duthost, prefix):
     patch = [{"op": "remove", "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}"}]
 
+    apply_gcu_patch(duthost, patch)
+
+
+def safe_remove_aggregate(duthost, prefix):
+    """Best-effort removal for cleanup — never raises."""
+    try:
+        patch = [{"op": "remove", "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}"}]
+        tmpfile = generate_tmpfile(duthost)
+        try:
+            apply_patch(duthost, json_data=patch, dest_file=tmpfile)
+        finally:
+            delete_tmpfile(duthost, tmpfile)
+    except Exception:
+        logger.debug(f"Cleanup: aggregate {prefix} already absent or will be recovered by rollback")
+
+
+def gcu_add_multiple_aggregates(duthost, cfgs):
+    """Add several aggregate entries in a single GCU patch."""
+    patch = [
+        {
+            "op": "add",
+            "path": f"/BGP_AGGREGATE_ADDRESS/{c.prefix.replace('/', '~1')}",
+            "value": {
+                "bbr-required": "true" if c.bbr_required else "false",
+                "summary-only": "true" if c.summary_only else "false",
+                "as-set": "true" if c.as_set else "false",
+            },
+        }
+        for c in cfgs
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+def gcu_remove_multiple_aggregates(duthost, prefixes):
+    """Remove several aggregate entries in a single GCU patch."""
+    patch = [
+        {"op": "remove", "path": f"/BGP_AGGREGATE_ADDRESS/{p.replace('/', '~1')}"}
+        for p in prefixes
+    ]
+    apply_gcu_patch(duthost, patch)
+
+
+def gcu_update_aggregate_field(duthost, prefix, field, value):
+    """Update a single field of an existing aggregate via GCU."""
+    patch = [
+        {
+            "op": "replace",
+            "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}/{field}",
+            "value": value,
+        }
+    ]
     apply_gcu_patch(duthost, patch)
 
 

--- a/tests/bgp/test_bgp_aggregate_address.py
+++ b/tests/bgp/test_bgp_aggregate_address.py
@@ -13,224 +13,33 @@ Validations:
   - FRR running config: aggregate-address line contains expected flags
 """
 
-import ast
 import logging
-from collections import namedtuple
 
 import pytest
 
 # Functions
 from bgp_bbr_helpers import config_bbr_by_gcu, get_bbr_default_state, is_bbr_enabled
 
-from tests.common.gcu_utils import apply_gcu_patch, apply_patch, generate_tmpfile, delete_tmpfile
-from tests.common.gcu_utils import create_checkpoint, rollback_or_reload, delete_checkpoint
-from tests.common.helpers.assertions import pytest_assert
+from bgp_aggregate_helpers import (  # noqa: F401
+    AggregateCfg,
+    gcu_add_aggregate,
+    gcu_remove_aggregate,
+    setup_teardown,
+    verify_bgp_aggregate_consistence,
+    verify_bgp_aggregate_cleanup,
+)
 
 logger = logging.getLogger(__name__)
 
 # ---- Topology & device-type markers (register in pytest.ini to avoid warnings) ----
 pytestmark = [pytest.mark.topology("t1", "m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
 
-# ---- Constants & helper structures ----
+# ---- Constants ----
 CONSTANTS_FILE = "/etc/sonic/constants.yml"
 
 # Aggregate prefixes
 AGGR_V4 = "172.16.51.0/24"
 AGGR_V6 = "2000:172:16:50::/64"
-BGP_AGGREGATE_ADDRESS = "BGP_AGGREGATE_ADDRESS"
-PLACEHOLDER_PREFIX = "192.0.2.0/32"  # RFC5737 TEST-NET-1
-
-AggregateCfg = namedtuple("AggregateCfg", ["prefix", "bbr_required", "summary_only", "as_set"])
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_teardown(duthost):
-    # This testcase will use GCU to modify several entries in running-config.
-    # Restore the config via config_reload may cost too much time.
-    # So we leverage GCU for the config update. Setup checkpoint before the test
-    # and rollback to it after the test.
-    create_checkpoint(duthost)
-
-    # add placeholder aggregate to avoid GCU to remove empty table
-    default_aggregates = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
-    if not default_aggregates:
-        gcu_add_placeholder_aggregate(duthost, PLACEHOLDER_PREFIX)
-
-    yield
-
-    try:
-        rollback_or_reload(duthost, fail_on_rollback_error=False)
-    finally:
-        delete_checkpoint(duthost)
-
-
-# ---- DB & running-config helpers ----
-def dump_db(duthost, dbname, tablename):
-    """Return current DB content as dict."""
-    keys_out = duthost.shell(f"sonic-db-cli {dbname} keys '{tablename}*'", module_ignore_errors=True)["stdout"]
-    logger.info(f"dump {dbname} db, table {tablename}, keys output: {keys_out}")
-    keys = keys_out.strip().splitlines() if keys_out.strip() else []
-    res = {}
-    for k in keys:
-        fields = duthost.shell(f"sonic-db-cli {dbname} hgetall '{k}'", module_ignore_errors=True)["stdout"]
-        logger.info(f"all fields:{fields} for key: {k}")
-        prefix = k.removeprefix(f"{tablename}|")
-
-        res[prefix] = ast.literal_eval(fields)
-        logger.info("dump config db result: {}".format(res))
-    return res
-
-
-def running_bgp_has_aggregate(duthost, prefix):
-    """Grep FRR running BGP config for aggregate-address lines."""
-    return duthost.shell(
-        f"show runningconfiguration bgp | grep -i 'aggregate-address {prefix}'", module_ignore_errors=True
-    )["stdout"]
-
-
-# ---- GCU JSON patch helpers ----
-def gcu_add_placeholder_aggregate(duthost, prefix):
-    patch = [
-        {
-            "op": "add",
-            "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}",
-            "value": {"summary-only": "false", "as-set": "false"},
-        }
-    ]
-    logger.info(f"Adding placeholder BGP aggregate {prefix.replace('/', '~1')}")
-    return apply_gcu_patch(duthost, patch)
-
-
-def gcu_add_aggregate(duthost, aggregate_cfg: AggregateCfg):
-    logger.info("Add BGP_AGGREGATE_ADDRESS by GCU cmd")
-    patch = [
-        {
-            "op": "add",
-            "path": f"/BGP_AGGREGATE_ADDRESS/{aggregate_cfg.prefix.replace('/', '~1')}",
-            "value": {
-                "bbr-required": "true" if aggregate_cfg.bbr_required else "false",
-                "summary-only": "true" if aggregate_cfg.summary_only else "false",
-                "as-set": "true" if aggregate_cfg.as_set else "false",
-            },
-        }
-    ]
-
-    apply_gcu_patch(duthost, patch)
-
-
-def gcu_remove_aggregate(duthost, prefix):
-    patch = [{"op": "remove", "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}"}]
-
-    apply_gcu_patch(duthost, patch)
-
-
-def safe_remove_aggregate(duthost, prefix):
-    """Best-effort removal for cleanup — never raises."""
-    try:
-        patch = [{"op": "remove", "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}"}]
-        tmpfile = generate_tmpfile(duthost)
-        try:
-            apply_patch(duthost, json_data=patch, dest_file=tmpfile)
-        finally:
-            delete_tmpfile(duthost, tmpfile)
-    except Exception:
-        logger.debug(f"Cleanup: aggregate {prefix} already absent or will be recovered by rollback")
-
-
-def gcu_add_multiple_aggregates(duthost, cfgs):
-    """Add several aggregate entries in a single GCU patch."""
-    patch = [
-        {
-            "op": "add",
-            "path": f"/BGP_AGGREGATE_ADDRESS/{c.prefix.replace('/', '~1')}",
-            "value": {
-                "bbr-required": "true" if c.bbr_required else "false",
-                "summary-only": "true" if c.summary_only else "false",
-                "as-set": "true" if c.as_set else "false",
-            },
-        }
-        for c in cfgs
-    ]
-    apply_gcu_patch(duthost, patch)
-
-
-def gcu_remove_multiple_aggregates(duthost, prefixes):
-    """Remove several aggregate entries in a single GCU patch."""
-    patch = [
-        {"op": "remove", "path": f"/BGP_AGGREGATE_ADDRESS/{p.replace('/', '~1')}"}
-        for p in prefixes
-    ]
-    apply_gcu_patch(duthost, patch)
-
-
-def gcu_update_aggregate_field(duthost, prefix, field, value):
-    """Update a single field of an existing aggregate via GCU."""
-    patch = [
-        {
-            "op": "replace",
-            "path": f"/BGP_AGGREGATE_ADDRESS/{prefix.replace('/', '~1')}/{field}",
-            "value": value,
-        }
-    ]
-    apply_gcu_patch(duthost, patch)
-
-
-# ---- Common Validator for Every Case ----
-def verify_bgp_aggregate_consistence(duthost, bbr_enabled, cfg: AggregateCfg):
-    # CONFIG_DB validation
-    config_db = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
-    pytest_assert(cfg.prefix in config_db, f"Aggregate row {cfg.prefix} not found in CONFIG_DB")
-    pytest_assert(
-        config_db[cfg.prefix].get("bbr-required") == ("true" if cfg.bbr_required else "false"),
-        "bbr-required flag mismatch",
-    )
-    pytest_assert(
-        config_db[cfg.prefix].get("summary-only") == ("true" if cfg.summary_only else "false"),
-        "summary-only flag mismatch",
-    )
-    pytest_assert(config_db[cfg.prefix].get("as-set") == ("true" if cfg.as_set else "false"), "as-set flag mismatch")
-
-    # STATE_DB validation
-    state_db = dump_db(duthost, "STATE_DB", BGP_AGGREGATE_ADDRESS)
-    pytest_assert(cfg.prefix in state_db, f"Aggregate row {cfg.prefix} not found in STATE_DB")
-
-    # Running-config validation
-    running_config = running_bgp_has_aggregate(duthost, cfg.prefix)
-
-    if cfg.bbr_required and not bbr_enabled:
-        pytest_assert(state_db[cfg.prefix].get("state") == "inactive", "state flag mismatch")
-        pytest_assert(
-            cfg.prefix not in running_config,
-            f"aggregate-address {cfg.prefix} should not present in FRR running-config when bbr is disabled",
-        )
-    else:
-        pytest_assert(state_db[cfg.prefix].get("state") == "active", "state flag mismatch")
-        pytest_assert(cfg.prefix in running_config, f"aggregate-address {cfg.prefix} not present in FRR running-config")
-        if cfg.summary_only:
-            pytest_assert("summary-only" in running_config, "summary-only expected in running-config")
-        else:
-            pytest_assert("summary-only" not in running_config, "summary-only should NOT be present for this scenario")
-        if cfg.as_set:
-            pytest_assert("as-set" in running_config, "as_set expected in running-config")
-        else:
-            pytest_assert("as-set" not in running_config, "as_set should NOT be present for this scenario")
-
-
-def verify_bgp_aggregate_cleanup(duthost, prefix):
-    # CONFIG_DB validation
-    config_db = dump_db(duthost, "CONFIG_DB", BGP_AGGREGATE_ADDRESS)
-    pytest_assert(prefix not in config_db, f"Aggregate row {prefix} should be clean up from CONFIG_DB")
-
-    # STATE_DB validation
-    state_db = dump_db(duthost, "STATE_DB", BGP_AGGREGATE_ADDRESS)
-    pytest_assert(prefix not in state_db, f"Aggregate row {prefix} should be clean up from  STATE_DB")
-
-    # Running-config validation
-    running_config = running_bgp_has_aggregate(duthost, prefix)
-    pytest_assert(
-        prefix.split("/")[0] not in running_config,
-        f"aggregate-address {prefix} should not present in FRR running-config",
-    )
 
 
 # Test with parameters Combination

--- a/tests/bgp/test_bgp_aggregate_address_config_crud.py
+++ b/tests/bgp/test_bgp_aggregate_address_config_crud.py
@@ -13,7 +13,7 @@ import logging
 import pytest
 from natsort import natsorted
 
-from test_bgp_aggregate_address import (
+from bgp_aggregate_helpers import (  # noqa: F401
     AggregateCfg,
     gcu_add_aggregate,
     gcu_remove_aggregate,
@@ -21,8 +21,8 @@ from test_bgp_aggregate_address import (
     gcu_remove_multiple_aggregates,
     gcu_update_aggregate_field,
     safe_remove_aggregate,
+    setup_teardown,
 )
-from test_bgp_aggregate_address import setup_teardown  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.bgp_routing import inject_routes, verify_route_on_neighbors
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP

--- a/tests/bgp/test_bgp_aggregate_address_config_crud.py
+++ b/tests/bgp/test_bgp_aggregate_address_config_crud.py
@@ -1,0 +1,281 @@
+"""
+Tests for BGP aggregate-address CRUD (add / remove / update) operations.
+
+Test Group 4: Aggregate Address Lifecycle Operations
+  Validates that add, remove, and update operations via GCU produce the
+  expected route-advertisement changes observable on upstream (M2) neighbors.
+
+Aligned with: https://github.com/sonic-net/sonic-mgmt/blob/master/docs/testplan/BGP-Aggregate-Address.md
+"""
+
+import logging
+
+import pytest
+from natsort import natsorted
+
+from test_bgp_aggregate_address import (
+    AggregateCfg,
+    gcu_add_aggregate,
+    gcu_remove_aggregate,
+    gcu_add_multiple_aggregates,
+    gcu_remove_multiple_aggregates,
+    gcu_update_aggregate_field,
+    safe_remove_aggregate,
+)
+from test_bgp_aggregate_address import setup_teardown  # noqa: F401
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.helpers.bgp_routing import inject_routes, verify_route_on_neighbors
+from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.topology("t1", "m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
+
+EXABGP_BASE_PORT = 5000
+EXABGP_BASE_PORT_V6 = 6000
+
+# --- Test data ---
+AGGR_V4 = "10.100.0.0/16"
+AGGR_V6 = "2001:db8:100::/48"
+CONTRIBUTING_V4 = ["10.100.1.0/24", "10.100.2.0/24", "10.100.3.0/24"]
+CONTRIBUTING_V6 = ["2001:db8:100:1::/64", "2001:db8:100:2::/64", "2001:db8:100:3::/64"]
+
+# Additional aggregates for multi-aggregate / overlapping tests
+EXTRA_AGGR_V4_1 = "10.200.0.0/16"
+EXTRA_AGGR_V4_2 = "10.150.0.0/16"
+EXTRA_AGGR_V6_1 = "2001:db8:200::/48"
+EXTRA_AGGR_V6_2 = "2001:db8:150::/48"
+CONTRIBUTING_EXTRA_V4_1 = ["10.200.1.0/24"]
+CONTRIBUTING_EXTRA_V4_2 = ["10.150.1.0/24"]
+CONTRIBUTING_EXTRA_V6_1 = ["2001:db8:200:1::/64"]
+CONTRIBUTING_EXTRA_V6_2 = ["2001:db8:150:1::/64"]
+
+
+@pytest.fixture(scope="module")
+def crud_setup(duthosts, rand_one_dut_hostname, nbrhosts, tbinfo):
+    """Discover downstream/upstream neighbors and ExaBGP ports."""
+    topo_type = tbinfo["topo"]["type"]
+    downstream_suffix = DOWNSTREAM_NEIGHBOR_MAP[topo_type].upper()
+    upstream_suffix = UPSTREAM_NEIGHBOR_MAP[topo_type].upper()
+
+    downstream_neighbors = natsorted(
+        [n for n in nbrhosts if n.upper().endswith(downstream_suffix)]
+    )
+    pytest_assert(downstream_neighbors, f"No downstream ({downstream_suffix}) neighbors found")
+    m0 = downstream_neighbors[0]
+
+    upstream_neighbors = natsorted(
+        [n for n in nbrhosts if n.upper().endswith(upstream_suffix)]
+    )
+    pytest_assert(upstream_neighbors, f"No upstream ({upstream_suffix}) neighbors found")
+
+    m0_offset = tbinfo["topo"]["properties"]["topology"]["VMs"][m0]["vm_offset"]
+
+    common_cfg = tbinfo["topo"]["properties"]["configuration_properties"]["common"]
+
+    yield {
+        "m0": m0,
+        "m2_neighbors": upstream_neighbors,
+        "m0_exabgp_port": EXABGP_BASE_PORT + m0_offset,
+        "m0_exabgp_port_v6": EXABGP_BASE_PORT_V6 + m0_offset,
+        "nhipv4": common_cfg.get("nhipv4"),
+        "nhipv6": common_cfg.get("nhipv6"),
+    }
+
+
+# ===========================================================================
+# TC 4.1 — Add and remove single aggregate
+# ===========================================================================
+def test_add_and_remove_single_aggregate(
+    duthosts, rand_one_dut_hostname, nbrhosts, ptfhost, crud_setup
+):
+    """
+    TC 4.1: Add a single aggregate via GCU → verify it is received on M2.
+    Remove it → verify it is withdrawn on M2.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    setup = crud_setup
+    cfg = AggregateCfg(prefix=AGGR_V4, bbr_required=False, summary_only=False, as_set=False)
+
+    try:
+        inject_routes(setup, ptfhost, CONTRIBUTING_V4[:2], "announce")
+        gcu_add_aggregate(duthost, cfg)
+
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=True)
+
+        gcu_remove_aggregate(duthost, AGGR_V4)
+
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=False)
+    finally:
+        inject_routes(setup, ptfhost, CONTRIBUTING_V4[:2], "withdraw")
+        safe_remove_aggregate(duthost, AGGR_V4)
+
+
+# ===========================================================================
+# TC 4.2 — Remove aggregate restores contributing route visibility
+# ===========================================================================
+def test_remove_aggregate_restores_contributing(
+    duthosts, rand_one_dut_hostname, nbrhosts, ptfhost, crud_setup
+):
+    """
+    TC 4.2: With summary-only=true, contributing routes are suppressed on M2.
+    After removing the aggregate, contributing routes must reappear on M2.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    setup = crud_setup
+    contributing = CONTRIBUTING_V4[:2]
+    cfg = AggregateCfg(prefix=AGGR_V4, bbr_required=False, summary_only=True, as_set=False)
+
+    try:
+        inject_routes(setup, ptfhost, contributing, "announce")
+        gcu_add_aggregate(duthost, cfg)
+
+        # Aggregate present, contributing suppressed
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=True)
+        for route in contributing:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], route, expected_present=False, timeout=15)
+
+        # Remove aggregate
+        gcu_remove_aggregate(duthost, AGGR_V4)
+
+        # Contributing routes must reappear
+        for route in contributing:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], route, expected_present=True)
+    finally:
+        inject_routes(setup, ptfhost, contributing, "withdraw")
+        safe_remove_aggregate(duthost, AGGR_V4)
+
+
+# ===========================================================================
+# TC 4.3 — Update aggregate parameters: toggle summary-only
+# ===========================================================================
+def test_update_toggle_summary_only(
+    duthosts, rand_one_dut_hostname, nbrhosts, ptfhost, crud_setup
+):
+    """
+    TC 4.3: Start with summary-only=false (contributing visible), update to
+    summary-only=true (contributing suppressed), then back to false (visible
+    again).
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    setup = crud_setup
+    contributing = CONTRIBUTING_V4[:2]
+    cfg = AggregateCfg(prefix=AGGR_V4, bbr_required=False, summary_only=False, as_set=False)
+
+    try:
+        inject_routes(setup, ptfhost, contributing, "announce")
+        gcu_add_aggregate(duthost, cfg)
+
+        # Step 1-2: both aggregate and contributing visible
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=True)
+        for route in contributing:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], route, expected_present=True)
+
+        # Step 3: update to summary-only=true
+        gcu_update_aggregate_field(duthost, AGGR_V4, "summary-only", "true")
+
+        # Step 4: contributing now suppressed
+        for route in contributing:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], route, expected_present=False, timeout=15)
+
+        # Step 5: update back to summary-only=false
+        gcu_update_aggregate_field(duthost, AGGR_V4, "summary-only", "false")
+
+        # Step 6: contributing visible again
+        for route in contributing:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], route, expected_present=True)
+    finally:
+        inject_routes(setup, ptfhost, contributing, "withdraw")
+        safe_remove_aggregate(duthost, AGGR_V4)
+
+
+# ===========================================================================
+# TC 4.4 — Add multiple aggregates in single GCU patch
+# ===========================================================================
+def test_add_multiple_aggregates_single_patch(
+    duthosts, rand_one_dut_hostname, nbrhosts, ptfhost, crud_setup
+):
+    """
+    TC 4.4: Apply a single GCU patch that adds 5 aggregate addresses (mix of
+    IPv4 & IPv6).  Verify all are received on M2.  Remove all in one patch,
+    verify all withdrawn.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    setup = crud_setup
+
+    cfgs = [
+        AggregateCfg(prefix=AGGR_V4, bbr_required=False, summary_only=False, as_set=False),
+        AggregateCfg(prefix=EXTRA_AGGR_V4_1, bbr_required=False, summary_only=False, as_set=False),
+        AggregateCfg(prefix=EXTRA_AGGR_V4_2, bbr_required=False, summary_only=False, as_set=False),
+        AggregateCfg(prefix=AGGR_V6, bbr_required=False, summary_only=False, as_set=False),
+        AggregateCfg(prefix=EXTRA_AGGR_V6_1, bbr_required=False, summary_only=False, as_set=False),
+    ]
+    all_prefixes = [c.prefix for c in cfgs]
+    all_contributing = (
+        CONTRIBUTING_V4[:1]
+        + CONTRIBUTING_EXTRA_V4_1
+        + CONTRIBUTING_EXTRA_V4_2
+        + CONTRIBUTING_V6[:1]
+        + CONTRIBUTING_EXTRA_V6_1
+    )
+
+    try:
+        inject_routes(setup, ptfhost, all_contributing, "announce")
+        gcu_add_multiple_aggregates(duthost, cfgs)
+
+        for prefix in all_prefixes:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], prefix, expected_present=True)
+
+        gcu_remove_multiple_aggregates(duthost, all_prefixes)
+
+        for prefix in all_prefixes:
+            verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], prefix, expected_present=False, timeout=15)
+    finally:
+        inject_routes(setup, ptfhost, all_contributing, "withdraw")
+        for prefix in all_prefixes:
+            safe_remove_aggregate(duthost, prefix)
+
+
+# ===========================================================================
+# TC 4.5 — Sequential add/remove of independent aggregates
+# ===========================================================================
+def test_overlapping_aggregates_sequential(
+    duthosts, rand_one_dut_hostname, nbrhosts, ptfhost, crud_setup
+):
+    """
+    TC 4.5: Add two independent aggregates sequentially, each with its own
+    contributing routes.  Both should be received on M2.  Removing the first
+    must leave the second intact.
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    setup = crud_setup
+    contributing_a = CONTRIBUTING_V4[:2]
+    contributing_b = CONTRIBUTING_EXTRA_V4_1
+
+    cfg_a = AggregateCfg(prefix=AGGR_V4, bbr_required=False, summary_only=False, as_set=False)
+    cfg_b = AggregateCfg(prefix=EXTRA_AGGR_V4_1, bbr_required=False, summary_only=False, as_set=False)
+
+    try:
+        inject_routes(setup, ptfhost, contributing_a + contributing_b, "announce")
+
+        # Step 1: add first aggregate
+        gcu_add_aggregate(duthost, cfg_a)
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=True)
+
+        # Step 2: add second aggregate
+        gcu_add_aggregate(duthost, cfg_b)
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], EXTRA_AGGR_V4_1, expected_present=True)
+
+        # Step 3: both present
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=True)
+
+        # Step 4: remove first aggregate
+        gcu_remove_aggregate(duthost, AGGR_V4)
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], AGGR_V4, expected_present=False, timeout=15)
+
+        # Step 5: second still present
+        verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], EXTRA_AGGR_V4_1, expected_present=True)
+    finally:
+        inject_routes(setup, ptfhost, contributing_a + contributing_b, "withdraw")
+        for prefix in (AGGR_V4, EXTRA_AGGR_V4_1):
+            safe_remove_aggregate(duthost, prefix)

--- a/tests/bgp/test_bgp_aggregate_address_config_crud.py
+++ b/tests/bgp/test_bgp_aggregate_address_config_crud.py
@@ -29,7 +29,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology("t1", "m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
+pytestmark = [pytest.mark.topology("m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
 
 EXABGP_BASE_PORT = 5000
 EXABGP_BASE_PORT_V6 = 6000

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -1,5 +1,5 @@
 """
-Tests for BGP aggregate-address route lifecycle behavior.
+Tests for BGP aggregate-address route withdrawal behavior.
 
 Test Group 3: Route Presence and Withdrawal Behavior
   Validates that the aggregate route on upstream neighbors depends on the
@@ -19,10 +19,10 @@ from test_bgp_aggregate_address import (
     AggregateCfg,
     gcu_add_aggregate,
     gcu_remove_aggregate,
+    safe_remove_aggregate,
 )
 # Import autouse fixture so pytest discovers it for this module
 from test_bgp_aggregate_address import setup_teardown  # noqa: F401
-
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.bgp_routing import inject_routes, verify_route_on_neighbors
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP
@@ -123,10 +123,7 @@ def test_aggregate_no_contributing_routes(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, contributing, "withdraw")
-        try:
-            gcu_remove_aggregate(duthost, agg_prefix)
-        except Exception:
-            logger.warning(f"Cleanup: failed to remove aggregate {agg_prefix}, will be recovered by rollback")
+        safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -172,10 +169,7 @@ def test_aggregate_all_contributing_withdrawn(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, contributing, "withdraw")
-        try:
-            gcu_remove_aggregate(duthost, agg_prefix)
-        except Exception:
-            logger.warning(f"Cleanup: failed to remove aggregate {agg_prefix}, will be recovered by rollback")
+        safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -218,10 +212,7 @@ def test_aggregate_partial_contributing_withdrawal(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, set_a + set_b, "withdraw")
-        try:
-            gcu_remove_aggregate(duthost, agg_prefix)
-        except Exception:
-            logger.warning(f"Cleanup: failed to remove aggregate {agg_prefix}, will be recovered by rollback")
+        safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -268,7 +259,4 @@ def test_aggregate_new_contributing_route_added(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], new_contributing[0], expected_present=True)
     finally:
         inject_routes(setup, ptfhost, initial_contributing + new_contributing, "withdraw")
-        try:
-            gcu_remove_aggregate(duthost, agg_prefix)
-        except Exception:
-            logger.warning(f"Cleanup: failed to remove aggregate {agg_prefix}, will be recovered by rollback")
+        safe_remove_aggregate(duthost, agg_prefix)

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -18,7 +18,6 @@ from natsort import natsorted
 from test_bgp_aggregate_address import (
     AggregateCfg,
     gcu_add_aggregate,
-    gcu_remove_aggregate,
     safe_remove_aggregate,
 )
 # Import autouse fixture so pytest discovers it for this module
@@ -123,7 +122,7 @@ def test_aggregate_no_contributing_routes(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, contributing, "withdraw")
-        safe_remove_aggregate(duthost, agg_prefix)
+        _safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -169,7 +168,7 @@ def test_aggregate_all_contributing_withdrawn(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, contributing, "withdraw")
-        safe_remove_aggregate(duthost, agg_prefix)
+        _safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -212,7 +211,7 @@ def test_aggregate_partial_contributing_withdrawal(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, set_a + set_b, "withdraw")
-        safe_remove_aggregate(duthost, agg_prefix)
+        _safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -259,4 +258,4 @@ def test_aggregate_new_contributing_route_added(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], new_contributing[0], expected_present=True)
     finally:
         inject_routes(setup, ptfhost, initial_contributing + new_contributing, "withdraw")
-        safe_remove_aggregate(duthost, agg_prefix)
+        _safe_remove_aggregate(duthost, agg_prefix)

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -27,7 +27,7 @@ from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEI
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.topology("t1", "m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
+pytestmark = [pytest.mark.topology("m1"), pytest.mark.device_type("vs"), pytest.mark.disable_loganalyzer]
 
 # ExaBGP base ports (downstream PTF ports)
 EXABGP_BASE_PORT = 5000

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -122,7 +122,7 @@ def test_aggregate_no_contributing_routes(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, contributing, "withdraw")
-        _safe_remove_aggregate(duthost, agg_prefix)
+        safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -168,7 +168,7 @@ def test_aggregate_all_contributing_withdrawn(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, contributing, "withdraw")
-        _safe_remove_aggregate(duthost, agg_prefix)
+        safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -211,7 +211,7 @@ def test_aggregate_partial_contributing_withdrawal(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], agg_prefix, expected_present=True)
     finally:
         inject_routes(setup, ptfhost, set_a + set_b, "withdraw")
-        _safe_remove_aggregate(duthost, agg_prefix)
+        safe_remove_aggregate(duthost, agg_prefix)
 
 
 # ===========================================================================
@@ -258,4 +258,4 @@ def test_aggregate_new_contributing_route_added(
         verify_route_on_neighbors(nbrhosts, setup["m2_neighbors"], new_contributing[0], expected_present=True)
     finally:
         inject_routes(setup, ptfhost, initial_contributing + new_contributing, "withdraw")
-        _safe_remove_aggregate(duthost, agg_prefix)
+        safe_remove_aggregate(duthost, agg_prefix)

--- a/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
+++ b/tests/bgp/test_bgp_aggregate_address_route_withdrawal.py
@@ -14,14 +14,13 @@ import logging
 import pytest
 from natsort import natsorted
 
-# Shared helpers from the base aggregate-address test module
-from test_bgp_aggregate_address import (
+# Shared helpers from the aggregate-address helpers module
+from bgp_aggregate_helpers import (  # noqa: F401
     AggregateCfg,
     gcu_add_aggregate,
     safe_remove_aggregate,
+    setup_teardown,
 )
-# Import autouse fixture so pytest discovers it for this module
-from test_bgp_aggregate_address import setup_teardown  # noqa: F401
 from tests.common.helpers.assertions import pytest_assert
 from tests.common.helpers.bgp_routing import inject_routes, verify_route_on_neighbors
 from tests.common.helpers.constants import UPSTREAM_NEIGHBOR_MAP, DOWNSTREAM_NEIGHBOR_MAP


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Add new BGP aggregate-address test cases for CRUD lifecycle operations (Test Group 4), plus refactor shared helpers into the base module for reuse.

ADO: 37506190

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
This PR adds Test Group 4 (Aggregate Address Lifecycle Operations) from the BGP-Aggregate-Address Test Plan.
#### How did you do it?

rename: test_bgp_aggregate_address_route_withdrawal.py

test_bgp_aggregate_address_config_crud.py (new, 5 test cases):

TC 4.1: Add/remove single aggregate via GCU
TC 4.2: Removing summary-only aggregate restores contributing route visibility
TC 4.3: Toggle summary-only field via GCU update
TC 4.4: Batch add/remove multiple aggregates (IPv4 + IPv6) in a single GCU patch
TC 4.5: Sequential add/remove of independent aggregates

test_bgp_aggregate_address.py (modified): Added shared helpers (safe_remove_aggregate, gcu_add_multiple_aggregates, gcu_remove_multiple_aggregates, gcu_update_aggregate_field) for reuse across test modules.

#### How did you verify/test it?
All 5 test cases passed on a physical testbed.
<img width="423" height="84" alt="image" src="https://github.com/user-attachments/assets/07a6f543-8bfb-4867-824f-b2d3e951dae4" />

#### Any platform specific information?
No platform-specific dependencies. Tests use GCU (Generic Config Update) and ExaBGP route injection, which are platform-agnostic.
#### Supported testbed topology if it's a new test case?
t1, m1
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
