### PR TITLE
Add non-unicast noise filter to missed check points in PFCtest and LossyQueueTest

### DIFF
--- a/tests/saitests/py3/sai_qos_tests.py
+++ b/tests/saitests/py3/sai_qos_tests.py
@@ -2472,15 +2472,24 @@ class PFCtest(sai_base_test.ThriftInterfaceDataPlane):
             # & may give inconsistent test results
             # Adding COUNTER_MARGIN to provide room to 2 pkt incase, extra traffic received
             for cntr in ingress_counters:
-                if (platform_asic and
-                        platform_asic in ["broadcom-dnx", "marvell-teralynx"]):
-                    qos_test_assert(
-                        self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
-                        'unexpectedly RX drop counter increase, {}'.format(test_stage))
-                else:
-                    qos_test_assert(
-                        self, recv_counters[cntr] == recv_counters_base[cntr],
-                        'unexpectedly RX drop counter increase, {}'.format(test_stage))
+                dnx_asics = ["broadcom-dnx", "marvell-teralynx"]
+                counter_margin = COUNTER_MARGIN if (
+                    platform_asic and platform_asic in dnx_asics) else 0
+                # Check if ingress drop is caused by environmental non-unicast noise
+                if not ignore_ingress_drop_caused_by_nonunicast_noise(
+                        self.src_client, port_list['src'][src_port_id],
+                        recv_counters, recv_counters_base, cntr,
+                        counter_margin=counter_margin):
+                    # Legitimate ingress drop, should fail test
+                    if (platform_asic and
+                            platform_asic in ["broadcom-dnx", "marvell-teralynx"]):
+                        qos_test_assert(
+                            self, recv_counters[cntr] <= recv_counters_base[cntr] + COUNTER_MARGIN,
+                            'unexpectedly RX drop counter increase, {}'.format(test_stage))
+                    else:
+                        qos_test_assert(
+                            self, recv_counters[cntr] == recv_counters_base[cntr],
+                            'unexpectedly RX drop counter increase, {}'.format(test_stage))
             # xmit port no egress drop
             for cntr in egress_counters:
                 qos_test_assert(
@@ -5126,12 +5135,16 @@ class LossyQueueTest(sai_base_test.ThriftInterfaceDataPlane):
                                     recv_counters[cntr] - recv_counters_base[cntr],
                                     cntr, port_counter_fields[cntr]))
                 else:
-                    qos_test_assert(
-                        self, recv_counters[cntr] == recv_counters_base[cntr],
-                        "Ingress drop encountered: {} packets dropped on "
-                        "counter {} ({})".format(
-                            recv_counters[cntr] - recv_counters_base[cntr],
-                            cntr, port_counter_fields[cntr]))
+                    # Check if ingress drop is caused by environmental non-unicast noise
+                    if not ignore_ingress_drop_caused_by_nonunicast_noise(
+                            self.src_client, port_list['src'][src_port_id],
+                            recv_counters, recv_counters_base, cntr):
+                        qos_test_assert(
+                            self, recv_counters[cntr] == recv_counters_base[cntr],
+                            "Ingress drop encountered: {} packets dropped on "
+                            "counter {} ({})".format(
+                                recv_counters[cntr] - recv_counters_base[cntr],
+                                cntr, port_counter_fields[cntr]))
 
             # xmit port egress drop
             if platform_asic and platform_asic == "broadcom-dnx" and dut_asic != 'q3d':


### PR DESCRIPTION
### Description of PR

PR #22871 added `ignore_ingress_drop_caused_by_nonunicast_noise()` but missed some ingress drop check points in PFCtest and LossyQueueTest. This PR fixes both.

### Type of change

- [x] Bug fix

### Back port request
- [x] 202511

### Approach
#### What is the motivation for this PR?
Two missed check points still cause false positive failures from broadcast/multicast noise:

**1. PFCtest "short of ingress drop" phase**
Observed on Arista-7260CX3-C64 (broadcom, T1, SONiC.20251110.17, test plan `69c0ad0a61a3c350441fc8fe`):
- Phase 1 "short of PFC trigger": InDiscard 22->23, InNonUcPkt 52->53 -> NOISE DETECTED, IGNORED
- Phase 3 "short of ingress drop": InDiscard 23->24, InNonUcPkt 54->55 -> No filter -> **FAIL at line 2458**

**2. LossyQueueTest 2nd ingress check (after "trigger egress drop")**
Same testbed, same test plan:
- InDiscard Delta=1 -> **FAIL at line 5106**
- Non-DNX broadcom platform, goes through else branch with no noise filter

Both are single-packet non-unicast noise (Delta=1).

#### How did you do it?
Applied `ignore_ingress_drop_caused_by_nonunicast_noise()` to:
1. PFCtest "short of ingress drop" ingress counter check (was line 2474-2483)
2. LossyQueueTest 2nd ingress check else branch (was line 5137-5143)

#### How did you verify/test it?
ElasticTest console log analysis confirming InDiscard and InNonUcPkt both increase by 1 at each failure point.

ADO PBIs: #37278664, #37142761