### PR TITLE
[HA] [smartswitch] call the flow compare utility

### DIFF
--- a/tests/ha/ha_dash_flow_utils.py
+++ b/tests/ha/ha_dash_flow_utils.py
@@ -14,7 +14,7 @@ def get_flow_array(flow_table):
 def parse_pdsctl_show_flow_output(output):
     keys = [
         "Session", "LookupId", "Dir", "SIP", "DIP",
-        "Proto", "Sport", "Dport", "Role", "Action"
+        "Proto", "Sport", "Dport", "Role", "Action", "Vni", "RegionId"
     ]
 
     lines = output.strip().splitlines()
@@ -48,8 +48,8 @@ def parse_pdsctl_show_flow_output(output):
 
 def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
     if 'pensando' not in dpuhost1.facts['asic_type'] or 'pensando' not in dpuhost2.facts['asic_type']:
-        logger.warning("Only Pensando is supported for this function")
-        return False
+        logger.warning("Only Pensando is supported - return true")
+        return True
 
     output1 = dpuhost1.shell("pdsctl show flow")["stdout"]
     output2 = dpuhost2.shell("pdsctl show flow")["stdout"]
@@ -63,8 +63,8 @@ def compare_flow_tables_pdsctl(dpuhost1, dpuhost2):
         logger.warning(f" flows table for {dpuhost2.hostname} is empty")
         return False
 
-    logger.debug(f"flows on primary: {flow_table1}")
-    logger.debug(f"flows on standby: {flow_table2}")
+    logger.info(f"flows on primary: {flow_table1}")
+    logger.info(f"flows on standby: {flow_table2}")
 
     if flow_table1 == flow_table2:
         logger.info(f" flows for {dpuhost1.hostname} and {dpuhost2.hostname} are identical")

--- a/tests/ha/test_ha_steady_state_pl.py
+++ b/tests/ha/test_ha_steady_state_pl.py
@@ -4,6 +4,7 @@ import configs.privatelink_config as pl
 import ptf.testutils as testutils
 import pytest
 import concurrent.futures
+from tests.common.helpers.assertions import pytest_assert
 from constants import LOCAL_PTF_INTF, REMOTE_PTF_RECV_INTF, REMOTE_PTF_SEND_INTF
 from gnmi_utils import apply_messages
 from packets import outbound_pl_packets, inbound_pl_packets
@@ -107,7 +108,6 @@ def test_privatelink_basic_transform(
     testutils.send(ptfadapter, dash_pl_config[0][LOCAL_PTF_INTF], vm_to_dpu_pkt, 1)
     testutils.verify_packet_any_port(ptfadapter, exp_dpu_to_pe_pkt, dash_pl_config[0][REMOTE_PTF_RECV_INTF])
     flow_op = compare_flow_tables_pdsctl(dpuhosts[0], dpuhosts[1])
-    if not flow_op:
-        logger.error("Flow tables are different")
+    pytest_assert(flow_op, "Expected identical flow tables on primary and standby")
     testutils.send(ptfadapter, dash_pl_config[0][REMOTE_PTF_SEND_INTF], pe_to_dpu_pkt, 1)
     testutils.verify_packet(ptfadapter, exp_dpu_to_vm_pkt, dash_pl_config[0][LOCAL_PTF_INTF])


### PR DESCRIPTION

### Description of PR
Summary:
Call the flow compare utility in the HA steady state test.
For HA, the DPUs in the primary and standby should have identical flows after packet flow starts. This is verified by this utility by running the "pdsctl show flow" command on the DPUs and compare the output.
The utility is only relevant for Pensando ASIC and will return True for any other platform.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Missing the call to verify that flows are identical

#### How did you do it?
Added a call to this utility
#### How did you verify/test it?
Tested on MtFuji
#### Any platform specific information?
MtFuji

#### Supported testbed topology if it's a new test case?
HA topology
### Documentation
N/A