### PR TITLE
[Mellanox] add sn6600_ld and sn6600_ld_simx platform for dynamic buffer test

### DIFF
--- a/tests/qos/files/dynamic_buffer_param.json
+++ b/tests/qos/files/dynamic_buffer_param.json
@@ -28,7 +28,9 @@
 	"extra_overhead": {
 	    "8": "95232",
 	    "default": "58368",
-		"x86_64-nvidia_sn6600_simx-r0": "96256"
+		"x86_64-nvidia_sn6600_simx-r0": "96256",
+		"x86_64-nvidia_sn6600_ld_simx-r0": "96256",
+		"x86_64-nvidia_sn6600_ld-r0": "96256"
 	},
 	"shared-headroom-pool": {
 	    "size": "1024000",
@@ -48,6 +50,16 @@
 			{"0-2": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
 			"3-4": "[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]",
 			"5-6": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"7-11": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"},
+			"x86_64-nvidia_sn6600_ld_simx-r0":
+			{"0-2": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"3-4": "[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]",
+			"5-6": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"7-11": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"},
+		"x86_64-nvidia_sn6600_ld-r0":
+			{"0-2": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
+			"3-4": "[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]",
+			"5-6": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]",
 			"7-11": "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"}
 	    },
 	    "BUFFER_PORT_INGRESS_PROFILE_LIST_TABLE": ["[BUFFER_PROFILE_TABLE:ingress_lossless_zero_profile]"],
@@ -64,11 +76,15 @@
 		"x86_64-nvidia_sn5600-r0": "800000",
 		"x86_64-nvidia_sn5640-r0": "800000",
 		"x86_64-nvidia_sn5600_simx-r0": "800000",
-		"x86_64-nvidia_sn6600_simx-r0": "800000"
+		"x86_64-nvidia_sn6600_simx-r0": "800000",
+		"x86_64-nvidia_sn6600_ld-r0": "800000",
+		"x86_64-nvidia_sn6600_ld_simx-r0": "800000"
 	},
 	"supported_speeds_to_test": {
 		"default": ["10000", "50000"],
-		"x86_64-nvidia_sn6600_simx-r0": ["100000"]
+		"x86_64-nvidia_sn6600_simx-r0": ["100000"],
+		"x86_64-nvidia_sn6600_ld-r0": ["100000"],
+		"x86_64-nvidia_sn6600_ld_simx-r0": ["100000"]
 	}
     }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
Add sn6600_ld platform for dynamic buffer test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
New platform - sn6600_ld

#### How did you do it?
added platform info for dynamic buffer test

#### How did you verify/test it?
internal regression run with dynamic buffer test

#### Any platform specific information?
sn6600_ld platform

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
