### PR TITLE
[override_config_table]: Enable loganalyzer in collect-only mode for  test_override_config_table.py

### DIFF
--- a/tests/override_config_table/test_override_config_table.py
+++ b/tests/override_config_table/test_override_config_table.py
@@ -18,7 +18,6 @@ CONFIG_DB_BACKUP = "/etc/sonic/config_db.json_before_override"
 
 pytestmark = [
     pytest.mark.topology('t0', 't1', 'any'),
-    pytest.mark.disable_loganalyzer,
 ]
 
 LOSSY_HWSKU = mellanox_data.LOSSY_ONLY_HWSKUS + broadcom_data.LOSSY_ONLY_HWSKUS
@@ -172,10 +171,17 @@ def load_minigraph_with_golden_empty_table_removal(duthost):
 
 
 def test_load_minigraph_with_golden_config(duthosts, setup_env,
-                                           enum_rand_one_per_hwsku_frontend_hostname):
+                                           enum_rand_one_per_hwsku_frontend_hostname, loganalyzer):
     """Test Golden Config override during load minigraph
     """
     duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+
+    # Set loganalyzer to collect-only mode (no error matching, just log collection)
+    if loganalyzer:
+        loganalyzer[duthost.hostname].match_regex = []
+        loganalyzer[duthost.hostname].expect_regex = []
+        loganalyzer[duthost.hostname].ignore_regex = []
+
     load_minigraph_with_golden_empty_input(duthost)
     load_minigraph_with_golden_partial_config(duthost)
     full_config = setup_env


### PR DESCRIPTION
### Description of PR
Previously, loganalyzer was disabled for test_override_config_table.py, making it difficult to debug failures due to lack of syslog data.

This change enables loganalyzer in collect-only mode test module:
- Collects syslogs for diagnostic purposes
- Does not perform error/exception pattern matching
- Does not enforce expected or ignored patterns

This improves debuggability by providing syslog data while avoiding false failures caused by log pattern matching.

Summary:
Fixes # https://github.com/sonic-net/sonic-mgmt/issues/23521

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [X] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

### Approach
#### What is the motivation for this PR?
The primary motivation is to improve the debuggability of the test_load_minigraph_with_golden_config() test case. Previously, loganalyzer was completely disabled for this test. When the test failed, developers had no access to syslog data, making it extremely difficult to perform root cause analysis. By enabling log collection, the PR ensures that diagnostic data is available for every run without the overhead or strictness of standard log analysis.

#### How did you do it?
Step 1: Remove blanket disable marker**
- Removed `pytest.mark.disable_loganalyzer` from `pytestmark` list

Step 2: Add loganalyzer parameter and set collect-only mode**
- Added `loganalyzer` fixture parameter to `test_load_minigraph_with_golden_config()`
- Set loganalyzer to collect-only mode:
  ```python
  if loganalyzer:
      loganalyzer[duthost.hostname].match_regex = []
      loganalyzer[duthost.hostname].expect_regex = []
      loganalyzer[duthost.hostname].ignore_regex = []

#### How did you verify/test it?
Execution Check: Ran the test_load_minigraph_with_golden_config test case to ensure it still executes correctly and that the transition to collect-only mode does not introduce new failures.

Log Verification: Verified that syslog files are now successfully captured and available in the test artifacts/results directory following the test run.

Pattern Matching Test: Confirmed that even if "error-like" strings appear in the logs, the loganalyzer does not trigger a test failure, validating that the collect-only flags are working as intended.

#### Any platform specific information?
No. Applies to all platforms in dualtor testbeds.

#### Supported testbed topology if it's a new test case?
N/A