### PR TITLE
[dhcp_relay] add dhcpmon check for dhcpv6

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py
@@ -129,8 +129,13 @@ class DHCPCounterTest(DataplaneBaseTest):
         packet /= IPv6(src=self.client_link_local, dst=self.BROADCAST_IP)
         packet /= ptf.packet.UDP(sport=self.DHCP_CLIENT_PORT,
                                  dport=self.DHCP_SERVER_PORT)
-        # changes optcode to be out of client scope to test malformed counters
-        packet /= message(trid=12345)/DHCP6OptAuth(optcode=148)
+        # dhcp6relay: option codes > 147 (DHCPv6_OPTION_LIMIT) are malformed
+        # dhcpmon:    option codes > 150 (DHCPV6_OPTION_CODE_MAX) are malformed
+        # Note: IANA has assigned up to option 148 (OPTION_RELAY_PORT, RFC 8357),
+        # so dhcp6relay's limit of 147 is outdated. Both limits are hardcoded
+        # and will go stale as IANA assigns new codes.
+        # Use optcode=300 (well above both limits) to trigger malformed detection
+        packet /= message(trid=12345)/DHCP6OptAuth(optcode=300)
         return packet
 
     def create_server_packet(self, message):
@@ -152,7 +157,11 @@ class DHCPCounterTest(DataplaneBaseTest):
 
         return packet
 
-    def create_unknown_server_packet(self):
+    def create_malformed_server_packet(self):
+        """Relay-Reply with no relay-msg option.
+        dhcp6relay: counts as Unknown (unrecognizable inner content)
+        dhcpmon: counts as Malformed (relay packet missing required relay-msg option)
+        """
         packet = ptf.packet.Ether(dst=self.dut_mac)
         if self.is_dualtor:
             packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
@@ -161,6 +170,24 @@ class DHCPCounterTest(DataplaneBaseTest):
         packet /= ptf.packet.UDP(sport=self.DHCP_SERVER_PORT,
                                  dport=self.DHCP_SERVER_PORT)
         packet /= DHCP6_RelayReply(msgtype=13, linkaddr=self.vlan_ip,
+                                   peeraddr=self.client_link_local)
+
+        return packet
+
+    def create_unknown_server_packet(self):
+        """DHCPv6 packet with message type 20 (beyond valid range 1-13).
+        dhcp6relay: counts as Unknown (unrecognized message type)
+        dhcpmon: counts as Unknown (msg_type > RELAY_REPL)
+        """
+        packet = ptf.packet.Ether(dst=self.dut_mac)
+        if self.is_dualtor:
+            packet /= IPv6(src=self.server_ip, dst=self.loopback_ipv6)
+        else:
+            packet /= IPv6(src=self.server_ip, dst=self.relay_iface_ip)
+        packet /= ptf.packet.UDP(sport=self.DHCP_SERVER_PORT,
+                                 dport=self.DHCP_SERVER_PORT)
+        # msgtype=20 is beyond the valid DHCPv6 range (1-13)
+        packet /= DHCP6_RelayReply(msgtype=20, linkaddr=self.vlan_ip,
                                    peeraddr=self.client_link_local)
 
         return packet
@@ -191,6 +218,15 @@ class DHCPCounterTest(DataplaneBaseTest):
             testutils.send_packet(self, self.server_port_indices[0], packet)
             time.sleep(1)
 
+        # malformed: valid Relay-Reply but missing relay-msg option
+        malformed_packet = self.create_malformed_server_packet()
+        malformed_packet.src = self.dataplane.get_mac(
+            0, self.server_port_indices[0])
+        testutils.send_packet(
+            self, self.server_port_indices[0], malformed_packet)
+        time.sleep(1)
+
+        # unknown: DHCPv6 packet with unrecognized message type (20)
         unknown_packet = self.create_unknown_server_packet()
         unknown_packet.src = self.dataplane.get_mac(
             0, self.server_port_indices[0])

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -126,6 +126,7 @@ class DHCPTest(DataplaneBaseTest):
         self.relay_link_local = self.test_params['relay_link_local']
         self.relay_linkaddr = '::'
         self.vlan_ip = self.test_params['vlan_ip']
+        self.downstream_relay_ip = self.test_params['downstream_relay_ip']
         self.client_mac = self.dataplane.get_mac(0, self.client_port_index)
         self.uplink_mac = self.test_params['uplink_mac']
         self.loopback_ipv6 = self.test_params['loopback_ipv6']
@@ -266,38 +267,6 @@ class DHCPTest(DataplaneBaseTest):
 
         return reply_relay_reply_packet
 
-    def create_dhcp_relay_forward_packet(self):
-        relay_forward_packet = packet.Ether(
-            src=self.client_mac, dst=self.BROADCAST_MAC)
-        relay_forward_packet /= IPv6(src=self.client_link_local,
-                                     dst=self.BROADCAST_IP)
-        relay_forward_packet /= packet.UDP(
-            sport=self.DHCP_CLIENT_PORT, dport=self.DHCP_SERVER_PORT)
-        relay_forward_packet /= DHCP6_RelayForward(
-            msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
-        relay_forward_packet /= DHCP6OptRelayMsg(
-            message=[DHCP6_Solicit(trid=12345)])
-        relay_forward_packet /= DHCP6OptElapsedTime(elapsedtime=0)
-
-        return relay_forward_packet
-
-    def create_dhcp_relayed_relay_packet(self):
-        relayed_relay_packet = packet.Ether(src=self.uplink_mac)
-        relayed_relay_packet /= IPv6()
-        relayed_relay_packet /= packet.UDP(
-            sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
-        packet_inside = DHCP6_RelayForward(
-            msgtype=12, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
-        packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Solicit(trid=12345)])
-        packet_inside /= DHCP6OptElapsedTime(elapsedtime=0)
-        relayed_relay_packet /= DHCP6_RelayForward(msgtype=12, hopcount=1, linkaddr=self.relay_linkaddr,
-                                                   peeraddr=self.client_link_local)
-        relayed_relay_packet /= DHCP6OptRelayMsg(message=[packet_inside])
-        if self.is_dualtor:
-            relayed_relay_packet /= DHCP6OptIfaceId(ifaceid=socket.inet_pton(socket.AF_INET6, self.vlan_ip))
-
-        return relayed_relay_packet
-
     def create_dhcp_relay_relay_reply_packet(self):
         relay_relay_reply_packet = packet.Ether(dst=self.uplink_mac)
         dst_ip = self.loopback_ipv6 if self.is_dualtor else self.relay_iface_ip
@@ -305,8 +274,8 @@ class DHCPTest(DataplaneBaseTest):
                                          dst=dst_ip)
         relay_relay_reply_packet /= packet.UDP(
             sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
-        relay_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, hopcount=1, linkaddr=self.vlan_ip,
-                                                     peeraddr=self.client_link_local)
+        relay_relay_reply_packet /= DHCP6_RelayReply(msgtype=13, hopcount=1, linkaddr=self.relay_linkaddr,
+                                                     peeraddr=self.downstream_relay_ip)
         packet_inside = DHCP6_RelayReply(
             msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Reply(trid=12345)])
@@ -318,10 +287,10 @@ class DHCPTest(DataplaneBaseTest):
     def create_dhcp_relay_reply_packet(self):
         relay_reply_packet = packet.Ether(
             src=self.relay_iface_mac, dst=self.client_mac)
