### PR TITLE
[VPP] enable BFD tests for VPP

### DIFF
--- a/.azure-pipelines/pr_test_scripts.yaml
+++ b/.azure-pipelines/pr_test_scripts.yaml
@@ -644,6 +644,7 @@ t1-lag-vpp:
   - arp/test_wr_arp.py
   - arp/test_arp_dualtor.py
   - arp/test_stress_arp.py
+  - bfd/test_bfd.py
   - bgp/test_bgp_speaker.py
   - bgp/test_bgp_stress_link_flap.py
   - bgp/test_bgp_sentinel.py

--- a/tests/bfd/test_bfd.py
+++ b/tests/bfd/test_bfd.py
@@ -12,10 +12,10 @@ from tests.common.snappi_tests.common_helpers import get_egress_queue_count
 from tests.common.sai_validation.sonic_db import start_db_monitor, stop_db_monitor, wait_until_condition, check_key
 from tests.common.utilities import wait_until
 from tests.common.helpers.multi_thread_utils import SafeThreadPoolExecutor
+from tests.common.helpers.assertions import pytest_assert
 
 pytestmark = [
-    pytest.mark.topology('t1'),
-    pytest.mark.device_type('physical')
+    pytest.mark.topology('t1')
 ]
 
 BFD_RESPONDER_SCRIPT_SRC_PATH = '../ansible/roles/test/files/helpers/bfd_responder.py'
@@ -431,6 +431,14 @@ def warm_up_ipv6_neighbors(duthost, neighbor_addrs):
     )
 
 
