### PR TITLE
Fix default_pfcwd_status KeyError in pfcwd_feature_enabled() when zebra_nexthop injected into golden config

### DIFF
--- a/ansible/library/generate_golden_config_db.py
+++ b/ansible/library/generate_golden_config_db.py
@@ -647,26 +647,13 @@ class GenerateGoldenConfigDBModule(object):
         ori_config_db = json.loads(config)
         if "DEVICE_METADATA" not in ori_config_db or \
                 "localhost" not in ori_config_db["DEVICE_METADATA"]:
-            # DEVICE_METADATA is absent from the golden_config_db (e.g. for t1
-            # topologies where golden config starts empty). Read the full
-            # localhost entry from the minigraph so that
-            # config override-config-table receives a *complete* entry
-            # (preserving hwsku, mac, hostname, etc.) rather than a bare
-            # {"zebra_nexthop": ...} stub that would wipe those fields.
-            rc, out, err = self.module.run_command(
-                "sonic-cfggen -H -m --var-json DEVICE_METADATA"
-            )
-            if rc != 0 or not out.strip():
-                return config
-            try:
-                device_metadata = json.loads(out)
-            except ValueError:
-                return config
-            if "localhost" not in device_metadata:
-                return config
-            if "DEVICE_METADATA" not in ori_config_db:
-                ori_config_db["DEVICE_METADATA"] = {}
-            ori_config_db["DEVICE_METADATA"]["localhost"] = device_metadata["localhost"]
+            # For topologies where golden config has no DEVICE_METADATA (e.g. T0/T1),
+            # do not inject a minigraph-derived entry. Injecting a full localhost entry
+            # from sonic-cfggen would cause config override-config-table to REPLACE the
+            # CONFIG_DB localhost entry, wiping fields like default_pfcwd_status that
+            # are only present via init_cfg.json (not in minigraph).
+            # zebra_nexthop is restored separately by config_reload.py via hset.
+            return config
         ori_config_db["DEVICE_METADATA"]["localhost"]["zebra_nexthop"] = zebra_nexthop
         return json.dumps(ori_config_db, indent=4)
 


### PR DESCRIPTION
Fix KeyError: default_pfcwd_status in pfcwd_feature_enabled() when config_reload runs with config_source=minigraph and safe_reload=True on T0/T1 topologies.

### Description of PR

Summary:

When DEVICE_METADATA is absent from the golden config (T0/T1 topologies), update_zebra_nexthop_config() was reading the full localhost entry from sonic-cfggen and injecting it. This caused config override-config-table to call set_entry() with REPLACE semantics, which wiped default_pfcwd_status -- a field only present via init_cfg.json, not in minigraph. pfcwd_feature_enabled() then crashed with KeyError.

Root cause: The injected minigraph-derived DEVICE_METADATA.localhost lacks default_pfcwd_status. set_entry() replaces the entire entry, removing fields not present in the new value.

Fix: Return early from update_zebra_nexthop_config() when DEVICE_METADATA is absent from the golden config. zebra_nexthop is already correctly restored by config_reload.py via hset for all config_source=minigraph calls -- no injection into the golden config is needed for T0/T1 topologies.

### Type of change

- [x] Bug fix
Microsoft ADO: 37358219

### Back port request
- [x] 202511

### Approach

#### What is the motivation for this PR?

pfcwd_feature_enabled() in tests/common/config_reload.py uses a bare dict key access (["default_pfcwd_status"]) with no .get() fallback. When update_zebra_nexthop_config() injects a minigraph-derived DEVICE_METADATA.localhost (which lacks default_pfcwd_status) into the golden config, the subsequent config override-config-table wipes that field from CONFIG_DB, causing a crash.

#### How did you do it?

Replace the fallback block in update_zebra_nexthop_config() with an early return when DEVICE_METADATA is absent from the golden config. config_reload.py already calls hset DEVICE_METADATA|localhost zebra_nexthop after config override-config-table, so zebra_nexthop is set correctly for T0/T1 topologies without needing the injection.

#### How did you verify/test it?

Code review and tracing the execution path. The ACL test failure was reproduced by analysis of PR 23418 (202511 backport).

#### Any platform specific information?

Affects T0/T1 topologies where golden config has no DEVICE_METADATA section. Not applicable to MX/M0, full-lossy, filterleaf, or SmartSwitch topologies.

#### Supported testbed topology if it is a new test case?

N/A (bug fix)

### Documentation

N/A

---
