### PR TITLE
Add sai FEC attribute error ignore patterns to loganalyzer

### DIFF
--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_common_ignore.txt
@@ -46,6 +46,15 @@ r, ".* ERR swss#orchagent: :- queryHashNativeHashFieldListAttrCapabilities: Fail
 r, ".* ERR swss#orchagent: :- querySwitchEcmpHashAlgorithmEnumCapabilities: Failed to get attribute.*"
 r, ".* ERR swss#orchagent: :- querySwitchLagHashAlgorithmEnumCapabilities: Failed to get attribute.*"
 r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.* failed with error Feature unavailable.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters_acc.*Get Port Phy Control FEC Symbol Error Count.*failed with error Operation disabled \(0xfffffff4\).*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*port info data get failed with error -2.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn.*Fec Alignment lock status failed.*with error -8.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_port_get_fec_alignment_lock_status.*FEC AM is not supported.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:brcm_sai_get_port_attribute_cmn.*Fec Alignment lock status failed.*with error -327680.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC RS Bit Error Count failed - port:.*rc: -16.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC Uncorrected Block Count failed - port:.*rc: -16.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC Corrected Block Count failed - port:.*rc: -16.*"
+r, ".* ERR syncd\d*#syncd.*SAI_API_PORT:_brcm_sai_read_fec_stat_err_counters.*Get Port Phy Control FEC Symbol Error Count failed - port:.*rc: -16.*"
 
 # White list below messages found on KVM for now. Need to address them later.
 r, ".* ERR macsec\d*#wpa_supplicant.*l2_packet_send.*Network is down.*"


### PR DESCRIPTION
### Description of PR
Add ignore patterns for known FEC-related SAI_API_PORT errors that don't impact functionality. These are called as part of standard capability tests.
  - FEC Symbol Error Count with Operation disabled (0xfffffff4)
  - FEC stat counters with SAI_STATUS_NOT_SUPPORTED (-2)
  - FEC Alignment lock status with SAI_STATUS_BUFFER_OVERFLOW (-8)
  - FEC AM not supported for port
  - FEC Alignment lock status with SAI_STATUS_ATTR_NOT_SUPPORTED_0 (-327680)
  - FEC RS Bit Error Count failed with rc: -16 (SAI_STATUS_ADDR_NOT_FOUND)
  - FEC Uncorrected Block Count failed with rc: -16
  - FEC Corrected Block Count failed with rc: -16
  - FEC Symbol Error Count failed with rc: -16
  - FEC RS Bit Error Count failed with rc: -16
  - FEC Uncorrected Block Count failed with rc: -16
  - FEC Corrected Block Count failed with rc: -16
  - FEC Symbol Error Count failed with rc: -16

  These errors occur on ports where FEC is not enabled or not supported
  and should not cause test failures.


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?

#### How did you do it?
Added ignore logs for logre

#### How did you verify/test it?
manually test case, and running python regex matches

#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
