### PR TITLE
Check if inner header hashing is supported before checking the ECMP balancing

### DIFF
--- a/ansible/roles/test/files/ptftests/py3/hash_test.py
+++ b/ansible/roles/test/files/ptftests/py3/hash_test.py
@@ -652,6 +652,11 @@ class IPinIPHashTest(HashTest):
     for IPinIP packet.
     '''
 
+    def setUp(self):
+        HashTest.setUp(self)
+        self.ecmp_inner_header_hash_supported = self.test_params.get(
+            'ecmp_inner_header_hash_supported', False)
+
     def send_and_verify_packets(self, src_port, pkt, masked_exp_pkt, dst_port_lists, is_timeout=False, logs=[]):
         """
         @summary: Send an IPinIP encapsulated packet and verify it is received on expected ports.
@@ -827,8 +832,13 @@ class IPinIPHashTest(HashTest):
                     matched_index, 0) + 1
             logging.info("hash_key={}, hit count map: {}".format(
                 hash_key, hit_count_map))
-            for next_hop in next_hops:
-                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
+
+            if self.ecmp_inner_header_hash_supported:
+                for next_hop in next_hops:
+                    self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
+            else:
+                logging.warning("Skipping balance check for hash_key={} because inner header hashing not supported."
+                                .format(hash_key))
 
 
 class VxlanHashTest(HashTest):
@@ -1019,6 +1029,11 @@ class NvgreHashTest(HashTest):
     The src_ip, dst_ip, src_port and dst_port of inner frame are expected to be hash keys
     for NvGRE packet.
     '''
+
+    def setUp(self):
+        HashTest.setUp(self)
+        self.ecmp_inner_header_hash_supported = self.test_params.get(
+            'ecmp_inner_header_hash_supported', False)
 
     def create_packets_logs(
             self, src_port, sport, dport, version='IP', pkt=None, ipinip_pkt=None,
@@ -1215,5 +1230,10 @@ class NvgreHashTest(HashTest):
                 matched_index, 0) + 1
         logging.info("hash_key={}, hit count map: {}".format(
             hash_key, hit_count_map))
-        for next_hop in next_hops:
-            self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
+
+        if self.ecmp_inner_header_hash_supported:
+            for next_hop in next_hops:
+                self.check_balancing(next_hop.get_next_hop(), hit_count_map, src_port, hash_key)
+        else:
+            logging.warning("Skipping balance check for hash_key={} because inner header hashing not supported."
+                            .format(hash_key))

--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -260,6 +260,22 @@ def fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, du
     return files
 
 
+@pytest.fixture(scope='module')
+def global_hash_capabilities(duthosts, rand_one_dut_hostname):
+    """
+    Get the generic hash capabilities.
+    Args:
+        duthost (AnsibleHost): Device Under Test (DUT)
+    Returns:
+        ecmp_hash_fields: a list of supported ecmp hash fields
+        lag_hash_fields: a list of supported lag hash fields
+    """
+    duthost = duthosts[rand_one_dut_hostname]
+    global_hash_capabilities = duthost.get_switch_hash_capabilities()
+    return {'ecmp': global_hash_capabilities['ecmp'], 'ecmp_algo': global_hash_capabilities['ecmp_algo'],
+            'lag': global_hash_capabilities['lag'], 'lag_algo': global_hash_capabilities['lag_algo']}
+
+
 @pytest.fixture(scope="module")
 def ignore_ttl(duthosts):
     # on the multi asic devices, the packet can have different ttl based on how the packet is routed
@@ -282,6 +298,14 @@ def updated_tbinfo(tbinfo):
             tbinfo['topo']['properties']['topology']['disabled_host_interfaces'].append(
                 iface)
     return tbinfo
+
+
+@pytest.fixture(scope="module")
+def ecmp_inner_header_hash_supported(global_hash_capabilities):
+    for field in global_hash_capabilities["ecmp"]:
+        if 'INNER' in field:
+            return True
+    return False
 
 
 @pytest.mark.parametrize("ipv4, ipv6, mtu", [pytest.param(True, True, 1514)])
@@ -600,7 +624,7 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,               
                      ignore_ttl, single_fib_for_duts, duts_running_config_facts,                    # noqa: F811
                      duts_minigraph_facts, toggle_all_simulator_ports_to_rand_selected_tor_m,       # noqa: F811
                      mux_status_from_nic_simulator, setup_standby_ports_on_rand_unselected_tor,     # noqa: F811
-                     request):                                                                      # noqa: F811
+                     ecmp_inner_header_hash_supported, request):                                    # noqa: F811
     # Only run this test on T1 or T0 (including dualtor) topologies
     pytest_require(tbinfo['topo']['type'] in ['t1', 't0'], "The test case runs on T1 or T0 topology")
     logging.info(f"Topology type: {tbinfo['topo']['type']}")
@@ -636,6 +660,7 @@ def test_ipinip_hash(add_default_route_to_dut, duthost, duthosts,               
                        "ipver": ipver,
                        "topo_name": tbinfo['topo']['name'],
                        "is_v6_topo": is_ipv6_only_topology(tbinfo),
+                       "ecmp_inner_header_hash_supported": ecmp_inner_header_hash_supported,
                        },
                log_file=log_file,
                qlen=PTF_QLEN,
@@ -759,7 +784,8 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                     ignore_ttl, single_fib_for_duts, duts_running_config_facts,             # noqa: F811
                     duts_minigraph_facts, request,                                          # noqa: F811
                     setup_active_active_ports, active_active_ports,                         # noqa: F811
-                    mux_status_from_nic_simulator):                                         # noqa: F811
+                    mux_status_from_nic_simulator,                                          # noqa: F811
+                    ecmp_inner_header_hash_supported):                                      # noqa: F811
 
     fib_files = fib_info_files_per_function(duthosts, ptfhost, duts_running_config_facts, duts_minigraph_facts,
                                             tbinfo, request)
@@ -806,6 +832,7 @@ def test_nvgre_hash(add_default_route_to_dut, duthost, duthosts,                
                        "topo_name": tbinfo['topo']['name'],
                        "topo_type": tbinfo['topo']['type'],
                        "is_v6_topo": is_ipv6_only_topology(tbinfo),
+                       "ecmp_inner_header_hash_supported": ecmp_inner_header_hash_supported,
                        },
                log_file=log_file,
                qlen=PTF_QLEN,


### PR DESCRIPTION
### Description of PR
Check if inner header hashing is supported before checking the ECMP balancing in test_everflow_testbed.

Fixes sonic-net/sonic-mgmt#22198

### Type of change
- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Some platforms may not support inner header hashing for ECMP. The test should check for this capability before verifying ECMP balancing.

#### How did you do it?
Added `ecmp_inner_header_hash_supported` fixture and capability check before calling `check_balancing` in `IPinIPHashTest` and `NvgreHashTest`.

#### How did you verify/test it?
Tested on hardware testbed.
