### PR TITLE
Update test_reboot_cause to support on CPO supported platform

### DIFF
--- a/tests/common/helpers/mellanox_thermal_control_test_helper.py
+++ b/tests/common/helpers/mellanox_thermal_control_test_helper.py
@@ -1318,6 +1318,7 @@ class PsuPowerThresholdMocker(object):
 @mocker('RebootCauseMocker')
 class RebootCauseMocker(object):
     RESET_RELOAD_BIOS = '/var/run/hw-management/system/reset_reload_bios'
+    RESET_RELOAD_BIOS_CPO = '/var/run/hw-management/system/reset_pwr_converter_fail'
     RESET_FROM_ASIC = '/var/run/hw-management/system/reset_from_asic'
 
     def __init__(self, dut):
@@ -1328,6 +1329,9 @@ class RebootCauseMocker(object):
 
     def mock_reset_reload_bios(self):
         self.mock_helper.mock_value(self.RESET_RELOAD_BIOS, 1)
+
+    def mock_reset_reload_bios_cpo(self):
+        self.mock_helper.mock_value(self.RESET_RELOAD_BIOS_CPO, 1)
 
     def mock_reset_from_asic(self):
         self.mock_helper.mock_value(self.RESET_FROM_ASIC, 1)

--- a/tests/platform_tests/mellanox/test_reboot_cause.py
+++ b/tests/platform_tests/mellanox/test_reboot_cause.py
@@ -16,7 +16,7 @@ REBOOT_CAUSE_TYPES = [REBOOT_TYPE_BIOS, REBOOT_TYPE_ASIC]
 
 
 @pytest.mark.parametrize("reboot_cause", REBOOT_CAUSE_TYPES)
-def test_reboot_cause(rand_selected_dut, mocker_factory, reboot_cause):  # noqa: F811
+def test_reboot_cause(rand_selected_dut, mocker_factory, reboot_cause, is_cpo_supported):  # noqa: F811
     """
     Validate reboot cause from cpu/bios/asic
     :param rand_selected_dut: The fixture returns a randomly selected DUT
@@ -29,9 +29,15 @@ def test_reboot_cause(rand_selected_dut, mocker_factory, reboot_cause):  # noqa:
 
     with allure.step('Mock reset from {}'.format(reboot_cause)):
         if reboot_cause == REBOOT_TYPE_BIOS:
-            mocker.mock_reset_reload_bios()
+            if is_cpo_supported:
+                mocker.mock_reset_reload_bios_cpo()
+            else:
+                mocker.mock_reset_reload_bios()
         elif reboot_cause == REBOOT_TYPE_ASIC:
-            mocker.mock_reset_from_asic()
+            if is_cpo_supported:
+                pytest.skip("Reset from ASIC is not supported on CPO platforms")
+            else:
+                mocker.mock_reset_from_asic()
 
     with allure.step('Restart determine-reboot-cause service'):
         duthost.restart_service('determine-reboot-cause')


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
On CPO supported platform, there are differences regarding the reboot cause sysfs:
system/reset_from_asic - removed
system/reset_reload_bios - replaced by reset_pwr_converter_fail


Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Update the reboot cause sysfs for CPO supported platform
#### How did you do it?
Update the test
#### How did you verify/test it?
Run it locally
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
