### PR TITLE
[testbed_health_check]: Skip missing fanout host failures on Snappi testbeds

### DIFF
--- a/.azure-pipelines/testbed_health_check.py
+++ b/.azure-pipelines/testbed_health_check.py
@@ -288,6 +288,20 @@ class TestbedHealthChecker:
                 # Create fanouthost instance.
                 fanouthost = init_host(inventories=self.inventory, host_pattern=fanout_hostname)
 
+                if fanouthost is None:
+                    if self.is_snappi_testbed:
+                        logger.info(
+                            "Skip fanout host {} health check because it is not present in inventories {}.".format(
+                                fanout_hostname, self.inventory
+                            )
+                        )
+                        continue
+                    raise HostInitFailed(
+                        "Failed to initialize fanout host {} from inventories {}.".format(
+                            fanout_hostname, self.inventory
+                        )
+                    )
+
                 # If sonic fannout, update ssh vars
                 is_sonic = self.localhost.get_host_vars(fanout_hostname).get("os", "eos") == "sonic"
 


### PR DESCRIPTION
### Description of PR

Summary:
Skip fanout host health check failures when a fanout host is absent from the configured inventory on Snappi testbeds.

During health check, testbed_health_check.py script loads connection-graph facts for the DUT and then checks every peer device connected to that DUT in testbed_health_check.py:259 through testbed_health_check.py:313. It skips only peer devices whose name contains ixia in testbed_health_check.py:284-286. Any other peer device is treated as a fanout host and must be resolvable from the supplied inventories in testbed_health_check.py:289.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Snappi testbeds may reference fanout hosts that are not present in the provided inventory set. The current health check flow treats this as a hard failure, which blocks pipeline execution even when the missing fanout host should simply be ignored for that testbed configuration.

#### How did you do it?
- Added a guard after fanout host initialization in the testbed health check flow
- Skip the fanout host health check when host initialization returns no host object for a Snappi testbed
- Preserve the existing failure behavior for non-Snappi testbeds by continuing to raise HostInitFailed
- Added an explicit log message to identify the missing fanout host and the inventories used

#### How did you verify/test it?
- Verified the code path for fanout host initialization failure in the health check logic
- Confirmed that Snappi testbeds now continue past missing fanout hosts instead of failing immediately
- Confirmed that non-Snappi testbeds still raise HostInitFailed for the same condition

#### Any platform specific information?
This change is specific to Snappi testbed handling in the testbed health check flow. Behavior for other testbed types is unchanged.

#### Supported testbed topology if it's a new test case?
Not applicable.

### Documentation
No documentation update is required because this change fixes health check behavior and does not introduce a new feature or test case.