### PR TITLE
Skip test_get_error_description test on all ports admin down sfp

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -995,8 +995,14 @@ class TestSfpApi(PlatformApiTestBase):
         """This function tests get_error_description() API (supported on 202106 and above)"""
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         skip_release(duthost, ["201811", "201911", "202012"])
+        admin_up_port_set = set(duthost.get_admin_up_ports())
 
         for i in self.sfp_setup["sfp_test_port_indices"]:
+            current_ports_set = set(self.sfp_setup["index_physical_port_map"][i])
+            if admin_up_port_set.isdisjoint(current_ports_set):
+                logger.warning(f"test_get_error_description: Skipping transceiver {i} as ports are not admin up:"
+                               f"{current_ports_set}")
+                continue
             error_description = sfp.get_error_description(platform_api_conn, i)
             if self.expect(error_description is not None,
                            "Unable to retrieve transceiver {} error description".format(i)):


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On the all ports admin down sfp, the output of api get_error_description is not stable, may be not 'OK'. When the port is optical, the get_error_description may be DataPathDeactivated.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
On the all ports admin down sfp, the output of api get_error_description is not stable, may be not 'OK'. When the port is optical, the get_error_description may be DataPathDeactivated.
#### How did you do it?
Skip the check on this kind of port
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
