### PR TITLE
[202305] Fix S6100 HeadroomPool skip conditions in tests_mark_conditions.yaml

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -971,18 +971,20 @@ qos/test_qos_sai.py::TestQosSai::testQosSaiDwrrWeightChange:
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolSize:
   skip:
     reason: "Headroom pool size not supported."
+    conditions_logical_operator: or
     conditions:
-      - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
+      - "hwsku in ['Force10-S6100'] and topo_type in ['t1']"
       - "hwsku not in ['Arista-7060CX-32S-C32', 'Celestica-DX010-C32', 'Arista-7260CX3-D108C8', 'Force10-S6100', 'Arista-7260CX3-Q64', 'Arista-7050CX3-32S-C32', 'Arista-7050CX3-32S-D48C8'] and asic_type not in ['mellanox']"
       - "asic_type in ['cisco-8000']"
 
 qos/test_qos_sai.py::TestQosSai::testQosSaiHeadroomPoolWatermark:
   skip:
     reason: "sai_thrift_read_buffer_pool_watermark are not supported on DNX"
+    conditions_logical_operator: or
     conditions:
       - "platform in ['x86_64-nokia_ixr7250e_36x400g-r0', 'x86_64-arista_7800r3_48cq2_lc', 'x86_64-arista_7800r3_48cqm2_lc', 'x86_64-arista_7800r3a_36d2_lc', 'x86_64-arista_7800r3a_36dm2_lc', 'x86_64-arista_7800r3ak_36dm2_lc'] or asic_type in ['mellanox']"
       - "asic_type in ['cisco-8000']"
-      - "https://github.com/sonic-net/sonic-mgmt/issues/12292 and hwsku in ['Force10-S6100'] and topo_type in ['t1-64-lag']"
+      - "hwsku in ['Force10-S6100'] and topo_type in ['t1']"
   xfail:
     reason: "Headroom pool size not supported."
     conditions:


### PR DESCRIPTION
### Description of PR

Summary:
Three fixes for HeadroomPool test skip conditions on Force10-S6100 to ensure the tests are correctly skipped on S6100 T1 topologies.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement

### Back port request
- [ ] 202205
- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

`testQosSaiHeadroomPoolSize` and `testQosSaiHeadroomPoolWatermark` always fail on S6100/T1 topologies with `Too many pkts needed to trigger pfc: 10`. The skip conditions were not working due to three issues:

1. **Remove closed GitHub issue #12292 URL** from conditions. The `conditional_mark` plugin checks GitHub issue state — since #12292 was closed (by PR #22909), it evaluates to `False` and the entire skip condition becomes `False`, so the skip never triggers.

2. **Add `conditions_logical_operator: or`** so that ANY matching condition triggers the skip. Without this, the plugin defaults to AND logic, requiring ALL conditions to be true simultaneously. Since the conditions are mutually exclusive (e.g., S6100-specific vs non-S6100 hwsku list vs cisco-8000), they can never all be true at once.

3. **Change `topo_type` from `'t1-64-lag'` to `'t1'`** — On S6100 T1 testbeds, `topo_type` is `"t1"` and `topo_name` is `"t1-64-lag"`. The original condition checked `topo_type in ['t1-64-lag']` which never matched because `topo_type` is `"t1"`, not `"t1-64-lag"`.

#### How did you do it?
Updated `tests_mark_conditions.yaml` to fix all three issues in both `testQosSaiHeadroomPoolSize` and `testQosSaiHeadroomPoolWatermark` skip entries.

#### How did you verify/test it?
Tested on S6100 (tbtk5-t1-s6100-5, SONiC.20230531.46):
- Before fix: Both tests FAILED with `Too many pkts needed to trigger pfc: 10`
- After fix: Both tests correctly SKIPPED

#### Any platform specific information?
Dell Force10-S6100 with 202305 image.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A