### PR TITLE
bgpmon_tc1: Improve pre-test sanity and reload options to report more details

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -8,7 +8,7 @@ from tests.common.plugins.loganalyzer.utils import support_ignore_loganalyzer
 from tests.common.platform.processes_utils import wait_critical_processes
 from tests.common.utilities import wait_until
 from tests.common.configlet.utils import chk_for_pfc_wd
-from tests.common.platform.interface_utils import check_interface_status_of_up_ports
+from tests.common.platform.interface_utils import check_interface_status_of_up_ports, get_last_intf_up_ports_failure_detail
 from tests.common.helpers.dut_utils import ignore_t2_syslog_msgs
 
 logger = logging.getLogger(__name__)
@@ -316,8 +316,12 @@ def config_reload(sonic_host, config_source='config_db', wait=120, start_bgp=Tru
                 pytest_assert(wait_until(wait + 300, 20, 0, chk_for_pfc_wd, sonic_host),
                               "PFC_WD is missing in CONFIG-DB")
         if check_intf_up_ports:
-            pytest_assert(wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, sonic_host),
-                          "Not all ports that are admin up on are operationally up")
+            intf_ok = wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, sonic_host)
+            intf_detail = get_last_intf_up_ports_failure_detail(sonic_host)
+            intf_msg = "Not all ports that are admin up on are operationally up"
+            if intf_detail:
+                intf_msg = "{}. {}".format(intf_msg, intf_detail)
+            pytest_assert(intf_ok, intf_msg)
     else:
         time.sleep(wait)
 

--- a/tests/common/platform/interface_utils.py
+++ b/tests/common/platform/interface_utils.py
@@ -13,6 +13,8 @@ from collections import defaultdict
 from natsort import natsorted
 from .transceiver_utils import all_transceivers_detected
 
+logger = logging.getLogger(__name__)
+
 
 def parse_intf_status(lines):
     """
@@ -46,6 +48,14 @@ def parse_intf_status(lines):
     return result
 
 
+def get_last_intf_up_ports_failure_detail(duthost):
+    """
+    After check_interface_status_of_up_ports returns False, holds a human-readable
+    reason (set on duthost by that check). Used to enrich reboot/config_reload errors.
+    """
+    return getattr(duthost, "_last_intf_up_ports_failure_detail", "")
+
+
 def get_dut_interfaces_status(duthost):
     output = duthost.command("show interface description")
     intf_status = parse_intf_status(output["stdout_lines"][2:])
@@ -68,8 +78,17 @@ def check_interface_status_of_up_ports(duthost):
         up_ports = [p for p, v in list(cfg_facts['PORT'].items()) if v.get('admin_status', None) == 'up']
 
     intf_facts = duthost.interface_facts(up_ports=up_ports)['ansible_facts']
-    if len(intf_facts['ansible_interface_link_down_ports']) != 0:
+    down_ports = intf_facts.get("ansible_interface_link_down_ports") or []
+    if len(down_ports) != 0:
+        detail = (
+            "admin-up ports still link-down ({}): "
+            "{}".format(len(down_ports), ", ".join(down_ports))
+        )
+        duthost._last_intf_up_ports_failure_detail = detail
+        logger.error("%s: %s", duthost.hostname, detail)
         return False
+    if hasattr(duthost, "_last_intf_up_ports_failure_detail"):
+        delattr(duthost, "_last_intf_up_ports_failure_detail")
     return True
 
 

--- a/tests/common/plugins/sanity_check/checks.py
+++ b/tests/common/plugins/sanity_check/checks.py
@@ -402,6 +402,7 @@ def _check_monit_services_status(check_result, monit_services_status):
              and the status of each service.
     """
     check_result["services_status"] = {}
+    monit_failures = []
     for service_name, service_info in list(monit_services_status.items()):
         check_result["services_status"].update({service_name: service_info["service_status"]})
         if service_info["service_status"] == "Not monitored":
@@ -413,6 +414,23 @@ def _check_monit_services_status(check_result, monit_services_status):
                 or (service_info["service_type"] == "Process" and service_info["service_status"] != "Running")
                 or (service_info["service_type"] == "Program" and service_info["service_status"] != "Status ok")):
             check_result["failed"] = True
+            monit_failures.append({
+                "service": service_name,
+                "service_type": service_info["service_type"],
+                "service_status": service_info["service_status"],
+            })
+
+    if monit_failures:
+        check_result["monit_failures"] = monit_failures
+        check_result["failed_reason"] = "; ".join(
+            "{} ({}) is '{}'".format(m["service"], m["service_type"], m["service_status"])
+            for m in monit_failures
+        )
+        logger.error(
+            "Monit sanity check failed on %s: %s",
+            check_result.get("host", ""),
+            check_result["failed_reason"],
+        )
 
     return check_result
 

--- a/tests/common/reboot.py
+++ b/tests/common/reboot.py
@@ -10,7 +10,7 @@ from collections import deque
 
 from .helpers.assertions import pytest_assert
 from .helpers.parallel_utils import synchronized_reboot
-from .platform.interface_utils import check_interface_status_of_up_ports
+from .platform.interface_utils import check_interface_status_of_up_ports, get_last_intf_up_ports_failure_detail
 from .platform.processes_utils import wait_critical_processes
 from .plugins.loganalyzer.utils import support_ignore_loganalyzer
 from .utilities import wait_until, get_plt_reboot_ctrl, is_ipv6_address
@@ -451,8 +451,12 @@ def reboot(duthost, localhost, reboot_type='cold', delay=10,
         wait_critical_processes(duthost)
 
         if check_intf_up_ports:
-            pytest_assert(wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, duthost),
-                          "{}: Not all ports that are admin up on are operationally up".format(hostname))
+            intf_ok = wait_until(wait + 300, 20, 0, check_interface_status_of_up_ports, duthost)
+            intf_detail = get_last_intf_up_ports_failure_detail(duthost)
+            intf_msg = "{}: Not all ports that are admin up on are operationally up".format(hostname)
+            if intf_detail:
+                intf_msg = "{}. {}".format(intf_msg, intf_detail)
+            pytest_assert(intf_ok, intf_msg)
 
         if duthost.facts['asic_type'] == "cisco-8000":
             # Wait dshell initialization finish


### PR DESCRIPTION
### Description of PR

Summary:
Fixes # 
Improve the pre-test sanity error reporting for ports down and monit failures. This is actually not particular to any specific tests, but if the setup failed early, such as "not all ports/processes are up", then it will list them and report instead of just quitting.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311

### Approach
#### What is the motivation for this PR?
To help diagnose sanity failures by giving more info

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation