### PR TITLE
Update the ecn mode test on dualtor setup

### DIFF
--- a/tests/decap/mellanox/conftest.py
+++ b/tests/decap/mellanox/conftest.py
@@ -12,7 +12,7 @@ ECN_MODE_LIST = [(2, 3)]
 
 
 @pytest.fixture(scope='module')
-def prepare_param(rand_selected_dut, ptfadapter, downstream_links, upstream_links, request):  # noqa F811
+def prepare_param(rand_selected_dut, ptfadapter, downstream_links, upstream_links, tbinfo, request):  # noqa F811
     prepare_param = {}
     prepare_param['outer_dst_mac'] = rand_selected_dut.facts["router_mac"]
     prepare_param['outer_src_ip'] = '100.0.0.1'
@@ -31,9 +31,11 @@ def prepare_param(rand_selected_dut, ptfadapter, downstream_links, upstream_link
     assert uplink_ptf_ports, "No uplink found"
     assert prepare_param['outer_dst_mac'], "No router MAC found"
 
-    prepare_param['ptf_downlink_port'] = downlink.get("ptf_port_id")
+    prepare_param['ptf_src_port'] = downlink.get("ptf_port_id")
+    if "dualtor-aa" in tbinfo["topo"]["name"]:
+        prepare_param['ptf_src_port'] = random.choice(uplink_ptf_ports)
     prepare_param['ptf_uplink_ports'] = uplink_ptf_ports
 
-    prepare_param['outer_src_mac'] = ptfadapter.dataplane.get_mac(0, prepare_param['ptf_downlink_port']).decode('utf-8')
+    prepare_param['outer_src_mac'] = ptfadapter.dataplane.get_mac(0, prepare_param['ptf_src_port']).decode('utf-8')
 
     return prepare_param

--- a/tests/decap/mellanox/test_ecn_mode.py
+++ b/tests/decap/mellanox/test_ecn_mode.py
@@ -40,15 +40,6 @@ def skip_non_mellanox(rand_selected_dut):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def skip_unsupported_image(rand_selected_dut):
-    """
-    The test would skip master image due to its ecn mode is not stable and no need to test
-    """
-    if rand_selected_dut.sonichost.sonic_release == MASTER_BRANCH:
-        pytest.skip("Skip test because the ecn_mode at master branch is not stable and no need to test")
-
-
-@pytest.fixture(scope="module", autouse=True)
 def restore_image(localhost, rand_selected_dut, request, tbinfo):
     restore_to_image = request.config.getoption('restore_to_image')
 
@@ -191,7 +182,7 @@ class TestECNMode:
             self.send_verify_ipinip_packet(ptfadapter=ptfadapter,
                                            pkt=pkt,
                                            exp_pkt=exp_pkt,
-                                           ptf_src_port_id=self.params['ptf_downlink_port'],
+                                           ptf_src_port_id=self.params['ptf_src_port'],
                                            ptf_dst_port_ids=self.params['ptf_uplink_ports'])
 
     def _check_bgp_route(self, duthost):
@@ -235,13 +226,11 @@ class TestECNMode:
             current_branch = rand_selected_dut.command(RELEASE_CMD)['stdout_lines'][0].strip()
 
         if current_branch:
-            if current_branch != "none" and current_branch != MASTER_BRANCH:
-                with allure.step("Verify ECN mode"):
-                    if current_branch < ECN_MODE_CHANGE_VERSION:
-                        self.verify_ecn_mode(rand_selected_dut, ptfadapter, self.ECN_MODE_STANDARD)
-                    else:
-                        self.verify_ecn_mode(rand_selected_dut, ptfadapter, self.ECN_MODE_COPY_FROM_OUTER)
-            else:
-                pytest.skip("Skip test because the ecn_mode at master branch is not stable and no need to test")
+            with allure.step("Verify ECN mode"):
+                if current_branch < ECN_MODE_CHANGE_VERSION:
+                    self.verify_ecn_mode(rand_selected_dut, ptfadapter, self.ECN_MODE_STANDARD)
+                else:
+                    self.verify_ecn_mode(rand_selected_dut, ptfadapter, self.ECN_MODE_COPY_FROM_OUTER)
+
         else:
             raise ValueError(f"Failed to get SONiC branch : {current_branch}")


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
1.Update the ecn mode test on dualtor setup
Pick one upstream port as source ptf port when sending traffic to trigger ip in ip tunnel decap action on dualtor setup

2.Execute ecn mode test on master image
Remove the skip condition on master branch image for ecn mode test

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
1. The IPinIP tunnel would not decap the IPinIP packet from downstream to upstream on dualtor setup.
2. The test should be run on master branch image.
#### How did you do it?
1. Update the script to send IPinIP packet from upstream port on dualtor setup.
2. Run the test on master branch image.
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
