### PR TITLE
Fix sanity check to detect crashed processes in supervisor groups

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -637,6 +637,8 @@ class SonicHost(AnsibleHostBase):
             service_critical_process['status'] = False
         for line in service_result['stdout_lines']:
             pname, status, _ = re.split('\\s+', line, 2)
+            # Extract group name from supervisor "group:process" format
+            group_name = pname.split(':')[0] if ':' in pname else None
             # 1. Check status is valid
             # Sometimes, stdout_lines may be error messages but not emtpy
             # In this situation, service container status should be false
@@ -646,12 +648,12 @@ class SonicHost(AnsibleHostBase):
                 service_critical_process['status'] = False
             # 2. Check status is not running
             elif status != 'RUNNING':
-                # 3. Check process is critical
-                if pname in critical_group_list or pname in critical_process_list:
+                # 3. Check process is critical (match by exact name or supervisor group prefix)
+                if pname in critical_process_list or (group_name and group_name in critical_group_list):
                     service_critical_process['exited_critical_process'].append(pname)
                     service_critical_process['status'] = False
             else:
-                if pname in critical_group_list or pname in critical_process_list:
+                if pname in critical_process_list or (group_name and group_name in critical_group_list):
                     service_critical_process['running_critical_process'].append(pname)
 
         return service_critical_process


### PR DESCRIPTION
### Description of PR

Summary:
Fix sanity check to properly detect crashed critical processes in supervisor groups.

When a container's `critical_processes` file specifies a group (e.g., `group:dhcp-relay`), the sanity check collects `dhcp-relay` in `critical_group_list`. However, `supervisorctl status` outputs process names in `group:process` format (e.g., `dhcp-relay:dhcprelayd`). The current exact string match never matches group members, so crashed processes in groups go undetected.

Fixes #23313

### Type of change

- [x] Bug fix

### Back port request

- [ ] 202411
- [ ] 202405
- [ ] 202311
- [ ] 202305
- [ ] 202211
- [ ] 202012

### Approach
#### What is the motivation for this PR?
The sanity check's `parse_service_status_and_critical_process()` silently ignores crashed processes that belong to supervisor groups, making `--allow_recover` unable to trigger recovery for those containers.

#### How did you do it?
Extract the group prefix from supervisor process names (splitting on `:`) and match against `critical_group_list` in addition to the existing exact match against `critical_process_list`.

#### How did you verify/test it?
Verified through code analysis:
- `supervisorctl status` outputs `dhcp-relay:dhcprelayd RUNNING pid 100, uptime 1:00:00`
- Before fix: `pname = "dhcp-relay:dhcprelayd"`, `"dhcp-relay:dhcprelayd" in critical_group_list` → `False` (bug)
- After fix: `group_name = "dhcp-relay"`, `"dhcp-relay" in critical_group_list` → `True` (correct)

The fix is minimal and backward-compatible — processes without a `:` in their name continue to match via `critical_process_list` as before.

#### Any platform specific information?
Generic — affects all platforms using supervisor groups in critical_processes files.

#### Supported testbed topology if it's a new test case?
N/A — bug fix to existing infrastructure code.

### Documentation
N/A
