### PR TITLE
Skip liquid cooling leakage tests on m0, mx, m1, c0 topologies

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml
@@ -382,6 +382,15 @@ platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_spe
       - https://github.com/sonic-net/sonic-mgmt/issues/6512
 
 #######################################
+#####   test_liquid_cooling_leakage.py   #####
+#######################################
+platform_tests/api/test_liquid_cooling_leakage.py:
+  skip:
+    reason: "Liquid cooling leakage tests not applicable to m0, mx, m1, c0 topologies"
+    conditions:
+      - "topo_type in ['m0', 'mx', 'm1', 'c0']"
+
+#######################################
 ##### api/test_module.py #####
 #######################################
 platform_tests/api/test_module.py:
@@ -1242,6 +1251,15 @@ platform_tests/test_kdump.py:
     reason: "Not supported on Nokia-7215 platform"
     conditions:
       - "platform in ['armhf-nokia_ixs7215_52x-r0']"
+
+#######################################
+#####   test_liquid_cooling_leakage_detection.py   #####
+#######################################
+platform_tests/test_liquid_cooling_leakage_detection.py:
+  skip:
+    reason: "Liquid cooling leakage detection tests not applicable to m0, mx, m1, c0 topologies"
+    conditions:
+      - "topo_type in ['m0', 'mx', 'm1', 'c0']"
 
 #######################################
 ####  test_memory_exhaustion.py   #####


### PR DESCRIPTION
### Description of PR

Skip liquid cooling leakage tests (`test_liquid_cooling_leakage.py` and `test_liquid_cooling_leakage_detection.py`) on m0, mx, m1, c0 topologies by adding conditional mark entries to `tests_mark_conditions_platform_tests.yaml`.

These tests require physical liquid cooling hardware (leak sensors) and are not applicable to m0/mx/m1/c0 topology testbeds which don't have liquid cooling systems.

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

Liquid cooling leakage tests are marked with `pytest.mark.topology('any')`, so they get collected on all topologies including m0, mx, m1, and c0. These tests always fail on those topologies since the DUTs don't have liquid cooling hardware, resulting in unnecessary noise in nightly test results.

#### How did you do it?

Added skip conditions in `tests/common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml` for both test files:
- `platform_tests/api/test_liquid_cooling_leakage.py`
- `platform_tests/test_liquid_cooling_leakage_detection.py`

Condition: `topo_type in ['m0', 'mx', 'm1', 'c0']`

#### How did you verify/test it?

Ran both test files on an Arista-720DT mx topology testbed with `--mark-conditions-files` pointing to the updated conditions file. All 7 tests were correctly skipped:

```
$ pytest platform_tests/api/test_liquid_cooling_leakage.py platform_tests/test_liquid_cooling_leakage_detection.py \
    --mark-conditions-files common/plugins/conditional_mark/tests_mark_conditions_platform_tests.yaml -v

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
collected 7 items

platform_tests/api/test_liquid_cooling_leakage.py::TestLiquidCoolingLeakage::test_get_name[dut-1] SKIPPED [ 14%]
platform_tests/api/test_liquid_cooling_leakage.py::TestLiquidCoolingLeakage::test_is_leak[dut-1] SKIPPED [ 28%]
platform_tests/api/test_liquid_cooling_leakage.py::TestLiquidCoolingLeakage::test_get_leak_sensor_status[dut-1] SKIPPED [ 42%]
platform_tests/api/test_liquid_cooling_leakage.py::TestLiquidCoolingLeakage::test_get_num_leak_sensors[dut-1] SKIPPED [ 57%]
platform_tests/api/test_liquid_cooling_leakage.py::TestLiquidCoolingLeakage::test_get_all_leak_sensors[dut-1] SKIPPED [ 71%]
platform_tests/test_liquid_cooling_leakage_detection.py::test_verify_liquid_senors_number_and_status[dut-1] SKIPPED [ 85%]
platform_tests/test_liquid_cooling_leakage_detection.py::test_mock_liquid_leak_event[dut-1] SKIPPED [100%]

================= 7 skipped, 148 warnings in 141.93s (0:02:21) =================
```

#### Any platform specific information?

N/A — this applies to all platforms running on m0, mx, m1, or c0 topologies.

#### Supported testbed topology if it's a new test case?

N/A — this is a skip condition change, not a new test case.

### Documentation

N/A
