### PR TITLE
Add one check for lossy pg hd watermark

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -48,6 +48,20 @@ PROCESS_TO_CONTAINER_MAP = {
     "syncd": "syncd"
 }
 UNKNOWN_ASIC = "unknown"
+COUNTER_TYPE_CLI_MAP = {
+    'QUEUE_STAT': 'queue',
+    'PORT_STAT': 'port',
+    'SWITCH_STAT': 'switch',
+    'PORT_BUFFER_DROP': 'port-buffer-drop',
+    'RIF_STAT': 'rif',
+    'QUEUE_WATERMARK_STAT': 'watermark',
+    'PG_WATERMARK_STAT': 'watermark',
+    'BUFFER_POOL_WATERMARK_STAT': 'watermark',
+    'ACL': 'acl',
+    'TUNNEL_STAT': 'tunnel',
+    'FLOW_CNT_TRAP_STAT': 'flowcnt-trap',
+    'FLOW_CNT_ROUTE_STAT': 'flowcnt-route'
+}
 
 
 class SonicHost(AnsibleHostBase):
@@ -2758,27 +2772,20 @@ Totals               6450                 6449
             result_dict[counter_type]['status'] = status
         return result_dict
 
+    def set_counter_poll_status(self, counter_type, status):
+        """
+        A function to config the status of counterpoll.
+        """
+        cmd = 'counterpoll {} {}'.format(COUNTER_TYPE_CLI_MAP[counter_type], status)
+        self.shell(cmd)
+
     def set_counter_poll_interval(self, counter_type, interval, wait_for_new_interval=True):
         """
         A function to config the interval of counterpoll. The counter type should be a key of
         the 'counterpoll show' cli output.
         """
-        counter_type_cli_map = {
-            'QUEUE_STAT': 'queue',
-            'PORT_STAT': 'port',
-            'SWITCH_STAT': 'switch',
-            'PORT_BUFFER_DROP': 'port-buffer-drop',
-            'RIF_STAT': 'rif',
-            'QUEUE_WATERMARK_STAT': 'watermark',
-            'PG_WATERMARK_STAT': 'watermark',
-            'BUFFER_POOL_WATERMARK_STAT': 'watermark',
-            'ACL': 'acl',
-            'TUNNEL_STAT': 'tunnel',
-            'FLOW_CNT_TRAP_STAT': 'flowcnt-trap',
-            'FLOW_CNT_ROUTE_STAT': 'flowcnt-route'
-        }
         origin_interval = self.get_counter_poll_status()[counter_type]['interval']
-        cmd = 'counterpoll {} interval {}'.format(counter_type_cli_map[counter_type], interval)
+        cmd = 'counterpoll {} interval {}'.format(COUNTER_TYPE_CLI_MAP[counter_type], interval)
         self.shell(cmd)
         # Sleep for the old interval for the new interval to take effect
         if wait_for_new_interval:

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -47,6 +47,7 @@ from tests.common.helpers.ptf_tests_helper import (downstream_links, upstream_li
                                                    fetch_test_logs_ptf)
 from tests.common.utilities import get_ipv4_loopback_ip
 from tests.common.helpers.base_helper import read_logs
+from tests.common.mellanox_data import is_mellanox_device
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,26 @@ PTF_PORT_MAPPING_MODE = 'use_orig_interface'
 DUMMY_OUTER_SRC_IP = '8.8.8.8'
 DUMMY_INNER_SRC_IP = '9.9.9.9'
 DUMMY_INNER_DST_IP = '10.10.10.10'
+# SAI profile key for lossy headroom counter (PG xoff headroom watermark)
+SAI_KEY_INGRESS_PG_XOFF_STAT_LOSSY_HR_ENABLED = "SAI_KEY_INGRESS_PG_XOFF_STAT_LOSSY_HR_ENABLED=1"
+
+
+def _sai_profile_has_lossy_hr_enabled(duthost):
+    """Check if sai.profile on DUT has SAI_KEY_INGRESS_PG_XOFF_STAT_LOSSY_HR_ENABLED=1."""
+    if not is_mellanox_device(duthost):
+        return False
+    platform = duthost.facts.get("platform")
+    hwsku = duthost.facts.get("hwsku")
+    if not platform or not hwsku:
+        return False
+    sai_profile_path = f"/usr/share/sonic/device/{platform}/{hwsku}/sai.profile"
+    try:
+        out = duthost.shell(f"cat {sai_profile_path}", module_ignore_errors=True)
+        if out["rc"] != 0:
+            return False
+        return SAI_KEY_INGRESS_PG_XOFF_STAT_LOSSY_HR_ENABLED in out.get("stdout", "")
+    except Exception:
+        return False
 
 
 @pytest.fixture(autouse=True)
@@ -1256,10 +1277,46 @@ class TestQosSai(QosSaiBase):
         if "pkts_num_margin" in list(qosConfig["lossy_queue_1"].keys()):
             testParams["pkts_num_margin"] = qosConfig["lossy_queue_1"]["pkts_num_margin"]
 
+        duthost = get_src_dst_asic_and_duts["src_dut"]
+        enable_lossy_pg_headroom = _sai_profile_has_lossy_hr_enabled(duthost)
+
+        if enable_lossy_pg_headroom:
+            clear_pg_headroom_cmd = "sudo sonic-clear priority-group watermark headroom"
+            duthost.shell(clear_pg_headroom_cmd)
+            logger.info("Cleared PG headroom watermark before LossyQueueTest (lossy HR enabled)")
+
         self.runPtfTest(
             ptfhost, testCase="sai_qos_tests.LossyQueueTest",
             testParams=testParams
         )