-        relay_reply_packet /= IPv6(src=self.relay_link_local,
-                                   dst=self.client_link_local)
+        relay_reply_packet /= IPv6(src=self.relay_iface_ip,
+                                   dst=self.downstream_relay_ip)
         relay_reply_packet /= packet.UDP(sport=self.DHCP_SERVER_PORT,
-                                         dport=self.DHCP_CLIENT_PORT)
+                                         dport=self.DHCP_SERVER_PORT)
         relay_reply_packet /= DHCP6_RelayReply(
             msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         relay_reply_packet /= DHCP6OptRelayMsg(
@@ -443,34 +412,6 @@ class DHCPTest(DataplaneBaseTest):
         testutils.verify_packet(self, masked_packet, self.client_port_index)
 
     # Simulate a DHCP server sending a DHCPv6 RELAY-FORWARD encapsulating SOLICIT packet message to client.
-    def client_send_relayed_relay_forward(self):
-        # Form and send DHCPv6 RELAY-FORWARD encapsulating REPLY packet
-        relay_forward_packet = self.create_dhcp_relay_forward_packet()
-        testutils.send_packet(
-            self, self.client_port_index, relay_forward_packet)
-
-    # Verify that the DHCPv6 RELAYED RELAY would be received by our simulated server
-    def verify_relayed_relay_forward(self):
-        # Create a packet resembling a DHCPv6 RELAYED RELAY FORWARD packet
-        relayed_relay_forward_count = self.create_dhcp_relayed_relay_packet()
-
-        # Mask off fields we don't care about matching
-        masked_packet = Mask(relayed_relay_forward_count)
-        masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
-        masked_packet.set_do_not_care_scapy(IPv6, "src")
-        masked_packet.set_do_not_care_scapy(IPv6, "dst")
-        masked_packet.set_do_not_care_scapy(IPv6, "fl")
-        masked_packet.set_do_not_care_scapy(IPv6, "tc")
-        masked_packet.set_do_not_care_scapy(IPv6, "plen")
-        masked_packet.set_do_not_care_scapy(IPv6, "nh")
-        masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
-        masked_packet.set_do_not_care_scapy(packet.UDP, "len")
-
-        relayed_relay_forward_count = testutils.count_matched_packets_all_ports(self, masked_packet,
-                                                                                self.server_port_indices, timeout=4.0)
-        self.assertTrue(relayed_relay_forward_count >= 1, "Failed: Relayed Relay Forward count of %d"
-                        % relayed_relay_forward_count)
-
     # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating RELAY-REPLY packet message to next relay agent
     def server_send_relay_relay_reply(self):
         # Form and send DHCPv6 RELAY-REPLY encapsulating REPLY packet
@@ -508,8 +449,18 @@ class DHCPTest(DataplaneBaseTest):
         self.server_send_reply_relay_reply()
         self.verify_relayed_reply()
 
-        self.client_send_relayed_relay_forward()
-        self.verify_relayed_relay_forward()
-
+        # Relay-to-relay topology: Client -> Relay A (PTF) -> Relay B (DUT) -> Server.
+        # This explicitly tests the RFC 8415 section 19.3 return path, not the
+        # normal t0/m0/mx first-hop exchange; the regular path above uses an
+        # end-client link-local peer. PTF simulates downstream Relay A with a GUA,
+        # so the outer Relay-Reply uses linkaddr=:: and peeraddr=<Relay A GUA>,
+        # matching the relay-to-relay model implemented by dhcp6relay and validated
+        # by dhcpmon. The mgmt test configures PTF's arp_responder so DUT Relay B
+        # can resolve Relay A. A link-local relay-to-relay hop is allowed by
+        # RFC8415, but current SONiC dhcp6relay/dhcpmon profiles assume GUA. They
+        # also assume first-hop downstream VLANs, which is fundamentally incompatible
+        # with making the DUT a second-or-later relay; this only models GUA return.
+        # This is a hypothetical test; there is no current SONiC topology where
+        # we use the DUT this way.
         self.server_send_relay_relay_reply()
         self.verify_relay_relay_reply()

--- a/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
+++ b/ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py
@@ -267,7 +267,54 @@ class DHCPTest(DataplaneBaseTest):
 
         return reply_relay_reply_packet
 
+    def create_downstream_relay_forward(self):
+        """Create the opaque Relay-Forward received from downstream Relay A."""
+        # Relay B must preserve this entire envelope. Its inner link, peer,
+        # and client message describe topology behind Relay A and are not
+        # behavior under test here.
+        relay_forward = DHCP6_RelayForward(
+            msgtype=12,
+            hopcount=0,
+            linkaddr=self.vlan_ip,
+            peeraddr=self.client_link_local)
+        relay_forward /= DHCP6OptRelayMsg(
+            message=[DHCP6_Solicit(trid=12345)])
+
+        return relay_forward
+
+    def create_dhcp_relay_forward_packet(self):
+        """Create the packet sent from immediate downstream Relay A."""
+        relay_forward_packet = packet.Ether(
+            src=self.client_mac, dst=self.relay_iface_mac)
+        relay_forward_packet /= IPv6(
+            src=self.downstream_relay_ip, dst=self.relay_iface_ip)
+        relay_forward_packet /= packet.UDP(
+            sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
+        relay_forward_packet /= self.create_downstream_relay_forward()
+
+        return relay_forward_packet
+
+    def create_dhcp_relayed_relay_packet(self):
+        """Create the nested Relay-Forward Relay B should send upstream."""
+        relayed_relay_packet = packet.Ether(src=self.uplink_mac)
+        relayed_relay_packet /= IPv6()
+        relayed_relay_packet /= packet.UDP(
+            sport=self.DHCP_SERVER_PORT, dport=self.DHCP_SERVER_PORT)
+        relayed_relay_packet /= DHCP6_RelayForward(
+            msgtype=12,
+            hopcount=1,
+            linkaddr=self.relay_linkaddr,
+            peeraddr=self.downstream_relay_ip)
+        relayed_relay_packet /= DHCP6OptRelayMsg(
+            message=[self.create_downstream_relay_forward()])
+        if self.is_dualtor:
+            relayed_relay_packet /= DHCP6OptIfaceId(
+                ifaceid=socket.inet_pton(socket.AF_INET6, self.vlan_ip))
+
+        return relayed_relay_packet
+
     def create_dhcp_relay_relay_reply_packet(self):
+        """Create the nested Relay-Reply sent to Relay B by its upstream."""
         relay_relay_reply_packet = packet.Ether(dst=self.uplink_mac)
         dst_ip = self.loopback_ipv6 if self.is_dualtor else self.relay_iface_ip
         relay_relay_reply_packet /= IPv6(src=self.server_ip,
@@ -280,11 +327,15 @@ class DHCPTest(DataplaneBaseTest):
             msgtype=13, linkaddr=self.vlan_ip, peeraddr=self.client_link_local)
         packet_inside /= DHCP6OptRelayMsg(message=[DHCP6_Reply(trid=12345)])
         relay_relay_reply_packet /= DHCP6OptServerId(duid=DUID_LL(lladdr="00:11:22:33:44:55"))
+        if self.is_dualtor:
+            relay_relay_reply_packet /= DHCP6OptIfaceId(
+                ifaceid=socket.inet_pton(socket.AF_INET6, self.vlan_ip))
         relay_relay_reply_packet /= DHCP6OptRelayMsg(message=[packet_inside])
 
         return relay_relay_reply_packet
 
     def create_dhcp_relay_reply_packet(self):
+        """Create the Relay-Reply Relay B should forward to Relay A."""
         relay_reply_packet = packet.Ether(
             src=self.relay_iface_mac, dst=self.client_mac)
         relay_reply_packet /= IPv6(src=self.relay_iface_ip,
@@ -411,19 +462,44 @@ class DHCPTest(DataplaneBaseTest):
         # NOTE: verify_packet() will fail for us via an assert, so no need to check a return value here
         testutils.verify_packet(self, masked_packet, self.client_port_index)
 
-    # Simulate a DHCP server sending a DHCPv6 RELAY-FORWARD encapsulating SOLICIT packet message to client.
-    # Simulate a DHCP server sending a DHCPv6 RELAY-REPLY encapsulating RELAY-REPLY packet message to next relay agent
+    def downstream_relay_send_relay_forward(self):
+        """Inject a Relay-Forward from Relay B's immediate downstream."""
+        relay_forward_packet = self.create_dhcp_relay_forward_packet()
+        testutils.send_packet(
+            self, self.client_port_index, relay_forward_packet)
+
+    def verify_relayed_relay_forward(self):
+        """Verify Relay B adds one envelope toward its immediate upstream."""
+        relayed_relay_forward_packet = self.create_dhcp_relayed_relay_packet()
+
+        masked_packet = Mask(relayed_relay_forward_packet)
+        masked_packet.set_do_not_care_scapy(packet.Ether, "dst")
+        masked_packet.set_do_not_care_scapy(IPv6, "src")
+        masked_packet.set_do_not_care_scapy(IPv6, "dst")
+        masked_packet.set_do_not_care_scapy(IPv6, "fl")
+        masked_packet.set_do_not_care_scapy(IPv6, "tc")
+        masked_packet.set_do_not_care_scapy(IPv6, "plen")
+        masked_packet.set_do_not_care_scapy(IPv6, "nh")
+        masked_packet.set_do_not_care_scapy(packet.UDP, "chksum")
+        masked_packet.set_do_not_care_scapy(packet.UDP, "len")
+
+        relayed_relay_forward_count = testutils.count_matched_packets_all_ports(
+            self, masked_packet, self.server_port_indices, timeout=4.0)
+        self.assertTrue(
+            relayed_relay_forward_count >= 1,
+            "Failed: Relayed Relay-Forward count of %d"
+            % relayed_relay_forward_count)
+
     def server_send_relay_relay_reply(self):
-        # Form and send DHCPv6 RELAY-REPLY encapsulating REPLY packet
+        """Inject the nested Relay-Reply from Relay B's upstream."""
         relay_relay_reply_packet = self.create_dhcp_relay_relay_reply_packet()
         relay_relay_reply_packet.src = self.dataplane.get_mac(
             0, self.server_port_indices[0])
         testutils.send_packet(
             self, self.server_port_indices[0], relay_relay_reply_packet)
 
-    # Verify that the DHCPv6 RELAY REPLY would be uncapsulated and forwarded to the next relay agent
     def verify_relay_relay_reply(self):
-        # Create a packet resembling a DHCPv6 RELAY REPLY packet
+        """Verify Relay B removes its outer header and forwards the enclosed Relay-Reply unchanged."""
         relay_reply_packet = self.create_dhcp_relay_reply_packet()
 
         # Mask off fields we don't care about matching
@@ -449,7 +525,16 @@ class DHCPTest(DataplaneBaseTest):
         self.server_send_reply_relay_reply()
         self.verify_relayed_reply()
 
-        # Relay-to-relay topology: Client -> Relay A (PTF) -> Relay B (DUT) -> Server.
+        # Relay-to-relay topology: Client <-> Relay A (PTF) <-> Relay B (DUT) <-> Server.
+        # This is different from all previous tests where our DUT is the Relay A.
+        # This tests the RFC 8415 section 19.1.2 forward path. PTF simulates
+        # Relay A unicasting a Relay-Forward from its GUA to Relay B's GUA.
+        # Relay B should encapsulate it in another Relay-Forward and send it
+        # toward the server. dhcp6relay currently does not accept this unicast
+        # Relay-Forward, so the code is retained but its calls are commented out.
+        # This is a feature gap for a topology SONiC does not currently use.
+        # self.downstream_relay_send_relay_forward()
+        # self.verify_relayed_relay_forward()
         # This explicitly tests the RFC 8415 section 19.3 return path, not the
         # normal t0/m0/mx first-hop exchange; the regular path above uses an
         # end-client link-local peer. PTF simulates downstream Relay A with a GUA,

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -20,183 +20,47 @@ SUPPORTED_DHCPV6_TYPE = [
 SUPPORTED_DIR = ["TX", "RX"]
 
 
-def _validate_relay_types(caller, relay_types):
-    """
-    Validate relay_types up front and return it as a list.
+def restart_dhcpmon_in_debug(duthost):
+    program_name = "dhcpmon"
+    program_pid_list = []
+    program_list = duthost.shell("ps aux | grep {}".format(program_name))
+    matches = re.findall(r'/usr/sbin/dhcpmon.*', program_list["stdout"])
 
-    Enforces the shared contract (non-empty, known agent identifiers, at most one
-    v4 mode) so both restart_dhcp_service and wait_dhcp_relay_ready reject bad input
-    *before* any side effect (e.g. restarting dhcp_relay).
-    """
-    if not relay_types:
-        raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
-    relay_types = list(relay_types)
-    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
-    bad = [t for t in relay_types if t not in valid]
-    if bad:
-        raise ValueError("%s: invalid relay_types %s; allowed %s"
-                         % (caller, bad, sorted(valid)))
-    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
-    if len(v4_modes) > 1:
-        raise ValueError(
-            "%s: at most one of {'isc', 'isc-internal', 'sonic'} "
-            "may be requested per call (mutually exclusive in the relay container); got %s"
-            % (caller, v4_modes))
-    return relay_types
+    for program_info in program_list["stdout_lines"]:
+        if program_name in program_info:
+            program_pid = int(program_info.split()[1])
+            program_pid_list.append(program_pid)
+
+    for program_pid in program_pid_list:
+        kill_cmd_result = duthost.shell("sudo kill -9 {} || true".format(program_pid), module_ignore_errors=True)
+        # Get the exit code of 'kill' command
+        exit_code = kill_cmd_result["rc"]
+        if exit_code != 0:
+            stderr = kill_cmd_result.get("stderr", "")
+            if "No such process" not in stderr:
+                pytest.fail("Failed to stop program '{}' before test. Error: {}".format(program_name, stderr))
+
+    if matches:
+        for dhcpmon_cmd in matches:
+            if "-D" not in dhcpmon_cmd:
+                dhcpmon_cmd += " -D"
+            duthost.shell("docker exec -d dhcp_relay %s" % dhcpmon_cmd)
+    else:
+        assert False, "Failed to start dhcpmon in debug counter mode\n"
 
 
-def restart_dhcp_service(duthost, relay_types):
-    """
-    Restart dhcp_relay and wait until the requested relay agent(s) are ready.
-
-    relay_types: a non-empty iterable of agent identifiers. Each entry must be one of:
-        'isc'          -> Legacy / external v4 relay layout
-                          (dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2).
-                          Required RUNNING:
-                            - every isc-dhcpv4-relay-<Vlan> supervisord entry
-                            - every dhcpmon-<Vlan> supervisord entry (paired
-                              1:1 with the isc helpers via
-                              dhcp-relay.monitors.j2)
-                          Notes:
-                            - The expected per-Vlan entries are read from
-                              supervisord at poll time (parsed from
-                              `supervisorctl status`), not derived from
-                              CONFIG_DB's VLAN / DHCP_RELAY config. The j2
-                              template only renders an isc-dhcpv4-relay-<Vlan>
-                              + dhcpmon-<Vlan> pair for Vlans that actually
-                              have v4 dhcp_servers configured, so supervisord
-                              is the authoritative source for which entries
-                              we wait on.
-                            - If no Vlan has v4 dhcp_servers defined, the
-                              matching set of isc-dhcpv4-relay-<Vlan> /
-                              dhcpmon-<Vlan> entries is empty, the loops
-                              iterate over nothing, and the 'isc' check
-                              passes immediately. This is intentional:
-                              there is genuinely nothing to wait for.
-
-        'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
-                          into a single `dhcrelay -iu docker0 ...` proc
-                          (not a supervisord entry).
-                          Required:
-                            - exactly one such dhcrelay proc
-                          Not checked:
-                            - isc-dhcpv4-relay-<Vlan> supervisord entries
-                              (stay STOPPED by design in this mode)
-                            - dhcpmon-<Vlan> supervisord entries (also stay
-                              STOPPED today: dhcpmon does not yet support
-                              the mx/isc-internal layout, so when dhcprelayd
-                              takes over the v4 relay it does not (re)spawn
-                              dhcpmon)
-                          TODO: extend this check once dhcpmon supports the
-                          mx/isc-internal layout (when a single dhcpmon can
-                          monitor the consolidated `dhcrelay -iu docker0`
-                          proc); at that point we should require dhcpmon
-                          RUNNING here too, mirroring the 'isc' check.
-
-        'sonic'        -> Consolidated v4 relay layout
-                          (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
-                          One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
-                          Required RUNNING:
-                            - the single `dhcp4relay` supervisord entry
-                          Not checked:
-                            - dhcpmon-<Vlan> supervisord entries (dhcp4relay
-                              publishes its own counters, so per-Vlan dhcpmon
-                              is not part of this layout)
-
-        'v6'           -> IPv6 relay.
-                          Required RUNNING:
-                            - the `dhcp6relay` supervisord entry
-                          Not checked:
-                            - any dhcpv6mon / dhcp6mon equivalent. No such
-                              daemon ships today; when one lands this check
-                              will need to be extended to mirror the 'isc'
-                              dhcpmon-<Vlan> check above.
-                          TODO: revisit when dhcpv6mon ships.
-
-    The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
-    no default; each caller must declare which agent(s) it expects to be active.
-
-    At most one of {'isc', 'isc-internal', 'sonic'} may appear in relay_types: the
-    container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
-    + mx internal mode), so any combination is unsatisfiable and is rejected up front.
-    """
-    relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
-
+def restart_dhcp_service(duthost):
     duthost.shell('systemctl reset-failed dhcp_relay')
     duthost.shell('systemctl restart dhcp_relay')
     duthost.shell('systemctl reset-failed dhcp_relay')
 
-    wait_dhcp_relay_ready(duthost, relay_types)
-
-
-def wait_dhcp_relay_ready(duthost, relay_types):
-    """
-    Wait (without restarting) until the requested relay agent(s) are ready.
-
-    Same `relay_types` contract as `restart_dhcp_service`. Use this when the caller
-    has already restarted dhcp_relay (or applied config that triggers a restart, e.g.
-    `config reload`, `config load_minigraph`, GCU `apply-patch`) and only needs to
-    block on readiness.
-    """
-    relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
-
-    last_state = {'states': {}, 'internal_procs': []}
-
-    def _supervisor_status_map():
-        # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
-        # 'start' / 'dependent-startup' entries are EXITED by design). Ignore the rc and
-        # parse stdout - the per-entry RUNNING checks below are the real readiness gate.
-        out = duthost.shell('docker exec dhcp_relay supervisorctl status',
-                            module_ignore_errors=True)['stdout_lines']
-        states = {}
-        for line in out:
-            parts = line.split()
-            if len(parts) >= 2:
-                # Strip optional "group:" prefix (e.g. "dhcp-relay:dhcprelayd" -> "dhcprelayd").
-                states[parts[0].split(':')[-1]] = parts[1]
-        return states
-
     def _is_dhcp_relay_ready():
-        states = _supervisor_status_map()
-        last_state['states'] = states
-        if states.get('dhcprelayd') != 'RUNNING':
-            return False
-        if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
-            return False
-        if 'isc' in relay_types:
-            # Drive from supervisord's actual layout: every isc-dhcpv4-relay-*
-            # entry currently present must be RUNNING. If none are present,
-            # the container has no v4 helpers configured for this layout and
-            # the 'isc' check is a no-op (legitimately so - callers expecting
-            # specific helpers should pair with their own config setup).
-            for name, state in states.items():
-                if name.startswith('isc-dhcpv4-relay-') and state != 'RUNNING':
-                    return False
-            # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
-            # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
-            # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
-            # / 'sonic' / 'v6' modes - see the docstring for the per-mode
-            # rationale (and the v6 TODO for the upcoming dhcpv6mon).
-            for name, state in states.items():
-                if name.startswith('dhcpmon-') and state != 'RUNNING':
-                    return False
-        if 'isc-internal' in relay_types:
-            internal = duthost.shell(
-                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true"
-            )['stdout_lines']
-            internal = [line for line in internal if line.strip()]
-            last_state['internal_procs'] = internal
-            if len(internal) != 1:
-                return False
-        if 'sonic' in relay_types:
-            if states.get('dhcp4relay') != 'RUNNING':
-                return False
-        return True
+        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhc | awk \'{print $2}\'',
+                               module_ignore_errors=True)
+        return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
+                all(element == 'RUNNING' for element in output['stdout_lines']))
 
-    pytest_assert(
-        wait_until(240, 5, 10, _is_dhcp_relay_ready),
-        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s isc_internal_procs=%s)"
-        % (relay_types, last_state['states'], last_state['internal_procs']))
+    pytest_assert(wait_until(120, 1, 10, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):
@@ -248,14 +112,14 @@ def query_and_sum_dhcpmon_counters(duthost, vlan_name, interface_name_list, is_v
 
 
 def compare_dhcp_counters_with_warning(actual_counter, expected_counter, warning_msg,
-                                       error_in_percentage=0, is_v6=False):
+                                       error_in_percentage=0.0, is_v6=False):
     compare_result = compare_dhcp_counters(
         actual_counter, expected_counter, error_in_percentage, is_v6)
     while msg := next(compare_result, False):
         logger.warning(warning_msg + ": " + str(msg))
 
 
-def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=0, is_v6=False):
+def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=0.0, is_v6=False):
     """Compare the DHCP counter (could come from relay or dhcpmon or anywhere) value with the expected counter."""
     for dir in SUPPORTED_DIR:
         for dhcp_type in SUPPORTED_DHCPV6_TYPE if is_v6 else SUPPORTED_DHCPV4_TYPE:
@@ -274,7 +138,7 @@ def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=
 
 
 def validate_dhcpmon_counters(dhcp_relay, duthost, expected_uplink_counter,
-                              expected_downlink_counter, error_in_percentage=0, is_v6=False):
+                              expected_downlink_counter, error_in_percentage=0.0, is_v6=False):
     """Validate the dhcpmon counters against the expected counters."""
     logger.info("Expected uplink counters: {}, expected downlink counters: {}, error in percentage: {}%".format(
         expected_uplink_counter, expected_downlink_counter, error_in_percentage))
