### PR TITLE
Fix an issue in get_vlan_brief()

### DIFF
--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -1828,20 +1828,22 @@ Totals               6450                 6449
         """
         config = self.get_running_config_facts()
         vlan_brief = {}
-        for vlan_name, members in config["VLAN_MEMBER"].items():
-            vlan_brief[vlan_name] = {
-                "interface_ipv4": [],
-                "interface_ipv6": [],
-                "members": list(members.keys())
-            }
-        for vlan_name, vlan_info in config["VLAN_INTERFACE"].items():
-            if vlan_name not in vlan_brief:
-                continue
-            for prefix in vlan_info.keys():
-                if '.' in prefix:
-                    vlan_brief[vlan_name]["interface_ipv4"].append(prefix)
-                elif ':' in prefix:
-                    vlan_brief[vlan_name]["interface_ipv6"].append(prefix)
+        if config.get('VLAN_MEMBER'):
+            for vlan_name, members in config["VLAN_MEMBER"].items():
+                vlan_brief[vlan_name] = {
+                    "interface_ipv4": [],
+                    "interface_ipv6": [],
+                    "members": list(members.keys())
+                }
+        if config.get('VLAN_INTERFACE'):
+            for vlan_name, vlan_info in config["VLAN_INTERFACE"].items():
+                if vlan_name not in vlan_brief:
+                    continue
+                for prefix in vlan_info.keys():
+                    if '.' in prefix:
+                        vlan_brief[vlan_name]["interface_ipv4"].append(prefix)
+                    elif ':' in prefix:
+                        vlan_brief[vlan_name]["interface_ipv6"].append(prefix)
         return vlan_brief
 
     def get_interfaces_status(self, namespace=None):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
If there is no VLAN_MEMBER or VLAN_INTERFACE in the running config, don't throw KeyError.


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

### Approach
#### What is the motivation for this PR?
Fix an issue in get_vlan_brief()
#### How did you do it?
Check whether there is the key before getting the value.
#### How did you verify/test it?
Run the test test_dash_privatelink.py which invokes this method in https://github.com/sonic-net/sonic-mgmt/blob/6f61a885cbcc9103a84cd0bdf675bd52a4af82a4/tests/common/helpers/smartswitch_util.py#L17
#### Any platform specific information?
No
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
