### PR TITLE
refactor: enhance bfd static and traffic test

### DIFF
--- a/tests/bfd/bfd_base.py
+++ b/tests/bfd/bfd_base.py
@@ -116,11 +116,6 @@ class BfdBase:
         logger.info("Source dut: %s", src_dut)
         logger.info("Destination dut: %s", dst_dut)
 
-        request.config.src_asic = src_asic
-        request.config.dst_asic = dst_asic
-        request.config.src_dut = src_dut
-        request.config.dst_dut = dst_dut
-
         src_asic_routes = get_dut_asic_static_routes(version, src_dut)
         dst_asic_routes = get_dut_asic_static_routes(version, dst_dut)
 
@@ -146,14 +141,12 @@ class BfdBase:
             src_asic_routes, src_dut_nexthops.values()
         )
         logger.info("Source prefix: %s", src_prefix)
-        request.config.src_prefix = src_prefix
         assert src_prefix is not None and src_prefix != "", "Source prefix not found"
 
         dst_prefix = selecting_route_to_delete(
             dst_asic_routes, dst_dut_nexthops.values()
         )
         logger.info("Destination prefix: %s", dst_prefix)
-        request.config.dst_prefix = dst_prefix
         assert (
             dst_prefix is not None and dst_prefix != ""
         ), "Destination prefix not found"
@@ -169,3 +162,8 @@ class BfdBase:
             "dst_prefix": dst_prefix,
             "version": version,
         }
+
+    @pytest.fixture(autouse=True)
+    def set_bfd_cleanup_context(self, bfd_cleanup_db,
+                                select_src_dst_dut_with_asic):
+        bfd_cleanup_db.set_bfd_endpoints(select_src_dst_dut_with_asic)

--- a/tests/bfd/bfd_helpers.py
+++ b/tests/bfd/bfd_helpers.py
@@ -56,17 +56,18 @@ def create_and_verify_bfd_state(asic, prefix, dut, dut_nexthops):
     verify_bfd_only(dut, dut_nexthops, asic, "Up")
 
 
-def verify_bfd_and_static_route(dut, dut_nexthops, asic, expected_bfd_state, request, prefix,
-                                expected_prefix_state, version):
+def verify_bfd_and_static_route(dut, dut_nexthops, asic, expected_bfd_state, prefix,
+                                expected_prefix_state, version,
+                                allow_empty_static_routes_on_removal=False):
     logger.info("BFD & Static route verifications")
     verify_bfd_only(dut, dut_nexthops, asic, expected_bfd_state)
     verify_static_route(
-        request,
         asic,
         prefix,
         dut,
         expected_prefix_state,
         version,
+        allow_empty_static_routes_on_removal=allow_empty_static_routes_on_removal,
     )
 
 
@@ -80,7 +81,7 @@ def get_dut_asic_static_routes(version, dut):
             "Invalid version specified: '{}'. Expected 'ipv4' or 'ipv6'."
         ).format(version)
 
-    stdout = dut.shell(static_route_command, module_ignore_errors=True)["stdout"]
+    stdout = run_static_route_command(dut, static_route_command)
     if sys.version_info.major < 3:
         static_routes_output = stdout.encode("utf-8").strip().split("\n")
     else:
@@ -93,6 +94,19 @@ def get_dut_asic_static_routes(version, dut):
     ).format(asic_static_routes)
 
     return asic_static_routes
+
+
+def run_static_route_command(dut, command):
+    result = dut.shell(command, module_ignore_errors=True)
+    assert result.get("rc") == 0, (
+        "Failed to run static route command '{}'. rc={}, stdout='{}', stderr='{}'"
+    ).format(
+        command,
+        result.get("rc"),
+        result.get("stdout", ""),
+        result.get("stderr", ""),
+    )
+    return result["stdout"]
 
 
 def verify_bfd_state(dut, dut_nexthops, dut_asic, expected_bfd_state):
@@ -108,14 +122,8 @@ def verify_bfd_state(dut, dut_nexthops, dut_asic, expected_bfd_state):
     return True
 
 
-def verify_static_route(
-    request,
-    asic,
-    prefix,
-    dut,
-    expected_prefix_state,
-    version,
-):
+def verify_static_route(asic, prefix, dut, expected_prefix_state, version,
+                        allow_empty_static_routes_on_removal=False):
     # Verification of static route
     if version == "ipv4":
         command = "show ip route static"