+def check_ptf_neighbours(ptfhost, neighbor_addrs, local_addrs):
+
+    for idx, neighbor_addr in enumerate(neighbor_addrs):
+        if check_ptf_bfd_status(ptfhost, neighbor_addr, local_addrs[idx], "Up") is False:
+            return False
+    return True
+
+
 @pytest.mark.parametrize('dut_init_first', [True, False], ids=['dut_init_first', 'ptf_init_first'])
 @pytest.mark.parametrize('ipv6', [False, True], ids=['ipv4', 'ipv6'])
 def test_bfd_basic(request, gnmi_connection,
@@ -467,15 +475,12 @@ def test_bfd_basic(request, gnmi_connection,
         logger.debug(f'All up; Wait for {neighbor_addrs} to be Up completed with'
                      f' {status} and time taken {actual_wait} seconds')
         assert status is True, "Assertion failed: Expected 'status' to be True, but got {}.".format(status)
-        for idx, neighbor_addr in enumerate(neighbor_addrs):
-            assert check_ptf_bfd_status(
-                ptfhost, neighbor_addr, local_addrs[idx], "Up"
-            ) is True, (
-                "Assertion failed: BFD session status is not 'Up'. "
-                "Details: Neighbor address '{}', Local address '{}', PTF host '{}'.".format(
-                    neighbor_addr, local_addrs[idx], ptfhost.hostname
-                )
-            )
+        pytest_assert(
+            wait_until(120, 5, 0, check_ptf_neighbours, ptfhost, neighbor_addrs, local_addrs),
+            "IPv6:{} dut_init_first:{} PTF BFD sessions did not reach 'Up' state as expected."
+            .format(ipv6, dut_init_first)
+        )
+
         update_idx = random.choice(list(range(bfd_session_cnt)))
         update_bfd_session_state(ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "admin")
         # check all STATE_DB BFD_SESSION_TABLE neighbors' state is Up except
@@ -528,13 +533,11 @@ def test_bfd_basic(request, gnmi_connection,
         logger.debug(f'Reset to Up check; Wait for {neighbor_addrs[update_idx]}'
                      f' to be Up completed with {status} and time taken {actual_wait} seconds')
         assert status is True, "Assertion failed: Expected 'status' to be True, but got {}.".format(status)
-        assert check_ptf_bfd_status(
-            ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "Up"
-        ) is True, (
-            "Assertion failed: BFD session status is not 'Up' for neighbor address '{}', "
-            "local address '{}', on PTF host '{}'.".format(
-                neighbor_addrs[update_idx], local_addrs[update_idx], ptfhost.hostname
-            )
+        pytest_assert(
+            wait_until(120, 5, 0, check_ptf_bfd_status, ptfhost, neighbor_addrs[update_idx], local_addrs[update_idx], "Up"),  # noqa: E501
+            "BFD session status is not Up for neighbor address {}, "
+            "local address {}, on PTF host {}."
+            .format(neighbor_addrs[update_idx], local_addrs[update_idx], ptfhost.hostname)
         )
 
         update_idx = random.choice(list(range(bfd_session_cnt)))

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -260,18 +260,18 @@ bfd:
 
 bfd/test_bfd.py:
   skip:
-    reason: "Test not supported for platforms other than Nvidia 4280/4600c/4700/5600 and cisco-8102. Skipping the test / KVM do not support bfd test"
+    reason: "Test not supported for platforms other than Nvidia 4280/4600c/4700/5600 and cisco-8102. Skipping the test / VS do not support bfd test"
     conditions_logical_operator: or
     conditions:
-      -  "(release in ['201811', '201911']) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0'])"
+      -  "(release in ['201811', '201911']) or (platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0'])"
       - "asic_type in ['vs']"
 
 bfd/test_bfd.py::test_bfd_basic:
   skip:
-    reason: "Test not supported on platforms other than Cisco 8101/8102, Nvidia 4280/4600c/4700/5600. KVM platforms do not support bfd test"
+    reason: "Test not supported on platforms other than Cisco 8101/8102, Nvidia 4280/4600c/4700/5600. VS platforms do not support bfd test"
     conditions_logical_operator: or
     conditions:
-      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0']"
+      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"
       - "release in ['201811', '201911']"
       - "asic_type in ['vs']"
   xfail:
@@ -289,10 +289,10 @@ bfd/test_bfd.py::test_bfd_echo_mode:
 
 bfd/test_bfd.py::test_bfd_scale:
   skip:
-    reason: "Test is not supported for platforms other than Cisco 8102/8101, Nvidia 4280/4600c/4700/5600. KVM platforms do not support bfd test"
+    reason: "Test is not supported for platforms other than Cisco 8102/8101, Nvidia 4280/4600c/4700/5600. VS platforms do not support bfd test"
     conditions_logical_operator: or
     conditions:
-      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0']"
+      - "platform not in ['x86_64-mlnx_msn4600c-r0', 'x86_64-mlnx_msn4700-r0', 'x86_64-nvidia_sn5600-r0', 'x86_64-8102_64h_o-r0', 'x86_64-8101_32fh_o-r0', 'x86_64-nvidia_sn4280-r0', 'x86_64-8102_28fh_dpu_o-r0', 'x86_64-kvm_x86_64-r0']"
       - "release in ['201811', '201911']"
       - "asic_type in ['vs']"
 

--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_sonic_vpp.yaml
@@ -18,39 +18,7 @@ acl/test_stress_acl.py::test_acl_add_del_stress:
 #######################################
 #####           BFD               #####
 #######################################
-bfd/test_bfd.py:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-bfd/test_bfd.py::test_bfd_basic:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-bfd/test_bfd.py::test_bfd_echo_mode:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
 bfd/test_bfd.py::test_bfd_multihop:
-  skip:
-    reason: >
-            Failed/Errored: To be included
-    conditions_logical_operator: or
-    conditions:
-      - "asic_type in ['vpp']"
-
-bfd/test_bfd.py::test_bfd_scale:
   skip:
     reason: >
             Failed/Errored: To be included


### PR DESCRIPTION
### Description of PR
Summary:
This change is enabling the BFD tests on the VPP platform.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
BFD tests on VPP have been skipped because they were not working. After these changes the tests will be enabled and will succeed.

#### How did you do it?
Added the VPP platform to the list of supported platforms for BFD tests. Also introduced a polling mechanism for determining if BFD sessions are up on PTF.

#### How did you verify/test it?
I run the tests.
XPASS bfd/test_bfd.py::test_bfd_basic[ipv4-dut_init_first] Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519
XPASS bfd/test_bfd.py::test_bfd_basic[ipv4-ptf_init_first] Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519
XPASS bfd/test_bfd.py::test_bfd_basic[ipv6-dut_init_first] Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519
XPASS bfd/test_bfd.py::test_bfd_basic[ipv6-ptf_init_first] Test might failed due to https://github.com/sonic-net/sonic-mgmt/issues/19519
#### Any platform specific information?
VPP
#### Supported testbed topology if it's a new test case?
Any

### Documentation
N/A
