### PR TITLE
cisco:Skip Ethernet1 for console Switch.

### DIFF
--- a/tests/platform_tests/conftest.py
+++ b/tests/platform_tests/conftest.py
@@ -51,6 +51,9 @@ def xcvr_skip_list(duthosts, dpu_npu_port_list, tbinfo):
             logging.debug(
                 "hwsku.json absent or port_type for interfaces not included for hwsku {}".format(hwsku))
 
+        if platform in ['arm64-c8220tg_48a_o-r0']:
+            intf_skip_list[dut.hostname] = ['Ethernet1']
+
         # No hwsku.json for Arista-7050-QX-32S/Arista-7050QX-32S-S4Q31
         if hwsku in ['Arista-7050-QX-32S', 'Arista-7050QX-32S-S4Q31']:
             sfp_list = ['Ethernet0', 'Ethernet1', 'Ethernet2', 'Ethernet3']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For cisco-console switch, "Ethernet1" is an RJ45 port. The script test_sfputil.py is for SFP ports only. So we have to skip Ethernet1 for this platform in this tests.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
test_sfputil.py is failing in cisco switch runs, because it treats Ethernet1 as a SFP port. Ethernet1 is a RJ45 port. So we need to skip this port for these tests.

#### How did you do it?
Added a platform check and added the port to xcvr_skip_list.

#### How did you verify/test it?
Ran it on our platform:
```====================================================================================================== PASSES =======================================================================================================
____________________________________________________________________________________ test_check_sfputil_presence[c0lo-dut-None] _____________________________________________________________________________________
___________________________________________________________________ test_check_sfputil_error_status[c0lo-dut-None-sudo sfputil show error-status] ___________________________________________________________________
________________________________________________________ test_check_sfputil_error_status[c0lo-dut-None-sudo sfputil show error-status --fetch-from-hardware] ________________________________________________________
_____________________________________________________________________________________ test_check_sfputil_eeprom[c0lo-dut-None] ______________________________________________________________________________________
_________________________________________________________________________________ test_check_sfputil_eeprom_hexdump[c0lo-dut-None] __________________________________________________________________________________
______________________________________________________________________________________ test_check_sfputil_reset[c0lo-dut-None] ______________________________________________________________________________________
--------------------------------------------------------------- generated xml file: /run_logs/sfputil/2026-03-27-21-03-07/tr_2026-03-27-21-03-07.xml ----------------------------------------------------------------
INFO:root:Can not get Allure report URL. Please check logs
============================================================================================== short test summary info ==============================================================================================
PASSED platform_tests/sfp/test_sfputil.py::test_check_sfputil_presence[c0lo-dut-None]
PASSED platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status[c0lo-dut-None-sudo sfputil show error-status]
PASSED platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status[c0lo-dut-None-sudo sfputil show error-status --fetch-from-hardware]
PASSED platform_tests/sfp/test_sfputil.py::test_check_sfputil_eeprom[c0lo-dut-None]
PASSED platform_tests/sfp/test_sfputil.py::test_check_sfputil_eeprom_hexdump[c0lo-dut-None]
PASSED platform_tests/sfp/test_sfputil.py::test_check_sfputil_reset[c0lo-dut-None]
SKIPPED [1] platform_tests/sfp/test_sfputil.py:640: None of the ports supporting LPM, skip the test
================================================================================ 6 passed, 1 skipped, 1 warning in 294.63s (0:04:54) ================================================================================
sonic@sj04-sonic-ucs:/data/tests$ 
```
#### Any platform specific information?
Specific to cisco console switch.