### PR TITLE
Skipping platform_tests/api/test_liquid_cooling_leakage.py[Cisco-8000]

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -381,7 +381,7 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_spe
       - "hwsku in ['Celestica-DX010-C32']"
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
-platform_tests/api/test_liquid_cooling_leakage.py
+platform_tests/api/test_liquid_cooling_leakage.py:
   skip:
     reason: "Unsupported platform API"
     conditions_logical_operator: or


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Test_liquid_cooling_leakage.py is not supported on asic_type in ['cisco-8000'].

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Skip Test_liquid_cooling_leakage.py for  cisco-8000 in  tests\common\plugins\conditional_mark\tests_mark_conditions_platform_tests.yaml

#### How did you verify/test it?
run platform_tests/api/test_liquid_cooling_leakage.py after correction 
#### Any platform specific information?
skiped for "asic_type in ['cisco-8000']"
