### PR TITLE
[ha][npu-driven] open ports for swbusd communication

### DIFF
--- a/ansible/roles/vm_set/library/vm_topology.py
+++ b/ansible/roles/vm_set/library/vm_topology.py
@@ -1306,8 +1306,10 @@ class VMTopology(object):
                         (br_name, dut_iface_id, vm_iface_id, injected_iface_id))
             # added ovs rules for HA
             # cp_data_channel_port: 11362, dp_channel_dst_port: 11364
+            # swbus_port: 23606-23613 (one per DPU)
             # Match dst and src ports, for both TCP and UDP
-            for ha_port in [11362, 11364, 11367, 11368]:
+            for ha_port in [11362, 11364, 11367, 11368,
+                            23606, 23607, 23608, 23609, 23610, 23611, 23612, 23613]:
                 for proto in ['tcp', 'udp', 'tcp6', 'udp6']:
                     bind_helper("ovs-ofctl add-flow %s table=0,priority=10,%s,in_port=%s,tp_dst=%d,action=output:%s,%s" %  # noqa: E501
                                 (br_name, proto, dut_iface_id, ha_port, vm_iface_id, injected_iface_id))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Today we are missing ovs flow rules to allow swbusd communication. This PR is to add rules to match swbusd traffic and redirect the packets accordingly. 

Without this change, HA scope actors won't be able to talk to each other for NPU driven HA. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
To make swbusd communication work.

#### How did you do it?
Add ovs flow rules to match the swbus ports.

#### How did you verify/test it?
After applying the changes, connections established. 
<img width="996" height="519" alt="image" src="https://github.com/user-attachments/assets/dc84415e-82fa-4dfb-8b1f-3e8c6a367e64" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
