### PR TITLE
bgp_update_timer_session_down: add wait instead of blind sleep for route

### DIFF
--- a/tests/bgp/test_bgp_update_timer.py
+++ b/tests/bgp/test_bgp_update_timer.py
@@ -460,9 +460,14 @@ def test_bgp_update_timer_session_down(
         for _, route in enumerate(constants.routes):
             withdraw_intervals.append(-1)
             n0.announce_route(route)
-            time.sleep(constants.sleep_interval)
-            dut_route = duthost.get_route(route["prefix"], n0.namespace)
-            if not dut_route:
+            # Route install can lag announce (suppress-fib-pending, slow orchagent). A fixed
+            # sleep is flaky; poll until the prefix appears in BGP like test_bgp_peer_shutdown.
+            if not wait_until(
+                WAIT_TIMEOUT,
+                5,
+                0,
+                lambda: bool(duthost.get_route(route["prefix"], n0.namespace)),
+            ):
                 pytest.fail("announce route %s from n0 to dut failed" % route["prefix"])
         # close bgp session n0, monitor withdraw info from dut to n1
         bgp_pcap = BGP_DOWN_LOG_TMPL


### PR DESCRIPTION
### Description of PR

Summary:
Fixes #
The test failed some of the time due to the blind "sleep" in checking the present of route download into fib. Changing it to timed wait to make the test more deterministic.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?

The test failed some of the time due to the blind "sleep" in checking the present of route download into fib. Changing it to timed wait to make the test more deterministic.

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation