### PR TITLE
[gnmi] Add retry logic to test_gnmi_appldb_01 gNMI GET operations

### DIFF
--- a/tests/gnmi/test_gnmi_appldb.py
+++ b/tests/gnmi/test_gnmi_appldb.py
@@ -1,9 +1,13 @@
+import time
 import logging
 import pytest
 
 from .helper import gnmi_set, gnmi_get
 
 logger = logging.getLogger(__name__)
+
+GNMI_GET_RETRY_COUNT = 3
+GNMI_GET_RETRY_INTERVAL = 10
 
 pytestmark = [
     pytest.mark.topology('any'),
@@ -27,23 +31,33 @@ def test_gnmi_appldb_01(duthosts, rand_one_dut_hostname, ptfhost):
     # Add DASH_VNET_TABLE
     update_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE:@/root/%s" % (file_name)]
     gnmi_set(duthost, ptfhost, [], update_list, [])
-    # Check gnmi_get result
+    # Check gnmi_get result with retry for gNMI service readiness
     path_list1 = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1/vni"]
     path_list2 = ["/sonic-db:APPL_DB/localhost/_DASH_VNET_TABLE/Vnet1/vni"]
     output = None
-    try:
-        msg_list1 = gnmi_get(duthost, ptfhost, path_list1)
-    except Exception as e:
-        logger.info("Failed to read path1: " + str(e))
-    else:
-        output = msg_list1[0]
-    try:
-        msg_list2 = gnmi_get(duthost, ptfhost, path_list2)
-    except Exception as e:
-        logger.info("Failed to read path2: " + str(e))
-    else:
-        output = msg_list2[0]
-    assert output == "\"1000\"", "Unexpected output: '{}'".format(output)
+    for attempt in range(GNMI_GET_RETRY_COUNT):
+        try:
+            msg_list1 = gnmi_get(duthost, ptfhost, path_list1)
+        except Exception as e:
+            logger.info("Failed to read path1 (attempt %d/%d): %s",
+                        attempt + 1, GNMI_GET_RETRY_COUNT, str(e))
+        else:
+            output = msg_list1[0]
+            break
+        try:
+            msg_list2 = gnmi_get(duthost, ptfhost, path_list2)
+        except Exception as e:
+            logger.info("Failed to read path2 (attempt %d/%d): %s",
+                        attempt + 1, GNMI_GET_RETRY_COUNT, str(e))
+        else:
+            output = msg_list2[0]
+            break
+        if attempt < GNMI_GET_RETRY_COUNT - 1:
+            logger.info("Retrying gNMI GET after %ds wait...", GNMI_GET_RETRY_INTERVAL)
+            time.sleep(GNMI_GET_RETRY_INTERVAL)
+    assert output == "\"1000\"", \
+        "gNMI APPL_DB read failed on {} after {} retries: output='{}'".format(
+            duthost.hostname, GNMI_GET_RETRY_COUNT, output)
 
     # Remove DASH_VNET_TABLE
     delete_list = ["/sonic-db:APPL_DB/localhost/DASH_VNET_TABLE/Vnet1"]


### PR DESCRIPTION
### Description of PR

Add retry logic to `test_gnmi_appldb_01` gNMI GET operations to handle intermittent gNMI service unavailability.

**Root Cause:** After `gnmi_set` writes DASH_VNET_TABLE, the subsequent `gnmi_get` can fail when the gNMI server is temporarily unavailable (SSL handshake failures on Cisco, connection drops on Force10, general timeouts on Mellanox/Arista). Both path variants (`DASH_VNET_TABLE` and `_DASH_VNET_TABLE`) raise exceptions, `output` stays `None`, and the assertion fails as `AssertionError: None`.

**Timeline:** Failures started appearing ~Feb 24, 2026 — one week after [PR #22412](https://github.com/sonic-net/sonic-mgmt/pull/22412) converted gNMI fixtures from `autouse=True` to explicit `usefixtures`. While the fixture refactor itself is correct, it may have introduced subtle timing changes in fixture execution order that expose a pre-existing race condition in gNMI service readiness.

**Cross-vendor data (14d):**
| SKU | Topology | PassRate | Runs | Error |
|-----|----------|----------|------|-------|
| Cisco-8101-O8V48 | t1-56-lag | **0%** | 4 | AssertionError: None |
| Force10-S6100 | t0-64 | **0%** | 2 | gNMI Set failed: connection closed |
| Cisco-8101-O8C48 | t1-56-lag | **22%** | 9 | AssertionError: None |
| Cisco-8101C01-C32 | dualtor | **43%** | 7 | SSL CERTIFICATE_VERIFY_FAILED |
| Mellanox-SN2700 | t1-lag | 57% | 7 | AssertionError: None |
| Arista-7050CX3-32S-C32 | t0 | 64% | 11 | AssertionError: None |
| All other platforms | various | **100%** | 100+ | — |

**Fix:** Adds retry with backoff (3 attempts, 10s interval) around the gNMI GET calls, consistent with the health-check pattern already used in `gnmi_set()`. Also improves the assertion message to include the DUT hostname.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach

#### What is the motivation for this PR?

`test_gnmi_appldb_01` has 84% overall pass rate but fails intermittently across multiple vendors (Cisco-8101, Force10, Mellanox, Arista) due to gNMI GET failing after a successful SET. The `gnmi_set` helper already has a health check (`wait_until(120, 1, 5, ...)`) but `gnmi_get` does not — if gNMI becomes briefly unavailable between SET and GET, both path reads fail.

#### How did you do it?

1. Added `GNMI_GET_RETRY_COUNT = 3` and `GNMI_GET_RETRY_INTERVAL = 10` constants
2. Wrapped the dual-path GET logic in a retry loop — on failure, waits 10s before retrying
3. Improved assertion message to include DUT hostname and retry count for debugging

#### How did you verify/test it?

Cross-vendor Kusto analysis confirms the failure pattern is transient gNMI unavailability. The retry approach mirrors the proven health-check pattern in `gnmi_set()`.

#### Any platform specific information?

Affects all platforms but most frequently Cisco-8101 variants (slower gNMI startup) and Force10-S6100. Cisco-8102, Nokia, and Arista-7060X6 are unaffected (100% pass rate).

### Documentation

ADO: [#37230121](https://msazure.visualstudio.com/One/_workitems/edit/37230121)