### PR TITLE
[Mellanox] Add SPC6 skus ports splits for community deployment

### DIFF
--- a/ansible/module_utils/port_utils.py
+++ b/ansible/module_utils/port_utils.py
@@ -640,6 +640,26 @@ def get_port_alias_to_name_map(hwsku, asic_name=None):
                         port_alias_to_name_map[alias] = eth_name
             port_alias_to_name_map['etp65'] = "Ethernet512"
             port_alias_to_name_map['etp66'] = "Ethernet520"
+        elif hwsku in ["ACS-SN6600"]:
+            split_alias_list = ["a", "b"]
+            for i in range(1, 65):
+                for idx, split_alias in enumerate(split_alias_list):
+                    alias = "etp{}{}".format(i, split_alias)
+                    eth_name = "Ethernet{}".format((i - 1) * 8 + idx * 4)
+                    port_alias_to_name_map[alias] = eth_name
+            port_alias_to_name_map['etp65a'] = "Ethernet512"
+            port_alias_to_name_map['etp65b'] = "Ethernet513"
+            port_alias_to_name_map['etp67'] = "Ethernet520"
+            port_alias_to_name_map['etp68'] = "Ethernet528"
+        elif hwsku in ["Mellanox-SN6600_LD-V512C2", "Mellanox-SN6600_LD-V448P16C2"]:
+            split_alias_list = ["a", "b", "c", "d", "e", "f", "g", "h"]
+            for i in range(1, 65):
+                for idx, split_alias in enumerate(split_alias_list):
+                    alias = "etp{}{}".format(i, split_alias)
+                    eth_name = "Ethernet{}".format((i - 1) * 8 + idx)
+                    port_alias_to_name_map[alias] = eth_name
+            port_alias_to_name_map['etp65a'] = "Ethernet512"
+            port_alias_to_name_map['etp65b'] = "Ethernet513"
         elif hwsku in ["Mellanox-SN4280-O8C80"]:
             idx = 0
             for i in range(1, 13):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add ports map generation for spc6 new hwsku - needed for deploy.
Added default sku - "ACS-SN6600" and non-default - "Mellanox-SN6600-V512X4", "Mellanox-SN6600-V448P16X4", "Mellanox-SN6600-C512S4".


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
New platform added.

#### How did you do it?
Added new skus and ports split used for each of them

#### How did you verify/test it?
Internal regression

#### Any platform specific information?
sn6600 platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
