### PR TITLE
tests: add zebra interface ifindex consistency test

### DIFF
--- a/tests/bgp/test_zebra_interface_consistency.py
+++ b/tests/bgp/test_zebra_interface_consistency.py
@@ -1,0 +1,93 @@
+"""
+Test zebra interface consistency after boot and config reload.
+
+Validates that all Ethernet interfaces have valid (non-zero) ifindex in FRR's
+zebra daemon. This guards against a race condition where the speed update timer
+sets ZEBRA_INTERFACE_ACTIVE before RTM_NEWLINK assigns a real ifindex, causing
+interfaces to be missing from zebra's per-NS ifindex rbtree.
+
+See: https://github.com/sonic-net/sonic-buildimage/issues/XXXX
+"""
+
+import json
+import logging
+import pytest
+import re
+
+from tests.common import config_reload as config_reload_helper
+from tests.common.helpers.assertions import pytest_assert
+from tests.common.platform.processes_utils import wait_critical_processes
+
+pytestmark = [
+    pytest.mark.topology('any'),
+]
+
+logger = logging.getLogger(__name__)
+
+
+def get_zebra_interface_data(duthost):
+    """Get interface data from zebra via vtysh and return parsed JSON."""
+    result = duthost.shell('docker exec bgp vtysh -c "show interface json"')
+    return json.loads(result['stdout'])
+
+
+def get_ethernet_interfaces(duthost):
+    """Get list of Ethernet interface names from CONFIG_DB."""
+    result = duthost.shell('sonic-db-cli CONFIG_DB keys "PORT|Ethernet*"')
+    interfaces = []
+    for line in result['stdout_lines']:
+        match = re.match(r'PORT\|(Ethernet\d+)', line)
+        if match:
+            interfaces.append(match.group(1))
+    return sorted(interfaces)
+
+
+def check_interface_ifindex(duthost):
+    """
+    Verify all Ethernet interfaces have valid (non-zero) ifindex in zebra.
+
+    Returns list of interfaces with ifindex == 0 (should be empty).
+    """
+    iface_data = get_zebra_interface_data(duthost)
+    ethernet_interfaces = get_ethernet_interfaces(duthost)
+    bad_interfaces = []
+
+    for intf_name in ethernet_interfaces:
+        if intf_name not in iface_data:
+            logger.warning("Interface %s not found in zebra output", intf_name)
+            bad_interfaces.append((intf_name, "missing"))
+            continue
+
+        ifindex = iface_data[intf_name].get('index', 0)
+        if ifindex == 0:
+            logger.error("Interface %s has ifindex=0 (IFINDEX_INTERNAL)", intf_name)
+            bad_interfaces.append((intf_name, "ifindex=0"))
+
+    return bad_interfaces
+
+
+class TestZebraInterfaceConsistency:
+    """Test suite for zebra interface ifindex consistency."""
+
+    def test_interface_ifindex_after_boot(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+        """Verify all interfaces have valid ifindex after normal boot."""
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+        bad = check_interface_ifindex(duthost)
+        pytest_assert(
+            len(bad) == 0,
+            "Interfaces with invalid ifindex after boot: {}".format(bad)
+        )
+
+    def test_interface_ifindex_after_config_reload(self, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
+        """Verify all interfaces have valid ifindex after config reload."""
+        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+        config_reload_helper(duthost, safe_reload=True, check_intf_up_ports=True)
+        wait_critical_processes(duthost)
+
+        bad = check_interface_ifindex(duthost)
+        pytest_assert(
+            len(bad) == 0,
+            "Interfaces with invalid ifindex after config reload: {}".format(bad)
+        )


### PR DESCRIPTION
### Description of PR

Summary:
Add `test_zebra_interface_consistency.py` to validate that all Ethernet interfaces have valid (non-zero) ifindex in FRR zebra after boot and after config reload.

Related: sonic-net/sonic-buildimage#26458 (fix), sonic-net/sonic-buildimage#26457 (issue)

This test detects the race condition where the speed update timer sets `ZEBRA_INTERFACE_ACTIVE` before `RTM_NEWLINK` assigns a real ifindex, causing interfaces to be missing from zebra's per-NS ifindex rbtree. The bug manifests on high-port-count devices (512+ ports) but this test provides a regression safety net on all platforms.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

Provide a regression test for sonic-net/sonic-buildimage#26457 — a race condition between zebra's speed update timer and `RTM_NEWLINK` processing that causes silent routing failures on high-port-count devices. Pre/post sanity checks cover BGP sessions and crashes, but no existing test validates the interface ifindex consistency in zebra's internal data structures.

#### How did you do it?

New test file: `tests/bgp/test_zebra_interface_consistency.py`

Two test cases in `TestZebraInterfaceConsistency`:

1. **`test_interface_ifindex_after_boot`** — Queries `docker exec bgp vtysh -c "show interface json"` and verifies every Ethernet interface (from CONFIG_DB `PORT` table) has `index > 0`.

2. **`test_interface_ifindex_after_config_reload`** — Runs `config reload`, waits for critical processes, then re-checks all ifindexes.

Helper functions:
- `get_zebra_interface_data()` — parses `show interface json` from vtysh
- `get_ethernet_interfaces()` — reads PORT table from CONFIG_DB
- `check_interface_ifindex()` — compares and returns bad interfaces

#### How did you verify/test it?

Ran on VS KVM T0 testbed with image `SONiC.fix_zebra-speed-timer-race.0-c2a5daad9`:
- ✅ `test_interface_ifindex_after_boot` — 32/32 interfaces valid
- ✅ `test_interface_ifindex_after_config_reload` — 32/32 interfaces valid after reload

#### Any platform specific information?

No — test uses topology `any` and works on all platforms.

#### Supported testbed topology if it's a new test case?

`any` (tested on VS T0)

### Documentation

N/A

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>