### PR TITLE
[master][sonic-mgmt]: Fix test_poll_mode_delete failure due to race condition

### DIFF
--- a/tests/telemetry/test_telemetry_poll.py
+++ b/tests/telemetry/test_telemetry_poll.py
@@ -145,7 +145,7 @@ def test_poll_mode_delete(duthosts, enum_rand_one_per_hwsku_hostname, ptfhost,
     cmd = generate_client_cli(duthost=duthost, gnxi_path=gnxi_path, method=METHOD_SUBSCRIBE,
                               subscribe_mode=SUBSCRIBE_MODE_POLL, polling_interval=2,
                               xpath="FAKE_APPL_DB_TABLE_0 FAKE_APPL_DB_TABLE_1/fake_key1", target="APPL_DB",
-                              max_sync_count=6, update_count=0, timeout=30, namespace=namespace)
+                              max_sync_count=15, update_count=0, timeout=30, namespace=namespace)
 
     def callback(show_gnmi_out):
         result = str(show_gnmi_out)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
 Fix flaky test_poll_mode_delete failure caused by a race condition between the gNMI session expiring and the DB delete operation being reflected in the final poll response.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The test uses max_sync_count=6 with polling_interval=2s. Every gNMI POLL session starts with a double sync burst — two sync_response messages within ~5ms of each other at session open (Sync 1 from the server's pre-seeded initial state delivery, Sync 2 from the client's immediate first POLL trigger). This consumes 2 of the 6 sync budget in the opening milliseconds, leaving only 4 interval-based poll cycles. 

`check_gnmi_cli_running` invokes `GNMIEnvironment()` which executes 3-4 DUT shell commands (docker images, docker ps, docker exec supervisorctl status, CONFIG_DB read) adding ~8 seconds of overhead.

The Race: On slower platforms, wait_until only returns True at T+8s. By this point, the session is already at its final sync (Sync 6 at ~T+8.2s). The `hdel` command executes too late; the gNMI server reads the DB before the delete completes, and since the `max_sync_count` is reached, the session terminates before another poll can capture the change.

Fixes [qual issue](https://github.com/aristanetworks/sonic-qual.msft/issues/1162)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_poll_mode_delete (Phase 2) was observed to fail with: `AssertionError: No delete responses`.
Root cause was a race between gNMI server reading the DB for successful delete and `hdel` command for the db itself.
#### How did you do it?
Increased the max sync count to utilize the timeout and give extra time to gNMI server to catch the db delete.
#### How did you verify/test it?
Manual testing done.
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
