### PR TITLE
vpp: adapt test_techsupport to vpp arctos and kvm platform

### DIFF
--- a/tests/show_techsupport/test_techsupport.py
+++ b/tests/show_techsupport/test_techsupport.py
@@ -226,7 +226,7 @@ def mirroring(duthosts, enum_rand_one_per_hwsku_hostname, neighbor_ip, mirror_se
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     if duthost.facts['asic_type'] == 'vpp':
-        pytest.skip('Memory mirroring is not supported on VPP platform')
+        pytest.skip('Mirroring is not supported on VPP platform')
     logger.info("Adding mirror_session to DUT")
     acl_rule_file = os.path.join(mirror_setup['dut_tmp_dir'], ACL_RULE_PERSISTENT_FILE)
     extra_vars = {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
adapt test_techsupport to vpp arctos and kvm platform
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
adapt test_techsupport to vpp arctos and kvm platform
1. vpp platforms doesn't support mirroring yet
2. vpp kvm platform and arm64 platform (arctos) do not have /proc/dma. The command needs to be removed similarly to other arm platforms.
#### How did you do it?
1. Add pytest.skip to mirroring fixture if asic-type is vpp
2. remove /proc/dma command if asic-type is vpp and platform contains arm64 or kvm.
#### How did you verify/test it?
run sonic-mgmt 
#### Any platform specific information?
vpp
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