@@ -358,13 +222,9 @@ def calculate_counters_per_pkts(pkts, is_v6=False):
                 elif scapy.DHCP6_RelayReply in pkt:
                     message_type_int = pkt[scapy.DHCP6_RelayReply].msgtype  # Relay-Reply
             else:
-                for message_type_value in pkt[scapy.DHCP].options:
-                    if message_type_value[0] == 'message-type':
-                        message_type_int = message_type_value[1]
-                        # Get the message type value and convert it to an integer
-                        break
-                else:
-                    continue
+                for opt, val in pkt[scapy.DHCP].options:
+                    if opt == "message-type":
+                        message_type_int = val
             message_type_str = (SUPPORTED_DHCPV6_TYPE if is_v6 else SUPPORTED_DHCPV4_TYPE)[message_type_int - 1] \
                 if message_type_int is not None and message_type_int > 0 else "Unknown"
             sport = pkt[scapy.UDP].sport if pkt.haslayer(scapy.UDP) else None
@@ -394,7 +254,7 @@ def calculate_counters_per_pkts(pkts, is_v6=False):
 
 
 def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping,
-                                           error_in_percentage=0, is_v6=False):
+                                           error_in_percentage=0.0, is_v6=False):
     """Validate the dhcpmon counters and packets consistence"""
     downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
     # it can be portchannel or interface, it depends on the topology
@@ -562,19 +422,17 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
+    restart_dhcp_service(duthost)
 
 
 @pytest.fixture()
-def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
+def enable_sonic_dhcpv4_relay_agent(duthost, request):
     """
     Fixture to enable the DHCP relay feature flag and restart the service.
     """
     if "skip_config_dhcpv4_relay_agent" in request.keywords:
         yield
         return
-
-    duthost = rand_selected_dut
 
     if "dut_dhcp_relay_data" in request.fixturenames:
         dut_dhcp_relay_data = request.getfixturevalue("dut_dhcp_relay_data")

--- a/tests/common/dhcp_relay_utils.py
+++ b/tests/common/dhcp_relay_utils.py
@@ -33,7 +33,6 @@ def restart_dhcpmon_in_debug(duthost):
 
     for program_pid in program_pid_list:
         kill_cmd_result = duthost.shell("sudo kill -9 {} || true".format(program_pid), module_ignore_errors=True)
-        # Get the exit code of 'kill' command
         exit_code = kill_cmd_result["rc"]
         if exit_code != 0:
             stderr = kill_cmd_result.get("stderr", "")
@@ -46,21 +45,186 @@ def restart_dhcpmon_in_debug(duthost):
                 dhcpmon_cmd += " -D"
             duthost.shell("docker exec -d dhcp_relay %s" % dhcpmon_cmd)
     else:
-        assert False, "Failed to start dhcpmon in debug counter mode\n"
+        pytest.fail("Failed to start dhcpmon in debug counter mode")
 
 
-def restart_dhcp_service(duthost):
+def _validate_relay_types(caller, relay_types):
+    """
+    Validate relay_types up front and return it as a list.
+
+    Enforces the shared contract (non-empty, known agent identifiers, at most one
+    v4 mode) so both restart_dhcp_service and wait_dhcp_relay_ready reject bad input
+    *before* any side effect (e.g. restarting dhcp_relay).
+    """
+    if not relay_types:
+        raise ValueError("%s: relay_types must be a non-empty iterable" % caller)
+    relay_types = list(relay_types)
+    valid = {'isc', 'isc-internal', 'sonic', 'v6'}
+    bad = [t for t in relay_types if t not in valid]
+    if bad:
+        raise ValueError("%s: invalid relay_types %s; allowed %s"
+                         % (caller, bad, sorted(valid)))
+    v4_modes = [t for t in relay_types if t in {'isc', 'isc-internal', 'sonic'}]
+    if len(v4_modes) > 1:
+        raise ValueError(
+            "%s: at most one of {'isc', 'isc-internal', 'sonic'} "
+            "may be requested per call (mutually exclusive in the relay container); got %s"
+            % (caller, v4_modes))
+    return relay_types
+
+
+def restart_dhcp_service(duthost, relay_types):
+    """
+    Restart dhcp_relay and wait until the requested relay agent(s) are ready.
+
+    relay_types: a non-empty iterable of agent identifiers. Each entry must be one of:
+        'isc'          -> Legacy / external v4 relay layout
+                          (dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2).
+                          Required RUNNING:
+                            - every isc-dhcpv4-relay-<Vlan> supervisord entry
+                            - every dhcpmon-<Vlan> supervisord entry (paired
+                              1:1 with the isc helpers via
+                              dhcp-relay.monitors.j2)
+                          Notes:
+                            - The expected per-Vlan entries are read from
+                              supervisord at poll time (parsed from
+                              `supervisorctl status`), not derived from
+                              CONFIG_DB's VLAN / DHCP_RELAY config. The j2
+                              template only renders an isc-dhcpv4-relay-<Vlan>
+                              + dhcpmon-<Vlan> pair for Vlans that actually
+                              have v4 dhcp_servers configured, so supervisord
+                              is the authoritative source for which entries
+                              we wait on.
+                            - If no Vlan has v4 dhcp_servers defined, the
+                              matching set of isc-dhcpv4-relay-<Vlan> /
+                              dhcpmon-<Vlan> entries is empty, the loops
+                              iterate over nothing, and the 'isc' check
+                              passes immediately. This is intentional:
+                              there is genuinely nothing to wait for.
+
+        'isc-internal' -> mx internal mode. dhcprelayd consolidates v4 relay
+                          into a single `dhcrelay -iu docker0 ...` proc
+                          (not a supervisord entry).
+                          Required:
+                            - exactly one such dhcrelay proc
+                          Not checked:
+                            - isc-dhcpv4-relay-<Vlan> supervisord entries
+                              (stay STOPPED by design in this mode)
+                            - dhcpmon-<Vlan> supervisord entries (also stay
+                              STOPPED today: dhcpmon does not yet support
+                              the mx/isc-internal layout, so when dhcprelayd
+                              takes over the v4 relay it does not (re)spawn
+                              dhcpmon)
+                          TODO: extend this check once dhcpmon supports the
+                          mx/isc-internal layout (when a single dhcpmon can
+                          monitor the consolidated `dhcrelay -iu docker0`
+                          proc); at that point we should require dhcpmon
+                          RUNNING here too, mirroring the 'isc' check.
+
+        'sonic'        -> Consolidated v4 relay layout
+                          (dockers/docker-dhcp-relay/dhcpv4-sonic-relay.agents.j2).
+                          One `/usr/sbin/dhcp4relay` proc handles all v4 VLANs.
+                          Required RUNNING:
+                            - the single `dhcp4relay` supervisord entry
+                          Not checked:
+                            - dhcpmon-<Vlan> supervisord entries (dhcp4relay
+                              publishes its own counters, so per-Vlan dhcpmon
+                              is not part of this layout)
+
+        'v6'           -> IPv6 relay.
+                          Required RUNNING:
+                            - the `dhcp6relay` supervisord entry
+                          Not checked:
+                            - any dhcpv6mon / dhcp6mon equivalent. No such
+                              daemon ships today; when one lands this check
+                              will need to be extended to mirror the 'isc'
+                              dhcpmon-<Vlan> check above.
+                          TODO: revisit when dhcpv6mon ships.
+
+    The orchestrator (`dhcprelayd`) is always required RUNNING. There is intentionally
+    no default; each caller must declare which agent(s) it expects to be active.
+
+    At most one of {'isc', 'isc-internal', 'sonic'} may appear in relay_types: the
+    container layout makes them mutually exclusive (driven by has_sonic_dhcpv4_relay
+    + mx internal mode), so any combination is unsatisfiable and is rejected up front.
+    """
+    relay_types = _validate_relay_types('restart_dhcp_service', relay_types)
+
     duthost.shell('systemctl reset-failed dhcp_relay')
     duthost.shell('systemctl restart dhcp_relay')
     duthost.shell('systemctl reset-failed dhcp_relay')
 
-    def _is_dhcp_relay_ready():
-        output = duthost.shell('docker exec dhcp_relay supervisorctl status | grep dhc | awk \'{print $2}\'',
-                               module_ignore_errors=True)
-        return (not output['rc'] and output['stderr'] == '' and len(output['stdout_lines']) != 0 and
-                all(element == 'RUNNING' for element in output['stdout_lines']))
+    wait_dhcp_relay_ready(duthost, relay_types)
 
-    pytest_assert(wait_until(120, 1, 10, _is_dhcp_relay_ready), "dhcp_relay is not ready after restarting")
+
+def wait_dhcp_relay_ready(duthost, relay_types):
+    """
+    Wait (without restarting) until the requested relay agent(s) are ready.
+
+    Same `relay_types` contract as `restart_dhcp_service`. Use this when the caller
+    has already restarted dhcp_relay (or applied config that triggers a restart, e.g.
+    `config reload`, `config load_minigraph`, GCU `apply-patch`) and only needs to
+    block on readiness.
+    """
+    relay_types = _validate_relay_types('wait_dhcp_relay_ready', relay_types)
+
+    last_state = {'states': {}, 'internal_procs': []}
+
+    def _supervisor_status_map():
+        # supervisorctl returns rc != 0 if ANY entry is not RUNNING (e.g. the one-shot
+        # 'start' / 'dependent-startup' entries are EXITED by design). Ignore the rc and
+        # parse stdout - the per-entry RUNNING checks below are the real readiness gate.
+        out = duthost.shell('docker exec dhcp_relay supervisorctl status',
+                            module_ignore_errors=True)['stdout_lines']
+        states = {}
+        for line in out:
+            parts = line.split()
+            if len(parts) >= 2:
+                # Strip optional "group:" prefix (e.g. "dhcp-relay:dhcprelayd" -> "dhcprelayd").
+                states[parts[0].split(':')[-1]] = parts[1]
+        return states
+
+    def _is_dhcp_relay_ready():
+        states = _supervisor_status_map()
+        last_state['states'] = states
+        if states.get('dhcprelayd') != 'RUNNING':
+            return False
+        if 'v6' in relay_types and states.get('dhcp6relay') != 'RUNNING':
+            return False
+        if 'isc' in relay_types:
+            # Drive from supervisord's actual layout: every isc-dhcpv4-relay-*
+            # entry currently present must be RUNNING. If none are present,
+            # the container has no v4 helpers configured for this layout and
+            # the 'isc' check is a no-op (legitimately so - callers expecting
+            # specific helpers should pair with their own config setup).
+            for name, state in states.items():
+                if name.startswith('isc-dhcpv4-relay-') and state != 'RUNNING':
+                    return False
+            # Same layout-driven rule for dhcpmon-Vlan*: each entry is paired
+            # 1:1 with isc-dhcpv4-relay-<Vlan> in the same supervisord conf
+            # and must be RUNNING. Intentionally NOT checked in 'isc-internal'
+            # / 'sonic' / 'v6' modes - see the docstring for the per-mode
+            # rationale (and the v6 TODO for the upcoming dhcpv6mon).
+            for name, state in states.items():
+                if name.startswith('dhcpmon-') and state != 'RUNNING':
+                    return False
+        if 'isc-internal' in relay_types:
+            internal = duthost.shell(
+                "docker exec dhcp_relay pgrep -af '/usr/sbin/dhcrelay.*-iu docker0' || true"
+            )['stdout_lines']
+            internal = [line for line in internal if line.strip()]
+            last_state['internal_procs'] = internal
+            if len(internal) != 1:
+                return False
+        if 'sonic' in relay_types:
+            if states.get('dhcp4relay') != 'RUNNING':
+                return False
+        return True
+
+    pytest_assert(
+        wait_until(240, 5, 10, _is_dhcp_relay_ready),
+        "dhcp_relay is not ready (relay_types=%s last_supervisor_states=%s isc_internal_procs=%s)"
+        % (relay_types, last_state['states'], last_state['internal_procs']))
 
 
 def init_dhcpmon_counters(duthost, is_v6=False):
@@ -112,14 +276,14 @@ def query_and_sum_dhcpmon_counters(duthost, vlan_name, interface_name_list, is_v
 
 
 def compare_dhcp_counters_with_warning(actual_counter, expected_counter, warning_msg,
-                                       error_in_percentage=0.0, is_v6=False):
+                                       error_in_percentage=0, is_v6=False):
     compare_result = compare_dhcp_counters(
         actual_counter, expected_counter, error_in_percentage, is_v6)
     while msg := next(compare_result, False):
         logger.warning(warning_msg + ": " + str(msg))
 
 
