### PR TITLE
copp: fix DHCPTopoT1Test/DHCP6TopoT1Test false failure from background traffic on T1

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/copp_tests.py
+++ b/ansible/roles/test/files/ptftests/py3/copp_tests.py
@@ -328,6 +328,37 @@ class DHCPTopoT1Test(PolicyTest):
         self.log("DHCPTopoT1Test")
         self.run_suite()
 
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
+        """
+        Use packet-matched recv_count instead of unfiltered NN counter rx_pps.
+        The NN counter (AF_PACKET ETH_P_ALL) captures all traffic on the interface
+        including BGP keepalives, LLDP, and TCP ACKs that are unrelated to DHCP.
+        recv_count is matched against the exact DHCP packet template and correctly
+        verifies that DHCP is not being punted to CPU on T1 topology.
+        """
+        self.log("")
+        if self.is_smartswitch_light_mode:
+            self.log("Checking constraints (PolicyApplied - SmartSwitch):")
+            self.log(
+                "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
+                (int(self.PPS_LIMIT_MIN),
+                 int(rx_pps),
+                 int(self.PPS_LIMIT_MAX),
+                 str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
+            )
+            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, (
+                "Copp policer constraint check failed, Actual PPS: {} "
+                "Expected PPS range: {} - {}".format(
+                    rx_pps, self.PPS_LIMIT_MIN, self.PPS_LIMIT_MAX))
+        else:
+            self.log("Checking constraints (NoPolicyApplied - T1 DHCP):")
+            self.log(
+                "DHCP-matched recv_count (%d) should be 0 (DHCP not punted on T1)" % recv_count
+            )
+            assert recv_count == 0, (
+                "Copp policer constraint check failed, Expected 0 DHCP packets punted "
+                "to CPU on T1, but received {} packets".format(recv_count))
+
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]
 
@@ -456,6 +487,37 @@ class DHCP6TopoT1Test(PolicyTest):
     def runTest(self):
         self.log("DHCP6TopoT1Test")
         self.run_suite()
+
+    def check_constraints(self, send_count, recv_count, time_delta_ms, rx_pps):
+        """
+        Use packet-matched recv_count instead of unfiltered NN counter rx_pps.
+        The NN counter (AF_PACKET ETH_P_ALL) captures all traffic on the interface
+        including BGP keepalives, LLDP, and TCP ACKs that are unrelated to DHCP.
+        recv_count is matched against the exact DHCP packet template and correctly
+        verifies that DHCP is not being punted to CPU on T1 topology.
+        """
+        self.log("")
+        if self.is_smartswitch_light_mode:
+            self.log("Checking constraints (PolicyApplied - SmartSwitch):")
+            self.log(
+                "PPS_LIMIT_MIN (%d) <= rx_pps (%d) <= PPS_LIMIT_MAX (%d): %s" %
+                (int(self.PPS_LIMIT_MIN),
+                 int(rx_pps),
+                 int(self.PPS_LIMIT_MAX),
+                 str(self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX))
+            )
+            assert self.PPS_LIMIT_MIN <= rx_pps <= self.PPS_LIMIT_MAX, (
+                "Copp policer constraint check failed, Actual PPS: {} "
+                "Expected PPS range: {} - {}".format(
+                    rx_pps, self.PPS_LIMIT_MIN, self.PPS_LIMIT_MAX))
+        else:
+            self.log("Checking constraints (NoPolicyApplied - T1 DHCP):")
+            self.log(
+                "DHCP-matched recv_count (%d) should be 0 (DHCP not punted on T1)" % recv_count
+            )
+            assert recv_count == 0, (
+                "Copp policer constraint check failed, Expected 0 DHCP packets punted "
+                "to CPU on T1, but received {} packets".format(recv_count))
 
     def construct_packet(self, port_number):
         src_mac = self.my_mac[port_number]


### PR DESCRIPTION
On T1 topology, the DHCP/DHCP6 COPP test verifies that DHCP packets are NOT punted
to the CPU (PPS_LIMIT_MAX=0). However, the NN counter used for measurement is based on
AF_PACKET ETH_P_ALL, which counts ALL control-plane packets on the interface — including
BGP keepalives, LLDP frames, and TCP ACKs. On T1 testbeds with active BGP neighbors on
the PTF port, background traffic causes persistent false failures even when DHCP is
correctly blocked.

### ADO Work Item

https://msazure.visualstudio.com/One/_workitems/edit/37343598

### Description of PR

Summary:

Override check_constraints() in DHCPTopoT1Test and DHCP6TopoT1Test to use
recv_count (matched against the exact DHCP packet template via
count_matched_packets_all_ports()) instead of rx_pps (from the unfiltered NN
counter). Background traffic (BGP keepalives, LLDP, TCP ACKs) does not match the DHCP
packet bytes and is correctly excluded. SmartSwitch behavior is preserved via the
is_smartswitch_light_mode branch.

### Type of change

- [x] Bug fix

### Back port request
- [x] 202511

### Approach

#### What is the motivation for this PR?
The NN counter (get_nn_counters()) uses AF_PACKET SOCK_RAW ETH_P_ALL which captures
all packets on the Linux netdev, not just DHCP. On T1 testbeds, BGP keepalives (~60s
interval) + LLDP (~30s interval) + TCP ACKs generate ~1 PPS background traffic on the
PTF port. This causes rx_pps=1 > PPS_LIMIT_MAX=0 assertion failure even when DHCP is
correctly not being punted.

#### How did you do it?
Override check_constraints() in DHCPTopoT1Test and DHCP6TopoT1Test. For T1
(non-SmartSwitch): assert recv_count == 0 using the packet-matched counter that
filters by exact DHCP bytes. For SmartSwitch: preserve original PPS-based range check.

#### How did you verify/test it?
- Root cause confirmed via 20s tcpdump on DUT showing BGP+LLDP+TCP-ACK background traffic
- recv_count is DHCP-specific: bytes matched against Ether/IP/UDP(sport=68,dport=67)/BOOTP/DHCP template
- Failure was reproducible 3/3 times on bjw3-can-t1-7060-2 testbed

#### Any platform specific information?
T1 topology testbeds with active BGP routing neighbors on PTF ports.

#### Supported testbed topology if it is a new test case?
Existing test, topology: t1

### Documentation

N/A