### PR TITLE
Fix VLAN_INTERFACE iteration in bgp test templates

### DIFF
--- a/tests/bgp/templates/bgp_no_export.j2
+++ b/tests/bgp/templates/bgp_no_export.j2
@@ -57,7 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock bgp_init %}
 {% endif %}
 {% block vlan_advertisement %}
-{% for (name, prefix) in VLAN_INTERFACE %}
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %}
   network {{ prefix }}
 {% elif prefix | ipv6 %}

--- a/tests/bgp/templates/bgp_plain.j2
+++ b/tests/bgp/templates/bgp_plain.j2
@@ -49,7 +49,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock bgp_init %}
 {% endif %}
 {% block vlan_advertisement %}
-{% for (name, prefix) in VLAN_INTERFACE %}
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %}
   network {{ prefix }}
 {% elif prefix | ipv6 %}


### PR DESCRIPTION
Summary: Fix VLAN_INTERFACE iteration in bgp test templates
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
test_bgp_bounce fails. When BGP service restarts during the test, sonic-cfggen fails to render the bgp_plain.j2 and bgp_no_export.j2 templates with ValueError: too many values to unpack (expected 2) at the VLAN_INTERFACE iteration. This is because the VLAN_INTERFACE table in Config DB contains both interface-level entries (e.g. `VLAN_INTERFACE|Vlan55`) and IP address entries (e.g. `VLAN_INTERFACE|Vlan55|20.0.200.254/24`). 
The template pattern for (name, prefix) in VLAN_INTERFACE cannot unpack entries that don't have exactly 2 fields. Since template rendering fails, the no-export BGP config is never actually applied, causing the test to always fail at the second assertion.

```
admin@router:~$ redis-cli -n 4 keys "VLAN_INTERFACE*"
1) "VLAN_INTERFACE|Vlan55|20.0.200.254/24"
2) "VLAN_INTERFACE|Vlan55"        <<<
```

#### How did you do it?
Added pfx_filter to the VLAN_INTERFACE iteration in both bgp_plain.j2 and bgp_no_export.j2, changing `{% for (name, prefix) in VLAN_INTERFACE %}` to `{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}`. The pfx_filter filters out interface-level entries that don't contain IP addresses and only returns (name, prefix) tuples. This is consistent with how LOOPBACK_INTERFACE is already handled in the same templates.

#### How did you verify/test it?
Regression pass

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
