### PR TITLE
[tests/parallel_fixture]: Fix `RuntimeError` when submitting task

### DIFF
--- a/tests/common/plugins/parallel_fixture/__init__.py
+++ b/tests/common/plugins/parallel_fixture/__init__.py
@@ -550,9 +550,16 @@ def teardown_barrier_function(parallel_manager):
 def pytest_runtest_setup(item):
     """
     HOOK: Runs once BEFORE every fixture setup.
-    Reorder the setup/teardown barriers to ensure barriers should run
-    after ALL fixtures of the same-scope.
+    Reset the parallel manager from the previous test (deferred from
+    pytest_runtest_teardown so that pytest_runtest_logreport fires first),
+    then reorder the setup/teardown barriers to ensure barriers run after
+    ALL fixtures of the same scope.
     """
+    parallel_manager = _PARALLEL_MANAGER
+    if parallel_manager and parallel_manager.terminated:
+        parallel_manager.reset()
+        parallel_manager.current_scope = TaskScope.SESSION
+
     logging.debug("[Parallel Fixture] Setup barrier fixtures")
 
     barriers = {
@@ -678,9 +685,6 @@ def pytest_runtest_teardown(item, nextitem):
                     parallel_manager.wait_for_setup_tasks(scope)
             finally:
                 parallel_manager.terminate()
-            logging.debug("[Parallel Fixture] Test was skipped or failed early, "
-                          "terminating parallel manager")
-            parallel_manager.terminate()
 
         parallel_manager.reset()
         parallel_manager.current_scope = TaskScope.FUNCTION


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Fix the following parallel fixture manager not running issue:
```
self = <concurrent.futures.thread.ThreadPoolExecutor object at 0x73608907d9a0>
fn = <function print_logs.<locals>.run_cmd at 0x736087b86700>
args = (<MultiAsicSonicHost vlab-01>, 'show version'), kwargs = {}

    def submit(self, fn, /, *args, **kwargs):
        with self._shutdown_lock, _global_shutdown_lock:
            if self._broken:
                raise BrokenThreadPool(self._broken)
    
            if self._shutdown:
>               raise RuntimeError('cannot schedule new futures after shutdown')
E               RuntimeError: cannot schedule new futures after shutdown
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?

If a test is skipped, the parallel fixture manager is terminated, so
subsequent testcase cannot use the parallel fixture manager anymore.

Fix by adding a reset() call at the start of pytest_runtest_setup, guarded
by parallel_manager.terminated. This ensures the executor used for setup
tasks is only created after pytest_runtest_logreport has had its chance to
fire. The reset() in pytest_runtest_teardown is retained so that fixture
teardowns still have a live executor for teardown task submissions.

Also remove the redundant second terminate() call in the skipped/failed-early
path of pytest_runtest_teardown (already called in the finally block).


#### How did you verify/test it?
Run on kvm-t0

```
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-ingress_lossless_pool/xoff] s                                                                                                                  10% █
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-ingress_lossless_pool/size] s                                                                                                                  20% ██
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[add-egress_lossy_pool/size] s                                                                                                                      30% ███
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-ingress_lossless_pool/xoff] s                                                                                                              40% ████
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-ingress_lossless_pool/size] s                                                                                                              50% █████
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[replace-egress_lossy_pool/size] s                                                                                                                  60% ██████
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[remove-ingress_lossless_pool/xoff] s                                                                                                               70% ███████
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[remove-ingress_lossless_pool/size] s                                                                                                               80% ████████
 tests/generic_config_updater/test_incremental_qos.py::test_incremental_qos_config_updates[remove-egress_lossy_pool/size] s                                                                                                                   90% █████████
 tests/generic_config_updater/test_incremental_qos.py::test_buffer_profile_create_remove_rollback ✓                                                                                                                                          100% ██████████
===================================================================================================================== warnings summary =====================================================================================================================
```

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
