### PR TITLE
iface_namingmode: fix native_speed to read from CONFIG_DB instead of platform files

### DIFF
--- a/tests/iface_namingmode/test_iface_namingmode.py
+++ b/tests/iface_namingmode/test_iface_namingmode.py
@@ -194,7 +194,11 @@ def sample_intf(setup, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
         setup: Fixture defined in this module
     Returns:
         sample_intf: a dictionary containing the alias, name and native
-        speed of the test interface
+        speed of the test interface. 'native_speed' is read from CONFIG_DB
+        to reflect the speed actually configured on the interface before the
+        test runs. This ensures restore and verify operations leave the testbed
+        exactly as found, even when the operator has configured a speed that
+        differs from the platform file (e.g. due to fanout hardware limits).
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
     minigraph_interfaces = setup['minigraph_facts']['minigraph_interfaces']
@@ -220,8 +224,16 @@ def sample_intf(setup, duthosts, enum_rand_one_per_hwsku_frontend_hostname):
     interface_info['default'] = interface
     interface_info['asic_index'] = asic_index
     interface_info['alias'] = setup['port_name_map'][interface]
-    interface_info['native_speed'] = setup['port_speed'][interface_info['alias']]
     interface_info['cli_ns_option'] = duthost.asic_instance(asic_index).cli_ns_option
+
+    # Read native_speed from CONFIG_DB rather than from the platform files.
+    # The platform file value may not match the actual configured speed when
+    # the testbed operator has set a different speed (e.g. a 400G port running
+    # at 100G because the fanout does not support 400G). Using the CONFIG_DB
+    # value ensures that speed restore and verification use the pre-test state.
+    db_cmd = 'sudo {} CONFIG_DB HGET "PORT|{}" speed'.format(
+        duthost.asic_instance(asic_index).sonic_db_cli, interface)
+    interface_info['native_speed'] = duthost.shell(db_cmd)['stdout'].strip()
 
     return interface_info
 
@@ -1096,6 +1108,7 @@ class TestConfigInterface():
         interface = sample_intf['default']
         interface_ip = sample_intf['ip']
         native_speed = sample_intf['native_speed']
+
         cli_ns_option = sample_intf['cli_ns_option']
         asic_index = sample_intf['asic_index']
 
@@ -1105,6 +1118,8 @@ class TestConfigInterface():
             duthost.shell('config interface {} ip add {} {}'.format(cli_ns_option, interface, interface_ip))
 
         duthost.shell('config interface {} startup {}'.format(cli_ns_option, interface))
+        # Restore to the speed that was configured before this test class ran
+        # to avoid corrupting testbed configuration.
         if self.check_speed_change(duthost, asic_index, interface, native_speed):
             duthost.shell('config interface {} speed {} {}'.format(cli_ns_option, interface, native_speed))
 
@@ -1230,13 +1245,16 @@ class TestConfigInterface():
         test_intf = sample_intf[mode]
         interface = sample_intf['default']
         native_speed = sample_intf['native_speed']
+
         cli_ns_option = sample_intf['cli_ns_option']
         asic_index = sample_intf['asic_index']
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
         # Get supported speeds for interface
         supported_speeds = duthost.get_supported_speeds(interface)
-        # Remove native speed from supported speeds
-        if supported_speeds is not None:
+        # Remove native_speed from supported speeds to pick a different speed to test with.
+        # native_speed is read from CONFIG_DB so this remove() is safe even when the
+        # testbed is configured at a non-platform-default speed.
+        if supported_speeds is not None and native_speed in supported_speeds:
             supported_speeds.remove(native_speed)
         # Set speed to configure
         configure_speed = supported_speeds[0] if supported_speeds else native_speed
@@ -1269,6 +1287,7 @@ class TestConfigInterface():
             "Expected speed: '{}', actual speed: '{}'."
         ).format(configure_speed, speed)
 
+        # Restore to the pre-test configured speed.
         out = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} sudo config interface {}  speed {} {}'.format(
             ifmode, cli_ns_option, test_intf, native_speed))
         if out['rc'] != 0:
