### PR TITLE
Add the cleanup_modules function to remove and add the kernel modules for console ports before and after script runs.

### DIFF
--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -61,3 +61,26 @@ def setup_c0(request, duthost, tbinfo):
 @pytest.fixture(scope='module')
 def console_facts(duthost):
     return duthost.console_facts()['ansible_facts']['console_facts']
+
+
+@pytest.fixture(scope="module")
+def cleanup_modules(setup_c0):
+    '''
+    Reset all console lines before and after the script runs. Sometime socat or
+    other programs can leave the lines inaccessible.
+    '''
+    duthost, console_fanout = setup_c0
+    duthost.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+    duthost.shell("sudo killall socat", module_ignore_errors=True)
+
+    if console_fanout != duthost:
+        console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+        console_fanout.shell("sudo killall socat", module_ignore_errors=True)
+
+    yield
+    duthost.shell("sudo killall socat", module_ignore_errors=True)
+    duthost.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")
+
+    if console_fanout != duthost:
+        console_fanout.shell("sudo killall socat", module_ignore_errors=True)
+        console_fanout.shell("rmmod nim_async_lite; rmmod tty_async; modprobe nim_async_lite ")

--- a/tests/console/test_console_availability.py
+++ b/tests/console/test_console_availability.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 
 @pytest.mark.parametrize("target_line", ["1", "2", "3", "4"])
-def test_console_availability(duthost, creds, target_line):
+def test_console_availability(duthost, creds, target_line, cleanup_modules):
     """
     Test console are well functional.
     Verify console access is available after connecting from DUT

--- a/tests/console/test_console_loopback.py
+++ b/tests/console/test_console_loopback.py
@@ -15,7 +15,7 @@ console_lines = list(map(str, range(1, 49)))
 
 @pytest.mark.parametrize("target_line", console_lines)
 @pytest.mark.parametrize("baud_rate", ["9600", "115200"])
-def test_console_loopback_echo(setup_c0, creds, target_line, baud_rate):
+def test_console_loopback_echo(setup_c0, creds, target_line, baud_rate, cleanup_modules):
     """
     Test data transfer is working as expect.
     Verify data can go out through the console switch and come back through the console switch
@@ -69,7 +69,7 @@ def test_console_loopback_echo(setup_c0, creds, target_line, baud_rate):
 @pytest.mark.topology('c0')
 @pytest.mark.parametrize("src_line,dst_line", [random.sample(console_lines, 2) for _ in range(4)])
 @pytest.mark.parametrize("baud_rate", ["9600", "115200"])
-def test_console_loopback_pingpong(setup_c0, creds, src_line, dst_line, baud_rate):
+def test_console_loopback_pingpong(setup_c0, creds, src_line, dst_line, baud_rate, cleanup_modules):
     """
     Test data transfer is working as expect.
     Verify data can go out through the console switch and come back through the console switch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
The console scripts use socat extensively during the runs. Sometimes the socat is not finished, or left hanging in py-expect process. We have to kill the hanging processes before next test can use the same console port. So we do that in a fixture at the end of the script. In addition since an earlier instance might have left it in a bad shape, we do the same in the beginning of the script as well.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
Hanging socat processes in the DUT in case of a failure in the test script or py-expect process.

#### How did you do it?
Implemented a fixture to run before and after script run, to killall the socat process and reload the kernel modules for console lines.

#### How did you verify/test it?
Ran it successfully in my testbed:
```<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="26" failures="6" skipped="200" tests="230" time="819.988" timestamp="2026-03-04T20:26:01.677297" hostname="sj04-sonic-ucs"><proper
ties><property name="topology" value="c0" /><property name="testbed" value="arc-c0" /><property name="timestamp" value="2026-03-04 20:27:08.654033" /><property name="host" value="arc-c0-dut" /><property name="asic
" value="vpp" /><property name="platform" value="arm64-c8220tg_48a_o-r0" /><property name="hwsku" value="Cisco-C8220TG-48A-O" /><property name="os_version" value="azure_cisco_202511.0-dirty-20260226.132601" /></pr
operties><testcase classname="console.test_console_availability" name="test_console_availability[5]" file="console/test_console_availability.py" line="13" time="51.815"><failure message="Failed: Timeout reached">d
uthost = &lt;MultiAsicSonicHost arc-c0-dut&gt;
creds = {'7nodes_cisco_P1': 'vars/configdb_jsons/7nodes_cisco/P1.json', '7nodes_cisco_P2': 'vars/configdb_jsons/7nodes_cisco/P...co_P3': '
```
The failures are not related to this PR.
