### PR TITLE
[ha] fix argument order in planned shutdown test case 

### DIFF
--- a/tests/ha/test_ha_planned_shutdown.py
+++ b/tests/ha/test_ha_planned_shutdown.py
@@ -107,7 +107,7 @@ def test_ha_planned_shutdown(
         while packet_sending_flag.empty() or (not packet_sending_flag.get()):
             time.sleep(0.2)
         logging.info("Set primary to dead")
-        set_dead_dash_ha_scope(localhost, ptfhost, duthosts[0], "vdpu0_0:haset0_0")
+        set_dead_dash_ha_scope(localhost, duthosts[0], ptfhost, "vdpu0_0:haset0_0")
 
     t = threading.Thread(target=primary_ha_action, name="primary_ha_action_thread")
     t.start()
@@ -152,7 +152,7 @@ def test_ha_planned_shutdown(
         while packet_sending_flag.empty() or (not packet_sending_flag.get()):
             time.sleep(0.2)
         logging.info("Set standby to dead")
-        set_dead_dash_ha_scope(localhost, ptfhost, duthosts[1], "vdpu1_0:haset0_0")
+        set_dead_dash_ha_scope(localhost, duthosts[1], ptfhost, "vdpu1_0:haset0_0")
 
     t = threading.Thread(target=standby_ha_action, name="standby_ha_action_thread")
     t.start()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The argument order is wrong when setting ha scope desired_state to `dead`. It failed the GNMI call, and led to test failures. 
Submitting this PR to fix the issue. 

Reference: https://github.com/sonic-net/sonic-mgmt/blob/6a548d3fb1a1c86acdbe9d7620019808964d5c88/tests/ha/ha_utils.py#L268

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
To fix the syntax error in test cases. 

#### How did you do it?
Swapped the argument back to the right order. 

#### How did you verify/test it?
Ran the test, confirmed the GNMI call was successful this time. 

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