@@ -1278,9 +1297,18 @@ class TestConfigInterface():
         logger.info('speed: {}'.format(speed))
 
         assert speed == native_speed, (
-            "Interface speed mismatch after restoring to native speed. "
-            "Expected native speed: '{}', actual speed: '{}'."
+            "Interface speed mismatch after restoring to pre-test speed. "
+            "Expected current speed: '{}', actual speed: '{}'."
         ).format(native_speed, speed)
+
+        # Verify the link comes back up after speed restore. Without this check a bad
+        # restore (e.g. fanout does not support the target speed) would silently leave
+        # the interface down and cause a confusing failure in the next test case.
+        pytest_assert(
+            wait_until(PORT_TOGGLE_TIMEOUT, 2, 0, duthost.links_status_up, [interface]),
+            "Interface '{}' did not come back up after restoring speed to '{}'.".format(
+                interface, native_speed)
+        )
 
     def test_config_interface_speed_40G_100G(self, setup_config_mode, sample_intf, duthosts, fanouthosts,
                                              enum_rand_one_per_hwsku_frontend_hostname):
@@ -1288,6 +1316,7 @@ class TestConfigInterface():
         test_intf = sample_intf[mode]
         interface = sample_intf['default']
         native_speed = sample_intf['native_speed']
+
         cli_ns_option = sample_intf['cli_ns_option']
         asic_index = sample_intf['asic_index']
         duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
@@ -1301,6 +1330,7 @@ class TestConfigInterface():
         if 'arista' in duthost.facts.get('platform', '').lower():
             pytest.skip("Skip Arista platform for now.")
 
+        # Skip if the interface does not support toggling between 40G and 100G.
         if native_speed not in speeds_to_test:
             pytest.skip("Native speed is not 100G or 40G, it is {}".format(native_speed))
 
@@ -1354,7 +1384,7 @@ class TestConfigInterface():
             )
             # With DUT speed verified and link up, the fanout speed can be safely assumed correct.
 
-        # Save native (i.e. pre-test) FEC config
+        # Save pre-test FEC config
         native_fec = duthost.get_port_fec(interface)
         logger.info(f"Native speed: {native_speed}, Native FEC: {native_fec}")
 


### PR DESCRIPTION
### Description of PR

Summary:
`native_speed` in the `sample_intf` fixture was read from `port_config.ini` / platform files. Tests in `TestConfigInterface` used it as the restore target and ground-truth assertion for interface speed.

This breaks on testbeds where the interface is intentionally configured at a speed different from the platform default ΓÇö for example, a 400G port running at 100G because the fanout does not support 400G. In that case, `test_config_interface_speed` restores the interface to the platform speed (400G), which the fanout cannot negotiate, leaving the interface link-down. The next test `test_config_interface_state` then fails with a misleading admin/oper state error, completely unrelated to the actual root cause.

Additionally, `supported_speeds.remove(native_speed)` can raise an unhandled `ValueError` if the platform speed is absent from the driver supported-speed list.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
On testbeds where the interface speed in CONFIG_DB differs from the platform file (e.g. due to fanout hardware limitations), `test_config_interface_speed` was restoring the interface to the wrong speed, leaving it link-down and causing a cascading failure in `test_config_interface_state`.

#### How did you do it?
- Read `native_speed` from `CONFIG_DB` (`PORT|<intf> speed`) in `sample_intf` fixture instead of `port_alias_facts['port_speed']` (platform file). This ensures `native_speed` always reflects the actual pre-test configured speed.
- Add an `in` guard before `supported_speeds.remove(native_speed)` in `test_config_interface_speed` to prevent a `ValueError` crash.
- Add `wait_until(links_status_up)` after speed restore in `test_config_interface_speed` so a bad restore is caught immediately with a clear diagnostic message, rather than silently leaving the interface down for subsequent tests.

#### How did you verify/test it?
Verified on Cisco-8101-O8V48 testbed (str3-8101-04, t1 topology, SONiC 20251110.18) via Elastictest:
- [Elastictest run](https://elastictest.org/scheduler/testplan/69ccbad0eb4653619e057708) - test_config_interface_state[default] **PASSED** (previously 0% pass rate over 60+ days on this hwsku).
- test_config_interface_state[alias] continues to pass.
- test_config_interface_speed correctly restores to CONFIG_DB speed (100G) instead of platform default (200G).

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A

Signed-off-by: zitingguo <zitingguo@microsoft.com>