+
+        def check_lossy_pg_hd_watermark(duthost, src_port_name, show_cmd, packet_size):
+            pg0_headroom = 0
+            pg_headroom_counter = duthost.show_and_parse(show_cmd, start_line_index=1)
+            for counter_info in pg_headroom_counter:
+                if counter_info["port"] == src_port_name:
+                    pg0_headroom = int(counter_info["pg0"])
+                    break
+            else:
+                pytest.fail("Failed to find PG0 headroom watermark for port {}".format(src_port_name))
+            pytest_assert(
+                pg0_headroom is not None and pg0_headroom >= packet_size,
+                "When SAI_KEY_INGRESS_PG_XOFF_STAT_LOSSY_HR_ENABLED=1, PG0 headroom watermark on {} ({}) "
+                "must be >= packet_size ({}).".format(
+                    src_port_name, pg0_headroom if pg0_headroom is not None else "N/A", packet_size
+                )
+            )
+
+        if enable_lossy_pg_headroom:
+            packet_size = int(testParams["packet_size"])
+            src_port_id = dutConfig["testPorts"]["src_port_id"]
+            src_port_name = dutConfig["dutInterfaces"][src_port_id]
+
+            show_pg_headroom_cmd = "show priority-group watermark headroom"
+            check_lossy_pg_hd_watermark(duthost, src_port_name, show_pg_headroom_cmd, packet_size)
+
+            show_pg_persistent_hd_watermark_cmd = "show priority-group persistent-watermark headroom"
+            check_lossy_pg_hd_watermark(duthost, src_port_name, show_pg_persistent_hd_watermark_cmd, packet_size)
 
     @pytest.mark.parametrize("LossyVoq", ["lossy_queue_voq_1", "lossy_queue_voq_2"])
     def testQosSaiLossyQueueVoq(

--- a/tests/qos/test_qos_sai.py
+++ b/tests/qos/test_qos_sai.py
@@ -83,6 +83,27 @@ def _sai_profile_has_lossy_hr_enabled(duthost):
         return False
 
 
+@pytest.fixture(autouse=False)
+def enable_lossy_pg_headroom(get_src_dst_asic_and_duts):
+    duthost = get_src_dst_asic_and_duts["src_dut"]
+    is_enable_lossy_pg_headroom = _sai_profile_has_lossy_hr_enabled(duthost)
+    if is_enable_lossy_pg_headroom:
+        watermark_stat_type = "PG_WATERMARK_STAT"
+        original_interval = duthost.get_counter_poll_status()[watermark_stat_type]["interval"]
+        original_status = duthost.get_counter_poll_status()[watermark_stat_type]["status"]
+        if original_status == "disable":
+            duthost.set_counter_poll_status(watermark_stat_type, "enable")
+        new_poll_interval = 5000  # 5 seconds
+        duthost.set_counter_poll_interval(watermark_stat_type, new_poll_interval)
+
+    yield is_enable_lossy_pg_headroom
+
+    if is_enable_lossy_pg_headroom:
+        duthost.set_counter_poll_interval(watermark_stat_type, original_interval)
+        if original_status == "disable":
+            duthost.set_counter_poll_status(watermark_stat_type, "disable")
+
+
 @pytest.fixture(autouse=True)
 def ignore_expected_loganalyzer_exception(get_src_dst_asic_and_duts, loganalyzer, duthosts):
     """ignore the syslog ERR syncd0#syncd: [03:00.0] brcm_sai_set_switch_
@@ -1211,7 +1232,8 @@ class TestQosSai(QosSaiBase):
 
     def testQosSaiLossyQueue(
         self, ptfhost, get_src_dst_asic_and_duts, dutTestParams, dutConfig, dutQosConfig,
-        ingressLossyProfile, skip_src_dst_different_asic, change_lag_lacp_timer, blockGrpcTraffic
+        ingressLossyProfile, skip_src_dst_different_asic, change_lag_lacp_timer, blockGrpcTraffic,
+        enable_lossy_pg_headroom
     ):
         """
             Test QoS SAI Lossy queue, shared buffer dynamic allocation
@@ -1278,7 +1300,6 @@ class TestQosSai(QosSaiBase):
             testParams["pkts_num_margin"] = qosConfig["lossy_queue_1"]["pkts_num_margin"]
 
         duthost = get_src_dst_asic_and_duts["src_dut"]
-        enable_lossy_pg_headroom = _sai_profile_has_lossy_hr_enabled(duthost)
 
         if enable_lossy_pg_headroom:
             clear_pg_headroom_cmd = "sudo sonic-clear priority-group watermark headroom"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
When ingress lossy PG headroom (HR) is enabled, verify that the corresponding PG0 headroom watermark and persistent watermark is greater than or equal to the packet size sent to the test port.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
When ingress lossy PG headroom (HR) is enabled, verify that the corresponding PG0 headroom watermark and persistent watermark is greater than or equal to the packet size sent to the test port.

#### How did you do it?
Add one checker in the testQosSaiLossyQueue

#### How did you verify/test it?
run the test on device that enabling ingress lossy PG headroom

#### Any platform specific information?
Device enabling enabling ingress lossy PG headroom

#### Supported testbed topology if it's a new test case?


### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
