### PR TITLE
Fix syncd swap image name for broadcom-legacy-th (7060) platform

### DIFF
--- a/tests/common/system_utils/docker.py
+++ b/tests/common/system_utils/docker.py
@@ -126,6 +126,8 @@ def swap_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
 
     if duthost.facts.get("platform_asic") == 'broadcom-dnx':
         docker_syncd_name = docker_syncd_name + "-dnx"
+    elif duthost.facts.get("platform_asic") == "broadcom-legacy-th":
+        docker_syncd_name = docker_syncd_name + "-legacy-th"
 
     docker_rpc_image = docker_syncd_name + "-rpc"
 
@@ -191,6 +193,8 @@ def restore_default_syncd(duthost, creds, namespace=DEFAULT_NAMESPACE):
 
     if duthost.facts.get("platform_asic") == 'broadcom-dnx':
         docker_syncd_name = docker_syncd_name + "-dnx"
+    elif duthost.facts.get("platform_asic") == "broadcom-legacy-th":
+        docker_syncd_name = docker_syncd_name + "-legacy-th"
 
     for asic in asics_list:
         asic.stop_service("swss")


### PR DESCRIPTION
Fix `swap_syncd` and `restore_default_syncd` to use the correct docker image name for `broadcom-legacy-th` platforms (Arista 7060CX). Without this fix, QoS SAI tests fail with `TTransportException` on Thrift port 9092 because the wrong syncd RPC image is pulled.

### Description of PR

Summary:

For `broadcom-legacy-th` platforms (Arista 7060CX), `swap_syncd` was missing an `elif` branch to append the `-legacy-th` suffix to `docker_syncd_name`. It fell through to the default, constructing `docker-syncd-brcm-rpc` (wrong image), which does not have Thrift RPC support configured for this platform. This caused QoS SAI tests to fail at setup with `TTransportException: Could not connect to ('...', 9092)`.

The fix adds `elif platform_asic == 'broadcom-legacy-th'` in both `swap_syncd` and `restore_default_syncd`, making `docker_rpc_image` correctly resolve to `docker-syncd-brcm-legacy-th-rpc` (follows same naming pattern as `broadcom-dnx` → `docker-syncd-brcm-dnx-rpc`).

### Type of change

- [x] Bug fix

### Back port request
- [x] 202511

### Approach

#### What is the motivation for this PR?
`swap_syncd` in `tests/common/system_utils/docker.py` only handled `broadcom-dnx` as a special case. For `broadcom-legacy-th` (Arista 7060CX), it generated the wrong RPC image name, causing QoS SAI tests to fail.

#### How did you do it?
Added `elif duthost.facts.get("platform_asic") == "broadcom-legacy-th": docker_syncd_name = docker_syncd_name + "-legacy-th"` in both `swap_syncd` (line ~129) and `restore_default_syncd` (line ~196). This makes `docker_rpc_image = docker_syncd_name + "-rpc"` produce `docker-syncd-brcm-legacy-th-rpc`.

#### How did you verify/test it?
- Confirmed root cause from QoS SAI test failure on plan `69caf5bc8d95038c79e91c58`, DUT `bjw-can-7060-1` (`platform_asic=broadcom-legacy-th`, `os_version=20251110.18`)
- Verified `docker-syncd-brcm-legacy-th-rpc:20251110.18` exists in ACR (`soniccr1.azurecr.io`)
- Verified `docker-syncd-brcm-rpc-legacy-th` does NOT exist (wrong name)
- Triggered validation job `69cb4e1088c2a5c54db587b4` on `testbed-bjw-can-t1-7060-1` with the fix

#### Any platform specific information?
Affects Arista 7060CX (`platform_asic=broadcom-legacy-th`) only. No impact on other platforms.

#### Supported testbed topology if it's a new test case?
N/A (bug fix, not new test case)

### Documentation

N/A