### PR TITLE
[console] fix bug where non-sonic device do not have is_console_switch

### DIFF
--- a/tests/console/conftest.py
+++ b/tests/console/conftest.py
@@ -41,7 +41,8 @@ def setup_c0(request, duthost, tbinfo):
 
     if tbinfo["topo"]["name"] == "c0":
         fanouthosts = request.getfixturevalue("fanouthosts")
-        console_fanouts = list(filter(lambda fanouthost: fanouthost.is_console_switch(), fanouthosts))
+        console_fanouts = list(filter(lambda fh: fh.get_fanout_os() == 'sonic' and fh.is_console_switch(),
+                                      fanouthosts.values()))
         if len(console_fanouts) != 1:
             pytest.fail("Test requires exactly one console switch fanout device (could be dut itself)")
         console_fanout = console_fanouts[0]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

nonsonic device do not have is_console_switch so when conftest checks all fanouthosts, is_console_switch fail on non sonic fanouthosts

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix the bug

#### How did you do it?
check host is sonic before checking for console

#### How did you verify/test it?
Run test

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
