### PR TITLE
Update test_crm_neighbor TC to handle NH scale

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -965,7 +965,7 @@ def test_crm_neighbor(duthosts, enum_rand_one_per_hwsku_frontend_hostname,
                                         ip_ver=ip_ver)
     nexthop_used, nexthop_available = get_crm_stats(get_nexthop_stats, duthost)
     if is_cisco_device(duthost):
-        CISCO_8000_ADD_NEIGHBORS = nexthop_available
+        CISCO_8000_ADD_NEIGHBORS = min(2000, nexthop_available)
     asic_type = duthost.facts['asic_type']
     skip_stats_check = True if asic_type == "vs" else False
     RESTORE_CMDS["crm_threshold_name"] = "ipv{ip_ver}_neighbor".format(ip_ver=ip_ver)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Problem:
On cisco asics, scale for NHs can be up to ~32k, currently we try to add 32k neighbors as that is the number set to CISCO_8000_ADD_NEIGHBORS which will cause timeout failure because adding tens of thousands of neighbors takes longer than the 60-second polling window used to verify CRM counter convergence, causing the test to fail. the test only needs enough neighbors to push above 1% for threshold verification.

Fix:
For 202605/202511, to avoid this issue, we cap neighbors at 2000 or ( nexthops available if its lower since we cannot add more neighbors than NHs supported), this is well above 1% of any current Cisco 8000 resource pool for NHs (AFAIK) per CRM, which will satisfy the threshold verification requirement and is future proof until scale reaches ~200k for NHs. Also addresses this issue: https://github.com/sonic-net/sonic-mgmt/issues/19451 that occurs

UT:
202605 specific logs passing: 
<img width="733" height="34" alt="image" src="https://github.com/user-attachments/assets/03391c06-acab-46d0-aa76-8a1bd11a7a27" />
<img width="739" height="70" alt="image" src="https://github.com/user-attachments/assets/9ba02d9e-44a1-4a3d-a609-95645f0e7ca8" />

Ran with this scale and tc passes (202511)
`----------------------------------------------------------------------- generated xml file: /run_logs/isiddeeq/crm/test_crm.py::test_crm_neighbor_2026-03-11-23-11-12.xml ------------------------------------------------------------------------- INFO:root:Can not get Allure report URL. Please check logs -------------------------------------------------------------------------------------------------------------- live log sessionfinish -------------------------------------------------------------------------------------------------------------- 11/03/2026 23:15:48 __init__.pytest_terminal_summary         L0067 INFO   | Can not get Allure report URL. Please check logs ===================================================================================================== 2 passed, 1 warning in 275.14s (0:04:35) =====================================================================================================`
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

CRM NH scale issue 
https://github.com/sonic-net/sonic-mgmt/issues/19451
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202605

### Approach
#### What is the motivation for this PR?
handle NH scale for newer platforms
#### How did you do it?
ran CRM neighbor testcase on setup with scale at 32k NH
#### How did you verify/test it?
ran CRM neighbor testcase on setup with scale at 32k NH
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