-def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=0.0, is_v6=False):
+def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=0, is_v6=False):
     """Compare the DHCP counter (could come from relay or dhcpmon or anywhere) value with the expected counter."""
     for dir in SUPPORTED_DIR:
         for dhcp_type in SUPPORTED_DHCPV6_TYPE if is_v6 else SUPPORTED_DHCPV4_TYPE:
@@ -138,7 +302,7 @@ def compare_dhcp_counters(actual_counter, expected_counter, error_in_percentage=
 
 
 def validate_dhcpmon_counters(dhcp_relay, duthost, expected_uplink_counter,
-                              expected_downlink_counter, error_in_percentage=0.0, is_v6=False):
+                              expected_downlink_counter, error_in_percentage=0, is_v6=False):
     """Validate the dhcpmon counters against the expected counters."""
     logger.info("Expected uplink counters: {}, expected downlink counters: {}, error in percentage: {}%".format(
         expected_uplink_counter, expected_downlink_counter, error_in_percentage))
@@ -222,9 +386,13 @@ def calculate_counters_per_pkts(pkts, is_v6=False):
                 elif scapy.DHCP6_RelayReply in pkt:
                     message_type_int = pkt[scapy.DHCP6_RelayReply].msgtype  # Relay-Reply
             else:
-                for opt, val in pkt[scapy.DHCP].options:
-                    if opt == "message-type":
-                        message_type_int = val
+                for message_type_value in pkt[scapy.DHCP].options:
+                    if message_type_value[0] == 'message-type':
+                        message_type_int = message_type_value[1]
+                        # Get the message type value and convert it to an integer
+                        break
+                else:
+                    continue
             message_type_str = (SUPPORTED_DHCPV6_TYPE if is_v6 else SUPPORTED_DHCPV4_TYPE)[message_type_int - 1] \
                 if message_type_int is not None and message_type_int > 0 else "Unknown"
             sport = pkt[scapy.UDP].sport if pkt.haslayer(scapy.UDP) else None
@@ -254,7 +422,7 @@ def calculate_counters_per_pkts(pkts, is_v6=False):
 
 
 def validate_counters_and_pkts_consistency(dhcp_relay, duthost, pkts, interface_name_index_mapping,
-                                           error_in_percentage=0.0, is_v6=False):
+                                           error_in_percentage=0, is_v6=False):
     """Validate the dhcpmon counters and packets consistence"""
     downlink_vlan_iface = dhcp_relay['downlink_vlan_iface']['name']
     # it can be portchannel or interface, it depends on the topology
@@ -422,17 +590,19 @@ def sonic_dhcpv4_flag_config_and_unconfig(duthost, dhcpv4_config_flag=False):
 
     # Save the config and restart DHCP relay service
     duthost.shell('sudo config save -y', module_ignore_errors=True)
-    restart_dhcp_service(duthost)
+    restart_dhcp_service(duthost, ['sonic'] if dhcpv4_config_flag else ['isc'])
 
 
 @pytest.fixture()
-def enable_sonic_dhcpv4_relay_agent(duthost, request):
+def enable_sonic_dhcpv4_relay_agent(rand_selected_dut, request):
     """
     Fixture to enable the DHCP relay feature flag and restart the service.
     """
     if "skip_config_dhcpv4_relay_agent" in request.keywords:
         yield
         return
+
+    duthost = rand_selected_dut
 
     if "dut_dhcp_relay_data" in request.fixturenames:
         dut_dhcp_relay_data = request.getfixturevalue("dut_dhcp_relay_data")

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 import json
 import time
 import os
@@ -39,6 +38,7 @@ GARP_SERVICE_PY = 'garp_service.py'
 GARP_SERVICE_CONF_TEMPL = 'garp_service.conf.j2'
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 PROBER_INTERVAL_MS = 3000
+PTFHOST_EXCEPTION_RC = 16
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -198,8 +198,7 @@ def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pai
     ptfhost.file(path=responder_conf_path, state="absent")
     ptfhost.file(path="/etc/supervisor/conf.d/arp_responder.conf", state="absent")
     ptfhost.shell("supervisorctl reread && supervisorctl update", module_ignore_errors=True)
-    if route:
-        assert ip_intf_pairs, "ip_intf_pairs is required when route=True to clean up host routes"
+    if route and ip_intf_pairs:
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("del", ip, dut_intf), module_ignore_errors=True)
     duthost.command("sonic-clear fdb all")
@@ -231,11 +230,6 @@ def copy_arp_responder_py(ptfhost):
 
     logger.info("Delete arp_responder.py from ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.file(path=os.path.join(OPT_DIR, ARP_RESPONDER_PY), state="absent")
-
-
-# responder_cfg: eth<ptf_index> -> [ipv4, ipv6] ([ipv6] on IPv6-only topos),
-# the exact IP(s) the responder answers per port.
-ArpResponderInfo = namedtuple("ArpResponderInfo", ["vlan", "responder_cfg"])
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -310,14 +304,9 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     logger.info("Start arp_responder")
     ptfhost.command('supervisorctl start arp_responder')
 
-    yield ArpResponderInfo(vlan=vlan, responder_cfg=arp_responder_cfg)
+    yield vlan, ipv4_base, ipv6_base, ip_offset
 
     ptfhost.command('supervisorctl stop arp_responder')
-    # Remove the rendered config so it can't mislead diagnostics or be picked up
-    # by a later, stale invocation of arp_responder. The supervisor unit file
-    # itself is intentionally left in place because the autouse fixture re-renders
-    # it on every module setup; deleting only the data file is enough.
-    ptfhost.file(path=CFG_FILE, state="absent")
 
 
 def _ptf_portmap_file(duthost, ptfhost, tbinfo):
@@ -367,6 +356,12 @@ def ptf_portmap_file_module(rand_selected_dut, ptfhost, tbinfo):
     A module level fixture that calls _ptf_portmap_file
     """
     yield _ptf_portmap_file(rand_selected_dut, ptfhost, tbinfo)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if session.config.cache.get("ptfhost_exception", None):
+        session.config.cache.set("ptfhost_exception", None)
+        session.exitstatus = PTFHOST_EXCEPTION_RC
 
 
 icmp_responder_session_started = False
@@ -762,6 +757,6 @@ def skip_traffic_test(request):
 
 @pytest.fixture(scope='function')
 def iptables_drop_ipv6_tx(ptfhost):
-    ptfhost.shell("ip6tables -P OUTPUT DROP || true")
+    ptfhost.shell("ip6tables -P OUTPUT DROP")
     yield
-    ptfhost.shell("ip6tables -P OUTPUT ACCEPT || true")
+    ptfhost.shell("ip6tables -P OUTPUT ACCEPT")

--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import json
 import time
 import os
@@ -38,7 +39,6 @@ GARP_SERVICE_PY = 'garp_service.py'
 GARP_SERVICE_CONF_TEMPL = 'garp_service.conf.j2'
 PTF_TEST_PORT_MAP = '/root/ptf_test_port_map.json'
 PROBER_INTERVAL_MS = 3000
-PTFHOST_EXCEPTION_RC = 16
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -198,7 +198,8 @@ def teardown_ptf_ip_responder(duthost, ptfhost, responder_conf_path, ip_intf_pai
     ptfhost.file(path=responder_conf_path, state="absent")
     ptfhost.file(path="/etc/supervisor/conf.d/arp_responder.conf", state="absent")
     ptfhost.shell("supervisorctl reread && supervisorctl update", module_ignore_errors=True)
-    if route and ip_intf_pairs:
+    if route:
+        assert ip_intf_pairs, "ip_intf_pairs is required when route=True to clean up host routes"
         for ip, dut_intf, _ in ip_intf_pairs:
             duthost.shell(_ptf_ip_route_cmd("del", ip, dut_intf), module_ignore_errors=True)
     duthost.command("sonic-clear fdb all")
@@ -230,6 +231,11 @@ def copy_arp_responder_py(ptfhost):
 
     logger.info("Delete arp_responder.py from ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.file(path=os.path.join(OPT_DIR, ARP_RESPONDER_PY), state="absent")
+
+
+# responder_cfg: eth<ptf_index> -> [ipv4, ipv6] ([ipv6] on IPv6-only topos),
+# the exact IP(s) the responder answers per port.
+ArpResponderInfo = namedtuple("ArpResponderInfo", ["vlan", "responder_cfg"])
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -304,9 +310,14 @@ def setup_vlan_arp_responder(ptfhost, rand_selected_dut, tbinfo):
     logger.info("Start arp_responder")
     ptfhost.command('supervisorctl start arp_responder')
 
-    yield vlan, ipv4_base, ipv6_base, ip_offset
+    yield ArpResponderInfo(vlan=vlan, responder_cfg=arp_responder_cfg)
 
     ptfhost.command('supervisorctl stop arp_responder')
+    # Remove the rendered config so it can't mislead diagnostics or be picked up
+    # by a later, stale invocation of arp_responder. The supervisor unit file
+    # itself is intentionally left in place because the autouse fixture re-renders
+    # it on every module setup; deleting only the data file is enough.
+    ptfhost.file(path=CFG_FILE, state="absent")
 
 
 def _ptf_portmap_file(duthost, ptfhost, tbinfo):
@@ -356,12 +367,6 @@ def ptf_portmap_file_module(rand_selected_dut, ptfhost, tbinfo):
     A module level fixture that calls _ptf_portmap_file
     """
     yield _ptf_portmap_file(rand_selected_dut, ptfhost, tbinfo)
-
-
-def pytest_sessionfinish(session, exitstatus):
-    if session.config.cache.get("ptfhost_exception", None):
-        session.config.cache.set("ptfhost_exception", None)
-        session.exitstatus = PTFHOST_EXCEPTION_RC
 
 
 icmp_responder_session_started = False
@@ -757,6 +762,6 @@ def skip_traffic_test(request):
 
 @pytest.fixture(scope='function')
 def iptables_drop_ipv6_tx(ptfhost):
-    ptfhost.shell("ip6tables -P OUTPUT DROP")
+    ptfhost.shell("ip6tables -P OUTPUT DROP || true")
     yield
-    ptfhost.shell("ip6tables -P OUTPUT ACCEPT")
+    ptfhost.shell("ip6tables -P OUTPUT ACCEPT || true")

--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -2,9 +2,8 @@ import pytest
 import random
 import time
 import logging
-import re
 
-from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters
+from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, restart_dhcpmon_in_debug
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.dualtor.mux_simulator_control import toggle_all_simulator_ports_to_rand_selected_tor_m    # noqa F401
@@ -165,35 +164,6 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
                 assert "{}:67".format(iface) in output, "{} is not found in {}".format("{}:67".format(iface), output)
 
 
-def restart_dhcpmon_in_debug(duthost):
-    program_name = "dhcpmon"
-    program_pid_list = []
-    program_list = duthost.shell("ps aux | grep {}".format(program_name))
-    matches = re.findall(r'/usr/sbin/dhcpmon.*', program_list["stdout"])
-
-    for program_info in program_list["stdout_lines"]:
-        if program_name in program_info:
-            program_pid = int(program_info.split()[1])
-            program_pid_list.append(program_pid)
-
-    for program_pid in program_pid_list:
-        kill_cmd_result = duthost.shell("sudo kill -9 {} || true".format(program_pid), module_ignore_errors=True)
-        # Get the exit code of 'kill' command
-        exit_code = kill_cmd_result["rc"]
-        if exit_code != 0:
-            stderr = kill_cmd_result.get("stderr", "")
-            if "No such process" not in stderr:
-                pytest.fail("Failed to stop program '{}' before test. Error: {}".format(program_name, stderr))
-
-    if matches:
-        for dhcpmon_cmd in matches:
-            if "-D" not in dhcpmon_cmd:
-                dhcpmon_cmd += " -D"
-            duthost.shell("docker exec -d dhcp_relay %s" % dhcpmon_cmd)
-    else:
-        assert False, "Failed to start dhcpmon in debug counter mode\n"
-
-
 def get_acl_count_by_mark(rand_unselected_dut, mark):
     output = rand_unselected_dut.shell("iptables -nvL DHCP | grep 'DROP' | grep '{}' | awk '{{print $1}}'"
                                        .format(mark))
@@ -310,7 +280,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                  .format(dhcp_relay["downlink_vlan_iface"]["name"])),
                        is_python3=True)
             if not skip_dhcpmon:
-                time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
+                time.sleep(36)      # dhcpmon: health check every 18s, DB write every 20s
                 loganalyzer.analyze(marker)
                 dhcp_server_sum = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
                 dhcp_relay_request_times = 2
@@ -432,7 +402,7 @@ def test_dhcp_relay_with_source_port_ip_in_relay_enabled(
                        is_python3=True)
 
             if not skip_dhcpmon:
-                time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
+                time.sleep(36)      # dhcpmon: health check every 18s, DB write every 20s
                 loganalyzer.analyze(marker)
                 dhcp_server_sum = len(dhcp_relay['downlink_vlan_iface']['dhcp_server_addrs'])
                 dhcp_relay_request_times = 2
@@ -706,7 +676,7 @@ def test_dhcp_relay_monitor_checksum_validation(ptfhost, dut_dhcp_relay_data, va
                        log_file=("/tmp/dhcp_relay_test.DHCPTest.default.{}.log"
                                  .format(dhcp_relay["downlink_vlan_iface"]["name"])),
                        is_python3=True)
-            time.sleep(36)      # dhcpmon debug counter prints every 18 seconds
+            time.sleep(36)      # dhcpmon: health check every 18s, DB write every 20s
             if testing_mode == DUAL_TOR_MODE:
                 # If the testing mode is DUAL_TOR_MODE, standby tor's dhcpmon relay counters should all be 0
                 validate_dhcpmon_counters(dhcp_relay, standby_duthost, {}, {})

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -17,7 +17,6 @@ from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
 from tests.common.fixtures.ptfhost_utils import setup_ptf_ip_responder, teardown_ptf_ip_responder
