### PR TITLE
Upload a testbed topology configuration file designed for OCS testing environments 

### DIFF
--- a/ansible/testbed_ocs.yaml
+++ b/ansible/testbed_ocs.yaml
@@ -1,0 +1,16 @@
+---
+
+- conf-name: single-dut-ocs-testbed-demo
+  group-name: ptf_2
+  topo: ocs
+  ptf_image_name: docker-ptf
+  ptf: ptf_2
+  ptf_ip: 10.250.0.189/24
+  ptf_ipv6: 2001:db8:1::189
+  mgmt_gw: 10.250.0.1
+  server: vm_host
+  dut:
+    - mgmt141
+  inv_name: ocs
+  vm_type: vsonic
+  comment: used to test ocs device


### PR DESCRIPTION
## Summary
Add a new testbed configuration file `testbed_ocs_new.yaml` for OCS (Open Compute System) device testing.

## Description
This testbed configuration file is used to set up a single-dut OCS testbed environment with the following settings:

- **Topology**: OCS
- **PTF Container**: docker-ptf
- **Management IP**: 10.250.0.189/24
- **IPv6 Management**: 2001:db8:1::189
- **Management Gateway**: 10.250.0.1
- **DUT**: mgmt141
- **VM Type**: vsonic

## Usage
This configuration can be used with the existing sonic-mgmt testbed scripts to deploy and test OCS devices.

## Files Added
- `ansible/testbed_ocs_new.yaml`