### PR TITLE
Fix port issue on fwutil test.

### DIFF
--- a/tests/platform_tests/fwutil/conftest.py
+++ b/tests/platform_tests/fwutil/conftest.py
@@ -14,6 +14,7 @@ FS_RW_TEMPLATE = "/host/image-{}/rw"
 FS_WORK_TEMPLATE = "/host/image-{}/work"
 FS_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-fs"
 OVERLAY_MOUNTPOINT_TEMPLATE = "/tmp/image-{}-overlay"
+LOCAL_HTTP_SERVER_PORT = 8081
 
 
 def pytest_addoption(parser):
@@ -95,10 +96,11 @@ def component(request, duthost, fw_pkg):
 
 @pytest.fixture(scope='function')
 def host_firmware(localhost, duthost):
-    logger.info("Starting local python server to test URL firmware update....")
-    comm = "python3 -m http.server --directory {}".format(os.path.join(DEVICES_PATH, duthost.facts['platform']))
-    duthost.command(comm, module_ignore_errors=True, module_async=True)
-    yield "http://localhost:8000/"
+    logger.info("Starting local python server on port {} to test URL firmware update".format(LOCAL_HTTP_SERVER_PORT))
+    comm = "python3 -m http.server {} --directory {}".format(
+        LOCAL_HTTP_SERVER_PORT, os.path.join(DEVICES_PATH, duthost.facts['platform']))
+    duthost.command(comm, module_async=True)
+    yield "http://localhost:{}/".format(LOCAL_HTTP_SERVER_PORT)
     logger.info("Stopping local python server.")
     duthost.command('pkill -f "{}"'.format(comm), module_ignore_errors=True)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
From time to time we see that the port used by http server for localhost is in use by platform API, and unavailable, so I changed the port to a different one, and also removed the ignore errors flag to raise failure in case the server init fails.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [] 202511

### Approach
#### What is the motivation for this PR?
Fix race condition between local http server to platform api

#### How did you do it?
Added available port to be used for the local http server

#### How did you verify/test it?
Ran the test fwutil

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