-from tests.common.fixtures.split_vlan import setup_multiple_vlans_and_teardown  # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -529,12 +528,9 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
 
             # Relay A's GUA is arbitrary and outside the DUT VLAN prefix; the
             # responder helper must install a route so DUT Relay B can resolve it.
-            downstream_relay_ip = DOWNSTREAM_RELAY_IP
-            downlink_vlan = dhcp_relay['downlink_vlan_iface']['name']
-            downstream_relay_responder = [
-                (downstream_relay_ip, downlink_vlan, dhcp_relay['client_iface']['port_idx'])]
-            setup_ptf_ip_responder(
-                duthost, ptfhost, DHCPV6_RELAY_ARP_RESPONDER_CONF, downstream_relay_responder, route=True)
+            downstream_relay_responder = setup_downstream_relay_responder(
+                duthost, ptfhost, dhcp_relay['downlink_vlan_iface']['name'],
+                dhcp_relay['client_iface']['port_idx'])
 
             # Run the DHCP relay test on the PTF host
             try:
@@ -553,13 +549,12 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                    "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
                                    "uplink_mac": str(dhcp_relay['uplink_mac']),
                                    "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                                   "downstream_relay_ip": downstream_relay_ip,
+                                   "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
                                    "is_dualtor": str(dhcp_relay['is_dualtor']),
                                    "kvm_support": True},
                            log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
             finally:
-                teardown_ptf_ip_responder(
-                    duthost, ptfhost, DHCPV6_RELAY_ARP_RESPONDER_CONF, downstream_relay_responder, route=True)
+                teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
 
             expected_downlink_counter, expected_uplink_counter = \
                 get_dhcptest_expected_counters(dhcp_server_num)
@@ -743,67 +738,69 @@ class TestDhcpv6RelayWithMultipleVlan:
         common_dhcp_relay_data = dut_dhcp_relay_data[0]
 
         restart_dhcp_service(duthost, ['v6'])  # restart dhcp_relay to make new vlans config take into effect
-        for vlan_info in vlans_info:
-            vlan_name = vlan_info['vlan_name']
-            members_with_ptf_idx = vlan_info['members_with_ptf_idx']
-            if not members_with_ptf_idx:
-                logger.info("Vlan %s has no PTF-mapped members (PortChannel-only); skipping", vlan_name)
-                continue
-            exp_link_addr = vlan_info['interface_ipv6'].split('/')[0]
-            client_iface_name, ptf_port_index = random.choice(members_with_ptf_idx)
-            logger.info("Randomly selected PTF port index: {}".format(ptf_port_index))
-            ensure_client_reachability(duthost, vlan_name)
-            command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1" \
-                .format(vlan_name)
-            down_interface_link_local = duthost.shell(command)['stdout']
-            vlan_mac = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_name))['stdout']
+        try:
+            for vlan_info in vlans_info:
+                vlan_name = vlan_info['vlan_name']
+                members_with_ptf_idx = vlan_info['members_with_ptf_idx']
+                if not members_with_ptf_idx:
+                    logger.info("Vlan %s has no PTF-mapped members (PortChannel-only); skipping", vlan_name)
+                    continue
+                exp_link_addr = vlan_info['interface_ipv6'].split('/')[0]
+                client_iface_name, ptf_port_index = random.choice(members_with_ptf_idx)
+                logger.info("Randomly selected PTF port index: {}".format(ptf_port_index))
+                ensure_client_reachability(duthost, vlan_name)
+                command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1" \
+                    .format(vlan_name)
+                down_interface_link_local = duthost.shell(command)['stdout']
+                vlan_mac = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_name))['stdout']
 
-            dhcp_server_num = len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs'])
-            restart_dhcpmon_in_debug(duthost)
-            time.sleep(5)  # wait for dhcpmon to initialize
-            init_dhcpmon_counters(duthost, is_v6=True)
+                dhcp_server_num = len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs'])
+                restart_dhcpmon_in_debug(duthost)
+                time.sleep(5)  # wait for dhcpmon to initialize
+                init_dhcpmon_counters(duthost, is_v6=True)
 
-            downstream_relay_responder = setup_downstream_relay_responder(
-                duthost, ptfhost, vlan_name, ptf_port_index)
-            # Run the DHCP relay test on the PTF host
-            try:
-                ptf_runner(ptfhost,
-                           "ptftests",
-                           "dhcpv6_relay_test.DHCPTest",
-                           platform_dir="ptftests",
-                           params={"hostname": duthost.hostname,
-                                   "client_port_index": ptf_port_index,
-                                   "leaf_port_indices": repr(common_dhcp_relay_data['uplink_port_indices']),
-                                   "num_dhcp_servers":
-                                       len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs']),
-                                   "server_ip":
-                                       str(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
-                                   "relay_iface_ip": str(exp_link_addr),
-                                   "relay_iface_mac": str(vlan_mac),
-                                   "relay_link_local": str(down_interface_link_local),
-                                   "vlan_ip": str(exp_link_addr),
-                                   "uplink_mac": str(common_dhcp_relay_data['uplink_mac']),
-                                   "loopback_ipv6": str(common_dhcp_relay_data['loopback_ipv6']),
-                                   "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
-                                   "is_dualtor": str(common_dhcp_relay_data['is_dualtor']),
-                                   "kvm_support": True},
-                           log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
-            finally:
-                teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
+                downstream_relay_responder = setup_downstream_relay_responder(
+                    duthost, ptfhost, vlan_name, ptf_port_index)
+                # Run the DHCP relay test on the PTF host
+                try:
+                    ptf_runner(ptfhost,
+                               "ptftests",
+                               "dhcpv6_relay_test.DHCPTest",
+                               platform_dir="ptftests",
+                               params={"hostname": duthost.hostname,
+                                       "client_port_index": ptf_port_index,
+                                       "leaf_port_indices": repr(common_dhcp_relay_data['uplink_port_indices']),
+                                       "num_dhcp_servers":
+                                           len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs']),
+                                       "server_ip":
+                                           str(common_dhcp_relay_data['downlink_vlan_iface']
+                                               ['dhcpv6_server_addrs'][0]),
+                                       "relay_iface_ip": str(exp_link_addr),
+                                       "relay_iface_mac": str(vlan_mac),
+                                       "relay_link_local": str(down_interface_link_local),
+                                       "vlan_ip": str(exp_link_addr),
+                                       "uplink_mac": str(common_dhcp_relay_data['uplink_mac']),
+                                       "loopback_ipv6": str(common_dhcp_relay_data['loopback_ipv6']),
+                                       "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
+                                       "is_dualtor": str(common_dhcp_relay_data['is_dualtor']),
+                                       "kvm_support": True},
+                               log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+                finally:
+                    teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
 
-            time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
-            # Build a relay data dict for this dynamic VLAN to pass to validate_dhcpmon_counters
-            vlan_dhcp_relay_data = copy.deepcopy(common_dhcp_relay_data)
-            vlan_dhcp_relay_data['downlink_vlan_iface'] = dict(common_dhcp_relay_data['downlink_vlan_iface'])
-            vlan_dhcp_relay_data['downlink_vlan_iface']['name'] = vlan_name
-            vlan_dhcp_relay_data['client_iface'] = {'name': client_iface_name}
+                time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
+                # Build a relay data dict for this dynamic VLAN to pass to validate_dhcpmon_counters
+                vlan_dhcp_relay_data = copy.deepcopy(common_dhcp_relay_data)
+                vlan_dhcp_relay_data['downlink_vlan_iface'] = dict(common_dhcp_relay_data['downlink_vlan_iface'])
+                vlan_dhcp_relay_data['downlink_vlan_iface']['name'] = vlan_name
+                vlan_dhcp_relay_data['client_iface'] = {'name': client_iface_name}
 
-            expected_downlink_counter, expected_uplink_counter = \
-                get_dhcptest_expected_counters(dhcp_server_num)
-            validate_dhcpmon_counters(vlan_dhcp_relay_data, duthost,
-                                      expected_uplink_counter,
-                                      expected_downlink_counter, is_v6=True)
-
-        # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost, ['v6'])
-        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
+                expected_downlink_counter, expected_uplink_counter = \
+                    get_dhcptest_expected_counters(dhcp_server_num)
+                validate_dhcpmon_counters(vlan_dhcp_relay_data, duthost,
+                                          expected_uplink_counter,
+                                          expected_downlink_counter, is_v6=True)
+        finally:
+            # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
+            restart_dhcp_service(duthost, ['v6'])
+            pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -1,3 +1,4 @@
+import copy
 import ipaddress
 import pytest
 import random
@@ -5,9 +6,13 @@ import time
 import netaddr
 import logging
 
-from tests.common.dhcp_relay_utils import restart_dhcp_service, wait_dhcp_relay_ready
+from tests.common.dhcp_relay_utils import restart_dhcp_service
+from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, restart_dhcpmon_in_debug
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
+from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
+from tests.common.fixtures.ptfhost_utils import setup_ptf_ip_responder, teardown_ptf_ip_responder
+from tests.common.fixtures.split_vlan import setup_multiple_vlans_and_teardown  # noqa F401
 from tests.ptf_runner import ptf_runner
 from tests.common import config_reload
 from tests.common.platform.processes_utils import wait_critical_processes
@@ -34,11 +39,28 @@ NEW_COUNTER_VALUE_FORMAT = (
 logger = logging.getLogger(__name__)
 
 
+DHCPV6_RELAY_ARP_RESPONDER_CONF = "/tmp/dhcpv6_downstream_relay_arp_responder.json"
+# Arbitrary GUA outside the DUT VLAN prefix, used to simulate the downstream relay
+# agent (Relay A) that the RFC 8415 relay-to-relay return path forwards to.
+DOWNSTREAM_RELAY_IP = "fc02:ffff::1"
+
+
 def wait_all_bgp_up(duthost):
     config_facts = duthost.config_facts(host=duthost.hostname, source="running")['ansible_facts']
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     if not wait_until(180, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())):
         pytest.fail("not all bgp sessions are up after config change")
+
+
+def skip_dhcpv6_dhcptest_on_kvm(duthost):
+    # DHCPTest wrappers never passed kvm_support=True, so ptf_runner already
+    # skipped them on KVM/VS. Keep that behavior explicit now that these
+    # wrappers validate dhcpmon counters after the PTF run.
+    if (
+        duthost.facts.get("platform") == "x86_64-kvm_x86_64-r0"
+        and duthost.facts.get("asic_type") != "vpp"
+    ):
+        pytest.skip("dhcpv6_relay_test.DHCPTest is not supported on KVM non-VPP DUTs")
 
 
 def check_dhcpv6_relay_counter(duthost, ifname, type, dir):
@@ -204,6 +226,7 @@ def dut_dhcp_relay_data(duthosts, rand_one_dut_hostname, tbinfo):
 
         res = duthost.shell('cat /sys/class/net/{}/address'.format(uplink_interfaces[0]))
         dhcp_relay_data['uplink_mac'] = res['stdout']
+        dhcp_relay_data['portchannels'] = mg_facts['minigraph_portchannels']
 
         dhcp_relay_data_list.append(dhcp_relay_data)
 
@@ -267,6 +290,39 @@ def setup_and_teardown_no_servers_vlan(duthosts, rand_one_dut_hostname):
     restart_dhcp_relay_and_check_dhcp6relay(duthost)
 
 
+def get_dhcptest_expected_counters(dhcp_server_num):
+    """Expected dhcpmon counters for DHCPTest PTF class.
+    DHCPTest sends 2 client messages (Solicit, Request) and 3 server
+    Relay-Replies (Advertise, Reply, nested Relay-Reply for the RFC 8415
+    multi-relay return path).
+    """
+    expected_downlink = {
+        "RX": {"Solicit": 1, "Request": 1},
+        "TX": {"Advertise": 1, "Reply": 1, "Relay-Reply": 1}
+    }
+    expected_uplink = {
+        "TX": {"Relay-Forward": dhcp_server_num * 2},
+        "RX": {"Relay-Reply": 3}
+    }
+    return expected_downlink, expected_uplink
+
+
+def setup_downstream_relay_responder(duthost, ptfhost, downlink_vlan, client_ptf_index):
+    """Configure PTF's ndp responder + host route for the simulated downstream relay
+    agent (Relay A, DOWNSTREAM_RELAY_IP). Its GUA is outside the DUT VLAN prefix, so a
+    host route is installed and PTF answers NDP for it, letting DUT Relay B forward the
+    RFC 8415 nested Relay-Reply back to it. Returns the responder pairs for teardown."""
+    downstream_relay_responder = [(DOWNSTREAM_RELAY_IP, downlink_vlan, client_ptf_index)]
+    setup_ptf_ip_responder(
+        duthost, ptfhost, DHCPV6_RELAY_ARP_RESPONDER_CONF, downstream_relay_responder, route=True)
+    return downstream_relay_responder
+
+
+def teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder):
+    teardown_ptf_ip_responder(
+        duthost, ptfhost, DHCPV6_RELAY_ARP_RESPONDER_CONF, downstream_relay_responder, route=True)
+
+
 def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data, setup_and_teardown_no_servers_vlan):
     # Add vlan without dhcpv6_server, which should not be bound
     new_vlan_id = setup_and_teardown_no_servers_vlan
@@ -276,7 +332,6 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
-        wait_dhcp_relay_ready(duthost, ['v6'])
 
     # Cmds to delete LLA for all Vlans
     delete_cmds = ["ip -6 address del {} dev {}"
@@ -306,7 +361,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
 
     try:
         duthost.shell_cmds(cmds=delete_cmds)
-        restart_dhcp_service(duthost, ['v6'])
+        restart_dhcp_service(duthost)
         time.sleep(10)
 
         output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
@@ -360,61 +415,105 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
     message_types = ["Unknown", "Solicit", "Advertise", "Request", "Confirm", "Renew", "Rebind", "Reply", "Release",
                      "Decline", "Reconfigure", "Information-Request", "Relay-Forward", "Relay-Reply", "Malformed"]
 
-    for dhcp_relay in dut_dhcp_relay_data:
-        init_counter(duthost, dhcp_relay['client_iface']['name'], message_types)
-        init_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], message_types)
-        if dhcp_relay['is_dualtor']:
-            init_counter(duthost, dhcp_relay['loopback_iface'][0]['name'], message_types)
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            init_counter(duthost, dhcp_relay['client_iface']['name'], message_types)
+            init_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], message_types)
+            if dhcp_relay['is_dualtor']:
+                init_counter(duthost, dhcp_relay['loopback_iface'][0]['name'], message_types)
 
