### PR TITLE
chore: skip GCU pg headroom on Cisco T2

### DIFF
--- a/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
+++ b/tests/common/plugins/conditional_mark/tests_mark_conditions.yaml
@@ -2711,10 +2711,11 @@ generic_config_updater/test_pfcwd_status.py:
 
 generic_config_updater/test_pg_headroom_update.py:
   skip:
-    reason: "Unsupported topology."
+    reason: "Unsupported topology or platform."
     conditions_logical_operator: "OR"
     conditions:
       - "topo_type in ['bmc', 'm0', 'm1', 'mx']"
+      - "asic_type in ['cisco-8000'] and topo_type in ['t2']"
 
 generic_config_updater/test_srv6:
   skip:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Skip `generic_config_updater/test_pg_headroom_update.py` on Cisco 8800

Summary:
Fixes # (issue) Microsoft ADO 35815182

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
The pg_lossless profile should not be tested via GCU as discussed in past. We have other tests covering the buffer configs.

#### How did you do it?

#### How did you verify/test it?
Test is skipped after the mark change:
<img width="979" height="48" alt="image" src="https://github.com/user-attachments/assets/2d79c5a6-13d0-49a6-b017-2209bdbaaef6" />


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
