### PR TITLE
Move deep clean from pytest to deploy-mg playbook

### DIFF
--- a/ansible/config_sonic_basedon_testbed.yml
+++ b/ansible/config_sonic_basedon_testbed.yml
@@ -440,6 +440,16 @@
     delegate_to: localhost
     when: local_minigraph is defined and local_minigraph|bool == true
 
+  - name: Deep clean DUT filesystem (logs, cores, dumps)
+    shell: |
+      find /var/log/ -name '*.gz' | xargs rm -f
+      rm -f /var/core/*
+      rm -rf /var/dump/*
+      find /var/log/ -mtime +1 | xargs rm -f
+    become: true
+    ignore_errors: true
+    when: deep_clean is defined and deep_clean|bool == true
+
   - block:
     - name: Init telemetry keys
       set_fact:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,8 +238,6 @@ def pytest_addoption(parser):
     ########################
     #   pre-test options   #
     ########################
-    parser.addoption("--deep_clean", action="store_true", default=False,
-                     help="Deep clean DUT before tests (remove old logs, cores, dumps)")
     parser.addoption("--py_saithrift_url", action="store", default=None, type=str,
                      help="Specify the url of the saithrift package to be installed on the ptf "
                           "(should be http://<serverip>/path/python-saithrift_0.9.4_amd64.deb")

--- a/tests/test_pretest.py
+++ b/tests/test_pretest.py
@@ -64,35 +64,6 @@ def test_cleanup_cache():
         os.system('rm -rf {}'.format(folder))
 
 
-def test_cleanup_testbed(duthosts, request, ptfhost):
-    deep_clean = request.config.getoption("--deep_clean")
-    if deep_clean:
-
-        def deep_clean_dut(dut):
-            logger.info("Deep cleaning DUT {}".format(dut.hostname))
-            # Remove old log files.
-            dut.shell("sudo find /var/log/ -name '*.gz' | sudo xargs rm -f", executable="/bin/bash")
-            # Remove old core files.
-            dut.shell("sudo rm -f /var/core/*", executable="/bin/bash")
-            # Remove old dump files.
-            dut.shell("sudo rm -rf /var/dump/*", executable="/bin/bash")
-
-            # delete other log files that are more than a day old,
-            # this step is needed to remove some backup files or the debug files added by users
-            # which can create issue for log-analyzer
-            dut.shell("sudo find /var/log/ -mtime +1 | sudo xargs rm -f",
-                      module_ignore_errors=True, executable="/bin/bash")
-
-        with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
-            for duthost in duthosts:
-                executor.submit(deep_clean_dut, duthost)
-
-    # Cleanup rsyslog configuration file that might have damaged by test_syslog.py
-    if ptfhost:
-        ptfhost.shell("if [[ -f /etc/rsyslog.conf ]]; then mv /etc/rsyslog.conf /etc/rsyslog.conf.orig; "
-                      "uniq /etc/rsyslog.conf.orig > /etc/rsyslog.conf; fi", executable="/bin/bash")
-
-
 def test_disable_container_autorestart(duthosts, disable_container_autorestart):
     with SafeThreadPoolExecutor(max_workers=len(duthosts)) as executor:
         for duthost in duthosts:


### PR DESCRIPTION
### Description of PR

Summary:
Move the DUT filesystem deep clean (logs, cores, dumps) from `test_pretest.py` into `config_sonic_basedon_testbed.yml` so that DUTs are cleaned during `testbed-cli.sh deploy-mg` before tests run. Also remove the stale `test_cleanup_testbed` function entirely.

### Type of change

- [x] Testbed and Framework(new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The deep clean was previously a pytest option (`--deep_clean`) that ran during test_pretest. Moving it to the deploy-mg playbook ensures DUTs are clean before any test execution begins, following the principle of "clean first, then configure". Ansible's fork mechanism handles parallel execution across multiple DUTs naturally.

#### How did you do it?

- Added a `deep_clean` task to `config_sonic_basedon_testbed.yml` (before config deployment), controlled by `deep_clean` variable (default: false)
- Removed the `--deep_clean` pytest option from `conftest.py`
- Removed `test_cleanup_testbed` from `test_pretest.py` entirely:
  - The deep clean logic is now in the playbook
  - The ptfhost rsyslog cleanup (added in https://github.com/sonic-net/sonic-mgmt/pull/2085) is stale - `test_syslog.py` does not use ptfhost or modify rsyslog.conf on the PTF container

**Usage:** `testbed-cli.sh deploy-mg ... -e deep_clean=true`

#### How did you verify/test it?

Code review, syntax verification, and analysis of test_syslog.py confirming ptfhost rsyslog cleanup is no longer needed.

#### Any platform specific information?

N/A

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A