-        # Send the DHCP relay traffic on the PTF host
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "dhcpv6_counter_test.DHCPCounterTest",
-                   platform_dir="ptftests",
-                   params={"hostname": duthost.hostname,
-                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
-                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
-                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
-                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
-                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
-                           "dut_mac": str(dhcp_relay['uplink_mac']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor']),
-                           "kvm_support": True},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log", is_python3=True)
+            dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
+            restart_dhcpmon_in_debug(duthost)
+            time.sleep(5)  # wait for dhcpmon to initialize
+            init_dhcpmon_counters(duthost, is_v6=True)
 
-        for type in message_types:
-            if type in ["Solicit", "Request", "Confirm", "Renew", "Rebind", "Release", "Decline",
-                        "Information-Request"]:
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['client_iface']['name'], type, "RX")
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
-            if type in ["Malformed"]:
-                # Malformed DHCPv6 Client packet, depend on malformed content. If Type is good but option is malformed
-                # First Type will be increased on downlink Ethernet interface first. Then increase Malformed counter
-                # on downlink_vlan_iface.
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
-            if type in ["Unknown"]:
-                # From Server Relay-Reply Unknown DHCPv6 type, it's a valid Relay-Reply so Relay-Reply counter
-                # is normal increased. But in relay message type is unknown type so drop on downlink_vlan_iface
-                # interface
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
-            if type in ["Advertise", "Reply", "Reconfigure"]:
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "TX")
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['client_iface']['name'], type, "TX")
-            if type in ["Relay-Forward"]:
-                # Relay-Forward, send out from downlink_vlan_iface first, then send out from uplink interfaces
-                check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "TX")
-                # TBD, add uplink interface TX counter check in future
-            if type in ["Relay-Reply"]:
-                if dhcp_relay['is_dualtor']:
-                    # dual tor, Relay-Reply will be received on loopback interface
-                    check_dhcpv6_relay_counter(duthost, dhcp_relay['loopback_iface'][0]['name'], type, "RX")
-                else:
-                    # Single tor, Relay-Reply will be received on downlink_vlan_iface
+            # Send the DHCP relay traffic on the PTF host
+            ptf_runner(ptfhost,
+                       "ptftests",
+                       "dhcpv6_counter_test.DHCPCounterTest",
+                       platform_dir="ptftests",
+                       params={"hostname": duthost.hostname,
+                               "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                               "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                               "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
+                               "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
+                               "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                               "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                               "relay_link_local": str(dhcp_relay['down_interface_link_local']),
+                               "dut_mac": str(dhcp_relay['uplink_mac']),
+                               "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                               "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                               "is_dualtor": str(dhcp_relay['is_dualtor']),
+                               "kvm_support": True},
+                       log_file="/tmp/dhcpv6_relay_test.DHCPCounterTest.log", is_python3=True)
+
+            # Validate dhcp6relay counters (STATE_DB DHCPv6_COUNTER_TABLE)
+            for type in message_types:
+                if type in ["Solicit", "Request", "Confirm", "Renew", "Rebind", "Release", "Decline",
+                            "Information-Request"]:
+                    check_dhcpv6_relay_counter(duthost, dhcp_relay['client_iface']['name'], type, "RX")
                     check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
+                if type in ["Malformed"]:
+                    # Malformed DHCPv6 Client packet, depend on malformed content.
+                    # If Type is good but option is malformed
+                    # First Type will be increased on downlink Ethernet interface first. Then increase Malformed counter
+                    # on downlink_vlan_iface.
+                    check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
+                if type in ["Unknown"]:
+                    # dhcp6relay counts two packets as Unknown:
+                    # 1. Relay-Reply with no relay-msg option (bare Relay-Reply)
+                    # 2. Relay-Reply wrapping an unrecognized inner message type (msgtype=20)
+                    # Note: dhcpmon counts #1 as Malformed instead (see dhcpmon expected counters
+                    # below), which is arguably more correct since the packet structure is invalid
+                    # (relay messages must contain a relay-msg option per RFC 8415), not just an
+                    # unrecognized type.
+                    check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
+                if type in ["Advertise", "Reply", "Reconfigure"]:
+                    check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "TX")
+                    check_dhcpv6_relay_counter(duthost, dhcp_relay['client_iface']['name'], type, "TX")
+                if type in ["Relay-Forward"]:
+                    # Relay-Forward, send out from downlink_vlan_iface first, then send out from uplink interfaces
+                    check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "TX")
+                    # TBD, add uplink interface TX counter check in future
+                if type in ["Relay-Reply"]:
+                    if dhcp_relay['is_dualtor']:
+                        # dual tor, Relay-Reply will be received on loopback interface
+                        check_dhcpv6_relay_counter(duthost, dhcp_relay['loopback_iface'][0]['name'], type, "RX")
+                    else:
+                        # Single tor, Relay-Reply will be received on downlink_vlan_iface
+                        check_dhcpv6_relay_counter(duthost, dhcp_relay['downlink_vlan_iface']['name'], type, "RX")
+
+            # Validate dhcpmon counters (COUNTERS_DB DHCPV6_COUNTER_TABLE)
+            # Downlink RX: 8 valid client messages + 1 malformed Solicit (optcode=300
+            # fails sanity check since code > DHCPV6_OPTION_CODE_MAX).
+            # No Unknown on downlink -- all client packets have valid message types.
+            expected_downlink_counter = {
+                "RX": {"Solicit": 1, "Request": 1, "Confirm": 1, "Renew": 1, "Rebind": 1,
+                       "Release": 1, "Decline": 1, "Information-Request": 1, "Malformed": 1},
+                "TX": {"Advertise": 1, "Reply": 1, "Reconfigure": 1}
+            }
+            # Uplink RX: 5 server packets, classified by dhcpmon as:
+            # - Relay-Reply=3: valid Relay-Replies (Advertise, Reply, Reconfigure)
+            # - Malformed=1: bare Relay-Reply with no relay-msg option. dhcpmon validates
+            #   that relay messages must contain relay-msg and rejects structurally invalid
+            #   packets as Malformed (dhcp6relay counts this as Unknown instead, but
+            #   Malformed is more precise since the packet structure itself is invalid
+            #   per RFC 8415, not just an unrecognized type).
+            # - Unknown=1: packet with msgtype=20 (beyond valid range 1-13), rejected
+            #   before sanity check since msg_type > RELAY_REPL.
+            expected_uplink_counter = {
+                "TX": {"Relay-Forward": dhcp_server_num * 8},
+                "RX": {"Relay-Reply": 3, "Malformed": 1, "Unknown": 1}
+            }
+            time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
+            validate_dhcpmon_counters(dhcp_relay, duthost,
+                                      expected_uplink_counter,
+                                      expected_downlink_counter, is_v6=True)
+
+    finally:
+        # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
+        restart_dhcp_service(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
 def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
@@ -425,27 +524,60 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
     """
     _, duthost = testing_config
 
+    skip_dhcpv6_dhcptest_on_kvm(duthost)
+
     # Please note: relay interface always means vlan interface
-    for dhcp_relay in dut_dhcp_relay_data:
-        # Run the DHCP relay test on the PTF host
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "dhcpv6_relay_test.DHCPTest",
-                   platform_dir="ptftests",
-                   params={"hostname": duthost.hostname,
-                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
-                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
-                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
-                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
-                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac']),
-                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor']),
-                           "kvm_support": True},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
+            restart_dhcpmon_in_debug(duthost)
+            time.sleep(5)  # wait for dhcpmon to initialize
+            init_dhcpmon_counters(duthost, is_v6=True)
+
+            # Relay A's GUA is arbitrary and outside the DUT VLAN prefix; the
+            # responder helper must install a route so DUT Relay B can resolve it.
+            downstream_relay_ip = DOWNSTREAM_RELAY_IP
+            downlink_vlan = dhcp_relay['downlink_vlan_iface']['name']
+            downstream_relay_responder = [
+                (downstream_relay_ip, downlink_vlan, dhcp_relay['client_iface']['port_idx'])]
+            setup_ptf_ip_responder(
+                duthost, ptfhost, DHCPV6_RELAY_ARP_RESPONDER_CONF, downstream_relay_responder, route=True)
+
+            # Run the DHCP relay test on the PTF host
+            try:
+                ptf_runner(ptfhost,
+                           "ptftests",
+                           "dhcpv6_relay_test.DHCPTest",
+                           platform_dir="ptftests",
+                           params={"hostname": duthost.hostname,
+                                   "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                                   "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                                   "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
+                                   "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
+                                   "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                                   "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                                   "relay_link_local": str(dhcp_relay['down_interface_link_local']),
+                                   "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                                   "uplink_mac": str(dhcp_relay['uplink_mac']),
+                                   "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                                   "downstream_relay_ip": downstream_relay_ip,
+                                   "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                           log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            finally:
+                teardown_ptf_ip_responder(
+                    duthost, ptfhost, DHCPV6_RELAY_ARP_RESPONDER_CONF, downstream_relay_responder, route=True)
+
+            expected_downlink_counter, expected_uplink_counter = \
+                get_dhcptest_expected_counters(dhcp_server_num)
+            time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
+            validate_dhcpmon_counters(dhcp_relay, duthost,
+                                      expected_uplink_counter,
+                                      expected_downlink_counter, is_v6=True)
+
+    finally:
+        # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
+        restart_dhcp_service(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
 def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
@@ -455,40 +587,66 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
     """
     testing_mode, duthost = testing_config
 
-    for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('ifconfig {} down'.format(iface))
+    skip_dhcpv6_dhcptest_on_kvm(duthost)
 
-        # Sleep a bit to ensure uplinks are down
-        time.sleep(20)
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            # Bring all uplink interfaces down
+            for iface in dhcp_relay['uplink_interfaces']:
+                duthost.shell('ifconfig {} down'.format(iface))
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('ifconfig {} up'.format(iface))
+            # Sleep a bit to ensure uplinks are down
+            time.sleep(20)
 
-        # Sleep a bit to ensure uplinks are up
-        wait_all_bgp_up(duthost)
+            # Bring all uplink interfaces back up
+            for iface in dhcp_relay['uplink_interfaces']:
+                duthost.shell('ifconfig {} up'.format(iface))
 
-        # Run the DHCP relay test on the PTF host
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "dhcpv6_relay_test.DHCPTest",
-                   platform_dir="ptftests",
-                   params={"hostname": duthost.hostname,
-                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
-                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
-                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
-                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
-                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac']),
-                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor']),
-                           "kvm_support": True},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            # Sleep a bit to ensure uplinks are up
+            wait_all_bgp_up(duthost)
+
+            dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
+            restart_dhcpmon_in_debug(duthost)
+            time.sleep(5)  # wait for dhcpmon to initialize
+            init_dhcpmon_counters(duthost, is_v6=True)
+
+            downstream_relay_responder = setup_downstream_relay_responder(
+                duthost, ptfhost, dhcp_relay['downlink_vlan_iface']['name'],
+                dhcp_relay['client_iface']['port_idx'])
+            # Run the DHCP relay test on the PTF host
+            try:
+                ptf_runner(ptfhost,
+                           "ptftests",
+                           "dhcpv6_relay_test.DHCPTest",
+                           platform_dir="ptftests",
+                           params={"hostname": duthost.hostname,
+                                   "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                                   "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                                   "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
+                                   "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
+                                   "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                                   "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                                   "relay_link_local": str(dhcp_relay['down_interface_link_local']),
+                                   "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                                   "uplink_mac": str(dhcp_relay['uplink_mac']),
+                                   "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                                   "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
+                                   "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                           log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            finally:
+                teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
+
+            expected_downlink_counter, expected_uplink_counter = \
+                get_dhcptest_expected_counters(dhcp_server_num)
+            time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
+            validate_dhcpmon_counters(dhcp_relay, duthost,
+                                      expected_uplink_counter,
+                                      expected_downlink_counter, is_v6=True)
+
+    finally:
+        # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
+        restart_dhcp_service(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
 def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config):
@@ -499,50 +657,76 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
     """
     testing_mode, duthost = testing_config
 
-    for dhcp_relay in dut_dhcp_relay_data:
-        # Bring all uplink interfaces down
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('ifconfig {} down'.format(iface))
+    skip_dhcpv6_dhcptest_on_kvm(duthost)
 
-        # Sleep a bit to ensure uplinks are down
-        time.sleep(20)
+    try:
+        for dhcp_relay in dut_dhcp_relay_data:
+            # Bring all uplink interfaces down
+            for iface in dhcp_relay['uplink_interfaces']:
+                duthost.shell('ifconfig {} down'.format(iface))
 
-        # Restart DHCP relay service on DUT
-        # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
-        # reset-failed before restart service
-        cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
-        duthost.shell_cmds(cmds=cmds)
+            # Sleep a bit to ensure uplinks are down
+            time.sleep(20)
 
-        # Sleep to give the DHCP relay container time to start up and
-        # allow the relay agent to begin listening on the down interfaces
-        time.sleep(40)
+            # Restart DHCP relay service on DUT
+            # dhcp_relay service has 3 times restart limit in 20 mins, for 4 vlans config it will hit the maximum limit
+            # reset-failed before restart service
+            cmds = ['systemctl reset-failed dhcp_relay', 'systemctl restart dhcp_relay']
+            duthost.shell_cmds(cmds=cmds)
 
-        # Bring all uplink interfaces back up
-        for iface in dhcp_relay['uplink_interfaces']:
-            duthost.shell('ifconfig {} up'.format(iface))
+            # Sleep to give the DHCP relay container time to start up and
+            # allow the relay agent to begin listening on the down interfaces
+            time.sleep(40)
 
-        # Sleep a bit to ensure uplinks are up
-        wait_all_bgp_up(duthost)
+            # Bring all uplink interfaces back up
+            for iface in dhcp_relay['uplink_interfaces']:
+                duthost.shell('ifconfig {} up'.format(iface))
 
-        # Run the DHCP relay test on the PTF host
-        ptf_runner(ptfhost,
-                   "ptftests",
-                   "dhcpv6_relay_test.DHCPTest",
-                   platform_dir="ptftests",
-                   params={"hostname": duthost.hostname,
-                           "client_port_index": dhcp_relay['client_iface']['port_idx'],
-                           "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
-                           "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
-                           "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
-                           "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
-                           "relay_link_local": str(dhcp_relay['down_interface_link_local']),
-                           "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
-                           "uplink_mac": str(dhcp_relay['uplink_mac']),
-                           "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
-                           "is_dualtor": str(dhcp_relay['is_dualtor']),
-                           "kvm_support": True},
-                   log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            # Sleep a bit to ensure uplinks are up
+            wait_all_bgp_up(duthost)
+
+            dhcp_server_num = len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'])
+            restart_dhcpmon_in_debug(duthost)
+            time.sleep(5)  # wait for dhcpmon to initialize
+            init_dhcpmon_counters(duthost, is_v6=True)
+
+            downstream_relay_responder = setup_downstream_relay_responder(
+                duthost, ptfhost, dhcp_relay['downlink_vlan_iface']['name'],
+                dhcp_relay['client_iface']['port_idx'])
+            # Run the DHCP relay test on the PTF host
+            try:
+                ptf_runner(ptfhost,
+                           "ptftests",
+                           "dhcpv6_relay_test.DHCPTest",
+                           platform_dir="ptftests",
+                           params={"hostname": duthost.hostname,
+                                   "client_port_index": dhcp_relay['client_iface']['port_idx'],
+                                   "leaf_port_indices": repr(dhcp_relay['uplink_port_indices']),
+                                   "num_dhcp_servers": len(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs']),
+                                   "server_ip": str(dhcp_relay['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
+                                   "relay_iface_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                                   "relay_iface_mac": str(dhcp_relay['downlink_vlan_iface']['mac']),
+                                   "relay_link_local": str(dhcp_relay['down_interface_link_local']),
+                                   "vlan_ip": str(dhcp_relay['downlink_vlan_iface']['addr']),
+                                   "uplink_mac": str(dhcp_relay['uplink_mac']),
+                                   "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
+                                   "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
+                                   "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                           log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            finally:
+                teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
+
+            expected_downlink_counter, expected_uplink_counter = \
+                get_dhcptest_expected_counters(dhcp_server_num)
+            time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
+            validate_dhcpmon_counters(dhcp_relay, duthost,
+                                      expected_uplink_counter,
+                                      expected_downlink_counter, is_v6=True)
+
+    finally:
+        # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
+        restart_dhcp_service(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
 class TestDhcpv6RelayWithMultipleVlan:
@@ -551,54 +735,80 @@ class TestDhcpv6RelayWithMultipleVlan:
     def restart_dhcp_relay_after_test(self, duthost):
 
         yield
-        restart_dhcp_service(duthost, ['v6'])
+        restart_dhcp_service(duthost)
 
+    @pytest.mark.parametrize("setup_multiple_vlans_and_teardown", [3], indirect=True)
     def test_dhcp_relay_default(self, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                                                 toggle_all_simulator_ports_to_rand_selected_tor_m, # noqa F811
                                                 setup_active_active_as_active_standby,             # noqa F811
-                                                parametrize_vlan_config_from_topo):                # noqa F811
+                                                setup_multiple_vlans_and_teardown):                # noqa F811
         '''
             Test DHCP relay should set correct link address when relay packet to DHCP server
         '''
-        vlans_info = parametrize_vlan_config_from_topo
+        vlans_info = setup_multiple_vlans_and_teardown
         _, duthost = testing_config
+        skip_dhcpv6_dhcptest_on_kvm(duthost)
         # Please note: relay interface always means vlan interface
         pytest_assert(len(dut_dhcp_relay_data) > 0, "No VLAN data")
         common_dhcp_relay_data = dut_dhcp_relay_data[0]
 
-        restart_dhcp_service(duthost, ['v6'])  # restart dhcp_relay to make new vlans config take into effect
+        restart_dhcp_service(duthost)  # restart dhcp_relay to make new vlans config take into effect
         for vlan_info in vlans_info:
             vlan_name = vlan_info['vlan_name']
-            members_with_ptf_idx = vlan_info['members_with_ptf_idx']
-            if not members_with_ptf_idx:
-                logger.info("Vlan %s has no PTF-mapped members (PortChannel-only); skipping", vlan_name)
-                continue
             exp_link_addr = vlan_info['interface_ipv6'].split('/')[0]
-            _, ptf_port_index = random.choice(members_with_ptf_idx)
+            client_iface_name, ptf_port_index = random.choice(vlan_info['members_with_ptf_idx'])
             logger.info("Randomly selected PTF port index: {}".format(ptf_port_index))
             ensure_client_reachability(duthost, vlan_name)
             command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1" \
                 .format(vlan_name)
             down_interface_link_local = duthost.shell(command)['stdout']
             vlan_mac = duthost.shell('cat /sys/class/net/{}/address'.format(vlan_name))['stdout']
+
+            dhcp_server_num = len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs'])
+            restart_dhcpmon_in_debug(duthost)
+            time.sleep(5)  # wait for dhcpmon to initialize
+            init_dhcpmon_counters(duthost, is_v6=True)
+
+            downstream_relay_responder = setup_downstream_relay_responder(
+                duthost, ptfhost, vlan_name, ptf_port_index)
             # Run the DHCP relay test on the PTF host
-            ptf_runner(ptfhost,
-                       "ptftests",
-                       "dhcpv6_relay_test.DHCPTest",
-                       platform_dir="ptftests",
-                       params={"hostname": duthost.hostname,
-                               "client_port_index": ptf_port_index,
-                               "leaf_port_indices": repr(common_dhcp_relay_data['uplink_port_indices']),
-                               "num_dhcp_servers":
-                                   len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs']),
-                               "server_ip":
-                                   str(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
-                               "relay_iface_ip": str(exp_link_addr),
-                               "relay_iface_mac": str(vlan_mac),
-                               "relay_link_local": str(down_interface_link_local),
-                               "vlan_ip": str(exp_link_addr),
-                               "uplink_mac": str(common_dhcp_relay_data['uplink_mac']),
-                               "loopback_ipv6": str(common_dhcp_relay_data['loopback_ipv6']),
-                               "is_dualtor": str(common_dhcp_relay_data['is_dualtor']),
-                               "kvm_support": True},
-                       log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            try:
+                ptf_runner(ptfhost,
+                           "ptftests",
+                           "dhcpv6_relay_test.DHCPTest",
+                           platform_dir="ptftests",
+                           params={"hostname": duthost.hostname,
+                                   "client_port_index": ptf_port_index,
+                                   "leaf_port_indices": repr(common_dhcp_relay_data['uplink_port_indices']),
+                                   "num_dhcp_servers":
+                                       len(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs']),
+                                   "server_ip":
+                                       str(common_dhcp_relay_data['downlink_vlan_iface']['dhcpv6_server_addrs'][0]),
+                                   "relay_iface_ip": str(exp_link_addr),
+                                   "relay_iface_mac": str(vlan_mac),
+                                   "relay_link_local": str(down_interface_link_local),
+                                   "vlan_ip": str(exp_link_addr),
+                                   "uplink_mac": str(common_dhcp_relay_data['uplink_mac']),
+                                   "loopback_ipv6": str(common_dhcp_relay_data['loopback_ipv6']),
+                                   "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
+                                   "is_dualtor": str(common_dhcp_relay_data['is_dualtor'])},
+                           log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
+            finally:
+                teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
+
+            time.sleep(36)  # dhcpmon: health check every 18s, DB write every 20s
+            # Build a relay data dict for this dynamic VLAN to pass to validate_dhcpmon_counters
+            vlan_dhcp_relay_data = copy.deepcopy(common_dhcp_relay_data)
+            vlan_dhcp_relay_data['downlink_vlan_iface'] = dict(common_dhcp_relay_data['downlink_vlan_iface'])
+            vlan_dhcp_relay_data['downlink_vlan_iface']['name'] = vlan_name
+            vlan_dhcp_relay_data['client_iface'] = {'name': client_iface_name}
+
+            expected_downlink_counter, expected_uplink_counter = \
+                get_dhcptest_expected_counters(dhcp_server_num)
+            validate_dhcpmon_counters(vlan_dhcp_relay_data, duthost,
+                                      expected_uplink_counter,
+                                      expected_downlink_counter, is_v6=True)
+
+        # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
+        restart_dhcp_service(duthost)
+        pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))

--- a/tests/dhcp_relay/test_dhcpv6_relay.py
+++ b/tests/dhcp_relay/test_dhcpv6_relay.py
@@ -6,8 +6,13 @@ import time
 import netaddr
 import logging
 
-from tests.common.dhcp_relay_utils import restart_dhcp_service
-from tests.common.dhcp_relay_utils import init_dhcpmon_counters, validate_dhcpmon_counters, restart_dhcpmon_in_debug
+from tests.common.dhcp_relay_utils import (
+    init_dhcpmon_counters,
+    restart_dhcp_service,
+    restart_dhcpmon_in_debug,
+    validate_dhcpmon_counters,
+    wait_dhcp_relay_ready,
+)
 from tests.common.fixtures.ptfhost_utils import copy_ptftests_directory   # noqa F401
 from tests.common.fixtures.ptfhost_utils import change_mac_addresses      # noqa F401
 from tests.common.fixtures.ptfhost_utils import copy_arp_responder_py     # noqa F401
@@ -50,17 +55,6 @@ def wait_all_bgp_up(duthost):
     bgp_neighbors = config_facts.get('BGP_NEIGHBOR', {})
     if not wait_until(180, 10, 0, duthost.check_bgp_session_state, list(bgp_neighbors.keys())):
         pytest.fail("not all bgp sessions are up after config change")
-
-
-def skip_dhcpv6_dhcptest_on_kvm(duthost):
-    # DHCPTest wrappers never passed kvm_support=True, so ptf_runner already
-    # skipped them on KVM/VS. Keep that behavior explicit now that these
-    # wrappers validate dhcpmon counters after the PTF run.
-    if (
-        duthost.facts.get("platform") == "x86_64-kvm_x86_64-r0"
-        and duthost.facts.get("asic_type") != "vpp"
-    ):
-        pytest.skip("dhcpv6_relay_test.DHCPTest is not supported on KVM non-VPP DUTs")
 
 
 def check_dhcpv6_relay_counter(duthost, ifname, type, dir):
@@ -332,6 +326,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
         config_reload(duthost)
         wait_critical_processes(duthost)
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
+        wait_dhcp_relay_ready(duthost, ['v6'])
 
     # Cmds to delete LLA for all Vlans
     delete_cmds = ["ip -6 address del {} dev {}"
@@ -361,7 +356,7 @@ def test_interface_binding(duthosts, rand_one_dut_hostname, dut_dhcp_relay_data,
 
     try:
         duthost.shell_cmds(cmds=delete_cmds)
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         time.sleep(10)
 
         output = duthost.shell("docker exec -t dhcp_relay ss -nlp | grep dhcp6relay")["stdout"]
@@ -512,7 +507,7 @@ def test_dhcpv6_relay_counter(ptfhost, duthosts, rand_one_dut_hostname, dut_dhcp
 
     finally:
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
@@ -523,8 +518,6 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
        For each DHCP relay agent running on the DuT, verify DHCP packets are relayed properly
     """
     _, duthost = testing_config
-
-    skip_dhcpv6_dhcptest_on_kvm(duthost)
 
     # Please note: relay interface always means vlan interface
     try:
@@ -561,7 +554,8 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
                                    "uplink_mac": str(dhcp_relay['uplink_mac']),
                                    "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
                                    "downstream_relay_ip": downstream_relay_ip,
-                                   "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                                   "is_dualtor": str(dhcp_relay['is_dualtor']),
+                                   "kvm_support": True},
                            log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
             finally:
                 teardown_ptf_ip_responder(
@@ -576,7 +570,7 @@ def test_dhcp_relay_default(ptfhost, dut_dhcp_relay_data, validate_dut_routes_ex
 
     finally:
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
@@ -586,8 +580,6 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
        then test whether the DHCP relay agent relays packets properly.
     """
     testing_mode, duthost = testing_config
-
-    skip_dhcpv6_dhcptest_on_kvm(duthost)
 
     try:
         for dhcp_relay in dut_dhcp_relay_data:
@@ -631,7 +623,8 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
                                    "uplink_mac": str(dhcp_relay['uplink_mac']),
                                    "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
                                    "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
-                                   "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                                   "is_dualtor": str(dhcp_relay['is_dualtor']),
+                                   "kvm_support": True},
                            log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
             finally:
                 teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
@@ -645,7 +638,7 @@ def test_dhcp_relay_after_link_flap(ptfhost, dut_dhcp_relay_data, validate_dut_r
 
     finally:
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
@@ -656,8 +649,6 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
        relays packets properly.
     """
     testing_mode, duthost = testing_config
-
-    skip_dhcpv6_dhcptest_on_kvm(duthost)
 
     try:
         for dhcp_relay in dut_dhcp_relay_data:
@@ -711,7 +702,8 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
                                    "uplink_mac": str(dhcp_relay['uplink_mac']),
                                    "loopback_ipv6": str(dhcp_relay['loopback_ipv6']),
                                    "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
-                                   "is_dualtor": str(dhcp_relay['is_dualtor'])},
+                                   "is_dualtor": str(dhcp_relay['is_dualtor']),
+                                   "kvm_support": True},
                            log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
             finally:
                 teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
@@ -725,7 +717,7 @@ def test_dhcp_relay_start_with_uplinks_down(ptfhost, dut_dhcp_relay_data, valida
 
     finally:
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))
 
 
@@ -735,28 +727,30 @@ class TestDhcpv6RelayWithMultipleVlan:
     def restart_dhcp_relay_after_test(self, duthost):
 
         yield
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
 
-    @pytest.mark.parametrize("setup_multiple_vlans_and_teardown", [3], indirect=True)
     def test_dhcp_relay_default(self, ptfhost, dut_dhcp_relay_data, validate_dut_routes_exist, testing_config,
                                                 toggle_all_simulator_ports_to_rand_selected_tor_m, # noqa F811
                                                 setup_active_active_as_active_standby,             # noqa F811
-                                                setup_multiple_vlans_and_teardown):                # noqa F811
+                                                parametrize_vlan_config_from_topo):                # noqa F811
         '''
             Test DHCP relay should set correct link address when relay packet to DHCP server
         '''