@@ -126,7 +134,7 @@ def verify_static_route(
             "Invalid version specified: '{}'. Expected 'ipv4' or 'ipv6'."
         ).format(version)
 
-    static_route = dut.shell(command, module_ignore_errors=True)["stdout"]
+    static_route = run_static_route_command(dut, command)
     if sys.version_info.major < 3:
         static_route_output = static_route.encode("utf-8").strip().split("\n")
     else:
@@ -136,7 +144,7 @@ def verify_static_route(
     logger.info("Here are asic routes, {}".format(asic_routes))
 
     if expected_prefix_state == "Route Removal":
-        if len(asic_routes) == 0 and request.config.interface_shutdown:
+        if len(asic_routes) == 0 and allow_empty_static_routes_on_removal:
             logger.info("asic routes are empty post interface shutdown")
         else:
             assert len(asic_routes) > 0, (
@@ -390,9 +398,7 @@ def list_to_dict(sample_list):
 
 
 def extract_current_bfd_state(nexthop, asic_number, dut):
-    bfd_peer_command = "ip netns exec asic{} show bfd peer {}".format(
-        asic_number, nexthop
-    )
+    bfd_peer_command = "show bfd peer {} -n asic{}".format(nexthop, asic_number)
     logger.info("Verifying BFD status on {}".format(dut))
     logger.info(bfd_peer_command)
     bfd_peer_status = dut.shell(bfd_peer_command, module_ignore_errors=True)["stdout"]
@@ -429,7 +435,7 @@ def parse_bfd_output(output):
 
 def find_bfd_peers_with_given_state(dut, dut_asic, expected_bfd_state):
     # Expected BFD states: Up, Down, No BFD sessions found
-    bfd_cmd = "ip netns exec asic{} show bfd sum"
+    bfd_cmd = "show bfd sum -n asic{}"
     result = True
     asic_bfd_sum = dut.shell(bfd_cmd.format(dut_asic))["stdout"]
     if sys.version_info.major < 3:
@@ -584,14 +590,8 @@ def clear_interface_counters(dut):
     dut.shell("sonic-clear counters")
 
 
-def send_packets_batch_from_ptf(
-    packet_count,
-    version,
-    src_asic_router_mac,
-    ptfadapter,
-    ptf_src_port,
-    dst_neighbor_ip,
-):
+def send_packets_batch_from_ptf(packet_count, version, src_asic_router_mac,
+                                ptfadapter, ptf_src_port, dst_neighbor_ip):
     for _ in range(packet_count):
         if version == "ipv4":
             pkt = testutils.simple_ip_packet(
@@ -617,18 +617,10 @@ def send_packets_batch_from_ptf(
         testutils.send(test=ptfadapter, port_id=ptf_src_port, pkt=pkt)
 
 
-def get_backend_interface_in_use_by_counter(
-    src_dut,
-    dst_dut,
-    packet_count,
-    version,
-    src_asic_router_mac,
-    ptfadapter,
-    ptf_src_port,
-    dst_neighbor_ip,
-    src_asic_index,
-    dst_asic_index,
-):
+def get_backend_interface_in_use_by_counter(src_dut, dst_dut, packet_count, version,
+                                            src_asic_router_mac, ptfadapter,
+                                            ptf_src_port, dst_neighbor_ip,
+                                            src_asic_index, dst_asic_index):
     with SafeThreadPoolExecutor(max_workers=8) as executor:
         for dut in [src_dut, dst_dut]:
             executor.submit(clear_interface_counters, dut)
@@ -652,7 +644,8 @@ def get_backend_interface_in_use_by_counter(
     return src_bp_iface, dst_bp_iface
 
 
-def get_src_dst_asic_next_hops(version, src_dut, src_asic, src_backend_port_channels, dst_dut, dst_asic,
+def get_src_dst_asic_next_hops(version, src_dut, src_asic,
+                               src_backend_port_channels, dst_dut, dst_asic,
                                dst_backend_port_channels):
     src_asic_next_hops = extract_ip_addresses_for_backend_portchannels(
         dst_dut,
@@ -689,17 +682,10 @@ def get_port_channel_by_member(backend_port_channels, member):
     return None
 
 
-def toggle_port_channel_or_member(
-    target_to_toggle,
-    dut,
-    asic,
-    request,
-    action,
-):
-    request.config.portchannels_on_dut = "dut"
-    request.config.selected_portchannels = [target_to_toggle]
-    request.config.dut = dut
-    request.config.asic = asic
+def toggle_port_channel_or_member(target_to_toggle, dut, asic, cleanup_context,
+                                  action):
+    if action == "shutdown":
+        cleanup_context.register_restore(dut, asic, [target_to_toggle])
 
     batch_control_interface_state(dut, asic, [target_to_toggle], action)
     if action == "shutdown":
@@ -779,20 +765,14 @@ def wait_until_given_bfd_down(next_hops, port_channel, asic_index, dut):
     )
 
 
-def assert_traffic_switching(
-    src_dut,
-    dst_dut,
-    src_backend_port_channels,
-    dst_backend_port_channels,
-    src_asic_index,
-    src_bp_iface_before_shutdown,
-    src_bp_iface_after_shutdown,
-    src_port_channel_before_shutdown,
-    dst_asic_index,
-    dst_bp_iface_after_shutdown,
-    dst_bp_iface_before_shutdown,
-    dst_port_channel_before_shutdown,
-):
+def assert_traffic_switching(src_dut, dst_dut, src_backend_port_channels,
+                             dst_backend_port_channels, src_asic_index,
+                             src_bp_iface_before_shutdown,
+                             src_bp_iface_after_shutdown,
+                             src_port_channel_before_shutdown, dst_asic_index,
+                             dst_bp_iface_after_shutdown,
+                             dst_bp_iface_before_shutdown,
+                             dst_port_channel_before_shutdown):
     assert_bp_iface_after_shutdown(
         src_bp_iface_before_shutdown,
         dst_bp_iface_before_shutdown,

--- a/tests/bfd/conftest.py
+++ b/tests/bfd/conftest.py
@@ -10,6 +10,39 @@ from tests.common.config_reload import config_reload
 logger = logging.getLogger(__name__)
 
 
+class BfdCleanupContext(object):
+    def __init__(self):
+        self.src_dut = None
+        self.src_asic = None
+        self.src_prefix = None
+        self.dst_dut = None
+        self.dst_asic = None
+        self.dst_prefix = None
+        self.rp_asic_ids = []
+        self.allow_empty_static_routes_on_removal = False
+        self.restore_targets = []
+
+    def set_bfd_endpoints(self, selection):
+        self.src_dut = selection.get("src_dut")
+        self.src_asic = selection.get("src_asic")
+        self.src_prefix = selection.get("src_prefix")
+        self.dst_dut = selection.get("dst_dut")
+        self.dst_asic = selection.get("dst_asic")
+        self.dst_prefix = selection.get("dst_prefix")
+
+    def register_restore(self, dut, asic, interfaces):
+        if not interfaces:
+            return
+
+        self.restore_targets.append(
+            {
+                "dut": dut,
+                "asic": asic,
+                "interfaces": list(interfaces),
+            }
+        )
+
+
 def pytest_addoption(parser):
     parser.addoption("--num_sessions", action="store", default=5)
     parser.addoption("--num_sessions_scale", action="store", default=128)
@@ -21,7 +54,7 @@ def get_function_completeness_level(pytestconfig):
 
 
 @pytest.fixture(scope="function")
-def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
+def bfd_cleanup_db(duthosts, enum_supervisor_dut_hostname):
     # Temporarily disable orchagent CPU check before starting test as it is not stable
     # orch_cpu_threshold = 10
     # # Make Sure Orch CPU < orch_cpu_threshold before starting test.
@@ -35,7 +68,8 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
     #         100, 2, 0, check_orch_cpu_utilization, dut, orch_cpu_threshold
     #     ), "Orch CPU utilization exceeds orch cpu threshold {} before starting the test".format(orch_cpu_threshold)
 
-    yield
+    cleanup_context = BfdCleanupContext()
+    yield cleanup_context
 
     # Temporarily disable orchagent CPU check after finishing test as it is not stable
     # orch_cpu_threshold = 10
@@ -50,11 +84,11 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
 
     rp = duthosts[enum_supervisor_dut_hostname]
     container_status = True
-    if hasattr(request.config, "rp_asic_ids"):
+    if cleanup_context.rp_asic_ids:
         logger.info("Verifying swss container status on RP")
-        for id in request.config.rp_asic_ids:
+        for asic_id in cleanup_context.rp_asic_ids:
             docker_output = rp.shell(
-                "docker ps | grep swss{} | awk '{{print $NF}}'".format(id)
+                "docker ps | grep swss{} | awk '{{print $NF}}'".format(asic_id)
             )["stdout"]
             if len(docker_output) == 0:
                 container_status = False
@@ -63,38 +97,27 @@ def bfd_cleanup_db(request, duthosts, enum_supervisor_dut_hostname):
         logger.error("swss container is not running on RP, so running config reload")
         config_reload(rp, safe_reload=True)
 
-    if hasattr(request.config, "src_dut") and hasattr(request.config, "dst_dut"):
-        clear_bfd_configs(request.config.src_dut, request.config.src_asic.asic_index, request.config.src_prefix)
-        clear_bfd_configs(request.config.dst_dut, request.config.dst_asic.asic_index, request.config.dst_prefix)
+    if cleanup_context.src_dut and cleanup_context.dst_dut:
+        clear_bfd_configs(
+            cleanup_context.src_dut,
+            cleanup_context.src_asic.asic_index,
+            cleanup_context.src_prefix,
+        )
+        clear_bfd_configs(
+            cleanup_context.dst_dut,
+            cleanup_context.dst_asic.asic_index,
+            cleanup_context.dst_prefix,
+        )
 
-    portchannels_on_dut = None
-    if hasattr(request.config, "portchannels_on_dut"):
-        portchannels_on_dut = request.config.portchannels_on_dut
-        selected_interfaces = request.config.selected_portchannels
-    elif hasattr(request.config, "selected_portchannel_members"):
-        portchannels_on_dut = request.config.portchannels_on_dut
-        selected_interfaces = request.config.selected_portchannel_members
-    else:
-        selected_interfaces = []
-
-    if selected_interfaces:
-        logger.info("Bringing up portchannels or respective members")
-        if portchannels_on_dut == "src":
-            dut = request.config.src_dut
-        elif portchannels_on_dut == "dst":
-            dut = request.config.dst_dut
-        else:
-            dut = request.config.dut
-
-        if portchannels_on_dut == "src":
-            asic = request.config.src_asic
-        elif portchannels_on_dut == "dst":
-            asic = request.config.dst_asic
-        else:
-            asic = request.config.asic
-
-        ensure_interfaces_are_up(dut, asic, selected_interfaces)
+    if cleanup_context.restore_targets:
+        logger.info("Bringing up registered interfaces")
+        for restore_target in cleanup_context.restore_targets:
+            ensure_interfaces_are_up(
+                restore_target["dut"],
+                restore_target["asic"],
+                restore_target["interfaces"],
+            )
     else:
         logger.info(
-            "None of the portchannels are selected to flap. So skipping portchannel interface check"
+            "No interfaces were registered for cleanup. So skipping interface check"
         )

--- a/tests/bfd/test_bfd_static_route.py
+++ b/tests/bfd/test_bfd_static_route.py
@@ -80,7 +80,7 @@ class TestBfdStaticRoute(BfdBase):
             for _, asic, _, dut, dut_nexthops in src_dst_context:
                 executor.submit(verify_bfd_only, dut, dut_nexthops, asic, "No BFD sessions found")
 
-    def test_bfd_static_route_deletion(self, request, select_src_dst_dut_with_asic, bfd_cleanup_db):
+    def test_bfd_static_route_deletion(self, select_src_dst_dut_with_asic, bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
@@ -121,7 +121,6 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "No BFD sessions found" if target == "src" else "Down",
-                    request,
                     prefix,
                     "Route Addition" if target == "src" else "Route Removal",
                     version,
@@ -137,7 +136,6 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "No BFD sessions found",
-                    request,
                     prefix,
                     "Route Addition",
                     version,
@@ -145,13 +143,8 @@ class TestBfdStaticRoute(BfdBase):
 
         logger.info("BFD deletion did not influence static routes and test completed successfully")
 
-    def test_bfd_flap(
-        self,
-        request,
-        select_src_dst_dut_with_asic,
-        bfd_cleanup_db,
-        get_function_completeness_level,
-    ):
+    def test_bfd_flap(self, select_src_dst_dut_with_asic, bfd_cleanup_db,
+                      get_function_completeness_level):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
@@ -208,7 +201,6 @@ class TestBfdStaticRoute(BfdBase):
                         dut_nexthops,
                         asic,
                         "No BFD sessions found" if target == "src" else "Down",
-                        request,
                         prefix,
                         "Route Addition" if target == "src" else "Route Removal",
                         version,
@@ -225,7 +217,6 @@ class TestBfdStaticRoute(BfdBase):
                         dut_nexthops,
                         asic,
                         "Up",
-                        request,
                         prefix,
                         "Route Addition",
                         version,
@@ -246,15 +237,9 @@ class TestBfdStaticRoute(BfdBase):
 
         logger.info("test_bfd_flap completed")
 
-    def test_bfd_with_rp_reboot(
-        self,
-        localhost,
-        request,
-        duthosts,
-        enum_supervisor_dut_hostname,
-        select_src_dst_dut_with_asic,
-        bfd_cleanup_db,
-    ):
+    def test_bfd_with_rp_reboot(self, localhost, request, duthosts,
+                                enum_supervisor_dut_hostname,
+                                select_src_dst_dut_with_asic, bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
@@ -318,12 +303,12 @@ class TestBfdStaticRoute(BfdBase):
             for _, asic, _, dut, dut_nexthops in src_dst_context:
                 executor.submit(verify_bfd_only, dut, dut_nexthops, asic, "No BFD sessions found")
 
-    def test_bfd_remote_link_flap(self, request, select_src_dst_dut_with_asic, bfd_cleanup_db):
+    def test_bfd_remote_link_flap(self, select_src_dst_dut_with_asic, bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
         """
-        request.config.interface_shutdown = True
+        bfd_cleanup_db.allow_empty_static_routes_on_removal = True
 
         src_asic = select_src_dst_dut_with_asic["src_asic"]
         dst_asic = select_src_dst_dut_with_asic["dst_asic"]
@@ -344,9 +329,8 @@ class TestBfdStaticRoute(BfdBase):
                 executor.submit(create_and_verify_bfd_state, asic, prefix, dut, dut_nexthops)
 
         # Extract portchannel interfaces on dst
-        list_of_portchannels_on_dst = src_dut_nexthops.keys()
-        request.config.portchannels_on_dut = "dst"
-        request.config.selected_portchannels = list_of_portchannels_on_dst
+        list_of_portchannels_on_dst = list(src_dut_nexthops.keys())
+        bfd_cleanup_db.register_restore(dst_dut, dst_asic, list_of_portchannels_on_dst)
 
         # Shutdown PortChannels on destination dut
         batch_control_interface_state(dst_dut, dst_asic, list_of_portchannels_on_dst, "shutdown")
@@ -357,10 +341,10 @@ class TestBfdStaticRoute(BfdBase):
             src_dut_nexthops,
             src_asic,
             "Down",
-            request,
             src_prefix,
             "Route Removal",
             version,
+            allow_empty_static_routes_on_removal=bfd_cleanup_db.allow_empty_static_routes_on_removal,
         )
 
         batch_control_interface_state(dst_dut, dst_asic, list_of_portchannels_on_dst, "startup")
@@ -372,18 +356,17 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "Up",
-                    request,
                     prefix,
                     "Route Addition",
                     version,
                 )
 
-    def test_bfd_lc_asic_shutdown(self, request, select_src_dst_dut_with_asic, bfd_cleanup_db):
+    def test_bfd_lc_asic_shutdown(self, select_src_dst_dut_with_asic, bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
         """
-        request.config.interface_shutdown = True
+        bfd_cleanup_db.allow_empty_static_routes_on_removal = True
 
         src_asic = select_src_dst_dut_with_asic["src_asic"]
         dst_asic = select_src_dst_dut_with_asic["dst_asic"]
@@ -404,9 +387,8 @@ class TestBfdStaticRoute(BfdBase):
                 executor.submit(create_and_verify_bfd_state, asic, prefix, dut, dut_nexthops)
 
         # Extract portchannel interfaces on src
-        list_of_portchannels_on_src = dst_dut_nexthops.keys()
-        request.config.portchannels_on_dut = "src"
-        request.config.selected_portchannels = list_of_portchannels_on_src
+        list_of_portchannels_on_src = list(dst_dut_nexthops.keys())
+        bfd_cleanup_db.register_restore(src_dut, src_asic, list_of_portchannels_on_src)
 
         # Shutdown PortChannels
         batch_control_interface_state(src_dut, src_asic, list_of_portchannels_on_src, "shutdown")
@@ -420,10 +402,10 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "Down",
-                    request,
                     prefix,
                     "Route Removal",
                     version,
+                    allow_empty_static_routes_on_removal=bfd_cleanup_db.allow_empty_static_routes_on_removal,
                 )
 
         batch_control_interface_state(src_dut, src_asic, list_of_portchannels_on_src, "startup")
@@ -437,18 +419,17 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "Up",
-                    request,
                     prefix,
                     "Route Addition",
                     version,
                 )
 
-    def test_bfd_portchannel_member_flap(self, request, select_src_dst_dut_with_asic, bfd_cleanup_db):
+    def test_bfd_portchannel_member_flap(self, select_src_dst_dut_with_asic, bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
         """
-        request.config.interface_shutdown = True
+        bfd_cleanup_db.allow_empty_static_routes_on_removal = True
 
         src_asic = select_src_dst_dut_with_asic["src_asic"]
         dst_asic = select_src_dst_dut_with_asic["dst_asic"]
@@ -469,9 +450,7 @@ class TestBfdStaticRoute(BfdBase):
                 executor.submit(create_and_verify_bfd_state, asic, prefix, dut, dut_nexthops)
 
         # Extract portchannel interfaces on src
-        list_of_portchannels_on_src = dst_dut_nexthops.keys()
-        request.config.portchannels_on_dut = "src"
-        request.config.selected_portchannels = list_of_portchannels_on_src
+        list_of_portchannels_on_src = list(dst_dut_nexthops.keys())
 
         # Shutdown PortChannel members
         port_channel_members_on_src = []
@@ -482,7 +461,7 @@ class TestBfdStaticRoute(BfdBase):
 
             port_channel_members_on_src.extend(list_of_portchannel_members_on_src)
 
-        request.config.selected_portchannel_members = port_channel_members_on_src
+        bfd_cleanup_db.register_restore(src_dut, src_asic, port_channel_members_on_src)
         batch_control_interface_state(src_dut, src_asic, port_channel_members_on_src, "shutdown")
 
         # Verify BFD and static routes
@@ -494,10 +473,10 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "Down",
-                    request,
                     prefix,
                     "Route Removal",
                     version,
+                    allow_empty_static_routes_on_removal=bfd_cleanup_db.allow_empty_static_routes_on_removal,
                 )
 
         # Bring up of PortChannel members
@@ -512,7 +491,85 @@ class TestBfdStaticRoute(BfdBase):
                     dut_nexthops,
                     asic,
                     "Up",
-                    request,
+                    prefix,
+                    "Route Addition",
+                    version,
+                )
+
+    def test_bfd_single_portchannel_member_flap(self, select_src_dst_dut_with_asic, bfd_cleanup_db):
+        """
+        Validate BFD static route behavior when one member from each selected
+        source backend portchannel is shut down and brought back up.
+
+        Author:  Harsha Golla
+        Email : harsgoll@cisco.com
+        """
+        bfd_cleanup_db.allow_empty_static_routes_on_removal = True
+
+        src_asic = select_src_dst_dut_with_asic["src_asic"]
+        dst_asic = select_src_dst_dut_with_asic["dst_asic"]
+        src_dut = select_src_dst_dut_with_asic["src_dut"]
+        dst_dut = select_src_dst_dut_with_asic["dst_dut"]
+        src_dut_nexthops = select_src_dst_dut_with_asic["src_dut_nexthops"]
+        dst_dut_nexthops = select_src_dst_dut_with_asic["dst_dut_nexthops"]
+        src_prefix = select_src_dst_dut_with_asic["src_prefix"]
+        dst_prefix = select_src_dst_dut_with_asic["dst_prefix"]
+        version = select_src_dst_dut_with_asic["version"]
+        src_dst_context = [
+            ("src", src_asic, src_prefix, src_dut, src_dut_nexthops),
+            ("dst", dst_asic, dst_prefix, dst_dut, dst_dut_nexthops),
+        ]
+
+        with SafeThreadPoolExecutor(max_workers=8) as executor:
+            for _, asic, prefix, dut, dut_nexthops in src_dst_context:
+                executor.submit(create_and_verify_bfd_state, asic, prefix, dut, dut_nexthops)
+
+        # Extract portchannel interfaces on src
+        list_of_portchannels_on_src = list(dst_dut_nexthops.keys())
+
+        # Shutdown one PortChannel member per portchannel
+        selected_portchannel_members_on_src = []
+        for portchannel_interface in list_of_portchannels_on_src:
+            list_of_portchannel_members_on_src = (
+                extract_backend_portchannels(src_dut)[portchannel_interface]["members"]
+            )
+            if not list_of_portchannel_members_on_src:
+                pytest.fail(
+                    "No members found for backend portchannel {}".format(portchannel_interface)
+                )
+
+            selected_portchannel_members_on_src.append(list_of_portchannel_members_on_src[0])
+
+        bfd_cleanup_db.register_restore(src_dut, src_asic, selected_portchannel_members_on_src)
+        batch_control_interface_state(src_dut, src_asic, selected_portchannel_members_on_src, "shutdown")
+
+        # Verify BFD and static routes
+        with SafeThreadPoolExecutor(max_workers=8) as executor:
+            for _, asic, prefix, dut, dut_nexthops in src_dst_context:
+                executor.submit(
+                    verify_bfd_and_static_route,
+                    dut,
+                    dut_nexthops,
+                    asic,
+                    "Down",
+                    prefix,
+                    "Route Removal",
+                    version,
+                    allow_empty_static_routes_on_removal=bfd_cleanup_db.allow_empty_static_routes_on_removal,
+                )
+
+        # Bring up PortChannel members
+        batch_control_interface_state(src_dut, src_asic, selected_portchannel_members_on_src, "startup")
+
+        # Verify BFD and static routes
+        with SafeThreadPoolExecutor(max_workers=8) as executor:
+            for _, asic, prefix, dut, dut_nexthops in src_dst_context:
+                executor.submit(
+                    verify_bfd_and_static_route,
+                    dut,
+                    dut_nexthops,
+                    asic,
+                    "Up",
                     prefix,
                     "Route Addition",
                     version,
@@ -570,14 +627,10 @@ class TestBfdStaticRoute(BfdBase):
             for _, asic, _, dut, dut_nexthops in src_dst_context:
                 executor.submit(verify_bfd_only, dut, dut_nexthops, asic, "No BFD sessions found")
 
-    def test_bfd_with_rp_config_reload(
-        self,
-        request,
-        duthosts,
-        select_src_dst_dut_with_asic,
-        enum_supervisor_dut_hostname,
-        bfd_cleanup_db,
-    ):
+    def test_bfd_with_rp_config_reload(self, request, duthosts,
+                                       select_src_dst_dut_with_asic,
+                                       enum_supervisor_dut_hostname,
+                                       bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com
@@ -643,14 +696,10 @@ class TestBfdStaticRoute(BfdBase):
             for _, asic, _, dut, dut_nexthops in src_dst_context:
                 executor.submit(verify_bfd_only, dut, dut_nexthops, asic, "No BFD sessions found")
 
-    def test_bfd_with_bad_fc_asic(
-        self,
-        request,
-        duthosts,
-        select_src_dst_dut_with_asic,
-        enum_supervisor_dut_hostname,
-        bfd_cleanup_db,
-    ):
+    def test_bfd_with_bad_fc_asic(self, request, duthosts,
+                                  select_src_dst_dut_with_asic,
+                                  enum_supervisor_dut_hostname,
+                                  bfd_cleanup_db):
         """
         Author:  Harsha Golla
         Email : harsgoll@cisco.com

--- a/tests/bfd/test_bfd_traffic.py
+++ b/tests/bfd/test_bfd_traffic.py
@@ -21,7 +21,7 @@ class TestBfdTraffic:
     PACKET_COUNT = 10000
 
     @pytest.fixture(scope="class")
-    def get_src_dst_asic(self, request, duthosts):
+    def get_src_dst_asic(self, duthosts):
         if not duthosts.frontend_nodes:
             pytest.skip("DUT does not have any frontend nodes")
 
@@ -103,7 +103,7 @@ class TestBfdTraffic:
             "version": version,
         }
 
-    def test_bfd_traffic_remote_port_channel_shutdown(self, request, tbinfo, ptfadapter,
+    def test_bfd_traffic_remote_port_channel_shutdown(self, tbinfo, ptfadapter,
                                                       prepare_traffic_test_variables, bfd_cleanup_db):
         src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
@@ -148,7 +148,7 @@ class TestBfdTraffic:
             dst_port_channel_before_shutdown,
             dst_dut,
             dst_asic,
-            request,
+            bfd_cleanup_db,
             "shutdown",
         )
 
@@ -196,7 +196,7 @@ class TestBfdTraffic:
             dst_port_channel_before_shutdown,
             dst_dut,
             dst_asic,
-            request,
+            bfd_cleanup_db,
             "startup",
         )
 
@@ -207,7 +207,7 @@ class TestBfdTraffic:
             ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")
 
-    def test_bfd_traffic_local_port_channel_shutdown(self, request, tbinfo, ptfadapter,
+    def test_bfd_traffic_local_port_channel_shutdown(self, tbinfo, ptfadapter,
                                                      prepare_traffic_test_variables, bfd_cleanup_db):
         src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
@@ -252,7 +252,7 @@ class TestBfdTraffic:
             src_port_channel_before_shutdown,
             src_dut,
             src_asic,
-            request,
+            bfd_cleanup_db,
             "shutdown",
         )
 
@@ -300,7 +300,7 @@ class TestBfdTraffic:
             src_port_channel_before_shutdown,
             src_dut,
             src_asic,
-            request,
+            bfd_cleanup_db,
             "startup",
         )
 
@@ -311,7 +311,7 @@ class TestBfdTraffic:
             ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")
 
-    def test_bfd_traffic_remote_port_channel_member_shutdown(self, request, tbinfo, ptfadapter,
+    def test_bfd_traffic_remote_port_channel_member_shutdown(self, tbinfo, ptfadapter,
                                                              prepare_traffic_test_variables, bfd_cleanup_db):
         src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
@@ -361,7 +361,7 @@ class TestBfdTraffic:
             dst_bp_iface_before_shutdown,
             dst_dut,
             dst_asic,
-            request,
+            bfd_cleanup_db,
             "shutdown",
         )
 
@@ -404,7 +404,7 @@ class TestBfdTraffic:
             dst_bp_iface_before_shutdown,
             dst_dut,
             dst_asic,
-            request,
+            bfd_cleanup_db,
             "startup",
         )
 
@@ -415,7 +415,7 @@ class TestBfdTraffic:
             ]:
                 executor.submit(verify_bfd_only, dut, next_hops, asic, "Up")
 
-    def test_bfd_traffic_local_port_channel_member_shutdown(self, request, tbinfo, ptfadapter,
+    def test_bfd_traffic_local_port_channel_member_shutdown(self, tbinfo, ptfadapter,
                                                             prepare_traffic_test_variables, bfd_cleanup_db):
         src_dut = prepare_traffic_test_variables["src_dut"]
         src_asic = prepare_traffic_test_variables["src_asic"]
@@ -465,7 +465,7 @@ class TestBfdTraffic:
             src_bp_iface_before_shutdown,
             src_dut,
             src_asic,
-            request,
+            bfd_cleanup_db,
             "shutdown",
         )
 
@@ -508,7 +508,7 @@ class TestBfdTraffic:
             src_bp_iface_before_shutdown,
             src_dut,
             src_asic,
-            request,
+            bfd_cleanup_db,
             "startup",
         )
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Refactor the BFD static-route and traffic test suites to use an explicit cleanup context instead of `request.config`, align helper commands with the current `show bfd ... -n asicX` CLI syntax (https://github.com/sonic-net/sonic-utilities/pull/3885 & https://github.com/sonic-net/sonic-utilities/pull/4242) , and add coverage for single backend portchannel member flap handling.

Fixes #13439

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [ ] Skipped for non-supported platforms
- [x] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
The current BFD tests rely on mutating `request.config` to persist cleanup state across fixtures and helper calls, which makes the control flow implicit and brittle. This change makes cleanup and interface restore behavior explicit, updates the helper CLI usage, and expands coverage for partial backend portchannel failures.

#### How did you do it?
Introduced a dedicated `BfdCleanupContext` in `tests/bfd/conftest.py` to track selected BFD endpoints, interface restore targets, RP ASIC state, and cases where route removal may leave empty ASIC routes after shutdown. Hooked that context into `BfdBase` with an autouse fixture, removed `request` plumbing from BFD helper APIs, and updated the traffic/static-route tests to register restore targets through the cleanup context. Also switched BFD helper commands to `show bfd peer/sum -n asicX` and added `test_bfd_single_portchannel_member_flap` to validate route/BFD behavior when one member per backend portchannel is flapped.

#### How did you verify/test it?
I ran the updated code and verified it's working: https://elastictest.org/scheduler/testplan/69cbb0e41e521e52821afe67
<img width="962" height="231" alt="image" src="https://github.com/user-attachments/assets/0b774799-d7c5-4b92-866f-23a7476dc63b" />


#### Any platform specific information?
Applies to the existing BFD test coverage on physical T2 topologies.

#### Supported testbed topology if it's a new test case?
T2

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
