### PR TITLE
[conditional_mark] Skip high_frequency_telemetry on T2 topology

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -3260,11 +3260,12 @@ hash/test_generic_hash.py::test_reboot[CRC_CCITT-IP_PROTOCOL-ipv4:
 #######################################
 high_frequency_telemetry:
   skip:
-    reason: "High frequency telemetry isn't supported in this platform"
+    reason: "High frequency telemetry isn't supported in this platform or on T2 topology"
     conditions_logical_operator: or
     conditions:
       - "platform not in ['x86_64-nvidia_sn5600-r0', 'x86_64-nvidia_sn5640-r0', 'x86_64-arista_7060x6_64pe_b']"
       - "'bmc' in topo_type"
+      - "'t2' in topo_type"
 
 high_frequency_telemetry/test_high_frequency_telemetry.py::test_hft_full_counters:
   skip:


### PR DESCRIPTION
### Description of PR

Summary: Skip high_frequency_telemetry tests on T2 topology since HFT is not yet supported on T2.

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
HFT (High Frequency Telemetry) is not supported on T2 topology. Running HFT tests on T2 testbeds causes unnecessary failures.

#### How did you do it?
Added `'t2' in topo_type` as an additional OR condition to the existing `high_frequency_telemetry` skip entry in `tests_mark_conditions.yaml`.

#### How did you verify/test it?
- YAML syntax validated
- Sorting check passed (pre-commit `check-conditional-mark-sort`)

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A