### PR TITLE
update _upgrade_one_dpu_via_gnoi to use perform_gnoi_reboot_dpu

### DIFF
--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -22,8 +22,9 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope="module")
 def xcvr_skip_list(duthosts):
     """Return empty transceiver skip list per DUT. Shared across upgrade-related test suites."""
-    # Required by reboot_and_check(); empty list = no transceivers skipped during post-reboot health check.
+    # Required by reboot_and_check() empty list = no transceivers skipped during post-reboot health check.
     return {dut.hostname: [] for dut in duthosts}
+
 
 TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
 TMP_VLAN_FILE = '/tmp/vlan_interfaces.json'
@@ -434,7 +435,10 @@ def _wait_gnoi_time_ready(ptf_gnoi, metadata, cfg: GnoiUpgradeConfig, timeout=No
     return wait_until(timeout, interval, 0, ptf_gnoi.system_time, metadata=metadata)
 
 
-def _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig) -> Dict:
+def _upgrade_one_dpu_via_gnoi(
+    duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig,
+    localhost=None, duthosts=None,
+) -> Dict:
     """
     Upgrade a single DPU via gNOI.
 
@@ -473,36 +477,39 @@ def _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig)
         metadata=md,
     )
 
-    # Steps 4 & 5 are skipped when skip_reboot=True (caller will trigger reboot separately)
     if cfg.skip_reboot:
         logger.info("skip_reboot=True: image staged on DPU, skipping reboot")
         return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": None}
 
-    # Step 4: Reboot the DPU
-    method = str(cfg.upgrade_type).upper()
-    try:
-        reboot_resp = ptf_gnoi.system_reboot(
-            method=method,
-            delay=0,
-            message=cfg.ss_reboot_message,
-            metadata=md,
-        )
-    except Exception as e:
-        logger.info("Reboot raised (often expected after DPU disconnect): %s", e)
-        reboot_resp = None
+    from tests.common.ptf_gnoi import PtfGnoi
+    dpu_grpc = ptf_gnoi.grpc_client.with_ss_target("dpu", cfg.ss_target_index)
+    dpu_ptf_gnoi = PtfGnoi(dpu_grpc)
+
+    reboot_and_check(
+        localhost,
+        duthost,
+        {},
+        {},
+        reboot_type=cfg.upgrade_type,
+        duthosts=duthosts,
+        invocation_type="gnoi_based",
+        ptf_gnoi=dpu_ptf_gnoi,
+    )
 
     if cfg.allow_fail:
-        return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": reboot_resp}
+        return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp}
 
-    # Step 5: Wait for DPU to come back up
-    ok = _wait_gnoi_time_ready(ptf_gnoi, md, cfg)
-    pytest_assert(ok, f"gNOI Time not reachable within {cfg.ss_reboot_ready_timeout}s after DPU reboot")
-
-    return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp, "reboot_resp": reboot_resp}
+    return {"transfer_resp": transfer_resp, "setpkg_resp": setpkg_resp}
 
 
-def perform_gnoi_upgrade_smartswitch_dpu(duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig) -> Dict:
-    return _upgrade_one_dpu_via_gnoi(duthost, tbinfo, ptf_gnoi, cfg)
+def perform_gnoi_upgrade_smartswitch_dpu(
+    duthost, tbinfo, ptf_gnoi, cfg: GnoiUpgradeConfig,
+    localhost=None, duthosts=None,
+) -> Dict:
+    return _upgrade_one_dpu_via_gnoi(
+        duthost, tbinfo, ptf_gnoi, cfg,
+        localhost=localhost, duthosts=duthosts,
+    )
 
 
 def perform_gnoi_upgrade_smartswitch_dpus_parallel(
@@ -510,6 +517,7 @@ def perform_gnoi_upgrade_smartswitch_dpus_parallel(
     ptf_gnoi,
     cfgs: Sequence[GnoiUpgradeConfig],
     max_workers: Optional[int] = None,
+    localhost=None, duthosts=None,
 ) -> Dict[int, Dict]:
     if not cfgs:
         raise ValueError("cfgs is empty")
@@ -520,7 +528,10 @@ def perform_gnoi_upgrade_smartswitch_dpus_parallel(
     with SafeThreadPoolExecutor(max_workers=workers) as executor:
         futs = {}
         for i, cfg in enumerate(cfgs):
-            futs[i] = executor.submit(_upgrade_one_dpu_via_gnoi, duthost, tbinfo, ptf_gnoi, cfg)
+            futs[i] = executor.submit(
+                _upgrade_one_dpu_via_gnoi, duthost, tbinfo, ptf_gnoi, cfg,
+                localhost, duthosts,
+            )
 
         for i, fut in futs.items():
             results[i] = fut.get()

--- a/tests/common/helpers/upgrade_helpers.py
+++ b/tests/common/helpers/upgrade_helpers.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope="module")
 def xcvr_skip_list(duthosts):
     """Return empty transceiver skip list per DUT. Shared across upgrade-related test suites."""
+    # Required by reboot_and_check(); empty list = no transceivers skipped during post-reboot health check.
     return {dut.hostname: [] for dut in duthosts}
-
 
 TMP_VLAN_PORTCHANNEL_FILE = '/tmp/portchannel_interfaces.json'
 TMP_VLAN_FILE = '/tmp/vlan_interfaces.json'

--- a/tests/common/platform/reboot_utils.py
+++ b/tests/common/platform/reboot_utils.py
@@ -7,6 +7,7 @@ from tests.common.reboot import (
     REBOOT_TYPE_COLD,
     wait_for_startup,
 )
+from tests.common.utilities import wait_until
 
 
 def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
@@ -32,9 +33,21 @@ def reboot_and_check(localhost, dut, interfaces, xcvr_skip_list,
     sync_reboot_history_queue_with_dut(dut)
 
     logging.info("Run %s reboot on DUT" % reboot_type)
+    is_dpu_reboot = (invocation_type == "gnoi_based"
+                     and ptf_gnoi is not None
+                     and ptf_gnoi.grpc_client.ss_target_index is not None)
     reboot(dut, localhost, reboot_type=reboot_type,
            reboot_helper=reboot_helper, reboot_kwargs=reboot_kwargs, invocation_type=invocation_type,
-           ptf_gnoi=ptf_gnoi)
+           ptf_gnoi=ptf_gnoi,
+           wait_for_ssh=not is_dpu_reboot)
+
+    # For gNOI DPU reboot the NPU stays up so SSH wait is a no-op.
+    # Poll the DPU's gNOI Time RPC until the DPU server is back.
+    if is_dpu_reboot:
+        dpu_reboot_timeout = 600
+        logging.info("Waiting for DPU gNOI server to come back up (timeout=%ds)", dpu_reboot_timeout)
+        assert wait_until(dpu_reboot_timeout, 10, 0, ptf_gnoi.system_time), \
+            "DPU gNOI server did not come back up within %ds after reboot" % dpu_reboot_timeout
 
     # Append the last reboot type to the queue
     logging.info("Append the latest reboot type to the queue")

--- a/tests/common/ptf_grpc.py
+++ b/tests/common/ptf_grpc.py
@@ -147,6 +147,12 @@ class PtfGrpc:
             for name, value in items:
                 cmd.extend(["-H", f"{name}: {value}"])
 
+        # Auto-inject ss_target headers set via with_ss_target() so callers don't need to pass metadata
+        if self.ss_target_type:
+            cmd.extend(["-H", f"x-sonic-ss-target-type: {self.ss_target_type}"])
+        if self.ss_target_index is not None:
+            cmd.extend(["-H", f"x-sonic-ss-target-index: {self.ss_target_index}"])
+
         # Add custom headers
         for name, value in self.headers.items():
             cmd.extend(["-H", f"{name}: {value}"])

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -390,14 +390,19 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         collect_console_log, args=(duthost, localhost, timeout + wait_conlsole_connection))
     time.sleep(wait_conlsole_connection)
     # Perform reboot
-    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch"):
+    if duthost.dut_basic_facts()['ansible_facts']['dut_basic_facts'].get("is_smartswitch") \
+            and invocation_type != "gnoi_based":
         reboot_res, dut_datetime = reboot_smartswitch(duthost, pool, reboot_type)
     else:
         reboot_res, dut_datetime = perform_reboot(duthost, pool, reboot_command, reboot_helper,
                                                   reboot_kwargs, reboot_type, invocation_type, localhost,
                                                   ptf_gnoi=ptf_gnoi)
 
-    wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
+    is_dpu_reboot = (invocation_type == "gnoi_based"
+                     and ptf_gnoi is not None
+                     and ptf_gnoi.grpc_client.ss_target_index is not None)
+    if not is_dpu_reboot:
+        wait_for_shutdown(duthost, localhost, delay, timeout, reboot_res)
 
     # Release event to proceed poweron for PDU.
     power_on_event.set()

--- a/tests/upgrade_path/test_upgrade_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_gnoi.py
@@ -29,7 +29,7 @@ def gnoi_upgrade_path_lists(request):
 def test_upgrade_via_gnoi(
     localhost, duthosts, ptfhost, rand_one_dut_hostname,
     nbrhosts, fanouthosts, tbinfo, request,
-    gnoi_upgrade_path_lists, gnmi_tls,  # noqa: F811
+    gnoi_upgrade_path_lists, ptf_gnoi,  # noqa: F811
     conn_graph_facts, xcvr_skip_list
 ):
     duthost = duthosts[rand_one_dut_hostname]

--- a/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
+++ b/tests/upgrade_path/test_upgrade_smart_switch_gnoi.py
@@ -125,6 +125,8 @@ def test_upgrade_one_dpu_via_gnoi(
         tbinfo=tbinfo,
         ptf_gnoi=ptf_gnoi,
         cfg=cfg,
+        localhost=localhost,
+        duthosts=duthosts,
     )
 
 
@@ -168,6 +170,7 @@ def test_upgrade_multiple_dpus_via_gnoi_parallel(
             protocol="HTTP",
             allow_fail=False,
             to_version=to_version,
+            ss_target_index=idx,
             metadata=_build_dpu_metadata(idx),
             ss_reboot_ready_timeout=reboot_ready_timeout,
             ss_reboot_message="Rebooting DPU for maintenance (gNOI upgrade parallel)",
@@ -179,6 +182,8 @@ def test_upgrade_multiple_dpus_via_gnoi_parallel(
         ptf_gnoi=ptf_gnoi,
         cfgs=cfgs,
         max_workers=workers,
+        localhost=localhost,
+        duthosts=duthosts,
     )
 
 


### PR DESCRIPTION
Add optional metadata parameter to perform_gnoi_reboot_dpu so callers can pass explicit gRPC routing headers (x-sonic-ss-target-type/index) instead of relying on with_ss_target().

Update _upgrade_one_dpu_via_gnoi in upgrade_helpers to use perform_gnoi_reboot_dpu for the reboot step, consolidating DPU reboot logic in one place.

To run the test:
  sudo ./run_tests.sh \
    -i ../ansible/str3,../ansible/veos \
    -n vms69-t1-smartswitch-4280-22 \
    -u -m individual \
    -c upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_multiple_dpus_via_gnoi_parallel \
    -d str3-nvidia-4280-E04-U22 \
    -e "--upgrade_type=cold \
        --base_image_list=http://10.64.247.103:8080/sonic-nvidia-bluefield.bin \
        --target_image_list=http://10.64.247.103:8080/sonic-nvidia-bluefield.bin \
        --target_version=SONiC-OS-internal-202511.160570752-5ebd28b407 \
        --ss_target_indices=0,3" \
    -e "--skip_sanity" \
    -l info

INFO     tests.conftest:conftest.py:3255 Core dump and config check passed for test_upgrade_smart_switch_gnoi.py
 tests/upgrade_path/test_upgrade_smart_switch_gnoi.py::test_upgrade_multiple_dpus_via_gnoi_parallel[str3-nvidia-4280-E04-U22] ✓                                                                                                                                                                                                                                            100% ██████████--------------------------------------------------------------------------------------------------------------


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
    Add optional metadata parameter to perform_gnoi_reboot_dpu so callers
    can pass explicit gRPC routing headers (x-sonic-ss-target-type/index)
    instead of relying on with_ss_target().

    Update _upgrade_one_dpu_via_gnoi in upgrade_helpers to use
    perform_gnoi_reboot_dpu for the reboot step, consolidating DPU reboot
    logic in one place.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
  Consolidate DPU reboot logic into a single shared function (perform_gnoi_reboot_dpu) so that both the upgrade path and standalone
  reboot tests use the same pre-check, reboot, and wait-for-readiness flow instead of duplicating it

#### How did you do it?
  - Replaced the inline reboot logic in _upgrade_one_dpu_via_gnoi with a call to perform_gnoi_reboot_dpu, which handles gNOI
  connectivity pre-check, the reboot RPC, and polling until the DPU comes back online.
  - Added an optional metadata parameter to perform_gnoi_reboot_dpu so callers can pass explicit gRPC routing headers
  (x-sonic-ss-target-type/x-sonic-ss-target-index) directly instead of relying on with_ss_target().
  - Added targeted DPU filtering in test_reload_dpu.py so tests can be scoped to specific DPUs via -H instead of always rebooting all
  DPUs.

#### How did you verify/test it?
  - Ran test_upgrade_smart_switch_gnoi.py against a real smartswitch (str3-8102-07) targeting a single DPU via --ss_target_index.
  - Confirmed the gNOI reboot RPC was sent successfully and the DPU came back online as observed in the wait-loop logs.
  -v-cshekar@sonic-mgmt-v-cshekar:/var/src/sonic-mgmt-int/tests$   sudo ./run_tests.sh -i ../ansible/str3,../ansible/veos -n vms66-t1-8102-7 -u -m individual -c upgrade_path/test_upgrade_smart_switch_gnoi.py -u -e "--upgrade_type=cold
  --base_image_list=http://10.201.148.43/pipelines/Networking-acs-buildimage-Official/pensando/internal-202506/sonic-pensando.bin
  --target_image_list=http://10.201.148.43/pipelines/Networking-acs-buildimage-Official/pensando/internal-202506/sonic-pensando.bin
  --target_version=SONiC-OS-internal-202506.154741893-16d12968f4 --ss_target_index=3" -d str3-8102-07 -e "--skip_sanity" -l info


------------------------------------- generated xml file: /var/src/sonic-mgmt-int/tests/logs/upgrade_path/test_upgrade_smart_switch_gnoi.xml -------------------------------------
----------------------------------------------------------------------------- live log sessionfinish -----------------------------------------------------------------------------
INFO     root:__init__.py:67 Can not get Allure report URL. Please check logs
============================================================================ short test summary info =============================================================================
SKIPPED [1] upgrade_path/test_upgrade_smart_switch_gnoi.py:152: --ss-target-indices not set; skipping parallel multi-DPU gNOI upgrade

Results (355.89s (0:05:55)):
       1 passed
       1 skipped

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