-        vlans_info = setup_multiple_vlans_and_teardown
+        vlans_info = parametrize_vlan_config_from_topo
         _, duthost = testing_config
-        skip_dhcpv6_dhcptest_on_kvm(duthost)
         # Please note: relay interface always means vlan interface
         pytest_assert(len(dut_dhcp_relay_data) > 0, "No VLAN data")
         common_dhcp_relay_data = dut_dhcp_relay_data[0]
 
-        restart_dhcp_service(duthost)  # restart dhcp_relay to make new vlans config take into effect
+        restart_dhcp_service(duthost, ['v6'])  # restart dhcp_relay to make new vlans config take into effect
         for vlan_info in vlans_info:
             vlan_name = vlan_info['vlan_name']
+            members_with_ptf_idx = vlan_info['members_with_ptf_idx']
+            if not members_with_ptf_idx:
+                logger.info("Vlan %s has no PTF-mapped members (PortChannel-only); skipping", vlan_name)
+                continue
             exp_link_addr = vlan_info['interface_ipv6'].split('/')[0]
-            client_iface_name, ptf_port_index = random.choice(vlan_info['members_with_ptf_idx'])
+            client_iface_name, ptf_port_index = random.choice(members_with_ptf_idx)
             logger.info("Randomly selected PTF port index: {}".format(ptf_port_index))
             ensure_client_reachability(duthost, vlan_name)
             command = "ip addr show {} | grep inet6 | grep 'scope link' | awk '{{print $2}}' | cut -d '/' -f1" \
@@ -791,7 +785,8 @@ class TestDhcpv6RelayWithMultipleVlan:
                                    "uplink_mac": str(common_dhcp_relay_data['uplink_mac']),
                                    "loopback_ipv6": str(common_dhcp_relay_data['loopback_ipv6']),
                                    "downstream_relay_ip": DOWNSTREAM_RELAY_IP,
-                                   "is_dualtor": str(common_dhcp_relay_data['is_dualtor'])},
+                                   "is_dualtor": str(common_dhcp_relay_data['is_dualtor']),
+                                   "kvm_support": True},
                            log_file="/tmp/dhcpv6_relay_test.DHCPTest.log", is_python3=True)
             finally:
                 teardown_downstream_relay_responder(duthost, ptfhost, downstream_relay_responder)
@@ -810,5 +805,5 @@ class TestDhcpv6RelayWithMultipleVlan:
                                       expected_downlink_counter, is_v6=True)
 
         # Clean up - Restart DHCP relay service on DUT to recover original dhcpmon setting
-        restart_dhcp_service(duthost)
+        restart_dhcp_service(duthost, ['v6'])
         pytest_assert(wait_until(120, 5, 0, check_interface_status, duthost))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Add dhcpmon DHCPv6 counter validation to DHCP relay tests and fix the DHCPv6 PTF packet models needed for those counters to match dhcpmon behavior.

Dependencies used by the current master-based change are already merged: sonic-dhcpmon#62, sonic-buildimage#26467, and sonic-mgmt #24669, #24672, #26008, and #26646.

Summary:
ADO: https://msazure.visualstudio.com/One/_workitems/edit/38699915

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
https://msazure.visualstudio.com/One/_workitems/edit/38699915

Failure type: other — release qualification for DHCPv6 dhcpmon test coverage

### Tested branch
- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A

### Test result
- master: exact active head [`76543c1e5f04da9f4e71c7630437bb06095633f4`](https://github.com/sonic-net/sonic-mgmt/commit/76543c1e5f04da9f4e71c7630437bb06095633f4); ready-state [Azure build 1184052](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1184052) is running, with all completed lanes green when this evidence was recorded.
- 202605: `SONiC.20260510.07` (build commit `1df5b92630`, build date `2026-07-21T13:37:41Z`) on [`testbed-bjw-can-720dt-3`](https://elastictest.org/testbed?searchKeyword=testbed-bjw-can-720dt-3), m0, DUT `bjw-can-720dt-3`. Validation used `internal-202605` baseline `6261f7471209b9412982eb22a47d794f48ffef52` plus merged prerequisites #24669/#24672 and exact PR head `76543c1e5f04da9f4e71c7630437bb06095633f4`. `test_pretest.py`: 11 passed, 3 skipped. Full `dhcp_relay/test_dhcpv6_relay.py` executed normally; two functional cases were rerun normally after first-run packet-receive misses and both passed. Final required exact-head coverage: `test_interface_binding`, `test_dhcpv6_relay_counter`, `test_dhcp_relay_default`, `test_dhcp_relay_after_link_flap`, and `test_dhcp_relay_start_with_uplinks_down` passed; `TestDhcpv6RelayWithMultipleVlan::test_dhcp_relay_default[one_vlan_a]` passed in a targeted run with only its stale expected-fail conditional mark disabled. No loganalyzer suppression was used. Logs: `xichenlin@10.150.22.231:~/copilot-validation/pr23432-202605-physical/`.

### Approach
#### What is the motivation for this PR?

`sonic-dhcpmon` now supports DHCPv6 counters in `DHCPV6_COUNTER_TABLE` in COUNTERS_DB. The existing DHCPv6 relay tests validate dhcp6relay STATE_DB counters and functional forwarding, but they did not validate dhcpmon DHCPv6 classification/counters.

This PR adds that coverage and adjusts the PTF traffic where the old packet model did not match the behavior dhcpmon is designed to validate.

#### How did you do it?

- Added dhcpmon DHCPv6 counter validation (`validate_dhcpmon_counters(..., is_v6=True)`) to DHCPv6 relay pytest wrappers.
- Added `restart_dhcpmon_in_debug()`, `init_dhcpmon_counters(is_v6=True)`, and DB-write wait handling around those validations.
- Relied on the module-level `asic_type in ['vs']` conditional skip supplied by merged #26646, which skips unsupported VS execution before fixtures; every DHCPv6 PTF call in this module explicitly passes `kvm_support=True`. This PR defines no local skip helper and does not manually skip individual wrappers.
- Consumed the shared PTF IP/NDP responder/WOL helper implementation already merged in #26008; this PR does not extract or author that helper.
- Removed the client-originated Relay-Forward step from `DHCPTest` because t0/m0/mx topologies model the DUT as the first-hop relay; client-side Relay-Forward is not part of that topology.
- Updated nested Relay-Reply to model the RFC8415 relay-to-relay return path using an outer `linkaddr=::` and a simulated downstream Relay A GUA peer.

Behavior notes / reviewer map:

1. **Bare Relay-Reply without relay-msg: dhcp6relay vs dhcpmon classify differently**

   PTF packet:
   `ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py`
   Function: `DHCPCounterTest.create_malformed_server_packet()`

   ```python
   """Relay-Reply with no relay-msg option.
   dhcp6relay: counts as Unknown (unrecognizable inner content)
   dhcpmon: counts as Malformed (relay packet missing required relay-msg option)
   """
   ```

   Test wrapper:
   `tests/dhcp_relay/test_dhcpv6_relay.py`
   Function: `test_dhcpv6_relay_counter()`

   - dhcp6relay side checks this under `Unknown`.
   - dhcpmon side expects:

   ```python
   "RX": {"Relay-Reply": 3, "Malformed": 1, "Unknown": 1}
   ```

   Reason: dhcpmon treats “relay packet missing required relay-msg” as structurally malformed; dhcp6relay reports it as unknown/unrecognizable content.

2. **Relay-Reply with invalid message type msgtype=20: both count as Unknown**

   PTF packet:
   `ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py`
   Function: `DHCPCounterTest.create_unknown_server_packet()`

   ```python
   """DHCPv6 packet with message type 20 (beyond valid range 1-13).
   dhcp6relay: counts as Unknown (unrecognized message type)
   dhcpmon: counts as Unknown (msg_type > RELAY_REPL)
   """
   ```

   Test wrapper:
   `tests/dhcp_relay/test_dhcpv6_relay.py`
   Function: `test_dhcpv6_relay_counter()`

   dhcpmon expected uplink RX includes:

   ```python
   "Unknown": 1
   ```

3. **Malformed client option code threshold differs, so test uses optcode=300**

   PTF packet:
   `ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py`
   Function: `DHCPCounterTest.create_malformed_client_packet()`

   ```python
   # dhcp6relay: option codes > 147 (DHCPv6_OPTION_LIMIT) are malformed
   # dhcpmon:    option codes > 150 (DHCPV6_OPTION_CODE_MAX) are malformed
   # Use optcode=300 (well above both limits) to trigger malformed detection
   ```

   Test wrapper:
   `tests/dhcp_relay/test_dhcpv6_relay.py`
   Function: `test_dhcpv6_relay_counter()`

   dhcpmon expected downlink RX includes:

   ```python
   "Malformed": 1
   ```

   This avoids a gray area where one component might accept an option code that the other rejects.

4. **Malformed client packet does not generate Relay-Forward traffic**

   This one is not a dhcpmon-vs-dhcp6relay classification difference. It is a packet-flow expectation.

   PTF sender:
   `ansible/roles/test/files/ptftests/py3/dhcpv6_counter_test.py`
   Function: `DHCPCounterTest.client_send()`

   It sends:

   ```text
   8 valid client messages
   + 1 malformed Solicit
   ```

   Test wrapper:
   `tests/dhcp_relay/test_dhcpv6_relay.py`
   Function: `test_dhcpv6_relay_counter()`

   dhcpmon expected uplink TX is:

   ```python
   "TX": {"Relay-Forward": dhcp_server_num * 8}
   ```

   Not `* 9`, because the malformed Solicit is rejected and does not get relayed to servers.

5. **Nested Relay-Reply / relay-to-relay path must use the GUA model for dhcpmon**

   PTF packet:
   `ansible/roles/test/files/ptftests/py3/dhcpv6_relay_test.py`

   Functions:

   - `DHCPTest.create_dhcp_relay_relay_reply_packet()`
   - `DHCPTest.create_dhcp_relay_reply_packet()`
   - `DHCPTest.runTest()`

   Current model:

   ```text
   outer Relay-Reply:
     linkaddr = ::
     peeraddr = simulated downstream Relay A GUA

   inner Relay-Reply:
     linkaddr = DUT/client VLAN GUA
     peeraddr = client link-local
   ```

   Mgmt wrapper setup:
   `tests/dhcp_relay/test_dhcpv6_relay.py`

   Function:

   - `test_dhcp_relay_default()`

   This configures PTF to answer NDP for the simulated downstream Relay A GUA. The Relay A GUA is arbitrary and intentionally outside the DUT VLAN prefix; the test asks the responder helper to add a temporary /128 host route through the PTF-facing VLAN so DUT Relay B can resolve it on PTF.

   Reason: the nested case is explicitly modeling RFC8415 relay-to-relay return path. dhcp6relay forwards based on the outer peeraddr, and both dhcp6relay and dhcpmon assume first-hop downstream VLANs plus the current SONiC GUA relay-to-relay profile. That first-hop VLAN model is fundamentally incompatible with making the DUT act as a second-or-later relay; the nested case is a hypothetical test that only models the GUA relay-to-relay return profile. The old/link-local shortcut did not satisfy dhcpmon’s profile.

6. **KVM/VS behavior for DHCPv6 tests**

   Current master includes merged #26646, which supplies a module-level conditional skip for `asic_type in ['vs']`. The skip is applied before fixtures, so unsupported VS execution does not start dhcpmon or counter setup.

   Every DHCPv6 PTF invocation in this module explicitly passes `kvm_support=True`, including the functional `dhcpv6_relay_test.DHCPTest` wrappers and `dhcpv6_counter_test.DHCPCounterTest`. This PR defines no `skip_dhcpv6_dhcptest_on_kvm()` helper and does not manually skip individual wrappers.


#### How did you verify/test it?

- Ran `python3 -m py_compile` and pre-commit hooks for touched Python files.
- Executed physical 202605 readiness and all required DHCPv6 behaviors on m0 at the exact active head; detailed image, stack, commands, outcomes, and log location are recorded in **Test result** above.
- Ran without `--disable_loganalyzer`; initial packet-receive misses were reported distinctly and the affected cases passed on normal exact-head reruns.
- Confirmed the multivlan test body passes by rerunning it with only the stale issue-based expected-fail mark disabled.
- Verified ready-state GitHub/Azure checks restarted on the latest PR head.

#### Any platform specific information?

- KVM/VS: merged #26646 supplies the module-level `asic_type in ['vs']` conditional skip before fixtures.
- All DHCPv6 PTF calls explicitly pass `kvm_support=True`; this PR defines no local KVM skip helper and does not manually skip wrappers.
- Physical m0 exact-head coverage is recorded in **Test result** above.

#### Supported testbed topology if it's a new test case?

DHCPv6 relay topologies covered by the existing `test_dhcpv6_relay.py` topology marks: `t0`, `m0`, `mx`, and `t0-2vlans`. Merged #26646 separately supplies the module-level `asic_type in ['vs']` conditional skip before fixtures.

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->

The behavior differences are documented inline at each PTF/test location listed above.

##### Work item tracking
- Microsoft ADO (number only): 38699915
